### PR TITLE
[chip dv] Add support for tiled RAM instances

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.sv
+++ b/hw/top_earlgrey/dv/env/chip_env.sv
@@ -45,9 +45,17 @@ class chip_env extends cip_base_env #(
     end
 
     for (chip_mem_e mem = mem.first(), int i = 0; i < mem.num(); mem = mem.next(), i++) begin
-      if (!uvm_config_db#(mem_bkdr_util)::get(
-          this, "", $sformatf("mem_bkdr_util[%0s]", mem.name()), cfg.mem_bkdr_util_h[mem])) begin
-        `uvm_fatal(`gfn, $sformatf("failed to get mem_bkdr_util[%0s] from uvm_config_db", mem))
+      string inst = $sformatf("mem_bkdr_util[%0s]", mem.name());
+      bit is_invalid;
+
+      is_invalid = mem inside {[RamMain0:RamMain15]} && (int'(mem - RamMain0) >
+                                                         cfg.num_ram_main_tiles - 1);
+
+      is_invalid |= mem inside {[RamRet0:RamRet15]} && (int'(mem - RamRet0) >
+                                                        cfg.num_ram_ret_tiles - 1);
+      if (is_invalid) continue;
+      if (!uvm_config_db#(mem_bkdr_util)::get(this, "", inst, cfg.mem_bkdr_util_h[mem])) begin
+        `uvm_fatal(`gfn, {"failed to get ", inst, " from uvm_config_db"})
       end
     end
 

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -58,6 +58,10 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
   sw_test_status_vif  sw_test_status_vif;
   ast_supply_vif      ast_supply_vif;
 
+  // Number of RAM tiles for each RAM instance.
+  uint num_ram_main_tiles;
+  uint num_ram_ret_tiles;
+
   // ext component cfgs
   rand uart_agent_cfg       m_uart_agent_cfgs[NUM_UARTS];
   rand jtag_riscv_agent_cfg m_jtag_riscv_agent_cfg;
@@ -104,6 +108,9 @@ class chip_env_cfg extends cip_base_env_cfg #(.RAL_T(chip_reg_block));
     sw_images[SwTypeTest] = "./sw";
     sw_images[SwTypeOtbn] = "./otbn";
     sw_images[SwTypeOtp] = "./otp";
+
+    `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)
+    `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)
   endfunction
 
   // ral flow is limited in terms of setting correct field access policies and reset values

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -53,14 +53,17 @@ package chip_env_pkg;
   typedef virtual ast_supply_if         ast_supply_vif;
 
   // Types of memories in the chip.
+  //
+  // RAM instances have support for up to 16 tiles. Actual number of tiles in use in the design is a
+  // runtime setting in chip_env_cfg.
   typedef enum {
     FlashBank0Data,
     FlashBank1Data,
     FlashBank0Info,
     FlashBank1Info,
     Otp,
-    RamMain,
-    RamRet,
+    RamMain[16],
+    RamRet[16],
     Rom
   } chip_mem_e;
 

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -349,20 +349,20 @@ module tb;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Otp], `OTP_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init RAM", UVM_MEDIUM)
-      m_mem_bkdr_util[RamMain] = new(.name  ("mem_bkdr_util[RamMain]"),
-                                     .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
-                                     .depth ($size(`RAM_MAIN_MEM_HIER)),
-                                     .n_bits($bits(`RAM_MAIN_MEM_HIER)),
-                                     .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain], `RAM_MAIN_MEM_HIER)
+      m_mem_bkdr_util[RamMain0] = new(.name  ("mem_bkdr_util[RamMain0]"),
+                                      .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
+                                      .depth ($size(`RAM_MAIN_MEM_HIER)),
+                                      .n_bits($bits(`RAM_MAIN_MEM_HIER)),
+                                      .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain0], `RAM_MAIN_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init RAM RET", UVM_MEDIUM)
-      m_mem_bkdr_util[RamRet] = new(.name  ("mem_bkdr_util[RamRet]"),
-                                    .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
-                                    .depth ($size(`RAM_RET_MEM_HIER)),
-                                    .n_bits($bits(`RAM_RET_MEM_HIER)),
-                                    .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
-      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet], `RAM_RET_MEM_HIER)
+      m_mem_bkdr_util[RamRet0] = new(.name  ("mem_bkdr_util[RamRet0]"),
+                                     .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
+                                     .depth ($size(`RAM_RET_MEM_HIER)),
+                                     .n_bits($bits(`RAM_RET_MEM_HIER)),
+                                     .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
+      `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet0], `RAM_RET_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init ROM", UVM_MEDIUM)
       m_mem_bkdr_util[Rom] = new(.name  ("mem_bkdr_util[Rom]"),
@@ -373,6 +373,8 @@ module tb;
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[Rom], `ROM_MEM_HIER)
 
       for (chip_mem_e mem = mem.first(), int i = 0; i < mem.num(); mem = mem.next(), i++) begin
+        if (mem inside {[RamMain1:RamMain15]}) continue;
+        if (mem inside {[RamRet1:RamRet15]}) continue;
         uvm_config_db#(mem_bkdr_util)::set(
             null, "*.env", m_mem_bkdr_util[mem].get_name(), m_mem_bkdr_util[mem]);
       end

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -28,9 +28,12 @@ class chip_base_test extends cip_base_test #(
     // Set tl_agent's is_active bit based on the retrieved stub_cpu value.
     cfg.m_tl_agent_cfg.is_active = cfg.stub_cpu;
 
+    // Set the number of RAM tiles (1 each).
+    cfg.num_ram_main_tiles = 1;
+    cfg.num_ram_ret_tiles = 1;
+
     // Knob to set the UART baud rate (set to 2M by default).
     void'($value$plusargs("uart_baud_rate=%0d", cfg.uart_baud_rate));
-
 
     // The following plusargs are only valid for SW based tests (i.e., no stubbed CPU).
     // Knob to configure writing sw logs to a separate file (enabled by default).


### PR DESCRIPTION
- Adds support for attaching multiple mem backdoor util instances for
multiply-tiled RAMs in the design.
- Number of tiles for main / ret SRAM is a runtime setting that is set
to 1 in the open source testbench with a generic model.
- Extended class can set it to whatever the correct value is for that
environment.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>