### PR TITLE
[sw] Add message encoding to RSA-3072 interface.

### DIFF
--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.h
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.h
@@ -88,10 +88,29 @@ otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
                                         rsa_3072_constants_t *result);
 
 /**
+ * Encode the message according to RFC 8017, section 9.2, with a SHA2-256 hash
+ * function. See https://datatracker.ietf.org/doc/html/rfc8017#section-9.2
+ *
+ * Note that because we know the length of the modulus is 3072 bits, we know
+ * that emLen (the intended length in bytes of the message representative) is
+ * 3072/8 = 384, so it is not an argument here.
+ *
+ * Unlike in RFC 8017, the message representative returned here is in
+ * little-endian form.
+ *
+ * @param msg Message to encode
+ * @param msgLen Length of the message
+ * @param result Resulting 3072-bit message representative
+ * @return Result of the operation (OK or error).
+ */
+rom_error_t rsa_3072_encode_sha256(const char *msg, size_t msgLen,
+                                   rsa_3072_int_t *result);
+
+/**
  * Verifies an RSA-3072 signature.
  *
  * @param signature Signature to be verified.
- * @param message Digest of the message to check the signature against.
+ * @param message Encoded message representative to check the signature against.
  * @param public_key Key to check the signature against.
  * @param result Buffer in which to store output (true iff signature is valid)
  * @return Result of the operation (OK or error).


### PR DESCRIPTION
Adds a SHA2-256-specific message-encoding routine to the RSA-3072 code in the mask ROM. This will allow us to have a more typical signature-verification interface (taking in a dynamically-sized message as input instead of something that's already encoded). It will also make it easier for us to run test vectors that haven't pre-encoded the message.