### PR TITLE
[opentitantool] Add Skeleton of Ti50 host emulation driver

### DIFF
--- a/sw/host/opentitanlib/src/transport/emulation/mod.rs
+++ b/sw/host/opentitanlib/src/transport/emulation/mod.rs
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::io::gpio::GpioPin;
+use crate::io::spi::Target;
+use crate::io::uart::Uart;
+use crate::transport::{Capabilities, Capability, Transport};
+
+#[derive(Default)]
+pub struct HostEmulation {
+    pub port: u16,
+    _inner: RefCell<Inner>,
+}
+
+/// Internal mutable state of the HostEmulation struct.
+#[derive(Default)]
+struct Inner {
+}
+
+impl HostEmulation {
+    pub const DEFAULT_PORT: u16 = 5555;
+
+    /// Create a new `HostEmulation` struct, optionally specifying the
+    /// port to connect to.
+    pub fn new(port: Option<u16>) -> Self {
+        Self {
+            port: port.unwrap_or(Self::DEFAULT_PORT),
+            ..Default::default()
+        }
+    }
+}
+
+impl Transport for HostEmulation {
+    fn capabilities(&self) -> Capabilities {
+        Capabilities::new(Capability::UART | Capability::GPIO | Capability::SPI)
+    }
+
+    fn uart(&self, _instance: &str) -> Result<Rc<dyn Uart>> {
+        unimplemented!();
+    }
+
+    fn gpio_pin(&self, _instance: &str) -> Result<Rc<dyn GpioPin>> {
+        unimplemented!();
+    }
+
+    fn spi(&self, _instance: &str) -> Result<Rc<dyn Target>> {
+        unimplemented!();
+    }
+}

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -15,6 +15,7 @@ use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
 pub mod cw310;
+pub mod emulation;
 pub mod ultradebug;
 pub mod verilator;
 

--- a/sw/host/opentitantool/src/backend/emulation.rs
+++ b/sw/host/opentitantool/src/backend/emulation.rs
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use opentitanlib::transport::emulation::HostEmulation;
+use opentitanlib::transport::Transport;
+use opentitanlib::util::parse_int::ParseInt;
+
+use crate::backend::BackendOpts;
+
+pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
+    Ok(Box::new(HostEmulation::new(
+        match &args.usb_serial {
+            Some(serial) => Some(u16::from_str(&serial)?),
+            None => None,
+        }
+    )))
+}

--- a/sw/host/opentitantool/src/backend/mod.rs
+++ b/sw/host/opentitantool/src/backend/mod.rs
@@ -13,6 +13,7 @@ use opentitanlib::transport::{EmptyTransport, Transport};
 use opentitanlib::util::parse_int::ParseInt;
 
 pub mod cw310;
+pub mod emulation;
 pub mod ultradebug;
 pub mod verilator;
 
@@ -50,6 +51,7 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         "verilator" => verilator::create(&args.verilator_opts),
         "ultradebug" => ultradebug::create(args),
         "cw310" => cw310::create(args),
+        "emulation" => emulation::create(args),
         _ => Err(Error::UnknownInterface(args.interface.clone()).into()),
     }?);
     for conf_file in &args.conf {

--- a/sw/host/opentitantool/src/backend/ti50.rs
+++ b/sw/host/opentitantool/src/backend/ti50.rs
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use opentitanlib::transport::ti50::HostEmulation;
+use opentitanlib::transport::Transport;
+use opentitanlib::util::parse_int::ParseInt;
+
+use crate::backend::BackendOpts;
+
+pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
+    Ok(Box::new(HostEmulation::new(
+        match &args.usb_serial {
+            Some(serial) => Some(u16::from_str(&serial)?),
+            None => None,
+        }
+    )))
+}


### PR DESCRIPTION
The Ti50 team will compile our code to either OpenTitan, to past
Google Titan chips, or to a third target which is x86 code running
inside a number of Linux processes.

The team hopes to be able to run some of the same tests across all
three targets, ideally using the same sequence of OpenTitanTool
invocations.

This patch creates an empty Transport implementation, for the Ti50
team to later populate.  I am posting this pull request in part to
rubber stamp the approach of putting some Ti50-specific code of little
use to other teams into the OpenTitan repository.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>