### PR TITLE
[lc_ctrl] Added JTAG CSR infrastructure

### DIFF
--- a/hw/dv/sv/dv_utils/dv_report_catcher.sv
+++ b/hw/dv/sv/dv_utils/dv_report_catcher.sv
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Report catcher/demoter
+class dv_report_catcher extends uvm_report_catcher;
+
+  // Stores a new severity indexed by the ID and
+  // the regular expression to match the message
+  protected uvm_severity m_changed_sev[string][string];
+
+  `uvm_object_utils(dv_report_catcher)
+  `uvm_object_new
+
+  // Called for all report messages - defined in uvm_report_catcher
+  virtual function action_e catch();
+    string id = get_id();
+    if (m_changed_sev.exists(id)) begin
+      string report_msg = get_message();
+      foreach (m_changed_sev[id][msg]) begin
+        if (uvm_re_match(msg, report_msg)) begin
+          set_severity(m_changed_sev[id][msg]);
+        end
+      end
+    end
+    return THROW;
+  endfunction
+
+  // Change severity of a message with ID == id and message text
+  // matching msg which is treated as a regular expression
+  virtual function void add_change_sev(string id, string msg, uvm_severity sev);
+    m_changed_sev[id][msg] = sev;
+  endfunction
+
+  // Remove a change entry
+  // If msg == "" then remove all changes for a given id
+  virtual function void remove_change_sev(string id, string msg = "");
+    if (m_changed_sev.exists(id))
+      if (msg == "") begin
+        // Delete all with id if message is blank
+        m_changed_sev.delete(id);
+      end else if (m_changed_sev[id].exists(msg)) begin
+        m_changed_sev[id].delete(msg);
+      end
+  endfunction
+
+endclass

--- a/hw/dv/sv/dv_utils/dv_utils.core
+++ b/hw/dv/sv/dv_utils/dv_utils.core
@@ -17,6 +17,7 @@ filesets:
       - lowrisc:dv:dv_test_status
     files:
       - dv_utils_pkg.sv
+      - dv_report_catcher.sv: {is_include_file: true}
       - dv_report_server.sv: {is_include_file: true}
       - dv_vif_wrap.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/dv/sv/dv_utils/dv_utils_pkg.sv
+++ b/hw/dv/sv/dv_utils/dv_utils_pkg.sv
@@ -215,6 +215,7 @@ package dv_utils_pkg;
 
   // sources
 `ifdef UVM
+  `include "dv_report_catcher.sv"
   `include "dv_report_server.sv"
   `include "dv_vif_wrap.sv"
 `endif

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -2,19 +2,28 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
+class lc_ctrl_env_cfg extends cip_base_env_cfg #(
+  .RAL_T(lc_ctrl_reg_block)
+);
 
   // ext component cfgs
-  push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
-                       .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) m_otp_prog_pull_agent_cfg;
-  push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)) m_otp_token_pull_agent_cfg;
-  alert_esc_agent_cfg  m_esc_scrap_state1_agent_cfg;
-  alert_esc_agent_cfg  m_esc_scrap_state0_agent_cfg;
+  push_pull_agent_cfg #(
+    .HostDataWidth  (OTP_PROG_HDATA_WIDTH),
+    .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)
+  ) m_otp_prog_pull_agent_cfg;
+  push_pull_agent_cfg #(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)) m_otp_token_pull_agent_cfg;
+  alert_esc_agent_cfg m_esc_scrap_state1_agent_cfg;
+  alert_esc_agent_cfg m_esc_scrap_state0_agent_cfg;
   jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
+  uvm_reg_map jtag_riscv_map;
 
   // ext interfaces
-  pwr_lc_vif  pwr_lc_vif;
+  pwr_lc_vif pwr_lc_vif;
   lc_ctrl_vif lc_ctrl_vif;
+
+  // Use JTAG for register accesses
+  // TODO: use multiple address maps
+  bit jtag_csr;
 
   `uvm_object_utils_begin(lc_ctrl_env_cfg)
   `uvm_object_utils_end
@@ -26,34 +35,60 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(lc_ctrl_reg_block));
     tl_intg_alert_name = "fatal_bus_integ_error";
     super.initialize(csr_base_addr);
 
-    m_otp_prog_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
-        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))::type_id::create("m_otp_prog_pull_agent_cfg");
+    m_otp_prog_pull_agent_cfg = push_pull_agent_cfg#(
+      .HostDataWidth  (OTP_PROG_HDATA_WIDTH),
+      .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)
+    )::type_id::create(
+        "m_otp_prog_pull_agent_cfg"
+    );
     `DV_CHECK_RANDOMIZE_FATAL(m_otp_prog_pull_agent_cfg)
