### PR TITLE
[dif/rom_ctrl] Add ROM Controller DIFs.

### DIFF
--- a/sw/device/lib/dif/dif_rom_ctrl.c
+++ b/sw/device/lib/dif/dif_rom_ctrl.c
@@ -4,9 +4,59 @@
 
 #include "sw/device/lib/dif/dif_rom_ctrl.h"
 
+#include <stdint.h>
+
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_base.h"
 
 #include "rom_ctrl_regs.h"  // Generated.
 
-// TODO: Add DIFs.
+static_assert(ROM_CTRL_DIGEST_DIGEST_FIELD_WIDTH == 32,
+              "ROM Controller digest register width changed.");
+static_assert(ROM_CTRL_EXP_DIGEST_DIGEST_FIELD_WIDTH == 32,
+              "ROM Controller expected digest register width changed.");
+static_assert(ROM_CTRL_DIGEST_7_REG_OFFSET == ROM_CTRL_DIGEST_0_REG_OFFSET + 28,
+              "ROM Controller digest register layout is not consecutive.");
+static_assert(
+    ROM_CTRL_EXP_DIGEST_7_REG_OFFSET == ROM_CTRL_EXP_DIGEST_0_REG_OFFSET + 28,
+    "ROM Controller expected digest register layout is not consecutive.");
+
+dif_result_t dif_rom_ctrl_get_fatal_alert_cause(
+    const dif_rom_ctrl_t *rom_ctrl,
+    dif_rom_ctrl_fatal_alert_causes_t *alert_causes) {
+  if (rom_ctrl == NULL || alert_causes == NULL) {
+    return kDifBadArg;
+  }
+
+  *alert_causes = mmio_region_read32(rom_ctrl->base_addr,
+                                     ROM_CTRL_FATAL_ALERT_CAUSE_REG_OFFSET);
+
+  return kDifOk;
+}
+
+dif_result_t dif_rom_ctrl_get_digest(const dif_rom_ctrl_t *rom_ctrl,
+                                     dif_rom_ctrl_digest_t *digest) {
+  if (rom_ctrl == NULL || digest == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_memcpy_from_mmio32(
+      rom_ctrl->base_addr, ROM_CTRL_DIGEST_0_REG_OFFSET, digest->digest,
+      ROM_CTRL_DIGEST_MULTIREG_COUNT * sizeof(uint32_t));
+
+  return kDifOk;
+}
+
+dif_result_t dif_rom_ctrl_get_expected_digest(
+    const dif_rom_ctrl_t *rom_ctrl, dif_rom_ctrl_digest_t *expected_digest) {
+  if (rom_ctrl == NULL || expected_digest == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_memcpy_from_mmio32(
+      rom_ctrl->base_addr, ROM_CTRL_EXP_DIGEST_0_REG_OFFSET,
+      expected_digest->digest,
+      ROM_CTRL_EXP_DIGEST_MULTIREG_COUNT * sizeof(uint32_t));
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_rom_ctrl.h
+++ b/sw/device/lib/dif/dif_rom_ctrl.h
@@ -11,13 +11,82 @@
  * Functions
  */
 
+#include <stdint.h>
+
 #include "sw/device/lib/dif/autogen/dif_rom_ctrl_autogen.h"
+
+#include "rom_ctrl_regs.h"  // Generated.
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
-// TODO: Add DIFs.
+/**
+ * A fatal alert cause error.
+ *
+ * See also: `dif_rom_ctrl_fatal_alert_causes_t`.
+ */
+typedef enum dif_rom_ctrl_fatal_alert_cause {
+  /**
+   * No error has occured.
+   */
+  kDifRomCtrlFatalAlertCauseNoError = 0,
+  /**
+   * Set on a fatal error detected by the ROM checker.
+   */
+  kDifRomCtrlFatalAlertCauseCheckerError =
+      ROM_CTRL_FATAL_ALERT_CAUSE_CHECKER_ERROR_BIT,
+  /**
+   * Set on an integrity error from the register interface.
+   */
+  kDifRomCtrlFatalAlertCauseIntegrityError =
+      ROM_CTRL_FATAL_ALERT_CAUSE_INTEGRITY_ERROR_BIT,
+} dif_rom_ctrl_fatal_alert_cause_t;
+
+/**
+ * A set of fatal alert cause errors.
+ */
+typedef uint32_t dif_rom_ctrl_fatal_alert_causes_t;
+
+/**
+ * A typed representation of the ROM digest.
+ */
+typedef struct dif_rom_ctrl_digest {
+  uint32_t digest[ROM_CTRL_DIGEST_MULTIREG_COUNT];
+} dif_rom_ctrl_digest_t;
+
+/**
+ * Reads the fatal alert cause bits of the ROM Controller.
+ *
+ * @param rom_ctrl A ROM Controller handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rom_ctrl_get_fatal_alert_cause(
+    const dif_rom_ctrl_t *rom_ctrl,
+    dif_rom_ctrl_fatal_alert_causes_t *alert_causes);
+
+/**
+ * Reads the (KMAC computed) ROM digest.
+ *
+ * @param rom_ctrl A ROM Controller handle.
+ * @param digest KMAC digest of ROM.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rom_ctrl_get_digest(const dif_rom_ctrl_t *rom_ctrl,
+                                     dif_rom_ctrl_digest_t *digest);
+
+/**
+ * Reads the expected ROM digest contained in the top eight words of ROM.
+ *
+ * @param rom_ctrl A ROM Controller handle.
+ * @param expected_digest Expected KMAC digest of ROM.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rom_ctrl_get_expected_digest(
+    const dif_rom_ctrl_t *rom_ctrl, dif_rom_ctrl_digest_t *expected_digest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/util/make_new_dif/templates/dif_template.h.tpl
+++ b/util/make_new_dif/templates/dif_template.h.tpl
@@ -26,7 +26,6 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_${ip.name_upper}_H_
 #define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_${ip.name_upper}_H_
 
-
 #error "This file is a template, and not real code."
 
 /**
@@ -97,7 +96,7 @@ dif_result_t dif_${ip.name_snake}_start(
   const dif_${ip.name_snake}_t *${ip.name_snake},
   dif_${ip.name_snake}_transaction_t transaction);
 
-/** Ends a ${ip.name_long_lower} transaction, writing the results to the given output..
+/** Ends a ${ip.name_long_lower} transaction, writing the results to the given output.
  *
  * @param ${ip.name_snake} A ${ip.name_long_lower} handle.
  * @param output Transaction output parameters.
@@ -112,7 +111,7 @@ dif_result_t dif_${ip.name_snake}_end(
  * Locks out ${ip.name_long_lower} functionality.
  *
  * This function is reentrant: calling it while functionality is locked will
- * have no effect and return `kDif${ip.name_camel}Ok`.
+ * have no effect and return `kDifOk`.
  *
  * @param ${ip.name_snake} A ${ip.name_long_lower} handle.
  * @return The result of the operation.


### PR DESCRIPTION
The ROM Controller had no manually-implemented DIFs. This PR adds all of these DIFs (header and implementation) that are required given the current set of features made available by the hardware.