### PR TITLE
Bazel implicit opts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,5 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-#https://docs.opentitan.org/doc/rm/c_cpp_coding_style/#cxx-version specifies
+# https://docs.opentitan.org/doc/rm/c_cpp_coding_style/#cxx-version specifies
 build --cxxopt='-std=c++14'
+build --conlyopt='-std=c11'
+
+# Enable toolchain resolution with cc
+build --incompatible_enable_cc_toolchain_resolution

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,6 +1,9 @@
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# bazel_embedded has rules that support building for embedded targets.
+# We maintain a fork to build for RiscV32i
+
 git_repository(
     name = "bazel_embedded",
     commit = "f7299c20ea6182e164adabc336ba2a7c0d8caa71",

--- a/rules/bugfix.bzl
+++ b/rules/bugfix.bzl
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+def find_cc_toolchain(ctx):
+    """
+    Returns the current `CcToolchainInfo`.
+
+    Args:
+      ctx: The rule context for which to find a toolchain.
+
+    Returns:
+      A CcToolchainInfo.
+    """
+
+    # Check the incompatible flag for toolchain resolution.
+    if hasattr(cc_common, "is_cc_toolchain_resolution_enabled_do_not_use") and cc_common.is_cc_toolchain_resolution_enabled_do_not_use(ctx = ctx):
+        if "@rules_cc//cc:toolchain_type" in ctx.toolchains:
+            return ctx.toolchains["@rules_cc//cc:toolchain_type"]
+
+        # Fall back to the legacy implicit attribute lookup.
+    elif hasattr(ctx.attr, "_cc_toolchain"):
+        return ctx.attr._cc_toolchain[cc_common.CcToolchainInfo]
+
+    # We didn't find anything.
+    fail("In order to use find_cc_toolchain, your rule has to depend on C++ toolchain. See find_cc_toolchain.bzl docs for details.")

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -1,0 +1,204 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# TODO(drewmacrae) this should be in rules_cc
+# pending resolution of https://github.com/bazelbuild/rules_cc/issues/75
+load("//rules:bugfix.bzl", "find_cc_toolchain")
+
+"""Rules to build OpenTitan for the RiscV target"""
+
+OPENTITAN_CPU = "@bazel_embedded//constraints/cpu:riscv32"
+OPENTITAN_PLATFORM = "@bazel_embedded//platforms:opentitan_rv32imc"
+
+_targets_compatible_with = {
+    OPENTITAN_PLATFORM: [OPENTITAN_CPU],
+}
+
+def _platforms_transition_impl(settings, attr):
+    return {"//command_line_option:platforms": attr.platform}
+
+_platforms_transition = transition(
+    implementation = _platforms_transition_impl,
+    inputs = [],
+    outputs = ["//command_line_option:platforms"],
+)
+
+def _obj_transform(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    outputs = []
+    for src in ctx.files.srcs:
+        binary = ctx.actions.declare_file("{}.{}".format(src.basename, ctx.attr.suffix))
+        outputs.append(binary)
+        ctx.actions.run(
+            outputs = [binary],
+            inputs = [src] + cc_toolchain.all_files.to_list(),
+            arguments = [
+                "--output-target",
+                ctx.attr.format,
+                src.path,
+                binary.path,
+            ],
+            executable = cc_toolchain.objcopy_executable,
+        )
+    return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
+
+obj_transform = rule(
+    implementation = _obj_transform,
+    cfg = _platforms_transition,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "suffix": attr.string(default = "bin"),
+        "format": attr.string(default = "binary"),
+        "platform": attr.string(default = OPENTITAN_PLATFORM),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+)
+
+def _elf_to_disassembly(ctx):
+    cc_toolchain = find_cc_toolchain(ctx)
+    outputs = []
+    for src in ctx.files.srcs:
+        disassembly = ctx.actions.declare_file("{}.dis".format(src.basename))
+        outputs.append(disassembly)
+        ctx.actions.run_shell(
+            outputs = [disassembly],
+            inputs = [src] + cc_toolchain.all_files.to_list(),
+            arguments = [
+                cc_toolchain.objdump_executable,
+                src.path,
+                disassembly.path,
+            ],
+            command = "$1 --disassemble --headers --line-numbers --source $2 > $3",
+        )
+        return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
+
+elf_to_disassembly = rule(
+    implementation = _elf_to_disassembly,
+    cfg = _platforms_transition,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "platform": attr.string(default = OPENTITAN_PLATFORM),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
+)
+
+def _elf_to_scrambled(ctx):
+    outputs = []
+    for src in ctx.files.srcs:
+        scrambled = ctx.actions.declare_file("{}.scr.40.vmem".format(src.basename))
+        outputs.append(scrambled)
+        ctx.actions.run(
+            outputs = [scrambled],
+            inputs = [
+                src,
+                ctx.files._tool[0],
+                ctx.files._config[0],
+            ],
+            arguments = [
+                ctx.files._config[0].path,
+                src.path,
+                scrambled.path,
+            ],
+            executable = ctx.files._tool[0].path,
+        )
+        return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
+
+elf_to_scrambled = rule(
+    implementation = _elf_to_scrambled,
+    cfg = _platforms_transition,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "platform": attr.string(default = OPENTITAN_PLATFORM),
+        "_tool": attr.label(default = "//hw/ip/rom_ctrl/util:scramble_image.py", allow_files = True),
+        "_config": attr.label(default = "//hw/top_earlgrey:data/autogen/top_earlgrey.gen.hjson", allow_files = True),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+)
+
+def opentitan_binary(
+        name,
+        platform = OPENTITAN_PLATFORM,
+        per_device_deps = {
+            "verilator": ["//sw/device/lib/arch:sim_verilator"],
+            "dv": ["//sw/device/lib/arch:sim_dv"],
+            "fpga_nexysvideo": ["//sw/device/lib/arch:fpga_nexysvideo"],
+            "cw310": ["//sw/device/lib/arch:fpga_cw310"],
+        },
+        output_bin = True,
+        output_disassembly = True,
+        output_scrambled = False,
+        **kwargs):
+    """A helper macro for generating OpenTitan binary artifacts.
+    This macro is mostly a wrapper around cc_binary, but creates artifacts
+    for each of the keys in `per_device_deps`.  The actual artifacts
+    created are an ELF file, a BIN file, the disassembly and the scrambled
+    ROM image.  Each of these output targets performs a bazel transition to
+    the RV32I toolchain to build the target under the correct compiler.
+    Args:
+      @param name: The name of this rule.
+      @param platform: The target platform for the artifacts.
+      @param per_device_deps: The deps for each of the execution environments.
+      @param output_bin: Whether or not to emit a BIN file.
+      @param output_disassembly: Whether or not to emit a disassembly file.
+      @param output_scrambled: Whether or not to emit a SCR file.
+      @param **kwargs: Arguments to forward to `cc_binary`.
+    """
+
+    deps = kwargs.pop("deps", [])
+    targets = []
+    for (device, dev_deps) in per_device_deps.items():
+        devname = "{}_{}".format(name, device)
+        native.cc_binary(
+            name = devname,
+            deps = deps + dev_deps,
+            target_compatible_with = _targets_compatible_with[platform],
+            **kwargs
+        )
+        targets.append(":" + devname + "_elf")
+        obj_transform(
+            name = devname + "_elf",
+            srcs = [devname],
+            format = "elf32-little",
+            suffix = "elf",
+            platform = platform,
+        )
+
+        if output_bin:
+            targets.append(":" + devname + "_bin")
+            obj_transform(
+                name = devname + "_bin",
+                srcs = [devname],
+                platform = platform,
+            )
+
+        if output_disassembly:
+            targets.append(":" + devname + "_dis")
+            elf_to_disassembly(
+                name = devname + "_dis",
+                srcs = [devname],
+                platform = platform,
+            )
+        if output_scrambled:
+            targets.append(":" + devname + "_scr")
+            elf_to_scrambled(
+                name = devname + "_scr",
+                srcs = [devname],
+                platform = platform,
+            )
+
+    native.filegroup(
+        name = name,
+        srcs = targets,
+    )

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -139,6 +139,14 @@ def opentitan_binary(
         output_bin = True,
         output_disassembly = True,
         output_scrambled = False,
+        copts = [
+            "-nostdlib",
+            "-ffreestanding",
+        ],
+        linkopts = [
+            "-nostartfiles",
+            "-nostdlib",
+        ],
         **kwargs):
     """A helper macro for generating OpenTitan binary artifacts.
     This macro is mostly a wrapper around cc_binary, but creates artifacts
@@ -164,6 +172,8 @@ def opentitan_binary(
             name = devname,
             deps = deps + dev_deps,
             target_compatible_with = _targets_compatible_with[platform],
+            copts = copts,
+            linkopts = linkopts,
             **kwargs
         )
         targets.append(":" + devname + "_elf")

--- a/sw/device/BUILD
+++ b/sw/device/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "info_sections",
+    deps = ["info_sections.ld"],
+)

--- a/sw/device/examples/BUILD
+++ b/sw/device/examples/BUILD
@@ -1,0 +1,16 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "demos",
+    srcs = ["demos.c"],
+    hdrs = ["demos.h"],
+    deps = [
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing",
+    ],
+)

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -1,0 +1,47 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary")
+
+opentitan_binary(
+    name = "hello_world",
+    srcs = [
+        "hello_world.c",
+    ],
+    copts = [
+        "-nostdlib",
+        "-ffreestanding",
+        # Disable the date-time warning only for the hello world program.
+        "-Wno-date-time",
+    ],
+    linkopts = [
+        "-nostartfiles",
+        "-nostdlib",
+    ],
+    deps = [
+        ":hello_world_lib",
+        "//sw/device/lib/base:mmio",
+    ],
+)
+
+cc_library(
+    name = "hello_world_lib",
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/examples:demos",
+        "//sw/device/exts/common",
+        "//sw/device/lib:irq",
+        "//sw/device/lib:pinmux",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing",
+    ],
+)

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -15,10 +15,6 @@ opentitan_binary(
         # Disable the date-time warning only for the hello world program.
         "-Wno-date-time",
     ],
-    linkopts = [
-        "-nostartfiles",
-        "-nostdlib",
-    ],
     deps = [
         ":hello_world_lib",
         "//sw/device/lib/base:mmio",

--- a/sw/device/exts/common/BUILD
+++ b/sw/device/exts/common/BUILD
@@ -1,0 +1,28 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "common",
+    srcs = [
+        "flash_crt.S",
+        "ibex_interrupt_vectors.S",
+    ],
+    copts = [
+        "-nostdlib",
+        "-ffreestanding",
+    ],
+    linkopts = [
+        "-T $(location flash_link.ld)",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "flash_link.ld",
+        "//hw/top_earlgrey/sw/autogen:linker_script",
+        "//sw/device:info_sections",
+    ],
+)

--- a/sw/device/lib/BUILD
+++ b/sw/device/lib/BUILD
@@ -10,8 +10,8 @@ cc_library(
     name = "flash_ctrl",
     srcs = ["flash_ctrl.c"],
     hdrs = ["flash_ctrl.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deprecation = "Allegedly depricated",
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -41,8 +41,8 @@ cc_library(
     name = "pinmux",
     srcs = ["pinmux.c"],
     hdrs = ["pinmux.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deprecation = "Allegedly depricated",
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/lib/BUILD
+++ b/sw/device/lib/BUILD
@@ -1,0 +1,51 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "flash_ctrl",
+    srcs = ["flash_ctrl.c"],
+    hdrs = ["flash_ctrl.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deprecation = "Allegedly depricated",
+    deps = [
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+    ],
+)
+
+cc_library(
+    name = "irq",
+    srcs = [
+        "handler.c",
+        "irq.c",
+    ],
+    hdrs = [
+        "handler.h",
+        "irq.h",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/lib/runtime:log",
+    ],
+)
+
+cc_library(
+    name = "pinmux",
+    srcs = ["pinmux.c"],
+    hdrs = ["pinmux.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deprecation = "Allegedly depricated",
+    deps = [
+        "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+    ],
+)

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -1,0 +1,30 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "device",
+    hdrs = ["device.h"],
+)
+
+cc_library(
+    name = "fpga_nexysvideo",
+    srcs = ["device_fpga_nexysvideo.c"],
+    deps = [":device"],
+)
+
+cc_library(
+    name = "fpga_cw310",
+    srcs = ["device_fpga_cw310.c"],
+    deps = [":device"],
+)
+
+cc_library(
+    name = "sim_dv",
+    srcs = ["device_sim_dv.c"],
+    deps = [":device"],
+)
+
+cc_library(
+    name = "sim_verilator",
+    srcs = ["device_sim_verilator.c"],
+    deps = [":device"],
+)

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -97,7 +97,6 @@ extern const uint64_t kUartBaudrate;
  * The pre-calculated UART NCO value based on the Baudrate and Peripheral clock.
  */
 extern const uint32_t kUartNCOValue;
-;
 
 /**
  * An address to write to to report test status.

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -32,9 +32,6 @@ cc_library(
     srcs = [
         "mmio.c",
     ],
-    hdrs = [
-        "mmio.h",
-    ],
     deps = [
         ":base",
     ],

--- a/sw/device/lib/crt/BUILD
+++ b/sw/device/lib/crt/BUILD
@@ -1,0 +1,9 @@
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "crt",
+    srcs = ["crt.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+)

--- a/sw/device/lib/runtime/BUILD
+++ b/sw/device/lib/runtime/BUILD
@@ -1,0 +1,97 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "epmp",
+    srcs = ["epmp.c"],
+    hdrs = ["epmp.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base/freestanding",
+    ],
+)
+
+cc_library(
+    name = "hart",
+    srcs = ["hart.c"],
+    hdrs = ["hart.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":ibex",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/base/freestanding",
+    ],
+)
+
+cc_library(
+    name = "ibex",
+    srcs = ["ibex.c"],
+    hdrs = ["ibex.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+    ],
+)
+
+cc_library(
+    name = "log",
+    srcs = ["log.c"],
+    hdrs = ["log.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/base/freestanding",
+        "//sw/device/lib/runtime:print",
+    ],
+)
+
+cc_library(
+    name = "otbn",
+    srcs = ["otbn.c"],
+    hdrs = ["otbn.h"],
+    deps = [
+        ":log",
+        "//sw/device/lib/dif:otbn",
+    ],
+)
+
+cc_library(
+    name = "pmp",
+    srcs = ["pmp.c"],
+    hdrs = ["pmp.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    textual_hdrs = ["pmp_regions.def"],
+    deps = [
+        "//sw/device/lib/base",
+        "//sw/device/lib/base/freestanding",
+    ],
+)
+
+cc_library(
+    name = "print",
+    srcs = ["print.c"],
+    hdrs = ["print.h"],
+    deps = [
+        "//sw/device/lib/base",
+        "//sw/device/lib/dif:uart",
+    ],
+)
+
+cc_test(
+    name = "print_unittest",
+    srcs = ["print_unittest.cc"],
+    deps = [
+        ":print",
+        "//sw/device/lib/base/testing",
+        "@googletest//:gtest",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -1,0 +1,32 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+# TODO use more specific targets to avoid unnecesary dependencies
+# https://github.com/lowRISC/opentitan/issues/9098
+cc_library(
+    name = "testing",
+    srcs = [
+        "test_framework/test_coverage_none.c",
+        "test_framework/test_status.c",
+    ],
+    hdrs = [
+        "check.h",
+        "test_framework/test_coverage.h",
+        "test_framework/test_status.h",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+    ],
+)


### PR DESCRIPTION
@mcy suggested not passing in copts and linkopts we'd use for every opentitan_binary but instead making them implicit to the macro, so I've added a default and overridden it where hello_world needs an extra copt.