### PR TITLE
[chip,dv] Refactor CSR exclusion method

### DIFF
--- a/hw/dv/sv/dv_base_reg/csr_excl_item.sv
+++ b/hw/dv/sv/dv_base_reg/csr_excl_item.sv
@@ -9,6 +9,7 @@ class csr_excl_item extends uvm_object;
   `uvm_object_utils(csr_excl_item)
 
   typedef struct {
+    bit             enable;
     int             csr_test_type;
     csr_excl_type_e csr_excl_type;
   } csr_excl_s;
@@ -16,87 +17,133 @@ class csr_excl_item extends uvm_object;
 
   `uvm_object_new
 
-  // add exclusion for an individual block, csr or field
-  // arg obj: this is the hierarchical path name to the block, csr or field - passing * and ?
-  // wildcards for glob style matching is allowed. User needs to take care that wildcards does not
-  // end up inadvertently matching more that what was desired. Examples:
-  // To exclude ral.ctrl.tx field from writes, obj can be "ral.ctrl.tx" or "*.ctrl.tx"; passing
-  // "*.tx" might be too generic
+  // Adds an exclusion for an individual block, register or field.
+  //
+  // arg obj: Hierarchical path to the block, csr or field as string. Passing * and ? wildcards for
+  //          glob style matching is allowed. User needs to take care the wildcards don't match more
+  //          than desired. For example, for the ral.ctrl.tx field:
+  //          obj = "ral.ctrl.tx" or "*.ctrl.tx" should work; "*.tx" might be too generic.
+  // arg csr_excl_type: The desired exclusion type.
+  // arg csr_test_type: The desired test type for which the exclusion is in effect.
   virtual function void add_excl(string obj,
                                  csr_excl_type_e csr_excl_type,
                                  csr_test_type_e csr_test_type = CsrAllTests);
     bit [2:0] val = CsrNoExcl;
     bit [NUM_CSR_TESTS-1:0] test = CsrInvalidTest;
 
-    if (csr_test_type == CsrInvalidTest) begin
-      `uvm_fatal(`gfn, $sformatf("add %s exclusion without a test", obj))
+    `DV_CHECK_NE_FATAL(csr_test_type, CsrInvalidTest,
+                       $sformatf("Test type not specified for the exclusion of %0s.", obj))
+
+    if (!exclusions.exists(obj)) begin
+      exclusions[obj] = '{enable:1'b1, csr_test_type:csr_test_type, csr_excl_type:csr_excl_type};
+      return;
     end
 
-    if (!exclusions.exists(obj)) exclusions[obj] = '{default:CsrNoExcl};
     val = csr_excl_type | exclusions[obj].csr_excl_type;
     test = csr_test_type | exclusions[obj].csr_test_type;
     exclusions[obj].csr_excl_type = csr_excl_type_e'(val);
     exclusions[obj].csr_test_type = test;
   endfunction
 
-  // function to check if given blk / csr or field AND its parent has been excluded with the
-  // supplied exclusion type
-  // arg uvm_object obj: given blk, csr or field
-  // arg csr_excl_type_e csr_excl_type: exclusion type
+  // Turns exclusion on or off for a block, register or field.
+  //
+  // The originally set exclusions are untouched. This method only enables or disables the
+  // application of the exclusions temporarily.
+  //
+  // obj: The hierarchical path to block, register or field.
+  // enable: Bit indicating whether to enable or disable the application of exclusion.
+  // throw_error: Bit indicating whether to throw error if exclusions associated with obj do not
+  // exist.
+  virtual function void enable_excl(string obj, bit enable = 1'b1, bit throw_error = 1'b1);
+    string index;
+    if (get_excl_index(obj, index)) begin
+      exclusions[index].enable = enable;
+      return;
+    end
+    if (throw_error) begin
+      `uvm_fatal(`gfn, $sformatf("No exclusions found for %0s.", obj))
+    end
+  endfunction
+
+  // Checks if the given block, register or field is excluded.
+  //
+  // arg obj: The given block, register or field.
+  // arg csr_excl_type: The exclusion checked against.
+  // arg csr_test_type: The type of test for which the exclusion is in effect.
   function bit is_excl(uvm_object obj,
                        csr_excl_type_e csr_excl_type,
                        csr_test_type_e csr_test_type);
     uvm_reg_block blk;
-    uvm_reg       csr;
 
-    // if supplied obj is a uvm_reg_block or uvm_reg, then its parent is a uvm_reg_block
-    // check if obj's parent is excluded
-    if ($cast(blk, obj)) begin
-      if (blk.get_parent() != null) begin
-        blk = blk.get_parent();
-        if (has_excl(blk.`gfn, csr_excl_type, csr_test_type)) return 1'b1;
+    // Attempt cast to block. If it fails, then attempt to cast to CSR or field.
+    if (!$cast(blk, obj)) begin
+      csr_field_t csr_or_fld = decode_csr_or_field(obj);
+      if (csr_or_fld.field != null) begin
+        if (has_excl(csr_or_fld.field.`gfn, csr_excl_type, csr_test_type, is_excl)) return is_excl;
+      end else begin
+        if (has_excl(csr_or_fld.csr.`gfn, csr_excl_type, csr_test_type, is_excl)) return is_excl;
       end
