### PR TITLE
[top/pinmux/pads] Pull the IE signals into the pinmux and disable for unused inputs

### DIFF
--- a/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
@@ -19,11 +19,13 @@ module pinmux_strap_sampling
   output logic      [NumIOs-1:0]   out_padring_o,
   output logic      [NumIOs-1:0]   oe_padring_o,
   input  logic      [NumIOs-1:0]   in_padring_i,
+  output logic      [NumIOs-1:0]   ie_padring_o,
   // To core side
   input  pad_attr_t [NumIOs-1:0]   attr_core_i,
   input  logic      [NumIOs-1:0]   out_core_i,
   input  logic      [NumIOs-1:0]   oe_core_i,
   output logic      [NumIOs-1:0]   in_core_o,
+  input  logic      [NumIOs-1:0]   ie_core_i,
   // Used for TAP qualification
   input  logic                     strap_en_i,
   input  lc_ctrl_pkg::lc_tx_t      lc_dft_en_i,
@@ -257,10 +259,14 @@ module pinmux_strap_sampling
         // Override TDO output.
         assign out_padring_o[k] = (jtag_en) ? jtag_rsp.tdo    : out_core_i[k];
         assign oe_padring_o[k]  = (jtag_en) ? jtag_rsp.tdo_oe : oe_core_i[k];
+        // Input buffer does not have to be enabled in this case.
+        assign ie_padring_o[k]  = (jtag_en) ? 1'b0            : ie_core_i[k];
       end else begin : gen_output_tie_off
         // Make sure these pads are set to high-z.
         assign out_padring_o[k] = (jtag_en) ? 1'b0 : out_core_i[k];
         assign oe_padring_o[k]  = (jtag_en) ? 1'b0 : oe_core_i[k];
+        // Enable the input buffers.
+        assign ie_padring_o[k]  = (jtag_en) ? 1'b1 : ie_core_i[k];
       end
 
       // Also reset all corresponding pad attributes to the default ('0) when JTAG is enabled.
@@ -272,6 +278,7 @@ module pinmux_strap_sampling
       assign in_core_o[k]      = in_padring_i[k];
       assign out_padring_o[k]  = out_core_i[k];
       assign oe_padring_o[k]   = oe_core_i[k];
+      assign ie_padring_o[k]   = ie_core_i[k];
     end
   end
 

--- a/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_pad_wrapper.sv
@@ -48,7 +48,7 @@ module prim_generic_pad_wrapper
                               attr_i.virt_od_en,
                               attr_i.drive_strength};
 
-    assign in_raw_o = (ie_i) ? inout_io  : 1'bz;
+    assign in_raw_o = (ie_i) ? inout_io  : 1'b0;
     // input inversion
     assign in_o = attr_i.invert ^ in_raw_o;
 
@@ -61,7 +61,7 @@ module prim_generic_pad_wrapper
                PadType == BidirOd ||
                PadType == BidirStd) begin : gen_bidir
 
-    assign in_raw_o = (ie_i) ? inout_io  : 1'bz;
+    assign in_raw_o = (ie_i) ? inout_io  : 1'b0;
     // input inversion
     assign in_o = attr_i.invert ^ in_raw_o;
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -212,39 +212,52 @@ module chip_earlgrey_asic (
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_out;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
+  logic [pinmux_reg_pkg::NMioPads-1:0] mio_ie;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_raw;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_out;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_in;
+  logic [pinmux_reg_pkg::NDioPads-1:0] dio_ie;
 
   logic unused_mio_in_raw;
   assign unused_mio_in_raw = ^mio_in_raw;
 
   // Manual pads
-  logic manual_in_por_n, manual_out_por_n, manual_oe_por_n;
-  logic manual_in_usb_p, manual_out_usb_p, manual_oe_usb_p;
-  logic manual_in_usb_n, manual_out_usb_n, manual_oe_usb_n;
-  logic manual_in_cc1, manual_out_cc1, manual_oe_cc1;
-  logic manual_in_cc2, manual_out_cc2, manual_oe_cc2;
-  logic manual_in_flash_test_volt, manual_out_flash_test_volt, manual_oe_flash_test_volt;
-  logic manual_in_flash_test_mode0, manual_out_flash_test_mode0, manual_oe_flash_test_mode0;
-  logic manual_in_flash_test_mode1, manual_out_flash_test_mode1, manual_oe_flash_test_mode1;
-  logic manual_in_otp_ext_volt, manual_out_otp_ext_volt, manual_oe_otp_ext_volt;
-  logic manual_in_ast_misc, manual_out_ast_misc, manual_oe_ast_misc;
-  logic manual_in_usb_p1, manual_out_usb_p1, manual_oe_usb_p1;
-  logic manual_in_usb_n1, manual_out_usb_n1, manual_oe_usb_n1;
-
+  logic manual_in_por_n, manual_ie_por_n;
+  logic manual_out_por_n, manual_oe_por_n;
   pad_attr_t manual_attr_por_n;
+  logic manual_in_usb_p, manual_ie_usb_p;
+  logic manual_out_usb_p, manual_oe_usb_p;
   pad_attr_t manual_attr_usb_p;
+  logic manual_in_usb_n, manual_ie_usb_n;
+  logic manual_out_usb_n, manual_oe_usb_n;
   pad_attr_t manual_attr_usb_n;
+  logic manual_in_cc1, manual_ie_cc1;
+  logic manual_out_cc1, manual_oe_cc1;
   pad_attr_t manual_attr_cc1;
+  logic manual_in_cc2, manual_ie_cc2;
+  logic manual_out_cc2, manual_oe_cc2;
   pad_attr_t manual_attr_cc2;
+  logic manual_in_flash_test_volt, manual_ie_flash_test_volt;
+  logic manual_out_flash_test_volt, manual_oe_flash_test_volt;
   pad_attr_t manual_attr_flash_test_volt;
+  logic manual_in_flash_test_mode0, manual_ie_flash_test_mode0;
+  logic manual_out_flash_test_mode0, manual_oe_flash_test_mode0;
   pad_attr_t manual_attr_flash_test_mode0;
+  logic manual_in_flash_test_mode1, manual_ie_flash_test_mode1;
+  logic manual_out_flash_test_mode1, manual_oe_flash_test_mode1;
   pad_attr_t manual_attr_flash_test_mode1;
+  logic manual_in_otp_ext_volt, manual_ie_otp_ext_volt;
+  logic manual_out_otp_ext_volt, manual_oe_otp_ext_volt;
   pad_attr_t manual_attr_otp_ext_volt;
+  logic manual_in_ast_misc, manual_ie_ast_misc;
+  logic manual_out_ast_misc, manual_oe_ast_misc;
   pad_attr_t manual_attr_ast_misc;
+  logic manual_in_usb_p1, manual_ie_usb_p1;
+  logic manual_out_usb_p1, manual_oe_usb_p1;
   pad_attr_t manual_attr_usb_p1;
+  logic manual_in_usb_n1, manual_ie_usb_n1;
+  logic manual_out_usb_n1, manual_oe_usb_n1;
   pad_attr_t manual_attr_usb_n1;
 
 
@@ -610,6 +623,34 @@ module chip_earlgrey_asic (
         manual_in_usb_p,
         manual_in_por_n
       }),
