### PR TITLE
[fpv] Fix fpv enum cast err

### DIFF
--- a/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
+++ b/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
@@ -11,6 +11,11 @@ set_message -error VERI-9030
 # Error out when a parameter is defined twice for an instance
 set_message -error VERI-1402
 
+# Downgrade the enum cast error to warnings.
+# For example: JasperGold will throw an error and terminate if design assign an int to an enum
+# type.
+set_message -warning VERI-1348
+
 # Disabling warnings:
 # We use parameter instead of localparam in packages to allow redefinition
 # at elaboration time.

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -108,7 +108,8 @@
 % endfor
 % for src in clocks.derived_srcs.values():
 
-  prim_mubi_pkg::mubi4_t ${src.name}_div_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] ${src.name}_div_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -126,7 +127,7 @@
     .rst_ni(rst_${src.src.name}_ni),
     .step_down_req_i(${src.src.name}_step_down_req),
     .step_down_ack_o(step_down_acks[${loop.index}]),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(${src.name}_div_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(${src.name}_div_scanmode[0])),
     .clk_o(clk_${src.name}_i)
   );
 % endfor
@@ -392,7 +393,8 @@
     .q_o(${k}_sw_en)
   );
 
-  prim_mubi_pkg::mubi4_t ${k}_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] ${k}_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -410,7 +412,7 @@
   ) u_${k}_cg (
     .clk_i(clk_${v.src.name}_root),
     .en_i(${k}_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(${k}_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(${k}_scanmode[0])),
     .clk_o(clocks_o.${k})
   );
 
@@ -449,7 +451,8 @@
     .q_o(${clk}_hint)
   );
 
-  prim_mubi_pkg::mubi4_t ${clk}_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] ${clk}_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -473,7 +476,7 @@
   ) u_${clk}_cg (
     .clk_i(clk_${sig.src.name}_root),
     .en_i(${clk}_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(${clk}_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(${clk}_scanmode[0])),
     .clk_o(clocks_o.${clk})
   );
 

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -74,7 +74,8 @@ module rstmgr
 
   for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
 
-      prim_mubi_pkg::mubi4_t por_scanmode;
+      // Declared as size 1 packed array to avoid FPV warning.
+      prim_mubi_pkg::mubi4_t [0:0] por_scanmode;
       prim_mubi4_sync #(
         .NumCopies(1),
         .AsyncOn(0)
@@ -90,7 +91,7 @@ module rstmgr
         .clk_i(clk_aon_i),
         .rst_ni(por_n_i[i]),
         .scan_rst_ni,
-        .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode)),
+        .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode[0])),
         .rst_no(rst_por_aon_n[i])
       );
 
@@ -121,7 +122,7 @@ module rstmgr
       ) u_por_domain_mux (
         .clk0_i(rst_por_aon_premux),
         .clk1_i(scan_rst_ni),
-        .sel_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode)),
+        .sel_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode[0])),
         .clk_o(rst_por_aon_n[i])
       );
 
@@ -235,7 +236,8 @@ module rstmgr
   logic [PowerDomains-1:0] rst_lc_src_n;
   logic [PowerDomains-1:0] rst_sys_src_n;
 
-  prim_mubi_pkg::mubi4_t rst_ctrl_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] rst_ctrl_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -249,7 +251,7 @@ module rstmgr
   // lc reset sources
   rstmgr_ctrl u_lc_src (
     .clk_i,
-    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode)),
+    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
     .rst_ni,
     .rst_req_i(pwr_i.rst_lc_req),
@@ -260,7 +262,7 @@ module rstmgr
   // sys reset sources
   rstmgr_ctrl u_sys_src (
     .clk_i,
-    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode)),
+    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
     .rst_ni,
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -110,7 +110,8 @@
   );
 
 
-  prim_mubi_pkg::mubi4_t io_div2_div_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] io_div2_div_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -128,11 +129,12 @@
     .rst_ni(rst_io_ni),
     .step_down_req_i(io_step_down_req),
     .step_down_ack_o(step_down_acks[0]),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(io_div2_div_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(io_div2_div_scanmode[0])),
     .clk_o(clk_io_div2_i)
   );
 
-  prim_mubi_pkg::mubi4_t io_div4_div_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] io_div4_div_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -150,7 +152,7 @@
     .rst_ni(rst_io_ni),
     .step_down_req_i(io_step_down_req),
     .step_down_ack_o(step_down_acks[1]),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(io_div4_div_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(io_div4_div_scanmode[0])),
     .clk_o(clk_io_div4_i)
   );
 
@@ -836,7 +838,8 @@
     .q_o(clk_io_div4_peri_sw_en)
   );
 
-  prim_mubi_pkg::mubi4_t clk_io_div4_peri_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_io_div4_peri_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -854,7 +857,7 @@
   ) u_clk_io_div4_peri_cg (
     .clk_i(clk_io_div4_root),
     .en_i(clk_io_div4_peri_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_div4_peri_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_div4_peri_scanmode[0])),
     .clk_o(clocks_o.clk_io_div4_peri)
   );
 
@@ -877,7 +880,8 @@
     .q_o(clk_io_div2_peri_sw_en)
   );
 
-  prim_mubi_pkg::mubi4_t clk_io_div2_peri_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_io_div2_peri_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -895,7 +899,7 @@
   ) u_clk_io_div2_peri_cg (
     .clk_i(clk_io_div2_root),
     .en_i(clk_io_div2_peri_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_div2_peri_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_div2_peri_scanmode[0])),
     .clk_o(clocks_o.clk_io_div2_peri)
   );
 