-    m_otp_prog_pull_agent_cfg.agent_type            = PullAgent;
-    m_otp_prog_pull_agent_cfg.if_mode               = Device;
+    m_otp_prog_pull_agent_cfg.agent_type = PullAgent;
+    m_otp_prog_pull_agent_cfg.if_mode = Device;
     m_otp_prog_pull_agent_cfg.in_bidirectional_mode = 1;
 
-    m_otp_token_pull_agent_cfg = push_pull_agent_cfg#(
-                                 .HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth))
-        ::type_id::create("m_otp_token_pull_agent_cfg");
+    m_otp_token_pull_agent_cfg =
+        push_pull_agent_cfg#(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth))::type_id::create(
+        "m_otp_token_pull_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_otp_token_pull_agent_cfg)
-    m_otp_token_pull_agent_cfg.agent_type                 = PullAgent;
-    m_otp_token_pull_agent_cfg.if_mode                    = Device;
-    m_otp_token_pull_agent_cfg.in_bidirectional_mode      = 1;
+    m_otp_token_pull_agent_cfg.agent_type = PullAgent;
+    m_otp_token_pull_agent_cfg.if_mode = Device;
+    m_otp_token_pull_agent_cfg.in_bidirectional_mode = 1;
     m_otp_token_pull_agent_cfg.hold_d_data_until_next_req = 1;
 
