### PR TITLE
[dv/alert_handler] fix alert ping timeout seq regression error

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
@@ -40,6 +40,11 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
     esc_ping_timeout   == '1;
   }
 
+  // At least enable `NUM_ALERTS-4` alerts to avoid this sequence running too long.
+  constraint enable_one_alert_c {
+    $countones(alert_en) dist {NUM_ALERTS :/ 8, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 2};
+  }
+
   constraint ping_timeout_cyc_c {
     ping_timeout_cyc inside {[1:MAX_PING_TIMEOUT_CYCLE]};
   }

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -132,7 +132,7 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
                          .loc_alert_en(local_alert_en),
                          .loc_alert_class(local_alert_class_map));
 
-      // write class_ctrl and clren_reg
+      // write class_ctrl
       alert_handler_rand_wr_class_ctrl(lock_bit_en);
       alert_handler_wr_regwen_regs(clr_regwen, alert_regwen, local_alert_regwen, ping_timer_regwen,
                                    class_regwen);
@@ -151,6 +151,10 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
       // when all configuration registers are set, write lock register
       lock_config(do_lock_config);
+
+      // once all above configs are written, lock them with regwen
+      alert_handler_wr_regwen_regs(clr_regwen, alert_regwen, local_alert_regwen, ping_timer_regwen,
+                                   class_regwen);
 
       // if config is not locked, update max_intr_timeout and max_wait_phases cycles
       if (!config_locked) begin

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_ping_timeout_vseq.sv
@@ -40,6 +40,11 @@ class alert_handler_ping_timeout_vseq extends alert_handler_entropy_vseq;
     esc_ping_timeout   == '1;
   }
 
+  // At least enable `NUM_ALERTS-4` alerts to avoid this sequence running too long.
+  constraint enable_one_alert_c {
+    $countones(alert_en) dist {NUM_ALERTS :/ 8, [NUM_ALERTS-4 : NUM_ALERTS-1] :/ 2};
+  }
+
   constraint ping_timeout_cyc_c {
     ping_timeout_cyc inside {[1:MAX_PING_TIMEOUT_CYCLE]};
   }

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -132,7 +132,7 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
                          .loc_alert_en(local_alert_en),
                          .loc_alert_class(local_alert_class_map));
 
-      // write class_ctrl and clren_reg
+      // write class_ctrl
       alert_handler_rand_wr_class_ctrl(lock_bit_en);
       alert_handler_wr_regwen_regs(clr_regwen, alert_regwen, local_alert_regwen, ping_timer_regwen,
                                    class_regwen);
@@ -151,6 +151,10 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
 
       // when all configuration registers are set, write lock register
       lock_config(do_lock_config);
+
+      // once all above configs are written, lock them with regwen
+      alert_handler_wr_regwen_regs(clr_regwen, alert_regwen, local_alert_regwen, ping_timer_regwen,
+                                   class_regwen);
 
       // if config is not locked, update max_intr_timeout and max_wait_phases cycles
       if (!config_locked) begin


### PR DESCRIPTION
This PR fixes the timeout issue in nightly regression regarding
alert_handler_ping_timeout_vseq.
The issue is that we locked the ping_en register via regwen before
enabling the ping_en csr.
The solution is to move the order of regwen write task.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>