### PR TITLE
[entropy_src/rtl] repcnt health tests fail pulses

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
@@ -103,7 +103,7 @@ module entropy_src_repcnt_ht #(
     );
 
   // the pulses will be only one clock in length
-  assign test_fail_pulse_o = active_i && (test_cnt > '0);
+  assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
   assign test_cnt_o = test_cnt;
   assign count_err_o = test_cnt_err || (|rep_cntr_err);
 

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
@@ -100,7 +100,7 @@ module entropy_src_repcnts_ht #(
 
 
   // the pulses will be only one clock in length
-  assign test_fail_pulse_o = active_i && (test_cnt > '0);
+  assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
   assign test_cnt_o = test_cnt;
   assign count_err_o = test_cnt_err || (|rep_cntr_err);
 


### PR DESCRIPTION
When rep count health tests fails, the signal is on solid.
To properly predict counter values, the fail signal needs to be a pulse.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>