### PR TITLE
[sw, tests] Chip level retention SRAM execution test

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -114,4 +114,11 @@
  */
 #define OT_ATTR_WEAK __attribute__((weak))
 
+/**
+ * Returns the return address of the current function.
+ *
+ * See https://gcc.gnu.org/onlinedocs/gcc/Return-Address.html.
+ */
+#define OT_RETURN_ADDR() __builtin_return_address(0)
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_

--- a/sw/device/lib/runtime/ibex.c
+++ b/sw/device/lib/runtime/ibex.c
@@ -18,6 +18,14 @@ uint32_t ibex_mtval_read(void) {
   return mtval;
 }
 
+uint32_t ibex_mepc_read(void) {
+  uint32_t mepc;
+  CSR_READ(CSR_REG_MEPC, &mepc);
+  return mepc;
+}
+
+void ibex_mepc_write(uint32_t mepc) { CSR_WRITE(CSR_REG_MEPC, mepc); }
+
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
 

--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -93,6 +93,44 @@ uint32_t ibex_mcause_read(void);
 uint32_t ibex_mtval_read(void);
 
 /**
+ * Reads the mepc register.
+ *
+ * When an exception is encountered, the current program counter is saved in
+ * mepc, and the core jumps to the exception address. When an MRET instruction
+ * is executed, the value from mepc replaces the current program counter.
+ *
+ * From the Ibex documentation (found at
+ * https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html)
+ *
+ * Please note that in case of a fault, mepc must be modified to hold the
+ * address of the next instruction, which can be at the 2byte (16bit) or 4byte
+ * (32bit) offset, dependent on the fault cause instruction type (standard or
+ * compressed).
+ *
+ * @return The mepc register value.
+ */
+uint32_t ibex_mepc_read(void);
+
+/**
+ * Writes the mepc register.
+ *
+ * When an exception is encountered, the current program counter is saved in
+ * mepc, and the core jumps to the exception address. When an MRET instruction
+ * is executed, the value from mepc replaces the current program counter.
+ *
+ * From the Ibex documentation (found at
+ * https://ibex-core.readthedocs.io/en/latest/03_reference/cs_registers.html)
+ *
+ * Please note that in case of a fault, mepc must be modified to hold the
+ * address of the next instruction, which can be at the 2byte (16bit) or 4byte
+ * (32bit) offset, dependent on the fault cause instruction type (standard or
+ * compressed).
+ *
+ * @param The new value to be written to the mepc register.
+ */
+void ibex_mepc_write(uint32_t mepc);
+
+/**
  * Initializes the ibex timeout based on current mcycle count.
  *
  * @param timeout_usec Timeout in microseconds.

--- a/sw/device/lib/testing/sram_ctrl_testutils.h
+++ b/sw/device/lib/testing/sram_ctrl_testutils.h
@@ -10,6 +10,16 @@
 
 #include "sw/device/lib/dif/dif_sram_ctrl.h"
 
+/*
+ * Adds the first parameter to the second parameter and returns the result.
+ *
+ * The main use-case is to map this function pointer onto a buffer holding
+ * SRAM execution test instructions. The assumption is that this buffer holds
+ * instruction[0] = add a0, a1, a0, instruction[1] = jalr zero, 0(ra).
+ */
+typedef uint32_t (*sram_ctrl_testutils_exec_function_t)(volatile uint32_t,
+                                                        volatile uint32_t);
+
 /**
  * A typed representation of the test data.
  */

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -658,6 +658,27 @@ sw_tests += {
   }
 }
 
