### PR TITLE
[dv/otp_ctrl] Remove extra dut_init

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_wake_up_vseq.sv
@@ -15,8 +15,6 @@ class otp_ctrl_wake_up_vseq extends otp_ctrl_base_vseq;
   task body();
     bit [TL_DW-1:0] rand_addr = $urandom_range(CreatorSwCfgOffset,
                                                CreatorSwCfgOffset + CreatorSwCfgSize);
-    dut_init();
-
     // check status
     cfg.clk_rst_vif.wait_clks(1);
 


### PR DESCRIPTION
This PR excludes the redundant dut_init from otp_ctrl_wake_up_test.
Thanks @dkabely-ot for finding this issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>