### PR TITLE
[spi_device] Passthrough Intercept CSR

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -394,6 +394,33 @@
         }
       ],
     },
+    //=========================================================================
+    // Flash & Passthrough CSRs
+    { name: "INTERCEPT_EN"
+      desc: '''Intercept Passthrough datapath.
+
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "0"
+          name: "status"
+          desc: "If set, Read Status is processed internally."
+        } // f: status
+        { bits: "1"
+          name: "jedec"
+          desc: "If set, Read JEDEC ID is processed internally."
+        } // f: jedec
+        { bits: "2"
+          name: "sfdp"
+          desc: "If set, Read SFDP is processed internally."
+        } // f: sfdp
+        { bits: "3"
+          name: "mbx"
+          desc: "If set, Read Command to Mailbox region is processed internally."
+        } // f: mailbox
+      ]
+    } // R: INTERCEPT_EN
     { name: "LAST_READ_ADDR"
       desc: '''Last Read Address
 

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -225,6 +225,15 @@ module spi_device
   logic cfg_mailbox_en;
   logic [31:0] mailbox_addr;
 
+  // Intercept
+  typedef struct packed {
+    logic status;
+    logic jedec;
+    logic sfdp;
+    logic mbx;
+  } intercept_en_t;
+  intercept_en_t cfg_intercept_en;
+
   // Threshold value of a buffer in bytes
   logic [BufferAw:0] readbuf_threshold;
 
@@ -530,6 +539,16 @@ module spi_device
   );
 
   // SPI Flash commands registers
+
+  assign cfg_intercept_en = '{
+    status:  reg2hw.intercept_en.status.q,
+    jedec:   reg2hw.intercept_en.jedec.q,
+    sfdp:    reg2hw.intercept_en.sfdp.q,
+    mbx:     reg2hw.intercept_en.mbx.q
+  };
+  logic unused_cfg_intercept_en;
+  assign unused_cfg_intercept_en = ^cfg_intercept_en;
+
   // TODO: Add 2FF sync? or just waive?
   assign hw2reg.last_read_addr.d = readbuf_addr_busclk;
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -187,6 +187,21 @@ package spi_device_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } status;
+    struct packed {
+      logic        q;
+    } jedec;
+    struct packed {
+      logic        q;
+    } sfdp;
+    struct packed {
+      logic        q;
+    } mbx;
+  } spi_device_reg2hw_intercept_en_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic        q;
       logic        qe;
     } busy;
     struct packed {
@@ -531,17 +546,18 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1571:1565]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1564:1558]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1557:1544]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1543:1542]
-    spi_device_reg2hw_control_reg_t control; // [1541:1536]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1535:1522]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1521:1490]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1489:1474]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1473:1458]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1457:1426]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1425:1394]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1575:1569]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1568:1562]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1561:1548]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1547:1546]
+    spi_device_reg2hw_control_reg_t control; // [1545:1540]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1539:1526]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1525:1494]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1493:1478]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1477:1462]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1461:1430]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1429:1398]
+    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1397:1394]
     spi_device_reg2hw_flash_status_reg_t flash_status; // [1393:1368]
     spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1367:1344]
     spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1343:1334]
@@ -600,50 +616,51 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TXF_PTR_OFFSET = 13'h 28;
   parameter logic [BlockAw-1:0] SPI_DEVICE_RXF_ADDR_OFFSET = 13'h 2c;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TXF_ADDR_OFFSET = 13'h 30;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_LAST_READ_ADDR_OFFSET = 13'h 34;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_FLASH_STATUS_OFFSET = 13'h 38;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_ID_OFFSET = 13'h 3c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 40;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 44;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 48;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 4c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 50;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 54;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 58;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 5c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 60;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 64;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 68;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 6c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 70;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 74;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 78;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 7c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 80;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 84;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 98;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h 9c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h a0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h a4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h a8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h ac;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h b0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h b4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h b8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h bc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h c0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h c4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h c8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h cc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h d0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h d4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h d8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h dc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h e0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_INTERCEPT_EN_OFFSET = 13'h 34;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_LAST_READ_ADDR_OFFSET = 13'h 38;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_FLASH_STATUS_OFFSET = 13'h 3c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_ID_OFFSET = 13'h 40;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 44;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 48;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 4c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 50;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 54;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 58;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 5c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 60;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 64;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 68;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 6c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 70;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 74;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 78;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 7c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 80;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 84;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 88;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 9c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h a0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h a4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h a8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h ac;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h b0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h b4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h b8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h bc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h c0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h c4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h c8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h cc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h d0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h d8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h dc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h e0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h e4;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -704,6 +721,7 @@ package spi_device_reg_pkg;
     SPI_DEVICE_TXF_PTR,
     SPI_DEVICE_RXF_ADDR,
     SPI_DEVICE_TXF_ADDR,
+    SPI_DEVICE_INTERCEPT_EN,
     SPI_DEVICE_LAST_READ_ADDR,
     SPI_DEVICE_FLASH_STATUS,
     SPI_DEVICE_JEDEC_ID,
@@ -766,7 +784,7 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [72] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [73] = '{
     4'b 0001, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0001, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0001, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -780,65 +798,66 @@ package spi_device_reg_pkg;
     4'b 1111, // index[10] SPI_DEVICE_TXF_PTR
     4'b 1111, // index[11] SPI_DEVICE_RXF_ADDR
     4'b 1111, // index[12] SPI_DEVICE_TXF_ADDR
