### PR TITLE
[otbn,sw] Combine input and output buffers for RSA code

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
@@ -11,15 +11,13 @@
 OTBN_DECLARE_APP_SYMBOLS(rsa);          // The OTBN rsa app.
 OTBN_DECLARE_PTR_SYMBOL(rsa, mode);     // The RSA mode of operation.
 OTBN_DECLARE_PTR_SYMBOL(rsa, n_limbs);  // The number of 256-bit limbs.
-OTBN_DECLARE_PTR_SYMBOL(rsa, in);       // The input message.
-OTBN_DECLARE_PTR_SYMBOL(rsa, out);      // The output message.
+OTBN_DECLARE_PTR_SYMBOL(rsa, inout);    // The input/output message buffer
 OTBN_DECLARE_PTR_SYMBOL(rsa, modulus);  // The modulus to operate with.
 
 static const otbn_app_t kOtbnAppRsa = OTBN_APP_T_INIT(rsa);
 static const otbn_ptr_t kOtbnVarRsaMode = OTBN_PTR_T_INIT(rsa, mode);
 static const otbn_ptr_t kOtbnVarRsaNLimbs = OTBN_PTR_T_INIT(rsa, n_limbs);
-static const otbn_ptr_t kOtbnVarRsaIn = OTBN_PTR_T_INIT(rsa, in);
-static const otbn_ptr_t kOtbnVarRsaOut = OTBN_PTR_T_INIT(rsa, out);
+static const otbn_ptr_t kOtbnVarRsaInOut = OTBN_PTR_T_INIT(rsa, inout);
 static const otbn_ptr_t kOtbnVarRsaModulus = OTBN_PTR_T_INIT(rsa, modulus);
 
 static const uint32_t kOtbnModeEncrypt = 1;
@@ -57,7 +55,7 @@ otbn_error_t sigverify_mod_exp_otbn_run_app(const sigverify_rsa_key_t *key,
                                               key->n.data, kOtbnVarRsaModulus));
   // Set the message text.
   OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kSigVerifyRsaNumWords,
-                                              sig->data, kOtbnVarRsaIn));
+                                              sig->data, kOtbnVarRsaInOut));
 
   // Start the OTBN routine.
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
@@ -66,8 +64,8 @@ otbn_error_t sigverify_mod_exp_otbn_run_app(const sigverify_rsa_key_t *key,
   OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
 
   // Read digest out of OTBN dmem.
-  OTBN_RETURN_IF_ERROR(otbn_copy_data_from_otbn(&otbn, kSigVerifyRsaNumWords,
-                                                kOtbnVarRsaOut, result->data));
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_from_otbn(
+      &otbn, kSigVerifyRsaNumWords, kOtbnVarRsaInOut, result->data));
   return kOtbnErrorOk;
 }
 

--- a/sw/device/silicon_creator/otbn/rsa.s
+++ b/sw/device/silicon_creator/otbn/rsa.s
@@ -25,6 +25,21 @@ rsa_encrypt:
   ecall
 
 
+/**
+ * Copy the contents of work_buf onto inout
+ *
+ * clobbered registers: x3, x4
+ */
+cp_work_buf:
+  la  x3, work_buf
+  la  x4, inout
+  /* The buffers are 512 bytes long, which we can load/store with
+     sixteen 256b words. */
+  loopi 16, 2
+    bn.lid x0, 0(x3++)
+    bn.sid x0, 0(x4++)
+  ret
+
 .data
 /*
 The structure of the 256b below are mandated by the calling convention of the
@@ -55,7 +70,7 @@ dptr_m:
 
 /* pointer to base bignum buffer (dptr_in) */
 dptr_in:
-  .word in
+  .word inout
 
 /* pointer to exponent buffer (dptr_exp, unused for encrypt) */
 dptr_exp:
@@ -63,7 +78,7 @@ dptr_exp:
 
 /* pointer to out buffer (dptr_out) */
 dptr_out:
-  .word out
+  .word work_buf
 
 
 /* Freely available DMEM space. */
@@ -87,11 +102,11 @@ exp:
   .zero 512
 
 /* input data */
-.globl in
-in:
+.globl inout
+inout:
   .zero 512
 
 /* output data */
