### PR TITLE
[entropy_src/rtl] replacing health test counters with prim_count

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1245,6 +1245,15 @@
                 This bit will stay set until firmware clears it.
                 '''
         }
+        { bits: "22",
+          name: "ES_CNTR_ERR",
+          desc: '''
+                This bit will be set to one when a hardened counter has detected an error
+                condition. This error will signal a fatal alert, and also
+                an interrupt if enabled.
+                This bit will stay set until firmware clears it.
+                '''
+        }
         { bits: "28",
           name: "FIFO_WRITE_ERR",
           desc: '''

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
+      - lowrisc:prim:count
       - lowrisc:prim:assert
       - lowrisc:prim:lfsr
       - lowrisc:ip:tlul

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -371,11 +371,20 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic [32:0]              sha3_err;
   logic                     cs_aes_halt_req;
   logic                     sha3_msg_rdy;
+  logic [HalfRegWidth-1:0]  window_cntr;
 
 
   logic [sha3_pkg::StateW-1:0] sha3_state[Sha3Share];
   logic [PreCondWidth-1:0] msg_data[Sha3Share];
   logic                    es_rdata_capt_vld;
+  logic                    window_cntr_err;
+  logic                    repcnt_cntr_err;
+  logic                    repcnts_cntr_err;
+  logic                    adaptp_cntr_err;
+  logic                    bucket_cntr_err;
+  logic                    markov_cntr_err;
+  logic                    es_cntr_err;
+  logic                    es_cntr_err_sum;
 
   logic                    unused_err_code_test_bit;
   logic                    unused_sha3_state;
@@ -390,7 +399,6 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic        ht_failed_q, ht_failed_d;
   logic        ht_failed_pulse_q, ht_failed_pulse_d;
   logic        ht_done_pulse_q, ht_done_pulse_d;
-  logic [HalfRegWidth-1:0] window_cntr_q, window_cntr_d;
   logic                    sha3_msg_rdy_q, sha3_msg_rdy_d;
   logic                    sha3_err_q, sha3_err_d;
   logic        cs_aes_halt_q, cs_aes_halt_d;
@@ -407,7 +415,6 @@ module entropy_src_core import entropy_src_pkg::*; #(
       ht_esbus_dly_q        <= '0;
       ht_esbus_vld_dly_q    <= '0;
       ht_esbus_vld_dly2_q   <= '0;
-      window_cntr_q         <= '0;
       sha3_msg_rdy_q        <= '0;
       sha3_err_q            <= '0;
       cs_aes_halt_q         <= '0;
@@ -422,7 +429,6 @@ module entropy_src_core import entropy_src_pkg::*; #(
       ht_esbus_dly_q        <= ht_esbus_dly_d;
       ht_esbus_vld_dly_q    <= ht_esbus_vld_dly_d;
       ht_esbus_vld_dly2_q   <= ht_esbus_vld_dly2_d;
-      window_cntr_q         <= window_cntr_d;
       sha3_msg_rdy_q        <= sha3_msg_rdy_d;
       sha3_err_q            <= sha3_err_d;
       cs_aes_halt_q         <= cs_aes_halt_d;
@@ -564,11 +570,12 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   // set the interrupt sources
   assign event_es_fatal_err = es_enable && (
-         sfifo_esrng_err_sum ||
-         sfifo_observe_err_sum ||
-         sfifo_esfinal_err_sum ||
-         es_ack_sm_err_sum ||
-         es_main_sm_err_sum);
+                                            sfifo_esrng_err_sum ||
+                                            sfifo_observe_err_sum ||
+                                            sfifo_esfinal_err_sum ||
+                                            es_ack_sm_err_sum ||
+                                            es_main_sm_err_sum ||
+                                            es_cntr_err_sum);
 
   // set fifo errors that are single instances of source
   assign sfifo_esrng_err_sum = (|sfifo_esrng_err) ||
@@ -581,6 +588,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
          err_code_test_bit[20];
   assign es_main_sm_err_sum = es_main_sm_err ||
          err_code_test_bit[21];
