### PR TITLE
[otbn,dv] Fix is_valid_256b_addr check

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -88,7 +88,7 @@ class Dmem:
         if addr & 31:
             return False
 
-        word_addr = addr // 32
+        word_addr = addr // 4
         if word_addr >= len(self.data):
             return False
 
@@ -119,7 +119,7 @@ class Dmem:
         if addr & 3:
             return False
 
-        if (addr + 3) // 32 >= len(self.data):
+        if (addr + 3) // 4 >= len(self.data):
             return False
 
         return True


### PR DESCRIPTION
This check is supposed to be working out whether the word for the
address actually exists. The divide by 32 was right when our words
were 256 bits long, but needs to change to 4 now that they are just
32.

This fixes some failures in otbn_single that we're seeing in our nightly tests.