### PR TITLE
Bazel bootrom

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -8,3 +8,7 @@ build --conlyopt='-std=c11'
 
 # Enable toolchain resolution with cc
 build --incompatible_enable_cc_toolchain_resolution
+
+# This lets us generate key/value pairs for the workspace which can be 
+# accessed like we do in util/BUILD
+build --workspace_status_command=util/get_workspace_status.sh

--- a/hw/ip/rom_ctrl/util/BUILD
+++ b/hw/ip/rom_ctrl/util/BUILD
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["scramble_image.py"])

--- a/hw/ip/rv_core_ibex/data/BUILD
+++ b/hw/ip/rv_core_ibex/data/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:autogen.bzl", "autogen_hjson_header")
+
+autogen_hjson_header(
+    name = "rv_core_ibex_regs",
+    srcs = [
+        "rv_core_ibex.hjson",
+    ],
+)

--- a/hw/top_earlgrey/data/BUILD
+++ b/hw/top_earlgrey/data/BUILD
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["autogen/**"]))

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -9,7 +9,7 @@ used by the OpenTitan build, such as register definition files generated
 from hjson register descriptions.
 """
 
-def _autogen_hjson_header(ctx):
+def _hjson_header(ctx):
     header = ctx.actions.declare_file("{}.h".format(ctx.label.name))
     ctx.actions.run(
         outputs = [header],
@@ -21,15 +21,47 @@ def _autogen_hjson_header(ctx):
         ] + [src.path for src in ctx.files.srcs],
         executable = ctx.files._tool[0],
     )
-    return [CcInfo(compilation_context = cc_common.create_compilation_context(
-        includes = depset([header.dirname]),
-        headers = depset([header]),
-    ))]
+    return [
+        CcInfo(compilation_context = cc_common.create_compilation_context(
+            includes = depset([header.dirname]),
+            headers = depset([header]),
+        )),
+        DefaultInfo(files = depset([header])),
+    ]
 
 autogen_hjson_header = rule(
-    implementation = _autogen_hjson_header,
+    implementation = _hjson_header,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
         "_tool": attr.label(default = "//util:regtool.py", allow_files = True),
+    },
+)
+
+def _chip_info(ctx):
+    header = ctx.actions.declare_file("chip_info.h")
+    ctx.actions.run(
+        outputs = [header],
+        inputs = ctx.files.version + ctx.files._tool,
+        arguments = [
+            "-o",
+            header.dirname,
+            "--ot_version_file",
+            ctx.files.version[0].path,
+        ],
+        executable = ctx.files._tool[0],
+    )
+    return [
+        CcInfo(compilation_context = cc_common.create_compilation_context(
+            includes = depset([header.dirname]),
+            headers = depset([header]),
+        )),
+        DefaultInfo(files = depset([header])),
+    ]
+
+autogen_chip_info = rule(
+    implementation = _chip_info,
+    attrs = {
+        "version": attr.label(default = "//util:ot_version_file", allow_files = True),
+        "_tool": attr.label(default = "//util:rom_chip_info.py", allow_files = True),
     },
 )

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -120,7 +120,7 @@ elf_to_scrambled = rule(
         "srcs": attr.label_list(allow_files = True),
         "platform": attr.string(default = OPENTITAN_PLATFORM),
         "_tool": attr.label(default = "//hw/ip/rom_ctrl/util:scramble_image.py", allow_files = True),
-        "_config": attr.label(default = "//hw/top_earlgrey:data/autogen/top_earlgrey.gen.hjson", allow_files = True),
+        "_config": attr.label(default = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson", allow_files = True),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),

--- a/sw/device/boot_rom/BUILD
+++ b/sw/device/boot_rom/BUILD
@@ -1,0 +1,83 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary")
+load("//rules:autogen.bzl", "autogen_chip_info")
+
+autogen_chip_info(
+    name = "chip_info",
+)
+
+opentitan_binary(
+    name = "boot_rom",
+    srcs = [
+        "irq_vector.S",
+    ],
+    linkopts = [
+        "-T $(location rom_link.ld)",
+    ],
+    output_scrambled = True,
+    deps = [
+        "rom_link.ld",
+        ":boot_rom_lib",
+        "//sw/device/lib/base:mmio",
+    ],
+)
+
+cc_library(
+    name = "boot_rom_lib",
+    srcs = [
+        "boot_rom.c",
+        "rom_crt.S",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":bootstrap",
+        ":chip_info",
+        "//hw/ip/csrng/data:csrng_regs",
+        "//hw/ip/edn/data:edn_regs",
+        "//hw/ip/entropy_src/data:entropy_src_regs",
+        "//hw/ip/sram_ctrl/data:sram_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:linker_script",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device:info_sections",
+        "//sw/device/lib:ibex_peri",
+        "//sw/device/lib:pinmux",
+        "//sw/device/lib/base",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:hmac",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing",
+    ],
+)
+
+cc_library(
+    name = "bootstrap",
+    srcs = [
+        "bootstrap.c",
+    ],
+    hdrs = [
+        "bootstrap.h",
+        "spiflash_frame.h",
+    ],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib:flash_ctrl",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:hmac",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing",
+    ],
+)

--- a/sw/device/lib/BUILD
+++ b/sw/device/lib/BUILD
@@ -49,3 +49,15 @@ cc_library(
         "//sw/device/lib/base",
     ],
 )
+
+cc_library(
+    name = "ibex_peri",
+    srcs = ["ibex_peri.c"],
+    hdrs = ["ibex_peri.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+    ],
+)

--- a/util/BUILD
+++ b/util/BUILD
@@ -5,3 +5,10 @@
 package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["**"]))
+
+genrule(
+    name = "ot_version_file",
+    outs = ["ot_version.txt"],
+    cmd = """awk '/BUILD_GIT_VERSION/ { print $$2 }' bazel-out/volatile-status.txt > $@""",
+    stamp = 1,  # this provides volatile-status.txt
+)

--- a/util/get_workspace_status.sh
+++ b/util/get_workspace_status.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This script will be run by bazel when the build process wants to generate
+# information about the status of the workspace.
+#
+# The output will be key-value pairs in the form:
+# KEY1 VALUE1
+# KEY2 VALUE2
+#
+# If this script exits with a non-zero exit code, it's considered as a failure
+# and the output will be discarded.
+
+git_rev=$(git rev-parse HEAD)
+if [[ $? != 0 ]];
+then
+  exit 1
+fi
+echo "BUILD_SCM_REVISION ${git_rev}"
+
+git_version=$(git describe --always)
+if [[ $? != 0 ]];
+then
+  exit 1
+fi
+echo "BUILD_GIT_VERSION ${git_version}"
+
+git diff-index --quiet HEAD --
+if [[ $? == 0 ]];
+then
+  tree_status="clean"
+else
+  tree_status="modified"
+fi
+echo "BUILD_SCM_STATUS ${tree_status}"

--- a/util/rom_chip_info.py
+++ b/util/rom_chip_info.py
@@ -39,8 +39,12 @@ def main():
                         help='Output Directory'
                         )
     parser.add_argument('--ot_version',
-                        required=True,
+                        required=False,
                         help='OpenTitan Version'
+                        )
+    parser.add_argument('--ot_version_file',
+                        required=False,
+                        help='Path to a file with the OpenTitan Version'
                         )
 
     log.basicConfig(format="%(levelname)s: %(message)s")
@@ -49,12 +53,18 @@ def main():
     if not args.outdir:
         log.error("Missing --outdir.")
         raise SystemExit(sys.exc_info()[1])
-    if not args.ot_version:
-        log.error("Missing --ot_version.")
+
+    if args.ot_version:
+        version = args.ot_version
+    elif args.ot_version_file:
+        version = open(args.ot_version_file, "rt").read().strip()
+    else:
+        log.error(
+            "Missing ot_version, provide --ot_version or --ot_version_file."
+        )
         raise SystemExit(sys.exc_info()[1])
 
     outdir = Path(args.outdir)
-    version = args.ot_version
 
     outdir.mkdir(parents=True, exist_ok=True)
     out_path = outdir / "chip_info.h"


### PR DESCRIPTION
[bazel] Rules to build the boot-rom. 

* Adding resources to stamp the bootrom
* Fulfilling and tweaking boot-rom dependencies for bazel
 * scramble_image.py
 * rom_chip_info.py
  * take version input as a file not a command-line arg
* added autogen for hw/ip/rv_core_ibex/data
* Added a rule to autogen chip_info
* Added a rule to build ibex_peri.c in sw/device/lib
* added a shell script to list details of workspace for a boot-rom stamp

Tested:
```
build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb
--meminit=rom,bazel-out/k8-fastbuild-ST-b8775c98f59c/bin/sw/device/boot_rom/boot_rom_verilator.scr.40.vmem
--meminit=flash,bazel-out/k8-fastbuild-ST-b8775c98f59c/bin/sw/device/examples/hello_world/hello_world_verilator.elf
--meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
```
outputs:
```
I00001 boot_rom.c:70] Boot ROM initialisation has completed, jump into
flash!
```
to uart0.log