+# SRAM Controller execution from Ret SRAM test.
+sram_ctrl_execution_test_ret_lib = declare_dependency(
+  link_with: static_library(
+    'sram_ctrl_execution_test_ret_lib',
+    sources: ['sram_ctrl_execution_test_ret.c'],
+    dependencies: [
+      sw_lib_dif_sram_ctrl,
+      sw_lib_irq_handlers,
+      sw_lib_runtime_ibex,
+      sw_lib_runtime_log,
+      sw_lib_testing_sram_ctrl_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'sram_ctrl_execution_test_ret': {
+    'library': sram_ctrl_execution_test_ret_lib,
+  }
+}
+
 ###############################################################################
 # Auto-generated tests
 ###############################################################################

--- a/sw/device/tests/sram_ctrl_execution_test_main.c
+++ b/sw/device/tests/sram_ctrl_execution_test_main.c
@@ -87,13 +87,6 @@ __attribute__((section(
     0x00008067,
 };
 
-/**
- * Adds the first parameter to the second parameter and returns the result.
- *
- * Maps to the `execution_test_instructions` buffer as the function body.
- */
-typedef uint32_t (*ram_exec_function_t)(volatile uint32_t, volatile uint32_t);
-
 static bool otp_ifetch_enabled(void) {
   dif_otp_ctrl_t otp;
   CHECK_DIF_OK(dif_otp_ctrl_init(
@@ -130,7 +123,8 @@ static bool otp_ifetch_enabled(void) {
  */
 static void sram_execution_test(void) {
   // Map the function pointer onto the instruction buffer.
-  ram_exec_function_t func = (ram_exec_function_t)execution_test_instructions;
+  sram_ctrl_testutils_exec_function_t func =
+      (sram_ctrl_testutils_exec_function_t)execution_test_instructions;
 
   uintptr_t func_address = (uintptr_t)func;
   CHECK(func_address >= kRamStartAddr && func_address <= kRamEndAddr,

--- a/sw/device/tests/sram_ctrl_execution_test_ret.c
+++ b/sw/device/tests/sram_ctrl_execution_test_ret.c
@@ -1,0 +1,120 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/dif/dif_sram_ctrl.h"
+#include "sw/device/lib/handler.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/sram_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/test_main.h"
+#include "sw/device/lib/testing/test_framework/test_status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig;
+
+static dif_sram_ctrl_t sram_ctrl;
+
+/**
+ * This flag is used to verify that the instruction access fault has occurred,
+ * and has been successfully serviced. Declared as volatile, because it is
+ * referenced in the fault handler, as well as the main test flow.
+ */
+static volatile bool instruction_access_fault;
+
+static const uint32_t kRetRamStartAddr =
+    TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR;
+static const uint32_t kRetRamEndAddr =
+    TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
+    TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES - 1;
+
+/**
+ * Handles an exception.
+ *
+ * This exception handler only processes the faults that are relevant. It falls
+ * into an infinite `wait_for_interrupt` routine for the rest.
+ *
+ * The controlled fault originates in the retention SRAM, which means that
+ * normally the return address would be calculated relative to the offending
+ * instruction. However, due to execution from retention SRAM being permanently
+ * disabled, this approach would not work.
+ *
+ * Instead the control needs to be returned to the caller. In other words
+ * sram_execution_test -> retention_sram -> exception_handler
+ * -> sram_execution_test.
+ *
+ * Before the jump into the exception handler, the register set is saved on
+ * stack, which means that the return address can be loaded from there.
+ */
+void handler_exception(void) {
+  uintptr_t ret_addr = (uintptr_t)OT_RETURN_ADDR();
+  LOG_INFO("Fault address: mepc = 0x%x, return address = 0x%x",
+           ibex_mepc_read(), ret_addr);
+
+  exc_id_t exception_id = ibex_mcause_read();
+  switch (exception_id) {
+    case kInstAccFault:
+      LOG_INFO("Instruction access fault handler");
+      instruction_access_fault = true;
+      ibex_mepc_write(ret_addr);
+      break;
+    case kInstIllegalFault:
+      LOG_INFO("Instruction illegal fault handler");
+      instruction_access_fault = false;
+      ibex_mepc_write(ret_addr);
+      break;
+    default:
+      LOG_FATAL("Unexpected exception id = 0x%x", exception_id);
+      while (true) {
+        wait_for_interrupt();
+      }
+  }
+}
+
+/**
+ * Used to execute instructions in Retention SRAM.
+ */
+typedef void (*sram_ctrl_instruction_fault_function_t)(void);
+
+/**
+ * Performs SRAM execution test.
+ *
+ * `sram_ctrl_instruction_fault_function_t` is "mapped" onto the
+ * block of memory in Retention SRAM starting at `kRetRamStartAddr` and the
+ * size of `SRAM_CTRL_DATA_NUM_BYTES` that holds `unimp` instructions.
+ *
+ * Please see the following document for more context:
+ * https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md
+ */
+static void sram_execution_test(void) {
+  memset((void *)kRetRamStartAddr, 0, SRAM_CTRL_DATA_NUM_BYTES);
+
+  // Map the function pointer onto the instruction buffer.
+  sram_ctrl_instruction_fault_function_t instruction_access_fault_func =
+      (sram_ctrl_instruction_fault_function_t)kRetRamStartAddr;
+
+  uintptr_t func_address = (uintptr_t)instruction_access_fault_func;
+  CHECK(func_address >= kRetRamStartAddr && func_address <= kRetRamEndAddr,
+        "Test code resides outside of the Ret SRAM: function address = %x",
+        func_address);
+
+  instruction_access_fault = false;
+  instruction_access_fault_func();
+  CHECK(instruction_access_fault, "Expected instruction access fault");
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR),
+      &sram_ctrl));
+
+  sram_execution_test();
+
+  return true;
+}


### PR DESCRIPTION
# Introduction

This test aims to ensure that the execution from retention SRAM fails unconditionally. The overall change consists some refactoring and adding of relevant testutils to de-duplicate some common code.

# TODOs / follow-ups

- Move `execution_test_instructions` into the SRAM testutils library (will provide an API to return the address for the callers to copy into test relevant addresses)
- Improve the test accuracy, please see questions section
- Refactor PMP tests to use newly added fault handler testutils

# Questions

- Should we enable EXEC from SRAM, make sure that the OTP switch is on to make sure that execution from the retention SRAM is prohibited regardless?