+    .dio_ie_i ({
+        manual_ie_usb_n1,
+        manual_ie_usb_p1,
+        manual_ie_ast_misc,
+        dio_ie[DioSysrstCtrlAonFlashWpL],
+        dio_ie[DioSysrstCtrlAonEcRstL],
+        dio_ie[DioSpiDeviceCsb],
+        dio_ie[DioSpiDeviceSck],
+        dio_ie[DioSpiDeviceSd3],
+        dio_ie[DioSpiDeviceSd2],
+        dio_ie[DioSpiDeviceSd1],
+        dio_ie[DioSpiDeviceSd0],
+        dio_ie[DioSpiHost0Csb],
+        dio_ie[DioSpiHost0Sck],
+        dio_ie[DioSpiHost0Sd3],
+        dio_ie[DioSpiHost0Sd2],
+        dio_ie[DioSpiHost0Sd1],
+        dio_ie[DioSpiHost0Sd0],
+        manual_ie_otp_ext_volt,
+        manual_ie_flash_test_mode1,
+        manual_ie_flash_test_mode0,
+        manual_ie_flash_test_volt,
+        manual_ie_cc2,
+        manual_ie_cc1,
+        manual_ie_usb_n,
+        manual_ie_usb_p,
+        manual_ie_por_n
+      }),
     .dio_out_i ({
         manual_out_usb_n1,
         manual_out_usb_p1,
@@ -696,6 +737,7 @@ module chip_earlgrey_asic (
       }),
 
     .mio_in_o (mio_in[46:0]),
+    .mio_ie_i (mio_ie[46:0]),
     .mio_out_i (mio_out[46:0]),
     .mio_oe_i (mio_oe[46:0]),
     .mio_attr_i (mio_attr[46:0]),
@@ -1044,6 +1086,16 @@ module chip_earlgrey_asic (
     manual_in_otp_ext_volt
   };
 
+  // Input buffers are constantly enabled on these pads.
+  assign manual_ie_cc2              = 1'b1;
+  assign manual_ie_cc1              = 1'b1;
+  assign manual_ie_por_n            = 1'b1;
+  assign manual_ie_ast_misc         = 1'b1;
+  assign manual_ie_otp_ext_volt     = 1'b1;
+  assign manual_ie_flash_test_mode1 = 1'b1;
+  assign manual_ie_flash_test_mode0 = 1'b1;
+  assign manual_ie_flash_test_volt  = 1'b1;
+
   ///////////////////////////////
   // Differential USB Receiver //
   ///////////////////////////////
@@ -1053,6 +1105,7 @@ module chip_earlgrey_asic (
   // Connect the D+ pad
   // Note that we use two pads in parallel for the D+ channel to meet electrical specifications.
   assign dio_in[DioUsbdevDp] = manual_in_usb_p;
+  assign manual_ie_usb_p = dio_ie[DioUsbdevDp];
   assign manual_out_usb_p = dio_out[DioUsbdevDp];
   assign manual_oe_usb_p = dio_oe[DioUsbdevDp];
   assign manual_attr_usb_p = dio_attr[DioUsbdevDp];
@@ -1061,13 +1114,10 @@ module chip_earlgrey_asic (
   assign manual_oe_usb_p1 = dio_oe[DioUsbdevDp];
   assign manual_attr_usb_p1 = dio_attr[DioUsbdevDp];
 
-  // For the input, only the first pad is used.
-  logic unused_in_usb_p1;
-  assign unused_in_usb_p1 = manual_in_usb_p1;
-
   // Connect the D- pads
   // Note that we use two pads in parallel for the D- channel to meet electrical specifications.
   assign dio_in[DioUsbdevDn] = manual_in_usb_n;
+  assign manual_ie_usb_n = dio_ie[DioUsbdevDn];
   assign manual_out_usb_n = dio_out[DioUsbdevDn];
   assign manual_oe_usb_n = dio_oe[DioUsbdevDn];
   assign manual_attr_usb_n = dio_attr[DioUsbdevDn];
@@ -1076,9 +1126,12 @@ module chip_earlgrey_asic (
   assign manual_oe_usb_n1 = dio_oe[DioUsbdevDn];
   assign manual_attr_usb_n1 = dio_attr[DioUsbdevDn];
 
-  // For the input, only the first pad is used.
-  logic unused_in_usb_n1;
-  assign unused_in_usb_n1 = manual_in_usb_n1;
+  // For the input, only the first pads in a pair are used.
+  // We can therefore constantly drive the associated input enable to 0.
+  logic unused_in_usb;
+  assign unused_in_usb = manual_in_usb_p1 ^ manual_in_usb_n1;
+  assign manual_ie_usb_n1 = 1'b0;
+  assign manual_ie_usb_p1 = 1'b0;
 
   // These shorts are intentional to make sure the parallel pads drive the same net.
   assign USB_P1 = USB_P;
@@ -1206,11 +1259,13 @@ module chip_earlgrey_asic (
 
     // Multiplexed I/O
     .mio_in_i                     ( mio_in                     ),
+    .mio_ie_o                     ( mio_ie                     ),
     .mio_out_o                    ( mio_out                    ),
     .mio_oe_o                     ( mio_oe                     ),
 
     // Dedicated I/O
     .dio_in_i                     ( dio_in                     ),
+    .dio_ie_o                     ( dio_ie                     ),
     .dio_out_o                    ( dio_out                    ),
     .dio_oe_o                     ( dio_oe                     ),
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -200,51 +200,70 @@ module chip_earlgrey_cw310 #(
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_out;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
+  logic [pinmux_reg_pkg::NMioPads-1:0] mio_ie;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_raw;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_out;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_in;
+  logic [pinmux_reg_pkg::NDioPads-1:0] dio_ie;
 
   logic unused_mio_in_raw;
   assign unused_mio_in_raw = ^mio_in_raw;
 
   // Manual pads
-  logic manual_in_por_n, manual_out_por_n, manual_oe_por_n;
-  logic manual_in_usb_p, manual_out_usb_p, manual_oe_usb_p;
-  logic manual_in_usb_n, manual_out_usb_n, manual_oe_usb_n;
-  logic manual_in_io_clk, manual_out_io_clk, manual_oe_io_clk;
-  logic manual_in_io_jsrst_n, manual_out_io_jsrst_n, manual_oe_io_jsrst_n;
-  logic manual_in_io_usb_sense0, manual_out_io_usb_sense0, manual_oe_io_usb_sense0;
-  logic manual_in_io_usb_dnpullup0, manual_out_io_usb_dnpullup0, manual_oe_io_usb_dnpullup0;
-  logic manual_in_io_usb_dppullup0, manual_out_io_usb_dppullup0, manual_oe_io_usb_dppullup0;
-  logic manual_in_io_uphy_dp_tx, manual_out_io_uphy_dp_tx, manual_oe_io_uphy_dp_tx;
-  logic manual_in_io_uphy_dn_tx, manual_out_io_uphy_dn_tx, manual_oe_io_uphy_dn_tx;
-  logic manual_in_io_uphy_dp_rx, manual_out_io_uphy_dp_rx, manual_oe_io_uphy_dp_rx;
-  logic manual_in_io_uphy_dn_rx, manual_out_io_uphy_dn_rx, manual_oe_io_uphy_dn_rx;
-  logic manual_in_io_uphy_d_rx, manual_out_io_uphy_d_rx, manual_oe_io_uphy_d_rx;
-  logic manual_in_io_uphy_oe_n, manual_out_io_uphy_oe_n, manual_oe_io_uphy_oe_n;
-  logic manual_in_io_uphy_sense, manual_out_io_uphy_sense, manual_oe_io_uphy_sense;
-  logic manual_in_io_uphy_dppullup, manual_out_io_uphy_dppullup, manual_oe_io_uphy_dppullup;
-  logic manual_in_io_clkout, manual_out_io_clkout, manual_oe_io_clkout;
-  logic manual_in_io_trigger, manual_out_io_trigger, manual_oe_io_trigger;
-
+  logic manual_in_por_n, manual_ie_por_n;
+  logic manual_out_por_n, manual_oe_por_n;
   pad_attr_t manual_attr_por_n;
+  logic manual_in_usb_p, manual_ie_usb_p;
+  logic manual_out_usb_p, manual_oe_usb_p;
   pad_attr_t manual_attr_usb_p;
+  logic manual_in_usb_n, manual_ie_usb_n;
+  logic manual_out_usb_n, manual_oe_usb_n;
   pad_attr_t manual_attr_usb_n;
+  logic manual_in_io_clk, manual_ie_io_clk;
+  logic manual_out_io_clk, manual_oe_io_clk;
   pad_attr_t manual_attr_io_clk;
+  logic manual_in_io_jsrst_n, manual_ie_io_jsrst_n;
+  logic manual_out_io_jsrst_n, manual_oe_io_jsrst_n;
   pad_attr_t manual_attr_io_jsrst_n;
+  logic manual_in_io_usb_sense0, manual_ie_io_usb_sense0;
+  logic manual_out_io_usb_sense0, manual_oe_io_usb_sense0;
   pad_attr_t manual_attr_io_usb_sense0;
+  logic manual_in_io_usb_dnpullup0, manual_ie_io_usb_dnpullup0;
+  logic manual_out_io_usb_dnpullup0, manual_oe_io_usb_dnpullup0;
   pad_attr_t manual_attr_io_usb_dnpullup0;
+  logic manual_in_io_usb_dppullup0, manual_ie_io_usb_dppullup0;
+  logic manual_out_io_usb_dppullup0, manual_oe_io_usb_dppullup0;
   pad_attr_t manual_attr_io_usb_dppullup0;
+  logic manual_in_io_uphy_dp_tx, manual_ie_io_uphy_dp_tx;
+  logic manual_out_io_uphy_dp_tx, manual_oe_io_uphy_dp_tx;
   pad_attr_t manual_attr_io_uphy_dp_tx;
+  logic manual_in_io_uphy_dn_tx, manual_ie_io_uphy_dn_tx;
+  logic manual_out_io_uphy_dn_tx, manual_oe_io_uphy_dn_tx;
   pad_attr_t manual_attr_io_uphy_dn_tx;
+  logic manual_in_io_uphy_dp_rx, manual_ie_io_uphy_dp_rx;
+  logic manual_out_io_uphy_dp_rx, manual_oe_io_uphy_dp_rx;
   pad_attr_t manual_attr_io_uphy_dp_rx;
+  logic manual_in_io_uphy_dn_rx, manual_ie_io_uphy_dn_rx;
+  logic manual_out_io_uphy_dn_rx, manual_oe_io_uphy_dn_rx;
   pad_attr_t manual_attr_io_uphy_dn_rx;
+  logic manual_in_io_uphy_d_rx, manual_ie_io_uphy_d_rx;
+  logic manual_out_io_uphy_d_rx, manual_oe_io_uphy_d_rx;
   pad_attr_t manual_attr_io_uphy_d_rx;
+  logic manual_in_io_uphy_oe_n, manual_ie_io_uphy_oe_n;
+  logic manual_out_io_uphy_oe_n, manual_oe_io_uphy_oe_n;
   pad_attr_t manual_attr_io_uphy_oe_n;
+  logic manual_in_io_uphy_sense, manual_ie_io_uphy_sense;
+  logic manual_out_io_uphy_sense, manual_oe_io_uphy_sense;
   pad_attr_t manual_attr_io_uphy_sense;
+  logic manual_in_io_uphy_dppullup, manual_ie_io_uphy_dppullup;
+  logic manual_out_io_uphy_dppullup, manual_oe_io_uphy_dppullup;
   pad_attr_t manual_attr_io_uphy_dppullup;
+  logic manual_in_io_clkout, manual_ie_io_clkout;
+  logic manual_out_io_clkout, manual_oe_io_clkout;
   pad_attr_t manual_attr_io_clkout;
+  logic manual_in_io_trigger, manual_ie_io_trigger;
+  logic manual_out_io_trigger, manual_oe_io_trigger;
   pad_attr_t manual_attr_io_trigger;
 
   /////////////////////////
@@ -254,67 +273,139 @@ module chip_earlgrey_cw310 #(
   // Only signals going to non-custom pads need to be tied off.
   logic [69:0] unused_sig;
   assign dio_in[DioSpiDeviceSd2] = 1'b0;
-  assign unused_sig[17] = dio_out[DioSpiDeviceSd2] ^ dio_oe[DioSpiDeviceSd2];
+  assign unused_sig[17] = dio_out[DioSpiDeviceSd2] ^ dio_oe[DioSpiDeviceSd2] ^ dio_ie[DioSpiDeviceSd2];
   assign dio_in[DioSpiDeviceSd3] = 1'b0;
-  assign unused_sig[18] = dio_out[DioSpiDeviceSd3] ^ dio_oe[DioSpiDeviceSd3];
+  assign unused_sig[18] = dio_out[DioSpiDeviceSd3] ^ dio_oe[DioSpiDeviceSd3] ^ dio_ie[DioSpiDeviceSd3];
   assign mio_in[19] = 1'b0;
   assign mio_in_raw[19] = 1'b0;
-  assign unused_sig[40] = mio_out[19] ^ mio_oe[19];
+  assign unused_sig[40] = ^{
+    mio_out[19],
+    mio_oe[19],
+    mio_ie[19]
+  };
   assign mio_in[20] = 1'b0;
   assign mio_in_raw[20] = 1'b0;
-  assign unused_sig[41] = mio_out[20] ^ mio_oe[20];
+  assign unused_sig[41] = ^{
+    mio_out[20],
+    mio_oe[20],
+    mio_ie[20]
+  };
   assign mio_in[21] = 1'b0;
   assign mio_in_raw[21] = 1'b0;
-  assign unused_sig[42] = mio_out[21] ^ mio_oe[21];
+  assign unused_sig[42] = ^{
+    mio_out[21],
+    mio_oe[21],
+    mio_ie[21]
+  };
   assign mio_in[22] = 1'b0;
   assign mio_in_raw[22] = 1'b0;
-  assign unused_sig[43] = mio_out[22] ^ mio_oe[22];
+  assign unused_sig[43] = ^{
+    mio_out[22],
+    mio_oe[22],
+    mio_ie[22]
+  };
   assign mio_in[23] = 1'b0;
   assign mio_in_raw[23] = 1'b0;
-  assign unused_sig[44] = mio_out[23] ^ mio_oe[23];
+  assign unused_sig[44] = ^{
+    mio_out[23],
+    mio_oe[23],
+    mio_ie[23]
+  };
   assign mio_in[34] = 1'b0;
   assign mio_in_raw[34] = 1'b0;
-  assign unused_sig[55] = mio_out[34] ^ mio_oe[34];
+  assign unused_sig[55] = ^{
+    mio_out[34],
+    mio_oe[34],
+    mio_ie[34]
+  };
   assign mio_in[35] = 1'b0;
   assign mio_in_raw[35] = 1'b0;
-  assign unused_sig[56] = mio_out[35] ^ mio_oe[35];
+  assign unused_sig[56] = ^{
+    mio_out[35],
+    mio_oe[35],
+    mio_ie[35]
+  };
   assign mio_in[36] = 1'b0;
   assign mio_in_raw[36] = 1'b0;
-  assign unused_sig[57] = mio_out[36] ^ mio_oe[36];
+  assign unused_sig[57] = ^{
+    mio_out[36],
+    mio_oe[36],
+    mio_ie[36]
+  };
   assign mio_in[37] = 1'b0;
   assign mio_in_raw[37] = 1'b0;
-  assign unused_sig[58] = mio_out[37] ^ mio_oe[37];
+  assign unused_sig[58] = ^{
+    mio_out[37],
+    mio_oe[37],
+    mio_ie[37]
+  };
   assign mio_in[38] = 1'b0;
   assign mio_in_raw[38] = 1'b0;
-  assign unused_sig[59] = mio_out[38] ^ mio_oe[38];
+  assign unused_sig[59] = ^{
+    mio_out[38],
+    mio_oe[38],
+    mio_ie[38]
+  };
   assign mio_in[39] = 1'b0;
   assign mio_in_raw[39] = 1'b0;
-  assign unused_sig[60] = mio_out[39] ^ mio_oe[39];
+  assign unused_sig[60] = ^{
+    mio_out[39],
+    mio_oe[39],
+    mio_ie[39]
+  };
   assign mio_in[40] = 1'b0;
   assign mio_in_raw[40] = 1'b0;
-  assign unused_sig[61] = mio_out[40] ^ mio_oe[40];
+  assign unused_sig[61] = ^{
+    mio_out[40],
+    mio_oe[40],
+    mio_ie[40]
+  };
   assign mio_in[41] = 1'b0;
   assign mio_in_raw[41] = 1'b0;
-  assign unused_sig[62] = mio_out[41] ^ mio_oe[41];
+  assign unused_sig[62] = ^{
+    mio_out[41],
+    mio_oe[41],
+    mio_ie[41]
+  };
   assign mio_in[42] = 1'b0;
   assign mio_in_raw[42] = 1'b0;
-  assign unused_sig[63] = mio_out[42] ^ mio_oe[42];
+  assign unused_sig[63] = ^{
+    mio_out[42],
+    mio_oe[42],
+    mio_ie[42]
+  };
   assign dio_in[DioSysrstCtrlAonEcRstL] = 1'b0;
-  assign unused_sig[64] = dio_out[DioSysrstCtrlAonEcRstL] ^ dio_oe[DioSysrstCtrlAonEcRstL];
+  assign unused_sig[64] = dio_out[DioSysrstCtrlAonEcRstL] ^ dio_oe[DioSysrstCtrlAonEcRstL] ^ dio_ie[DioSysrstCtrlAonEcRstL];
   assign dio_in[DioSysrstCtrlAonFlashWpL] = 1'b0;
-  assign unused_sig[65] = dio_out[DioSysrstCtrlAonFlashWpL] ^ dio_oe[DioSysrstCtrlAonFlashWpL];
+  assign unused_sig[65] = dio_out[DioSysrstCtrlAonFlashWpL] ^ dio_oe[DioSysrstCtrlAonFlashWpL] ^ dio_ie[DioSysrstCtrlAonFlashWpL];
   assign mio_in[43] = 1'b0;
   assign mio_in_raw[43] = 1'b0;
-  assign unused_sig[66] = mio_out[43] ^ mio_oe[43];
+  assign unused_sig[66] = ^{
+    mio_out[43],
+    mio_oe[43],
+    mio_ie[43]
+  };
   assign mio_in[44] = 1'b0;
   assign mio_in_raw[44] = 1'b0;
-  assign unused_sig[67] = mio_out[44] ^ mio_oe[44];
+  assign unused_sig[67] = ^{
+    mio_out[44],
+    mio_oe[44],
+    mio_ie[44]
+  };
   assign mio_in[45] = 1'b0;
   assign mio_in_raw[45] = 1'b0;
-  assign unused_sig[68] = mio_out[45] ^ mio_oe[45];
+  assign unused_sig[68] = ^{
+    mio_out[45],
+    mio_oe[45],
+    mio_ie[45]
+  };
   assign mio_in[46] = 1'b0;
   assign mio_in_raw[46] = 1'b0;
-  assign unused_sig[69] = mio_out[46] ^ mio_oe[46];
+  assign unused_sig[69] = ^{
+    mio_out[46],
+    mio_oe[46],
+    mio_ie[46]
+  };
 
   //////////////////////
   // Padring Instance //
@@ -489,6 +580,36 @@ module chip_earlgrey_cw310 #(
         manual_in_usb_p,
         manual_in_por_n
       }),
+    .dio_ie_i ({
+        manual_ie_io_trigger,
+        manual_ie_io_clkout,
+        manual_ie_io_uphy_dppullup,
+        manual_ie_io_uphy_sense,
+        manual_ie_io_uphy_oe_n,
+        manual_ie_io_uphy_d_rx,
+        manual_ie_io_uphy_dn_rx,
+        manual_ie_io_uphy_dp_rx,
+        manual_ie_io_uphy_dn_tx,
+        manual_ie_io_uphy_dp_tx,
+        manual_ie_io_usb_dppullup0,
+        manual_ie_io_usb_dnpullup0,
+        manual_ie_io_usb_sense0,
+        manual_ie_io_jsrst_n,
+        manual_ie_io_clk,
+        dio_ie[DioSpiDeviceCsb],
+        dio_ie[DioSpiDeviceSck],
+        dio_ie[DioSpiDeviceSd1],
+        dio_ie[DioSpiDeviceSd0],
+        dio_ie[DioSpiHost0Csb],
+        dio_ie[DioSpiHost0Sck],
+        dio_ie[DioSpiHost0Sd3],
+        dio_ie[DioSpiHost0Sd2],
+        dio_ie[DioSpiHost0Sd1],
+        dio_ie[DioSpiHost0Sd0],
+        manual_ie_usb_n,
+        manual_ie_usb_p,
+        manual_ie_por_n
+      }),
     .dio_out_i ({
         manual_out_io_trigger,
         manual_out_io_clkout,
@@ -583,6 +704,10 @@ module chip_earlgrey_cw310 #(
     .mio_in_o ({
         mio_in[33:24],
         mio_in[18:0]
+      }),
+    .mio_ie_i ({
+        mio_ie[33:24],
+        mio_ie[18:0]
       }),
     .mio_out_i ({
         mio_out[33:24],
@@ -1121,14 +1246,16 @@ module chip_earlgrey_cw310 #(
     .ast_init_done_i              ( ast_init_done              ),
 
     // Multiplexed I/O
-    .mio_in_i        ( mio_in   ),
-    .mio_out_o       ( mio_out  ),
-    .mio_oe_o        ( mio_oe   ),
+    .mio_in_i                     ( mio_in                     ),
+    .mio_ie_o                     ( mio_ie                     ),
+    .mio_out_o                    ( mio_out                    ),
+    .mio_oe_o                     ( mio_oe                     ),
 
     // Dedicated I/O
-    .dio_in_i        ( dio_in   ),
-    .dio_out_o       ( dio_out  ),
-    .dio_oe_o        ( dio_oe   ),
+    .dio_in_i                     ( dio_in                     ),
+    .dio_ie_o                     ( dio_ie                     ),
+    .dio_out_o                    ( dio_out                    ),
+    .dio_oe_o                     ( dio_oe                     ),
 
     // Pad attributes
     .mio_attr_o      ( mio_attr      ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -192,47 +192,64 @@ module chip_earlgrey_nexysvideo #(
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_out;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_oe;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in;
+  logic [pinmux_reg_pkg::NMioPads-1:0] mio_ie;
   logic [pinmux_reg_pkg::NMioPads-1:0] mio_in_raw;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_out;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_oe;
   logic [pinmux_reg_pkg::NDioPads-1:0] dio_in;
+  logic [pinmux_reg_pkg::NDioPads-1:0] dio_ie;
 
   logic unused_mio_in_raw;
   assign unused_mio_in_raw = ^mio_in_raw;
 
   // Manual pads
-  logic manual_in_por_n, manual_out_por_n, manual_oe_por_n;
-  logic manual_in_usb_p, manual_out_usb_p, manual_oe_usb_p;
-  logic manual_in_usb_n, manual_out_usb_n, manual_oe_usb_n;
-  logic manual_in_io_clk, manual_out_io_clk, manual_oe_io_clk;
-  logic manual_in_io_jsrst_n, manual_out_io_jsrst_n, manual_oe_io_jsrst_n;
-  logic manual_in_io_usb_sense0, manual_out_io_usb_sense0, manual_oe_io_usb_sense0;
-  logic manual_in_io_usb_dnpullup0, manual_out_io_usb_dnpullup0, manual_oe_io_usb_dnpullup0;
-  logic manual_in_io_usb_dppullup0, manual_out_io_usb_dppullup0, manual_oe_io_usb_dppullup0;
-  logic manual_in_io_uphy_dp_tx, manual_out_io_uphy_dp_tx, manual_oe_io_uphy_dp_tx;
-  logic manual_in_io_uphy_dn_tx, manual_out_io_uphy_dn_tx, manual_oe_io_uphy_dn_tx;
-  logic manual_in_io_uphy_dp_rx, manual_out_io_uphy_dp_rx, manual_oe_io_uphy_dp_rx;
-  logic manual_in_io_uphy_dn_rx, manual_out_io_uphy_dn_rx, manual_oe_io_uphy_dn_rx;
-  logic manual_in_io_uphy_d_rx, manual_out_io_uphy_d_rx, manual_oe_io_uphy_d_rx;
-  logic manual_in_io_uphy_oe_n, manual_out_io_uphy_oe_n, manual_oe_io_uphy_oe_n;
-  logic manual_in_io_uphy_sense, manual_out_io_uphy_sense, manual_oe_io_uphy_sense;
-  logic manual_in_io_uphy_dppullup, manual_out_io_uphy_dppullup, manual_oe_io_uphy_dppullup;
-
+  logic manual_in_por_n, manual_ie_por_n;
+  logic manual_out_por_n, manual_oe_por_n;
   pad_attr_t manual_attr_por_n;
+  logic manual_in_usb_p, manual_ie_usb_p;
+  logic manual_out_usb_p, manual_oe_usb_p;
   pad_attr_t manual_attr_usb_p;
+  logic manual_in_usb_n, manual_ie_usb_n;
+  logic manual_out_usb_n, manual_oe_usb_n;
   pad_attr_t manual_attr_usb_n;
+  logic manual_in_io_clk, manual_ie_io_clk;
+  logic manual_out_io_clk, manual_oe_io_clk;
   pad_attr_t manual_attr_io_clk;
+  logic manual_in_io_jsrst_n, manual_ie_io_jsrst_n;
+  logic manual_out_io_jsrst_n, manual_oe_io_jsrst_n;
   pad_attr_t manual_attr_io_jsrst_n;
+  logic manual_in_io_usb_sense0, manual_ie_io_usb_sense0;
+  logic manual_out_io_usb_sense0, manual_oe_io_usb_sense0;
   pad_attr_t manual_attr_io_usb_sense0;
+  logic manual_in_io_usb_dnpullup0, manual_ie_io_usb_dnpullup0;
+  logic manual_out_io_usb_dnpullup0, manual_oe_io_usb_dnpullup0;
   pad_attr_t manual_attr_io_usb_dnpullup0;
+  logic manual_in_io_usb_dppullup0, manual_ie_io_usb_dppullup0;
+  logic manual_out_io_usb_dppullup0, manual_oe_io_usb_dppullup0;
   pad_attr_t manual_attr_io_usb_dppullup0;
+  logic manual_in_io_uphy_dp_tx, manual_ie_io_uphy_dp_tx;
+  logic manual_out_io_uphy_dp_tx, manual_oe_io_uphy_dp_tx;
   pad_attr_t manual_attr_io_uphy_dp_tx;
+  logic manual_in_io_uphy_dn_tx, manual_ie_io_uphy_dn_tx;
+  logic manual_out_io_uphy_dn_tx, manual_oe_io_uphy_dn_tx;
   pad_attr_t manual_attr_io_uphy_dn_tx;
+  logic manual_in_io_uphy_dp_rx, manual_ie_io_uphy_dp_rx;
+  logic manual_out_io_uphy_dp_rx, manual_oe_io_uphy_dp_rx;
   pad_attr_t manual_attr_io_uphy_dp_rx;
+  logic manual_in_io_uphy_dn_rx, manual_ie_io_uphy_dn_rx;
+  logic manual_out_io_uphy_dn_rx, manual_oe_io_uphy_dn_rx;
   pad_attr_t manual_attr_io_uphy_dn_rx;
+  logic manual_in_io_uphy_d_rx, manual_ie_io_uphy_d_rx;
+  logic manual_out_io_uphy_d_rx, manual_oe_io_uphy_d_rx;
   pad_attr_t manual_attr_io_uphy_d_rx;
+  logic manual_in_io_uphy_oe_n, manual_ie_io_uphy_oe_n;
+  logic manual_out_io_uphy_oe_n, manual_oe_io_uphy_oe_n;
   pad_attr_t manual_attr_io_uphy_oe_n;
+  logic manual_in_io_uphy_sense, manual_ie_io_uphy_sense;
+  logic manual_out_io_uphy_sense, manual_oe_io_uphy_sense;
   pad_attr_t manual_attr_io_uphy_sense;
+  logic manual_in_io_uphy_dppullup, manual_ie_io_uphy_dppullup;
+  logic manual_out_io_uphy_dppullup, manual_oe_io_uphy_dppullup;
   pad_attr_t manual_attr_io_uphy_dppullup;
 
   /////////////////////////
@@ -242,79 +259,151 @@ module chip_earlgrey_nexysvideo #(
   // Only signals going to non-custom pads need to be tied off.
   logic [69:0] unused_sig;
   assign dio_in[DioSpiHost0Sd0] = 1'b0;
-  assign unused_sig[9] = dio_out[DioSpiHost0Sd0] ^ dio_oe[DioSpiHost0Sd0];
+  assign unused_sig[9] = dio_out[DioSpiHost0Sd0] ^ dio_oe[DioSpiHost0Sd0] ^ dio_ie[DioSpiHost0Sd0];
   assign dio_in[DioSpiHost0Sd1] = 1'b0;
-  assign unused_sig[10] = dio_out[DioSpiHost0Sd1] ^ dio_oe[DioSpiHost0Sd1];
+  assign unused_sig[10] = dio_out[DioSpiHost0Sd1] ^ dio_oe[DioSpiHost0Sd1] ^ dio_ie[DioSpiHost0Sd1];
   assign dio_in[DioSpiHost0Sd2] = 1'b0;
-  assign unused_sig[11] = dio_out[DioSpiHost0Sd2] ^ dio_oe[DioSpiHost0Sd2];
+  assign unused_sig[11] = dio_out[DioSpiHost0Sd2] ^ dio_oe[DioSpiHost0Sd2] ^ dio_ie[DioSpiHost0Sd2];
   assign dio_in[DioSpiHost0Sd3] = 1'b0;
-  assign unused_sig[12] = dio_out[DioSpiHost0Sd3] ^ dio_oe[DioSpiHost0Sd3];
+  assign unused_sig[12] = dio_out[DioSpiHost0Sd3] ^ dio_oe[DioSpiHost0Sd3] ^ dio_ie[DioSpiHost0Sd3];
   assign dio_in[DioSpiHost0Sck] = 1'b0;
-  assign unused_sig[13] = dio_out[DioSpiHost0Sck] ^ dio_oe[DioSpiHost0Sck];
+  assign unused_sig[13] = dio_out[DioSpiHost0Sck] ^ dio_oe[DioSpiHost0Sck] ^ dio_ie[DioSpiHost0Sck];
   assign dio_in[DioSpiHost0Csb] = 1'b0;
-  assign unused_sig[14] = dio_out[DioSpiHost0Csb] ^ dio_oe[DioSpiHost0Csb];
+  assign unused_sig[14] = dio_out[DioSpiHost0Csb] ^ dio_oe[DioSpiHost0Csb] ^ dio_ie[DioSpiHost0Csb];
   assign dio_in[DioSpiDeviceSd2] = 1'b0;
-  assign unused_sig[17] = dio_out[DioSpiDeviceSd2] ^ dio_oe[DioSpiDeviceSd2];
+  assign unused_sig[17] = dio_out[DioSpiDeviceSd2] ^ dio_oe[DioSpiDeviceSd2] ^ dio_ie[DioSpiDeviceSd2];
   assign dio_in[DioSpiDeviceSd3] = 1'b0;
-  assign unused_sig[18] = dio_out[DioSpiDeviceSd3] ^ dio_oe[DioSpiDeviceSd3];
+  assign unused_sig[18] = dio_out[DioSpiDeviceSd3] ^ dio_oe[DioSpiDeviceSd3] ^ dio_ie[DioSpiDeviceSd3];
   assign mio_in[19] = 1'b0;
   assign mio_in_raw[19] = 1'b0;
-  assign unused_sig[40] = mio_out[19] ^ mio_oe[19];
+  assign unused_sig[40] = ^{
+    mio_out[19],
+    mio_oe[19],
+    mio_ie[19]
+  };
   assign mio_in[20] = 1'b0;
   assign mio_in_raw[20] = 1'b0;
-  assign unused_sig[41] = mio_out[20] ^ mio_oe[20];
+  assign unused_sig[41] = ^{
+    mio_out[20],
+    mio_oe[20],
+    mio_ie[20]
+  };
   assign mio_in[21] = 1'b0;
   assign mio_in_raw[21] = 1'b0;
-  assign unused_sig[42] = mio_out[21] ^ mio_oe[21];
+  assign unused_sig[42] = ^{
+    mio_out[21],
+    mio_oe[21],
+    mio_ie[21]
+  };
   assign mio_in[22] = 1'b0;
   assign mio_in_raw[22] = 1'b0;
-  assign unused_sig[43] = mio_out[22] ^ mio_oe[22];
+  assign unused_sig[43] = ^{
+    mio_out[22],
+    mio_oe[22],
+    mio_ie[22]
+  };
   assign mio_in[23] = 1'b0;
   assign mio_in_raw[23] = 1'b0;
-  assign unused_sig[44] = mio_out[23] ^ mio_oe[23];
+  assign unused_sig[44] = ^{
+    mio_out[23],
+    mio_oe[23],
+    mio_ie[23]
+  };
   assign mio_in[34] = 1'b0;
   assign mio_in_raw[34] = 1'b0;
-  assign unused_sig[55] = mio_out[34] ^ mio_oe[34];
+  assign unused_sig[55] = ^{
+    mio_out[34],
+    mio_oe[34],
+    mio_ie[34]
+  };
   assign mio_in[35] = 1'b0;
   assign mio_in_raw[35] = 1'b0;
-  assign unused_sig[56] = mio_out[35] ^ mio_oe[35];
+  assign unused_sig[56] = ^{
+    mio_out[35],
+    mio_oe[35],
+    mio_ie[35]
+  };
   assign mio_in[36] = 1'b0;
   assign mio_in_raw[36] = 1'b0;
-  assign unused_sig[57] = mio_out[36] ^ mio_oe[36];
+  assign unused_sig[57] = ^{
+    mio_out[36],
+    mio_oe[36],
+    mio_ie[36]
+  };
   assign mio_in[37] = 1'b0;
   assign mio_in_raw[37] = 1'b0;
-  assign unused_sig[58] = mio_out[37] ^ mio_oe[37];
+  assign unused_sig[58] = ^{
+    mio_out[37],
+    mio_oe[37],
+    mio_ie[37]
+  };
   assign mio_in[38] = 1'b0;
   assign mio_in_raw[38] = 1'b0;
-  assign unused_sig[59] = mio_out[38] ^ mio_oe[38];
+  assign unused_sig[59] = ^{
+    mio_out[38],
+    mio_oe[38],
+    mio_ie[38]
+  };
   assign mio_in[39] = 1'b0;
   assign mio_in_raw[39] = 1'b0;
-  assign unused_sig[60] = mio_out[39] ^ mio_oe[39];
+  assign unused_sig[60] = ^{
+    mio_out[39],
+    mio_oe[39],
+    mio_ie[39]
+  };
   assign mio_in[40] = 1'b0;
   assign mio_in_raw[40] = 1'b0;
-  assign unused_sig[61] = mio_out[40] ^ mio_oe[40];
+  assign unused_sig[61] = ^{
+    mio_out[40],
+    mio_oe[40],
+    mio_ie[40]
+  };
   assign mio_in[41] = 1'b0;
   assign mio_in_raw[41] = 1'b0;
-  assign unused_sig[62] = mio_out[41] ^ mio_oe[41];
+  assign unused_sig[62] = ^{
+    mio_out[41],
+    mio_oe[41],
+    mio_ie[41]
+  };
   assign mio_in[42] = 1'b0;
   assign mio_in_raw[42] = 1'b0;
-  assign unused_sig[63] = mio_out[42] ^ mio_oe[42];
+  assign unused_sig[63] = ^{
+    mio_out[42],
+    mio_oe[42],
+    mio_ie[42]
+  };
   assign dio_in[DioSysrstCtrlAonEcRstL] = 1'b0;
-  assign unused_sig[64] = dio_out[DioSysrstCtrlAonEcRstL] ^ dio_oe[DioSysrstCtrlAonEcRstL];
+  assign unused_sig[64] = dio_out[DioSysrstCtrlAonEcRstL] ^ dio_oe[DioSysrstCtrlAonEcRstL] ^ dio_ie[DioSysrstCtrlAonEcRstL];
   assign dio_in[DioSysrstCtrlAonFlashWpL] = 1'b0;
-  assign unused_sig[65] = dio_out[DioSysrstCtrlAonFlashWpL] ^ dio_oe[DioSysrstCtrlAonFlashWpL];
+  assign unused_sig[65] = dio_out[DioSysrstCtrlAonFlashWpL] ^ dio_oe[DioSysrstCtrlAonFlashWpL] ^ dio_ie[DioSysrstCtrlAonFlashWpL];
   assign mio_in[43] = 1'b0;
   assign mio_in_raw[43] = 1'b0;
-  assign unused_sig[66] = mio_out[43] ^ mio_oe[43];
+  assign unused_sig[66] = ^{
+    mio_out[43],
+    mio_oe[43],
+    mio_ie[43]
+  };
   assign mio_in[44] = 1'b0;
   assign mio_in_raw[44] = 1'b0;
-  assign unused_sig[67] = mio_out[44] ^ mio_oe[44];
+  assign unused_sig[67] = ^{
+    mio_out[44],
+    mio_oe[44],
+    mio_ie[44]
+  };
   assign mio_in[45] = 1'b0;
   assign mio_in_raw[45] = 1'b0;
-  assign unused_sig[68] = mio_out[45] ^ mio_oe[45];
+  assign unused_sig[68] = ^{
+    mio_out[45],
+    mio_oe[45],
+    mio_ie[45]
+  };
   assign mio_in[46] = 1'b0;
   assign mio_in_raw[46] = 1'b0;
-  assign unused_sig[69] = mio_out[46] ^ mio_oe[46];
+  assign unused_sig[69] = ^{
+    mio_out[46],
+    mio_oe[46],
+    mio_ie[46]
+  };
 
   //////////////////////
   // Padring Instance //
@@ -465,6 +554,28 @@ module chip_earlgrey_nexysvideo #(
         manual_in_usb_p,
         manual_in_por_n
       }),
+    .dio_ie_i ({
+        manual_ie_io_uphy_dppullup,
+        manual_ie_io_uphy_sense,
+        manual_ie_io_uphy_oe_n,
+        manual_ie_io_uphy_d_rx,
+        manual_ie_io_uphy_dn_rx,
+        manual_ie_io_uphy_dp_rx,
+        manual_ie_io_uphy_dn_tx,
+        manual_ie_io_uphy_dp_tx,
+        manual_ie_io_usb_dppullup0,
+        manual_ie_io_usb_dnpullup0,
+        manual_ie_io_usb_sense0,
+        manual_ie_io_jsrst_n,
+        manual_ie_io_clk,
+        dio_ie[DioSpiDeviceCsb],
+        dio_ie[DioSpiDeviceSck],
+        dio_ie[DioSpiDeviceSd1],
+        dio_ie[DioSpiDeviceSd0],
+        manual_ie_usb_n,
+        manual_ie_usb_p,
+        manual_ie_por_n
+      }),
     .dio_out_i ({
         manual_out_io_uphy_dppullup,
         manual_out_io_uphy_sense,
@@ -535,6 +646,10 @@ module chip_earlgrey_nexysvideo #(
     .mio_in_o ({
         mio_in[33:24],
         mio_in[18:0]
+      }),
+    .mio_ie_i ({
+        mio_ie[33:24],
+        mio_ie[18:0]
       }),
     .mio_out_i ({
         mio_out[33:24],
@@ -1073,14 +1188,16 @@ module chip_earlgrey_nexysvideo #(
     .ast_init_done_i              ( ast_init_done              ),
 
     // Multiplexed I/O
-    .mio_in_i        ( mio_in   ),
-    .mio_out_o       ( mio_out  ),
-    .mio_oe_o        ( mio_oe   ),
+    .mio_in_i                     ( mio_in                     ),
+    .mio_ie_o                     ( mio_ie                     ),
+    .mio_out_o                    ( mio_out                    ),
+    .mio_oe_o                     ( mio_oe                     ),
 
     // Dedicated I/O
-    .dio_in_i        ( dio_in   ),
-    .dio_out_o       ( dio_out  ),
-    .dio_oe_o        ( dio_oe   ),
+    .dio_in_i                     ( dio_in                     ),
+    .dio_ie_o                     ( dio_ie                     ),
+    .dio_out_o                    ( dio_out                    ),
+    .dio_oe_o                     ( dio_oe                     ),
 
     // Pad attributes
     .mio_attr_o      ( mio_attr      ),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -100,10 +100,12 @@ module top_earlgrey #(
 ) (
   // Multiplexed I/O
   input        [46:0] mio_in_i,
+  output logic [46:0] mio_ie_o,
   output logic [46:0] mio_out_o,
   output logic [46:0] mio_oe_o,
   // Dedicated I/O
   input        [23:0] dio_in_i,
+  output logic [23:0] dio_ie_o,
   output logic [23:0] dio_out_o,
   output logic [23:0] dio_oe_o,
 
@@ -194,10 +196,12 @@ module top_earlgrey #(
   // Signals
   logic [55:0] mio_p2d;
   logic [74:0] mio_d2p;
-  logic [74:0] mio_en_d2p;
+  logic [74:0] mio_oe_d2p;
+  logic [74:0] mio_ie_d2p;
   logic [23:0] dio_p2d;
   logic [23:0] dio_d2p;
-  logic [23:0] dio_en_d2p;
+  logic [23:0] dio_oe_d2p;
+  logic [23:0] dio_ie_d2p;
   // uart0
   logic        cio_uart0_rx_p2d;
   logic        cio_uart0_tx_d2p;
@@ -1878,22 +1882,26 @@ module top_earlgrey #(
       .tl_o(pinmux_aon_tl_rsp),
 
       .periph_to_mio_i      (mio_d2p    ),
-      .periph_to_mio_oe_i   (mio_en_d2p ),
+      .periph_to_mio_oe_i   (mio_oe_d2p ),
       .mio_to_periph_o      (mio_p2d    ),
+      .periph_to_mio_ie_i   (mio_ie_d2p ),
 
       .mio_attr_o,
       .mio_out_o,
       .mio_oe_o,
       .mio_in_i,
+      .mio_ie_o,
 
       .periph_to_dio_i      (dio_d2p    ),
-      .periph_to_dio_oe_i   (dio_en_d2p ),
+      .periph_to_dio_oe_i   (dio_oe_d2p ),
       .dio_to_periph_o      (dio_p2d    ),
+      .periph_to_dio_ie_i   (dio_ie_d2p ),
 
       .dio_attr_o,
       .dio_out_o,
       .dio_oe_o,
       .dio_in_i,
+      .dio_ie_o,
 
       .scanmode_i,
 
@@ -2971,6 +2979,12 @@ module top_earlgrey #(
   assign cio_sysrst_ctrl_aon_pwrb_in_p2d = mio_p2d[MioInSysrstCtrlAonPwrbIn];
   assign cio_sysrst_ctrl_aon_lid_open_p2d = mio_p2d[MioInSysrstCtrlAonLidOpen];
 
+  // All muxed input enables
+  // TODO(#9134): these are currently all hardwired to 1'b1.
+  // Long-term, these assignments should be pulled into the individual
+  // peripherals so that the IE can be modulated dynamically.
+  assign mio_ie_d2p = {$bits(mio_ie_d2p){1'b1}};
+
   // All muxed outputs
   assign mio_d2p[MioOutGpioGpio0] = cio_gpio_gpio_d2p[0];
   assign mio_d2p[MioOutGpioGpio1] = cio_gpio_gpio_d2p[1];
@@ -3049,81 +3063,81 @@ module top_earlgrey #(
   assign mio_d2p[MioOutSysrstCtrlAonZ3Wakeup] = cio_sysrst_ctrl_aon_z3_wakeup_d2p;
 
   // All muxed output enables
-  assign mio_en_d2p[MioOutGpioGpio0] = cio_gpio_gpio_en_d2p[0];
-  assign mio_en_d2p[MioOutGpioGpio1] = cio_gpio_gpio_en_d2p[1];
-  assign mio_en_d2p[MioOutGpioGpio2] = cio_gpio_gpio_en_d2p[2];
-  assign mio_en_d2p[MioOutGpioGpio3] = cio_gpio_gpio_en_d2p[3];
-  assign mio_en_d2p[MioOutGpioGpio4] = cio_gpio_gpio_en_d2p[4];
-  assign mio_en_d2p[MioOutGpioGpio5] = cio_gpio_gpio_en_d2p[5];
-  assign mio_en_d2p[MioOutGpioGpio6] = cio_gpio_gpio_en_d2p[6];
-  assign mio_en_d2p[MioOutGpioGpio7] = cio_gpio_gpio_en_d2p[7];
-  assign mio_en_d2p[MioOutGpioGpio8] = cio_gpio_gpio_en_d2p[8];
-  assign mio_en_d2p[MioOutGpioGpio9] = cio_gpio_gpio_en_d2p[9];
-  assign mio_en_d2p[MioOutGpioGpio10] = cio_gpio_gpio_en_d2p[10];
-  assign mio_en_d2p[MioOutGpioGpio11] = cio_gpio_gpio_en_d2p[11];
-  assign mio_en_d2p[MioOutGpioGpio12] = cio_gpio_gpio_en_d2p[12];
-  assign mio_en_d2p[MioOutGpioGpio13] = cio_gpio_gpio_en_d2p[13];
-  assign mio_en_d2p[MioOutGpioGpio14] = cio_gpio_gpio_en_d2p[14];
-  assign mio_en_d2p[MioOutGpioGpio15] = cio_gpio_gpio_en_d2p[15];
-  assign mio_en_d2p[MioOutGpioGpio16] = cio_gpio_gpio_en_d2p[16];
-  assign mio_en_d2p[MioOutGpioGpio17] = cio_gpio_gpio_en_d2p[17];
-  assign mio_en_d2p[MioOutGpioGpio18] = cio_gpio_gpio_en_d2p[18];
-  assign mio_en_d2p[MioOutGpioGpio19] = cio_gpio_gpio_en_d2p[19];
-  assign mio_en_d2p[MioOutGpioGpio20] = cio_gpio_gpio_en_d2p[20];
-  assign mio_en_d2p[MioOutGpioGpio21] = cio_gpio_gpio_en_d2p[21];
-  assign mio_en_d2p[MioOutGpioGpio22] = cio_gpio_gpio_en_d2p[22];
-  assign mio_en_d2p[MioOutGpioGpio23] = cio_gpio_gpio_en_d2p[23];
-  assign mio_en_d2p[MioOutGpioGpio24] = cio_gpio_gpio_en_d2p[24];
-  assign mio_en_d2p[MioOutGpioGpio25] = cio_gpio_gpio_en_d2p[25];
-  assign mio_en_d2p[MioOutGpioGpio26] = cio_gpio_gpio_en_d2p[26];
-  assign mio_en_d2p[MioOutGpioGpio27] = cio_gpio_gpio_en_d2p[27];
-  assign mio_en_d2p[MioOutGpioGpio28] = cio_gpio_gpio_en_d2p[28];
-  assign mio_en_d2p[MioOutGpioGpio29] = cio_gpio_gpio_en_d2p[29];
-  assign mio_en_d2p[MioOutGpioGpio30] = cio_gpio_gpio_en_d2p[30];
-  assign mio_en_d2p[MioOutGpioGpio31] = cio_gpio_gpio_en_d2p[31];
-  assign mio_en_d2p[MioOutI2c0Sda] = cio_i2c0_sda_en_d2p;
-  assign mio_en_d2p[MioOutI2c0Scl] = cio_i2c0_scl_en_d2p;
-  assign mio_en_d2p[MioOutI2c1Sda] = cio_i2c1_sda_en_d2p;
-  assign mio_en_d2p[MioOutI2c1Scl] = cio_i2c1_scl_en_d2p;
-  assign mio_en_d2p[MioOutI2c2Sda] = cio_i2c2_sda_en_d2p;
-  assign mio_en_d2p[MioOutI2c2Scl] = cio_i2c2_scl_en_d2p;
-  assign mio_en_d2p[MioOutSpiHost1Sd0] = cio_spi_host1_sd_en_d2p[0];
-  assign mio_en_d2p[MioOutSpiHost1Sd1] = cio_spi_host1_sd_en_d2p[1];
-  assign mio_en_d2p[MioOutSpiHost1Sd2] = cio_spi_host1_sd_en_d2p[2];
-  assign mio_en_d2p[MioOutSpiHost1Sd3] = cio_spi_host1_sd_en_d2p[3];
-  assign mio_en_d2p[MioOutUart0Tx] = cio_uart0_tx_en_d2p;
-  assign mio_en_d2p[MioOutUart1Tx] = cio_uart1_tx_en_d2p;
-  assign mio_en_d2p[MioOutUart2Tx] = cio_uart2_tx_en_d2p;
-  assign mio_en_d2p[MioOutUart3Tx] = cio_uart3_tx_en_d2p;
-  assign mio_en_d2p[MioOutPattgenPda0Tx] = cio_pattgen_pda0_tx_en_d2p;
-  assign mio_en_d2p[MioOutPattgenPcl0Tx] = cio_pattgen_pcl0_tx_en_d2p;
-  assign mio_en_d2p[MioOutPattgenPda1Tx] = cio_pattgen_pda1_tx_en_d2p;
-  assign mio_en_d2p[MioOutPattgenPcl1Tx] = cio_pattgen_pcl1_tx_en_d2p;
-  assign mio_en_d2p[MioOutSpiHost1Sck] = cio_spi_host1_sck_en_d2p;
-  assign mio_en_d2p[MioOutSpiHost1Csb] = cio_spi_host1_csb_en_d2p;
-  assign mio_en_d2p[MioOutFlashCtrlTdo] = cio_flash_ctrl_tdo_en_d2p;
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut0] = cio_sensor_ctrl_ast_debug_out_en_d2p[0];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut1] = cio_sensor_ctrl_ast_debug_out_en_d2p[1];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut2] = cio_sensor_ctrl_ast_debug_out_en_d2p[2];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut3] = cio_sensor_ctrl_ast_debug_out_en_d2p[3];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut4] = cio_sensor_ctrl_ast_debug_out_en_d2p[4];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut5] = cio_sensor_ctrl_ast_debug_out_en_d2p[5];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut6] = cio_sensor_ctrl_ast_debug_out_en_d2p[6];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut7] = cio_sensor_ctrl_ast_debug_out_en_d2p[7];
-  assign mio_en_d2p[MioOutSensorCtrlAstDebugOut8] = cio_sensor_ctrl_ast_debug_out_en_d2p[8];
-  assign mio_en_d2p[MioOutPwmAonPwm0] = cio_pwm_aon_pwm_en_d2p[0];
-  assign mio_en_d2p[MioOutPwmAonPwm1] = cio_pwm_aon_pwm_en_d2p[1];
-  assign mio_en_d2p[MioOutPwmAonPwm2] = cio_pwm_aon_pwm_en_d2p[2];
-  assign mio_en_d2p[MioOutPwmAonPwm3] = cio_pwm_aon_pwm_en_d2p[3];
-  assign mio_en_d2p[MioOutPwmAonPwm4] = cio_pwm_aon_pwm_en_d2p[4];
-  assign mio_en_d2p[MioOutPwmAonPwm5] = cio_pwm_aon_pwm_en_d2p[5];
-  assign mio_en_d2p[MioOutOtpCtrlTest0] = cio_otp_ctrl_test_en_d2p[0];
-  assign mio_en_d2p[MioOutSysrstCtrlAonBatDisable] = cio_sysrst_ctrl_aon_bat_disable_en_d2p;
-  assign mio_en_d2p[MioOutSysrstCtrlAonKey0Out] = cio_sysrst_ctrl_aon_key0_out_en_d2p;
-  assign mio_en_d2p[MioOutSysrstCtrlAonKey1Out] = cio_sysrst_ctrl_aon_key1_out_en_d2p;
-  assign mio_en_d2p[MioOutSysrstCtrlAonKey2Out] = cio_sysrst_ctrl_aon_key2_out_en_d2p;
-  assign mio_en_d2p[MioOutSysrstCtrlAonPwrbOut] = cio_sysrst_ctrl_aon_pwrb_out_en_d2p;
-  assign mio_en_d2p[MioOutSysrstCtrlAonZ3Wakeup] = cio_sysrst_ctrl_aon_z3_wakeup_en_d2p;
+  assign mio_oe_d2p[MioOutGpioGpio0] = cio_gpio_gpio_en_d2p[0];
+  assign mio_oe_d2p[MioOutGpioGpio1] = cio_gpio_gpio_en_d2p[1];
+  assign mio_oe_d2p[MioOutGpioGpio2] = cio_gpio_gpio_en_d2p[2];
+  assign mio_oe_d2p[MioOutGpioGpio3] = cio_gpio_gpio_en_d2p[3];
+  assign mio_oe_d2p[MioOutGpioGpio4] = cio_gpio_gpio_en_d2p[4];
+  assign mio_oe_d2p[MioOutGpioGpio5] = cio_gpio_gpio_en_d2p[5];
+  assign mio_oe_d2p[MioOutGpioGpio6] = cio_gpio_gpio_en_d2p[6];
+  assign mio_oe_d2p[MioOutGpioGpio7] = cio_gpio_gpio_en_d2p[7];
+  assign mio_oe_d2p[MioOutGpioGpio8] = cio_gpio_gpio_en_d2p[8];
+  assign mio_oe_d2p[MioOutGpioGpio9] = cio_gpio_gpio_en_d2p[9];
+  assign mio_oe_d2p[MioOutGpioGpio10] = cio_gpio_gpio_en_d2p[10];
+  assign mio_oe_d2p[MioOutGpioGpio11] = cio_gpio_gpio_en_d2p[11];
+  assign mio_oe_d2p[MioOutGpioGpio12] = cio_gpio_gpio_en_d2p[12];
+  assign mio_oe_d2p[MioOutGpioGpio13] = cio_gpio_gpio_en_d2p[13];
+  assign mio_oe_d2p[MioOutGpioGpio14] = cio_gpio_gpio_en_d2p[14];
+  assign mio_oe_d2p[MioOutGpioGpio15] = cio_gpio_gpio_en_d2p[15];
+  assign mio_oe_d2p[MioOutGpioGpio16] = cio_gpio_gpio_en_d2p[16];
+  assign mio_oe_d2p[MioOutGpioGpio17] = cio_gpio_gpio_en_d2p[17];
+  assign mio_oe_d2p[MioOutGpioGpio18] = cio_gpio_gpio_en_d2p[18];
+  assign mio_oe_d2p[MioOutGpioGpio19] = cio_gpio_gpio_en_d2p[19];
+  assign mio_oe_d2p[MioOutGpioGpio20] = cio_gpio_gpio_en_d2p[20];
+  assign mio_oe_d2p[MioOutGpioGpio21] = cio_gpio_gpio_en_d2p[21];
+  assign mio_oe_d2p[MioOutGpioGpio22] = cio_gpio_gpio_en_d2p[22];
+  assign mio_oe_d2p[MioOutGpioGpio23] = cio_gpio_gpio_en_d2p[23];
+  assign mio_oe_d2p[MioOutGpioGpio24] = cio_gpio_gpio_en_d2p[24];
+  assign mio_oe_d2p[MioOutGpioGpio25] = cio_gpio_gpio_en_d2p[25];
+  assign mio_oe_d2p[MioOutGpioGpio26] = cio_gpio_gpio_en_d2p[26];
+  assign mio_oe_d2p[MioOutGpioGpio27] = cio_gpio_gpio_en_d2p[27];
+  assign mio_oe_d2p[MioOutGpioGpio28] = cio_gpio_gpio_en_d2p[28];
+  assign mio_oe_d2p[MioOutGpioGpio29] = cio_gpio_gpio_en_d2p[29];
+  assign mio_oe_d2p[MioOutGpioGpio30] = cio_gpio_gpio_en_d2p[30];
+  assign mio_oe_d2p[MioOutGpioGpio31] = cio_gpio_gpio_en_d2p[31];
+  assign mio_oe_d2p[MioOutI2c0Sda] = cio_i2c0_sda_en_d2p;
+  assign mio_oe_d2p[MioOutI2c0Scl] = cio_i2c0_scl_en_d2p;
+  assign mio_oe_d2p[MioOutI2c1Sda] = cio_i2c1_sda_en_d2p;
+  assign mio_oe_d2p[MioOutI2c1Scl] = cio_i2c1_scl_en_d2p;
+  assign mio_oe_d2p[MioOutI2c2Sda] = cio_i2c2_sda_en_d2p;
+  assign mio_oe_d2p[MioOutI2c2Scl] = cio_i2c2_scl_en_d2p;
+  assign mio_oe_d2p[MioOutSpiHost1Sd0] = cio_spi_host1_sd_en_d2p[0];
+  assign mio_oe_d2p[MioOutSpiHost1Sd1] = cio_spi_host1_sd_en_d2p[1];
+  assign mio_oe_d2p[MioOutSpiHost1Sd2] = cio_spi_host1_sd_en_d2p[2];
+  assign mio_oe_d2p[MioOutSpiHost1Sd3] = cio_spi_host1_sd_en_d2p[3];
+  assign mio_oe_d2p[MioOutUart0Tx] = cio_uart0_tx_en_d2p;
+  assign mio_oe_d2p[MioOutUart1Tx] = cio_uart1_tx_en_d2p;
+  assign mio_oe_d2p[MioOutUart2Tx] = cio_uart2_tx_en_d2p;
+  assign mio_oe_d2p[MioOutUart3Tx] = cio_uart3_tx_en_d2p;
+  assign mio_oe_d2p[MioOutPattgenPda0Tx] = cio_pattgen_pda0_tx_en_d2p;
+  assign mio_oe_d2p[MioOutPattgenPcl0Tx] = cio_pattgen_pcl0_tx_en_d2p;
+  assign mio_oe_d2p[MioOutPattgenPda1Tx] = cio_pattgen_pda1_tx_en_d2p;
+  assign mio_oe_d2p[MioOutPattgenPcl1Tx] = cio_pattgen_pcl1_tx_en_d2p;
+  assign mio_oe_d2p[MioOutSpiHost1Sck] = cio_spi_host1_sck_en_d2p;
+  assign mio_oe_d2p[MioOutSpiHost1Csb] = cio_spi_host1_csb_en_d2p;
+  assign mio_oe_d2p[MioOutFlashCtrlTdo] = cio_flash_ctrl_tdo_en_d2p;
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut0] = cio_sensor_ctrl_ast_debug_out_en_d2p[0];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut1] = cio_sensor_ctrl_ast_debug_out_en_d2p[1];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut2] = cio_sensor_ctrl_ast_debug_out_en_d2p[2];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut3] = cio_sensor_ctrl_ast_debug_out_en_d2p[3];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut4] = cio_sensor_ctrl_ast_debug_out_en_d2p[4];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut5] = cio_sensor_ctrl_ast_debug_out_en_d2p[5];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut6] = cio_sensor_ctrl_ast_debug_out_en_d2p[6];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut7] = cio_sensor_ctrl_ast_debug_out_en_d2p[7];
+  assign mio_oe_d2p[MioOutSensorCtrlAstDebugOut8] = cio_sensor_ctrl_ast_debug_out_en_d2p[8];
+  assign mio_oe_d2p[MioOutPwmAonPwm0] = cio_pwm_aon_pwm_en_d2p[0];
+  assign mio_oe_d2p[MioOutPwmAonPwm1] = cio_pwm_aon_pwm_en_d2p[1];
+  assign mio_oe_d2p[MioOutPwmAonPwm2] = cio_pwm_aon_pwm_en_d2p[2];
+  assign mio_oe_d2p[MioOutPwmAonPwm3] = cio_pwm_aon_pwm_en_d2p[3];
+  assign mio_oe_d2p[MioOutPwmAonPwm4] = cio_pwm_aon_pwm_en_d2p[4];
+  assign mio_oe_d2p[MioOutPwmAonPwm5] = cio_pwm_aon_pwm_en_d2p[5];
+  assign mio_oe_d2p[MioOutOtpCtrlTest0] = cio_otp_ctrl_test_en_d2p[0];
+  assign mio_oe_d2p[MioOutSysrstCtrlAonBatDisable] = cio_sysrst_ctrl_aon_bat_disable_en_d2p;
+  assign mio_oe_d2p[MioOutSysrstCtrlAonKey0Out] = cio_sysrst_ctrl_aon_key0_out_en_d2p;
+  assign mio_oe_d2p[MioOutSysrstCtrlAonKey1Out] = cio_sysrst_ctrl_aon_key1_out_en_d2p;
+  assign mio_oe_d2p[MioOutSysrstCtrlAonKey2Out] = cio_sysrst_ctrl_aon_key2_out_en_d2p;
+  assign mio_oe_d2p[MioOutSysrstCtrlAonPwrbOut] = cio_sysrst_ctrl_aon_pwrb_out_en_d2p;
+  assign mio_oe_d2p[MioOutSysrstCtrlAonZ3Wakeup] = cio_sysrst_ctrl_aon_z3_wakeup_en_d2p;
 
   // All dedicated inputs
   logic [23:0] unused_dio_p2d;
