### PR TITLE
[opentitantool] Enable Command Sequencing

### DIFF
--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -9,3 +9,25 @@ pub mod hello;
 pub mod image;
 pub mod load_bitstream;
 pub mod spi;
+
+use anyhow::Result;
+use erased_serde::Serialize;
+use std::any::Any;
+use structopt::StructOpt;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+
+#[derive(Debug, StructOpt)]
+/// No Operation.
+pub struct NoOp {}
+
+impl CommandDispatch for NoOp {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        Ok(None)
+    }
+}


### PR DESCRIPTION
1. Add a `--exec` option that will allow multiple commands to run in
   sequence.

   Example:
     - Start the console with a timeout of zero (ie: force UART init).
     - Bootstrap `foo-code.bin` into the target.
     - Start the console in interactive mode to view the output.

   ```
   $ opentitantool --interface=cw310 \
       --exec="console -q -t 0" \
       --exec="bootstrap foo-code.bin" \
       console
   ```

Signed-off-by: Chris Frantz <cfrantz@google.com>