### PR TITLE
[otbn,rtl] Weaken assertion about imem_addr_o

### DIFF
--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -610,7 +610,7 @@ module otbn_core
   // All outputs should be known.
   `ASSERT_KNOWN(DoneOKnown_A, done_o)
   `ASSERT_KNOWN(ImemReqOKnown_A, imem_req_o)
-  `ASSERT_KNOWN(ImemAddrOKnown_A, imem_addr_o)
+  `ASSERT_KNOWN_IF(ImemAddrOKnown_A, imem_addr_o, imem_req_o)
   `ASSERT_KNOWN(ImemWdataOKnown_A, imem_wdata_o)
   `ASSERT_KNOWN(DmemReqOKnown_A, dmem_req_o)
   `ASSERT_KNOWN_IF(DmemWriteOKnown_A, dmem_write_o, dmem_req_o)


### PR DESCRIPTION
The core can sometimes send X on this signal, but it doesn't matter
because imem_req_o is false.

To see this happen, run:

    util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson \
        -i otbn_multi_err --fixed-seed 3982135834

this is running the "jalr-0" test, which does a

    jalr x0, x1, 0

with an empty callstack. I think the X's in the uninitialised call
stack are appearing as the next address to load. Of course, this
doesn't matter because we're also spotting the error and squashing the
request.