### PR TITLE
Pattgen v1

### DIFF
--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -67,31 +67,12 @@
               - Clear interrupts quickly
 
             Checking:
-              - Include functional cover point that rollover value is reached and counter is reset:
+              - Include functional cover point that rollover value is reached and counter is re-enabled:
               - Ensure patterns are correctly generated
               - Ensure interrupts are robust asserted and cleared (e.g. at the high data rate)
             '''
       milestone: V2
       tests: ["cnt_rollover"]
-    }
-    {
-      name: alert
-      desc: '''
-            Checking alert errors
-
-            Stimulus:
-            TODO: identify exactly what alerts are triggered, and for the V2
-            find out exactly what triggers alert, if anything
-            Checking:
-              - Check alert `fatal_fault_err` is triggered
-              and err_code is `INVALID_CMD`
-              - Check alert `recov_operation_err` is triggered
-              and err_code is `INVALID_DATA`
-              - Check that operations are not recoverable
-              after `fatal_fault_err` alert
-            '''
-      milestone: V2
-      tests: ["pattgen_alert"]
     }
     {
       name: error
@@ -100,12 +81,12 @@
 
             Stimulus:
               - Programm the configuration registers of the output channels
-              - Randomly reset the in progress output channels
+              - Randomly re-enable the in progress output channels
               - Re-program the configuration registers of the output channels
 
             Checking:
-              - Ensure patterns are dropped when reset
-              - Ensure the output channels get back normal after reset
+              - Ensure patterns are dropped when re-enabled
+              - Ensure the output channels get back normal after re-enable
             '''
       milestone: V2
       tests: ["pattgen_error"]
@@ -113,14 +94,8 @@
     {
       name: stress_all
       desc: '''
-            Combine above sequences in one test then randomly select for running.
-
-            Stimulus:
-              - Start sequences and randomly add reset between each sequence
-
-            Checking:
-              - All sequences should be finished and checked by the scoreboard
-      '''
+            Stress_all test is a random mix of all the test above except csr tests.
+            '''
       milestone: V2
       tests: ["pattgen_stress_all"]
     }
@@ -138,9 +113,6 @@
             * One bit width variables are wrapped in one cover point
               while counters and data have designated cover points
             * Channel enable signal is stand alone cover point
-            * Chennel enable signal is crossed with all other cover points
-            * When both channels are active, the enable signals of each
-              channel are each crossed with cover points of both channels
             '''
     }
     {
@@ -170,27 +142,10 @@
             '''
     }
     {
-      name: alert_cg
-      desc: '''
-            Covers fatal fault error alert when forcing command error
-            and recover operation error alert when forcing data error.
-            Individual alert settings and signals that will be covered include:
-            - fatal fault error alert
-            - recoverable operation error alert
-            '''
-    }
-    {
       name: inter_cg
       desc: '''
-            Covers that all valid settings of Interrupt Enable Register
-            and Interrupt State Register register have been tested.
-            Individual interrupt settings that will be covered include:
-            - Interrupt Enable Register[0] (done_ch0)
-            - Interrupt Enable Register[1] (done_ch1)
-            - Interrupt State Register[0] (done_ch0)
-            - Interrupt State Register[1] (done_ch1)
-            Combinations of Interrupt Enable and Interrupt State
-            registers for each channel will be crossed
+            intr_cg is defined in cip_base_env_cov and 
+            referenced in pattgen_scoreboard
             '''
     }
     {
@@ -245,7 +200,8 @@
             Covers various data_0 values of the channel0 seed pattern ranges,
             to ensure that Pattgen can operate successfully on different pattern lengths.
             we will cover that an acceptable distribution of lengths has been seen,
-            and specifically cover corner cases.
+            and specifically cover corner cases. The covergroup takes data from 
+            TL_UL scoreboard input
             '''
     }
     {
@@ -264,6 +220,12 @@
       name: pattern_data_ch1_1_cg
       desc: '''
             Similar to pattern_data_ch0_1_cg.
+            '''
+    }
+    {
+      name: program_while_busy_cg
+      desc: '''
+            Program the DUT while pattern is being produced to insure current pattern is not being corrupt.
             '''
     }
 

--- a/hw/ip/pattgen/doc/checklist.md
+++ b/hw/ip/pattgen/doc/checklist.md
@@ -118,7 +118,7 @@ Review        | Signoff date            | Not Started |
 
  Type         | Item                                  | Resolution  | Note/Collaterals
 --------------|---------------------------------------|-------------|------------------
-Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Not Started | [Pattgen DV document]({{<relref "dv" >}})
+Documentation | [DV_DOC_DRAFT_COMPLETED][]            | Done        | [Pattgen DV document]({{<relref "dv" >}})
 Documentation | [TESTPLAN_COMPLETED][]                | Done        | [Pattgen Testplan]({{<relref "dv/index.md#testplan" >}})
 Testbench     | [TB_TOP_CREATED][]                    | Done        |
 Testbench     | [PRELIMINARY_ASSERTION_CHECKS_ADDED][]| Done        |
@@ -137,7 +137,7 @@ Coverage      | [SIM_COVERAGE_MODEL_ADDED][]          | Done        |
 Code Quality  | [TB_LINT_SETUP][]                     | Done        |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V1][]       | N/A         | Except for IP module
 Review        | [DESIGN_SPEC_REVIEWED][]              | Done        |
-Review        | [TESTPLAN_REVIEWED][]                 | Not Started |
+Review        | [TESTPLAN_REVIEWED][]                 | Done        |
 Review        | [STD_TEST_CATEGORIES_PLANNED][]       | Done        | Exception (Security, Power, Debug)
 Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 


### PR DESCRIPTION
action items from V1 review


Action item1: - Pattgen_alert test is not needed, also remove the `alert_cg` coverpoint
What is done: - Removed the alert test

Action item2: - Change all reset to re-enable in test description
What is done: -Changed reset to re-enable

Action item3: -In the description remove the reference to reset injection
What is done - Removed reference to stress injection

Action item4: -Instantiate the intr_cg in pattgen_env_cov 
What is done -Intr_cg is defined in cip_base_env_cov and 
referenced in pattgen_scoreboard

Action item5: -When the environment was built, it would be 
better to build on channel and instantiate as many as design defined
What is done: -Built coverage in a channel and instantiated
for two channels

Action item6: -Shell we cross the length, prediv and reps?
Please document the cross
What is done: -Validated the existence of cross between 
length, prediv and reps

Action item7: -Do we need a cross of both channels' enable
signals with all other coverpoints
What is done: -Removed the cross of both channels

Action item8: -Might need a transition covergroup to capture
the value change
What is done: -Verified the code has already transition coverage

Action item9: -In the middle of pattern change the settings
via TLUL interface, and check the pattern is not affected.
What is done: -Generated stimulus to check that the pattern
is not affected and updated compare logic in the scoreboard
to make comparison correct