+  assign es_cntr_err_sum = es_cntr_err ||
+         err_code_test_bit[22];
   assign fifo_write_err_sum =
          sfifo_esrng_err[2] ||
          sfifo_observe_err[2] ||
@@ -612,6 +621,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   assign hw2reg.err_code.es_main_sm_err.d = 1'b1;
   assign hw2reg.err_code.es_main_sm_err.de = es_enable && es_main_sm_err_sum;
+
+  assign hw2reg.err_code.es_cntr_err.d = 1'b1;
+  assign hw2reg.err_code.es_cntr_err.de = es_enable && es_cntr_err_sum;
 
 
  // set the err code type bits
@@ -1173,15 +1185,33 @@ module entropy_src_core import entropy_src_pkg::*; #(
   //--------------------------------------------
 
   // Window counter
-  assign window_cntr_d =
-         (!es_enable) ? '0 :
-         health_test_clr ? '0 :
-         health_test_done_pulse ? '0  :
-         health_test_esbus_vld ? (window_cntr_q+1) :
-         window_cntr_q;
+    prim_count #(
+      .Width(HalfRegWidth),
+      .OutSelDnCnt(1'b0), // count up
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_prim_count_window_cntr (
+      .clk_i,
+      .rst_ni,
+      .clr_i(health_test_clr),
+      .set_i(health_test_done_pulse),
+      .set_cnt_i(HalfRegWidth'(0)),
+      .en_i(health_test_esbus_vld),
+      .step_i(HalfRegWidth'(1)),
+      .cnt_o(window_cntr),
+      .err_o(window_cntr_err)
+    );
 
   // Window wrap condition
-  assign health_test_done_pulse = (window_cntr_q == health_test_window);
+  assign health_test_done_pulse = (window_cntr == health_test_window);
+
+  // Summary of counter errors
+  assign es_cntr_err =
+         window_cntr_err ||
+         repcnt_cntr_err ||
+         repcnts_cntr_err ||
+         adaptp_cntr_err ||
+         bucket_cntr_err ||
+         markov_cntr_err;
 
   //--------------------------------------------
   // repetitive count test
@@ -1199,7 +1229,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .active_i            (repcnt_active),
     .thresh_i            (repcnt_threshold),
     .test_cnt_o          (repcnt_event_cnt),
-    .test_fail_pulse_o   (repcnt_fail_pulse)
+    .test_fail_pulse_o   (repcnt_fail_pulse),
+    .count_err_o         (repcnt_cntr_err)
   );
 
   entropy_src_watermark_reg #(
@@ -1259,7 +1290,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .active_i            (repcnts_active),
     .thresh_i            (repcnts_threshold),
     .test_cnt_o          (repcnts_event_cnt),
-    .test_fail_pulse_o   (repcnts_fail_pulse)
+    .test_fail_pulse_o   (repcnts_fail_pulse),
+    .count_err_o         (repcnts_cntr_err)
   );
 
   entropy_src_watermark_reg #(
@@ -1322,7 +1354,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .window_wrap_pulse_i (health_test_done_pulse),
     .test_cnt_o          (adaptp_event_cnt),
     .test_fail_hi_pulse_o(adaptp_hi_fail_pulse),
-    .test_fail_lo_pulse_o(adaptp_lo_fail_pulse)
+    .test_fail_lo_pulse_o(adaptp_lo_fail_pulse),
+    .count_err_o         (adaptp_cntr_err)
   );
 
 
@@ -1428,7 +1461,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .thresh_i            (bucket_threshold),
     .window_wrap_pulse_i (health_test_done_pulse),
     .test_cnt_o          (bucket_event_cnt),
-    .test_fail_pulse_o   (bucket_fail_pulse)
+    .test_fail_pulse_o   (bucket_fail_pulse),
+    .count_err_o         (bucket_cntr_err)
   );
 
   entropy_src_watermark_reg #(