@@ -3144,7 +3158,36 @@ module top_earlgrey #(
   assign cio_spi_device_csb_p2d = dio_p2d[DioSpiDeviceCsb];
   assign cio_usbdev_sense_p2d = dio_p2d[DioUsbdevSense];
 
-    // All dedicated outputs
+  // All dedicated input enables
+  // TODO(#9134): these are currently all hardwired to 1'b1 or 1'b0.
+  // Long-term, these assignments should be pulled into the individual
+  // peripherals so that the IE can be modulated dynamically.
+  assign dio_ie_d2p[DioSpiHost0Sd0] = 1'b1;
+  assign dio_ie_d2p[DioSpiHost0Sd1] = 1'b1;
+  assign dio_ie_d2p[DioSpiHost0Sd2] = 1'b1;
+  assign dio_ie_d2p[DioSpiHost0Sd3] = 1'b1;
+  assign dio_ie_d2p[DioSpiDeviceSd0] = 1'b1;
+  assign dio_ie_d2p[DioSpiDeviceSd1] = 1'b1;
+  assign dio_ie_d2p[DioSpiDeviceSd2] = 1'b1;
+  assign dio_ie_d2p[DioSpiDeviceSd3] = 1'b1;
+  assign dio_ie_d2p[DioUsbdevD] = 1'b1;
+  assign dio_ie_d2p[DioUsbdevDp] = 1'b1;
+  assign dio_ie_d2p[DioUsbdevDn] = 1'b1;
+  assign dio_ie_d2p[DioSysrstCtrlAonEcRstL] = 1'b1;
+  assign dio_ie_d2p[DioSpiDeviceSck] = 1'b1;
+  assign dio_ie_d2p[DioSpiDeviceCsb] = 1'b1;
+  assign dio_ie_d2p[DioUsbdevSense] = 1'b1;
+  assign dio_ie_d2p[DioSpiHost0Sck] = 1'b0;
+  assign dio_ie_d2p[DioSpiHost0Csb] = 1'b0;
+  assign dio_ie_d2p[DioUsbdevSe0] = 1'b0;
+  assign dio_ie_d2p[DioUsbdevDpPullup] = 1'b0;
+  assign dio_ie_d2p[DioUsbdevDnPullup] = 1'b0;
+  assign dio_ie_d2p[DioUsbdevTxModeSe] = 1'b0;
+  assign dio_ie_d2p[DioUsbdevSuspend] = 1'b0;
+  assign dio_ie_d2p[DioUsbdevRxEnable] = 1'b0;
+  assign dio_ie_d2p[DioSysrstCtrlAonFlashWpL] = 1'b0;
+
+  // All dedicated outputs
   assign dio_d2p[DioSpiHost0Sd0] = cio_spi_host0_sd_d2p[0];
   assign dio_d2p[DioSpiHost0Sd1] = cio_spi_host0_sd_d2p[1];
   assign dio_d2p[DioSpiHost0Sd2] = cio_spi_host0_sd_d2p[2];
