### PR TITLE
[dv] Teach encrypt/decrypt_sram_data to support OTBN

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
@@ -39,7 +39,7 @@ virtual function logic [7:0] sram_encrypt_read8(logic [bus_params_pkg::BUS_AW-1:
   rdata = read8(bus_addr);
   rdata_arr = {<<{rdata}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
-      rdata_arr, 8, 1, sram_addr, addr_width, key_arr, nonce_arr
+      rdata_arr, 8, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   rdata = {<<{rdata_arr}};
   return rdata;
@@ -79,7 +79,7 @@ virtual function logic [15:0] sram_encrypt_read16(logic [bus_params_pkg::BUS_AW-
   rdata = read16(bus_addr);
   rdata_arr = {<<{rdata}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
-      rdata_arr, 16, 1, sram_addr, addr_width, key_arr, nonce_arr
+      rdata_arr, 16, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   rdata = {<<{rdata_arr}};
   return rdata;
@@ -118,7 +118,7 @@ virtual function logic [31:0] sram_encrypt_read32(logic [bus_params_pkg::BUS_AW-
   rdata = read32(bus_addr);
   rdata_arr = {<<{rdata}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
-      rdata_arr, 32, 1, sram_addr, addr_width, key_arr, nonce_arr
+      rdata_arr, 32, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   rdata = {<<{rdata_arr}};
   return rdata;
@@ -159,7 +159,7 @@ virtual function logic [38:0] sram_encrypt_read32_integ(logic [bus_params_pkg::B
   `uvm_info(`gfn, $sformatf("scr data: 0x%0x", rdata), UVM_HIGH)
   rdata_arr = {<<{rdata}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
-      rdata_arr, 39, 0, sram_addr, addr_width, key_arr, nonce_arr
+      rdata_arr, 39, 39, sram_addr, addr_width, key_arr, nonce_arr
   );
   rdata = {<<{rdata_arr}};
   // Only return the data payload without ECC bits.
@@ -201,7 +201,7 @@ virtual function logic [63:0] sram_encrypt_read64(logic [bus_params_pkg::BUS_AW-
   rdata = read64(bus_addr);
   rdata_arr = {<<{rdata}};
   rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
-      rdata_arr, 64, 1, sram_addr, addr_width, key_arr, nonce_arr
+      rdata_arr, 64, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   rdata = {<<{rdata_arr}};
   return rdata;
@@ -234,7 +234,7 @@ virtual function void sram_encrypt_write8(logic [bus_params_pkg::BUS_AW-1:0] add
   // Calculate the scrambled data
   wdata_arr = {<<{data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 8, 1, sram_addr, addr_width, key_arr, nonce_arr
+      wdata_arr, 8, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   scrambled_data = {<<{wdata_arr}};
 
@@ -276,7 +276,7 @@ virtual function void sram_encrypt_write16(logic [bus_params_pkg::BUS_AW-1:0] ad
   // Calculate the scrambled data
   wdata_arr = {<<{data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 16, 1, sram_addr, addr_width, key_arr, nonce_arr
+      wdata_arr, 16, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   scrambled_data = {<<{wdata_arr}};
 
@@ -318,7 +318,7 @@ virtual function void sram_encrypt_write32(logic [bus_params_pkg::BUS_AW-1:0] ad
   // Calculate the scrambled data
   wdata_arr = {<<{data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 32, 1, sram_addr, addr_width, key_arr, nonce_arr
+      wdata_arr, 32, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   scrambled_data = {<<{wdata_arr}};
 
@@ -364,7 +364,7 @@ virtual function void sram_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1
   // Calculate the scrambled data
   wdata_arr = {<<{integ_data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 39, 0, sram_addr, addr_width, key_arr, nonce_arr
+      wdata_arr, 39, 39, sram_addr, addr_width, key_arr, nonce_arr
   );
   scrambled_data = {<<{wdata_arr}};
 
@@ -406,7 +406,7 @@ virtual function void sram_encrypt_write64(logic [bus_params_pkg::BUS_AW-1:0] ad
   // Calculate the scrambled data
   wdata_arr = {<<{data}};
   wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-      wdata_arr, 64, 1, sram_addr, addr_width, key_arr, nonce_arr
+      wdata_arr, 64, 8, sram_addr, addr_width, key_arr, nonce_arr
   );
   scrambled_data = {<<{wdata_arr}};
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -116,7 +116,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     scr_data_arr = {<<{scr_data}};
 
     // Descramble the data
-    clr_data_arr = sram_scrambler_pkg::decrypt_sram_data(scr_data_arr, 39, 1'b0,
+    clr_data_arr = sram_scrambler_pkg::decrypt_sram_data(scr_data_arr, 39, 39,
                                                          idx_arr, ImemIndexWidth,
                                                          key_arr, nonce_arr);
     clr_data = {<<{clr_data_arr}};
@@ -145,7 +145,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
 
     // Scramble the data
     clr_data_arr = {<<{clr_data}};
-    scr_data_arr = sram_scrambler_pkg::encrypt_sram_data(clr_data_arr, 39, 1'b0,
+    scr_data_arr = sram_scrambler_pkg::encrypt_sram_data(clr_data_arr, 39, 39,
                                                          idx_arr, ImemIndexWidth,
                                                          key_arr, nonce_arr);
     scr_data = {<<{scr_data_arr}};


### PR DESCRIPTION
This commit teaches those two functions to support replication of
keystreams (in OTBN, we re-use a 64-bit keystream by concatenating it
with itself as many times as needed for the very wide word).

It also generalises the functions to allow the caller to select the
width of the subst/perm network. Before this commit, there was a
"`byte_diff`" flag that allowed you to select between full-width and 8
bits. This commit changes the flag to an integer that gives the width
explicitly. Call-sites that set `byte_diff` should have an `sp_width` of
8; those that didn't should have an `sp_width` equal to `data_width`.
OTBN's dmem can use an `sp_width` of 39 (and a `data_width` of 312).

The implementation is a little finicky because you have to extract
"chunks" of an unpacked array. For the 8-bit case, you could do things
like "`data[i*8 +: 8]`" but you can't do that if you don't know the
width at compile time (because range selects need a constant for their
width). As such, there's a big loop on each side of the call to
`sp_encrypt` or `sp_decrypt` to grab a chunk of data, operate on it, and
write it back to the main word.
