### PR TITLE
[spi_device] Adding and connecting TPM interrupt in tb

### DIFF
--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -27,6 +27,7 @@ package spi_device_env_pkg;
     RxFwModeErr,
     RxFifoOverflow,
     TxFifoUnderflow,
+    TpmHeaderNotEmpty,
     NumSpiDevIntr
   } spi_device_intr_e;
 

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -30,6 +30,7 @@ module tb;
   wire intr_rxerr;
   wire intr_rxoverflow;
   wire intr_txunderflow;
+  wire intr_tpm_header_not_empty;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
@@ -65,7 +66,7 @@ module tb;
     .intr_rx_error_o            (intr_rxerr),
     .intr_rx_overflow_o         (intr_rxoverflow),
     .intr_tx_underflow_o        (intr_txunderflow),
-    .intr_tpm_header_not_empty_o(),
+    .intr_tpm_header_not_empty_o(intr_tpm_header_not_empty),
     .mbist_en_i     (1'b0),
     .scanmode_i     (lc_ctrl_pkg::Off)
   );
@@ -82,6 +83,7 @@ module tb;
   assign interrupts[RxFwModeErr]     = intr_rxerr;
   assign interrupts[RxFifoOverflow]  = intr_rxoverflow;
   assign interrupts[TxFifoUnderflow] = intr_txunderflow;
+  assign interrupts[TpmHeaderNotEmpty] = intr_tpm_header_not_empty;
 
   initial begin
     // drive clk and rst_n from clk_if


### PR DESCRIPTION
Analysing spi_device_intr_test failures, it came that tpm_header_not_empty was not connected in the testbench. Updated tb and env_pkg files to reflect addition of this interrupt.

Signed-off-by: kosta-kojdic <kosta.kojdic@ensilica.com>