### PR TITLE
[spi_device] Add write mask to RxFifo

### DIFF
--- a/hw/ip/spi_device/rtl/spi_fwmode.sv
+++ b/hw/ip/spi_device/rtl/spi_fwmode.sv
@@ -215,12 +215,12 @@ module spi_fwmode
     .sram_write  (fwm_sram_write [FwModeRxFifo]),
     .sram_addr   (fwm_sram_addr  [FwModeRxFifo]),
     .sram_wdata  (fwm_sram_wdata [FwModeRxFifo]),
+    .sram_wmask  (fwm_sram_wmask [FwModeRxFifo]),
     .sram_gnt    (fwm_sram_gnt   [FwModeRxFifo]),
     .sram_rvalid (fwm_sram_rvalid[FwModeRxFifo]),
     .sram_rdata  (fwm_sram_rdata [FwModeRxFifo]),
     .sram_error  (fwm_sram_error [FwModeRxFifo])
   );
-  assign fwm_sram_wmask [FwModeRxFifo] = '1;
 
   // TX Fifo control (SRAM read request --> FIFO write)
   spi_fwm_txf_ctrl #(


### PR DESCRIPTION
In the issue #9119, I decide to revise the design to support BitMask in
the Generic mode.

When Generic mode (a.k.a FwMode) was implemented, DPSRAM supported
full-word only. After introducing the Flash / Passthrough mode, the
DPSRAM is replaced to Bit-wise mask enabled DPSRAM.

As discussed in #9119, the RXF does "Read-Modify-Write" to support
partial write. With bit-wise mask, the RXF FSM becomes much simpler by
eliminating RMW operations.
