### PR TITLE
[dv] Update cip to support instr_type better

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -16,7 +16,7 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
 
   virtual function void randomize_req(REQ req, int idx);
     super.randomize_req(req, idx);
-    req.instr_type = instr_type;
+    req.set_instr_type(instr_type);
     req.tl_intg_err_type = tl_intg_err_type;
   endfunction
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -7,25 +7,36 @@ class cip_tl_seq_item extends tl_seq_item;
 
   `uvm_object_new
 
-  mubi4_e instr_type = MuBi4False;
   tl_intg_err_e       tl_intg_err_type = TlIntgErrNone;
   // the max errors that we can detect
   int                 max_ecc_errors = MAX_TL_ECC_ERRORS;
 
   `uvm_object_utils_begin(cip_tl_seq_item)
-    `uvm_field_enum(prim_mubi_pkg::mubi4_e, instr_type,       UVM_DEFAULT)
     `uvm_field_enum(tl_intg_err_e,          tl_intg_err_type, UVM_DEFAULT)
     `uvm_field_int(max_ecc_errors,                            UVM_DEFAULT)
   `uvm_object_utils_end
 
   function void post_randomize();
-    a_user = compute_a_user();
+    set_instr_type(MuBi4False);
+  endfunction
+
+  virtual function mubi4_e get_instr_type();
+    tl_a_user_t l_a_user = tl_a_user_t'(a_user);
+    return l_a_user.instr_type;
+  endfunction
+
+  virtual function void set_instr_type(mubi4_e instr_type);
+    // updating instr_type and re-calculate a_user
+    a_user = compute_a_user(instr_type);
+
+    // update intg to based on settings - tl_intg_err_type and max_ecc_errors
     inject_a_chan_intg_err();
   endfunction
 
-  // calculate ecc value for a_user and return a_user
+  // calculate data and cmd integrity value based on TLUL fields (such as addr, data etc) for a_user
+  // and return a_user
   // class member a_user isn't updated in this function
-  virtual function tl_a_user_t compute_a_user();
+  virtual function tl_a_user_t compute_a_user(mubi4_e instr_type = get_instr_type());
     tl_a_user_t user;
     tl_h2d_cmd_intg_t cmd_intg_payload;
     logic [H2DCmdFullWidth - 1 : 0] cmd_with_intg;


### PR DESCRIPTION
1. Fix finish_item calling item.randomize(sth), which invokes
post_randomize again
2. instr_type is part of a_user. Removed the replicated variable and
added set/get_instr_type functions

Signed-off-by: Weicai Yang <weicai@google.com>