@@ -1493,7 +1527,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .test_cnt_hi_o       (markov_hi_event_cnt),
     .test_cnt_lo_o       (markov_lo_event_cnt),
     .test_fail_hi_pulse_o (markov_hi_fail_pulse),
-    .test_fail_lo_pulse_o (markov_lo_fail_pulse)
+    .test_fail_lo_pulse_o (markov_lo_fail_pulse),
+    .count_err_o         (markov_cntr_err)
   );
 
   entropy_src_watermark_reg #(

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -616,6 +616,10 @@ package entropy_src_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } es_cntr_err;
+    struct packed {
+      logic        d;
+      logic        de;
     } fifo_write_err;
     struct packed {
       logic        d;
@@ -656,42 +660,42 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1044:1037]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1036:1005]
-    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1004:973]
-    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [972:941]
-    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [940:909]
-    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [908:877]
-    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [876:845]
-    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [844:813]
-    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [812:781]
-    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [780:749]
-    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [748:717]
-    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [716:685]
-    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [684:653]
-    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [652:621]
-    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [620:589]
-    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [588:557]
-    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [556:525]
-    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [524:493]
-    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [492:461]
-    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [460:429]
-    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [428:397]
-    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [396:365]
-    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [364:333]
-    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [332:301]
-    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [300:269]
-    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [268:237]
-    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [236:205]
-    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [204:173]
-    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [172:141]
-    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [140:125]
-    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [124:97]
-    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [96:89]
-    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [88:57]
-    entropy_src_hw2reg_debug_status_reg_t debug_status; // [56:38]
-    entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [37:16]
-    entropy_src_hw2reg_err_code_reg_t err_code; // [15:0]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1046:1039]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1038:1007]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1006:975]
+    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [974:943]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [942:911]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [910:879]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [878:847]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [846:815]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [814:783]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [782:751]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [750:719]
+    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [718:687]
+    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [686:655]
+    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [654:623]
+    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [622:591]
+    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [590:559]
+    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [558:527]
+    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [526:495]
+    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [494:463]
+    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [462:431]
+    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [430:399]
+    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [398:367]
+    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [366:335]
+    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [334:303]
+    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [302:271]
+    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [270:239]
+    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [238:207]
+    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [206:175]
+    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [174:143]
+    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [142:127]
+    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [126:99]
+    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [98:91]
+    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [90:59]
+    entropy_src_hw2reg_debug_status_reg_t debug_status; // [58:40]
+    entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [39:18]
+    entropy_src_hw2reg_err_code_reg_t err_code; // [17:0]
   } entropy_src_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -331,6 +331,7 @@ module entropy_src_reg_top (
   logic err_code_sfifo_esfinal_err_qs;
   logic err_code_es_ack_sm_err_qs;
   logic err_code_es_main_sm_err_qs;
+  logic err_code_es_cntr_err_qs;
   logic err_code_fifo_write_err_qs;
   logic err_code_fifo_read_err_qs;
   logic err_code_fifo_state_err_qs;
@@ -2439,6 +2440,31 @@ module entropy_src_reg_top (
     .qs     (err_code_es_main_sm_err_qs)
   );
 
+  //   F[es_cntr_err]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_err_code_es_cntr_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.es_cntr_err.de),
+    .d      (hw2reg.err_code.es_cntr_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_es_cntr_err_qs)
+  );
+
   //   F[fifo_write_err]: 28:28
   prim_subreg #(
     .DW      (1),
@@ -3091,6 +3117,7 @@ module entropy_src_reg_top (
         reg_rdata_next[2] = err_code_sfifo_esfinal_err_qs;
         reg_rdata_next[20] = err_code_es_ack_sm_err_qs;
         reg_rdata_next[21] = err_code_es_main_sm_err_qs;
+        reg_rdata_next[22] = err_code_es_cntr_err_qs;
         reg_rdata_next[28] = err_code_fifo_write_err_qs;
         reg_rdata_next[29] = err_code_fifo_read_err_qs;
         reg_rdata_next[30] = err_code_fifo_state_err_qs;

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
@@ -19,28 +19,27 @@ module entropy_src_repcnt_ht #(
   input logic                   active_i,
   input logic [RegWidth-1:0]    thresh_i,
   output logic [RegWidth-1:0]   test_cnt_o,
-  output logic                  test_fail_pulse_o
+  output logic                  test_fail_pulse_o,
+  output logic                  count_err_o
 );
 
   // signals
   logic [RngBusWidth-1:0] samples_match_pulse;
   logic [RngBusWidth-1:0] samples_no_match_pulse;
   logic [RngBusWidth-1:0] rep_cnt_fail;