-    m_esc_scrap_state1_agent_cfg = alert_esc_agent_cfg::type_id::create(
-        "m_esc_scrap_state1_agent_cfg");
+    m_esc_scrap_state1_agent_cfg =
+        alert_esc_agent_cfg::type_id::create("m_esc_scrap_state1_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_esc_scrap_state1_agent_cfg)
     m_esc_scrap_state1_agent_cfg.is_alert = 0;
 
-    m_esc_scrap_state0_agent_cfg = alert_esc_agent_cfg::type_id::create(
-        "m_esc_scrap_state0_agent_cfg");
+    m_esc_scrap_state0_agent_cfg =
+        alert_esc_agent_cfg::type_id::create("m_esc_scrap_state0_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_esc_scrap_state0_agent_cfg)
     m_esc_scrap_state0_agent_cfg.is_alert = 0;
 
     m_jtag_riscv_agent_cfg = jtag_riscv_agent_cfg::type_id::create("m_jtag_riscv_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_jtag_riscv_agent_cfg)
+
+    jtag_csr = 0;
+
+    // Set base address for JTAG map
+    ral.set_base_addr(ral.default_map.get_base_addr(), jtag_riscv_map);
+
+  endfunction
+
+  protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
+    // Clone the resister map for JTAG
+    jtag_riscv_map = clone_reg_map("jtag_riscv_map", ral.default_map);
+  endfunction
+
+  // Use these functions to propagate in_reset to JTAG RISCV agents
+  virtual function void reset_asserted();
+    super.reset_asserted();
+    m_jtag_riscv_agent_cfg.in_reset = 1;
+  endfunction
+
+  virtual function void reset_deasserted();
+    super.reset_deasserted();
+    m_jtag_riscv_agent_cfg.in_reset = 0;
   endfunction
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -27,12 +27,12 @@ package lc_ctrl_env_pkg;
   `include "dv_macros.svh"
 
   // parameters
-  parameter string LIST_OF_ALERTS[] = {"fatal_prog_error",
-                                       "fatal_state_error",
-                                       "fatal_bus_integ_error"};
-  parameter uint   NUM_ALERTS = 3;
-  parameter uint   CLAIM_TRANS_VAL = MuBi8True;
-  parameter uint   NUM_STATES = 24;
+  parameter string LIST_OF_ALERTS[] = {
+    "fatal_prog_error", "fatal_state_error", "fatal_bus_integ_error"
+  };
+  parameter uint NUM_ALERTS = 3;
+  parameter uint CLAIM_TRANS_VAL = MuBi8True;
+  parameter uint NUM_STATES = 24;
 
   // lc_otp_program host data width: lc_state_e width + lc_cnt_e width
   parameter uint OTP_PROG_HDATA_WIDTH = LcStateWidth + LcCountWidth;
@@ -52,6 +52,7 @@ package lc_ctrl_env_pkg;
     lc_ctrl_pkg::lc_tx_t lc_escalate_en_o;
   } lc_outputs_t;
 
+  // verilog_format: off - avoid bad reformatting
   const lc_outputs_t EXP_LC_OUTPUTS[NUM_STATES] = {
     // Raw (fixed size array index 0)
     {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, Off},
@@ -105,6 +106,7 @@ package lc_ctrl_env_pkg;
     // Invalid
     {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, On}
   };
+  // verilog_format: on
 
   // types
   typedef enum bit [1:0] {
@@ -115,7 +117,7 @@ package lc_ctrl_env_pkg;
   } lc_pwr_if_e;
 
   typedef virtual pins_if #(LcPwrIfWidth) pwr_lc_vif;
-  typedef virtual lc_ctrl_if              lc_ctrl_vif;
+  typedef virtual lc_ctrl_if lc_ctrl_vif;
 
   // functions
   function automatic bit valid_state_for_trans(lc_state_e curr_state);
@@ -141,6 +143,7 @@ package lc_ctrl_env_pkg;
                                LcStRma});
   endfunction
 
+  // verilog_format: off - avoid bad reformatting
   function automatic lc_ctrl_pkg::token_idx_e get_exp_token(dec_lc_state_e curr_state,
                                                             dec_lc_state_e next_state);
     // Raw Token
@@ -183,9 +186,10 @@ package lc_ctrl_env_pkg;
       get_exp_token = lc_ctrl_pkg::InvalidTokenIdx;
     end
   endfunction
+  // verilog_format: on
 
   function automatic lc_ctrl_state_pkg::lc_token_t get_random_token();
-    `DV_CHECK_STD_RANDOMIZE_FATAL(get_random_token, , "lc_ctrl_env_pkg");
+    `DV_CHECK_STD_RANDOMIZE_FATAL(get_random_token,, "lc_ctrl_env_pkg");
   endfunction
 
   // package sources

--- a/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
+++ b/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
@@ -3,18 +3,45 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class lc_ctrl_base_test extends cip_base_test #(
-    .CFG_T(lc_ctrl_env_cfg),
-    .ENV_T(lc_ctrl_env)
-  );
+  .CFG_T(lc_ctrl_env_cfg),
+  .ENV_T(lc_ctrl_env)
+);
 
   `uvm_component_utils(lc_ctrl_base_test)
   `uvm_component_new
 
-  // the base class dv_base_test creates the following instances:
-  // lc_ctrl_env_cfg: cfg
-  // lc_ctrl_env:     env
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
 
-  // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
-  // the run_phase; as such, nothing more needs to be done
+    // Enable JTAG TAP CSR access via command line option
+    void'($value$plusargs("jtag_csr=%0b", cfg.jtag_csr));
+
+  endfunction : build_phase
+
+  // Add message demotes here
+  virtual function void add_message_demotes(dv_report_catcher catcher);
+    string msg;
+
+    // Demote field access warnings to infos
+    msg = "\s*Individual field access not available for field.*";
+    catcher.add_change_sev("RegModel", msg, UVM_INFO);
+
+    // Demote field access warnings to infos
+    msg = "\s*Target bus does not support byte enabling.*";
+    catcher.add_change_sev("RegModel", msg, UVM_INFO);
+
+    // Demote address maps warnings
+    msg = "\s*map .* does not seem to be initialized correctly.*";
+    catcher.add_change_sev("RegModel", msg, UVM_INFO);
+
+    // Demote sequencer kill errors
+    msg = {
+      "\s*The task responsible for requesting a wait_for_grant on sequencer ",
+      ".*m_jtag_riscv_agent.sequencer' for sequence .* ",
+      "has been killed, to avoid a deadlock the sequence will be ",
+      "removed from the arbitration queues"
+    };
+    catcher.add_change_sev("SEQREQZMB", msg, UVM_INFO);
+  endfunction
 
 endclass : lc_ctrl_base_test

--- a/hw/ip/lc_ctrl/dv/tests/lc_ctrl_test_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/tests/lc_ctrl_test_pkg.sv
@@ -6,6 +6,7 @@ package lc_ctrl_test_pkg;
   // dep packages
   import uvm_pkg::*;
   import cip_base_pkg::*;
+  import dv_utils_pkg::*;
   import lc_ctrl_env_pkg::*;
 
   // macro includes


### PR DESCRIPTION
- Depends on: https://github.com/lowRISC/opentitan/pull/9149
- Added infrastructure to run CSR and functional tests via JTAG
- Added dv_report_catcher to dv_utils_pkg
- Added clone_reg_map to csr_utils_pkg
- Integrated dv_report_catcher in dv_base_test
- Registered jtag_riscv_reg_adapter to jtag_riscv_map
- Setting jtag_riscv_map as default map if +jtag_csr=1 on the command line

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>