### PR TITLE
[sw,otbn] Implement computation of Montgomery constants in OTBN

### DIFF
--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.h
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.h
@@ -58,14 +58,34 @@ typedef struct rsa_3072_constants_t {
 } rsa_3072_constants_t;
 
 /**
- * Precomputes Montgomery constants for an RSA-3072 public key.
+ * Computes Montgomery constant R^2 for an RSA-3072 public key.
  *
  * @param public_key Key for which to compute constants.
  * @param result Buffer in which to store output
  * @return Result of the operation (OK or error).
  */
-rom_error_t rsa_3072_precomp(const rsa_3072_public_key_t *public_key,
-                             rsa_3072_constants_t *result);
+rom_error_t rsa_3072_compute_rr(const rsa_3072_public_key_t *public_key,
+                                rsa_3072_int_t *result);
+
+/**
+ * Computes Montgomery constant m0_inv for an RSA-3072 public key.
+ *
+ * @param public_key Key for which to compute constants.
+ * @param result Buffer in which to store output
+ * @return Result of the operation (OK or error).
+ */
+rom_error_t rsa_3072_compute_m0_inv(const rsa_3072_public_key_t *public_key,
+                                    uint32_t result[kOtbnWideWordNumWords]);
+
+/**
+ * Computes Montgomery constants for an RSA-3072 public key.
+ *
+ * @param public_key Key for which to compute constants.
+ * @param result Buffer in which to store output
+ * @return Result of the operation (OK or error).
+ */
+rom_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
+                                       rsa_3072_constants_t *result);
 
 /**
  * Verifies an RSA-3072 signature.

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.s
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.s
@@ -13,29 +13,37 @@ run_rsa_3072:
   lw    x2, 0(x2)
 
   li    x3, 1
-  beq   x2, x3, precomp
-
-  li    x3, 2
   beq   x2, x3, verify
 
-  /* Mode is neither 1 (= precomp) nor 2 (= verify). Fail. */
+  li    x3, 2
+  beq   x2, x3, compute_rr
+
+  li    x3, 3
+  beq   x2, x3, compute_m0_inv
+
+  /* Mode is neither 1 (= verify) nor 2 (= compute_rr) nor 3 (= compute_m0_inv). Fail. */
   unimp
 
 .text
 
 /**
- * Precomputation of Montgomery constants R^2 and m0_inv.
+ * Precomputation of Montgomery constant R^2.
  *
- * Expects the modulus (in_mod) to be pre-populated. Results will be stored in
- * in_rr and in_m0_inv.
+ * Expects the modulus (in_mod) to be pre-populated. Result will be stored in
+ * in_rr.
  */
-precomp:
-  /* compute Montgomery constant R^2 */
+compute_rr:
   jal      x1, precomp_rr
+  ecall
 
-  /* compute Montgomery constant m0_inv */
+/**
+ * Precomputation of Montgomery constant m0_inv (= -M^-1 mod 2^256).
+ *
+ * Expects the modulus (in_mod) to be pre-populated. Result will be stored in
+ * in_m0_inv.
+ */
+compute_m0_inv:
   jal      x1, precomp_m0_inv
-
   ecall
 
 /**
@@ -45,7 +53,7 @@ precomp:
  * (in_mod) to be pre-populated. Recovered message will be stored in out_buf.
  */
 verify:
-  /* run modular exponentiation */
+  /* Run modular exponentiation. */
   jal      x1, modexp_var_3072_f4
 
   ecall

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.s
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.s
@@ -30,8 +30,13 @@ run_rsa_3072:
  * in_rr and in_m0_inv.
  */
 precomp:
-  /* TODO: not yet implemented */
-  unimp
+  /* compute Montgomery constant R^2 */
+  jal      x1, precomp_rr
+
+  /* compute Montgomery constant m0_inv */
+  jal      x1, precomp_m0_inv
+
+  ecall
 
 /**
  * RSA-3072 signature verification.

--- a/sw/device/silicon_creator/lib/crypto/tests/rsa_3072_verify_functest.c
+++ b/sw/device/silicon_creator/lib/crypto/tests/rsa_3072_verify_functest.c
@@ -102,11 +102,11 @@ static const rsa_3072_int_t kMessage = {
              0x55555555, 0x55555555, 0x55555555, 0x55555555, 0x55555555,
              0x55555555}};
 
-rom_error_t precomp_test(void) {
+rom_error_t compute_constants_test(void) {
   rsa_3072_constants_t act_constants;
 
   // Precompute constants
-  RETURN_IF_ERROR(rsa_3072_precomp(&kPublicKey, &act_constants));
+  RETURN_IF_ERROR(rsa_3072_compute_constants(&kPublicKey, &act_constants));
 
   // Check that RR matches expected value
   for (int i = 0; i < kRsa3072NumWords; i++) {
@@ -143,7 +143,7 @@ bool test_main(void) {
 
   entropy_testutils_boot_mode_init();
 
-  EXECUTE_TEST(result, precomp_test);
+  EXECUTE_TEST(result, compute_constants_test);
 
   EXECUTE_TEST(result, verify_test);
 

--- a/sw/device/silicon_creator/lib/crypto/tests/rsa_3072_verify_functest.c
+++ b/sw/device/silicon_creator/lib/crypto/tests/rsa_3072_verify_functest.c
@@ -102,6 +102,29 @@ static const rsa_3072_int_t kMessage = {
              0x55555555, 0x55555555, 0x55555555, 0x55555555, 0x55555555,
              0x55555555}};
 
+rom_error_t precomp_test(void) {
+  rsa_3072_constants_t act_constants;
+
+  // Precompute constants
+  RETURN_IF_ERROR(rsa_3072_precomp(&kPublicKey, &act_constants));
+
+  // Check that RR matches expected value
+  for (int i = 0; i < kRsa3072NumWords; i++) {
+    CHECK(act_constants.rr.data[i] == kExpConstants.rr.data[i],
+          "Mismatch at word %d of R^2: expected=0x%x, actual=0x%x", i,
+          kExpConstants.rr.data[i], act_constants.rr.data[i]);
+  }
+
+  // Check that m0_inv matches expected value
+  for (int i = 0; i < kOtbnWideWordNumWords; i++) {
+    CHECK(act_constants.m0_inv[i] == kExpConstants.m0_inv[i],
+          "Mismatch at word %d of m0_inv: expected=0x%x, actual=0x%x", i,
+          kExpConstants.m0_inv[i], act_constants.m0_inv[i]);
+  }
+
+  return kErrorOk;
+}
+
 rom_error_t verify_test(void) {
   hardened_bool_t result;
 
@@ -119,6 +142,8 @@ bool test_main(void) {
   rom_error_t result = kErrorOk;
 
   entropy_testutils_boot_mode_init();
+
+  EXECUTE_TEST(result, precomp_test);
 
   EXECUTE_TEST(result, verify_test);
 


### PR DESCRIPTION
RSA-3072 signature verification requires two constants that can be precomputed once per key. This PR adds an OTBN routine for computing them, following https://eprint.iacr.org/2017/1057.pdf.