### PR TITLE
[syn] Minor scripting alignment with CDC flow

### DIFF
--- a/hw/syn/tools/dc/run-syn.tcl
+++ b/hw/syn/tools/dc/run-syn.tcl
@@ -8,26 +8,25 @@
 ##  PREPARE FLOW   ##
 #####################
 
-set syn_root ""
-if {[info exists ::env(syn_root)]} {
-  set syn_root "$::env(syn_root)"
-} else {
-  puts "ERROR: Script run without syn_root environment variable."
-  quit
+proc get_env_var {name} {
+  if {[info exists ::env($name)]} {
+    set val "[set ::env([set name])]"
+    puts "::env($name) = $val"
+    return $val
+  } else {
+    puts "ERROR: Script run without $name environment variable."
+    quit
+  }
 }
 
-set foundry_root ""
-if {[info exists ::env(foundry_root)]} {
-  set foundry_root "$::env(foundry_root)"
-} else {
-  puts "ERROR: Script run without foundry_root environment variable."
-  quit
-}
-
-# Tool setup.
-# TODO: The below path assumes a certain directory structure in the foundry
-# area which does not exist in the open repo.
-source "${foundry_root}/syn/dc/setup.tcl"
+set FOUNDRY_ROOT       [get_env_var "FOUNDRY_ROOT"]
+set SYN_ROOT           [get_env_var "SYN_ROOT"]
+set SV_FLIST           [get_env_var "SV_FLIST"]
+set BUILD_DIR          [get_env_var "BUILD_DIR"]
+set DUT                [get_env_var "DUT"]
+set CONSTRAINT         [get_env_var "CONSTRAINT"]
+set FOUNDRY_CONSTRAINT [get_env_var "FOUNDRY_CONSTRAINT"]
+set PARAMS             [get_env_var "PARAMS"]
 
 # if in interactive mode, do not exit at the end of the script
 if { [info exists ::env(INTERACTIVE)] } {
@@ -35,16 +34,6 @@ if { [info exists ::env(INTERACTIVE)] } {
 } else {
   set RUN_INTERACTIVE 0
 }
-
-# path to directory containing the source list file
-set SV_FLIST $::env(SV_FLIST)
-set BUILD_DIR $::env(BUILD_DIR)
-
-# just compile the "core" toplevel at the moment
-# might want to switch to chip_earlgrey_asic later on (with pads)
-set DUT $::env(DUT)
-set CONSTRAINT $::env(CONSTRAINT)
-set FOUNDRY_CONSTRAINT $::env(FOUNDRY_CONSTRAINT)
 
 # paths
 set WORKLIB  "${BUILD_DIR}/WORK"
@@ -57,6 +46,21 @@ exec mkdir -p ${REPDIR} ${DDCDIR} ${VLOGDIR} ${WORKLIB} ${RESULTDIR}
 
 # define work lib path
 define_design_lib WORK -path $WORKLIB
+
+########################
+## Library Setup      ##
+########################
+
+# if the foundry root is specified, some more library setup is needed.
+if {$FOUNDRY_ROOT != ""} {
+  source "${FOUNDRY_ROOT}/syn/dc/setup.tcl"
+  # this PRIM_DEFAULT_IMPL selects the appropriate technology by defining
+  # PRIM_DEFAULT_IMPL=prim_pkg::Impl<tech identifier>
+  # PRIM_DEFAULT_IMPL is set inside the library setup script
+  set DEFINE "PRIM_DEFAULT_IMPL=${PRIM_DEFAULT_IMPL}+${PRIM_STD_CELL_VARIANT}"
+} else {
+  set DEFINE ""
+}
 
 #######################
 ## CONFIGURATIONS   ###
@@ -71,27 +75,14 @@ saif_map -start
 ###The following variable helps verification when there are differences between DC and FM while inferring logical hierarchies
 set_app_var hdlin_enable_hier_map true
 
-#######################
-##  DESIGN SOURCES  ###
-#######################
-
-# this PRIM_DEFAULT_IMPL selects the appropriate technology by defining
-# PRIM_DEFAULT_IMPL=prim_pkg::Impl<tech identifier>
-# PRIM_DEFAULT_IMPL is set inside the library setup script
-set DEFINE "PRIM_DEFAULT_IMPL=${PRIM_DEFAULT_IMPL}+${PRIM_STD_CELL_VARIANT}"
-
-# additional parameters
-set PARAMS "$::env(PARAMS)"
-
-
 ###########################
 ##   Env var file        ##
 ###########################
 
 set fp [open "${BUILD_DIR}/env_variables.tcl" w+]
 puts $fp "set ::env(INTERACTIVE) 1"
-puts $fp "set ::env(syn_root) $syn_root"
-puts $fp "set ::env(foundry_root) $foundry_root"
+puts $fp "set ::env(SYN_ROOT) $SYN_ROOT"
+puts $fp "set ::env(FOUNDRY_ROOT) $FOUNDRY_ROOT"
 puts $fp "set ::env(PARAMS) $PARAMS"
 puts $fp "set ::env(SV_FLIST) $SV_FLIST"
 puts $fp "set ::env(BUILD_DIR) $BUILD_DIR"

--- a/hw/syn/tools/dvsim/common_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_syn_cfg.hjson
@@ -48,7 +48,11 @@
                         "^ERROR:.*$"]
 
   exports: [
-    { syn_root: "{syn_root}" },
-    { foundry_root: "{foundry_root}" },
+    { SYN_ROOT:     "{syn_root}" },
+    { FOUNDRY_ROOT: "{foundry_root}" },
+    { BUILD_DIR:    "{build_dir}" },
+    { DUT:          "{dut}" },
+    { PARAMS:       "{params}" },
+    { SV_FLIST:     "{sv_flist}" }
   ]
 }

--- a/hw/syn/tools/dvsim/dc.hjson
+++ b/hw/syn/tools/dvsim/dc.hjson
@@ -4,12 +4,8 @@
 {
   // Environment variables that are needed in the synthesis script
   exports: [
-    { DUT:                "{dut}" },
-    { PARAMS:             "{params}" },
     { CONSTRAINT:         "{sdc_file}" },
     { FOUNDRY_CONSTRAINT: "{foundry_sdc_file}" },
-    { BUILD_DIR:          "{build_dir}" },
-    { SV_FLIST:           "{sv_flist}" }
   ]
 
   // Tool invocation
@@ -32,7 +28,7 @@
   expand_depth: 1
 
   // Restrict the maximum message count in each category
-  max_msg_count: 20
+  max_msg_count: 100
   // Do not sanitize regression mails, but do sanitize the published report
   sanitize_email_results:   false
   sanitize_publish_results: true


### PR DESCRIPTION
This has been split out from https://github.com/lowRISC/opentitan/pull/9031 and aligns the synthesis flow script with the upcoming CDC run script. This also involves some variable naming changes (standardize on capitalized env vars).

Signed-off-by: Michael Schaffner <msf@google.com>