### PR TITLE
[dv/pwrmgr] Add reset test

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -156,7 +156,7 @@
              conditional resets inputs.
             '''
       milestone: V2
-      tests: []
+      tests: ["pwrmgr_reset"]
     }
     {
       name: main_power_glitch_reset
@@ -166,7 +166,7 @@
             A power glitch causes an unconditional reset.
 
             **Stimulus**:
-            - Set the input from AST indicating a main power glitch.
+            - Set the rst_main_ni input low indicating a main power glitch.
 
             **Checks**:
             - Waits for fast fsm to become active reading `ctrl_cfg_regwen`
@@ -174,11 +174,10 @@
             - Checks the `reset_status` CSRs.
             - Checks `ip_clk_en` output has a low transition.
             - Checks the output `pwr_rst_req.reset_cause` matches HwReq.
-            - Checks the output `pwr_rst_req.rstreqs` matches the enabled
-              resets.
+            - Checks the output `pwr_rst_req.rstreqs` matches power glitch.
             '''
       milestone: V2
-      tests: []
+      tests: ["pwrmgr_reset"]
     }
     {
       name: reset_wakeup_race

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
@@ -20,6 +20,7 @@ filesets:
       - seq_lib/pwrmgr_vseq_list.sv: {is_include_file: true}
       - seq_lib/pwrmgr_base_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_common_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_reset_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_wakeup_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -87,6 +87,14 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
     control_cross: cross core_cp, io_cp, usb_lp_cp, usb_active_cp, main_pd_n_cp, sleep_cp;
   endgroup
 
+  covergroup reset_cg with function sample (resets_out_t resets_out, resets_t resets_en, bit sleep);
+    resets_out_cp: coverpoint resets_out;
+    resets_en_cp: coverpoint resets_en;
+    sleep_cp: coverpoint sleep;
+
+    resets_cross: cross resets_out_cp, resets_en_cp, sleep_cp;
+  endgroup
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
     foreach (wakeup_ctrl_cg_wrap[i]) begin

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
@@ -44,6 +44,9 @@ package pwrmgr_env_pkg;
   typedef bit [pwrmgr_reg_pkg::NumWkups-1:0] wakeups_t;
   typedef bit [pwrmgr_reg_pkg::NumRstReqs-1:0] resets_t;
 
+  // This is used to send all resets to rstmgr.
+  typedef bit [pwrmgr_pkg::HwResetWidth-1:0] resets_out_t;
+
   // functions
 
   // package sources

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -32,6 +32,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
       wakeup_ctrl_coverage_collector();
       wakeup_intr_coverage_collector();
       low_power_coverage_collector();
+      reset_coverage_collector();
     join_none
   endtask
 
@@ -74,6 +75,17 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
         if (cfg.en_cov) begin
           // At this point pwrmgr is awake.
           cov.control_cg.sample(cfg.pwrmgr_vif.control_enables, 1'b0);
+        end
+      end
+  endtask
+
+  // Resets are triggered without deep sleep at this point.
+  // TODO(maturana) Figure out how to determine a reset triggered while in sleep mode.
+  task reset_coverage_collector();
+    forever
+      @(posedge cfg.pwrmgr_vif.pwr_rst_req.reset_cause == pwrmgr_pkg::HwReq) begin
+        if (cfg.en_cov) begin
+          cov.reset_cg.sample(cfg.pwrmgr_vif.pwr_rst_req.rstreqs, cfg.pwrmgr_vif.reset_en, 1'b0);
         end
       end
   endtask
@@ -171,6 +183,9 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
         // rw0c, so writing a 1 is a no-op.
       end
       "reset_en": begin
+        if (data_phase_write) begin
+          cfg.pwrmgr_vif.update_reset_en(item.a_data);
+        end
       end
       "reset_status": begin
         // Read-only.

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The reset test randomly introduces external resets, power glitches, and escalation resets.
+class pwrmgr_reset_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_reset_vseq)
+
+  `uvm_object_new
+
+  rand bit power_glitch_reset;
+  rand bit escalation_reset;
+
+  // TODO(maturana) Enable escalation resets once there is support for driving them.
+  constraint escalation_reset_c {escalation_reset == 1'b0;}
+  constraint resets_en_c {
+    solve resets, power_glitch_reset, escalation_reset before resets_en;
+    |{resets_en & resets, power_glitch_reset, escalation_reset} == 1'b1;
+  }
+
+  constraint wakeups_c {wakeups == 0;}
+  constraint wakeups_en_c {wakeups_en == 0;}
+
+  task body();
+    logic [TL_DW-1:0] value;
+    resets_t enabled_resets;
+
+    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
+    csr_rd_check(.ptr(ral.reset_status[0]), .compare_value(0));
+    for (int i = 0; i < num_trans; ++i) begin
+      `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      enabled_resets = resets_en & resets;
+      `uvm_info(`gfn, $sformatf(
+                "Enabled resets=0x%x, power_reset=%b, escalation=%b",
+                enabled_resets,
+                power_glitch_reset,
+                escalation_reset
+                ), UVM_MEDIUM)
+
+      csr_wr(.ptr(ral.reset_en[0]), .value(resets_en));
+      // This is necessary to propagate reset_en.
+      wait_for_csr_to_propagate_to_slow_domain();
+
+      // Trigger resets. The glitch is sent prior to the externals since if it is delayed
+      // it will cause a separate reset after the externals, which complicates the checks.
+      if (power_glitch_reset) begin
+        `uvm_info(`gfn, "Sending power glitch", UVM_MEDIUM)
+        cfg.pwrmgr_vif.glitch_power_reset();
+      end
+      cfg.clk_rst_vif.wait_clks(cycles_before_reset);
+      `uvm_info(`gfn, $sformatf("Sending resets=0x%x", resets), UVM_MEDIUM)
+      cfg.pwrmgr_vif.update_resets(resets);
+
+      cfg.slow_clk_rst_vif.wait_clks(4);
+
+      // This read is not always possible since the CPU may be off.
+      csr_rd_check(.ptr(ral.reset_status[0]), .compare_value(enabled_resets),
+                   .err_msg("failed reset_status check"));
+
+      wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);
+
+      wait_for_fast_fsm_active();
+      `uvm_info(`gfn, "Back from reset", UVM_MEDIUM)
+
+      check_wake_info('0, .fall_through(1'b0), .abort(1'b0));
+
+      cfg.slow_clk_rst_vif.wait_clks(4);
+      csr_rd_check(.ptr(ral.reset_status[0]), .compare_value('0));
+    end
+  endtask
+
+endclass : pwrmgr_reset_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "pwrmgr_base_vseq.sv"
+`include "pwrmgr_reset_vseq.sv"
 `include "pwrmgr_smoke_vseq.sv"
 `include "pwrmgr_wakeup_vseq.sv"
 `include "pwrmgr_common_vseq.sv"

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -60,6 +60,11 @@
       run_opts: ["+test_timeout_ns=1000000"]
     }
     {
+      name: pwrmgr_reset
+      uvm_test_seq: pwrmgr_reset_vseq
+      run_opts: ["+test_timeout_ns=1000000"]
+    }
+    {
       name: pwrmgr_wakeup
       uvm_test_seq: pwrmgr_wakeup_vseq
       run_opts: ["+test_timeout_ns=1000000"]

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -51,7 +51,7 @@ module tb;
     .rst_ni     (rst_n),
     .clk_slow_i (clk_slow),
     .rst_slow_ni(rst_slow_n),
-    .rst_main_ni(rst_slow_n),
+    .rst_main_ni(pwrmgr_if.rst_main_n),
     .clk_esc_i  (clk),
     .rst_esc_ni (rst_n),
 


### PR DESCRIPTION
Add reset test, with no support for resets while in sleep mode at
this point.
Extend environment support for resets.

Signed-off-by: Guillermo Maturana <maturana@google.com>