### PR TITLE
[util] Remove debug prints to speed up secded_gen.py

### DIFF
--- a/util/design/secded_gen.py
+++ b/util/design/secded_gen.py
@@ -357,7 +357,6 @@ def ecc_encode(codetype: str, k: int, dataword: int) -> Tuple[int, int]:
         codeword_rev = codeword[::-1]
         for idx, f in enumerate(mask[::-1]):
             if int(f):
-                log.debug(f'xoring position {idx} value {codeword_rev[idx]}')
                 bit ^= int(codeword_rev[idx])
 
         codeword = str(bit) + codeword
@@ -548,13 +547,10 @@ def _hamming_code(k, m):
                 # If even, we are in the skip phase, do not include
                 # If odd, we are in the include phase
                 parity_chk = int((pos - (pos % parity_pos)) / parity_pos)
-                log.debug("At position {} parity value {}, {}".format(
-                    pos, parity_pos, parity_chk))
 
                 # valid for inclusion or final parity bit that includes everything
                 if is_odd(parity_chk) or p == m - 1:
                     code = code + (p, )
-                    log.info("add {} to tuple {}".format(p, code))
 
             codes.append(code)
 


### PR DESCRIPTION
Now that we're adding ECC check bits to flash images, a significant
fraction of SW build time is spent running gen-flash-img.py. Profiling
a run of:

    ../util/design/gen-flash-img.py \
      sw/device/tests/uart_smoketest_sim_dv.64.vmem \
      sw/device/tests/uart_smoketest_sim_dv.64.scr.vmem

(run this in the build-out directory; choice of test completely
arbitrary!) with py-spy, I realised that we were spending almost half
our time constructing debug messages that we didn't write out.

I'm sure there are cleverer things we can do, but it looks like we
probably don't really need these so let's just drop them for now.

After these changes, here are the big contributors to the total
runtime for the script:

     38%    load up secded_cfg.hjson
     36%    pick an ECC code (we choose it on-the-fly)
    ~15%    actually computing ECC bits

This still seems a little silly, but this patch gets us a factor of 2,
so maybe it's a good start!