-    4'b 1111, // index[13] SPI_DEVICE_LAST_READ_ADDR
-    4'b 0111, // index[14] SPI_DEVICE_FLASH_STATUS
-    4'b 0111, // index[15] SPI_DEVICE_JEDEC_ID
-    4'b 0011, // index[16] SPI_DEVICE_READ_THRESHOLD
-    4'b 1111, // index[17] SPI_DEVICE_MAILBOX_ADDR
-    4'b 1111, // index[18] SPI_DEVICE_UPLOAD_STATUS
-    4'b 0001, // index[19] SPI_DEVICE_UPLOAD_CMDFIFO
-    4'b 1111, // index[20] SPI_DEVICE_UPLOAD_ADDRFIFO
-    4'b 1111, // index[21] SPI_DEVICE_CMD_FILTER_0
-    4'b 1111, // index[22] SPI_DEVICE_CMD_FILTER_1
-    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_2
-    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_3
-    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_4
-    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_5
-    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_6
-    4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_7
-    4'b 1111, // index[29] SPI_DEVICE_ADDR_SWAP_MASK
-    4'b 1111, // index[30] SPI_DEVICE_ADDR_SWAP_DATA
-    4'b 1111, // index[31] SPI_DEVICE_PAYLOAD_SWAP_MASK
-    4'b 1111, // index[32] SPI_DEVICE_PAYLOAD_SWAP_DATA
-    4'b 1111, // index[33] SPI_DEVICE_CMD_INFO_0
-    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_1
-    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_2
-    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_3
-    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_4
-    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_5
-    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_6
-    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_7
-    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_8
-    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_9
-    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_10
-    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_11
-    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_12
-    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_13
-    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_14
-    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_15
-    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_16
-    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_17
-    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_18
-    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_19
-    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_20
-    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_21
-    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_22
-    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_23
-    4'b 0111, // index[57] SPI_DEVICE_TPM_CAP
-    4'b 0001, // index[58] SPI_DEVICE_TPM_CFG
-    4'b 0011, // index[59] SPI_DEVICE_TPM_STATUS
-    4'b 1111, // index[60] SPI_DEVICE_TPM_ACCESS_0
-    4'b 0001, // index[61] SPI_DEVICE_TPM_ACCESS_1
-    4'b 1111, // index[62] SPI_DEVICE_TPM_STS
-    4'b 1111, // index[63] SPI_DEVICE_TPM_INTF_CAPABILITY
-    4'b 1111, // index[64] SPI_DEVICE_TPM_INT_ENABLE
-    4'b 0001, // index[65] SPI_DEVICE_TPM_INT_VECTOR
-    4'b 1111, // index[66] SPI_DEVICE_TPM_INT_STATUS
-    4'b 1111, // index[67] SPI_DEVICE_TPM_DID_VID
-    4'b 0001, // index[68] SPI_DEVICE_TPM_RID
-    4'b 1111, // index[69] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 0001, // index[70] SPI_DEVICE_TPM_READ_FIFO
-    4'b 0001  // index[71] SPI_DEVICE_TPM_WRITE_FIFO
+    4'b 0001, // index[13] SPI_DEVICE_INTERCEPT_EN
+    4'b 1111, // index[14] SPI_DEVICE_LAST_READ_ADDR
+    4'b 0111, // index[15] SPI_DEVICE_FLASH_STATUS
+    4'b 0111, // index[16] SPI_DEVICE_JEDEC_ID
+    4'b 0011, // index[17] SPI_DEVICE_READ_THRESHOLD
+    4'b 1111, // index[18] SPI_DEVICE_MAILBOX_ADDR
+    4'b 1111, // index[19] SPI_DEVICE_UPLOAD_STATUS
+    4'b 0001, // index[20] SPI_DEVICE_UPLOAD_CMDFIFO
+    4'b 1111, // index[21] SPI_DEVICE_UPLOAD_ADDRFIFO
+    4'b 1111, // index[22] SPI_DEVICE_CMD_FILTER_0
+    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_1
+    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_2
+    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_3
+    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_4
+    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_5
+    4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_6
+    4'b 1111, // index[29] SPI_DEVICE_CMD_FILTER_7
+    4'b 1111, // index[30] SPI_DEVICE_ADDR_SWAP_MASK
+    4'b 1111, // index[31] SPI_DEVICE_ADDR_SWAP_DATA
+    4'b 1111, // index[32] SPI_DEVICE_PAYLOAD_SWAP_MASK
+    4'b 1111, // index[33] SPI_DEVICE_PAYLOAD_SWAP_DATA
+    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_0
+    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_1
+    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_2
+    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_3
+    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_4
+    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_5
+    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_6
+    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_7
+    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_8
+    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_9
+    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_10
+    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_11
+    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_12
+    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_13
+    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_14
+    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_16
+    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_17
+    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_18
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_19
+    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_20
+    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_21
+    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_22
+    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_23
+    4'b 0111, // index[58] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[59] SPI_DEVICE_TPM_CFG
+    4'b 0011, // index[60] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[61] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[62] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[63] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[64] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[65] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[66] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[67] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[68] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[69] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[70] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 0001, // index[71] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[72] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -255,6 +255,15 @@ module spi_device_reg_top (
   logic [15:0] txf_addr_base_wd;
   logic [15:0] txf_addr_limit_qs;
   logic [15:0] txf_addr_limit_wd;
+  logic intercept_en_we;
+  logic intercept_en_status_qs;
+  logic intercept_en_status_wd;
+  logic intercept_en_jedec_qs;
+  logic intercept_en_jedec_wd;
+  logic intercept_en_sfdp_qs;
+  logic intercept_en_sfdp_wd;
+  logic intercept_en_mbx_qs;
+  logic intercept_en_mbx_wd;
   logic last_read_addr_re;
   logic [31:0] last_read_addr_qs;
   logic flash_status_re;
