### PR TITLE
[dv/prim_alert_receiver] Fix assertion that consumes large mem

### DIFF
--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -337,7 +337,7 @@ module prim_alert_receiver
   // check in-band init sequence moves FSM into IDLE state
   `ASSERT(InBandInitSequence_A,
       (state_q == InitReq &&
-      mubi4_test_true_strict(init_trig_i) [*1:$]) ##1
+      mubi4_test_true_strict(init_trig_i)) ##1
       (alert_sigint &&
       mubi4_test_false_loose(init_trig_i)) [*1:$] ##1
       (!alert_sigint &&


### PR DESCRIPTION
This PR fixes an assertion sequence with large unbounded delays that
consumes large memory runtime.
If I understand correctly, we do not need to wait every clock cycle in
the init state for `init_trig_i` to change to True. We only need the
condition that we are in the init state and `init_trig_i` changes from
true to false, and in which we have an alert signal integrity error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>