### PR TITLE
[spi_device] Add payload_swp_en bit field in CMD_INFO

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -626,6 +626,43 @@
         }
       ]
     }
+    { name: "PAYLOAD_SWAP_MASK"
+      desc: '''Write Data Swap in the passthrough mode.
+
+        PAYLOAD_SWAP_MASK CSR provides the SW to change certain bits in the
+        first 4 bytes of the write payload in the passthrough mode.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits:   "31:0"
+          resval: "0"
+          name:   "mask"
+          desc:   "byte mask"
+        } // f: mask
+      ]
+    } // R: PAYLOAD_SWAP_MASK
+    { name: "PAYLOAD_SWAP_DATA"
+      desc: '''Write Data Swap in the passthrough mode.
+
+        PAYLOAD_SWAP_DATA combined with PAYLOAD_SWAP_MASK provides the SW to
+        change certain bits in the first 4 bytes of the write payload in the
+        passthrough mode.
+
+        The register should be written in Little-Endian order. [7:0] bits are
+        processed in the first received payload byte. [31:24] bits for the 4th
+        byte.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits:   "31:0"
+          resval: "0"
+          name:   "data"
+          desc:   "replaced data"
+        } // f: data
+      ]
+    } // R: PAYLOAD_SWAP_DATA
     { multireg: {
         cname: "SPI_DEVICE"
         name:  "CMD_INFO"
@@ -687,10 +724,31 @@
               this case, SW sets payload_en to 4'b 0010.
               '''
           }
-          { bits:   "20"
-            name:   "payload_dir"
-            desc:   "Set to 1 if the command returns data. If 0, the payload sends to the downstream Flash device."
-          }
+          { bits: "20"
+            name: "payload_dir"
+            desc: '''Set to 1 if the command returns data. If 0, the payload
+              sends to the downstream Flash device.
+              '''
+            enum: [
+              { value: "0"
+                name:  "PayloadIn"
+                desc:  "From host to the downstream flash device"
+              } // e: PayloadIn
+              { value: "1"
+                name:  "PayloadOut"
+                desc:  "From the downstream flash device to the host"
+              } // e: PayloadOut
+            ]
+          } // f: payload_dir
+          { bits: "21"
+            name: "payload_swap_en"
+            desc: '''Swap the first byte of the write payload.
+
+              If `payload_swap_en` is set, the passthrough logic swaps the first byte of the write payload with DATA_SWAP CSR.
+
+              `payload_swap_en` only works with write data and SingleIO mode. `payload_en` must be 4'b 0001 and `paylod_dir` to be PayloadIn.
+              '''
+          } // f: payload_swap_en
           { bits: "24"
             name: "upload"
             desc: '''Set to 1 to upload the command.

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -234,6 +234,12 @@ module spi_device
   logic [31:0] addr_swap_mask;
   logic [31:0] addr_swap_data;
 
+  logic [31:0] payload_swap_mask;
+  logic [31:0] payload_swap_data;
+
+  logic unused_payload_swap;
+  assign unused_payload_swap = ^{payload_swap_mask, payload_swap_data};
+
   // Command Info structure
   cmd_info_t [NumCmdInfo-1:0] cmd_info;
   // Broadcasted cmd_info. cmdparse compares the opcode up to CmdInfoReadCmdEnd
@@ -561,6 +567,17 @@ module spi_device
 
   assign addr_swap_mask = reg2hw.addr_swap_mask.q;
   assign addr_swap_data = reg2hw.addr_swap_data.q;
+
+  assign payload_swap_mask = reg2hw.payload_swap_mask.q;
+  assign payload_swap_data = reg2hw.payload_swap_data.q;
+
+  logic unused_payload_swap_en;
+  always_comb begin
+    unused_payload_swap_en = 1'b 1;
+    for (int unsigned i = 0 ; i < spi_device_reg_pkg::NumCmdInfo ; i++) begin
+      unused_payload_swap_en ^= reg2hw.cmd_info[i].payload_swap_en.q;
+    end
+  end
 
   // Connect command info
   always_comb begin

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -235,6 +235,14 @@ package spi_device_reg_pkg;
   } spi_device_reg2hw_addr_swap_data_reg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_payload_swap_mask_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } spi_device_reg2hw_payload_swap_data_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic [7:0]  q;
     } opcode;
@@ -262,6 +270,9 @@ package spi_device_reg_pkg;
     struct packed {
       logic        q;
     } payload_dir;
+    struct packed {
+      logic        q;
+    } payload_swap_en;
     struct packed {
       logic        q;
     } upload;
@@ -520,27 +531,29 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1483:1477]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1476:1470]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1469:1456]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1455:1454]
-    spi_device_reg2hw_control_reg_t control; // [1453:1448]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1447:1434]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1433:1402]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1401:1386]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1385:1370]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1369:1338]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1337:1306]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [1305:1280]
-    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1279:1256]
-    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1255:1246]
-    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1245:1214]
-    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1213:1205]
-    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1204:1172]
-    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1171:916]
-    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [915:884]
-    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [883:852]
-    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [851:276]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1571:1565]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1564:1558]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1557:1544]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1543:1542]
+    spi_device_reg2hw_control_reg_t control; // [1541:1536]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1535:1522]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1521:1490]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1489:1474]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1473:1458]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1457:1426]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1425:1394]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1393:1368]
+    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1367:1344]
+    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1343:1334]
+    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1333:1302]
+    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1301:1293]
+    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1292:1260]
+    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1259:1004]
+    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1003:972]
+    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [971:940]
+    spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [939:908]
+    spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [907:876]
+    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [875:276]
     spi_device_reg2hw_tpm_cfg_reg_t tpm_cfg; // [275:271]
     spi_device_reg2hw_tpm_access_mreg_t [4:0] tpm_access; // [270:231]
     spi_device_reg2hw_tpm_sts_reg_t tpm_sts; // [230:199]
@@ -605,30 +618,32 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 70;
   parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 74;
   parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 78;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 7c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 80;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 84;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h 98;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h 9c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h a0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h a4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h a8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h ac;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h b0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h b4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h b8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h bc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h c0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h c4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h c8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h cc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h d0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h d4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h d8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 7c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 80;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 84;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 88;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 9c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h a0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h a4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h a8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h ac;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h b0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h b4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h b8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h bc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h c0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h c4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h c8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h cc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h d0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h d8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h dc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h e0;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -707,6 +722,8 @@ package spi_device_reg_pkg;
     SPI_DEVICE_CMD_FILTER_7,
     SPI_DEVICE_ADDR_SWAP_MASK,
     SPI_DEVICE_ADDR_SWAP_DATA,
+    SPI_DEVICE_PAYLOAD_SWAP_MASK,
+    SPI_DEVICE_PAYLOAD_SWAP_DATA,
     SPI_DEVICE_CMD_INFO_0,
     SPI_DEVICE_CMD_INFO_1,
     SPI_DEVICE_CMD_INFO_2,
@@ -749,7 +766,7 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [70] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [72] = '{
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -781,45 +798,47 @@ package spi_device_reg_pkg;
     4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_7
     4'b 1111, // index[29] SPI_DEVICE_ADDR_SWAP_MASK
     4'b 1111, // index[30] SPI_DEVICE_ADDR_SWAP_DATA