@@ -2671,6 +2680,108 @@ module spi_device_reg_top (
 
     // to register interface (read)
     .qs     (txf_addr_limit_qs)
+  );
+
+
+  // R[intercept_en]: V(False)
+  //   F[status]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_intercept_en_status (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intercept_en_we),
+    .wd     (intercept_en_status_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intercept_en.status.q),
+
+    // to register interface (read)
+    .qs     (intercept_en_status_qs)
+  );
+
+  //   F[jedec]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_intercept_en_jedec (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intercept_en_we),
+    .wd     (intercept_en_jedec_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intercept_en.jedec.q),
+
+    // to register interface (read)
+    .qs     (intercept_en_jedec_qs)
+  );
+
+  //   F[sfdp]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_intercept_en_sfdp (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intercept_en_we),
+    .wd     (intercept_en_sfdp_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intercept_en.sfdp.q),
+
+    // to register interface (read)
+    .qs     (intercept_en_sfdp_qs)
+  );
+
+  //   F[mbx]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_intercept_en_mbx (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (intercept_en_we),
+    .wd     (intercept_en_mbx_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.intercept_en.mbx.q),
+
+    // to register interface (read)
+    .qs     (intercept_en_mbx_qs)
   );
 
 
@@ -18085,7 +18196,7 @@ module spi_device_reg_top (
 
 
 
-  logic [71:0] addr_hit;
+  logic [72:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -18101,65 +18212,66 @@ module spi_device_reg_top (
     addr_hit[10] = (reg_addr == SPI_DEVICE_TXF_PTR_OFFSET);
     addr_hit[11] = (reg_addr == SPI_DEVICE_RXF_ADDR_OFFSET);
     addr_hit[12] = (reg_addr == SPI_DEVICE_TXF_ADDR_OFFSET);
-    addr_hit[13] = (reg_addr == SPI_DEVICE_LAST_READ_ADDR_OFFSET);
-    addr_hit[14] = (reg_addr == SPI_DEVICE_FLASH_STATUS_OFFSET);
-    addr_hit[15] = (reg_addr == SPI_DEVICE_JEDEC_ID_OFFSET);
-    addr_hit[16] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
-    addr_hit[17] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
-    addr_hit[18] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
-    addr_hit[19] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
-    addr_hit[20] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
-    addr_hit[21] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
-    addr_hit[22] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
-    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
-    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
-    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
-    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
-    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
-    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
-    addr_hit[29] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
-    addr_hit[30] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
-    addr_hit[31] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
-    addr_hit[32] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
-    addr_hit[33] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
-    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
-    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
-    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
-    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
-    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
-    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
-    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
-    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
-    addr_hit[57] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
-    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
-    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
-    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
-    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
-    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
-    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
-    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
-    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
-    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
-    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
-    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
-    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
-    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
-    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
+    addr_hit[13] = (reg_addr == SPI_DEVICE_INTERCEPT_EN_OFFSET);
+    addr_hit[14] = (reg_addr == SPI_DEVICE_LAST_READ_ADDR_OFFSET);
+    addr_hit[15] = (reg_addr == SPI_DEVICE_FLASH_STATUS_OFFSET);
+    addr_hit[16] = (reg_addr == SPI_DEVICE_JEDEC_ID_OFFSET);
+    addr_hit[17] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
+    addr_hit[18] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
+    addr_hit[19] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
+    addr_hit[20] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
+    addr_hit[21] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
+    addr_hit[22] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
+    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
+    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
+    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
+    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
+    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
+    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
+    addr_hit[29] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
+    addr_hit[30] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
+    addr_hit[31] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
+    addr_hit[32] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
+    addr_hit[33] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
+    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
+    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
+    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
+    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -18238,7 +18350,8 @@ module spi_device_reg_top (
                (addr_hit[68] & (|(SPI_DEVICE_PERMIT[68] & ~reg_be))) |
                (addr_hit[69] & (|(SPI_DEVICE_PERMIT[69] & ~reg_be))) |
                (addr_hit[70] & (|(SPI_DEVICE_PERMIT[70] & ~reg_be))) |
-               (addr_hit[71] & (|(SPI_DEVICE_PERMIT[71] & ~reg_be)))));
+               (addr_hit[71] & (|(SPI_DEVICE_PERMIT[71] & ~reg_be))) |
+               (addr_hit[72] & (|(SPI_DEVICE_PERMIT[72] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -18337,27 +18450,36 @@ module spi_device_reg_top (
   assign txf_addr_base_wd = reg_wdata[15:0];
 
   assign txf_addr_limit_wd = reg_wdata[31:16];
-  assign last_read_addr_re = addr_hit[13] & reg_re & !reg_error;
-  assign flash_status_re = addr_hit[14] & reg_re & !reg_error;
-  assign flash_status_we = addr_hit[14] & reg_we & !reg_error;
+  assign intercept_en_we = addr_hit[13] & reg_we & !reg_error;
+
+  assign intercept_en_status_wd = reg_wdata[0];
+
+  assign intercept_en_jedec_wd = reg_wdata[1];
+
+  assign intercept_en_sfdp_wd = reg_wdata[2];
+
+  assign intercept_en_mbx_wd = reg_wdata[3];
+  assign last_read_addr_re = addr_hit[14] & reg_re & !reg_error;
+  assign flash_status_re = addr_hit[15] & reg_re & !reg_error;
+  assign flash_status_we = addr_hit[15] & reg_we & !reg_error;
 
   assign flash_status_busy_wd = reg_wdata[0];
 
   assign flash_status_status_wd = reg_wdata[23:1];
-  assign jedec_id_we = addr_hit[15] & reg_we & !reg_error;
+  assign jedec_id_we = addr_hit[16] & reg_we & !reg_error;
 
   assign jedec_id_id_wd = reg_wdata[15:0];
 
   assign jedec_id_mf_wd = reg_wdata[23:16];
-  assign read_threshold_we = addr_hit[16] & reg_we & !reg_error;
+  assign read_threshold_we = addr_hit[17] & reg_we & !reg_error;
 
   assign read_threshold_wd = reg_wdata[9:0];
-  assign mailbox_addr_we = addr_hit[17] & reg_we & !reg_error;
+  assign mailbox_addr_we = addr_hit[18] & reg_we & !reg_error;
 
   assign mailbox_addr_wd = reg_wdata[31:0];
-  assign upload_cmdfifo_re = addr_hit[19] & reg_re & !reg_error;
-  assign upload_addrfifo_re = addr_hit[20] & reg_re & !reg_error;
-  assign cmd_filter_0_we = addr_hit[21] & reg_we & !reg_error;
+  assign upload_cmdfifo_re = addr_hit[20] & reg_re & !reg_error;
+  assign upload_addrfifo_re = addr_hit[21] & reg_re & !reg_error;
+  assign cmd_filter_0_we = addr_hit[22] & reg_we & !reg_error;
 
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
 
@@ -18422,7 +18544,7 @@ module spi_device_reg_top (
   assign cmd_filter_0_filter_30_wd = reg_wdata[30];
 
   assign cmd_filter_0_filter_31_wd = reg_wdata[31];
-  assign cmd_filter_1_we = addr_hit[22] & reg_we & !reg_error;
+  assign cmd_filter_1_we = addr_hit[23] & reg_we & !reg_error;
 
   assign cmd_filter_1_filter_32_wd = reg_wdata[0];
 
@@ -18487,7 +18609,7 @@ module spi_device_reg_top (
   assign cmd_filter_1_filter_62_wd = reg_wdata[30];
 
   assign cmd_filter_1_filter_63_wd = reg_wdata[31];
-  assign cmd_filter_2_we = addr_hit[23] & reg_we & !reg_error;
+  assign cmd_filter_2_we = addr_hit[24] & reg_we & !reg_error;
 
   assign cmd_filter_2_filter_64_wd = reg_wdata[0];
 
@@ -18552,7 +18674,7 @@ module spi_device_reg_top (
   assign cmd_filter_2_filter_94_wd = reg_wdata[30];
 
   assign cmd_filter_2_filter_95_wd = reg_wdata[31];
-  assign cmd_filter_3_we = addr_hit[24] & reg_we & !reg_error;
+  assign cmd_filter_3_we = addr_hit[25] & reg_we & !reg_error;
 
   assign cmd_filter_3_filter_96_wd = reg_wdata[0];
 
@@ -18617,7 +18739,7 @@ module spi_device_reg_top (
   assign cmd_filter_3_filter_126_wd = reg_wdata[30];
 
   assign cmd_filter_3_filter_127_wd = reg_wdata[31];
-  assign cmd_filter_4_we = addr_hit[25] & reg_we & !reg_error;
+  assign cmd_filter_4_we = addr_hit[26] & reg_we & !reg_error;
 
   assign cmd_filter_4_filter_128_wd = reg_wdata[0];
 
@@ -18682,7 +18804,7 @@ module spi_device_reg_top (
   assign cmd_filter_4_filter_158_wd = reg_wdata[30];
 
   assign cmd_filter_4_filter_159_wd = reg_wdata[31];
-  assign cmd_filter_5_we = addr_hit[26] & reg_we & !reg_error;
+  assign cmd_filter_5_we = addr_hit[27] & reg_we & !reg_error;
 
   assign cmd_filter_5_filter_160_wd = reg_wdata[0];
 
@@ -18747,7 +18869,7 @@ module spi_device_reg_top (
   assign cmd_filter_5_filter_190_wd = reg_wdata[30];
 
   assign cmd_filter_5_filter_191_wd = reg_wdata[31];
-  assign cmd_filter_6_we = addr_hit[27] & reg_we & !reg_error;
+  assign cmd_filter_6_we = addr_hit[28] & reg_we & !reg_error;
 
   assign cmd_filter_6_filter_192_wd = reg_wdata[0];
 
@@ -18812,7 +18934,7 @@ module spi_device_reg_top (
   assign cmd_filter_6_filter_222_wd = reg_wdata[30];
 
   assign cmd_filter_6_filter_223_wd = reg_wdata[31];
-  assign cmd_filter_7_we = addr_hit[28] & reg_we & !reg_error;
+  assign cmd_filter_7_we = addr_hit[29] & reg_we & !reg_error;
 
   assign cmd_filter_7_filter_224_wd = reg_wdata[0];
 
@@ -18877,19 +18999,19 @@ module spi_device_reg_top (
   assign cmd_filter_7_filter_254_wd = reg_wdata[30];
 
   assign cmd_filter_7_filter_255_wd = reg_wdata[31];
-  assign addr_swap_mask_we = addr_hit[29] & reg_we & !reg_error;
+  assign addr_swap_mask_we = addr_hit[30] & reg_we & !reg_error;
 
   assign addr_swap_mask_wd = reg_wdata[31:0];
-  assign addr_swap_data_we = addr_hit[30] & reg_we & !reg_error;
+  assign addr_swap_data_we = addr_hit[31] & reg_we & !reg_error;
 
   assign addr_swap_data_wd = reg_wdata[31:0];
-  assign payload_swap_mask_we = addr_hit[31] & reg_we & !reg_error;
+  assign payload_swap_mask_we = addr_hit[32] & reg_we & !reg_error;
 
   assign payload_swap_mask_wd = reg_wdata[31:0];
-  assign payload_swap_data_we = addr_hit[32] & reg_we & !reg_error;
+  assign payload_swap_data_we = addr_hit[33] & reg_we & !reg_error;
 
   assign payload_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_0_we = addr_hit[33] & reg_we & !reg_error;
+  assign cmd_info_0_we = addr_hit[34] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -18916,7 +19038,7 @@ module spi_device_reg_top (
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
 
   assign cmd_info_0_valid_0_wd = reg_wdata[31];
-  assign cmd_info_1_we = addr_hit[34] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[35] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -18943,7 +19065,7 @@ module spi_device_reg_top (
   assign cmd_info_1_busy_1_wd = reg_wdata[25];
 
   assign cmd_info_1_valid_1_wd = reg_wdata[31];
-  assign cmd_info_2_we = addr_hit[35] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -18970,7 +19092,7 @@ module spi_device_reg_top (
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
 
   assign cmd_info_2_valid_2_wd = reg_wdata[31];
-  assign cmd_info_3_we = addr_hit[36] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -18997,7 +19119,7 @@ module spi_device_reg_top (
   assign cmd_info_3_busy_3_wd = reg_wdata[25];
 
   assign cmd_info_3_valid_3_wd = reg_wdata[31];
-  assign cmd_info_4_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -19024,7 +19146,7 @@ module spi_device_reg_top (
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
 
   assign cmd_info_4_valid_4_wd = reg_wdata[31];
-  assign cmd_info_5_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -19051,7 +19173,7 @@ module spi_device_reg_top (
   assign cmd_info_5_busy_5_wd = reg_wdata[25];
 
   assign cmd_info_5_valid_5_wd = reg_wdata[31];
-  assign cmd_info_6_we = addr_hit[39] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[40] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -19078,7 +19200,7 @@ module spi_device_reg_top (
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
 
   assign cmd_info_6_valid_6_wd = reg_wdata[31];
-  assign cmd_info_7_we = addr_hit[40] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[41] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -19105,7 +19227,7 @@ module spi_device_reg_top (
   assign cmd_info_7_busy_7_wd = reg_wdata[25];
 
   assign cmd_info_7_valid_7_wd = reg_wdata[31];
-  assign cmd_info_8_we = addr_hit[41] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[42] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -19132,7 +19254,7 @@ module spi_device_reg_top (
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
 
   assign cmd_info_8_valid_8_wd = reg_wdata[31];
-  assign cmd_info_9_we = addr_hit[42] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[43] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -19159,7 +19281,7 @@ module spi_device_reg_top (
   assign cmd_info_9_busy_9_wd = reg_wdata[25];
 
   assign cmd_info_9_valid_9_wd = reg_wdata[31];
-  assign cmd_info_10_we = addr_hit[43] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[44] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -19186,7 +19308,7 @@ module spi_device_reg_top (
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
 
   assign cmd_info_10_valid_10_wd = reg_wdata[31];
-  assign cmd_info_11_we = addr_hit[44] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[45] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -19213,7 +19335,7 @@ module spi_device_reg_top (
   assign cmd_info_11_busy_11_wd = reg_wdata[25];
 
   assign cmd_info_11_valid_11_wd = reg_wdata[31];
-  assign cmd_info_12_we = addr_hit[45] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[46] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -19240,7 +19362,7 @@ module spi_device_reg_top (
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
 
   assign cmd_info_12_valid_12_wd = reg_wdata[31];
-  assign cmd_info_13_we = addr_hit[46] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[47] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -19267,7 +19389,7 @@ module spi_device_reg_top (
   assign cmd_info_13_busy_13_wd = reg_wdata[25];
 
   assign cmd_info_13_valid_13_wd = reg_wdata[31];
-  assign cmd_info_14_we = addr_hit[47] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[48] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -19294,7 +19416,7 @@ module spi_device_reg_top (
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
 
   assign cmd_info_14_valid_14_wd = reg_wdata[31];
-  assign cmd_info_15_we = addr_hit[48] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[49] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -19321,7 +19443,7 @@ module spi_device_reg_top (
   assign cmd_info_15_busy_15_wd = reg_wdata[25];
 
   assign cmd_info_15_valid_15_wd = reg_wdata[31];
-  assign cmd_info_16_we = addr_hit[49] & reg_we & !reg_error;
+  assign cmd_info_16_we = addr_hit[50] & reg_we & !reg_error;
 
   assign cmd_info_16_opcode_16_wd = reg_wdata[7:0];
 
@@ -19348,7 +19470,7 @@ module spi_device_reg_top (
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
 
   assign cmd_info_16_valid_16_wd = reg_wdata[31];
-  assign cmd_info_17_we = addr_hit[50] & reg_we & !reg_error;
+  assign cmd_info_17_we = addr_hit[51] & reg_we & !reg_error;
 
   assign cmd_info_17_opcode_17_wd = reg_wdata[7:0];
 
@@ -19375,7 +19497,7 @@ module spi_device_reg_top (
   assign cmd_info_17_busy_17_wd = reg_wdata[25];
 
   assign cmd_info_17_valid_17_wd = reg_wdata[31];
-  assign cmd_info_18_we = addr_hit[51] & reg_we & !reg_error;
+  assign cmd_info_18_we = addr_hit[52] & reg_we & !reg_error;
 
   assign cmd_info_18_opcode_18_wd = reg_wdata[7:0];
 
@@ -19402,7 +19524,7 @@ module spi_device_reg_top (
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
 
   assign cmd_info_18_valid_18_wd = reg_wdata[31];
-  assign cmd_info_19_we = addr_hit[52] & reg_we & !reg_error;
+  assign cmd_info_19_we = addr_hit[53] & reg_we & !reg_error;
 
   assign cmd_info_19_opcode_19_wd = reg_wdata[7:0];
 
@@ -19429,7 +19551,7 @@ module spi_device_reg_top (
   assign cmd_info_19_busy_19_wd = reg_wdata[25];
 
   assign cmd_info_19_valid_19_wd = reg_wdata[31];
-  assign cmd_info_20_we = addr_hit[53] & reg_we & !reg_error;
+  assign cmd_info_20_we = addr_hit[54] & reg_we & !reg_error;
 
   assign cmd_info_20_opcode_20_wd = reg_wdata[7:0];
 
@@ -19456,7 +19578,7 @@ module spi_device_reg_top (
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
 
   assign cmd_info_20_valid_20_wd = reg_wdata[31];
-  assign cmd_info_21_we = addr_hit[54] & reg_we & !reg_error;
+  assign cmd_info_21_we = addr_hit[55] & reg_we & !reg_error;
 
   assign cmd_info_21_opcode_21_wd = reg_wdata[7:0];
 
@@ -19483,7 +19605,7 @@ module spi_device_reg_top (
   assign cmd_info_21_busy_21_wd = reg_wdata[25];
 
   assign cmd_info_21_valid_21_wd = reg_wdata[31];
-  assign cmd_info_22_we = addr_hit[55] & reg_we & !reg_error;
+  assign cmd_info_22_we = addr_hit[56] & reg_we & !reg_error;
 
   assign cmd_info_22_opcode_22_wd = reg_wdata[7:0];
 
@@ -19510,7 +19632,7 @@ module spi_device_reg_top (
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
 
   assign cmd_info_22_valid_22_wd = reg_wdata[31];
-  assign cmd_info_23_we = addr_hit[56] & reg_we & !reg_error;
+  assign cmd_info_23_we = addr_hit[57] & reg_we & !reg_error;
 
   assign cmd_info_23_opcode_23_wd = reg_wdata[7:0];
 
@@ -19537,7 +19659,7 @@ module spi_device_reg_top (
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
 
   assign cmd_info_23_valid_23_wd = reg_wdata[31];
-  assign tpm_cfg_we = addr_hit[58] & reg_we & !reg_error;
+  assign tpm_cfg_we = addr_hit[59] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
 
@@ -19548,7 +19670,7 @@ module spi_device_reg_top (
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_access_0_we = addr_hit[60] & reg_we & !reg_error;
+  assign tpm_access_0_we = addr_hit[61] & reg_we & !reg_error;
 
   assign tpm_access_0_access_0_wd = reg_wdata[7:0];
 
@@ -19557,37 +19679,37 @@ module spi_device_reg_top (
   assign tpm_access_0_access_2_wd = reg_wdata[23:16];
 
   assign tpm_access_0_access_3_wd = reg_wdata[31:24];
-  assign tpm_access_1_we = addr_hit[61] & reg_we & !reg_error;
+  assign tpm_access_1_we = addr_hit[62] & reg_we & !reg_error;
 
   assign tpm_access_1_wd = reg_wdata[7:0];
-  assign tpm_sts_we = addr_hit[62] & reg_we & !reg_error;
+  assign tpm_sts_we = addr_hit[63] & reg_we & !reg_error;
 
   assign tpm_sts_wd = reg_wdata[31:0];
-  assign tpm_intf_capability_we = addr_hit[63] & reg_we & !reg_error;
+  assign tpm_intf_capability_we = addr_hit[64] & reg_we & !reg_error;
 
   assign tpm_intf_capability_wd = reg_wdata[31:0];
-  assign tpm_int_enable_we = addr_hit[64] & reg_we & !reg_error;
+  assign tpm_int_enable_we = addr_hit[65] & reg_we & !reg_error;
 
   assign tpm_int_enable_wd = reg_wdata[31:0];
-  assign tpm_int_vector_we = addr_hit[65] & reg_we & !reg_error;
+  assign tpm_int_vector_we = addr_hit[66] & reg_we & !reg_error;
 
   assign tpm_int_vector_wd = reg_wdata[7:0];
-  assign tpm_int_status_we = addr_hit[66] & reg_we & !reg_error;
+  assign tpm_int_status_we = addr_hit[67] & reg_we & !reg_error;
 
   assign tpm_int_status_wd = reg_wdata[31:0];
-  assign tpm_did_vid_we = addr_hit[67] & reg_we & !reg_error;
+  assign tpm_did_vid_we = addr_hit[68] & reg_we & !reg_error;
 
   assign tpm_did_vid_vid_wd = reg_wdata[15:0];
 
   assign tpm_did_vid_did_wd = reg_wdata[31:16];
-  assign tpm_rid_we = addr_hit[68] & reg_we & !reg_error;
+  assign tpm_rid_we = addr_hit[69] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = addr_hit[69] & reg_re & !reg_error;
-  assign tpm_read_fifo_we = addr_hit[70] & reg_we & !reg_error;
+  assign tpm_cmd_addr_re = addr_hit[70] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[71] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[7:0];
-  assign tpm_write_fifo_re = addr_hit[71] & reg_re & !reg_error;
+  assign tpm_write_fifo_re = addr_hit[72] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -19685,28 +19807,35 @@ module spi_device_reg_top (
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[31:0] = last_read_addr_qs;
+        reg_rdata_next[0] = intercept_en_status_qs;
+        reg_rdata_next[1] = intercept_en_jedec_qs;
+        reg_rdata_next[2] = intercept_en_sfdp_qs;
+        reg_rdata_next[3] = intercept_en_mbx_qs;
       end
 
       addr_hit[14]: begin
+        reg_rdata_next[31:0] = last_read_addr_qs;
+      end
+
+      addr_hit[15]: begin
         reg_rdata_next[0] = flash_status_busy_qs;
         reg_rdata_next[23:1] = flash_status_status_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[16]: begin
         reg_rdata_next[15:0] = jedec_id_id_qs;
         reg_rdata_next[23:16] = jedec_id_mf_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[17]: begin
         reg_rdata_next[9:0] = read_threshold_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[31:0] = mailbox_addr_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[4:0] = upload_status_cmdfifo_depth_qs;
         reg_rdata_next[7] = upload_status_cmdfifo_notempty_qs;
         reg_rdata_next[12:8] = upload_status_addrfifo_depth_qs;
@@ -19714,15 +19843,15 @@ module spi_device_reg_top (
         reg_rdata_next[24:16] = upload_status_payload_depth_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[7:0] = upload_cmdfifo_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[31:0] = upload_addrfifo_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[0] = cmd_filter_0_filter_0_qs;
         reg_rdata_next[1] = cmd_filter_0_filter_1_qs;
         reg_rdata_next[2] = cmd_filter_0_filter_2_qs;
@@ -19757,7 +19886,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_0_filter_31_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = cmd_filter_1_filter_32_qs;
         reg_rdata_next[1] = cmd_filter_1_filter_33_qs;
         reg_rdata_next[2] = cmd_filter_1_filter_34_qs;
@@ -19792,7 +19921,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_1_filter_63_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = cmd_filter_2_filter_64_qs;
         reg_rdata_next[1] = cmd_filter_2_filter_65_qs;
         reg_rdata_next[2] = cmd_filter_2_filter_66_qs;
@@ -19827,7 +19956,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_2_filter_95_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = cmd_filter_3_filter_96_qs;
         reg_rdata_next[1] = cmd_filter_3_filter_97_qs;
         reg_rdata_next[2] = cmd_filter_3_filter_98_qs;
@@ -19862,7 +19991,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_3_filter_127_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = cmd_filter_4_filter_128_qs;
         reg_rdata_next[1] = cmd_filter_4_filter_129_qs;
         reg_rdata_next[2] = cmd_filter_4_filter_130_qs;
@@ -19897,7 +20026,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_4_filter_159_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = cmd_filter_5_filter_160_qs;
         reg_rdata_next[1] = cmd_filter_5_filter_161_qs;
         reg_rdata_next[2] = cmd_filter_5_filter_162_qs;
@@ -19932,7 +20061,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_5_filter_191_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = cmd_filter_6_filter_192_qs;
         reg_rdata_next[1] = cmd_filter_6_filter_193_qs;
         reg_rdata_next[2] = cmd_filter_6_filter_194_qs;
@@ -19967,7 +20096,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_6_filter_223_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[0] = cmd_filter_7_filter_224_qs;
         reg_rdata_next[1] = cmd_filter_7_filter_225_qs;
         reg_rdata_next[2] = cmd_filter_7_filter_226_qs;
@@ -20002,23 +20131,23 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_7_filter_255_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = addr_swap_mask_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = addr_swap_data_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = payload_swap_mask_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[31:0] = payload_swap_data_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[8] = cmd_info_0_addr_en_0_qs;
         reg_rdata_next[9] = cmd_info_0_addr_swap_en_0_qs;
@@ -20034,7 +20163,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_0_valid_0_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[8] = cmd_info_1_addr_en_1_qs;
         reg_rdata_next[9] = cmd_info_1_addr_swap_en_1_qs;
@@ -20050,7 +20179,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_1_valid_1_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[8] = cmd_info_2_addr_en_2_qs;
         reg_rdata_next[9] = cmd_info_2_addr_swap_en_2_qs;
@@ -20066,7 +20195,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_2_valid_2_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[8] = cmd_info_3_addr_en_3_qs;
         reg_rdata_next[9] = cmd_info_3_addr_swap_en_3_qs;
@@ -20082,7 +20211,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_3_valid_3_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[8] = cmd_info_4_addr_en_4_qs;
         reg_rdata_next[9] = cmd_info_4_addr_swap_en_4_qs;
@@ -20098,7 +20227,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_4_valid_4_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[8] = cmd_info_5_addr_en_5_qs;
         reg_rdata_next[9] = cmd_info_5_addr_swap_en_5_qs;
@@ -20114,7 +20243,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_5_valid_5_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[8] = cmd_info_6_addr_en_6_qs;
         reg_rdata_next[9] = cmd_info_6_addr_swap_en_6_qs;
@@ -20130,7 +20259,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_6_valid_6_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[8] = cmd_info_7_addr_en_7_qs;
         reg_rdata_next[9] = cmd_info_7_addr_swap_en_7_qs;
@@ -20146,7 +20275,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_7_valid_7_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[8] = cmd_info_8_addr_en_8_qs;
         reg_rdata_next[9] = cmd_info_8_addr_swap_en_8_qs;
@@ -20162,7 +20291,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_8_valid_8_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[8] = cmd_info_9_addr_en_9_qs;
         reg_rdata_next[9] = cmd_info_9_addr_swap_en_9_qs;
@@ -20178,7 +20307,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_9_valid_9_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[8] = cmd_info_10_addr_en_10_qs;
         reg_rdata_next[9] = cmd_info_10_addr_swap_en_10_qs;
@@ -20194,7 +20323,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_10_valid_10_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[45]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[8] = cmd_info_11_addr_en_11_qs;
         reg_rdata_next[9] = cmd_info_11_addr_swap_en_11_qs;
@@ -20210,7 +20339,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_11_valid_11_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[46]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[8] = cmd_info_12_addr_en_12_qs;
         reg_rdata_next[9] = cmd_info_12_addr_swap_en_12_qs;
@@ -20226,7 +20355,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_12_valid_12_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[47]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[8] = cmd_info_13_addr_en_13_qs;
         reg_rdata_next[9] = cmd_info_13_addr_swap_en_13_qs;
@@ -20242,7 +20371,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_13_valid_13_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[48]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[8] = cmd_info_14_addr_en_14_qs;
         reg_rdata_next[9] = cmd_info_14_addr_swap_en_14_qs;
@@ -20258,7 +20387,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_14_valid_14_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[49]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[8] = cmd_info_15_addr_en_15_qs;
         reg_rdata_next[9] = cmd_info_15_addr_swap_en_15_qs;
@@ -20274,7 +20403,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_15_valid_15_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[50]: begin
         reg_rdata_next[7:0] = cmd_info_16_opcode_16_qs;
         reg_rdata_next[8] = cmd_info_16_addr_en_16_qs;
         reg_rdata_next[9] = cmd_info_16_addr_swap_en_16_qs;
@@ -20290,7 +20419,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_16_valid_16_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[51]: begin
         reg_rdata_next[7:0] = cmd_info_17_opcode_17_qs;
         reg_rdata_next[8] = cmd_info_17_addr_en_17_qs;
         reg_rdata_next[9] = cmd_info_17_addr_swap_en_17_qs;
@@ -20306,7 +20435,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_17_valid_17_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[7:0] = cmd_info_18_opcode_18_qs;
         reg_rdata_next[8] = cmd_info_18_addr_en_18_qs;
         reg_rdata_next[9] = cmd_info_18_addr_swap_en_18_qs;
@@ -20322,7 +20451,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_18_valid_18_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[7:0] = cmd_info_19_opcode_19_qs;
         reg_rdata_next[8] = cmd_info_19_addr_en_19_qs;
         reg_rdata_next[9] = cmd_info_19_addr_swap_en_19_qs;
@@ -20338,7 +20467,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_19_valid_19_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[7:0] = cmd_info_20_opcode_20_qs;
         reg_rdata_next[8] = cmd_info_20_addr_en_20_qs;
         reg_rdata_next[9] = cmd_info_20_addr_swap_en_20_qs;
@@ -20354,7 +20483,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_20_valid_20_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[7:0] = cmd_info_21_opcode_21_qs;
         reg_rdata_next[8] = cmd_info_21_addr_en_21_qs;
         reg_rdata_next[9] = cmd_info_21_addr_swap_en_21_qs;
@@ -20370,7 +20499,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_21_valid_21_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[56]: begin
         reg_rdata_next[7:0] = cmd_info_22_opcode_22_qs;
         reg_rdata_next[8] = cmd_info_22_addr_en_22_qs;
         reg_rdata_next[9] = cmd_info_22_addr_swap_en_22_qs;
@@ -20386,7 +20515,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_22_valid_22_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[57]: begin
         reg_rdata_next[7:0] = cmd_info_23_opcode_23_qs;
         reg_rdata_next[8] = cmd_info_23_addr_en_23_qs;
         reg_rdata_next[9] = cmd_info_23_addr_swap_en_23_qs;
@@ -20402,13 +20531,13 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_23_valid_23_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[58]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
         reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[59]: begin
         reg_rdata_next[0] = tpm_cfg_en_qs;
         reg_rdata_next[1] = tpm_cfg_tpm_mode_qs;
         reg_rdata_next[2] = tpm_cfg_hw_reg_dis_qs;
@@ -20416,63 +20545,63 @@ module spi_device_reg_top (
         reg_rdata_next[4] = tpm_cfg_invalid_locality_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[60]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
         reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[61]: begin
         reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
         reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
         reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
         reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[62]: begin
         reg_rdata_next[7:0] = tpm_access_1_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[63]: begin
         reg_rdata_next[31:0] = tpm_sts_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[64]: begin
         reg_rdata_next[31:0] = tpm_intf_capability_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[65]: begin
         reg_rdata_next[31:0] = tpm_int_enable_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[66]: begin
         reg_rdata_next[7:0] = tpm_int_vector_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[67]: begin
         reg_rdata_next[31:0] = tpm_int_status_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[68]: begin
         reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
         reg_rdata_next[31:16] = tpm_did_vid_did_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[69]: begin
         reg_rdata_next[7:0] = tpm_rid_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[70]: begin
         reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
         reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[71]: begin
         reg_rdata_next[7:0] = '0;
       end
 
-      addr_hit[71]: begin
+      addr_hit[72]: begin
         reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 


### PR DESCRIPTION
This PR adds `INTERCEPT_EN` CSR to SPI_DEVICE.

If a bit is set, the command is processed internally even in Passthrough mode.