### PR TITLE
[sw/crypto] Clarify bounds assumptions for Montgomery R^2.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex.c
@@ -76,8 +76,9 @@ static uint32_t shift_left(sigverify_rsa_buffer_t *a) {
 static void calc_r_square(const sigverify_rsa_key_t *key,
                           sigverify_rsa_buffer_t *result) {
   memset(result->data, 0, sizeof(result->data));
-  // Since R/2 < n < R, this subtraction ensures that result = R mod n and
-  // fits in `kSigVerifyRsaNumWords` going into the loop.
+  // This subtraction sets result = -n mod R = R - n, which is equivalent to R
+  // modulo n and ensures that `result` fits in `kSigVerifyRsaNumWords` going
+  // into the loop.
   subtract_modulus(key, result);
 
   // Iteratively shift and reduce `result`.


### PR DESCRIPTION
See https://github.com/lowRISC/opentitan/issues/9072 for discussion/context

The Ibex implementation, on closer inspection, doesn't actually require R / 2 < M, so the comment is rephrased to not state that it does. The OTBN implementation is greatly simplified by the assumption that R / 2 < M, so it is modified to assume so and justify the assumption by citing FIPS.

This commit also includes a minor adjustment to the R^2 loop suggested by @rswarbrick [here](https://github.com/lowRISC/opentitan/pull/9070#discussion_r744927545), making it a loop instead of two loopis so as not to consume the loop stack unnecessarily.