-    4'b 1111, // index[31] SPI_DEVICE_CMD_INFO_0
-    4'b 1111, // index[32] SPI_DEVICE_CMD_INFO_1
-    4'b 1111, // index[33] SPI_DEVICE_CMD_INFO_2
-    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_3
-    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_4
-    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_5
-    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_6
-    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_7
-    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_8
-    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_9
-    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_10
-    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_11
-    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_12
-    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_13
-    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_14
-    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_15
-    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_16
-    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_17
-    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_18
-    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_19
-    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_20
-    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_21
-    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_22
-    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_23
-    4'b 0111, // index[55] SPI_DEVICE_TPM_CAP
-    4'b 0001, // index[56] SPI_DEVICE_TPM_CFG
-    4'b 0011, // index[57] SPI_DEVICE_TPM_STATUS
-    4'b 1111, // index[58] SPI_DEVICE_TPM_ACCESS_0
-    4'b 0001, // index[59] SPI_DEVICE_TPM_ACCESS_1
-    4'b 1111, // index[60] SPI_DEVICE_TPM_STS
-    4'b 1111, // index[61] SPI_DEVICE_TPM_INTF_CAPABILITY
-    4'b 1111, // index[62] SPI_DEVICE_TPM_INT_ENABLE
-    4'b 0001, // index[63] SPI_DEVICE_TPM_INT_VECTOR
-    4'b 1111, // index[64] SPI_DEVICE_TPM_INT_STATUS
-    4'b 1111, // index[65] SPI_DEVICE_TPM_DID_VID
-    4'b 0001, // index[66] SPI_DEVICE_TPM_RID
-    4'b 1111, // index[67] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 0001, // index[68] SPI_DEVICE_TPM_READ_FIFO
-    4'b 0001  // index[69] SPI_DEVICE_TPM_WRITE_FIFO
+    4'b 1111, // index[31] SPI_DEVICE_PAYLOAD_SWAP_MASK
+    4'b 1111, // index[32] SPI_DEVICE_PAYLOAD_SWAP_DATA
+    4'b 1111, // index[33] SPI_DEVICE_CMD_INFO_0
+    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_1
+    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_2
+    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_3
+    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_4
+    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_5
+    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_6
+    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_7
+    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_8
+    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_9
+    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_10
+    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_11
+    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_12
+    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_13
+    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_14
+    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_16
+    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_17
+    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_18
+    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_19
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_20
+    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_21
+    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_22
+    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_23
+    4'b 0111, // index[57] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[58] SPI_DEVICE_TPM_CFG
+    4'b 0011, // index[59] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[60] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[61] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[62] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[63] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[64] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[65] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[66] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[67] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[68] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[69] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 0001, // index[70] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[71] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -809,6 +809,12 @@ module spi_device_reg_top (
   logic addr_swap_data_we;
   logic [31:0] addr_swap_data_qs;
   logic [31:0] addr_swap_data_wd;
+  logic payload_swap_mask_we;
+  logic [31:0] payload_swap_mask_qs;
+  logic [31:0] payload_swap_mask_wd;
+  logic payload_swap_data_we;
+  logic [31:0] payload_swap_data_qs;
+  logic [31:0] payload_swap_data_wd;
   logic cmd_info_0_we;
   logic [7:0] cmd_info_0_opcode_0_qs;
   logic [7:0] cmd_info_0_opcode_0_wd;
@@ -828,6 +834,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_0_payload_en_0_wd;
   logic cmd_info_0_payload_dir_0_qs;
   logic cmd_info_0_payload_dir_0_wd;
+  logic cmd_info_0_payload_swap_en_0_qs;
+  logic cmd_info_0_payload_swap_en_0_wd;
   logic cmd_info_0_upload_0_qs;
   logic cmd_info_0_upload_0_wd;
   logic cmd_info_0_busy_0_qs;
@@ -853,6 +861,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_1_payload_en_1_wd;
   logic cmd_info_1_payload_dir_1_qs;
   logic cmd_info_1_payload_dir_1_wd;
+  logic cmd_info_1_payload_swap_en_1_qs;
+  logic cmd_info_1_payload_swap_en_1_wd;
   logic cmd_info_1_upload_1_qs;
   logic cmd_info_1_upload_1_wd;
   logic cmd_info_1_busy_1_qs;
@@ -878,6 +888,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_2_payload_en_2_wd;
   logic cmd_info_2_payload_dir_2_qs;
   logic cmd_info_2_payload_dir_2_wd;
+  logic cmd_info_2_payload_swap_en_2_qs;
+  logic cmd_info_2_payload_swap_en_2_wd;
   logic cmd_info_2_upload_2_qs;
   logic cmd_info_2_upload_2_wd;
   logic cmd_info_2_busy_2_qs;
@@ -903,6 +915,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_3_payload_en_3_wd;
   logic cmd_info_3_payload_dir_3_qs;
   logic cmd_info_3_payload_dir_3_wd;
+  logic cmd_info_3_payload_swap_en_3_qs;
+  logic cmd_info_3_payload_swap_en_3_wd;
   logic cmd_info_3_upload_3_qs;
   logic cmd_info_3_upload_3_wd;
   logic cmd_info_3_busy_3_qs;
@@ -928,6 +942,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_4_payload_en_4_wd;
   logic cmd_info_4_payload_dir_4_qs;
   logic cmd_info_4_payload_dir_4_wd;
+  logic cmd_info_4_payload_swap_en_4_qs;
+  logic cmd_info_4_payload_swap_en_4_wd;
   logic cmd_info_4_upload_4_qs;
   logic cmd_info_4_upload_4_wd;
   logic cmd_info_4_busy_4_qs;
@@ -953,6 +969,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_5_payload_en_5_wd;
   logic cmd_info_5_payload_dir_5_qs;
   logic cmd_info_5_payload_dir_5_wd;
+  logic cmd_info_5_payload_swap_en_5_qs;
+  logic cmd_info_5_payload_swap_en_5_wd;
   logic cmd_info_5_upload_5_qs;
   logic cmd_info_5_upload_5_wd;
   logic cmd_info_5_busy_5_qs;
@@ -978,6 +996,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_6_payload_en_6_wd;
   logic cmd_info_6_payload_dir_6_qs;
   logic cmd_info_6_payload_dir_6_wd;
+  logic cmd_info_6_payload_swap_en_6_qs;
+  logic cmd_info_6_payload_swap_en_6_wd;
   logic cmd_info_6_upload_6_qs;
   logic cmd_info_6_upload_6_wd;
   logic cmd_info_6_busy_6_qs;
@@ -1003,6 +1023,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_7_payload_en_7_wd;
   logic cmd_info_7_payload_dir_7_qs;
   logic cmd_info_7_payload_dir_7_wd;
+  logic cmd_info_7_payload_swap_en_7_qs;
+  logic cmd_info_7_payload_swap_en_7_wd;
   logic cmd_info_7_upload_7_qs;
   logic cmd_info_7_upload_7_wd;
   logic cmd_info_7_busy_7_qs;
@@ -1028,6 +1050,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_8_payload_en_8_wd;
   logic cmd_info_8_payload_dir_8_qs;
   logic cmd_info_8_payload_dir_8_wd;
+  logic cmd_info_8_payload_swap_en_8_qs;
+  logic cmd_info_8_payload_swap_en_8_wd;
   logic cmd_info_8_upload_8_qs;
   logic cmd_info_8_upload_8_wd;
   logic cmd_info_8_busy_8_qs;
@@ -1053,6 +1077,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_9_payload_en_9_wd;
   logic cmd_info_9_payload_dir_9_qs;
   logic cmd_info_9_payload_dir_9_wd;
+  logic cmd_info_9_payload_swap_en_9_qs;
+  logic cmd_info_9_payload_swap_en_9_wd;
   logic cmd_info_9_upload_9_qs;
   logic cmd_info_9_upload_9_wd;
   logic cmd_info_9_busy_9_qs;
@@ -1078,6 +1104,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_10_payload_en_10_wd;
   logic cmd_info_10_payload_dir_10_qs;
   logic cmd_info_10_payload_dir_10_wd;
+  logic cmd_info_10_payload_swap_en_10_qs;
+  logic cmd_info_10_payload_swap_en_10_wd;
   logic cmd_info_10_upload_10_qs;
   logic cmd_info_10_upload_10_wd;
   logic cmd_info_10_busy_10_qs;
@@ -1103,6 +1131,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_11_payload_en_11_wd;
   logic cmd_info_11_payload_dir_11_qs;
   logic cmd_info_11_payload_dir_11_wd;
+  logic cmd_info_11_payload_swap_en_11_qs;
+  logic cmd_info_11_payload_swap_en_11_wd;
   logic cmd_info_11_upload_11_qs;
   logic cmd_info_11_upload_11_wd;
   logic cmd_info_11_busy_11_qs;
@@ -1128,6 +1158,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_12_payload_en_12_wd;
   logic cmd_info_12_payload_dir_12_qs;
   logic cmd_info_12_payload_dir_12_wd;
+  logic cmd_info_12_payload_swap_en_12_qs;
+  logic cmd_info_12_payload_swap_en_12_wd;
   logic cmd_info_12_upload_12_qs;
   logic cmd_info_12_upload_12_wd;
   logic cmd_info_12_busy_12_qs;
@@ -1153,6 +1185,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_13_payload_en_13_wd;
   logic cmd_info_13_payload_dir_13_qs;
   logic cmd_info_13_payload_dir_13_wd;
+  logic cmd_info_13_payload_swap_en_13_qs;
+  logic cmd_info_13_payload_swap_en_13_wd;
   logic cmd_info_13_upload_13_qs;
   logic cmd_info_13_upload_13_wd;
   logic cmd_info_13_busy_13_qs;
@@ -1178,6 +1212,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_14_payload_en_14_wd;
   logic cmd_info_14_payload_dir_14_qs;
   logic cmd_info_14_payload_dir_14_wd;