+  logic [RegWidth-1:0]    rep_cntr[RngBusWidth];
+  logic [RngBusWidth-1:0] rep_cntr_err;
+  logic [RegWidth-1:0]    test_cnt;
+  logic                   test_cnt_err;
 
   // flops
   logic [RngBusWidth-1:0] prev_sample_q, prev_sample_d;
-  logic [RegWidth-1:0]  rep_cntr_q[RngBusWidth], rep_cntr_d[RngBusWidth];
-  logic [RegWidth-1:0]  test_cnt_q, test_cnt_d;
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
       prev_sample_q    <= '0;
-      rep_cntr_q       <= '{default:0};
-      test_cnt_q       <= '0;
     end else begin
       prev_sample_q    <= prev_sample_d;
-      rep_cntr_q       <= rep_cntr_d;
-      test_cnt_q       <= test_cnt_d;
     end
 
 
@@ -53,6 +52,7 @@ module entropy_src_repcnt_ht #(
 
   for (genvar sh = 0; sh < RngBusWidth; sh = sh+1) begin : gen_cntrs
 
+
     // NIST A sample
     assign prev_sample_d[sh] = (!active_i || clear_i) ? '0 :
                                entropy_bit_vld_i ? entropy_bit_i[sh] :
@@ -64,26 +64,48 @@ module entropy_src_repcnt_ht #(
            (prev_sample_q[sh] != entropy_bit_i[sh]);
 
     // NIST B counter
