### PR TITLE
[reggen] This adds initial support for a cm list

### DIFF
--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -1,0 +1,80 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, List
+
+from .lib import check_keys, check_str, check_list
+
+# TO BE DEFINED
+CM_ASSETS = [
+    'FOO'
+]
+
+# TO BE DEFINED
+CM_TYPES = [
+    'BAR'
+]
+
+
+class CounterMeasure:
+    """Object holding details for one countermeasure within an IP block."""
+
+    def __init__(self, asset: str, cm_type: str, desc: str):
+        self.asset = asset
+        self.cm_type = cm_type
+        self.desc = desc
+
+    @staticmethod
+    def from_raw(what: str, raw: object) -> 'CounterMeasure':
+        """
+        Create a CounterMeasure object from a dict.
+
+        The 'raw' dict must have the keys 'name' and 'desc', where 'name' has
+        to follow the canonical countermeasure naming convention.
+        """
+        rd = check_keys(raw, what, ['name', 'desc'], [])
+
+        name = check_str(rd['name'], f'name field of {what}')
+        desc = check_str(rd['desc'], f'desc field of {what}')
+
+        try:
+            asset, cm_type = name.split('.')
+        except ValueError:
+            raise ValueError(
+                f'Invalid format: {name} ({what}).')
+
+        if asset not in CM_ASSETS:
+            raise ValueError(
+                f'Invalid asset: {asset} ({what}).')
+
+        if cm_type not in CM_TYPES:
+            raise ValueError(
+                f'Invalid type: {cm_type} ({what}).')
+        return CounterMeasure(asset, cm_type, desc)
+
+    @staticmethod
+    def from_raw_list(what: str,
+                      raw: object) -> List['CounterMeasure']:
+        """
+        Create a list of CounterMeasure objects from a list of dicts.
+
+        The dicts in 'raw' must have the keys 'name' and 'desc', where 'name'
+        has to follow the canonical countermeasure naming convention.
+        """
+        ret = []
+        for idx, entry in enumerate(check_list(raw, what)):
+            entry_what = f'entry {idx} of {what}'
+            cm = CounterMeasure.from_raw(entry_what, entry)
+            ret.append(cm)
+        return ret
+
+    def _asdict(self) -> Dict[str, object]:
+        """Returns a dict with 'name' and 'desc' fields"""
+        return {
+            'name': str(self),
+            'desc': self.desc
+        }
+
+    def __str__(self) -> str:
+        return self.asset + '.' + self.cm_type

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -17,6 +17,7 @@ from .lib import (check_keys, check_name, check_int, check_bool,
 from .params import ReggenParams, LocalParam
 from .reg_block import RegBlock
 from .signal import Signal
+from .countermeasure import CounterMeasure
 
 
 REQUIRED_FIELDS = {
@@ -66,7 +67,8 @@ OPTIONAL_FIELDS = {
         "information in a comment at the top of the "
         "file."
     ],
-    'wakeup_list': ['lnw', "list of peripheral wakeups"]
+    'wakeup_list': ['lnw', "list of peripheral wakeups"],
+    'countermeasures': ["ln", "list of countermeasures in this block"]
 }
 
 
@@ -92,7 +94,8 @@ class IpBlock:
                  reset_requests: Sequence[Signal],
                  expose_reg_if: bool,
                  scan_reset: bool,
-                 scan_en: bool):
+                 scan_en: bool,
+                 countermeasures: List[CounterMeasure]):
         assert reg_blocks
 
         # Check that register blocks are in bijection with device interfaces
@@ -122,6 +125,7 @@ class IpBlock:
         self.expose_reg_if = expose_reg_if
         self.scan_reset = scan_reset
         self.scan_en = scan_en
+        self.countermeasures = countermeasures
 
     @staticmethod
     def from_raw(param_defaults: List[Tuple[str, str]],
@@ -162,6 +166,11 @@ class IpBlock:
         alerts = Alert.from_raw_list('alert_list for block {}'
                                      .format(name),
                                      rd.get('alert_list', []))
+
+        countermeasures = CounterMeasure.from_raw_list(
+            'countermeasure list for block {}'
+            .format(name),
+            rd.get('countermeasures', []))
 
         no_auto_intr = check_bool(rd.get('no_auto_intr_regs', not interrupts),
                                   'no_auto_intr_regs field of ' + what)
@@ -265,7 +274,8 @@ class IpBlock:
                        interrupts, no_auto_intr, alerts, no_auto_alert,
                        scan, inter_signals, bus_interfaces,
                        hier_path, clocking, xputs,
-                       wakeups, rst_reqs, expose_reg_if, scan_reset, scan_en)
+                       wakeups, rst_reqs, expose_reg_if, scan_reset, scan_en,
+                       countermeasures)
 
     @staticmethod
     def from_text(txt: str,


### PR DESCRIPTION
Note that this is a draft, implementing the tentative proposal [here](https://docs.google.com/presentation/d/1F8gk-WcxwF-g2mn29A_ko0De8amiyv965Od3FKJCj0U/edit#slide=id.gfa6dc7b147_0_7).

----------------------------------------------------

This adds initial support for declaring an optional list of countermeasures in the IP Hjson.

The list is parsed into a list of `CounterMeasure` objects, and the hierarchical naming is checked against a predefined format.

The actual `CM_ASSETS` and `CM_TYPES` definitions are not declared yet as this is pending further internal feedback.

Signed-off-by: Michael Schaffner <msf@google.com>