### PR TITLE
[dv] Change intg_err test from V3 to V2S

### DIFF
--- a/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson
@@ -60,7 +60,7 @@
 
             Randomly inject errors on the control, data, or the ECC bits during CSR accesses.
             Verify that triggers the correct fatal alert.'''
-      milestone: V3
+      milestone: V2S
       tests: ["{name}_tl_intg_err"]
     }
   ]


### PR DESCRIPTION
This test is part of the security countermeasures
Signed-off-by: Weicai Yang <weicai@google.com>