### PR TITLE
[es/csrng/edn] Don't clear packer FIFOs upon read

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -795,7 +795,8 @@ module csrng_core import csrng_pkg::*; #(
 
   prim_packer_fifo #(
     .InW(BlkLen),
-    .OutW(32)
+    .OutW(32),
+    .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_sw_genbits (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
@@ -989,7 +990,8 @@ module csrng_core import csrng_pkg::*; #(
 
   prim_packer_fifo #(
     .InW(32),
-    .OutW(SeedLen)
+    .OutW(SeedLen),
+    .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_adata (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -615,7 +615,8 @@ module edn_core import edn_pkg::*;
 
   prim_packer_fifo #(
      .InW(CSGenBitsWidth),
-     .OutW(CSGenBitsWidth)
+     .OutW(CSGenBitsWidth),
+     .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_cs (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
@@ -675,7 +676,8 @@ module edn_core import edn_pkg::*;
 
     prim_packer_fifo #(
       .InW(CSGenBitsWidth),
-      .OutW(EndPointBusWidth)
+      .OutW(EndPointBusWidth),
+      .ClearOnRead(1'b0)
     ) u_prim_packer_fifo_ep (
       .clk_i      (clk_i),
       .rst_ni     (rst_ni),

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -723,7 +723,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_packer_fifo #(
     .InW(1),
-    .OutW(RngBusWidth)
+    .OutW(RngBusWidth),
+    .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_esbit (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
@@ -1919,7 +1920,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_packer_fifo #(
     .InW(RngBusWidth),
-    .OutW(PostHTWidth)
+    .OutW(PostHTWidth),
+    .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_postht (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
@@ -1991,7 +1993,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_packer_fifo #(
     .InW(ObserveFifoWidth),
-    .OutW(PreCondWidth)
+    .OutW(PreCondWidth),
+    .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_precon (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
@@ -2090,7 +2093,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_packer_fifo #(
      .InW(PreCondWidth),
-     .OutW(SeedLen)
+     .OutW(SeedLen),
+     .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_bypass (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),
@@ -2236,7 +2240,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_packer_fifo #(
     .InW(SeedLen),
-    .OutW(FullRegWidth)
+    .OutW(FullRegWidth),
+    .ClearOnRead(1'b0)
   ) u_prim_packer_fifo_swread (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),


### PR DESCRIPTION
Previously, all packer FIFOs in the entropy complex where by default cleared to zero upon read. However, as this may simplify attacks trying to manipulate the random number distribution it should better be avoided. Leaving around the previous random data on the bus/wires after the read is preferred over outputting a deterministic value in this case.

This is a follow-up PR of #8893 and we've discussed this in the security meeting on Oct 28.

@mwbranstad, you mentioned in https://github.com/lowRISC/opentitan/pull/8893#pullrequestreview-789573139 that the clearing was originally added for debugging and is functionally not required. Right now, the packers are still cleared using the `clr` input port e.g. when turning off the entropy complex. I think this is reasonable. However, if we decide clearing the data flops is not needed at all, we can fix that input to 0 and expect some area savings especially inside CSRNG (1 384-bit packer, 1 32-bit packer) and the EDNs (1 128-bit + NumEndPoints 32-bit packers each) - that's quite some muxing. Earlier this year we did something similar with the `prim_fifo_sync` primitive which together with some other changes led to an area reduction of ~6.5% of CSRNG (see https://github.com/lowRISC/opentitan/issues/4451#issuecomment-789763965). WDYT?

