### PR TITLE
[dif unittests] fix mixed signedness warning

### DIFF
--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -22,19 +22,19 @@ using testing::Test;
 class AesTest : public testing::Test, public mock_mmio::MmioTest {
  public:
   void setExpectedKey(const dif_aes_key_share_t &key, uint32_t key_size = 8) {
-    for (int i = 0; i < key_size; ++i) {
+    for (uint32_t i = 0; i < key_size; ++i) {
       ptrdiff_t offset = AES_KEY_SHARE0_0_REG_OFFSET + (i * sizeof(uint32_t));
       EXPECT_WRITE32(offset, key.share0[i]);
     }
 
-    for (int i = 0; i < key_size; ++i) {
+    for (uint32_t i = 0; i < key_size; ++i) {
       ptrdiff_t offset = AES_KEY_SHARE1_0_REG_OFFSET + (i * sizeof(uint32_t));
       EXPECT_WRITE32(offset, key.share1[i]);
     }
   }
 
   void setExpectedIv(const dif_aes_iv_t &iv, const uint32_t kIvSize = 4) {
-    for (int i = 0; i < kIvSize; ++i) {
+    for (uint32_t i = 0; i < kIvSize; ++i) {
       ptrdiff_t offset = AES_IV_0_REG_OFFSET + (i * sizeof(uint32_t));
       EXPECT_WRITE32(offset, iv.iv[i]);
     }

--- a/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
@@ -598,7 +598,7 @@ class BlockingIoTest : public OtpTest {
 };
 
 TEST_F(BlockingIoTest, Read) {
-  for (int i = 0; i < kWords; ++i) {
+  for (size_t i = 0; i < kWords; ++i) {
     auto offset =
         OTP_CTRL_PARAM_OWNER_SW_CFG_OFFSET + 0x10 + i * sizeof(uint32_t);
     EXPECT_READ32(OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + offset, i + 1);


### PR DESCRIPTION
Two of our unit-tests compare signed ints with unsigned ints and throw a
warning when built. This fixes it to silence the error.

Signed-off-by: Drew Macrae <drewmacrae@google.com>