### PR TITLE
[flash_ctrl] Fix bank erase / info partition issue

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -484,14 +484,13 @@
           { bits: "8",
             name: "PARTITION_SEL",
             desc: '''
-              Selects either info or data partition for operation.
+              When doing a read, program or page erase operation, selects either info or data partition for operation.
+              When 0, select data partition - this is the portion of flash that is accessible both by the host and by the controller.
+              When 1, select info partition - this is the portion of flash that is only accessible by the controller.
 
-              When 0, select data partition - this is the portion of flash that is accessible both
-              by the host and by the controller.
-
-              When 1, select info partition - this is the portion of flash that is only accessible
-              by the controller.
-
+              When doing a bank erase operation, selects info partition also for erase.
+              When 0, bank erase only erases data partition.
+              When 1, bank erase erases data partition and info partition.
             '''
             resval: "0"
           },

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -481,14 +481,13 @@
           { bits: "8",
             name: "PARTITION_SEL",
             desc: '''
-              Selects either info or data partition for operation.
+              When doing a read, program or page erase operation, selects either info or data partition for operation.
+              When 0, select data partition - this is the portion of flash that is accessible both by the host and by the controller.
+              When 1, select info partition - this is the portion of flash that is only accessible by the controller.
 
-              When 0, select data partition - this is the portion of flash that is accessible both
-              by the host and by the controller.
-
-              When 1, select info partition - this is the portion of flash that is only accessible
-              by the controller.
-
+              When doing a bank erase operation, selects info partition also for erase.
+              When 0, bank erase only erases data partition.
+              When 1, bank erase erases data partition and info partition.
             '''
             resval: "0"
           },

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -410,7 +410,6 @@ module flash_phy_rd
   logic hint_forward;
   logic hint_descram;
   logic data_err_q;
-  logic ecc_en_q; // this is used for the integrity ECC check
   logic [NumBuf-1:0] alloc_q2;
 
   assign scramble_stage_rdy = data_fifo_rdy & mask_fifo_rdy;
@@ -456,7 +455,7 @@ module flash_phy_rd
 
   //TODO: Cleanup the FIFO popping a bit more
   prim_fifo_sync #(
-    .Width   (PlainDataWidth + 4 + NumBuf),
+    .Width   (PlainDataWidth + 3 + NumBuf),
     .Pass    (0),
     .Depth   (2),
     .OutputZeroIfEmpty (1)
@@ -466,12 +465,12 @@ module flash_phy_rd
     .clr_i   (1'b0),
     .wvalid_i(rd_done),
     .wready_o(data_fifo_rdy),
-    .wdata_i ({alloc_q, descram, forward, data_err, rd_attrs.ecc, data_int}),
+    .wdata_i ({alloc_q, descram, forward, data_err, data_int}),
     .depth_o (unused_rd_depth),
     .full_o (),
     .rvalid_o(fifo_data_valid),
     .rready_i(rd_and_mask_fifo_pop),
-    .rdata_o ({alloc_q2, descram_q, forward_q, data_err_q, ecc_en_q, fifo_data})
+    .rdata_o ({alloc_q2, descram_q, forward_q, data_err_q, fifo_data})
   );
 
   // storage for mask calculations

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -490,14 +490,13 @@
           { bits: "8",
             name: "PARTITION_SEL",
             desc: '''
-              Selects either info or data partition for operation.
+              When doing a read, program or page erase operation, selects either info or data partition for operation.
+              When 0, select data partition - this is the portion of flash that is accessible both by the host and by the controller.
+              When 1, select info partition - this is the portion of flash that is only accessible by the controller.
 
-              When 0, select data partition - this is the portion of flash that is accessible both
-              by the host and by the controller.
-
-              When 1, select info partition - this is the portion of flash that is only accessible
-              by the controller.
-
+              When doing a bank erase operation, selects info partition also for erase.
+              When 0, bank erase only erases data partition.
+              When 1, bank erase erases data partition and info partition.
             '''
             resval: "0"
           },


### PR DESCRIPTION
- Fixes #8934
- Software is now able to select whether info partitions should
  also be erased when bank erase is invoked.

Signed-off-by: Timothy Chen <timothytim@google.com>