+  logic cmd_info_14_payload_swap_en_14_qs;
+  logic cmd_info_14_payload_swap_en_14_wd;
   logic cmd_info_14_upload_14_qs;
   logic cmd_info_14_upload_14_wd;
   logic cmd_info_14_busy_14_qs;
@@ -1203,6 +1239,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_15_payload_en_15_wd;
   logic cmd_info_15_payload_dir_15_qs;
   logic cmd_info_15_payload_dir_15_wd;
+  logic cmd_info_15_payload_swap_en_15_qs;
+  logic cmd_info_15_payload_swap_en_15_wd;
   logic cmd_info_15_upload_15_qs;
   logic cmd_info_15_upload_15_wd;
   logic cmd_info_15_busy_15_qs;
@@ -1228,6 +1266,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_16_payload_en_16_wd;
   logic cmd_info_16_payload_dir_16_qs;
   logic cmd_info_16_payload_dir_16_wd;
+  logic cmd_info_16_payload_swap_en_16_qs;
+  logic cmd_info_16_payload_swap_en_16_wd;
   logic cmd_info_16_upload_16_qs;
   logic cmd_info_16_upload_16_wd;
   logic cmd_info_16_busy_16_qs;
@@ -1253,6 +1293,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_17_payload_en_17_wd;
   logic cmd_info_17_payload_dir_17_qs;
   logic cmd_info_17_payload_dir_17_wd;
+  logic cmd_info_17_payload_swap_en_17_qs;
+  logic cmd_info_17_payload_swap_en_17_wd;
   logic cmd_info_17_upload_17_qs;
   logic cmd_info_17_upload_17_wd;
   logic cmd_info_17_busy_17_qs;
@@ -1278,6 +1320,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_18_payload_en_18_wd;
   logic cmd_info_18_payload_dir_18_qs;
   logic cmd_info_18_payload_dir_18_wd;
+  logic cmd_info_18_payload_swap_en_18_qs;
+  logic cmd_info_18_payload_swap_en_18_wd;
   logic cmd_info_18_upload_18_qs;
   logic cmd_info_18_upload_18_wd;
   logic cmd_info_18_busy_18_qs;
@@ -1303,6 +1347,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_19_payload_en_19_wd;
   logic cmd_info_19_payload_dir_19_qs;
   logic cmd_info_19_payload_dir_19_wd;
+  logic cmd_info_19_payload_swap_en_19_qs;
+  logic cmd_info_19_payload_swap_en_19_wd;
   logic cmd_info_19_upload_19_qs;
   logic cmd_info_19_upload_19_wd;
   logic cmd_info_19_busy_19_qs;
@@ -1328,6 +1374,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_20_payload_en_20_wd;
   logic cmd_info_20_payload_dir_20_qs;
   logic cmd_info_20_payload_dir_20_wd;
+  logic cmd_info_20_payload_swap_en_20_qs;
+  logic cmd_info_20_payload_swap_en_20_wd;
   logic cmd_info_20_upload_20_qs;
   logic cmd_info_20_upload_20_wd;
   logic cmd_info_20_busy_20_qs;
@@ -1353,6 +1401,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_21_payload_en_21_wd;
   logic cmd_info_21_payload_dir_21_qs;
   logic cmd_info_21_payload_dir_21_wd;
+  logic cmd_info_21_payload_swap_en_21_qs;
+  logic cmd_info_21_payload_swap_en_21_wd;
   logic cmd_info_21_upload_21_qs;
   logic cmd_info_21_upload_21_wd;
   logic cmd_info_21_busy_21_qs;
@@ -1378,6 +1428,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_22_payload_en_22_wd;
   logic cmd_info_22_payload_dir_22_qs;
   logic cmd_info_22_payload_dir_22_wd;
+  logic cmd_info_22_payload_swap_en_22_qs;
+  logic cmd_info_22_payload_swap_en_22_wd;
   logic cmd_info_22_upload_22_qs;
   logic cmd_info_22_upload_22_wd;
   logic cmd_info_22_busy_22_qs;
@@ -1403,6 +1455,8 @@ module spi_device_reg_top (
   logic [3:0] cmd_info_23_payload_en_23_wd;
   logic cmd_info_23_payload_dir_23_qs;
   logic cmd_info_23_payload_dir_23_wd;
+  logic cmd_info_23_payload_swap_en_23_qs;
+  logic cmd_info_23_payload_swap_en_23_wd;
   logic cmd_info_23_upload_23_qs;
   logic cmd_info_23_upload_23_wd;
   logic cmd_info_23_busy_23_qs;
@@ -9402,6 +9456,58 @@ module spi_device_reg_top (
   );
 
 
+  // R[payload_swap_mask]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_payload_swap_mask (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (payload_swap_mask_we),
+    .wd     (payload_swap_mask_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.payload_swap_mask.q),
+
+    // to register interface (read)
+    .qs     (payload_swap_mask_qs)
+  );
+
+
+  // R[payload_swap_data]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h0)
+  ) u_payload_swap_data (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (payload_swap_data_we),
+    .wd     (payload_swap_data_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.payload_swap_data.q),
+
+    // to register interface (read)
+    .qs     (payload_swap_data_qs)
+  );
+
+
   // Subregister 0 of Multireg cmd_info
   // R[cmd_info_0]: V(False)
   //   F[opcode_0]: 7:0
@@ -9627,6 +9733,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_0_payload_dir_0_qs)
+  );
+
+  //   F[payload_swap_en_0]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_0_payload_swap_en_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_0_we),
+    .wd     (cmd_info_0_payload_swap_en_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[0].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_0_payload_swap_en_0_qs)
   );
 
   //   F[upload_0]: 24:24
@@ -9932,6 +10063,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_1_payload_dir_1_qs)
   );
 
+  //   F[payload_swap_en_1]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_1_payload_swap_en_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_1_we),
+    .wd     (cmd_info_1_payload_swap_en_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[1].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_1_payload_swap_en_1_qs)
+  );
+
   //   F[upload_1]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -10233,6 +10389,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_2_payload_dir_2_qs)
+  );
+
+  //   F[payload_swap_en_2]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_2_payload_swap_en_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_2_we),
+    .wd     (cmd_info_2_payload_swap_en_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[2].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_2_payload_swap_en_2_qs)
   );
 
   //   F[upload_2]: 24:24
@@ -10538,6 +10719,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_3_payload_dir_3_qs)
   );
 
+  //   F[payload_swap_en_3]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_3_payload_swap_en_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_3_we),
+    .wd     (cmd_info_3_payload_swap_en_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[3].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_3_payload_swap_en_3_qs)
+  );
+
   //   F[upload_3]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -10839,6 +11045,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_4_payload_dir_4_qs)
+  );
+
+  //   F[payload_swap_en_4]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_4_payload_swap_en_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_4_we),
+    .wd     (cmd_info_4_payload_swap_en_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[4].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_4_payload_swap_en_4_qs)
   );
 
   //   F[upload_4]: 24:24
@@ -11144,6 +11375,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_5_payload_dir_5_qs)
   );
 
+  //   F[payload_swap_en_5]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_5_payload_swap_en_5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_5_we),
+    .wd     (cmd_info_5_payload_swap_en_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[5].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_5_payload_swap_en_5_qs)
+  );
+
   //   F[upload_5]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -11445,6 +11701,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_6_payload_dir_6_qs)
+  );
+
+  //   F[payload_swap_en_6]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_6_payload_swap_en_6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_6_we),
+    .wd     (cmd_info_6_payload_swap_en_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[6].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_6_payload_swap_en_6_qs)
   );
 
   //   F[upload_6]: 24:24
@@ -11750,6 +12031,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_7_payload_dir_7_qs)
   );
 
+  //   F[payload_swap_en_7]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_7_payload_swap_en_7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_7_we),
+    .wd     (cmd_info_7_payload_swap_en_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[7].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_7_payload_swap_en_7_qs)
+  );
+
   //   F[upload_7]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -12051,6 +12357,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_8_payload_dir_8_qs)
+  );
+
+  //   F[payload_swap_en_8]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_8_payload_swap_en_8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_8_we),
+    .wd     (cmd_info_8_payload_swap_en_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[8].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_8_payload_swap_en_8_qs)
   );
 
   //   F[upload_8]: 24:24
@@ -12356,6 +12687,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_9_payload_dir_9_qs)
   );
 
+  //   F[payload_swap_en_9]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_9_payload_swap_en_9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_9_we),
+    .wd     (cmd_info_9_payload_swap_en_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[9].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_9_payload_swap_en_9_qs)
+  );
+
   //   F[upload_9]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -12657,6 +13013,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_10_payload_dir_10_qs)
