### PR TITLE
[sw/silicon_creator] Separate read, write, and erase operations for data and info partitions

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -87,15 +87,19 @@ static rom_error_t transaction_start(transaction_params_t params) {
   // Set the address.
   abs_mmio_write32(kBase + FLASH_CTRL_ADDR_REG_OFFSET, params.addr);
   // Configure flash_ctrl and start the transaction.
+  const bool is_info =
+      bitfield_bit32_read(params.partition, FLASH_CTRL_PARTITION_BIT_IS_INFO);
+  const uint32_t info_type = bitfield_field32_read(
+      params.partition, FLASH_CTRL_PARTITION_FIELD_INFO_TYPE);
+  const bool bank_erase = params.erase_type == kFlashCtrlEraseTypeBank;
   uint32_t reg = bitfield_bit32_write(0, FLASH_CTRL_CONTROL_START_BIT, true);
   reg =
       bitfield_field32_write(reg, FLASH_CTRL_CONTROL_OP_FIELD, params.op_type);
-  reg = bitfield_bit32_write(reg, FLASH_CTRL_CONTROL_PARTITION_SEL_BIT,
-                             params.partition != kFlashCtrlPartitionData);
-  reg = bitfield_field32_write(reg, FLASH_CTRL_CONTROL_INFO_SEL_FIELD,
-                               (uint32_t)params.partition >> 1);
-  reg = bitfield_bit32_write(reg, FLASH_CTRL_CONTROL_ERASE_SEL_BIT,
-                             params.erase_type == kFlashCtrlEraseTypeBank);
+  reg =
+      bitfield_bit32_write(reg, FLASH_CTRL_CONTROL_PARTITION_SEL_BIT, is_info);
+  reg =
+      bitfield_field32_write(reg, FLASH_CTRL_CONTROL_INFO_SEL_FIELD, info_type);
+  reg = bitfield_bit32_write(reg, FLASH_CTRL_CONTROL_ERASE_SEL_BIT, bank_erase);
   // TODO(#3353): Remove -1 when flash_ctrl is updated.
   reg = bitfield_field32_write(reg, FLASH_CTRL_CONTROL_NUM_FIELD,
                                params.word_count - 1);
@@ -109,11 +113,11 @@ static rom_error_t transaction_start(transaction_params_t params) {
  * Large reads may create back pressure.
  *
  * @param word_count Number of words to read from the FIFO.
- * @param[out] data_out Output buffer.
+ * @param[out] data Output buffer.
  */
-static void fifo_read(size_t word_count, uint32_t *data_out) {
+static void fifo_read(size_t word_count, uint32_t *data) {
   for (size_t i = 0; i < word_count; ++i) {
-    data_out[i] = abs_mmio_read32(kBase + FLASH_CTRL_RD_FIFO_REG_OFFSET);
+    data[i] = abs_mmio_read32(kBase + FLASH_CTRL_RD_FIFO_REG_OFFSET);
   }
 }
 
@@ -125,7 +129,7 @@ static void fifo_read(size_t word_count, uint32_t *data_out) {
  * @param word_count Number of words to write to the FIFO.
  * @param data Input buffer.
  */
-static void fifo_write(const uint32_t *data, size_t word_count) {
+static void fifo_write(size_t word_count, const uint32_t *data) {
   for (size_t i = 0; i < word_count; ++i) {
     abs_mmio_write32(kBase + FLASH_CTRL_PROG_FIFO_REG_OFFSET, data[i]);
   }
@@ -146,6 +150,50 @@ static rom_error_t wait_for_done(void) {
   if (bitfield_bit32_read(op_status, FLASH_CTRL_OP_STATUS_ERR_BIT)) {
     return kErrorFlashCtrlInternal;
   }
+  return kErrorOk;
+}
+
+/**
+ * Writes data to the given partition.
+ *
+ * @param addr Full byte address to write to.
+ * @param partition The partition to write to.
+ * @param word_count Number of bus words to write.
+ * @return Result of the operation.
+ */
+static rom_error_t write(uint32_t addr, flash_ctrl_partition_t partition,
+                         uint32_t word_count, const uint32_t *data) {
+  enum {
+    kWindowWordCount =
+        FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES / sizeof(uint32_t),
+  };
+
+  // Find the number of words that can be written in the first window.
+  uint32_t window_word_count =
+      kWindowWordCount - ((addr / sizeof(uint32_t)) % kWindowWordCount);
+  while (word_count > 0) {
+    // Program operations can't cross window boundaries.
+    window_word_count =
+        word_count < window_word_count ? word_count : window_word_count;
+
+    RETURN_IF_ERROR(transaction_start((transaction_params_t){
+        .addr = addr,
+        .op_type = FLASH_CTRL_CONTROL_OP_VALUE_PROG,
+        .partition = partition,
+        .word_count = window_word_count,
+        // Does not apply to program transactions.
+        .erase_type = kFlashCtrlEraseTypePage,
+    }));
+
+    fifo_write(window_word_count, data);
+    RETURN_IF_ERROR(wait_for_done());
+
+    addr += window_word_count * sizeof(uint32_t);
+    data += window_word_count;
+    word_count -= window_word_count;
+    window_word_count = kWindowWordCount;
+  }
+
   return kErrorOk;
 }
 
@@ -188,8 +236,26 @@ void flash_ctrl_status_get(flash_ctrl_status_t *status) {
       bitfield_bit32_read(fc_status, FLASH_CTRL_STATUS_INIT_WIP_BIT);
 }
 
-rom_error_t flash_ctrl_read(uint32_t addr, uint32_t word_count,
-                            flash_ctrl_partition_t partition, uint32_t *data) {
+rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
+                                 uint32_t *data) {
+  RETURN_IF_ERROR(transaction_start((transaction_params_t){
+      .addr = addr,
+      .op_type = FLASH_CTRL_CONTROL_OP_VALUE_READ,
+      .partition = kFlashCtrlPartitionData,
+      .word_count = word_count,
+      // Does not apply to read transactions.
+      .erase_type = kFlashCtrlEraseTypePage,
+  }));
+  fifo_read(word_count, data);
+  return wait_for_done();
+}
+
+rom_error_t flash_ctrl_info_read(flash_ctrl_info_page_t info_page,
+                                 uint32_t offset, uint32_t word_count,
+                                 uint32_t *data) {
+  const uint32_t addr = info_page_addr(info_page) + offset;
+  const flash_ctrl_partition_t partition =
+      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_PARTITION);
   RETURN_IF_ERROR(transaction_start((transaction_params_t){
       .addr = addr,
       .op_type = FLASH_CTRL_CONTROL_OP_VALUE_READ,
@@ -202,45 +268,39 @@ rom_error_t flash_ctrl_read(uint32_t addr, uint32_t word_count,
   return wait_for_done();
 }
 
-rom_error_t flash_ctrl_prog(uint32_t addr, uint32_t word_count,
-                            flash_ctrl_partition_t partition,
-                            const uint32_t *data) {
-  enum {
-    kWindowWordCount =
-        FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES / sizeof(uint32_t),
-  };
-
-  // Find the number of words that can be written in the first window.
-  uint32_t window_word_count =
-      kWindowWordCount - ((addr / sizeof(uint32_t)) % kWindowWordCount);
-  while (word_count > 0) {
-    // Program operations can't cross window boundaries.
-    window_word_count =
-        word_count < window_word_count ? word_count : window_word_count;
-
-    RETURN_IF_ERROR(transaction_start((transaction_params_t){
-        .addr = addr,
-        .op_type = FLASH_CTRL_CONTROL_OP_VALUE_PROG,
-        .partition = partition,
-        .word_count = window_word_count,
-        // Does not apply to program transactions.
-        .erase_type = kFlashCtrlEraseTypePage,
-    }));
-
-    fifo_write(data, window_word_count);
-    RETURN_IF_ERROR(wait_for_done());
-
-    addr += window_word_count * sizeof(uint32_t);
-    data += window_word_count;
-    word_count -= window_word_count;
-    window_word_count = kWindowWordCount;
-  }
-
-  return kErrorOk;
+rom_error_t flash_ctrl_data_write(uint32_t addr, uint32_t word_count,
+                                  const uint32_t *data) {
+  return write(addr, kFlashCtrlPartitionData, word_count, data);
 }
 
-rom_error_t flash_ctrl_erase(uint32_t addr, flash_ctrl_partition_t partition,
-                             flash_ctrl_erase_type_t erase_type) {
+rom_error_t flash_ctrl_info_write(flash_ctrl_info_page_t info_page,
+                                  uint32_t offset, uint32_t word_count,
+                                  const uint32_t *data) {
+  const uint32_t addr = info_page_addr(info_page) + offset;
+  const flash_ctrl_partition_t partition =
+      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_PARTITION);
+  return write(addr, partition, word_count, data);
+}
+
+rom_error_t flash_ctrl_data_erase(uint32_t addr,
+                                  flash_ctrl_erase_type_t erase_type) {
+  RETURN_IF_ERROR(transaction_start((transaction_params_t){
+      .addr = addr,
+      .op_type = FLASH_CTRL_CONTROL_OP_VALUE_ERASE,
+      .erase_type = erase_type,
+      .partition = kFlashCtrlPartitionData,
+      // Does not apply to erase transactions.
+      .word_count = 1,
+  }));
+
+  return wait_for_done();
+}
+
+rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
+                                  flash_ctrl_erase_type_t erase_type) {
+  const uint32_t addr = info_page_addr(info_page);
+  const flash_ctrl_partition_t partition =
+      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_PARTITION);
   RETURN_IF_ERROR(transaction_start((transaction_params_t){
       .addr = addr,
       .op_type = FLASH_CTRL_CONTROL_OP_VALUE_ERASE,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -149,6 +149,22 @@ static rom_error_t wait_for_done(void) {
   return kErrorOk;
 }
 
+/**
+ * Returns the base address of an information page.
+ *
+ * @param info_page An information page.
+ * @return Base address of the given page.
+ */
+static uint32_t info_page_addr(flash_ctrl_info_page_t info_page) {
+  const uint32_t bank_index =
+      bitfield_bit32_read(info_page, FLASH_CTRL_INFO_PAGE_BIT_BANK);
+  const uint32_t page_index =
+      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_INDEX);
+  return TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR +
+         bank_index * FLASH_CTRL_PARAM_BYTES_PER_BANK +
+         page_index * FLASH_CTRL_PARAM_BYTES_PER_PAGE;
+}
+
 void flash_ctrl_init(void) {
   // Initialize the flash controller.
   abs_mmio_write32(kBase + FLASH_CTRL_INIT_REG_OFFSET,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -202,85 +202,104 @@ typedef struct flash_ctrl_status {
 void flash_ctrl_status_get(flash_ctrl_status_t *status);
 
 /**
- * Perform a read transaction.
+ * Reads data from the data partition.
  *
  * The flash controller will truncate to the closest, lower word aligned
  * address. For example, if 0x13 is supplied, the controller will perform a read
  * at address 0x10.
  *
- * On success, `data` is populated with the read data.
- *
- * For operations that fail with `kErrorFlashCtrlInternal`, `err` is set to the
- * internal error mask for flash_ctrl, which can be checked against the
- * `kFlashCtrlErr*` bits. The internal error state is cleared after each call.
- *
- * @param addr The address to read from.
- * @param word_count The number of bus words the flash operation should read.
- * @param region The region to read from.
- * @param[out] data The buffer to store the read data.
- * @param[out] err The internal error state of flash_ctrl.
- * @return `kErrorFlashCtrlBusy` if the flash controller is already processing a
- * transaction, `kErrorFlashCtrlInternal` if the operations fails, `kErrorOk`
- * otherwise.
+ * @param addr Address to read from.
+ * @param word_count Number of bus words to read.
+ * @param[out] data Buffer to store the read data.
+ * @return Result of the operation.
  */
-rom_error_t flash_ctrl_read(uint32_t addr, uint32_t word_count,
-                            flash_ctrl_partition_t partition, uint32_t *data);
+rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
+                                 uint32_t *data);
 
 /**
- * Perform a program transaction.
+ * Reads data from an information page.
+ *
+ * The flash controller will truncate to the closest, lower word aligned
+ * address. For example, if 0x13 is supplied, the controller will start reading
+ * at address 0x10.
+ *
+ * @param info_page Information page to read from.
+ * @param offset Offset from the start of the page.
+ * @param word_count Number of bus words to read.
+ * @param[out] data Buffer to store the read data.
+ * @return Result of the operation.
+ */
+rom_error_t flash_ctrl_info_read(flash_ctrl_info_page_t info_page,
+                                 uint32_t offset, uint32_t word_count,
+                                 uint32_t *data);
+
+/**
+ * Writes data to the data partition.
  *
  * The flash controller will truncate to the closest, lower word aligned
  * address. For example, if 0x13 is supplied, the controller will start writing
  * at address 0x10.
  *
- * For operations that fail with `kErrorFlashCtrlInternal`, `err` is set to the
- * internal error mask for flash_ctrl, which can be checked against the
- * `kFlashCtrlErr*` bits. The internal error state is cleared after each call.
- *
- * @param addr The address to write to.
- * @param word_count The number of bus words the flash operation should program.
- * @param region The region to program.
- * @param data The buffer containing the data to program to flash.
- * @param[out] err The internal error state of flash_ctrl.
- * @return `kErrorFlashCtrlBusy` if the flash controller is already processing a
- * transaction, `kErrorFlashCtrlInternal` if the operations fails, `kErrorOk`
- * otherwise.
+ * @param addr Address to write to.
+ * @param word_count Number of bus words to write.
+ * @param data Data to write.
+ * @return Result of the operation.
  */
-rom_error_t flash_ctrl_prog(uint32_t addr, uint32_t word_count,
-                            flash_ctrl_partition_t partition,
-                            const uint32_t *data);
+rom_error_t flash_ctrl_data_write(uint32_t addr, uint32_t word_count,
+                                  const uint32_t *data);
+
+/**
+ * Writes data to an information page.
+ *
+ * The flash controller will truncate to the closest, lower word aligned
+ * address. For example, if 0x13 is supplied, the controller will start writing
+ * at address 0x10.
+ *
+ * @param info_page Information page to write to.
+ * @param offset Offset from the start of the page.
+ * @param word_count Number of bus words to write.
+ * @param data Data to write.
+ * @return Result of the operation.
+ */
+rom_error_t flash_ctrl_info_write(flash_ctrl_info_page_t info_page,
+                                  uint32_t offset, uint32_t word_count,
+                                  const uint32_t *data);
 
 typedef enum flash_ctrl_erase_type {
   /**
    * Erase a page.
    */
-  kFlashCtrlEraseTypePage = 0x0000,
+  kFlashCtrlEraseTypePage = 0,
   /**
    * Erase a bank.
    */
-  kFlashCtrlEraseTypeBank = 0x0080,
+  kFlashCtrlEraseTypeBank = 1,
 } flash_ctrl_erase_type_t;
 
 /**
- * Invoke a blocking erase transaction.
+ * Erases a data partition page or bank.
  *
  * The flash controller will truncate to the closest page boundary for page
  * erase operations, and to the nearest bank aligned boundary for bank erase
  * operations.
  *
- * For operations that fail with `kErrorFlashCtrlInternal`, `err` is set to the
- * internal error mask for flash_ctrl, which can be checked against the
- * `kFlashCtrlErr*` bits. The internal error state is cleared after each call.
- *
- * @param addr The address that falls within the bank or page being deleted.
- * @param region The region that contains the bank or page being deleted.
- * @param[out] err The internal error state of flash_ctrl.
- * @return `kErrorFlashCtrlBusy` if the flash controller is already processing a
- * transaction, `kErrorFlashCtrlInternal` if the operations fails, `kErrorOk`
- * otherwise.
+ * @param addr Address that falls within the bank or page being deleted.
+ * @param erase_type Whether to erase a page or a bank.
+ * @return Result of the operation.
  */
-rom_error_t flash_ctrl_erase(uint32_t addr, flash_ctrl_partition_t partition,
-                             flash_ctrl_erase_type_t erase_type);
+rom_error_t flash_ctrl_data_erase(uint32_t addr,
+                                  flash_ctrl_erase_type_t erase_type);
+
+/**
+ * Erases an information partition page or bank.
+ *
+ * @param info_page Information page to erase for page erases, or a page within
+ * the bank to erase for bank erases.
+ * @param erase_type Whether to erase a page or a bank.
+ * @return Result of the operation.
+ */
+rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
+                                  flash_ctrl_erase_type_t erase_type);
 
 typedef enum flash_ctrl_exec {
   kFlashCtrlExecDisable = kMultiBitBool4False,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -114,21 +114,18 @@ class TransferTest : public FlashCtrlTest {
 
 TEST_F(TransferTest, ReadBusy) {
   ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_read(0, 0, kFlashCtrlPartitionData, NULL),
-            kErrorFlashCtrlBusy);
+  EXPECT_EQ(flash_ctrl_data_read(0, 0, NULL), kErrorFlashCtrlBusy);
 }
 
 TEST_F(TransferTest, ProgBusy) {
   ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_prog(0, 4, kFlashCtrlPartitionData, NULL),
-            kErrorFlashCtrlBusy);
+  EXPECT_EQ(flash_ctrl_data_write(0, 4, NULL), kErrorFlashCtrlBusy);
 }
 
 TEST_F(TransferTest, EraseBusy) {
   ExpectCheckBusy(true);
-  EXPECT_EQ(
-      flash_ctrl_erase(0, kFlashCtrlPartitionData, kFlashCtrlEraseTypePage),
-      kErrorFlashCtrlBusy);
+  EXPECT_EQ(flash_ctrl_data_erase(0, kFlashCtrlEraseTypePage),
+            kErrorFlashCtrlBusy);
 }
 
 TEST_F(TransferTest, ReadDataOk) {
@@ -137,8 +134,7 @@ TEST_F(TransferTest, ReadDataOk) {
   ExpectReadData(words_);
   ExpectWaitForDone(true, false);
   std::vector<uint32_t> words_out(words_.size());
-  EXPECT_EQ(flash_ctrl_read(0x01234567, words_.size(), kFlashCtrlPartitionData,
-                            &words_out.front()),
+  EXPECT_EQ(flash_ctrl_data_read(0x01234567, words_.size(), &words_out.front()),
             kErrorOk);
   EXPECT_EQ(words_out, words_);
 }
@@ -148,8 +144,7 @@ TEST_F(TransferTest, ProgDataOk) {
                       words_.size());
   ExpectProgData(words_);
   ExpectWaitForDone(true, false);
-  EXPECT_EQ(flash_ctrl_prog(0x01234567, words_.size(), kFlashCtrlPartitionData,
-                            &words_.front()),
+  EXPECT_EQ(flash_ctrl_data_write(0x01234567, words_.size(), &words_.front()),
             kErrorOk);
 }
 
@@ -157,8 +152,7 @@ TEST_F(TransferTest, EraseDataPageOk) {
   ExpectTransferStart(0, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_ERASE, 0x01234567,
                       1);
   ExpectWaitForDone(true, false);
-  EXPECT_EQ(flash_ctrl_erase(0x01234567, kFlashCtrlPartitionData,
-                             kFlashCtrlEraseTypePage),
+  EXPECT_EQ(flash_ctrl_data_erase(0x01234567, kFlashCtrlEraseTypePage),
             kErrorOk);
 }
 
@@ -196,8 +190,8 @@ TEST_F(TransferTest, ProgAcrossWindows) {
 
   EXPECT_EQ(iter + half_step, many_words.end());
 
-  EXPECT_EQ(flash_ctrl_prog(kWinSize / 2, many_words.size(),
-                            kFlashCtrlPartitionData, &many_words.front()),
+  EXPECT_EQ(flash_ctrl_data_write(kWinSize / 2, many_words.size(),
+                                  &many_words.front()),
             kErrorOk);
 }
 
@@ -207,8 +201,7 @@ TEST_F(TransferTest, TransferInternalError) {
   ExpectReadData(words_);
   ExpectWaitForDone(true, true);
   std::vector<uint32_t> words_out(words_.size());
-  EXPECT_EQ(flash_ctrl_read(0x01234567, words_.size(), kFlashCtrlPartitionData,
-                            &words_out.front()),
+  EXPECT_EQ(flash_ctrl_data_read(0x01234567, words_.size(), &words_out.front()),
             kErrorFlashCtrlInternal);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -202,7 +202,7 @@ TEST_F(TransferTest, TransferInternalError) {
   ExpectWaitForDone(true, true);
   std::vector<uint32_t> words_out(words_.size());
   EXPECT_EQ(flash_ctrl_data_read(0x01234567, words_.size(), &words_out.front()),
-            kErrorFlashCtrlInternal);
+            kErrorFlashCtrlDataRead);
 }
 
 class ExecTest : public FlashCtrlTest {};

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -92,9 +92,13 @@ enum module_ {
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   X(kErrorOtpBadAlignment,            ERROR_(1, kModuleOtp, kInvalidArgument)), \
   X(kErrorOtbnInternal,               ERROR_(4, kModuleOtbn, kInternal)), \
-  X(kErrorFlashCtrlInvalidArgument,   ERROR_(1, kModuleFlashCtrl, kInvalidArgument)), \
-  X(kErrorFlashCtrlBusy,              ERROR_(2, kModuleFlashCtrl, kUnavailable)), \
-  X(kErrorFlashCtrlInternal,          ERROR_(3, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlDataRead,          ERROR_(1, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlInfoRead,          ERROR_(2, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlDataWrite,         ERROR_(3, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlInfoWrite,         ERROR_(4, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlDataErase,         ERROR_(5, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlInfoErase,         ERROR_(6, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlBusy,              ERROR_(7, kModuleFlashCtrl, kUnavailable)), \
   X(kErrorSecMmioRegFileSize,         ERROR_(0, kModuleSecMmio, kResourceExhausted)), \
   X(kErrorSecMmioReadFault,           ERROR_(1, kModuleSecMmio, kInternal)), \
   X(kErrorSecMmioWriteFault,          ERROR_(2, kModuleSecMmio, kInternal)), \


### PR DESCRIPTION
This change adds individual read, write, and erase functions for data and information partitions. Functions for data partitions use full byte addresses whereas functions for information partitions use info page enum constants and offsets which simplifies call sites. This will also hopefully make the code easier to review and audit, e.g. calls to `flash_ctrl_info_{read,write,erase}()` should be surrounded by calls to `flash_ctrl_info_mp_set()` (will be added in another PR).

This change also add individual error codes for each of these operations.