### PR TITLE
[dv/otp_ctrl] Add wait for callback done in dut_init

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_callback_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_callback_vseq.sv
@@ -12,8 +12,9 @@ class otp_ctrl_callback_vseq extends cip_base_vseq #(
   `uvm_object_utils(otp_ctrl_callback_vseq)
   `uvm_object_new
 
-  virtual task dut_init_callback();
+  virtual task dut_init_callback(ref bit callback_done);
     // Do nothing but can be overridden in closed source environment.
+    callback_done = 1;
   endtask
 
 endclass : otp_ctrl_callback_vseq


### PR DESCRIPTION
The otp_ctrl's callback sequence can be non-blocking, so in open sourced
dut_init, wait until the callback sequence is finished.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>