@@ -3171,30 +3214,30 @@ module top_earlgrey #(
   assign dio_d2p[DioSysrstCtrlAonFlashWpL] = cio_sysrst_ctrl_aon_flash_wp_l_d2p;
 
   // All dedicated output enables
-  assign dio_en_d2p[DioSpiHost0Sd0] = cio_spi_host0_sd_en_d2p[0];
-  assign dio_en_d2p[DioSpiHost0Sd1] = cio_spi_host0_sd_en_d2p[1];
-  assign dio_en_d2p[DioSpiHost0Sd2] = cio_spi_host0_sd_en_d2p[2];
-  assign dio_en_d2p[DioSpiHost0Sd3] = cio_spi_host0_sd_en_d2p[3];
-  assign dio_en_d2p[DioSpiDeviceSd0] = cio_spi_device_sd_en_d2p[0];
-  assign dio_en_d2p[DioSpiDeviceSd1] = cio_spi_device_sd_en_d2p[1];
-  assign dio_en_d2p[DioSpiDeviceSd2] = cio_spi_device_sd_en_d2p[2];
-  assign dio_en_d2p[DioSpiDeviceSd3] = cio_spi_device_sd_en_d2p[3];
-  assign dio_en_d2p[DioUsbdevD] = cio_usbdev_d_en_d2p;
-  assign dio_en_d2p[DioUsbdevDp] = cio_usbdev_dp_en_d2p;
-  assign dio_en_d2p[DioUsbdevDn] = cio_usbdev_dn_en_d2p;
-  assign dio_en_d2p[DioSysrstCtrlAonEcRstL] = cio_sysrst_ctrl_aon_ec_rst_l_en_d2p;
-  assign dio_en_d2p[DioSpiDeviceSck] = 1'b0;
-  assign dio_en_d2p[DioSpiDeviceCsb] = 1'b0;
-  assign dio_en_d2p[DioUsbdevSense] = 1'b0;
-  assign dio_en_d2p[DioSpiHost0Sck] = cio_spi_host0_sck_en_d2p;
-  assign dio_en_d2p[DioSpiHost0Csb] = cio_spi_host0_csb_en_d2p;
-  assign dio_en_d2p[DioUsbdevSe0] = cio_usbdev_se0_en_d2p;
-  assign dio_en_d2p[DioUsbdevDpPullup] = cio_usbdev_dp_pullup_en_d2p;
-  assign dio_en_d2p[DioUsbdevDnPullup] = cio_usbdev_dn_pullup_en_d2p;
-  assign dio_en_d2p[DioUsbdevTxModeSe] = cio_usbdev_tx_mode_se_en_d2p;
-  assign dio_en_d2p[DioUsbdevSuspend] = cio_usbdev_suspend_en_d2p;
-  assign dio_en_d2p[DioUsbdevRxEnable] = cio_usbdev_rx_enable_en_d2p;
-  assign dio_en_d2p[DioSysrstCtrlAonFlashWpL] = cio_sysrst_ctrl_aon_flash_wp_l_en_d2p;
+  assign dio_oe_d2p[DioSpiHost0Sd0] = cio_spi_host0_sd_en_d2p[0];
+  assign dio_oe_d2p[DioSpiHost0Sd1] = cio_spi_host0_sd_en_d2p[1];
+  assign dio_oe_d2p[DioSpiHost0Sd2] = cio_spi_host0_sd_en_d2p[2];
+  assign dio_oe_d2p[DioSpiHost0Sd3] = cio_spi_host0_sd_en_d2p[3];
+  assign dio_oe_d2p[DioSpiDeviceSd0] = cio_spi_device_sd_en_d2p[0];
+  assign dio_oe_d2p[DioSpiDeviceSd1] = cio_spi_device_sd_en_d2p[1];
+  assign dio_oe_d2p[DioSpiDeviceSd2] = cio_spi_device_sd_en_d2p[2];
+  assign dio_oe_d2p[DioSpiDeviceSd3] = cio_spi_device_sd_en_d2p[3];
+  assign dio_oe_d2p[DioUsbdevD] = cio_usbdev_d_en_d2p;
+  assign dio_oe_d2p[DioUsbdevDp] = cio_usbdev_dp_en_d2p;
+  assign dio_oe_d2p[DioUsbdevDn] = cio_usbdev_dn_en_d2p;
+  assign dio_oe_d2p[DioSysrstCtrlAonEcRstL] = cio_sysrst_ctrl_aon_ec_rst_l_en_d2p;
+  assign dio_oe_d2p[DioSpiDeviceSck] = 1'b0;
+  assign dio_oe_d2p[DioSpiDeviceCsb] = 1'b0;
+  assign dio_oe_d2p[DioUsbdevSense] = 1'b0;
+  assign dio_oe_d2p[DioSpiHost0Sck] = cio_spi_host0_sck_en_d2p;
+  assign dio_oe_d2p[DioSpiHost0Csb] = cio_spi_host0_csb_en_d2p;
+  assign dio_oe_d2p[DioUsbdevSe0] = cio_usbdev_se0_en_d2p;
+  assign dio_oe_d2p[DioUsbdevDpPullup] = cio_usbdev_dp_pullup_en_d2p;
+  assign dio_oe_d2p[DioUsbdevDnPullup] = cio_usbdev_dn_pullup_en_d2p;
+  assign dio_oe_d2p[DioUsbdevTxModeSe] = cio_usbdev_tx_mode_se_en_d2p;
+  assign dio_oe_d2p[DioUsbdevSuspend] = cio_usbdev_suspend_en_d2p;
+  assign dio_oe_d2p[DioUsbdevRxEnable] = cio_usbdev_rx_enable_en_d2p;
+  assign dio_oe_d2p[DioSysrstCtrlAonFlashWpL] = cio_sysrst_ctrl_aon_flash_wp_l_en_d2p;
 
 
   // make sure scanmode_i is never X (including during reset)

