### PR TITLE
[sw/testing] Fix comment typos in `check.h`.

### DIFF
--- a/sw/device/lib/testing/check.h
+++ b/sw/device/lib/testing/check.h
@@ -50,8 +50,10 @@
 /**
  * Compare `num_items_` of `actual_` against `expected_` buffer.
  *
- * Prints differences between `actual_` and `expected_` before assigning the
- * comparison `result_` value.
+ * Prints differences between `actual_` and `expected_` before logging an error.
+ * Note, the differences between the actual and expected buffer values are
+ * logged via LOG_INFO _before_ the error is logged with LOG_ERROR, since by
+ * default DV simulations are configured to terminate upon the first error.
  *
  * @param actual_ Buffer containing actual values.
  * @param expected_ Buffer containing expected values.


### PR DESCRIPTION
This addresses [this](https://github.com/lowRISC/opentitan/pull/9003#discussion_r741938985) review comment on a previous (merged) PR.