### PR TITLE
[syn/aes/otbn] Minor fixes to fix block level synthesis

### DIFF
--- a/hw/ip/aes/syn/aes_syn_cfg.hjson
+++ b/hw/ip/aes/syn/aes_syn_cfg.hjson
@@ -11,6 +11,18 @@
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
+  // Overrides
+  overrides: [
+    // This expands the dut hierarchy in the report
+    {
+      name: expand_modules
+      value: "{name}"
+    }
+  ]
+
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/ip/aes/syn/constraints.sdc"
+
+  // This is not needed for this module
+  foundry_sdc_file: ""
 }

--- a/hw/ip/otbn/syn/otbn_syn_cfg.hjson
+++ b/hw/ip/otbn/syn/otbn_syn_cfg.hjson
@@ -11,6 +11,19 @@
   import_cfgs: [// Project wide common synthesis config file
                 "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
 
+  // Overrides
+  overrides: [
+    // This expands the dut hierarchy in the report
+    {
+      name: expand_modules
+      value: "{name}"
+    }
+  ]
+
   // Timing constraints for this module
   sdc_file: "{proj_root}/hw/ip/otbn/syn/constraints.sdc"
- }
+
+  // This is not needed for this module
+  foundry_sdc_file: ""
+}
+

--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -131,8 +131,11 @@ class SynCfg(OneShotCfg):
             """
             if val is not None and norm is not None:
                 if total is not None:
-                    perc = float(val) / float(total) * 100.0
-                    entry = "%2.1f %s" % (perc, perctag)
+                    if total <= 0.0:
+                        entry = "--"
+                    else:
+                        perc = float(val) / float(total) * 100.0
+                        entry = "%2.1f %s" % (perc, perctag)
                 else:
                     value = float(val) / norm
                     if value < 1.0:
@@ -238,17 +241,15 @@ class SynCfg(OneShotCfg):
                     for name in self.result["area"]["instances"].keys():
                         row = []
                         is_top = (self.result["area"]["instances"][name]["depth"] == 0)
-                        if is_top:
-                            row = ["**" + name + "**"]
-                        else:
-                            row = [name]
+                        row = ["**" + name + "**"] if is_top else [name]
 
                         for field in ["comb", "buf", "reg", "logic", "macro", "total"]:
-                            row.append(
-                                _create_entry(
-                                    self.result["area"]["instances"][name]
-                                    [field], kge)
-                            )
+                            entry = _create_entry(
+                                        self.result["area"]["instances"][name]
+                                        [field], kge)
+                            entry = "**" + entry + "**" if is_top else entry
+                            row.append(entry)
+
 
                         for k, field in enumerate(["logic", "macro", "total"]):
                             if is_top:


### PR DESCRIPTION
The block-level synthesis setups for AES and OTBN got out of sync.
This also fixes a minor issue with divisions by zero in the report calculation that only occurred when no macros are present in the design (like in AES).

I will probably hook these up to CI at some point (need to update some Dvsim tooling for that first, though).

CC @who93 

Signed-off-by: Michael Schaffner <msf@google.com>