### PR TITLE
[edn/rtl] prim counter replacing standard counter

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -9,9 +9,6 @@
   interrupt_list: [
     { name: "edn_cmd_req_done"
       desc: "Asserted when a software CSRNG request has completed."}
-// TODO: add intrp
-//    { name: "edn_ebus_check_failed"
-//      desc: "Asserted when the entropy bus integrity check has failed."}
     { name: "edn_fatal_err"
       desc: "Asserted when a FIFO error occurs."}
   ],
@@ -336,8 +333,7 @@
           name: "EDN_ACK_SM_ERR",
           desc: '''
                 This bit will be set to one when an illegal state has been detected for the
-                EDN ack stage state machine. This error will signal a fatal alert, and also
-                an interrupt if enabled.
+                EDN ack stage state machine. This error will signal a fatal alert.
                 This bit will stay set until firmware clears it.
                 '''
         }
@@ -345,8 +341,15 @@
           name: "EDN_MAIN_SM_ERR",
           desc: '''
                 This bit will be set to one when an illegal state has been detected for the
-                EDN main stage state machine. This error will signal a fatal alert, and also
-                an interrupt if enabled.
+                EDN main stage state machine. This error will signal a fatal alert.
+                This bit will stay set until firmware clears it.
+                '''
+        }
+        { bits: "22",
+          name: "EDN_CNTR_ERR",
+          desc: '''
+                This bit will be set to one when a hardened counter has detected an error
+                condition. This error will signal a fatal alert.
                 This bit will stay set until firmware clears it.
                 '''
         }

--- a/hw/ip/edn/edn.core
+++ b/hw/ip/edn/edn.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
+      - lowrisc:prim:count
       - lowrisc:prim:assert
       - lowrisc:ip:tlul
       - lowrisc:ip:edn_pkg

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -172,6 +172,10 @@ package edn_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } edn_cntr_err;
+    struct packed {
+      logic        d;
+      logic        de;
     } fifo_write_err;
     struct packed {
       logic        d;
@@ -199,11 +203,11 @@ package edn_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    edn_hw2reg_intr_state_reg_t intr_state; // [35:32]
-    edn_hw2reg_sum_sts_reg_t sum_sts; // [31:28]
-    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [27:24]
-    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [23:14]
-    edn_hw2reg_err_code_reg_t err_code; // [13:0]
+    edn_hw2reg_intr_state_reg_t intr_state; // [37:34]
+    edn_hw2reg_sum_sts_reg_t sum_sts; // [33:30]
+    edn_hw2reg_sw_cmd_sts_reg_t sw_cmd_sts; // [29:26]
+    edn_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [25:16]
+    edn_hw2reg_err_code_reg_t err_code; // [15:0]
   } edn_hw2reg_t;
 
   // Register offsets

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -167,6 +167,7 @@ module edn_reg_top (
   logic err_code_sfifo_gencmd_err_qs;
   logic err_code_edn_ack_sm_err_qs;
   logic err_code_edn_main_sm_err_qs;
+  logic err_code_edn_cntr_err_qs;
   logic err_code_fifo_write_err_qs;
   logic err_code_fifo_read_err_qs;
   logic err_code_fifo_state_err_qs;
@@ -870,6 +871,31 @@ module edn_reg_top (
     .qs     (err_code_edn_main_sm_err_qs)
   );
 
+  //   F[edn_cntr_err]: 22:22
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_err_code_edn_cntr_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.err_code.edn_cntr_err.de),
+    .d      (hw2reg.err_code.edn_cntr_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (err_code_edn_cntr_err_qs)
+  );
+
   //   F[fifo_write_err]: 28:28
   prim_subreg #(
     .DW      (1),
@@ -1152,6 +1178,7 @@ module edn_reg_top (
         reg_rdata_next[1] = err_code_sfifo_gencmd_err_qs;
         reg_rdata_next[20] = err_code_edn_ack_sm_err_qs;
         reg_rdata_next[21] = err_code_edn_main_sm_err_qs;
+        reg_rdata_next[22] = err_code_edn_cntr_err_qs;
         reg_rdata_next[28] = err_code_fifo_write_err_qs;
         reg_rdata_next[29] = err_code_fifo_read_err_qs;
         reg_rdata_next[30] = err_code_fifo_state_err_qs;


### PR DESCRIPTION
A counter used to track long generate commands has been replaced with the hardened version.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>