### PR TITLE
[util] Fix make_new_diff in "new" mode.

### DIFF
--- a/util/make_new_dif.py
+++ b/util/make_new_dif.py
@@ -102,7 +102,7 @@ def main():
     else:
         assert args.ip_name_snake and args.ip_name_long, \
             "ERROR: pass --ip-name-snake and --ip-name-long when --mode=new."
-        ips.append(Ip(args.ip, args.peripheral))
+        ips.append(Ip(args.ip_name_snake, args.ip_name_long))
 
     # Default to generating all parts.
     if len(args.only) == 0:


### PR DESCRIPTION
New mode raise an error in the make_new_diff.py script.
Parameters passed to the Ip class constructor are not existant.
Pass the correct one using the args parameters.

Signed-off-by: Adrien Grassein <adrien.grassein@gmail.com>