### PR TITLE
[dv/alert] Support LPG in alert_sender/receiver pair

### DIFF
--- a/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
+++ b/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
@@ -35,6 +35,24 @@
     }
 
     {
+      name: prim_alert_init_trigger_test
+      desc: '''Verify init_trigger input from prim_alert_receiver.
+
+            Based on the prim_alert_test, this test adds a parallel sequence to randomly drive
+            init_trigger_i in prim_alert_receiver.
+
+            Check if alert sender/receiver pairs can resume normal handshake after init_trigger_i
+            is set.
+            For fatal alert, check if fatal alerts keep firing until reset is issued.
+            '''
+      milestone: V1
+      tests: ["prim_async_alert",
+              "prim_async_fatal_alert",
+              "prim_sync_alert",
+              "prim_sync_fatal_alert"]
+    }
+
+    {
       name: prim_alert_ping_request_test
       desc: '''Verify ping request from prim_alert_sender.
 

--- a/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
+++ b/hw/ip/prim/dv/prim_alert/prim_alert_sim_cfg.hjson
@@ -24,7 +24,7 @@
   import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
 
   // Default iterations for all tests - each test entry can override this.
-  reseed: 1
+  reseed: 20
 
   build_modes: [
     {


### PR DESCRIPTION
This PR supports LPG in prim_alert testbench by randomly issue
init_trigger_i in alert_receiver side when alert handshake is on-going.
This PR implements part of the TODO in issue #8814.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>