### PR TITLE
[prim] Add time-out functionality to prim_clock_meas

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -394,6 +394,16 @@
           desc: '''
             ${src} has encountered a measurement error.
           '''
+        },
+% endfor
+% for src in typed_clocks.rg_srcs:
+        {
+          bits: "${loop.index + len(typed_clocks.rg_srcs)}",
+          name: "${src.upper()}_TIMEOUT_ERR",
+          resval: 0,
+          desc: '''
+            ${src} has timed out.
+          '''
         }
 % endfor
       ]

--- a/hw/ip/clkmgr/doc/_index.md
+++ b/hw/ip/clkmgr/doc/_index.md
@@ -11,7 +11,7 @@ This document specifies the functionality of the OpenTitan clock manager.
 - Attribute based controls of OpenTitan clocks.
 - Minimal software clock controls to reduce risks in clock manipulation.
 - External clock switch support
-- Clock frequency measurement
+- Clock frequency /time-out measurement
 
 # Theory of Operation
 
@@ -227,7 +227,7 @@ The table below summarises the valid modes and the settings required.
 
 
 
-### Clock Frequency Measurements
+### Clock Frequency / Time-out Measurements
 
 Clock manager can continuously measure root clock frequencies to see if any of the root clocks have deviated from the expected frequency.
 This feature can be enabled through the various measurement control registers such as {{< regref "IO_MEASURE_CTRL" >}}.
@@ -238,12 +238,17 @@ Software sets both an expected maximum and minimum for each measured clock.
 Clock manager then counts the number of relevant root clock cycles in each always-on clock period.
 If the resulting count differs from the programmed thresholds, a recoverable error is registered.
 
-There are two types of errors:
+Additionally, clock manager uses a similar time-out mechanism to see if any of the root clocks have stopped toggling altogether.
+This is done by creating an artificial handshake between the two domains that must complete within a certain amount of time based on known clock ratios.
+
+There are three types of errors:
 * Clock too fast error
 * Clock too slow error
+* Clock time-out error
 
 Clock too fast is registered when the clock cycle count is greater than the software programmed max threshold.
 Clock too slow is registered when the clock cycle count is less than the software programmed min threshold.
+Clock time-out is registered when the clock stops toggling and the timeout threshold is reached.
 
 As these are all software supplied values, the entire measurement control can be locked from further programming through {{< regref "MEASURE_CTRL_REGWEN" >}}.
 

--- a/hw/ip/prim/prim_clock_meas.core
+++ b/hw/ip/prim/prim_clock_meas.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:assert
     files:
       - rtl/prim_clock_meas.sv