+      `downcast(blk, csr_or_fld.csr.get_parent(), , , msg_id)
     end
-    if ($cast(csr, obj)) begin
-      blk = csr.get_parent();
-      if (has_excl(blk.`gfn, csr_excl_type, csr_test_type)) return 1'b1;
-    end
-    // TODO: check if any parent in the hierarchy above is excluded
-    // check if obj is excluded
-    return (has_excl(obj.`gfn, csr_excl_type, csr_test_type));
+
+    // Recurse through block's ancestors.
+    do begin
+      if (has_excl(blk.`gfn, csr_excl_type, csr_test_type, is_excl)) return is_excl;
+      blk = blk.get_parent();
+    end while (blk != null);
+    return 1'b0;
   endfunction
 
-  // check if applied string obj has a match in existing exclusions lookup in defined csr_test_type
-  // function is to not be called externally
-  local function bit has_excl(string obj,
-                     csr_excl_type_e csr_excl_type,
-                     csr_test_type_e csr_test_type);
-    // check if obj exists verbatim
+  // Retrieves the string index of the exclusions data structure.
+  //
+  // The provided object for lookup is a string itself. It however, may or may
+  // not exist verbatim as an associative array index in the `exclusions` data
+  // structure, since glob-style wildcards are supported when adding the
+  // exclusions. The provided object must hence be a fully resolved
+  // hierarchical path to the CSR block, register or field.
+  //
+  // Returns 1 if index is found, else 0.
+  // Returns the actual index as output arg.
+  local function bit get_excl_index(input string obj, output string index);
+    // If obj is a index of exclusions, return it, else loop through available
+    // keys to find a glob match.
     if (exclusions.exists(obj)) begin
-      `uvm_info(`gfn, $sformatf("has_excl: found exact excl match for %0s: %0s",
-                                obj, exclusions[obj].csr_excl_type.name()), UVM_DEBUG)
-      // check if bit(s) corresponding to csr_excl_type are set in defined csr_test_type
-      if ((exclusions[obj].csr_test_type & csr_test_type) != CsrInvalidTest) begin
-        if ((exclusions[obj].csr_excl_type & csr_excl_type) != CsrNoExcl) return 1'b1;
-      end
-    end
-    else begin
-      // attempt glob style matching
+      index = obj;
+      return 1'b1;
+    end else begin
       foreach (exclusions[str]) begin
         if (!uvm_re_match(str, obj)) begin
-          `uvm_info(`gfn, $sformatf("has_excl: found glob excl match for %0s(%0s): %0s",
-                                    obj, str, exclusions[str].csr_excl_type.name()), UVM_DEBUG)
-          // check if bit(s) corresponding to csr_excl_type are set in defined csr_test_type
-          if ((exclusions[str].csr_test_type & csr_test_type) != CsrInvalidTest) begin
-            if ((exclusions[str].csr_excl_type & csr_excl_type) != CsrNoExcl) return 1'b1;
-          end
+          index = str;
+          return 1'b1;
         end
       end
     end
     return 1'b0;
   endfunction
 
