### PR TITLE
[sram/dv] update scb and seq for exec test and tl_err test

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -48,7 +48,9 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
   // Request a memory init.
   //
   virtual task req_mem_init();
-    csr_wr(.ptr(ral.ctrl), .value(3));
+    ral.ctrl.renew_scr_key.set(1);
+    ral.ctrl.init.set(1);
+    csr_update(.csr(ral.ctrl));
     csr_spinwait(.ptr(ral.status.init_done), .exp_data(1));
   endtask
 
@@ -119,7 +121,8 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
       `DV_CHECK_STD_RANDOMIZE_FATAL(data)
 
       // never send InstrType transactions unless en_ifetch is enabled
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(instr_type, !en_ifetch -> instr_type == MuBi4False;)
+      if (en_ifetch) instr_type = get_rand_mubi4_val();
+      else           instr_type = MuBi4False;
 
       tl_access(.addr(addr),
                 .data(data),
@@ -155,7 +158,8 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
           addr inside {[cfg.sram_start_addr : cfg.sram_end_addr]};)
 
       // never send InstrType transactions unless en_ifetch is enabled
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(instr_type, !en_ifetch -> instr_type == MuBi4False;)
+      if (en_ifetch) instr_type = get_rand_mubi4_val();
+      else           instr_type = MuBi4False;
 
       tl_access_w_abort(.addr(addr),
                         .data(data),

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
@@ -13,75 +13,23 @@ class sram_ctrl_executable_vseq extends sram_ctrl_multiple_keys_vseq;
   `uvm_object_utils(sram_ctrl_executable_vseq)
   `uvm_object_new
 
-  bit [3:0] hw_debug_en;
-  bit [7:0] en_sram_ifetch;
-  bit [3:0] en_exec_csr;
-
-  // These bits are used to create pseudo-weights for the constraint distributions
-  // of the above values
-  bit       is_valid;
-  bit [1:0] is_off;
-
   virtual task pre_start();
     en_ifetch = 1;
     super.pre_start();
   endtask
 
-  task req_scr_key();
-    super.req_scr_key();
+  task req_mem_init();
+    super.req_mem_init();
     randomize_and_drive_ifetch_en();
   endtask
 
   task randomize_and_drive_ifetch_en();
-    `DV_CHECK_STD_RANDOMIZE_FATAL(is_valid);
-    `DV_CHECK_STD_RANDOMIZE_FATAL(is_off);
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(en_exec_csr,
-        // 50% chance to enable
-        if (is_valid) {
-          en_exec_csr == MuBi4True;
-        } else {
-          // 75% chance to set garbage invalid data
-          if (is_off == 0) {
-            en_exec_csr == MuBi4False;
-          } else {
-            !(en_exec_csr inside {MuBi4True, MuBi4False});
-          }
-        }
-    )
+    mubi8_e en_sram_ifetch = get_rand_mubi8_val();
+    mubi4_e en_exec_csr = get_rand_mubi4_val();
+    lc_ctrl_pkg::lc_tx_e hw_debug_en = get_rand_lc_tx_val();
+
     `uvm_info(`gfn, $sformatf("en_exec_csr: 0b%0b", en_exec_csr), UVM_HIGH)
-
-    `DV_CHECK_STD_RANDOMIZE_FATAL(is_valid);
-    `DV_CHECK_STD_RANDOMIZE_FATAL(is_off);
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(en_sram_ifetch,
-        // 50% chance to enable
-        if (is_valid) {
-          en_sram_ifetch == MuBi8True;
-        } else {
-          // 75% chance to set garbage invalid data
-          if (is_off == 0) {
-            en_sram_ifetch == MuBi8False;
-          } else {
-            !(en_sram_ifetch inside {MuBi8True, MuBi8False});
-          }
-        }
-    )
     `uvm_info(`gfn, $sformatf("en_sram_ifetch: 0b%0b", en_sram_ifetch), UVM_HIGH)
-
-    `DV_CHECK_STD_RANDOMIZE_FATAL(is_valid);
-    `DV_CHECK_STD_RANDOMIZE_FATAL(is_off);
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(hw_debug_en,
-        // 50% chance to enable
-        if (is_valid) {
-          hw_debug_en == lc_ctrl_pkg::On;
-        } else {
-          // 75% chance to set garbage invalid data
-          if (is_off == 0) {
-            hw_debug_en == lc_ctrl_pkg::Off;
-          } else {
-            !(hw_debug_en inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off});
-          }
-        }
-    )
     `uvm_info(`gfn, $sformatf("hw_debug_en: 0b%0b",  hw_debug_en), UVM_HIGH)
 
     csr_wr(ral.exec, en_exec_csr);

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -61,8 +61,8 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
 
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_ops)
 
-      // Request a new scrambling key
-      req_scr_key();
+      // Request a new scrambling key and do init
+      if ($urandom_range(0, 1)) req_mem_init();
 
       fork
         begin


### PR DESCRIPTION
Please ignore the first 2 commits, which are from #9191 and #9243,
which will be rebased away.
1. simplify seq to randomize mubi and lc_tx variables
2. update scb to fix tl_err test