+      - rtl/prim_clock_timeout.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/prim/rtl/prim_clock_timeout.sv
+++ b/hw/ip/prim/rtl/prim_clock_timeout.sv
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// prim_clk_timeout is a simple module that assesses whether the input clock
+// has stopped ticking as measured by the reference clock.
+//
+// If both clocks are stopped for whatever reason, this module is effectively dead.
+
+`include "prim_assert.sv"
+
+module prim_clock_timeout #(
+  parameter int TimeOutCnt = 16,
+  localparam int CntWidth = prim_util_pkg::vbits(TimeOutCnt+1)
+) (
+  // clock to be checked
+  input clk_chk_i,
+  input rst_chk_ni,
+
+  // clock used to measure whether clk_chk has stopped ticking
+  input clk_i,
+  input rst_ni,
+  input en_i,
+  output logic timeout_o
+);
+
+  logic [CntWidth-1:0] cnt;
+  logic ack;
+  logic timeout;
+  assign timeout = cnt >= TimeOutCnt;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      cnt <= '0;
+    end else if (ack || !en_i) begin
+      cnt <= '0;
+    end else if (timeout) begin
+      cnt <= '{default: '1};
+    end else if (en_i) begin
+      cnt <= cnt + 1'b1;
+    end
+  end
+
+  logic chk_req;
+  prim_sync_reqack u_ref_timeout (
+    .clk_src_i(clk_i),
+    .rst_src_ni(rst_ni),
+    .clk_dst_i(clk_chk_i),
+    .rst_dst_ni(rst_chk_ni),
+    .req_chk_i('0),
+    .src_req_i(1'b1),
+    .src_ack_o(ack),
+    .dst_req_o(chk_req),
+    .dst_ack_i(chk_req)
+  );
+
+  prim_flop #(
+    .ResetValue('0)
+  ) u_out (
+    .clk_i,
+    .rst_ni,
+    .d_i(timeout),
+    .q_o(timeout_o)
+  );
+
+endmodule // prim_clk_timeout

--- a/hw/top_earlgrey/ip/clkmgr/clkmgr.core
+++ b/hw/top_earlgrey/ip/clkmgr/clkmgr.core
@@ -16,6 +16,7 @@ filesets:
       - lowrisc:prim:clock_buf
       - lowrisc:prim:clock_div
       - lowrisc:prim:clock_gating
+      - lowrisc:prim:edge_detector
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lc_sender
       - lowrisc:systems:clkmgr_pkg

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -629,7 +629,7 @@
           desc: '''
             io has encountered a measurement error.
           '''
-        }
+        },
         {
           bits: "1",
           name: "IO_DIV2_MEASURE_ERR",
@@ -637,7 +637,7 @@
           desc: '''
             io_div2 has encountered a measurement error.
           '''
-        }
+        },
         {
           bits: "2",
           name: "IO_DIV4_MEASURE_ERR",
@@ -645,7 +645,7 @@
           desc: '''
             io_div4 has encountered a measurement error.
           '''
-        }
+        },
         {
           bits: "3",
           name: "MAIN_MEASURE_ERR",
@@ -653,13 +653,53 @@
           desc: '''
             main has encountered a measurement error.
           '''
-        }
+        },
         {
           bits: "4",
           name: "USB_MEASURE_ERR",
           resval: 0,
           desc: '''
             usb has encountered a measurement error.
+          '''
+        },
+        {
+          bits: "5",
+          name: "IO_TIMEOUT_ERR",
+          resval: 0,
+          desc: '''
+            io has timed out.
+          '''
+        }
+        {
+          bits: "6",
+          name: "IO_DIV2_TIMEOUT_ERR",
+          resval: 0,
+          desc: '''
+            io_div2 has timed out.
+          '''
+        }
+        {
+          bits: "7",
+          name: "IO_DIV4_TIMEOUT_ERR",
+          resval: 0,
+          desc: '''
+            io_div4 has timed out.
+          '''
+        }
+        {
+          bits: "8",
+          name: "MAIN_TIMEOUT_ERR",
+          resval: 0,
+          desc: '''
+            main has timed out.
+          '''
+        }
+        {
+          bits: "9",
+          name: "USB_TIMEOUT_ERR",
+          resval: 0,
+          desc: '''
+            usb has timed out.
           '''
         }
       ]

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -467,9 +467,12 @@
 
   logic io_fast_err;
   logic io_slow_err;
+  logic io_timeout_err;
     prim_clock_meas #(
     .Cnt(960),
-    .RefCnt(1)
+    .RefCnt(1),
+    .ClkTimeOutChkEn(1'b1),
+    .RefTimeOutChkEn(1'b0)
   ) u_io_meas (
     .clk_i(clk_io_i),
     .rst_ni(rst_io_ni),
@@ -480,7 +483,9 @@
     .min_cnt(reg2hw.io_measure_ctrl.min_thresh.q),
     .valid_o(),
     .fast_o(io_fast_err),
-    .slow_o(io_slow_err)
+    .slow_o(io_slow_err),
+    .timeout_clk_ref_o(),
+    .ref_timeout_clk_o(io_timeout_err)
   );
 
   logic synced_io_err;
@@ -493,14 +498,33 @@
     .dst_pulse_o(synced_io_err)
   );
 
+  logic synced_io_timeout_err;
+  prim_edge_detector #(
+    .Width(1),
+    .ResetValue('0),
+    .EnSync(1'b1)
+  ) u_io_timeout_err_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(io_timeout_err),
+    .q_sync_o(),
+    .q_posedge_pulse_o(synced_io_timeout_err),
+    .q_negedge_pulse_o()
+  );
+
   assign hw2reg.recov_err_code.io_measure_err.d = 1'b1;
   assign hw2reg.recov_err_code.io_measure_err.de = synced_io_err;
+  assign hw2reg.recov_err_code.io_timeout_err.d = 1'b1;
+  assign hw2reg.recov_err_code.io_timeout_err.de = synced_io_timeout_err;
 
   logic io_div2_fast_err;
   logic io_div2_slow_err;
+  logic io_div2_timeout_err;
     prim_clock_meas #(
     .Cnt(480),
-    .RefCnt(1)
+    .RefCnt(1),
+    .ClkTimeOutChkEn(1'b1),
+    .RefTimeOutChkEn(1'b0)
   ) u_io_div2_meas (
     .clk_i(clk_io_div2_i),
     .rst_ni(rst_io_div2_ni),
@@ -511,7 +535,9 @@
     .min_cnt(reg2hw.io_div2_measure_ctrl.min_thresh.q),
     .valid_o(),
     .fast_o(io_div2_fast_err),
-    .slow_o(io_div2_slow_err)
+    .slow_o(io_div2_slow_err),
+    .timeout_clk_ref_o(),
+    .ref_timeout_clk_o(io_div2_timeout_err)
   );
 
   logic synced_io_div2_err;
@@ -524,14 +550,33 @@
     .dst_pulse_o(synced_io_div2_err)
   );
 
+  logic synced_io_div2_timeout_err;
+  prim_edge_detector #(
+    .Width(1),
+    .ResetValue('0),
+    .EnSync(1'b1)
+  ) u_io_div2_timeout_err_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(io_div2_timeout_err),
+    .q_sync_o(),
+    .q_posedge_pulse_o(synced_io_div2_timeout_err),
+    .q_negedge_pulse_o()
+  );
+
   assign hw2reg.recov_err_code.io_div2_measure_err.d = 1'b1;
   assign hw2reg.recov_err_code.io_div2_measure_err.de = synced_io_div2_err;
+  assign hw2reg.recov_err_code.io_div2_timeout_err.d = 1'b1;
+  assign hw2reg.recov_err_code.io_div2_timeout_err.de = synced_io_div2_timeout_err;
 
   logic io_div4_fast_err;
   logic io_div4_slow_err;
+  logic io_div4_timeout_err;
     prim_clock_meas #(
     .Cnt(240),
-    .RefCnt(1)
+    .RefCnt(1),
+    .ClkTimeOutChkEn(1'b1),
+    .RefTimeOutChkEn(1'b0)
   ) u_io_div4_meas (
     .clk_i(clk_io_div4_i),
     .rst_ni(rst_io_div4_ni),
@@ -542,7 +587,9 @@
     .min_cnt(reg2hw.io_div4_measure_ctrl.min_thresh.q),
     .valid_o(),
     .fast_o(io_div4_fast_err),
-    .slow_o(io_div4_slow_err)
+    .slow_o(io_div4_slow_err),
+    .timeout_clk_ref_o(),
+    .ref_timeout_clk_o(io_div4_timeout_err)
   );
 
   logic synced_io_div4_err;
@@ -555,14 +602,33 @@
     .dst_pulse_o(synced_io_div4_err)
   );
 
+  logic synced_io_div4_timeout_err;
+  prim_edge_detector #(
+    .Width(1),
+    .ResetValue('0),
+    .EnSync(1'b1)
+  ) u_io_div4_timeout_err_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(io_div4_timeout_err),
+    .q_sync_o(),
+    .q_posedge_pulse_o(synced_io_div4_timeout_err),
+    .q_negedge_pulse_o()
+  );
+
   assign hw2reg.recov_err_code.io_div4_measure_err.d = 1'b1;
   assign hw2reg.recov_err_code.io_div4_measure_err.de = synced_io_div4_err;
+  assign hw2reg.recov_err_code.io_div4_timeout_err.d = 1'b1;
+  assign hw2reg.recov_err_code.io_div4_timeout_err.de = synced_io_div4_timeout_err;
 
   logic main_fast_err;
   logic main_slow_err;
+  logic main_timeout_err;
     prim_clock_meas #(
     .Cnt(1000),
-    .RefCnt(1)
+    .RefCnt(1),
+    .ClkTimeOutChkEn(1'b1),
+    .RefTimeOutChkEn(1'b0)
   ) u_main_meas (
     .clk_i(clk_main_i),
     .rst_ni(rst_main_ni),
@@ -573,7 +639,9 @@
     .min_cnt(reg2hw.main_measure_ctrl.min_thresh.q),
     .valid_o(),
     .fast_o(main_fast_err),
-    .slow_o(main_slow_err)
+    .slow_o(main_slow_err),
+    .timeout_clk_ref_o(),
+    .ref_timeout_clk_o(main_timeout_err)
   );
 
   logic synced_main_err;
@@ -586,14 +654,33 @@
     .dst_pulse_o(synced_main_err)
   );
 
+  logic synced_main_timeout_err;
+  prim_edge_detector #(
+    .Width(1),
+    .ResetValue('0),
+    .EnSync(1'b1)
+  ) u_main_timeout_err_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(main_timeout_err),
+    .q_sync_o(),
+    .q_posedge_pulse_o(synced_main_timeout_err),
+    .q_negedge_pulse_o()
+  );
+
   assign hw2reg.recov_err_code.main_measure_err.d = 1'b1;
   assign hw2reg.recov_err_code.main_measure_err.de = synced_main_err;
+  assign hw2reg.recov_err_code.main_timeout_err.d = 1'b1;
+  assign hw2reg.recov_err_code.main_timeout_err.de = synced_main_timeout_err;
 
   logic usb_fast_err;
   logic usb_slow_err;
+  logic usb_timeout_err;
     prim_clock_meas #(
     .Cnt(480),
-    .RefCnt(1)
+    .RefCnt(1),
+    .ClkTimeOutChkEn(1'b1),
+    .RefTimeOutChkEn(1'b0)
   ) u_usb_meas (
     .clk_i(clk_usb_i),
     .rst_ni(rst_usb_ni),
@@ -604,7 +691,9 @@
     .min_cnt(reg2hw.usb_measure_ctrl.min_thresh.q),
     .valid_o(),
     .fast_o(usb_fast_err),
-    .slow_o(usb_slow_err)
+    .slow_o(usb_slow_err),
+    .timeout_clk_ref_o(),
+    .ref_timeout_clk_o(usb_timeout_err)
   );
 
   logic synced_usb_err;
@@ -617,8 +706,24 @@
     .dst_pulse_o(synced_usb_err)
   );
 
+  logic synced_usb_timeout_err;
+  prim_edge_detector #(
+    .Width(1),
+    .ResetValue('0),
+    .EnSync(1'b1)
+  ) u_usb_timeout_err_sync (
+    .clk_i,
+    .rst_ni,
+    .d_i(usb_timeout_err),
+    .q_sync_o(),
+    .q_posedge_pulse_o(synced_usb_timeout_err),
+    .q_negedge_pulse_o()
+  );
+
   assign hw2reg.recov_err_code.usb_measure_err.d = 1'b1;
   assign hw2reg.recov_err_code.usb_measure_err.de = synced_usb_err;
+  assign hw2reg.recov_err_code.usb_timeout_err.d = 1'b1;
+  assign hw2reg.recov_err_code.usb_timeout_err.de = synced_usb_timeout_err;
 
 
   ////////////////////////////////////////////////////

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -184,6 +184,26 @@ package clkmgr_reg_pkg;
       logic        d;
       logic        de;
     } usb_measure_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div2_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div4_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } main_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } usb_timeout_err;
   } clkmgr_hw2reg_recov_err_code_reg_t;
 
   typedef struct packed {
@@ -208,8 +228,8 @@ package clkmgr_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [21:12]
-    clkmgr_hw2reg_recov_err_code_reg_t recov_err_code; // [11:2]
+    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [31:22]
+    clkmgr_hw2reg_recov_err_code_reg_t recov_err_code; // [21:2]
     clkmgr_hw2reg_fatal_err_code_reg_t fatal_err_code; // [1:0]
   } clkmgr_hw2reg_t;
 
@@ -269,7 +289,7 @@ package clkmgr_reg_pkg;
     4'b 0111, // index[10] CLKMGR_IO_DIV4_MEASURE_CTRL
     4'b 0111, // index[11] CLKMGR_MAIN_MEASURE_CTRL
     4'b 0111, // index[12] CLKMGR_USB_MEASURE_CTRL
-    4'b 0001, // index[13] CLKMGR_RECOV_ERR_CODE
+    4'b 0011, // index[13] CLKMGR_RECOV_ERR_CODE
     4'b 0001  // index[14] CLKMGR_FATAL_ERR_CODE
   };
 

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -246,6 +246,16 @@ module clkmgr_reg_top (
   logic recov_err_code_main_measure_err_wd;
   logic recov_err_code_usb_measure_err_qs;
   logic recov_err_code_usb_measure_err_wd;
+  logic recov_err_code_io_timeout_err_qs;
+  logic recov_err_code_io_timeout_err_wd;
+  logic recov_err_code_io_div2_timeout_err_qs;
+  logic recov_err_code_io_div2_timeout_err_wd;
+  logic recov_err_code_io_div4_timeout_err_qs;
+  logic recov_err_code_io_div4_timeout_err_wd;
+  logic recov_err_code_main_timeout_err_qs;
+  logic recov_err_code_main_timeout_err_wd;
+  logic recov_err_code_usb_timeout_err_qs;
+  logic recov_err_code_usb_timeout_err_wd;
   logic fatal_err_code_qs;
   // Define register CDC handling.
   // CDC handling is done on a per-reg instead of per-field boundary.
@@ -1478,6 +1488,131 @@ module clkmgr_reg_top (
     .qs     (recov_err_code_usb_measure_err_qs)
   );
 
+  //   F[io_timeout_err]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_recov_err_code_io_timeout_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_err_code_we),
+    .wd     (recov_err_code_io_timeout_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_err_code.io_timeout_err.de),
+    .d      (hw2reg.recov_err_code.io_timeout_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_err_code_io_timeout_err_qs)
+  );
+
+  //   F[io_div2_timeout_err]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_recov_err_code_io_div2_timeout_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_err_code_we),
+    .wd     (recov_err_code_io_div2_timeout_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_err_code.io_div2_timeout_err.de),
+    .d      (hw2reg.recov_err_code.io_div2_timeout_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_err_code_io_div2_timeout_err_qs)
+  );
+
+  //   F[io_div4_timeout_err]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_recov_err_code_io_div4_timeout_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_err_code_we),
+    .wd     (recov_err_code_io_div4_timeout_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_err_code.io_div4_timeout_err.de),
+    .d      (hw2reg.recov_err_code.io_div4_timeout_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_err_code_io_div4_timeout_err_qs)
+  );
+
+  //   F[main_timeout_err]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_recov_err_code_main_timeout_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_err_code_we),
+    .wd     (recov_err_code_main_timeout_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_err_code.main_timeout_err.de),
+    .d      (hw2reg.recov_err_code.main_timeout_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_err_code_main_timeout_err_qs)
+  );
+
+  //   F[usb_timeout_err]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW1C),
+    .RESVAL  (1'h0)
+  ) u_recov_err_code_usb_timeout_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_err_code_we),
+    .wd     (recov_err_code_usb_timeout_err_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_err_code.usb_timeout_err.de),
+    .d      (hw2reg.recov_err_code.usb_timeout_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_err_code_usb_timeout_err_qs)
+  );
+
 
   // R[fatal_err_code]: V(False)
   prim_subreg #(
@@ -1618,6 +1753,16 @@ module clkmgr_reg_top (
 
   assign recov_err_code_usb_measure_err_wd = reg_wdata[4];
 
+  assign recov_err_code_io_timeout_err_wd = reg_wdata[5];
+
+  assign recov_err_code_io_div2_timeout_err_wd = reg_wdata[6];
+
+  assign recov_err_code_io_div4_timeout_err_wd = reg_wdata[7];
+
+  assign recov_err_code_main_timeout_err_wd = reg_wdata[8];
+
+  assign recov_err_code_usb_timeout_err_wd = reg_wdata[9];
+
   // Read data return
   always_comb begin
     reg_rdata_next = '0;
@@ -1688,6 +1833,11 @@ module clkmgr_reg_top (
         reg_rdata_next[2] = recov_err_code_io_div4_measure_err_qs;
         reg_rdata_next[3] = recov_err_code_main_measure_err_qs;
         reg_rdata_next[4] = recov_err_code_usb_measure_err_qs;
+        reg_rdata_next[5] = recov_err_code_io_timeout_err_qs;
+        reg_rdata_next[6] = recov_err_code_io_div2_timeout_err_qs;
+        reg_rdata_next[7] = recov_err_code_io_div4_timeout_err_qs;
+        reg_rdata_next[8] = recov_err_code_main_timeout_err_qs;
+        reg_rdata_next[9] = recov_err_code_usb_timeout_err_qs;
       end
 
       addr_hit[14]: begin


### PR DESCRIPTION
prim_clock_meas can now also detect if a clock has stopped.

This is done for 2 reasons:

1. clkmgr needs to have both clock presence and accuracy detection.  The former was missed in a previous PR.

2. The same module will be re-used for #8658, which needs a time-out mechanism.

Signed-off-by: Timothy Chen <timothytim@google.com>