--- a/hw/top_earlgrey/rtl/padring.sv
+++ b/hw/top_earlgrey/rtl/padring.sv
@@ -36,10 +36,12 @@ module padring
   inout wire       [NMioPads-1:0] mio_pad_io,
   // Dedicated IO signals coming from peripherals
   output logic     [NDioPads-1:0] dio_in_o,
+  input            [NDioPads-1:0] dio_ie_i,
   input            [NDioPads-1:0] dio_out_i,
   input            [NDioPads-1:0] dio_oe_i,
   // Muxed IO signals coming from pinmux
   output logic     [NMioPads-1:0] mio_in_o,
+  input            [NMioPads-1:0] mio_ie_i,
   input            [NMioPads-1:0] mio_out_i,
   input            [NMioPads-1:0] mio_oe_i,
   // Pad attributes from top level instance
@@ -66,10 +68,7 @@ module padring
       .inout_io   ( dio_pad_io[k]            ),
       .in_o       ( dio_in_o[k]              ),
       .in_raw_o   ( dio_in_raw_o[k]          ),
-      // This is currently not dynamically controlled.
-      // However, this may change in the future if the
-      // need arises (e.g. as part of to power sequencing).
-      .ie_i       ( 1'b1                     ),
+      .ie_i       ( dio_ie_i[k]              ),
       .out_i      ( dio_out_i[k]             ),
       .oe_i       ( dio_oe_i[k]              ),
       .attr_i     ( dio_attr_i[k]            )
@@ -87,10 +86,7 @@ module padring
       .inout_io   ( mio_pad_io[k]            ),
       .in_o       ( mio_in_o[k]              ),
       .in_raw_o   ( mio_in_raw_o[k]          ),
-      // This is currently not dynamically controlled.
-      // However, this may change in the future if the
-      // need arises (e.g. as part of to power sequencing).
-      .ie_i       ( 1'b1                     ),
+      .ie_i       ( mio_ie_i[k]              ),
       .out_i      ( mio_out_i[k]             ),
       .oe_i       ( mio_oe_i[k]              ),
       .attr_i     ( mio_attr_i[k]            )


### PR DESCRIPTION
Following the discussions about unused input signals in #9046 and #9059, this pulls the input buffer enable signals from the padring down into the pinmux so that the input buffers can be turned off if the pad input is not used in order to save power.

For muxed pads the input buffer is only enabled if the pad is either selected via an INSEL CSR configuration in the pinmux matrix, or a wakeup detector is configured to listen on that MIO.

For dedicated pads, the input buffer is statically enabled if the DIO is configured as an `input` or `input`. The input buffer is also enabled if a wakeup detector is configured to listen on that DIO.

For the USB pad pairs, the first pad in a pair is always connected to the signal comming from the pinmux.
The input buffer of the second pad in a pair is permanently disabled.

Note that long-term, the IE signals should be pulled all the way into the peripherals for even more granular control - but this change would be too invasive right now, so it is deferred for later (see #9134).

We should also discuss how this affects `pad2ast` signals, and whether the associated input buffers need to be constantly enabled (@arnonsha).