+  );
+
+  //   F[payload_swap_en_10]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_10_payload_swap_en_10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_10_we),
+    .wd     (cmd_info_10_payload_swap_en_10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[10].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_10_payload_swap_en_10_qs)
   );
 
   //   F[upload_10]: 24:24
@@ -12962,6 +13343,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_11_payload_dir_11_qs)
   );
 
+  //   F[payload_swap_en_11]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_11_payload_swap_en_11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_11_we),
+    .wd     (cmd_info_11_payload_swap_en_11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[11].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_11_payload_swap_en_11_qs)
+  );
+
   //   F[upload_11]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -13263,6 +13669,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_12_payload_dir_12_qs)
+  );
+
+  //   F[payload_swap_en_12]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_12_payload_swap_en_12 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_12_we),
+    .wd     (cmd_info_12_payload_swap_en_12_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[12].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_12_payload_swap_en_12_qs)
   );
 
   //   F[upload_12]: 24:24
@@ -13568,6 +13999,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_13_payload_dir_13_qs)
   );
 
+  //   F[payload_swap_en_13]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_13_payload_swap_en_13 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_13_we),
+    .wd     (cmd_info_13_payload_swap_en_13_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[13].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_13_payload_swap_en_13_qs)
+  );
+
   //   F[upload_13]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -13869,6 +14325,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_14_payload_dir_14_qs)
+  );
+
+  //   F[payload_swap_en_14]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_14_payload_swap_en_14 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_14_we),
+    .wd     (cmd_info_14_payload_swap_en_14_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[14].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_14_payload_swap_en_14_qs)
   );
 
   //   F[upload_14]: 24:24
@@ -14174,6 +14655,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_15_payload_dir_15_qs)
   );
 
+  //   F[payload_swap_en_15]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_15_payload_swap_en_15 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_15_we),
+    .wd     (cmd_info_15_payload_swap_en_15_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[15].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_15_payload_swap_en_15_qs)
+  );
+
   //   F[upload_15]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -14475,6 +14981,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_16_payload_dir_16_qs)
+  );
+
+  //   F[payload_swap_en_16]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_16_payload_swap_en_16 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_16_we),
+    .wd     (cmd_info_16_payload_swap_en_16_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[16].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_16_payload_swap_en_16_qs)
   );
 
   //   F[upload_16]: 24:24
@@ -14780,6 +15311,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_17_payload_dir_17_qs)
   );
 
+  //   F[payload_swap_en_17]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_17_payload_swap_en_17 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_17_we),
+    .wd     (cmd_info_17_payload_swap_en_17_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[17].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_17_payload_swap_en_17_qs)
+  );
+
   //   F[upload_17]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -15081,6 +15637,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_18_payload_dir_18_qs)
+  );
+
+  //   F[payload_swap_en_18]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_18_payload_swap_en_18 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_18_we),
+    .wd     (cmd_info_18_payload_swap_en_18_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[18].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_18_payload_swap_en_18_qs)
   );
 
   //   F[upload_18]: 24:24
@@ -15386,6 +15967,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_19_payload_dir_19_qs)
   );
 
+  //   F[payload_swap_en_19]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_19_payload_swap_en_19 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_19_we),
+    .wd     (cmd_info_19_payload_swap_en_19_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[19].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_19_payload_swap_en_19_qs)
+  );
+
   //   F[upload_19]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -15687,6 +16293,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_20_payload_dir_20_qs)
+  );
+
+  //   F[payload_swap_en_20]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_20_payload_swap_en_20 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_20_we),
+    .wd     (cmd_info_20_payload_swap_en_20_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[20].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_20_payload_swap_en_20_qs)
   );
 
   //   F[upload_20]: 24:24
@@ -15992,6 +16623,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_21_payload_dir_21_qs)
   );
 
+  //   F[payload_swap_en_21]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_21_payload_swap_en_21 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_21_we),
+    .wd     (cmd_info_21_payload_swap_en_21_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[21].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_21_payload_swap_en_21_qs)
+  );
+
   //   F[upload_21]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -16295,6 +16951,31 @@ module spi_device_reg_top (
     .qs     (cmd_info_22_payload_dir_22_qs)
   );
 
+  //   F[payload_swap_en_22]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_22_payload_swap_en_22 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_22_we),
+    .wd     (cmd_info_22_payload_swap_en_22_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[22].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_22_payload_swap_en_22_qs)
+  );
+
   //   F[upload_22]: 24:24
   prim_subreg #(
     .DW      (1),
@@ -16596,6 +17277,31 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (cmd_info_23_payload_dir_23_qs)
+  );
+
+  //   F[payload_swap_en_23]: 21:21
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_23_payload_swap_en_23 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_23_we),
+    .wd     (cmd_info_23_payload_swap_en_23_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info[23].payload_swap_en.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_23_payload_swap_en_23_qs)
   );
 
   //   F[upload_23]: 24:24
