### PR TITLE
[pwrmgr] Streamline usb clock enable controls

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -307,7 +307,10 @@
             { value: "1",
               name: "Enabled",
               desc: '''
-                USB clock enabled during low power state
+                USB clock enabled during low power state.
+
+                However, if !!CONTROL.MAIN_PD_N is 0, USB clock is disabled
+                during low power state.
                 '''
             },
           ]

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
@@ -54,6 +54,6 @@ interface pwrmgr_clock_enables_sva_if (
   `ASSERT(CoreClkPwrDown_A, transitionDown_S |=> core_clk_en == core_clk_en_i, clk_i,
           reset_or_disable)
   `ASSERT(IoClkPwrDown_A, transitionDown_S |=> io_clk_en == io_clk_en_i, clk_i, reset_or_disable)
-  `ASSERT(UsbClkPwrDown_A, transitionDown_S |=> usb_clk_en == main_pd_ni & usb_clk_en_lp_i, clk_i,
+  `ASSERT(UsbClkPwrDown_A, transitionDown_S |=> usb_clk_en == (main_pd_ni & usb_clk_en_lp_i), clk_i,
           reset_or_disable)
 endinterface

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
@@ -54,6 +54,6 @@ interface pwrmgr_clock_enables_sva_if (
   `ASSERT(CoreClkPwrDown_A, transitionDown_S |=> core_clk_en == core_clk_en_i, clk_i,
           reset_or_disable)
   `ASSERT(IoClkPwrDown_A, transitionDown_S |=> io_clk_en == io_clk_en_i, clk_i, reset_or_disable)
-  `ASSERT(UsbClkPwrDown_A, transitionDown_S |=> usb_clk_en == usb_clk_en_lp_i, clk_i,
+  `ASSERT(UsbClkPwrDown_A, transitionDown_S |=> usb_clk_en == main_pd_ni & usb_clk_en_lp_i, clk_i,
           reset_or_disable)
 endinterface

--- a/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
@@ -81,10 +81,16 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
   logic usb_clk_en_lp;
   assign usb_clk_en_lp = main_pd_ni & usb_clk_en_lp_i;
 
+  // all other clocks are also diasbled when power is turned off.
+  logic core_clk_en;
+  logic io_clk_en;
+  assign core_clk_en = main_pd_ni & core_clk_en_i;
+  assign io_clk_en = main_pd_ni & io_clk_en_i;
+
   // if clocks were configured to turn off, make sure val is invalid
   // if clocks were not configured to turn off, just bypass the check
-  assign all_clks_invalid = (core_clk_en_i | ~ast_i.core_clk_val) &
-                            (io_clk_en_i | ~ast_i.io_clk_val) &
+  assign all_clks_invalid = (core_clk_en | ~ast_i.core_clk_val) &
+                            (io_clk_en | ~ast_i.io_clk_val) &
                             (usb_clk_en_lp | ~ast_i.usb_clk_val);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -223,8 +229,8 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
       end
 
       SlowPwrStateClocksOff: begin
-        core_clk_en_d = core_clk_en_i;
-        io_clk_en_d = io_clk_en_i;
+        core_clk_en_d = core_clk_en;
+        io_clk_en_d = io_clk_en;
         usb_clk_en_d = usb_clk_en_lp;
 
         if (all_clks_invalid) begin

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -346,7 +346,10 @@
             { value: "1",
               name: "Enabled",
               desc: '''
-                USB clock enabled during low power state
+                USB clock enabled during low power state.
+
+                However, if !!CONTROL.MAIN_PD_N is 0, USB clock is disabled
+                during low power state.
                 '''
             },
           ]


### PR DESCRIPTION
- Fixes #9064
- Now whenever device power is powered down, usb clock is also
  disabled.  The usb_clk_en_lp configuration only applies during
  lighter levels of sleep.

Signed-off-by: Timothy Chen <timothytim@google.com>