### PR TITLE
[spi_host] Cleanup AscentLint errors, add waivers

### DIFF
--- a/hw/ip/spi_host/lint/spi_host.waiver
+++ b/hw/ip/spi_host/lint/spi_host.waiver
@@ -3,3 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # waiver file for SPI_HOST
+
+# This waiver applies to the SPI_HOST FSM which uses signals next_state_after_idle and
+# next_state_after_idle_csb_active to determine the following state.
+#
+# This is done because in certain conditions the Idle and IdleCSBActive states can be bypassed,
+# meaning the idle state is never actually entered, and the FSM jumps immediately to the appropriate
+# exit state after idle. This allows smooth transitions from one command segment to the other. By
+# using a signal to define the following state, we can be sure that the logic is consistent
+# regardless of whether the idle state is occupied or bypassed.
+
+waive -rules {CALC_NEXT_STATE} -regexp {next_state_after_idle.*}

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -251,8 +251,6 @@ module spi_host
   // Any qe pin from COMMAND will suffice.
   assign command_valid = |cmd_qes;
 
-  `ASSERT(CmdAtomicity_A, ~(&cmd_qes ^ |cmd_qes), clk_i, rst_ni);
-
   logic active;
   logic rx_stall;
   logic tx_stall;


### PR DESCRIPTION
- Remove an ASSERT that was being flagged as a null assertion.
- Request waivers for ascent lint rule CALC_NEXT_STATE for certain FSM state
  transitions, in which the SPI_HOST FSM uses signals to ensure that idle state
  transitions are performed consistently.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>