### PR TITLE
[sw/silicon_creator] Migrate boot_data to silicon_creator flash_ctrl driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -69,11 +69,6 @@ class TransferTest : public FlashCtrlTest {
  protected:
   const std::vector<uint32_t> words_ = {0x12345678, 0x90ABCDEF, 0x0F1E2D3C,
                                         0x4B5A6978};
-  void ExpectCheckBusy(bool busy) {
-    EXPECT_ABS_READ32(base_ + FLASH_CTRL_CTRL_REGWEN_REG_OFFSET,
-                      {{FLASH_CTRL_CTRL_REGWEN_EN_BIT, !busy}});
-  }
-
   void ExpectWaitForDone(bool done, bool error) {
     EXPECT_ABS_READ32(base_ + FLASH_CTRL_OP_STATUS_REG_OFFSET,
                       {{FLASH_CTRL_OP_STATUS_DONE_BIT, done},
@@ -86,7 +81,6 @@ class TransferTest : public FlashCtrlTest {
   void ExpectTransferStart(uint8_t part_sel, uint8_t info_sel,
                            uint8_t erase_sel, uint32_t op, uint32_t addr,
                            uint32_t word_count) {
-    ExpectCheckBusy(false);
     EXPECT_ABS_WRITE32(base_ + FLASH_CTRL_ADDR_REG_OFFSET, addr);
     EXPECT_ABS_WRITE32(base_ + FLASH_CTRL_CONTROL_REG_OFFSET,
                        {
@@ -111,22 +105,6 @@ class TransferTest : public FlashCtrlTest {
     }
   }
 };
-
-TEST_F(TransferTest, ReadBusy) {
-  ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_data_read(0, 0, NULL), kErrorFlashCtrlBusy);
-}
-
-TEST_F(TransferTest, ProgBusy) {
-  ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_data_write(0, 4, NULL), kErrorFlashCtrlBusy);
-}
-
-TEST_F(TransferTest, EraseBusy) {
-  ExpectCheckBusy(true);
-  EXPECT_EQ(flash_ctrl_data_erase(0, kFlashCtrlEraseTypePage),
-            kErrorFlashCtrlBusy);
-}
 
 TEST_F(TransferTest, ReadDataOk) {
   ExpectTransferStart(0, 0, 0, FLASH_CTRL_CONTROL_OP_VALUE_READ, 0x01234567,

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -119,7 +119,7 @@ enum module_ {
   X(kErrorBootstrapUnknown,           ERROR_(7, kModuleBootstrap, kInternal)), \
   X(kErrorLogBadFormatSpecifier,      ERROR_(1, kModuleLog, kInternal)), \
   X(kErrorBootDataNotFound,           ERROR_(1, kModuleBootData, kInternal)), \
-  X(kErrorBootDataFlash,              ERROR_(2, kModuleBootData, kInternal)), \
+  X(kErrorBootDataWriteCheck,         ERROR_(2, kModuleBootData, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -98,7 +98,6 @@ enum module_ {
   X(kErrorFlashCtrlInfoWrite,         ERROR_(4, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataErase,         ERROR_(5, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoErase,         ERROR_(6, kModuleFlashCtrl, kInternal)), \
-  X(kErrorFlashCtrlBusy,              ERROR_(7, kModuleFlashCtrl, kUnavailable)), \
   X(kErrorSecMmioRegFileSize,         ERROR_(0, kModuleSecMmio, kResourceExhausted)), \
   X(kErrorSecMmioReadFault,           ERROR_(1, kModuleSecMmio, kInternal)), \
   X(kErrorSecMmioWriteFault,          ERROR_(2, kModuleSecMmio, kInternal)), \

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -42,9 +42,7 @@ sw_silicon_creator_lib_boot_data = declare_dependency(
       'boot_data.c',
     ],
     dependencies: [
-      #TODO(#8777): Replace with silicon_creator version.
-      #sw_silicon_creator_lib_driver_flash_ctrl,
-      sw_lib_flash_ctrl,
+      sw_silicon_creator_lib_driver_flash_ctrl,
       sw_silicon_creator_lib_driver_hmac,
     ],
   ),


### PR DESCRIPTION
This change migrates `boot_data.c` to the silicon creator `flash_ctrl` driver.

This change also removes the `is_busy()` check that was performed before each flash operation since all operations are blocking. Performing this check before each operation adds ~700 and ~7k cycles to the `boot_data_read()` calls in `read_single_page_1_test()` and `read_full_page_1_test()` in `boot_data_functest.c`, respectively. Removing this check brings the numbers down to their current levels.

Enum constants for boot data page addresses are still in use by boot_data_functest. I'll remove them in a separate PR after migrating the functest.