-    assign rep_cntr_d[sh] =
-           (!active_i || clear_i) ? RegWidth'(1) :
-           samples_match_pulse[sh] ? (rep_cntr_q[sh]+1) :
-           samples_no_match_pulse[sh] ? RegWidth'(1) :
-           rep_cntr_q[sh];
+    prim_count #(
+      .Width(RegWidth),
+      .OutSelDnCnt(1'b0), // count up
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_prim_count_rep_cntr (
+      .clk_i,
+      .rst_ni,
+      .clr_i(!active_i || clear_i),
+      .set_i(samples_no_match_pulse[sh]),
+      .set_cnt_i(RegWidth'(1)),
+      .en_i(samples_match_pulse[sh]),
+      .step_i(RegWidth'(1)),
+      .cnt_o(rep_cntr[sh]),
+      .err_o(rep_cntr_err[sh])
+    );
 
-    assign rep_cnt_fail[sh] = (rep_cntr_q[sh] >= thresh_i);
+    assign rep_cnt_fail[sh] = (rep_cntr[sh] >= thresh_i);
 
   end : gen_cntrs
 
 
   // Test event counter
-  assign test_cnt_d =
-         (!active_i || clear_i) ? '0 :
-         entropy_bit_vld_i && (|rep_cnt_fail) ? (test_cnt_q+1) :
-         test_cnt_q;
+    prim_count #(
+      .Width(RegWidth),
+      .OutSelDnCnt(1'b0), // count up
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_prim_count_test_cnt (
+      .clk_i,
+      .rst_ni,
+      .clr_i(1'b0),
+      .set_i(!active_i || clear_i),
+      .set_cnt_i(RegWidth'(0)),
+      .en_i(entropy_bit_vld_i && (|rep_cnt_fail)),
+      .step_i(RegWidth'(1)),
+      .cnt_o(test_cnt),
+      .err_o(test_cnt_err)
+    );
 
   // the pulses will be only one clock in length
-  assign test_fail_pulse_o = active_i && (test_cnt_q > '0);
-  assign test_cnt_o = test_cnt_q;
+  assign test_fail_pulse_o = active_i && (test_cnt > '0);
+  assign test_cnt_o = test_cnt;
+  assign count_err_o = test_cnt_err || (|rep_cntr_err);
 
 
 endmodule

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
@@ -19,28 +19,27 @@ module entropy_src_repcnts_ht #(
   input logic                   active_i,
   input logic [RegWidth-1:0]    thresh_i,
   output logic [RegWidth-1:0]   test_cnt_o,
-  output logic                  test_fail_pulse_o
+  output logic                  test_fail_pulse_o,
+  output logic                  count_err_o
 );
 
   // signals
   logic  samples_match_pulse;
   logic  samples_no_match_pulse;
   logic  rep_cnt_fail;
+  logic [RegWidth-1:0]    rep_cntr;
+  logic                   rep_cntr_err;
+  logic [RegWidth-1:0]    test_cnt;
+  logic                   test_cnt_err;
 
   // flops
   logic [RngBusWidth-1:0] prev_sample_q, prev_sample_d;
-  logic [RegWidth-1:0]  rep_cntr_q, rep_cntr_d;
-  logic [RegWidth-1:0]  test_cnt_q, test_cnt_d;
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin
       prev_sample_q    <= '0;
-      rep_cntr_q       <= '{default:0};
-      test_cnt_q       <= '0;
     end else begin
       prev_sample_q    <= prev_sample_d;
-      rep_cntr_q       <= rep_cntr_d;
-      test_cnt_q       <= test_cnt_d;
     end
 
 
@@ -62,25 +61,48 @@ module entropy_src_repcnts_ht #(
            (prev_sample_q != entropy_bit_i);
 
     // NIST B counter
-    assign rep_cntr_d =
-           (!active_i || clear_i) ? RegWidth'(1) :
-           samples_match_pulse ? (rep_cntr_q+1) :
-           samples_no_match_pulse ? RegWidth'(1) :
-           rep_cntr_q;
+    prim_count #(
+      .Width(RegWidth),
+      .OutSelDnCnt(1'b0), // count up
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_prim_count_rep_cntr (
+      .clk_i,
+      .rst_ni,
+      .clr_i(!active_i || clear_i),
+      .set_i(samples_no_match_pulse),
+      .set_cnt_i(RegWidth'(1)),
+      .en_i(samples_match_pulse),
+      .step_i(RegWidth'(1)),
+      .cnt_o(rep_cntr),
+      .err_o(rep_cntr_err)
+    );
 
-    assign rep_cnt_fail = (rep_cntr_q >= thresh_i);
+    assign rep_cnt_fail = (rep_cntr >= thresh_i);
 
 
 
   // Test event counter
-  assign test_cnt_d =
-         (!active_i || clear_i) ? '0 :
-         entropy_bit_vld_i && (|rep_cnt_fail) ? (test_cnt_q+1) :
-         test_cnt_q;
+    prim_count #(
+      .Width(RegWidth),
+      .OutSelDnCnt(1'b0), // count up
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_prim_count_test_cnt (
+      .clk_i,
+      .rst_ni,
+      .clr_i(1'b0),
+      .set_i(!active_i || clear_i),
+      .set_cnt_i(RegWidth'(0)),
+      .en_i(entropy_bit_vld_i && (|rep_cnt_fail)),
+      .step_i(RegWidth'(1)),
+      .cnt_o(test_cnt),
+      .err_o(test_cnt_err)
+    );
+
 
   // the pulses will be only one clock in length
-  assign test_fail_pulse_o = active_i && (test_cnt_q > '0);
-  assign test_cnt_o = test_cnt_q;
+  assign test_fail_pulse_o = active_i && (test_cnt > '0);
+  assign test_cnt_o = test_cnt;
+  assign count_err_o = test_cnt_err || (|rep_cntr_err);
 
 
 endmodule


### PR DESCRIPTION
The health test counters should be hardened, so replacing simple counters with prim_count.
These errors are reflected in the fatal error status register.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>