### PR TITLE
[sw, tests] Refactor sram_ctrl scramble test and test utils

### DIFF
--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -116,7 +116,6 @@ sw_lib_testing_sram_ctrl_testutils = declare_dependency(
   link_with: static_library(
     'sw_lib_testing_sram_ctrl_testutils',
     sources: [
-      hw_ip_sram_ctrl_reg_h,
       'sram_ctrl_testutils.c'
     ],
     dependencies: [

--- a/sw/device/lib/testing/sram_ctrl_testutils.c
+++ b/sw/device/lib/testing/sram_ctrl_testutils.c
@@ -10,84 +10,26 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
 
-/**
- * Main RAM parameters.
- */
-static const sram_ctrl_params_t sram_main = {
-    .reg_base = TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR,
-    .ram_start = TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR,
-    .ram_end = TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR +
-               TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES -
-               SRAM_CTRL_DATA_NUM_BYTES,
-};
-
-/**
- * Retention RAM parameters.
- */
-static const sram_ctrl_params_t sram_ret = {
-    .reg_base = TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR,
-    .ram_start = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
-    .ram_end = TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
-               TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES -
-               SRAM_CTRL_DATA_NUM_BYTES,
-};
-
-/**
- * Creates SRAM Control handle and initializes the peripheral.
- */
-static sram_ctrl_t sram_ctrl_init(const sram_ctrl_params_t *params) {
-  sram_ctrl_t sram = {
-      .params = params,
-  };
-
-  mmio_region_t region = mmio_region_from_addr(params->reg_base);
-  CHECK_DIF_OK(dif_sram_ctrl_init(region, &sram.dif));
-
-  return sram;
-}
-
-sram_ctrl_t sram_ctrl_main_init(void) { return sram_ctrl_init(&sram_main); }
-sram_ctrl_t sram_ctrl_ret_init(void) { return sram_ctrl_init(&sram_ret); }
-
-/**
- * Writes `data` at the `address` in RAM.
- */
-static void write_to_ram(uintptr_t address, const sram_ctrl_data_t *data) {
+void sram_ctrl_testutils_write(uintptr_t address,
+                               const sram_ctrl_data_t *data) {
   mmio_region_t region = mmio_region_from_addr(address);
   for (size_t index = 0; index < SRAM_CTRL_DATA_NUM_WORDS; ++index) {
     mmio_region_write32(region, index, data->words[index]);
   }
 }
 
-void sram_ctrl_write_to_ram(const sram_ctrl_t *sram,
-                            const sram_ctrl_data_t *data) {
-  LOG_INFO("Writing data to the start of RAM = %x", sram->params->ram_start);
-  write_to_ram(sram->params->ram_start, data);
-
-  LOG_INFO("Writing data to the end of RAM = %x", sram->params->ram_end);
-  write_to_ram(sram->params->ram_end, data);
-}
-
 /**
- * Reads and compares `data` at the `address` in RAM.
+ * Reads data from `address` in SRAM and compares against `expected`.
  *
  * The read data is word by word compared against the expected data.
- * Caller can request to check for equality or inequality.
+ * Caller can request to check for equality or inequality through `eq`.
  */
 static bool read_from_ram_check(uintptr_t address,
                                 const sram_ctrl_data_t *expected, bool eq) {
   mmio_region_t region = mmio_region_from_addr(address);
   for (size_t index = 0; index < SRAM_CTRL_DATA_NUM_WORDS; ++index) {
-    // The read data is tested for equality against the expected data, and
-    // then the result is checked against the requested equality condition.
     uint32_t read_word = mmio_region_read32(region, index);
     if ((read_word == expected->words[index]) != eq) {
-      if (eq) {
-        LOG_INFO("Equality check failure:");
-      } else {
-        LOG_INFO("Inequality check failure:");
-      }
-
       LOG_INFO("READ_WORD[%x], CONTROL_WORD[%x], INDEX = %d", read_word,
                expected->words[index], index);
 
@@ -98,45 +40,37 @@ static bool read_from_ram_check(uintptr_t address,
   return true;
 }
 
-bool sram_ctrl_read_from_ram_eq(const sram_ctrl_t *sram,
-                                const sram_ctrl_data_t *expected) {
-  LOG_INFO("Reading from the start of RAM = %x", sram->params->ram_start);
-  if (!read_from_ram_check(sram->params->ram_start, expected, true)) {
-    return false;
-  }
-
-  LOG_INFO("Reading from the end of RAM = %x", sram->params->ram_end);
-  if (!read_from_ram_check(sram->params->ram_end, expected, true)) {
+bool sram_ctrl_testutils_read_check_eq(uintptr_t address,
+                                       const sram_ctrl_data_t *expected) {
+  if (!read_from_ram_check(address, expected, true)) {
+    LOG_INFO("Equality check failure");
     return false;
   }
 
   return true;
 }
 
-bool sram_ctrl_read_from_ram_neq(const sram_ctrl_t *sram,
-                                 const sram_ctrl_data_t *expected) {
-  LOG_INFO("Reading from the start of RAM = %x", sram->params->ram_start);
-  if (!read_from_ram_check(sram->params->ram_start, expected, false)) {
-    return false;
-  }
-
-  LOG_INFO("Reading from the end of RAM = %x", sram->params->ram_end);
-  if (!read_from_ram_check(sram->params->ram_end, expected, false)) {
+bool sram_ctrl_testutils_read_check_neq(uintptr_t address,
+                                        const sram_ctrl_data_t *expected) {
+  if (!read_from_ram_check(address, expected, false)) {
+    LOG_INFO("Inequality check failure");
     return false;
   }
 
   return true;
 }
 
-// Checks whether the SRAM scramble operation has finished.
-static bool scramble_finished(const sram_ctrl_t *sram) {
+/**
+ * Checks whether the SRAM scramble operation has finished.
+ */
+static bool scramble_finished(const dif_sram_ctrl_t *sram_ctrl) {
   dif_sram_ctrl_status_bitfield_t status;
-  CHECK_DIF_OK(dif_sram_ctrl_get_status(&sram->dif, &status));
+  CHECK_DIF_OK(dif_sram_ctrl_get_status(sram_ctrl, &status));
   return status & kDifSramCtrlStatusScrKeyValid;
 }
 
-void sram_ctrl_scramble(const sram_ctrl_t *sram) {
-  CHECK_DIF_OK(dif_sram_ctrl_request_new_key(&sram->dif));
+void sram_ctrl_testutils_scramble(const dif_sram_ctrl_t *sram_ctrl) {
+  CHECK_DIF_OK(dif_sram_ctrl_request_new_key(sram_ctrl));
 
   // Calculate the timeout time.
   // The SRAM Controller documentation says that it takes approximately 800
@@ -157,5 +91,5 @@ void sram_ctrl_scramble(const sram_ctrl_t *sram) {
 
   // Loop until new scrambling key has been obtained.
   LOG_INFO("Waiting for SRAM scrambling to finish");
-  IBEX_SPIN_FOR(scramble_finished(sram), usec);
+  IBEX_SPIN_FOR(scramble_finished(sram_ctrl), usec);
 }

--- a/sw/device/lib/testing/sram_ctrl_testutils.h
+++ b/sw/device/lib/testing/sram_ctrl_testutils.h
@@ -10,43 +10,6 @@
 
 #include "sw/device/lib/dif/dif_sram_ctrl.h"
 
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-
-/**
- * Parameters to be used in utility functions and SRAM tests.
- *
- * Note: utility and SRAM tests will use only a subset of the parameters
- *       that are relevant for the particular use-case.
- */
-typedef struct sram_ctrl_params {
-  /**
-   * SRAM Controller register base.
-   */
-  uintptr_t reg_base;
-  /**
-   * SRAM Controller RAM start address (including the first word).
-   */
-  uintptr_t ram_start;
-  /**
-   * SRAM Controller RAM end address (including the last word).
-   */
-  uintptr_t ram_end;
-} sram_ctrl_params_t;
-
-/**
- * SRAM Controller type.
- */
-typedef struct sram_ctrl {
-  /**
-   * SRAM Controller parameters.
-   */
-  const sram_ctrl_params_t *params;
-  /**
-   * SRAM Controller peripheral interface.
-   */
-  dif_sram_ctrl_t dif;
-} sram_ctrl_t;
-
 /**
  * A typed representation of the test data.
  */
@@ -57,36 +20,25 @@ typedef struct sram_ctrl_data {
 } sram_ctrl_data_t;
 
 /**
- * Initialize Main SRAM Controller.
+ * Writes `data` at the `address` in RAM.
  */
-sram_ctrl_t sram_ctrl_main_init(void);
+void sram_ctrl_testutils_write(uintptr_t address, const sram_ctrl_data_t *data);
 
 /**
- * Initialize Retention SRAM Controller.
- */
-sram_ctrl_t sram_ctrl_ret_init(void);
-
-/**
- * Writes data to the beginning and end of RAM.
- */
-void sram_ctrl_write_to_ram(const sram_ctrl_t *sram,
-                            const sram_ctrl_data_t *data_in);
-
-/**
- * Reads and compares data at the beginning and end of RAM.
+ * Reads data from `address` in SRAM and compares against `expected`.
  *
- * The read data is checked for equality against the `expected` data.
+ * The data is checked for equality.
  */
-bool sram_ctrl_read_from_ram_eq(const sram_ctrl_t *sram,
-                                const sram_ctrl_data_t *expected);
+bool sram_ctrl_testutils_read_check_eq(uintptr_t address,
+                                       const sram_ctrl_data_t *expected);
 
 /**
- * Reads and compares data at the beginning and end of RAM.
+ * Reads data from `address` in SRAM and compares against `expected`.
  *
- * The read data is checked for inequality against the `expected` data.
+ * The data is checked for inequality.
  */
-bool sram_ctrl_read_from_ram_neq(const sram_ctrl_t *sram,
-                                 const sram_ctrl_data_t *expected);
+bool sram_ctrl_testutils_read_check_neq(uintptr_t address,
+                                        const sram_ctrl_data_t *expected);
 
 /**
  * Triggers the SRAM scrambling operation.
@@ -96,6 +48,6 @@ bool sram_ctrl_read_from_ram_neq(const sram_ctrl_t *sram,
  * The SRAM documentation stated that the scrambling operation takes around
  * 800 cycles, so another 50 are added just to be on a safe side.
  */
-void sram_ctrl_scramble(const sram_ctrl_t *sram);
+void sram_ctrl_testutils_scramble(const dif_sram_ctrl_t *sram_ctrl);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SRAM_CTRL_TESTUTILS_H_

--- a/sw/device/tests/sram_ctrl_execution_test_main.c
+++ b/sw/device/tests/sram_ctrl_execution_test_main.c
@@ -15,7 +15,11 @@
 #include "sw/device/lib/testing/test_framework/test_main.h"
 #include "sw/device/lib/testing/test_framework/test_status.h"
 
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
 const test_config_t kTestConfig;
+
+static dif_sram_ctrl_t sram_ctrl;
 
 static volatile const uint32_t kExecParam1 = 2;
 static volatile const uint32_t kExecParam2 = 3;
@@ -147,22 +151,25 @@ static void sram_execution_test(void) {
  * determines whether the execution from SRAM is enabled.
  */
 bool test_main(void) {
-  sram_ctrl_t sram = sram_ctrl_main_init();
+  CHECK_DIF_OK(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
+      &sram_ctrl));
+
   dif_lc_ctrl_t lc;
   CHECK_DIF_OK(dif_lc_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc));
 
   if (otp_ifetch_enabled()) {
     dif_toggle_t state;
-    CHECK_DIF_OK(dif_sram_ctrl_exec_get_enabled(&sram.dif, &state));
+    CHECK_DIF_OK(dif_sram_ctrl_exec_get_enabled(&sram_ctrl, &state));
     if (state == kDifToggleDisabled) {
       bool locked;
       CHECK_DIF_OK(
-          dif_sram_ctrl_is_locked(&sram.dif, kDifSramCtrlLockExec, &locked));
+          dif_sram_ctrl_is_locked(&sram_ctrl, kDifSramCtrlLockExec, &locked));
       CHECK(!locked,
             "Execution is disabled and locked, cannot perform the test");
       CHECK_DIF_OK(
-          dif_sram_ctrl_exec_set_enabled(&sram.dif, kDifToggleEnabled));
+          dif_sram_ctrl_exec_set_enabled(&sram_ctrl, kDifToggleEnabled));
 
       sram_execution_test();
     }


### PR DESCRIPTION
The main purpose of this change is to make the test util more
generic. It also includes some suggestions from the other PRs, such as
avoiding dependencies on top_earlgrey in test utils.

- Renamed test utils API to match accepted style
  `sram_ctrl_testutils_<...>`.

- Testutils are more generic, they operate on the passed in address
  instead of top_earlgrey addresses calculated inside the util.

- Init functions have been removed from test utils.

- Unnecessary data structures have been removed from test utils.

- Test has been simplified to only perform a single check at the start
  of RAM, as opposed to former the start and the end of RAM. If
  required, we can always add the end of RAM check later.

In a nutshell, the test util API was simplified and some of this
complexity was moved to the test instead.

Signed-off-by: Silvestrs Timofejevs <silvestrst@lowrisc.org>