-  // print all exclusions for ease of debug (call this ideally after adding all exclusions)
+  // Checks if a particular exclusion for an object for a test is in effect.
+  //
+  // arg obj: The given block, register or field as string lookup.
+  // arg csr_excl_type: The exclusion checked against.
+  // arg csr_test_type: The type of test for which the exclusion is in effect.
+  // arg is_excl: Bit indicating the object is excluded.
+  //
+  // Returns 1 if an associated exclusion is found, else 0.
+  local function bit has_excl(input string obj,
+                              input csr_excl_type_e csr_excl_type,
+                              input csr_test_type_e csr_test_type,
+                              output bit is_excl);
+    string index;
+    if (get_excl_index(obj, index)) begin
+      is_excl = exclusions[index].enable &&
+                ((exclusions[index].csr_test_type & csr_test_type) != CsrInvalidTest) &&
+                ((exclusions[index].csr_excl_type & csr_excl_type) != CsrNoExcl);
+      return 1'b1;
+    end
+    return 1'b0;
+  endfunction
+
+  // Prints all exclusions for ease of debug.
   virtual function void print_exclusions(uvm_verbosity verbosity = UVM_HIGH);
     string test_names;
     for (int i = NUM_CSR_TESTS - 1; i >= 0; i--) begin
@@ -104,8 +151,9 @@ class csr_excl_item extends uvm_object;
       test_names = {test_names, csr_test.name(),  (i > 0) ? " " : ""};
     end
     foreach (exclusions[item]) begin
-      `uvm_info(`gfn, $sformatf("CSR/field [%0s] excluded with %0s in csr_tests: {%s} = {%0b}",
-                                item, exclusions[item].csr_excl_type.name(), test_names,
+      string enabled = exclusions[item].enable ? "[enabled]" : "[disabled]";
+      `uvm_info(`gfn, $sformatf("CSR/field [%s] exclusion %s %s in csr_tests: {%s} = {%0b}",
+                                item, exclusions[item].csr_excl_type.name(), enabled, test_names,
                                 exclusions[item].csr_test_type), verbosity)
     end
   endfunction

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -12,7 +12,8 @@ class dv_base_reg_block extends uvm_reg_block;
   // name as {ip_name}_{alert_name}. Hence, we need this ip_name in reg_block
   local string ip_name;
 
-  csr_excl_item csr_excl;
+  // CSR exclusion object that holds exclusion tags for the sub-blocks, CSRs and fields.
+  protected csr_excl_item csr_excl;
 
   // The address mask for the register block specific to a map. This will be (1 << K) - 1 for some
   // K. All relative offsets in the register block have addresses less than (1 << K), so an address
@@ -44,6 +45,11 @@ class dv_base_reg_block extends uvm_reg_block;
     string empty_str = "";
     `DV_CHECK_NE_FATAL(ip_name, empty_str, "ip_name hasn't been set yet")
     return ip_name;
+  endfunction
+
+  // Returns the CSR exclusion item attached to the block.
+  virtual function csr_excl_item get_excl_item();
+    return csr_excl;
   endfunction
 
   // provide build function to supply base addr

--- a/hw/dv/sv/dv_lib/dv_base_vseq.sv
+++ b/hw/dv/sv/dv_lib/dv_base_vseq.sv
@@ -205,6 +205,12 @@ class dv_base_vseq #(type RAL_T               = dv_base_reg_block,
       default   : `uvm_fatal(`gfn, $sformatf("specified opt is invalid: +csr_%0s", csr_test_type))
     endcase
 
+    // Print the list of available exclusions that are in effect for debug.
+    foreach (cfg.ral_models[i]) begin
+      csr_excl_item csr_excl = csr_utils_pkg::get_excl_item(cfg.ral_models[i]);
+      if (csr_excl != null) csr_excl.print_exclusions();
+    end
+
     // if hw_reset test, then write all CSRs first and reset the whole dut
     if (csr_test_type == "hw_reset" && do_rand_wr_and_reset) begin
       string        reset_type = "HARD";


### PR DESCRIPTION
- Minor refactor of `csr_excl_item`
  - fixed minor bugs that existed in original code
  - split `has_excl` to cleanly separate the task of retrieving the
  associative array index from `exclusions` data structure into a
  separate local task.
  - cleaned up method doc comments

- Added support for tmporarily disable exclusions in effect (request
from @NigelScales)

Signed-off-by: Srikrishna Iyer <sriyer@google.com>