@@ -17379,7 +18085,7 @@ module spi_device_reg_top (
 
 
 
-  logic [69:0] addr_hit;
+  logic [71:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -17413,45 +18119,47 @@ module spi_device_reg_top (
     addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
     addr_hit[29] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
     addr_hit[30] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
-    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[32] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
-    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
-    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
-    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
-    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
-    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
-    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
-    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
-    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
-    addr_hit[55] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
-    addr_hit[56] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
-    addr_hit[57] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
-    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
-    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
-    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
-    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
-    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
-    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
-    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
-    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
-    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
-    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
-    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
-    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
+    addr_hit[31] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
+    addr_hit[32] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
+    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
+    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
+    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
+    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
+    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -17528,7 +18236,9 @@ module spi_device_reg_top (
                (addr_hit[66] & (|(SPI_DEVICE_PERMIT[66] & ~reg_be))) |
                (addr_hit[67] & (|(SPI_DEVICE_PERMIT[67] & ~reg_be))) |
                (addr_hit[68] & (|(SPI_DEVICE_PERMIT[68] & ~reg_be))) |
-               (addr_hit[69] & (|(SPI_DEVICE_PERMIT[69] & ~reg_be)))));
+               (addr_hit[69] & (|(SPI_DEVICE_PERMIT[69] & ~reg_be))) |
+               (addr_hit[70] & (|(SPI_DEVICE_PERMIT[70] & ~reg_be))) |
+               (addr_hit[71] & (|(SPI_DEVICE_PERMIT[71] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -18173,7 +18883,13 @@ module spi_device_reg_top (
   assign addr_swap_data_we = addr_hit[30] & reg_we & !reg_error;
 
   assign addr_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_0_we = addr_hit[31] & reg_we & !reg_error;
+  assign payload_swap_mask_we = addr_hit[31] & reg_we & !reg_error;
+
+  assign payload_swap_mask_wd = reg_wdata[31:0];
+  assign payload_swap_data_we = addr_hit[32] & reg_we & !reg_error;
+
+  assign payload_swap_data_wd = reg_wdata[31:0];
+  assign cmd_info_0_we = addr_hit[33] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -18193,12 +18909,14 @@ module spi_device_reg_top (
 
   assign cmd_info_0_payload_dir_0_wd = reg_wdata[20];
 
+  assign cmd_info_0_payload_swap_en_0_wd = reg_wdata[21];
+
   assign cmd_info_0_upload_0_wd = reg_wdata[24];
 
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
 
   assign cmd_info_0_valid_0_wd = reg_wdata[31];
-  assign cmd_info_1_we = addr_hit[32] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[34] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -18218,12 +18936,14 @@ module spi_device_reg_top (
 
   assign cmd_info_1_payload_dir_1_wd = reg_wdata[20];
 
+  assign cmd_info_1_payload_swap_en_1_wd = reg_wdata[21];
+
   assign cmd_info_1_upload_1_wd = reg_wdata[24];
 
   assign cmd_info_1_busy_1_wd = reg_wdata[25];
 
   assign cmd_info_1_valid_1_wd = reg_wdata[31];
-  assign cmd_info_2_we = addr_hit[33] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[35] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -18243,12 +18963,14 @@ module spi_device_reg_top (
 
   assign cmd_info_2_payload_dir_2_wd = reg_wdata[20];
 
+  assign cmd_info_2_payload_swap_en_2_wd = reg_wdata[21];
+
   assign cmd_info_2_upload_2_wd = reg_wdata[24];
 
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
 
   assign cmd_info_2_valid_2_wd = reg_wdata[31];
-  assign cmd_info_3_we = addr_hit[34] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -18268,12 +18990,14 @@ module spi_device_reg_top (
 
   assign cmd_info_3_payload_dir_3_wd = reg_wdata[20];
 
+  assign cmd_info_3_payload_swap_en_3_wd = reg_wdata[21];
+
   assign cmd_info_3_upload_3_wd = reg_wdata[24];
 
   assign cmd_info_3_busy_3_wd = reg_wdata[25];
 
   assign cmd_info_3_valid_3_wd = reg_wdata[31];
-  assign cmd_info_4_we = addr_hit[35] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -18293,12 +19017,14 @@ module spi_device_reg_top (
 
   assign cmd_info_4_payload_dir_4_wd = reg_wdata[20];
 
+  assign cmd_info_4_payload_swap_en_4_wd = reg_wdata[21];
+
   assign cmd_info_4_upload_4_wd = reg_wdata[24];
 
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
 
   assign cmd_info_4_valid_4_wd = reg_wdata[31];
-  assign cmd_info_5_we = addr_hit[36] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -18318,12 +19044,14 @@ module spi_device_reg_top (
 
   assign cmd_info_5_payload_dir_5_wd = reg_wdata[20];
 
+  assign cmd_info_5_payload_swap_en_5_wd = reg_wdata[21];
+
   assign cmd_info_5_upload_5_wd = reg_wdata[24];
 
   assign cmd_info_5_busy_5_wd = reg_wdata[25];
 
   assign cmd_info_5_valid_5_wd = reg_wdata[31];
-  assign cmd_info_6_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -18343,12 +19071,14 @@ module spi_device_reg_top (
 
   assign cmd_info_6_payload_dir_6_wd = reg_wdata[20];
 
+  assign cmd_info_6_payload_swap_en_6_wd = reg_wdata[21];
+
   assign cmd_info_6_upload_6_wd = reg_wdata[24];
 
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
 
   assign cmd_info_6_valid_6_wd = reg_wdata[31];
-  assign cmd_info_7_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[40] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -18368,12 +19098,14 @@ module spi_device_reg_top (
 
   assign cmd_info_7_payload_dir_7_wd = reg_wdata[20];
 
+  assign cmd_info_7_payload_swap_en_7_wd = reg_wdata[21];
+
   assign cmd_info_7_upload_7_wd = reg_wdata[24];
 
   assign cmd_info_7_busy_7_wd = reg_wdata[25];
 
   assign cmd_info_7_valid_7_wd = reg_wdata[31];
-  assign cmd_info_8_we = addr_hit[39] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[41] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -18393,12 +19125,14 @@ module spi_device_reg_top (
 
   assign cmd_info_8_payload_dir_8_wd = reg_wdata[20];
 
+  assign cmd_info_8_payload_swap_en_8_wd = reg_wdata[21];
+
   assign cmd_info_8_upload_8_wd = reg_wdata[24];
 
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
 
   assign cmd_info_8_valid_8_wd = reg_wdata[31];
-  assign cmd_info_9_we = addr_hit[40] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[42] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -18418,12 +19152,14 @@ module spi_device_reg_top (
 
   assign cmd_info_9_payload_dir_9_wd = reg_wdata[20];
 
+  assign cmd_info_9_payload_swap_en_9_wd = reg_wdata[21];
+
   assign cmd_info_9_upload_9_wd = reg_wdata[24];
 
   assign cmd_info_9_busy_9_wd = reg_wdata[25];
 
   assign cmd_info_9_valid_9_wd = reg_wdata[31];
-  assign cmd_info_10_we = addr_hit[41] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[43] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -18443,12 +19179,14 @@ module spi_device_reg_top (
 
   assign cmd_info_10_payload_dir_10_wd = reg_wdata[20];
 
+  assign cmd_info_10_payload_swap_en_10_wd = reg_wdata[21];
+
   assign cmd_info_10_upload_10_wd = reg_wdata[24];
 
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
 
   assign cmd_info_10_valid_10_wd = reg_wdata[31];
-  assign cmd_info_11_we = addr_hit[42] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[44] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -18468,12 +19206,14 @@ module spi_device_reg_top (
 
   assign cmd_info_11_payload_dir_11_wd = reg_wdata[20];
 
+  assign cmd_info_11_payload_swap_en_11_wd = reg_wdata[21];
+
   assign cmd_info_11_upload_11_wd = reg_wdata[24];
 
   assign cmd_info_11_busy_11_wd = reg_wdata[25];
 
   assign cmd_info_11_valid_11_wd = reg_wdata[31];
-  assign cmd_info_12_we = addr_hit[43] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[45] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -18493,12 +19233,14 @@ module spi_device_reg_top (
 
   assign cmd_info_12_payload_dir_12_wd = reg_wdata[20];
 
+  assign cmd_info_12_payload_swap_en_12_wd = reg_wdata[21];
+
   assign cmd_info_12_upload_12_wd = reg_wdata[24];
 
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
 
   assign cmd_info_12_valid_12_wd = reg_wdata[31];
-  assign cmd_info_13_we = addr_hit[44] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[46] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -18518,12 +19260,14 @@ module spi_device_reg_top (
 
   assign cmd_info_13_payload_dir_13_wd = reg_wdata[20];
 
+  assign cmd_info_13_payload_swap_en_13_wd = reg_wdata[21];
+
   assign cmd_info_13_upload_13_wd = reg_wdata[24];
 
   assign cmd_info_13_busy_13_wd = reg_wdata[25];
 
   assign cmd_info_13_valid_13_wd = reg_wdata[31];
-  assign cmd_info_14_we = addr_hit[45] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[47] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -18543,12 +19287,14 @@ module spi_device_reg_top (
 
   assign cmd_info_14_payload_dir_14_wd = reg_wdata[20];
 
+  assign cmd_info_14_payload_swap_en_14_wd = reg_wdata[21];
+
   assign cmd_info_14_upload_14_wd = reg_wdata[24];
 
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
 
   assign cmd_info_14_valid_14_wd = reg_wdata[31];
-  assign cmd_info_15_we = addr_hit[46] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[48] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -18568,12 +19314,14 @@ module spi_device_reg_top (
 
   assign cmd_info_15_payload_dir_15_wd = reg_wdata[20];
 
+  assign cmd_info_15_payload_swap_en_15_wd = reg_wdata[21];
+
   assign cmd_info_15_upload_15_wd = reg_wdata[24];
 
   assign cmd_info_15_busy_15_wd = reg_wdata[25];
 
   assign cmd_info_15_valid_15_wd = reg_wdata[31];
-  assign cmd_info_16_we = addr_hit[47] & reg_we & !reg_error;
+  assign cmd_info_16_we = addr_hit[49] & reg_we & !reg_error;
 
   assign cmd_info_16_opcode_16_wd = reg_wdata[7:0];
 
@@ -18593,12 +19341,14 @@ module spi_device_reg_top (
 
   assign cmd_info_16_payload_dir_16_wd = reg_wdata[20];
 
+  assign cmd_info_16_payload_swap_en_16_wd = reg_wdata[21];
+
   assign cmd_info_16_upload_16_wd = reg_wdata[24];
 
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
 
   assign cmd_info_16_valid_16_wd = reg_wdata[31];
-  assign cmd_info_17_we = addr_hit[48] & reg_we & !reg_error;
+  assign cmd_info_17_we = addr_hit[50] & reg_we & !reg_error;
 
   assign cmd_info_17_opcode_17_wd = reg_wdata[7:0];
 
@@ -18618,12 +19368,14 @@ module spi_device_reg_top (
 
   assign cmd_info_17_payload_dir_17_wd = reg_wdata[20];
 
+  assign cmd_info_17_payload_swap_en_17_wd = reg_wdata[21];
+
   assign cmd_info_17_upload_17_wd = reg_wdata[24];
 
   assign cmd_info_17_busy_17_wd = reg_wdata[25];
 
   assign cmd_info_17_valid_17_wd = reg_wdata[31];
-  assign cmd_info_18_we = addr_hit[49] & reg_we & !reg_error;
+  assign cmd_info_18_we = addr_hit[51] & reg_we & !reg_error;
 
   assign cmd_info_18_opcode_18_wd = reg_wdata[7:0];
 
@@ -18643,12 +19395,14 @@ module spi_device_reg_top (
 
   assign cmd_info_18_payload_dir_18_wd = reg_wdata[20];
 
+  assign cmd_info_18_payload_swap_en_18_wd = reg_wdata[21];
+
   assign cmd_info_18_upload_18_wd = reg_wdata[24];
 
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
 
   assign cmd_info_18_valid_18_wd = reg_wdata[31];
-  assign cmd_info_19_we = addr_hit[50] & reg_we & !reg_error;
+  assign cmd_info_19_we = addr_hit[52] & reg_we & !reg_error;
 
   assign cmd_info_19_opcode_19_wd = reg_wdata[7:0];
 
@@ -18668,12 +19422,14 @@ module spi_device_reg_top (
 
   assign cmd_info_19_payload_dir_19_wd = reg_wdata[20];
 
+  assign cmd_info_19_payload_swap_en_19_wd = reg_wdata[21];
+
   assign cmd_info_19_upload_19_wd = reg_wdata[24];
 
   assign cmd_info_19_busy_19_wd = reg_wdata[25];
 
   assign cmd_info_19_valid_19_wd = reg_wdata[31];
-  assign cmd_info_20_we = addr_hit[51] & reg_we & !reg_error;
+  assign cmd_info_20_we = addr_hit[53] & reg_we & !reg_error;
 
   assign cmd_info_20_opcode_20_wd = reg_wdata[7:0];
 
@@ -18693,12 +19449,14 @@ module spi_device_reg_top (
 
   assign cmd_info_20_payload_dir_20_wd = reg_wdata[20];
 
+  assign cmd_info_20_payload_swap_en_20_wd = reg_wdata[21];
+
   assign cmd_info_20_upload_20_wd = reg_wdata[24];
 
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
 
   assign cmd_info_20_valid_20_wd = reg_wdata[31];
-  assign cmd_info_21_we = addr_hit[52] & reg_we & !reg_error;
+  assign cmd_info_21_we = addr_hit[54] & reg_we & !reg_error;
 
   assign cmd_info_21_opcode_21_wd = reg_wdata[7:0];
 
@@ -18718,12 +19476,14 @@ module spi_device_reg_top (
 
   assign cmd_info_21_payload_dir_21_wd = reg_wdata[20];
 
+  assign cmd_info_21_payload_swap_en_21_wd = reg_wdata[21];
+
   assign cmd_info_21_upload_21_wd = reg_wdata[24];
 
   assign cmd_info_21_busy_21_wd = reg_wdata[25];
 
   assign cmd_info_21_valid_21_wd = reg_wdata[31];
-  assign cmd_info_22_we = addr_hit[53] & reg_we & !reg_error;
+  assign cmd_info_22_we = addr_hit[55] & reg_we & !reg_error;
 
   assign cmd_info_22_opcode_22_wd = reg_wdata[7:0];
 
@@ -18743,12 +19503,14 @@ module spi_device_reg_top (
 
   assign cmd_info_22_payload_dir_22_wd = reg_wdata[20];
 
+  assign cmd_info_22_payload_swap_en_22_wd = reg_wdata[21];
+
   assign cmd_info_22_upload_22_wd = reg_wdata[24];
 
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
 
   assign cmd_info_22_valid_22_wd = reg_wdata[31];
-  assign cmd_info_23_we = addr_hit[54] & reg_we & !reg_error;
+  assign cmd_info_23_we = addr_hit[56] & reg_we & !reg_error;
 
   assign cmd_info_23_opcode_23_wd = reg_wdata[7:0];
 
@@ -18768,12 +19530,14 @@ module spi_device_reg_top (
 
   assign cmd_info_23_payload_dir_23_wd = reg_wdata[20];
 
+  assign cmd_info_23_payload_swap_en_23_wd = reg_wdata[21];
+
   assign cmd_info_23_upload_23_wd = reg_wdata[24];
 
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
 
   assign cmd_info_23_valid_23_wd = reg_wdata[31];
-  assign tpm_cfg_we = addr_hit[56] & reg_we & !reg_error;
+  assign tpm_cfg_we = addr_hit[58] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
 
@@ -18784,7 +19548,7 @@ module spi_device_reg_top (
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_access_0_we = addr_hit[58] & reg_we & !reg_error;
+  assign tpm_access_0_we = addr_hit[60] & reg_we & !reg_error;
 
   assign tpm_access_0_access_0_wd = reg_wdata[7:0];
 
@@ -18793,37 +19557,37 @@ module spi_device_reg_top (
   assign tpm_access_0_access_2_wd = reg_wdata[23:16];
 
   assign tpm_access_0_access_3_wd = reg_wdata[31:24];
-  assign tpm_access_1_we = addr_hit[59] & reg_we & !reg_error;
+  assign tpm_access_1_we = addr_hit[61] & reg_we & !reg_error;
 
   assign tpm_access_1_wd = reg_wdata[7:0];
-  assign tpm_sts_we = addr_hit[60] & reg_we & !reg_error;
+  assign tpm_sts_we = addr_hit[62] & reg_we & !reg_error;
 
   assign tpm_sts_wd = reg_wdata[31:0];
-  assign tpm_intf_capability_we = addr_hit[61] & reg_we & !reg_error;
+  assign tpm_intf_capability_we = addr_hit[63] & reg_we & !reg_error;
 
   assign tpm_intf_capability_wd = reg_wdata[31:0];
-  assign tpm_int_enable_we = addr_hit[62] & reg_we & !reg_error;
+  assign tpm_int_enable_we = addr_hit[64] & reg_we & !reg_error;
 
   assign tpm_int_enable_wd = reg_wdata[31:0];
-  assign tpm_int_vector_we = addr_hit[63] & reg_we & !reg_error;
+  assign tpm_int_vector_we = addr_hit[65] & reg_we & !reg_error;
 
   assign tpm_int_vector_wd = reg_wdata[7:0];
-  assign tpm_int_status_we = addr_hit[64] & reg_we & !reg_error;
+  assign tpm_int_status_we = addr_hit[66] & reg_we & !reg_error;
 
   assign tpm_int_status_wd = reg_wdata[31:0];
-  assign tpm_did_vid_we = addr_hit[65] & reg_we & !reg_error;
+  assign tpm_did_vid_we = addr_hit[67] & reg_we & !reg_error;
 
   assign tpm_did_vid_vid_wd = reg_wdata[15:0];
 
   assign tpm_did_vid_did_wd = reg_wdata[31:16];
-  assign tpm_rid_we = addr_hit[66] & reg_we & !reg_error;
+  assign tpm_rid_we = addr_hit[68] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = addr_hit[67] & reg_re & !reg_error;
-  assign tpm_read_fifo_we = addr_hit[68] & reg_we & !reg_error;
+  assign tpm_cmd_addr_re = addr_hit[69] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[70] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[7:0];
-  assign tpm_write_fifo_re = addr_hit[69] & reg_re & !reg_error;
+  assign tpm_write_fifo_re = addr_hit[71] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -19247,6 +20011,14 @@ module spi_device_reg_top (
       end
 
       addr_hit[31]: begin
+        reg_rdata_next[31:0] = payload_swap_mask_qs;
+      end
+
+      addr_hit[32]: begin
+        reg_rdata_next[31:0] = payload_swap_data_qs;
+      end
+
+      addr_hit[33]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[8] = cmd_info_0_addr_en_0_qs;
         reg_rdata_next[9] = cmd_info_0_addr_swap_en_0_qs;
@@ -19256,12 +20028,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_0_dummy_en_0_qs;
         reg_rdata_next[19:16] = cmd_info_0_payload_en_0_qs;
         reg_rdata_next[20] = cmd_info_0_payload_dir_0_qs;
+        reg_rdata_next[21] = cmd_info_0_payload_swap_en_0_qs;
         reg_rdata_next[24] = cmd_info_0_upload_0_qs;
         reg_rdata_next[25] = cmd_info_0_busy_0_qs;
         reg_rdata_next[31] = cmd_info_0_valid_0_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[34]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[8] = cmd_info_1_addr_en_1_qs;
         reg_rdata_next[9] = cmd_info_1_addr_swap_en_1_qs;
@@ -19271,12 +20044,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_1_dummy_en_1_qs;
         reg_rdata_next[19:16] = cmd_info_1_payload_en_1_qs;
         reg_rdata_next[20] = cmd_info_1_payload_dir_1_qs;
+        reg_rdata_next[21] = cmd_info_1_payload_swap_en_1_qs;
         reg_rdata_next[24] = cmd_info_1_upload_1_qs;
         reg_rdata_next[25] = cmd_info_1_busy_1_qs;
         reg_rdata_next[31] = cmd_info_1_valid_1_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[35]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[8] = cmd_info_2_addr_en_2_qs;
         reg_rdata_next[9] = cmd_info_2_addr_swap_en_2_qs;
@@ -19286,12 +20060,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_2_dummy_en_2_qs;
         reg_rdata_next[19:16] = cmd_info_2_payload_en_2_qs;
         reg_rdata_next[20] = cmd_info_2_payload_dir_2_qs;
+        reg_rdata_next[21] = cmd_info_2_payload_swap_en_2_qs;
         reg_rdata_next[24] = cmd_info_2_upload_2_qs;
         reg_rdata_next[25] = cmd_info_2_busy_2_qs;
         reg_rdata_next[31] = cmd_info_2_valid_2_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[8] = cmd_info_3_addr_en_3_qs;
         reg_rdata_next[9] = cmd_info_3_addr_swap_en_3_qs;
@@ -19301,12 +20076,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_3_dummy_en_3_qs;
         reg_rdata_next[19:16] = cmd_info_3_payload_en_3_qs;
         reg_rdata_next[20] = cmd_info_3_payload_dir_3_qs;
+        reg_rdata_next[21] = cmd_info_3_payload_swap_en_3_qs;
         reg_rdata_next[24] = cmd_info_3_upload_3_qs;
         reg_rdata_next[25] = cmd_info_3_busy_3_qs;
         reg_rdata_next[31] = cmd_info_3_valid_3_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[8] = cmd_info_4_addr_en_4_qs;
         reg_rdata_next[9] = cmd_info_4_addr_swap_en_4_qs;
@@ -19316,12 +20092,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_4_dummy_en_4_qs;
         reg_rdata_next[19:16] = cmd_info_4_payload_en_4_qs;
         reg_rdata_next[20] = cmd_info_4_payload_dir_4_qs;
+        reg_rdata_next[21] = cmd_info_4_payload_swap_en_4_qs;
         reg_rdata_next[24] = cmd_info_4_upload_4_qs;
         reg_rdata_next[25] = cmd_info_4_busy_4_qs;
         reg_rdata_next[31] = cmd_info_4_valid_4_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[8] = cmd_info_5_addr_en_5_qs;
         reg_rdata_next[9] = cmd_info_5_addr_swap_en_5_qs;
@@ -19331,12 +20108,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_5_dummy_en_5_qs;
         reg_rdata_next[19:16] = cmd_info_5_payload_en_5_qs;
         reg_rdata_next[20] = cmd_info_5_payload_dir_5_qs;
+        reg_rdata_next[21] = cmd_info_5_payload_swap_en_5_qs;
         reg_rdata_next[24] = cmd_info_5_upload_5_qs;
         reg_rdata_next[25] = cmd_info_5_busy_5_qs;
         reg_rdata_next[31] = cmd_info_5_valid_5_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[8] = cmd_info_6_addr_en_6_qs;
         reg_rdata_next[9] = cmd_info_6_addr_swap_en_6_qs;
@@ -19346,12 +20124,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_6_dummy_en_6_qs;
         reg_rdata_next[19:16] = cmd_info_6_payload_en_6_qs;
         reg_rdata_next[20] = cmd_info_6_payload_dir_6_qs;
+        reg_rdata_next[21] = cmd_info_6_payload_swap_en_6_qs;
         reg_rdata_next[24] = cmd_info_6_upload_6_qs;
         reg_rdata_next[25] = cmd_info_6_busy_6_qs;
         reg_rdata_next[31] = cmd_info_6_valid_6_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[40]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[8] = cmd_info_7_addr_en_7_qs;
         reg_rdata_next[9] = cmd_info_7_addr_swap_en_7_qs;
@@ -19361,12 +20140,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_7_dummy_en_7_qs;
         reg_rdata_next[19:16] = cmd_info_7_payload_en_7_qs;
         reg_rdata_next[20] = cmd_info_7_payload_dir_7_qs;
+        reg_rdata_next[21] = cmd_info_7_payload_swap_en_7_qs;
         reg_rdata_next[24] = cmd_info_7_upload_7_qs;
         reg_rdata_next[25] = cmd_info_7_busy_7_qs;
         reg_rdata_next[31] = cmd_info_7_valid_7_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[8] = cmd_info_8_addr_en_8_qs;
         reg_rdata_next[9] = cmd_info_8_addr_swap_en_8_qs;
@@ -19376,12 +20156,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_8_dummy_en_8_qs;
         reg_rdata_next[19:16] = cmd_info_8_payload_en_8_qs;
         reg_rdata_next[20] = cmd_info_8_payload_dir_8_qs;
+        reg_rdata_next[21] = cmd_info_8_payload_swap_en_8_qs;
         reg_rdata_next[24] = cmd_info_8_upload_8_qs;
         reg_rdata_next[25] = cmd_info_8_busy_8_qs;
         reg_rdata_next[31] = cmd_info_8_valid_8_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[42]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[8] = cmd_info_9_addr_en_9_qs;
         reg_rdata_next[9] = cmd_info_9_addr_swap_en_9_qs;
@@ -19391,12 +20172,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_9_dummy_en_9_qs;
         reg_rdata_next[19:16] = cmd_info_9_payload_en_9_qs;
         reg_rdata_next[20] = cmd_info_9_payload_dir_9_qs;
+        reg_rdata_next[21] = cmd_info_9_payload_swap_en_9_qs;
         reg_rdata_next[24] = cmd_info_9_upload_9_qs;
         reg_rdata_next[25] = cmd_info_9_busy_9_qs;
         reg_rdata_next[31] = cmd_info_9_valid_9_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[43]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[8] = cmd_info_10_addr_en_10_qs;
         reg_rdata_next[9] = cmd_info_10_addr_swap_en_10_qs;
@@ -19406,12 +20188,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_10_dummy_en_10_qs;
         reg_rdata_next[19:16] = cmd_info_10_payload_en_10_qs;
         reg_rdata_next[20] = cmd_info_10_payload_dir_10_qs;
+        reg_rdata_next[21] = cmd_info_10_payload_swap_en_10_qs;
         reg_rdata_next[24] = cmd_info_10_upload_10_qs;
         reg_rdata_next[25] = cmd_info_10_busy_10_qs;
         reg_rdata_next[31] = cmd_info_10_valid_10_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[44]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[8] = cmd_info_11_addr_en_11_qs;
         reg_rdata_next[9] = cmd_info_11_addr_swap_en_11_qs;
@@ -19421,12 +20204,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_11_dummy_en_11_qs;
         reg_rdata_next[19:16] = cmd_info_11_payload_en_11_qs;
         reg_rdata_next[20] = cmd_info_11_payload_dir_11_qs;
+        reg_rdata_next[21] = cmd_info_11_payload_swap_en_11_qs;
         reg_rdata_next[24] = cmd_info_11_upload_11_qs;
         reg_rdata_next[25] = cmd_info_11_busy_11_qs;
         reg_rdata_next[31] = cmd_info_11_valid_11_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[45]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[8] = cmd_info_12_addr_en_12_qs;
         reg_rdata_next[9] = cmd_info_12_addr_swap_en_12_qs;
@@ -19436,12 +20220,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_12_dummy_en_12_qs;
         reg_rdata_next[19:16] = cmd_info_12_payload_en_12_qs;
         reg_rdata_next[20] = cmd_info_12_payload_dir_12_qs;
+        reg_rdata_next[21] = cmd_info_12_payload_swap_en_12_qs;
         reg_rdata_next[24] = cmd_info_12_upload_12_qs;
         reg_rdata_next[25] = cmd_info_12_busy_12_qs;
         reg_rdata_next[31] = cmd_info_12_valid_12_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[46]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[8] = cmd_info_13_addr_en_13_qs;
         reg_rdata_next[9] = cmd_info_13_addr_swap_en_13_qs;
@@ -19451,12 +20236,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_13_dummy_en_13_qs;
         reg_rdata_next[19:16] = cmd_info_13_payload_en_13_qs;
         reg_rdata_next[20] = cmd_info_13_payload_dir_13_qs;
+        reg_rdata_next[21] = cmd_info_13_payload_swap_en_13_qs;
         reg_rdata_next[24] = cmd_info_13_upload_13_qs;
         reg_rdata_next[25] = cmd_info_13_busy_13_qs;
         reg_rdata_next[31] = cmd_info_13_valid_13_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[47]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[8] = cmd_info_14_addr_en_14_qs;
         reg_rdata_next[9] = cmd_info_14_addr_swap_en_14_qs;
@@ -19466,12 +20252,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_14_dummy_en_14_qs;
         reg_rdata_next[19:16] = cmd_info_14_payload_en_14_qs;
         reg_rdata_next[20] = cmd_info_14_payload_dir_14_qs;
+        reg_rdata_next[21] = cmd_info_14_payload_swap_en_14_qs;
         reg_rdata_next[24] = cmd_info_14_upload_14_qs;
         reg_rdata_next[25] = cmd_info_14_busy_14_qs;
         reg_rdata_next[31] = cmd_info_14_valid_14_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[48]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[8] = cmd_info_15_addr_en_15_qs;
         reg_rdata_next[9] = cmd_info_15_addr_swap_en_15_qs;
@@ -19481,12 +20268,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_15_dummy_en_15_qs;
         reg_rdata_next[19:16] = cmd_info_15_payload_en_15_qs;
         reg_rdata_next[20] = cmd_info_15_payload_dir_15_qs;
+        reg_rdata_next[21] = cmd_info_15_payload_swap_en_15_qs;
         reg_rdata_next[24] = cmd_info_15_upload_15_qs;
         reg_rdata_next[25] = cmd_info_15_busy_15_qs;
         reg_rdata_next[31] = cmd_info_15_valid_15_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[49]: begin
         reg_rdata_next[7:0] = cmd_info_16_opcode_16_qs;
         reg_rdata_next[8] = cmd_info_16_addr_en_16_qs;
         reg_rdata_next[9] = cmd_info_16_addr_swap_en_16_qs;
@@ -19496,12 +20284,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_16_dummy_en_16_qs;
         reg_rdata_next[19:16] = cmd_info_16_payload_en_16_qs;
         reg_rdata_next[20] = cmd_info_16_payload_dir_16_qs;
+        reg_rdata_next[21] = cmd_info_16_payload_swap_en_16_qs;
         reg_rdata_next[24] = cmd_info_16_upload_16_qs;
         reg_rdata_next[25] = cmd_info_16_busy_16_qs;
         reg_rdata_next[31] = cmd_info_16_valid_16_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[50]: begin
         reg_rdata_next[7:0] = cmd_info_17_opcode_17_qs;
         reg_rdata_next[8] = cmd_info_17_addr_en_17_qs;
         reg_rdata_next[9] = cmd_info_17_addr_swap_en_17_qs;
@@ -19511,12 +20300,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_17_dummy_en_17_qs;
         reg_rdata_next[19:16] = cmd_info_17_payload_en_17_qs;
         reg_rdata_next[20] = cmd_info_17_payload_dir_17_qs;
+        reg_rdata_next[21] = cmd_info_17_payload_swap_en_17_qs;
         reg_rdata_next[24] = cmd_info_17_upload_17_qs;
         reg_rdata_next[25] = cmd_info_17_busy_17_qs;
         reg_rdata_next[31] = cmd_info_17_valid_17_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[51]: begin
         reg_rdata_next[7:0] = cmd_info_18_opcode_18_qs;
         reg_rdata_next[8] = cmd_info_18_addr_en_18_qs;
         reg_rdata_next[9] = cmd_info_18_addr_swap_en_18_qs;
@@ -19526,12 +20316,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_18_dummy_en_18_qs;
         reg_rdata_next[19:16] = cmd_info_18_payload_en_18_qs;
         reg_rdata_next[20] = cmd_info_18_payload_dir_18_qs;
+        reg_rdata_next[21] = cmd_info_18_payload_swap_en_18_qs;
         reg_rdata_next[24] = cmd_info_18_upload_18_qs;
         reg_rdata_next[25] = cmd_info_18_busy_18_qs;
         reg_rdata_next[31] = cmd_info_18_valid_18_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[52]: begin
         reg_rdata_next[7:0] = cmd_info_19_opcode_19_qs;
         reg_rdata_next[8] = cmd_info_19_addr_en_19_qs;
         reg_rdata_next[9] = cmd_info_19_addr_swap_en_19_qs;
@@ -19541,12 +20332,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_19_dummy_en_19_qs;
         reg_rdata_next[19:16] = cmd_info_19_payload_en_19_qs;
         reg_rdata_next[20] = cmd_info_19_payload_dir_19_qs;
+        reg_rdata_next[21] = cmd_info_19_payload_swap_en_19_qs;
         reg_rdata_next[24] = cmd_info_19_upload_19_qs;
         reg_rdata_next[25] = cmd_info_19_busy_19_qs;
         reg_rdata_next[31] = cmd_info_19_valid_19_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[53]: begin
         reg_rdata_next[7:0] = cmd_info_20_opcode_20_qs;
         reg_rdata_next[8] = cmd_info_20_addr_en_20_qs;
         reg_rdata_next[9] = cmd_info_20_addr_swap_en_20_qs;
@@ -19556,12 +20348,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_20_dummy_en_20_qs;
         reg_rdata_next[19:16] = cmd_info_20_payload_en_20_qs;
         reg_rdata_next[20] = cmd_info_20_payload_dir_20_qs;
+        reg_rdata_next[21] = cmd_info_20_payload_swap_en_20_qs;
         reg_rdata_next[24] = cmd_info_20_upload_20_qs;
         reg_rdata_next[25] = cmd_info_20_busy_20_qs;
         reg_rdata_next[31] = cmd_info_20_valid_20_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[54]: begin
         reg_rdata_next[7:0] = cmd_info_21_opcode_21_qs;
         reg_rdata_next[8] = cmd_info_21_addr_en_21_qs;
         reg_rdata_next[9] = cmd_info_21_addr_swap_en_21_qs;
@@ -19571,12 +20364,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_21_dummy_en_21_qs;
         reg_rdata_next[19:16] = cmd_info_21_payload_en_21_qs;
         reg_rdata_next[20] = cmd_info_21_payload_dir_21_qs;
+        reg_rdata_next[21] = cmd_info_21_payload_swap_en_21_qs;
         reg_rdata_next[24] = cmd_info_21_upload_21_qs;
         reg_rdata_next[25] = cmd_info_21_busy_21_qs;
         reg_rdata_next[31] = cmd_info_21_valid_21_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[55]: begin
         reg_rdata_next[7:0] = cmd_info_22_opcode_22_qs;
         reg_rdata_next[8] = cmd_info_22_addr_en_22_qs;
         reg_rdata_next[9] = cmd_info_22_addr_swap_en_22_qs;
@@ -19586,12 +20380,13 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_22_dummy_en_22_qs;
         reg_rdata_next[19:16] = cmd_info_22_payload_en_22_qs;
         reg_rdata_next[20] = cmd_info_22_payload_dir_22_qs;
+        reg_rdata_next[21] = cmd_info_22_payload_swap_en_22_qs;
         reg_rdata_next[24] = cmd_info_22_upload_22_qs;
         reg_rdata_next[25] = cmd_info_22_busy_22_qs;
         reg_rdata_next[31] = cmd_info_22_valid_22_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[56]: begin
         reg_rdata_next[7:0] = cmd_info_23_opcode_23_qs;
         reg_rdata_next[8] = cmd_info_23_addr_en_23_qs;
         reg_rdata_next[9] = cmd_info_23_addr_swap_en_23_qs;
@@ -19601,18 +20396,19 @@ module spi_device_reg_top (
         reg_rdata_next[15] = cmd_info_23_dummy_en_23_qs;
         reg_rdata_next[19:16] = cmd_info_23_payload_en_23_qs;
         reg_rdata_next[20] = cmd_info_23_payload_dir_23_qs;
+        reg_rdata_next[21] = cmd_info_23_payload_swap_en_23_qs;
         reg_rdata_next[24] = cmd_info_23_upload_23_qs;
         reg_rdata_next[25] = cmd_info_23_busy_23_qs;
         reg_rdata_next[31] = cmd_info_23_valid_23_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[57]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
         reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[58]: begin
         reg_rdata_next[0] = tpm_cfg_en_qs;
         reg_rdata_next[1] = tpm_cfg_tpm_mode_qs;
         reg_rdata_next[2] = tpm_cfg_hw_reg_dis_qs;
@@ -19620,63 +20416,63 @@ module spi_device_reg_top (
         reg_rdata_next[4] = tpm_cfg_invalid_locality_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[59]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
         reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[60]: begin
         reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
         reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
         reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
         reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[61]: begin
         reg_rdata_next[7:0] = tpm_access_1_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[62]: begin
         reg_rdata_next[31:0] = tpm_sts_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[63]: begin
         reg_rdata_next[31:0] = tpm_intf_capability_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[64]: begin
         reg_rdata_next[31:0] = tpm_int_enable_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[65]: begin
         reg_rdata_next[7:0] = tpm_int_vector_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[66]: begin
         reg_rdata_next[31:0] = tpm_int_status_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[67]: begin
         reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
         reg_rdata_next[31:16] = tpm_did_vid_did_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[68]: begin
         reg_rdata_next[7:0] = tpm_rid_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[69]: begin
         reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
         reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[70]: begin
         reg_rdata_next[7:0] = '0;
       end
 
-      addr_hit[69]: begin
+      addr_hit[71]: begin
         reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 


### PR DESCRIPTION

Adding one field in the command info list. payload_swap_en is to support
the write status data manipulation in the passthrough mode.

This commit also defines `DATA_SWAP` register to provide the SW to
configure which bit of the first byte to be changed.