-.globl out
-out:
+.globl work_buf
+work_buf:
   .zero 512

--- a/sw/device/tests/otbn_rsa_test.c
+++ b/sw/device/tests/otbn_rsa_test.c
@@ -69,16 +69,14 @@ static const bool kTestRsaGreater1k = false;
 OTBN_DECLARE_APP_SYMBOLS(rsa);
 OTBN_DECLARE_PTR_SYMBOL(rsa, mode);
 OTBN_DECLARE_PTR_SYMBOL(rsa, n_limbs);
-OTBN_DECLARE_PTR_SYMBOL(rsa, in);
-OTBN_DECLARE_PTR_SYMBOL(rsa, out);
+OTBN_DECLARE_PTR_SYMBOL(rsa, inout);
 OTBN_DECLARE_PTR_SYMBOL(rsa, modulus);
 OTBN_DECLARE_PTR_SYMBOL(rsa, exp);
 
 static const otbn_app_t kOtbnAppRsa = OTBN_APP_T_INIT(rsa);
 static const otbn_ptr_t kOtbnVarRsaMode = OTBN_PTR_T_INIT(rsa, mode);
 static const otbn_ptr_t kOtbnVarRsaNLimbs = OTBN_PTR_T_INIT(rsa, n_limbs);
-static const otbn_ptr_t kOtbnVarRsaIn = OTBN_PTR_T_INIT(rsa, in);
-static const otbn_ptr_t kOtbnVarRsaOut = OTBN_PTR_T_INIT(rsa, out);
+static const otbn_ptr_t kOtbnVarRsaInOut = OTBN_PTR_T_INIT(rsa, inout);
 static const otbn_ptr_t kOtbnVarRsaModulus = OTBN_PTR_T_INIT(rsa, modulus);
 static const otbn_ptr_t kOtbnVarRsaExp = OTBN_PTR_T_INIT(rsa, exp);
 
@@ -121,7 +119,7 @@ static void rsa_encrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
                                kOtbnVarRsaNLimbs) == kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, modulus,
                                kOtbnVarRsaModulus) == kOtbnOk);
-  CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, in, kOtbnVarRsaIn) ==
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, in, kOtbnVarRsaInOut) ==
         kOtbnOk);
 
   // Call OTBN to perform operation, and wait for it to complete.
@@ -129,7 +127,7 @@ static void rsa_encrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnOk);
 
   // Read back results.
-  CHECK(otbn_copy_data_from_otbn(otbn_ctx, size_bytes, kOtbnVarRsaOut, out) ==
+  CHECK(otbn_copy_data_from_otbn(otbn_ctx, size_bytes, kOtbnVarRsaInOut, out) ==
         kOtbnOk);
 }
 
@@ -165,7 +163,7 @@ static void rsa_decrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
                                kOtbnVarRsaModulus) == kOtbnOk);
   CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, private_exponent,
                                kOtbnVarRsaExp) == kOtbnOk);
-  CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, in, kOtbnVarRsaIn) ==
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, size_bytes, in, kOtbnVarRsaInOut) ==
         kOtbnOk);
 
   // Call OTBN to perform operation
@@ -173,7 +171,7 @@ static void rsa_decrypt(otbn_t *otbn_ctx, const uint8_t *modulus,
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnOk);
 
   // Read back results.
-  CHECK(otbn_copy_data_from_otbn(otbn_ctx, size_bytes, kOtbnVarRsaOut, out) ==
+  CHECK(otbn_copy_data_from_otbn(otbn_ctx, size_bytes, kOtbnVarRsaInOut, out) ==
         kOtbnOk);
 }
 


### PR DESCRIPTION
The existing RSA code had 4 * 512 bytes = 2kb of buffers, plus 256
bytes of config data, all of which needed to be accessible over the
bus. This is a problem because we're trying to cut down the
bus-accessible portion of DMEM to 2kb.

Fortunately, two of these buffers are "input" and "output". Merge the
two into an "inout" buffer and add a (non-globally-visible) work_buf
buffer on the OTBN side. Now, OTBN encrypts or decrypts the contents
of inout, writing to work_buf. Once that's done, it copies that buffer
back to inout.

This will add ~53 cycles to each operation, which is a tiny fraction
of the total time.
