### PR TITLE
[sw, cleanup] Move `ARRAYSIZE` to `macros.h`.

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -15,6 +15,22 @@
  */
 
 /**
+ * Computes the number of elements in the given array.
+ *
+ * Note that this can only determine the length of *fixed-size* arrays. Due to
+ * limitations of C, it will incorrectly compute the size of an array passed as
+ * a function argument, because those automatically decay into pointers. This
+ * function can only be used correctly with:
+ * - Arrays declared as stack variables.
+ * - Arrays declared at global scope.
+ * - Arrays that are members of a struct or union.
+ *
+ * @param array The array expression to measure.
+ * @return The number of elements in the array, as a `size_t`.
+ */
+#define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
+
+/**
  * An annotation that a switch/case fallthrough is the intended behavior.
  */
 #define FALLTHROUGH_INTENDED __attribute__((fallthrough))

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -22,22 +22,6 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * Computes the number of elements in the given array.
- *
- * Note that this can only determine the length of *fixed-size* arrays. Due to
- * limitations of C, it will incorrectly compute the size of an array passed as
- * a function argument, because those automatically decay into pointers. This
- * function can only be used correctly with:
- * - Arrays declared as stack variables.
- * - Arrays declared at global scope.
- * - Arrays that are members of a struct or union.
- *
- * @param array The array expression to measure.
- * @return The number of elements in the array, as a `size_t`.
- */
-#define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
-
-/**
  * Load a word from memory directly, bypassing aliasing rules.
  *
  * ISO C forbids, in general, casting a pointer to non-character types and

--- a/sw/device/lib/dif/dif_csrng.c
+++ b/sw/device/lib/dif/dif_csrng.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/dif/dif_csrng.h"
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 
 #include "kmac_regs.h"  // Generated.

--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/multibits.h"
 

--- a/sw/device/lib/dif/dif_otp_ctrl.c
+++ b/sw/device/lib/dif/dif_otp_ctrl.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 
 #include "sw/device/lib/base/bitfield.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_base.h"
 
 #include "otp_ctrl_regs.h"  // Generated.

--- a/sw/device/sca/lib/simple_serial.c
+++ b/sw/device/sca/lib/simple_serial.c
@@ -5,6 +5,7 @@
 #include "sw/device/sca/lib/simple_serial.h"
 
 #include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/print.h"

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_kmac.h"
 #include "sw/device/lib/runtime/log.h"

--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -6,7 +6,7 @@
 
 #include <assert.h>
 
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 
 // The context is declared as weak so that the mask ROM and ROM_EXT may

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/flash_ctrl.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/check.h"

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -5,6 +5,7 @@
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -6,7 +6,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -5,7 +5,7 @@
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 
 #include "sw/device/lib/base/freestanding/assert.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -6,7 +6,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/dif/dif_kmac.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/bitfield.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -4,7 +4,7 @@
 
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
 
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_functest.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -5,6 +5,7 @@
 #include "sw/device/silicon_creator/lib/shutdown.h"
 
 #include "gtest/gtest.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
@@ -18,10 +19,6 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "lc_ctrl_regs.h"
 #include "otp_ctrl_regs.h"
-
-// FIXME: I can't get ARRAYSIZE from `memory.h` because the definitions of
-// memcpy and friends there conflict with the standard definitions.
-#define ARRAYSIZE(x) ((sizeof x) / (sizeof x[0]))
 
 namespace shutdown_unittest {
 

--- a/sw/device/silicon_creator/lib/sigverify.c
+++ b/sw/device/silicon_creator/lib/sigverify.c
@@ -6,6 +6,7 @@
 
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex.c
@@ -4,6 +4,7 @@
 
 #include <stddef.h>
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
 

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -10,7 +10,7 @@
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/csr.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/pinmux.h"
 #include "sw/device/lib/runtime/hart.h"

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -6,7 +6,7 @@
 
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/csr.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"

--- a/sw/device/tests/crt_test.c
+++ b/sw/device/tests/crt_test.c
@@ -6,7 +6,7 @@
 #include <stdint.h>
 
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/log.h"

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_csrng.h"
 #include "sw/device/lib/runtime/log.h"

--- a/sw/device/tests/flash_ctrl_test.c
+++ b/sw/device/tests/flash_ctrl_test.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/flash_ctrl.h"
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/runtime/log.h"

--- a/sw/device/tests/gpio_smoketest.c
+++ b/sw/device/tests/gpio_smoketest.c
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_gpio.h"
 #include "sw/device/lib/runtime/log.h"

--- a/sw/device/tests/kmac_mode_cshake_test.c
+++ b/sw/device/tests/kmac_mode_cshake_test.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_kmac.h"
 #include "sw/device/lib/flash_ctrl.h"

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_kmac.h"
 #include "sw/device/lib/flash_ctrl.h"

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/arch/device.h"
-#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_kmac.h"
 #include "sw/device/lib/flash_ctrl.h"

--- a/sw/device/tests/otp_ctrl_smoketest.c
+++ b/sw/device/tests/otp_ctrl_smoketest.c
@@ -6,6 +6,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_otp_ctrl.h"
 #include "sw/device/lib/runtime/log.h"


### PR DESCRIPTION
Fixes #9037.

Signed-off-by: Chris Frantz <cfrantz@google.com>