### PR TITLE
[sw] Fix inline functions without linking location

### DIFF
--- a/sw/device/lib/base/hardened.c
+++ b/sw/device/lib/base/hardened.c
@@ -4,7 +4,9 @@
 
 #include "sw/device/lib/base/hardened.h"
 
-// Instantiate inline functions in this TU.
+// `extern` declarations to give the inline functions in the corresponding
+// header a link location.
+
 extern uint32_t launder32(uint32_t);
 extern uintptr_t launderw(uintptr_t);
 extern void barrier32(uint32_t);

--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -4,9 +4,6 @@
 
 #include "sw/device/lib/base/memory.h"
 
-extern uint32_t read_32(const void *);
-extern void write_32(uint32_t, void *);
-
 // Some symbols below are only defined for device builds. For host builds, we
 // their implementations will be provided by the host's libc implementation.
 //
@@ -84,3 +81,9 @@ void *memrchr(const void *ptr, int value, size_t len) {
   }
   return NULL;
 }
+
+// `extern` declarations to give the inline functions in the corresponding
+// header a link location.
+
+extern uint32_t read_32(const void *);
+extern void write_32(uint32_t, void *);

--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -122,6 +122,7 @@ void mmio_region_memcpy_to_mmio32(mmio_region_t base, uint32_t offset,
 
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
+extern mmio_region_t mmio_region_from_addr(uintptr_t address);
 extern uint8_t mmio_region_read8(mmio_region_t base, ptrdiff_t offset);
 extern uint32_t mmio_region_read32(mmio_region_t base, ptrdiff_t offset);
 extern void mmio_region_write8(mmio_region_t base, ptrdiff_t offset,

--- a/sw/device/lib/runtime/hart.c
+++ b/sw/device/lib/runtime/hart.c
@@ -9,8 +9,6 @@
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/runtime/ibex.h"
 
-extern void wait_for_interrupt(void);
-
 void usleep(uint32_t usec) {
   uint64_t cycles = kClockFreqCpuHz * usec / 1000000;
   uint64_t start = ibex_mcycle_read();
@@ -23,3 +21,8 @@ noreturn void abort(void) {
     wait_for_interrupt();
   }
 }
+
+// `extern` declarations to give the inline functions in the
+// corresponding header a link location.
+
+extern void wait_for_interrupt(void);

--- a/sw/device/lib/runtime/ibex.c
+++ b/sw/device/lib/runtime/ibex.c
@@ -6,8 +6,6 @@
 
 #include "sw/device/lib/base/csr.h"
 
-extern uint64_t ibex_mcycle_read(void);
-
 uint32_t ibex_mcause_read(void) {
   uint32_t mtval;
   CSR_READ(CSR_REG_MCAUSE, &mtval);
@@ -20,5 +18,9 @@ uint32_t ibex_mtval_read(void) {
   return mtval;
 }
 
+// `extern` declarations to give the inline functions in the
+// corresponding header a link location.
+
+extern uint64_t ibex_mcycle_read(void);
 extern ibex_timeout_t ibex_timeout_init(uint32_t timeout_usec);
 extern bool ibex_timeout_check(const ibex_timeout_t *timeout);

--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -4,6 +4,9 @@
 
 #include "sw/device/lib/testing/aes_testutils.h"
 
+// `extern` declarations to give the inline functions in the
+// corresponding header a link location.
+
 extern bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag);
 
 extern void aes_testutils_wait_for_status(dif_aes_t *aes, dif_aes_status_t flag,

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -6,6 +6,9 @@
 
 #include "sw/device/lib/dif/dif_clkmgr.h"
 
+// `extern` declarations to give the inline functions in the
+// corresponding header a link location.
+
 extern bool clkmgr_testutils_get_trans_clock_status(
     dif_clkmgr_t *clkmgr, dif_clkmgr_hintable_clock_t clock);
 

--- a/sw/device/lib/usbdev.c
+++ b/sw/device/lib/usbdev.c
@@ -335,3 +335,9 @@ void usbdev_wake(bool set) {
   }
   REG32(USBDEV_BASE_ADDR + USBDEV_WAKE_CONFIG_REG_OFFSET) = reg_val;
 }
+
+// `extern` declarations to give the inline functions in the
+// corresponding header a link location.
+
+extern int usbdev_halted(usbdev_ctx_t *ctx, int endpoint);
+extern void usbdev_rem_wake_en(usbdev_ctx_t *ctx, int enable);

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -132,6 +132,7 @@ sw_silicon_creator_lib_driver_uart = declare_dependency(
     ],
     dependencies: [
       sw_lib_mmio,
+      sw_silicon_creator_lib_base_abs_mmio,
     ],
   ),
 )

--- a/sw/device/silicon_creator/mask_rom/boot_policy.c
+++ b/sw/device/silicon_creator/mask_rom/boot_policy.c
@@ -37,5 +37,8 @@ rom_error_t boot_policy_manifest_check(const manifest_t *manifest) {
   return kErrorOk;
 }
 
+// `extern` declarations to give the inline functions in the
+// corresponding header a link location.
+
 extern const manifest_t *boot_policy_manifest_a_get(void);
 extern const manifest_t *boot_policy_manifest_b_get(void);


### PR DESCRIPTION
When creating builds with optimizations disabled (`-O0`) or with just inlining disabled (e.g. `-fno-inline`) there would be linking errors due to inline functions missing the corresponding extern declaration and thus not having linking locations. This fixes such errors, by adding the missing declarations and library dependencies. It also improves the consistency of those declarations, e.g. by adding the usual explanatory comment where it was missing.