### PR TITLE
[sw] Clean up mtvec load code

### DIFF
--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -45,7 +45,7 @@ _start:
   .option pop
 
   // Set up the new interrupt vector.
-  la   t0, crt_interrupt_vector
+  la   t0, (crt_interrupt_vector + 1)
   csrw mtvec, t0
 
   // Zero out the `.bss` segment.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -154,9 +154,7 @@ _rom_ext_start_boot:
    *
    * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
    */
-  la   t0, _rom_ext_interrupt_vector
-  andi t0, t0, -4
-  ori  t0, t0, 0b01
+  la   t0, (_rom_ext_interrupt_vector + 1)
   csrw mtvec, t0
 
   /**

--- a/sw/device/silicon_owner/bare_metal/bare_metal_start.S
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_start.S
@@ -151,9 +151,7 @@ _start_boot:
    *
    * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
    */
-  la   t0, _interrupt_vector
-  andi t0, t0, -4
-  ori  t0, t0, 0b01
+  la   t0, (_interrupt_vector + 1)
   csrw mtvec, t0
 
   /**


### PR DESCRIPTION
# What
Clean up the assembly code responsable for loading the vector table to `mtvec` register.

# Why
As the address is aligned by 256 bytes, it means that the two less significant bit of will be always `0b00`
