### PR TITLE
[dv/pwrmgr] Enhance wakeup test

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -76,7 +76,7 @@
             - Coverage collected by `wakeup_cg` and `wakeup_intr_cg`.
             '''
       milestone: V2
-      tests: []
+      tests: ["pwrmgr_wakeup"]
     }
     {
       name: control_clks
@@ -98,7 +98,7 @@
               the control register.
             '''
       milestone: V2
-      tests: []
+      tests: ["pwrmgr_wakeup"]
     }
     {
       name: aborted_lowpower
@@ -253,10 +253,10 @@
             '''
     }
     {
-      name: clock_control_cg
+      name: control_cg
       desc: '''
-            Collects coverage on clock enable bits from `control` CSR during a
-            lowpower transition and active state.
+            Collects coverage on clock and power bits from `control` CSR during
+            a lowpower transition and active state.
             '''
     }
     {

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -75,14 +75,16 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
   pwrmgr_wakeup_ctrl_cg_wrap wakeup_ctrl_cg_wrap[pwrmgr_reg_pkg::NumWkups];
   pwrmgr_wakeup_intr_cg_wrap wakeup_intr_cg_wrap[pwrmgr_reg_pkg::NumWkups];
 
-  // This collects coverage on the clock control functionality.
-  covergroup clock_control_cg with function sample (bit core, bit io, bit usb_lp, bit usb_active);
-    core_cp: coverpoint core;
-    io_cp: coverpoint io;
-    usb_lp_cp: coverpoint usb_lp;
-    usb_active_cp: coverpoint usb_active;
+  // This collects coverage on the clock and power control functionality.
+  covergroup control_cg with function sample (control_enables_t control_enables, bit sleep);
+    core_cp: coverpoint control_enables.core_clk_en;
+    io_cp: coverpoint control_enables.io_clk_en;
+    usb_lp_cp: coverpoint control_enables.usb_clk_en_lp;
+    usb_active_cp: coverpoint control_enables.usb_clk_en_active;
+    main_pd_n_cp: coverpoint control_enables.main_pd_n;
+    sleep_cp: coverpoint sleep;
 
-    control_cross: cross core_cp, io_cp, usb_lp_cp, usb_active_cp;
+    control_cross: cross core_cp, io_cp, usb_lp_cp, usb_active_cp, main_pd_n_cp, sleep_cp;
   endgroup
 
   function new(string name, uvm_component parent);
@@ -92,7 +94,7 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
       wakeup_ctrl_cg_wrap[i] = new({wakeup.name, "_ctrl_cg"});
       wakeup_intr_cg_wrap[i] = new({wakeup.name, "_intr_cg"});
     end
-    clock_control_cg = new();
+    control_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
@@ -34,12 +34,15 @@ package pwrmgr_env_pkg;
   } wakeup_e;
 
   typedef struct packed {
-    logic core_clk_en;
-    logic io_clk_en;
-    logic usb_clk_en_lp;
-    logic usb_clk_en_active;
     logic main_pd_n;
-  } clk_enables_t;
+    logic usb_clk_en_active;
+    logic usb_clk_en_lp;
+    logic io_clk_en;
+    logic core_clk_en;
+  } control_enables_t;
+
+  typedef bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeups_t;
+  typedef bit [pwrmgr_reg_pkg::NumRstReqs-1:0] resets_t;
 
   // functions
 

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -15,50 +15,52 @@ interface pwrmgr_if (
 
   // Ports to the dut side.
 
-  pwrmgr_pkg::pwr_ast_req_t                                      pwr_ast_req;
-  pwrmgr_pkg::pwr_ast_rsp_t                                      pwr_ast_rsp;
+  pwrmgr_pkg::pwr_ast_req_t                                          pwr_ast_req;
+  pwrmgr_pkg::pwr_ast_rsp_t                                          pwr_ast_rsp;
 
-  pwrmgr_pkg::pwr_rst_req_t                                      pwr_rst_req;
-  pwrmgr_pkg::pwr_rst_rsp_t                                      pwr_rst_rsp;
+  pwrmgr_pkg::pwr_rst_req_t                                          pwr_rst_req;
+  pwrmgr_pkg::pwr_rst_rsp_t                                          pwr_rst_rsp;
 
-  pwrmgr_pkg::pwr_clk_req_t                                      pwr_clk_req;
-  pwrmgr_pkg::pwr_clk_rsp_t                                      pwr_clk_rsp;
+  pwrmgr_pkg::pwr_clk_req_t                                          pwr_clk_req;
+  pwrmgr_pkg::pwr_clk_rsp_t                                          pwr_clk_rsp;
 
-  pwrmgr_pkg::pwr_otp_req_t                                      pwr_otp_req;
-  pwrmgr_pkg::pwr_otp_rsp_t                                      pwr_otp_rsp;
+  pwrmgr_pkg::pwr_otp_req_t                                          pwr_otp_req;
+  pwrmgr_pkg::pwr_otp_rsp_t                                          pwr_otp_rsp;
 
-  pwrmgr_pkg::pwr_lc_req_t                                       pwr_lc_req;
-  pwrmgr_pkg::pwr_lc_rsp_t                                       pwr_lc_rsp;
+  pwrmgr_pkg::pwr_lc_req_t                                           pwr_lc_req;
+  pwrmgr_pkg::pwr_lc_rsp_t                                           pwr_lc_rsp;
 
-  pwrmgr_pkg::pwr_flash_t                                        pwr_flash;
+  pwrmgr_pkg::pwr_flash_t                                            pwr_flash;
 
-  pwrmgr_pkg::pwr_cpu_t                                          pwr_cpu;
+  pwrmgr_pkg::pwr_cpu_t                                              pwr_cpu;
 
-  lc_ctrl_pkg::lc_tx_t                                           fetch_en;
+  lc_ctrl_pkg::lc_tx_t                                               fetch_en;
 
-  logic                         [  pwrmgr_reg_pkg::NumWkups-1:0] wakeups_i;
+  logic                             [  pwrmgr_reg_pkg::NumWkups-1:0] wakeups_i;
 
-  logic                         [pwrmgr_reg_pkg::NumRstReqs-1:0] rstreqs_i;
+  logic                             [pwrmgr_reg_pkg::NumRstReqs-1:0] rstreqs_i;
 
-  logic                                                          strap;
-  logic                                                          low_power;
-  rom_ctrl_pkg::pwrmgr_data_t                                    rom_ctrl;
+  logic                                                              strap;
+  logic                                                              low_power;
+  rom_ctrl_pkg::pwrmgr_data_t                                        rom_ctrl;
 
-  prim_esc_pkg::esc_tx_t                                         esc_rst_tx;
-  prim_esc_pkg::esc_rx_t                                         esc_rst_rx;
+  prim_esc_pkg::esc_tx_t                                             esc_rst_tx;
+  prim_esc_pkg::esc_rx_t                                             esc_rst_rx;
 
-  logic                                                          intr_wakeup;
+  logic                                                              intr_wakeup;
 
   // Relevant CSR values.
-  pwrmgr_env_pkg::clk_enables_t                                  clk_enables;
+  logic                                                              low_power_hint;
 
-  logic                                                          wakeup_en_regwen;
-  logic                         [  pwrmgr_reg_pkg::NumWkups-1:0] wakeup_en;
-  logic                         [  pwrmgr_reg_pkg::NumWkups-1:0] wakeup_status;
-  logic                                                          wakeup_capture_en;
+  pwrmgr_env_pkg::control_enables_t                                  control_enables;
 
-  logic                         [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_en;
-  logic                         [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_status;
+  logic                                                              wakeup_en_regwen;
+  logic                             [  pwrmgr_reg_pkg::NumWkups-1:0] wakeup_en;
+  logic                             [  pwrmgr_reg_pkg::NumWkups-1:0] wakeup_status;
+  logic                                                              wakeup_capture_en;
+
+  logic                             [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_en;
+  logic                             [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_status;
 
   // Internal signals.
 `ifndef PATO_TO_DUT
@@ -139,8 +141,15 @@ interface pwrmgr_if (
     rstreqs_i = resets;
   endfunction
 
-  function automatic void update_clock_enables(pwrmgr_env_pkg::clk_enables_t clk_enables);
-    clk_enables = clk_enables;
+  function automatic void update_low_power_hint(logic value);
+    `uvm_info("pwrmgr_if", $sformatf("Updating low power hint to 0x%x", value), UVM_MEDIUM)
+    low_power_hint = value;
+  endfunction
+
+  function automatic void update_control_enables(pwrmgr_env_pkg::control_enables_t control_enables);
+    `uvm_info("pwrmgr_if", $sformatf("Updating control enables to 0x%x", control_enables),
+              UVM_MEDIUM)
+    control_enables = control_enables;
   endfunction
 
   // FIXME Move all these initializations to sequences.
@@ -162,7 +171,7 @@ interface pwrmgr_if (
   clocking slow_cb @(posedge clk_slow);
     input slow_state;
     input pwr_ast_req;
-    input clk_enables;
+    input control_enables;
     output pwr_ast_rsp;
   endclocking
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -18,9 +18,12 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   localparam int PropagationToSlowTimeoutInNanoSeconds = 15_000;
   localparam int FetchEnTimeoutNs = 40_000;
 
+  localparam int MaxCyclesBeforeEnable = 6;
+
+
   // Random wakeups and resets.
-  rand bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeups;
-  rand bit [pwrmgr_reg_pkg::NumRstReqs-1:0] resets;
+  rand wakeups_t wakeups;
+  rand resets_t resets;
 
   // Random delays.
   rand int cycles_before_pwrok;
@@ -55,10 +58,16 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   constraint cycles_before_otp_done_base_c {cycles_before_otp_done inside {[0 : 4]};}
   constraint cycles_before_lc_done_base_c {cycles_before_lc_done inside {[0 : 4]};}
   constraint cycles_before_wakeup_c {cycles_before_wakeup inside {[2 : 6]};}
-  constraint cycles_before_core_clk_en_c {cycles_before_core_clk_en inside {[0 : 6]};}
-  constraint cycles_before_io_clk_en_c {cycles_before_io_clk_en inside {[0 : 6]};}
-  constraint cycles_before_usb_clk_en_c {cycles_before_usb_clk_en inside {[0 : 6]};}
-  constraint cycles_before_main_pok_c {cycles_before_main_pok inside {[2 : 6]};}
+  constraint cycles_before_core_clk_en_c {
+    cycles_before_core_clk_en inside {[0 : MaxCyclesBeforeEnable]};
+  }
+  constraint cycles_before_io_clk_en_c {
+    cycles_before_io_clk_en inside {[0 : MaxCyclesBeforeEnable]};
+  }
+  constraint cycles_before_usb_clk_en_c {
+    cycles_before_usb_clk_en inside {[0 : MaxCyclesBeforeEnable]};
+  }
+  constraint cycles_before_main_pok_c {cycles_before_main_pok inside {[2 : MaxCyclesBeforeEnable]};}
 
   bit do_pwrmgr_init = 1'b1;
   // This static variable is incremented in each pre_start and decremented in each post_start.
@@ -147,37 +156,56 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   // Generates expected responses for the slow fsm.
   // - Completes the clock handshake with the ast: when a clk_en output changes, after a few
   //   cycles the ast is expected to set the corresponding clk_val input to the same value.
-  //
+  // - It is possible changes occur in fast succession, so the side-effect is pipelined.
   // Uses macros because VCS flags an error for assignments to automatic variables,
   // even if the variable is a ref to an interface variable.
 
-  `define SLOW_RESPONSE(rsp_name, cycles, req, rsp) \
+  `define SLOW_DETECT(rsp_name, req, rsp_sr) \
       forever \
         @req begin \
           raise_objection(); \
+          `uvm_info(`gfn, $sformatf("Will drive %0s to %b", rsp_name, req), UVM_MEDIUM) \
+        end
+
+  `define SLOW_SHIFT_SR(req, rsp_sr) \
+      forever \
+        @cfg.slow_clk_rst_vif.cb begin \
+          rsp_sr = {rsp_sr[MaxCyclesBeforeEnable-1:0], req}; \
+        end
+
+  `define SLOW_ASSIGN(rsp_name, cycles, rsp_sr, rsp) \
+      forever \
+        @(rsp_sr[cycles]) begin \
           `uvm_info(`gfn, $sformatf( \
-                    "Will drive %0s to %b in %0d slow clock cycles", \
-                    rsp_name, req, cycles), UVM_MEDIUM) \
-          cfg.slow_clk_rst_vif.wait_clks(cycles); \
-          rsp <= req; \
-          `uvm_info(`gfn, $sformatf("Driving %0s to %b", rsp_name, req), UVM_MEDIUM) \
+                    "Driving %0s to %b after %0d AON cycles.", rsp_name, rsp_sr[cycles], cycles \
+                    ), UVM_MEDIUM) \
+          rsp <= rsp_sr[cycles]; \
           drop_objection(); \
         end
 
   task slow_responder();
+    logic [MaxCyclesBeforeEnable:0] core_clk_val_sr;
+    logic [MaxCyclesBeforeEnable:0] io_clk_val_sr;
+    logic [MaxCyclesBeforeEnable:0] usb_clk_val_sr;
+    logic [MaxCyclesBeforeEnable:0] main_pd_val_sr;
+
     fork
-      `SLOW_RESPONSE("core_clk_val", cycles_before_core_clk_en,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_req.core_clk_en,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.core_clk_val)
-      `SLOW_RESPONSE("io_clk_val", cycles_before_io_clk_en,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_req.io_clk_en,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.io_clk_val)
-      `SLOW_RESPONSE("usb_clk_val", cycles_before_usb_clk_en,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_req.usb_clk_en,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.usb_clk_val)
-      `SLOW_RESPONSE("main_pok", cycles_before_main_pok,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_req.main_pd_n,
-                     cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.main_pok)
+      `SLOW_DETECT("core_clk_val", cfg.pwrmgr_vif.slow_cb.pwr_ast_req.core_clk_en, core_clk_val_sr)
+      `SLOW_SHIFT_SR(cfg.pwrmgr_vif.slow_cb.pwr_ast_req.core_clk_en, core_clk_val_sr)
+      `SLOW_ASSIGN("core_clk_val", cycles_before_core_clk_en, core_clk_val_sr,
+                   cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.core_clk_val)
+      `SLOW_DETECT("io_clk_val", cfg.pwrmgr_vif.slow_cb.pwr_ast_req.io_clk_en, io_clk_val_sr)
+      `SLOW_SHIFT_SR(cfg.pwrmgr_vif.slow_cb.pwr_ast_req.io_clk_en, io_clk_val_sr)
+      `SLOW_ASSIGN("io_clk_val", cycles_before_io_clk_en, io_clk_val_sr,
+                   cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.io_clk_val)
+      `SLOW_DETECT("usb_clk_val", cfg.pwrmgr_vif.slow_cb.pwr_ast_req.usb_clk_en, usb_clk_val_sr)
+      `SLOW_SHIFT_SR(cfg.pwrmgr_vif.slow_cb.pwr_ast_req.usb_clk_en, usb_clk_val_sr)
+      `SLOW_ASSIGN("usb_clk_val", cycles_before_usb_clk_en, usb_clk_val_sr,
+                   cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.usb_clk_val)
+      `SLOW_DETECT("main_pok", cfg.pwrmgr_vif.slow_cb.pwr_ast_req.main_pd_n, main_pd_val_sr)
+      `SLOW_SHIFT_SR(cfg.pwrmgr_vif.slow_cb.pwr_ast_req.main_pd_n, main_pd_val_sr)
+      `SLOW_ASSIGN("main_pok", cycles_before_main_pok, main_pd_val_sr,
+                   cfg.pwrmgr_vif.slow_cb.pwr_ast_rsp.main_pok)
     join_none
   endtask
   `undef SLOW_RESPONSE
@@ -193,10 +221,10 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   `define FAST_RESPONSE_ACTION(rsp_name, rsp, req, cycles) \
           `uvm_info(`gfn, $sformatf( \
                     "Will drive %0s to %b in %0d fast clock cycles", \
-                    rsp_name, req, cycles), UVM_MEDIUM) \
+                    rsp_name, req, cycles), UVM_HIGH) \
           cfg.clk_rst_vif.wait_clks(cycles); \
           rsp <= req; \
-          `uvm_info(`gfn, $sformatf("Driving %0s to %b", rsp_name, req), UVM_MEDIUM) \
+          `uvm_info(`gfn, $sformatf("Driving %0s to %b", rsp_name, req), UVM_HIGH) \
 
 
   task fast_responder();

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
@@ -19,8 +19,8 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
 
   task body();
     logic [TL_DW-1:0] value;
-    bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeup_en;
-    bit [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_en;
+    wakeups_t wakeup_en;
+    resets_t reset_en;
     cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
     csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(0));
     csr_rd_check(.ptr(ral.reset_status[0]), .compare_value(0));

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -9,23 +9,61 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
 
   `uvm_object_new
 
-  rand bit                                disable_wakeup_capture;
+  rand bit disable_wakeup_capture;
   constraint wakeups_c {wakeups != 0;}
 
-  rand bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeup_en;
+  rand bit prior_wakeup;
+  rand wakeups_t prior_wakeups;
+  constraint prior_wakeups_c {
+    solve wakeups, prior_wakeup before prior_wakeups;
+    if (prior_wakeup) {
+      prior_wakeups != 0;
+      prior_wakeups != wakeups;
+    }
+  }
+
+  rand wakeups_t wakeup_en;
   constraint wakeup_en_c {
     solve wakeups before wakeup_en;
     |(wakeup_en & wakeups) == 1'b1;
   }
-  rand bit core_clk_en;
-  rand bit io_clk_en;
-  rand bit usb_clk_en_lp;
-  rand bit usb_clk_en_active;
-  rand bit main_pd_n;
+  rand control_enables_t control_enables;
+
+  task update_control_enables(bit low_power_hint);
+    ral.control.core_clk_en.set(control_enables.core_clk_en);
+    ral.control.io_clk_en.set(control_enables.io_clk_en);
+    ral.control.usb_clk_en_lp.set(control_enables.usb_clk_en_lp);
+    ral.control.usb_clk_en_active.set(control_enables.usb_clk_en_active);
+    ral.control.main_pd_n.set(control_enables.main_pd_n);
+    ral.control.low_power_hint.set(low_power_hint);
+    // Disable assertions when main power is down.
+    control_assertions(control_enables.main_pd_n);
+    `uvm_info(`gfn, $sformatf(
+              "Setting control CSR to 0x%x, enables=%p, lph=%b",
+              ral.control.get(),
+              control_enables,
+              1'b1
+              ), UVM_MEDIUM)
+    csr_update(.csr(ral.control));
+  endtask
+
+  // Checks the wake_info matches expectations depending on capture disable.
+  task check_wake_info(wakeups_t enabled_wakeups, bit fall_through, bit abort);
+
+    if (disable_wakeup_capture) begin
+      csr_rd_check(.ptr(ral.wake_info.reasons), .compare_value('0),
+                   .err_msg("With capture disabled"));
+    end else begin
+      csr_rd_check(.ptr(ral.wake_info.reasons), .compare_value(enabled_wakeups),
+                   .err_msg("With capture enabled"));
+    end
+    csr_rd_check(.ptr(ral.wake_info.fall_through), .compare_value(fall_through));
+    csr_rd_check(.ptr(ral.wake_info.abort), .compare_value(abort));
+  endtask
 
   task body();
     logic [TL_DW-1:0] value;
-    bit [pwrmgr_reg_pkg::NumWkups-1:0] enabled_wakeups;
+    wakeups_t enabled_wakeups;
 
     cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
     csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(0));
@@ -35,26 +73,19 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       // Enable wakeups.
       enabled_wakeups = wakeup_en & wakeups;
       `DV_CHECK(enabled_wakeups, $sformatf(
-                "Some wakeup must be enabled: wkups=%b, wkup_en=%b",
-                wakeups,
-                wakeup_en
-                ))
+                "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeup_en))
       `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
       csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeup_en));
+      `uvm_info(`gfn, $sformatf("%0sabling wakeup capture", disable_wakeup_capture ? "Dis" : "En"),
+                UVM_MEDIUM)
       csr_wr(.ptr(ral.wake_info_capture_dis), .value(disable_wakeup_capture));
+
+      update_control_enables(1'b1);
+
       wait_for_csr_to_propagate_to_slow_domain();
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
 
       // Initiate low power transition.
-      ral.control.core_clk_en.set(core_clk_en);
-      ral.control.io_clk_en.set(io_clk_en);
-      ral.control.usb_clk_en_lp.set(usb_clk_en_lp);
-      ral.control.main_pd_n.set(main_pd_n);
-      ral.control.low_power_hint.set(1'b1);
-      // Disable assertions when main power is down.
-      control_assertions(main_pd_n);
-
-      csr_update(.csr(ral.control));
-      cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
       fast_to_low_power();
       if (ral.control.main_pd_n.get_mirrored_value() == 1'b0) begin
         wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
@@ -64,32 +95,34 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
       cfg.pwrmgr_vif.update_wakeups(wakeups);
       // Check wake_status prior to wakeup, or the unit requesting wakeup will have been reset.
+      // This read will not work in the chip, since the processor will be asleep.
       cfg.slow_clk_rst_vif.wait_clks(4);
       csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(enabled_wakeups),
                    .err_msg("failed wake_status check"));
       `uvm_info(`gfn, $sformatf("Got wake_status=0x%x", enabled_wakeups), UVM_MEDIUM)
       wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);
-      cfg.pwrmgr_vif.update_wakeups('0);
 
       wait_for_fast_fsm_active();
       `uvm_info(`gfn, "Back from wakeup", UVM_MEDIUM)
 
       csr_rd_check(.ptr(ral.reset_status[0]), .compare_value(0),
                    .err_msg("failed reset_status check"));
-      if (disable_wakeup_capture) begin
-        csr_rd_check(.ptr(ral.wake_info.reasons),
-                     .compare_value('0));
-      end else begin
-        csr_rd_check(.ptr(ral.wake_info.reasons),
-                     .compare_value(enabled_wakeups));
-      end
-      csr_rd_check(.ptr(ral.wake_info.fall_through), .compare_value(1'b0));
-      csr_rd_check(.ptr(ral.wake_info.abort), .compare_value(1'b0));
-      // Clear wake_info.
+
+      check_wake_info(enabled_wakeups, .fall_through(1'b0), .abort(1'b0));
+
+      // To clear wake_info capture must be disabled.
+      csr_wr(.ptr(ral.wake_info_capture_dis), .value(1'b1));
       csr_wr(.ptr(ral.wake_info), .value('1));
+
+      // This is the expected side-effect of the low power entry reset, since the source of the
+      // non-aon wakeup sources will deassert it as a consequence of their reset.
+      // Some aon wakeups may remain active until software clears them. If they didn't, such wakeups
+      // will remain active, preventing the device from going to sleep.
+      cfg.pwrmgr_vif.update_wakeups('0);
 
       // Wait for interrupt to be generated whether or not it is enabled.
       cfg.slow_clk_rst_vif.wait_clks(10);
+      csr_rd_check(.ptr(ral.wake_status[0]), .compare_value('0));
     end
   endtask
 

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
@@ -35,7 +35,7 @@ interface pwrmgr_clock_enables_sva_if (
     logic prev_en;
     (1'b1,
     prev_en = usb_clk_en_active_i
-    ) ##[1:4] usb_clk_en == prev_en;
+    ) ##[1:5] usb_clk_en == prev_en;
   endsequence
 
   `ASSERT(CoreClkPwrUp_A, transitionUp_S |=> core_clk_en == 1'b1, clk_i, reset_or_disable)


### PR DESCRIPTION
Randomize enabling wake_info capture.
Fix handling enables portion of `control` CSR.
Fix control coverage.
Enable the test in the testplan.

Signed-off-by: Guillermo Maturana <maturana@google.com>