### PR TITLE
[sw/ottf] Make FreeRTOS heap a NOLOAD section.

### DIFF
--- a/sw/device/exts/common/flash_link.ld
+++ b/sw/device/exts/common/flash_link.ld
@@ -158,5 +158,17 @@ SECTIONS {
     _bss_end = .;
   } > ram_main
 
+  /**
+   * FreeRTOS heap.
+   *
+   * This is a separate NOLOAD section so that it does not end up in the `.bss`
+   * section which gets zeroed during the second boot stage initialization,
+   * causing wasted simulation cycles.
+   */
+  .freertos.heap (NOLOAD): ALIGN(4) {
+    _freertos_heap_start = .;
+    *(.freertos.heap)
+  } > ram_main
+
   INCLUDE sw/device/info_sections.ld
 }

--- a/sw/device/lib/testing/test_framework/FreeRTOSConfig.h
+++ b/sw/device/lib/testing/test_framework/FreeRTOSConfig.h
@@ -24,6 +24,7 @@
 #define configUSE_TICK_HOOK 0
 
 // Memory
+#define configAPPLICATION_ALLOCATED_HEAP 1
 #define configCHECK_FOR_STACK_OVERFLOW 1
 #define configMINIMAL_STACK_SIZE 256  // in words
 #define configSTACK_DEPTH_TYPE uint16_t

--- a/sw/device/lib/testing/test_framework/freertos_port.c
+++ b/sw/device/lib/testing/test_framework/freertos_port.c
@@ -20,6 +20,16 @@
 // functions.
 
 // ----------------------------------------------------------------------------
+// Heap Setup
+//
+// We allocate the heap here and mark it so the linker can make a
+// NOLOAD section. Otherwise, it will end up in the `.bss` section, which gets
+// zeroed during boot initializations which wastes simulation cycles.
+// ----------------------------------------------------------------------------
+__attribute__((section(".freertos.heap")))
+uint8_t ucHeap[configTOTAL_HEAP_SIZE];
+
+// ----------------------------------------------------------------------------
 // Timer Setup (for use when preemptive scheduling is enabled)
 // ----------------------------------------------------------------------------
 #if configUSE_PREEMPTION


### PR DESCRIPTION
The sw/device/exts/common/flash_crt.S (2nd boot stage initialization code) used in test images zeros out the `.bss` section before transferring control flow to the C program entry point (i.e., main()). FreeRTOS uses an uninitialized static array for its heap, which gets put in the `.bss` section. Zero-ing out the heap wastes simulation cycles in DV and Verilator, as described in #9163.

This PR moves the FreeRTOS heap to its own `NOLOAD` section that is not zero-ed out during the 2nd boot stage initialization, thus making the OTTF as performant as the current `test_main.c` test framework.

This is PR addresses the task described in #9163: "_make FreeRTOS heap it's own NOLOAD section in the flask_link.ld script_".

Signed-off-by: Timothy Trippel <ttrippel@google.com>