### PR TITLE
[sw/ottf] Optimize OTTF for non-concurrent tests.

### DIFF
--- a/sw/device/lib/testing/test_framework/example_ottf_test.c
+++ b/sw/device/lib/testing/test_framework/example_ottf_test.c
@@ -11,10 +11,11 @@
 
 const test_config_t kTestConfig = {
     .can_clobber_uart = false,
+    .enable_concurrency = true,
 };
 
 bool test_main(void) {
-  // Calling pcTaskGetName() with NULL gets the name of the current task.
-  LOG_INFO("Running %s in FreeRTOS ...", pcTaskGetName(NULL));
+  LOG_INFO("Running on-device test as FreeRTOS task (%s) using the OTTF.",
+           pcTaskGetName(NULL));
   return true;
 }

--- a/sw/device/lib/testing/test_framework/ottf.c
+++ b/sw/device/lib/testing/test_framework/ottf.c
@@ -35,16 +35,22 @@ static void init_uart(void) {
   base_uart_stdout(&uart0);
 }
 
-static void freertos_test_task(void *task_parameters) {
-  bool result = test_main();
-
-  // Must happen before any debug output.
-  if (kTestConfig.can_clobber_uart) {
+static void report_test_status(bool result) {
+  // Reinitialize UART before print any debug output if the test clobbered it.
+  if (kDeviceType != kDeviceSimDV && kTestConfig.can_clobber_uart) {
     init_uart();
+    test_coverage_send_buffer();
   }
 
-  test_coverage_send_buffer();
   test_status_set(result ? kTestStatusPassed : kTestStatusFailed);
+}
+
+// A wrapper function is required to enable `test_main()` and test teardown
+// logic to be invoked as a FreeRTOS task. This wrapper can be used by tests
+// that are run on bare-metal.
+static void test_wrapper(void *task_parameters) {
+  bool result = test_main();
+  report_test_status(result);
 }
 
 int main(int argc, char **argv) {
@@ -55,10 +61,17 @@ int main(int argc, char **argv) {
     init_uart();
   }
 
-  // Run the test, which is contained within `test_main()`, as a FreeRTOS task.
-  xTaskCreate(freertos_test_task, "OTTFTestTask", configMINIMAL_STACK_SIZE,
-              NULL, tskIDLE_PRIORITY + 1, NULL);
-  vTaskStartScheduler();
+  // Run the test.
+  if (kTestConfig.enable_concurrency) {
+    // Run `test_main()` in a FreeRTOS task, allowing other FreeRTOS tasks to be
+    // spawned, if requested in the main test task.
+    xTaskCreate(test_wrapper, "TestTask", configMINIMAL_STACK_SIZE, NULL,
+                tskIDLE_PRIORITY + 1, NULL);
+    vTaskStartScheduler();
+  } else {
+    // Otherwise, launch `test_main()` on bare-metal.
+    test_wrapper(NULL);
+  }
 
   // Unreachable code.
   return 1;

--- a/sw/device/lib/testing/test_framework/ottf.h
+++ b/sw/device/lib/testing/test_framework/ottf.h
@@ -32,6 +32,16 @@ typedef struct test_config {
    * by resetting the UART device before printing debug information.
    */
   bool can_clobber_uart;
+  /**
+   * If true, `test_main()` is run as a FreeRTOS task, enabling test writers to
+   * to spawn additional (concurrent) FreeRTOS tasks within the `test_main()`
+   * execution context.
+   *
+   * If false, `test_main()` is executed on bare-metal, and cannot spawn
+   * additional concurrent execution contexts. This is useful for tests that do
+   * not require concurrency, and seek to minimize simulation runtime.
+   */
+  bool enable_concurrency;
 } test_config_t;
 
 /**

--- a/sw/device/lib/testing/test_framework/test_main.c
+++ b/sw/device/lib/testing/test_framework/test_main.c
@@ -40,11 +40,11 @@ int main(int argc, char **argv) {
   bool result = test_main();
 
   // Must happen before any debug output.
-  if (kTestConfig.can_clobber_uart) {
+  if (kDeviceType != kDeviceSimDV && kTestConfig.can_clobber_uart) {
     init_uart();
+    test_coverage_send_buffer();
   }
 
-  test_coverage_send_buffer();
   test_status_set(result ? kTestStatusPassed : kTestStatusFailed);
 
   // Unreachable code.


### PR DESCRIPTION
Concurrency tests require a thin OS layer (e.g., FreeRTOS) to be able to spawn multiple tasks to stress the hardware. However, the majority of chip-level tests are sequential, and do not require any concurrency support from the OTTF. To minimize simulation runtimes for these tests, a configuration option is added to the OTTF test configuration struct to allow test developers to run their tests: 1) on bare-metal or 2) as a FreeRTOS task.

This partially addresses #8015, which proposes refactoring the on-device test framework to support concurrency testing.

Signed-off-by: Timothy Trippel <ttrippel@google.com>