@@ -918,7 +922,8 @@
     .q_o(clk_usb_peri_sw_en)
   );
 
-  prim_mubi_pkg::mubi4_t clk_usb_peri_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_usb_peri_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -936,7 +941,7 @@
   ) u_clk_usb_peri_cg (
     .clk_i(clk_usb_root),
     .en_i(clk_usb_peri_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_usb_peri_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_usb_peri_scanmode[0])),
     .clk_o(clocks_o.clk_usb_peri)
   );
 
@@ -959,7 +964,8 @@
     .q_o(clk_io_peri_sw_en)
   );
 
-  prim_mubi_pkg::mubi4_t clk_io_peri_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_io_peri_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -977,7 +983,7 @@
   ) u_clk_io_peri_cg (
     .clk_i(clk_io_root),
     .en_i(clk_io_peri_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_peri_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_peri_scanmode[0])),
     .clk_o(clocks_o.clk_io_peri)
   );
 
@@ -1020,7 +1026,8 @@
     .q_o(clk_main_aes_hint)
   );
 
-  prim_mubi_pkg::mubi4_t clk_main_aes_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_main_aes_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -1044,7 +1051,7 @@
   ) u_clk_main_aes_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_aes_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_aes_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_aes_scanmode[0])),
     .clk_o(clocks_o.clk_main_aes)
   );
 
@@ -1069,7 +1076,8 @@
     .q_o(clk_main_hmac_hint)
   );
 
-  prim_mubi_pkg::mubi4_t clk_main_hmac_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_main_hmac_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -1093,7 +1101,7 @@
   ) u_clk_main_hmac_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_hmac_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_hmac_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_hmac_scanmode[0])),
     .clk_o(clocks_o.clk_main_hmac)
   );
 
@@ -1118,7 +1126,8 @@
     .q_o(clk_main_kmac_hint)
   );
 
-  prim_mubi_pkg::mubi4_t clk_main_kmac_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_main_kmac_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -1142,7 +1151,7 @@
   ) u_clk_main_kmac_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_kmac_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_kmac_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_kmac_scanmode[0])),
     .clk_o(clocks_o.clk_main_kmac)
   );
 
@@ -1167,7 +1176,8 @@
     .q_o(clk_main_otbn_hint)
   );
 
-  prim_mubi_pkg::mubi4_t clk_main_otbn_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_main_otbn_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -1191,7 +1201,7 @@
   ) u_clk_main_otbn_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_otbn_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_otbn_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_main_otbn_scanmode[0])),
     .clk_o(clocks_o.clk_main_otbn)
   );
 
@@ -1216,7 +1226,8 @@
     .q_o(clk_io_div4_otbn_hint)
   );
 
-  prim_mubi_pkg::mubi4_t clk_io_div4_otbn_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] clk_io_div4_otbn_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -1240,7 +1251,7 @@
   ) u_clk_io_div4_otbn_cg (
     .clk_i(clk_io_div4_root),
     .en_i(clk_io_div4_otbn_combined_en),
-    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_div4_otbn_scanmode)),
+    .test_en_i(prim_mubi_pkg::mubi4_test_true_strict(clk_io_div4_otbn_scanmode[0])),
     .clk_o(clocks_o.clk_io_div4_otbn)
   );
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -80,7 +80,8 @@ module rstmgr
 
   for (genvar i = 0; i < PowerDomains; i++) begin : gen_rst_por_aon
 
-      prim_mubi_pkg::mubi4_t por_scanmode;
+      // Declared as size 1 packed array to avoid FPV warning.
+      prim_mubi_pkg::mubi4_t [0:0] por_scanmode;
       prim_mubi4_sync #(
         .NumCopies(1),
         .AsyncOn(0)
@@ -96,7 +97,7 @@ module rstmgr
         .clk_i(clk_aon_i),
         .rst_ni(por_n_i[i]),
         .scan_rst_ni,
-        .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode)),
+        .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode[0])),
         .rst_no(rst_por_aon_n[i])
       );
 
@@ -127,7 +128,7 @@ module rstmgr
       ) u_por_domain_mux (
         .clk0_i(rst_por_aon_premux),
         .clk1_i(scan_rst_ni),
-        .sel_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode)),
+        .sel_i(prim_mubi_pkg::mubi4_test_true_strict(por_scanmode[0])),
         .clk_o(rst_por_aon_n[i])
       );
 
@@ -241,7 +242,8 @@ module rstmgr
   logic [PowerDomains-1:0] rst_lc_src_n;
   logic [PowerDomains-1:0] rst_sys_src_n;
 
-  prim_mubi_pkg::mubi4_t rst_ctrl_scanmode;
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] rst_ctrl_scanmode;
   prim_mubi4_sync #(
     .NumCopies(1),
     .AsyncOn(0)
@@ -255,7 +257,7 @@ module rstmgr
   // lc reset sources
   rstmgr_ctrl u_lc_src (
     .clk_i,
-    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode)),
+    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
     .rst_ni,
     .rst_req_i(pwr_i.rst_lc_req),
@@ -266,7 +268,7 @@ module rstmgr
   // sys reset sources
   rstmgr_ctrl u_sys_src (
     .clk_i,
-    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode)),
+    .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
     .rst_ni,
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),


### PR DESCRIPTION
This PR fixes two compile errors in FPV:

1). In otp_ctrl_part_pkg, autogenerated code assign an enum type with an integer.
I think this is fine so I downgrade the error to warning.

2). The output of prim_mubi4_sync is an array of mubi4. However the output array size is 0.
Jaspergold still think the output is an array so I change the declaration from a mubi to an array of mubi with size 1.