### PR TITLE
[csrng / edn] Add required assertions from prim_count testing

### DIFF
--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -159,6 +159,11 @@ module csrng
   `ASSERT_KNOWN(IntrCsHwInstExcKnownO_A, intr_cs_hw_inst_exc_o)
   `ASSERT_KNOWN(IntrCsFatalErrKnownO_A, intr_cs_fatal_err_o)
 
+  for (genvar i = 0; i < NHwApps + 1; i++) begin : gen_cnt_asserts
+    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck_A,
+      u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.u_prim_count_cmd_gen_cntr,
+      alert_tx_o[1])
+  end
 
 
 endmodule

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -129,5 +129,9 @@ module edn
   // Interrupt Asserts
   `ASSERT_KNOWN(IntrEdnCmdReqDoneKnownO_A, intr_edn_cmd_req_done_o)
 
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck_A,
+    u_edn_core.u_prim_count_max_reqs_cntr,
+    alert_tx_o[1])
+
 
 endmodule


### PR DESCRIPTION
Hotfix for CI

The CI failure resulted from a cross of #9013, #9040 and #9006.
The two former PRs added `prim_count` to `csrng` and `edn` and the last PR added an assertion requirement wherever `prim_count` is used (this aids in automated testing of prim_counts). 

This PR just adds the necessary assertion to `csrng` and `edn`.  There are still some further things that need to be addressed, they will be handled in different issues and PRs. 