### PR TITLE
[sram/dv] Fix executable test and tl_err test

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
@@ -27,15 +27,9 @@ class sram_ctrl_executable_vseq extends sram_ctrl_multiple_keys_vseq;
     super.pre_start();
   endtask
 
-  task body();
-    `DV_SPINWAIT_EXIT(
-        forever begin
-          randomize_and_drive_ifetch_en();
-          cfg.clk_rst_vif.wait_clks($urandom_range(100, 500));
-        end
-        ,
-        super.body();
-    )
+  task req_scr_key();
+    super.req_scr_key();
+    randomize_and_drive_ifetch_en();
   endtask
 
   task randomize_and_drive_ifetch_en();

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -62,7 +62,7 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
 
       // Request a new scrambling key
-      // req_scr_key();
+      req_scr_key();
 
       fork
         begin


### PR DESCRIPTION
1. Fixed sram_ctrl_main_executable
  - change to only configure CSR exec, hw_debug_en and en_sram_ifetch
  at the begining of each iteration rather than randomly do it during
  mem access, so that scb doesn't need to be very cycle accurate
  - fix type of `a_user.instr_type`

2. Fixed tl_err test. The mem error needs to be handled separately as
instr_type may cause tl_err.

3. uncommented `req_scr_key` which was a mistake when solving conflict
Signed-off-by: Weicai Yang <weicai@google.com>