### PR TITLE
[sw/crypto] Make RSA .balign directives smaller.

### DIFF
--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.s
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.s
@@ -68,25 +68,25 @@ mode:
 
 /* Output buffer for the resulting, recovered message. */
 .globl out_buf
-.balign 512
+.balign 32
 out_buf:
   .zero 384
 
 /* Input buffer for the modulus. */
 .globl in_mod
-.balign 512
+.balign 32
 in_mod:
   .zero 384
 
 /* Input buffer for the signature. */
 .globl in_buf
-.balign 512
+.balign 32
 in_buf:
   .zero 384
 
 /* Input buffer for the Montgomery transformation constant R^2. */
 .globl in_rr
-.balign 512
+.balign 32
 in_rr:
   .zero 384
 


### PR DESCRIPTION
Minor fixup to the `.balign` directives in the cryptolib RSA-3072 wrapper assembly. It's sufficient for the 384-bit values to be 32-byte aligned, and more space-efficient.

See this [comment](https://github.com/lowRISC/opentitan/pull/9141#issuecomment-966360000) for context.