### PR TITLE
[sw, cleanup, opentitantool] Minor code formatting cleanups

### DIFF
--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -71,9 +71,7 @@ impl CW310 {
 
 impl Transport for CW310 {
     fn capabilities(&self) -> Capabilities {
-        Capabilities::new(
-            Capability::SPI | Capability::GPIO | Capability::UART,
-        )
+        Capabilities::new(Capability::SPI | Capability::GPIO | Capability::UART)
     }
 
     fn uart(&self, instance: &str) -> Result<Rc<dyn Uart>> {

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -70,7 +70,7 @@ impl BootstrapCommand {
             !(self.filename.len() > 1 || self.filename[0].contains('@')),
             "The `emulator` protocol does not support image assembly"
         );
-        transport.dispatch(&mut transport::Bootstrap {
+        transport.dispatch(&transport::Bootstrap {
             image_path: PathBuf::from(&self.filename[0]),
         })
     }

--- a/sw/host/opentitantool/src/command/load_bitstream.rs
+++ b/sw/host/opentitantool/src/command/load_bitstream.rs
@@ -26,7 +26,7 @@ impl CommandDispatch for LoadBitstream {
         _context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.dispatch(&mut cw310::FpgaProgram {
+        transport.dispatch(&cw310::FpgaProgram {
             bitstream: fs::read(&self.filename)?,
         })
     }

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -72,7 +72,7 @@ fn parse_command_line(opts: Opts, mut args: ArgsOs) -> Result<Opts> {
     let rcfile = if let Some(base) = ProjectDirs::from("org", "opentitan", "opentitantool") {
         base.config_dir().join(&opts.rcfile)
     } else {
-        opts.rcfile.clone()
+        opts.rcfile
     };
 
     // argument[0] is the executable name.


### PR DESCRIPTION
1. Run `cargo clippy`.  Heed its advice.
2. Run `cargo fmt`.

Signed-off-by: Chris Frantz <cfrantz@google.com>