### PR TITLE
[sw/silicon_creator] Minor fixups for mask ROM OTBN driver.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -57,9 +57,8 @@ static otbn_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
   return kOtbnErrorOk;
 }
 
-otbn_error_t otbn_execute(void) {
+void otbn_execute(void) {
   abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdExecute);
-  return kOtbnErrorOk;
 }
 
 bool otbn_is_busy() {

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -73,12 +73,9 @@ typedef enum otbn_error_t {
   } while (0)
 
 /**
- * Start the execution of the application loaded into OTBN
- *
- * @return `kOtbnErrorInvalidArgument` if `start_addr` is invalid,
- * `kOtbnErrorOk` otherwise.
+ * Start the execution of the application loaded into OTBN.
  */
-otbn_error_t otbn_execute(void);
+void otbn_execute(void);
 
 /**
  * Is OTBN busy executing an application?

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -32,7 +32,7 @@ TEST_F(StartTest, Success) {
   // Send EXECUTE command.
   EXPECT_ABS_WRITE32(base_ + OTBN_CMD_REG_OFFSET, kOtbnCmdExecute);
 
-  EXPECT_EQ(otbn_execute(), kOtbnErrorOk);
+  otbn_execute();
 }
 
 class IsBusyTest : public OtbnTest {};

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -91,7 +91,7 @@ enum module_ {
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   X(kErrorOtpBadAlignment,            ERROR_(1, kModuleOtp, kInvalidArgument)), \
-  X(kErrorOtbnInternal,               ERROR_(4, kModuleOtbn, kInternal)), \
+  X(kErrorOtbnInternal,               ERROR_(1, kModuleOtbn, kInternal)), \
   X(kErrorFlashCtrlDataRead,          ERROR_(1, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoRead,          ERROR_(2, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataWrite,         ERROR_(3, kModuleFlashCtrl, kInternal)), \

--- a/sw/device/silicon_creator/lib/otbn_util.c
+++ b/sw/device/silicon_creator/lib/otbn_util.c
@@ -71,7 +71,8 @@ otbn_error_t otbn_execute_app(otbn_t *ctx) {
     return kOtbnErrorInvalidArgument;
   }
 
-  return otbn_execute();
+  otbn_execute();
+  return kOtbnErrorOk;
 }
 
 otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,


### PR DESCRIPTION
Follow-up to #8966

Adjusts the return type and comment for `otbn_execute()` to reflect that it no longer has any path to return errors. Also fix the error code for OTBN internal errors.