### PR TITLE
[cleanup] Remove mubi4_e and replace it with mubi4_t

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -80,12 +80,12 @@ package cip_base_pkg;
   // f_weight: randomization weight of the value False
   // other_weight: randomization weight of values other than True or False
   `define _DV_MUBI_RAND_VAL(WIDTH_) \
-    function automatic mubi``WIDTH_``_e get_rand_mubi``WIDTH_``_val( \
+    function automatic mubi``WIDTH_``_t get_rand_mubi``WIDTH_``_val( \
         int t_weight = 2, int f_weight = 2, int other_weight = 1); \
       bit[WIDTH_-1:0] val; \
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val, \
           `DV_MUBI``WIDTH_``_DIST(val, t_weight, f_weight, other_weight), , msg_id) \
-      return mubi``WIDTH_``_e'(val); \
+      return mubi``WIDTH_``_t'(val); \
     endfunction
 
   // Create function - get_rand_mubi4_val
@@ -97,7 +97,7 @@ package cip_base_pkg;
 
   `undef _DV_MUBI_RAND_VAL
 
-  // Currently lc_tx_e is exactly the same as mubi4_e. create a separate function in case these
+  // Currently lc_tx_e is exactly the same as mubi4_t. create a separate function in case these
   // 2 types are changed differently in the future
   function automatic lc_ctrl_pkg::lc_tx_e get_rand_lc_tx_val(int t_weight = 2,
                                                              int f_weight = 2,

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -171,7 +171,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                          input bit [BUS_DW-1:0]  compare_mask = '1,
                          input bit               check_exp_data = 1'b0,
                          input bit               blocking = csr_utils_pkg::default_csr_blocking,
-                         input mubi4_e           instr_type = MuBi4False,
+                         input mubi4_t           instr_type = MuBi4False,
                          tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h,
                          input tl_intg_err_e     tl_intg_err_type = TlIntgErrNone);
     bit completed, saw_err;
@@ -195,7 +195,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
       input bit [BUS_DW-1:0]  compare_mask = '1,
       input bit               check_exp_data = 1'b0,
       input bit               blocking = csr_utils_pkg::default_csr_blocking,
-      input mubi4_e           instr_type = MuBi4False,
+      input mubi4_t           instr_type = MuBi4False,
       tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h,
       input tl_intg_err_e     tl_intg_err_type = TlIntgErrNone,
       input int               req_abort_pct = 0);
@@ -227,7 +227,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
                              input bit [BUS_DW-1:0]  compare_mask = '1,
                              input bit               check_exp_data = 1'b0,
                              input int               req_abort_pct = 0,
-                             input mubi4_e           instr_type = MuBi4False,
+                             input mubi4_t           instr_type = MuBi4False,
                              tl_sequencer            tl_sequencer_h = p_sequencer.tl_sequencer_h,
                              input tl_intg_err_e     tl_intg_err_type = TlIntgErrNone);
     `DV_SPINWAIT(

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -11,7 +11,7 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
   `uvm_object_utils(cip_tl_host_single_seq)
   `uvm_object_new
 
-  mubi4_e instr_type                   = MuBi4False;
+  mubi4_t instr_type                   = MuBi4False;
   tl_intg_err_e       tl_intg_err_type = TlIntgErrNone;
 
   virtual function void randomize_req(REQ req, int idx);

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -20,12 +20,12 @@ class cip_tl_seq_item extends tl_seq_item;
     set_instr_type(MuBi4False);
   endfunction
 
-  virtual function mubi4_e get_instr_type();
+  virtual function mubi4_t get_instr_type();
     tl_a_user_t l_a_user = tl_a_user_t'(a_user);
     return l_a_user.instr_type;
   endfunction
 
-  virtual function void set_instr_type(mubi4_e instr_type);
+  virtual function void set_instr_type(mubi4_t instr_type);
     // updating instr_type and re-calculate a_user
     a_user = compute_a_user(instr_type);
 
@@ -36,7 +36,7 @@ class cip_tl_seq_item extends tl_seq_item;
   // calculate data and cmd integrity value based on TLUL fields (such as addr, data etc) for a_user
   // and return a_user
   // class member a_user isn't updated in this function
-  virtual function tl_a_user_t compute_a_user(mubi4_e instr_type = get_instr_type());
+  virtual function tl_a_user_t compute_a_user(mubi4_t instr_type = get_instr_type());
     tl_a_user_t user;
     tl_h2d_cmd_intg_t cmd_intg_payload;
     logic [H2DCmdFullWidth - 1 : 0] cmd_with_intg;

--- a/hw/dv/sv/tl_agent/tl_host_driver.sv
+++ b/hw/dv/sv/tl_agent/tl_host_driver.sv
@@ -239,7 +239,7 @@ class tl_host_driver extends tl_base_driver;
     cfg.vif.h2d_int.a_data <= '{default:'x};
     // The assignment to tl_type must have a cast since the LRM doesn't allow enum assignment of
     // values not belonging to the enumeration set.
-    cfg.vif.h2d_int.a_user <= '{instr_type:prim_mubi_pkg::mubi4_e'('x), default:'x};
+    cfg.vif.h2d_int.a_user <= '{instr_type:prim_mubi_pkg::mubi4_t'('x), default:'x};
     cfg.vif.h2d_int.a_valid <= 1'b0;
   endfunction : invalidate_a_channel
 

--- a/hw/ip/csrng/dv/env/csrng_env_cfg.sv
+++ b/hw/ip/csrng/dv/env/csrng_env_cfg.sv
@@ -25,8 +25,8 @@ class csrng_env_cfg extends cip_base_env_cfg #(.RAL_T(csrng_reg_block));
 
   rand uint                     num_cmds;
   rand bit                      chk_int_state, regwen;
-  rand mubi4_e                  enable, sw_app_enable, read_int_state;
-  rand mubi8_e                  otp_en_cs_sw_app_read;
+  rand mubi4_t                  enable, sw_app_enable, read_int_state;
+  rand mubi8_t                  otp_en_cs_sw_app_read;
 
   // Variables
   bit                                    compliance[NUM_HW_APPS], status[NUM_HW_APPS];

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -694,27 +694,27 @@ module csrng_core import csrng_pkg::*; #(
   assign recov_alert_o = recov_alert_event;
 
 
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_test_invalid;
 
   // check for illegal enable field states, and set alert if detected
-  mubi4_e mubi_cs_enable;
-  assign mubi_cs_enable = mubi4_e'(reg2hw.ctrl.enable.q);
+  mubi4_t mubi_cs_enable;
+  assign mubi_cs_enable = mubi4_t'(reg2hw.ctrl.enable.q);
   assign cs_enable_pfe = mubi4_test_true_strict(mubi_cs_enable);
   assign cs_enable_pfa = mubi4_test_invalid(mubi_cs_enable);
   assign hw2reg.recov_alert_sts.enable_field_alert.de = cs_enable_pfa;
   assign hw2reg.recov_alert_sts.enable_field_alert.d  = cs_enable_pfa;
 
-  mubi4_e mubi_sw_app_enable;
-  assign mubi_sw_app_enable = mubi4_e'(reg2hw.ctrl.sw_app_enable.q);
+  mubi4_t mubi_sw_app_enable;
+  assign mubi_sw_app_enable = mubi4_t'(reg2hw.ctrl.sw_app_enable.q);
   assign sw_app_enable_pfe = mubi4_test_true_strict(mubi_sw_app_enable);
   assign sw_app_enable_pfa = mubi4_test_invalid(mubi_sw_app_enable);
   assign hw2reg.recov_alert_sts.sw_app_enable_field_alert.de = sw_app_enable_pfa;
   assign hw2reg.recov_alert_sts.sw_app_enable_field_alert.d  = sw_app_enable_pfa;
 
-  mubi4_e mubi_read_int_state;
-  assign mubi_read_int_state = mubi4_e'(reg2hw.ctrl.read_int_state.q);
+  mubi4_t mubi_read_int_state;
+  assign mubi_read_int_state = mubi4_t'(reg2hw.ctrl.read_int_state.q);
   assign read_int_state_pfe = mubi4_test_true_strict(mubi_read_int_state);
   assign read_int_state_pfa = mubi4_test_invalid(mubi_read_int_state);
   assign hw2reg.recov_alert_sts.read_int_state_field_alert.de = read_int_state_pfa;

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -318,19 +318,19 @@ module edn_core import edn_pkg::*;
   };
 
   // check for illegal enable field states, and set alert if detected
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_test_invalid;
 
-  mubi4_e mubi_edn_enable;
-  assign mubi_edn_enable = mubi4_e'(reg2hw.ctrl.edn_enable.q);
+  mubi4_t mubi_edn_enable;
+  assign mubi_edn_enable = mubi4_t'(reg2hw.ctrl.edn_enable.q);
   assign edn_enable_pfe = mubi4_test_true_strict(mubi_edn_enable);
   assign edn_enable_pfa = mubi4_test_invalid(mubi_edn_enable);
   assign hw2reg.recov_alert_sts.edn_enable_field_alert.de = edn_enable_pfa;
   assign hw2reg.recov_alert_sts.edn_enable_field_alert.d  = edn_enable_pfa;
 
-  mubi4_e mubi_cmd_fifo_rst;
-  assign mubi_cmd_fifo_rst = mubi4_e'(reg2hw.ctrl.cmd_fifo_rst.q);
+  mubi4_t mubi_cmd_fifo_rst;
+  assign mubi_cmd_fifo_rst = mubi4_t'(reg2hw.ctrl.cmd_fifo_rst.q);
   assign cmd_fifo_rst_pfe = mubi4_test_true_strict(mubi_cmd_fifo_rst);
   assign cmd_fifo_rst_pfa = mubi4_test_invalid(mubi_cmd_fifo_rst);
   assign hw2reg.recov_alert_sts.cmd_fifo_rst_field_alert.de = cmd_fifo_rst_pfa;
@@ -346,8 +346,8 @@ module edn_core import edn_pkg::*;
   //--------------------------------------------
   // sw register interface
   //--------------------------------------------
-  mubi4_e mubi_auto_req_mode;
-  assign mubi_auto_req_mode = mubi4_e'(reg2hw.ctrl.auto_req_mode.q);
+  mubi4_t mubi_auto_req_mode;
+  assign mubi_auto_req_mode = mubi4_t'(reg2hw.ctrl.auto_req_mode.q);
   assign auto_req_mode_pfe = mubi4_test_true_strict(mubi_auto_req_mode);
   assign auto_req_mode_pfa = mubi4_test_invalid(mubi_auto_req_mode);
   assign hw2reg.recov_alert_sts.auto_req_mode_field_alert.de = auto_req_mode_pfa;
@@ -547,8 +547,8 @@ module edn_core import edn_pkg::*;
 
   assign cmd_sent = (cmd_fifo_cnt_q == RescmdFifoIdxWidth'(1));
 
-  mubi4_e mubi_boot_req_mode;
-  assign mubi_boot_req_mode = mubi4_e'(reg2hw.ctrl.boot_req_mode.q);
+  mubi4_t mubi_boot_req_mode;
+  assign mubi_boot_req_mode = mubi4_t'(reg2hw.ctrl.boot_req_mode.q);
   assign boot_req_mode_pfe = mubi4_test_true_strict(mubi_boot_req_mode);
   assign boot_req_mode_pfa = mubi4_test_invalid(mubi_boot_req_mode);
   assign hw2reg.recov_alert_sts.boot_req_mode_field_alert.de = boot_req_mode_pfa;

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -27,11 +27,11 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   rand bit         regwen;
   rand bit [1:0]   rng_bit_sel;
 
-  rand prim_mubi_pkg::mubi4_e   enable, route_software, type_bypass,
+  rand prim_mubi_pkg::mubi4_t   enable, route_software, type_bypass,
                                 boot_bypass_disable, entropy_data_reg_enable,
                                 rng_bit_enable;
 
-  rand prim_mubi_pkg::mubi8_e   otp_en_es_fw_read, otp_en_es_fw_over;
+  rand prim_mubi_pkg::mubi8_t   otp_en_es_fw_read, otp_en_es_fw_over;
 
   // Constraints
   constraint c_regwen {regwen dist {

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -441,20 +441,20 @@ module entropy_src_core import entropy_src_pkg::*; #(
   //--------------------------------------------
   // set up secure enable bits
   //--------------------------------------------
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::mubi4_test_true_strict;
   import prim_mubi_pkg::mubi4_test_invalid;
 
   // check for illegal enable field states, and set alert if detected
-  mubi4_e mubi_conf_en;
-  assign mubi_conf_en  = mubi4_e'(reg2hw.conf.enable.q);
+  mubi4_t mubi_conf_en;
+  assign mubi_conf_en  = mubi4_t'(reg2hw.conf.enable.q);
   assign es_enable_pfe = mubi4_test_true_strict(mubi_conf_en);
   assign es_enable_pfa = mubi4_test_invalid(mubi_conf_en);
   assign hw2reg.recov_alert_sts.enable_field_alert.de = es_enable_pfa;
   assign hw2reg.recov_alert_sts.enable_field_alert.d  = es_enable_pfa;
 
-  mubi4_e mubi_entropy_reg_en;
-  assign mubi_entropy_reg_en = mubi4_e'(reg2hw.conf.entropy_data_reg_enable.q);
+  mubi4_t mubi_entropy_reg_en;
+  assign mubi_entropy_reg_en = mubi4_t'(reg2hw.conf.entropy_data_reg_enable.q);
   assign entropy_data_reg_en_pfe = mubi4_test_true_strict(mubi_entropy_reg_en);
   assign entropy_data_reg_en_pfa = mubi4_test_invalid(mubi_entropy_reg_en);
   assign hw2reg.recov_alert_sts.entropy_data_reg_en_field_alert.de = entropy_data_reg_en_pfa;
@@ -466,15 +466,15 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign es_enable_rng = es_enable_q;
   assign observe_fifo_thresh = reg2hw.observe_fifo_thresh.q;
 
-  mubi4_e mubi_fw_ov_mode;
-  assign mubi_fw_ov_mode = mubi4_e'(reg2hw.fw_ov_control.fw_ov_mode.q);
+  mubi4_t mubi_fw_ov_mode;
+  assign mubi_fw_ov_mode = mubi4_t'(reg2hw.fw_ov_control.fw_ov_mode.q);
   assign fw_ov_mode_pfe = mubi4_test_true_strict(mubi_fw_ov_mode);
   assign fw_ov_mode_pfa = mubi4_test_invalid(mubi_fw_ov_mode);
   assign hw2reg.recov_alert_sts.fw_ov_mode_field_alert.de = fw_ov_mode_pfa;
   assign hw2reg.recov_alert_sts.fw_ov_mode_field_alert.d  = fw_ov_mode_pfa;
 
-  mubi4_e mubi_fw_ov_entropy_insert;
-  assign mubi_fw_ov_entropy_insert = mubi4_e'(reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
+  mubi4_t mubi_fw_ov_entropy_insert;
+  assign mubi_fw_ov_entropy_insert = mubi4_t'(reg2hw.fw_ov_control.fw_ov_entropy_insert.q);
   assign fw_ov_entropy_insert_pfe = mubi4_test_true_strict(mubi_fw_ov_entropy_insert);
   assign fw_ov_entropy_insert_pfa = mubi4_test_invalid(mubi_fw_ov_entropy_insert);
   assign hw2reg.recov_alert_sts.fw_ov_entropy_insert_field_alert.de = fw_ov_entropy_insert_pfa;
@@ -710,8 +710,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
 
   // pack esrng bus into signal bit packer
-  mubi4_e mubi_rng_bit_en;
-  assign mubi_rng_bit_en = mubi4_e'(reg2hw.conf.rng_bit_enable.q);
+  mubi4_t mubi_rng_bit_en;
+  assign mubi_rng_bit_en = mubi4_t'(reg2hw.conf.rng_bit_enable.q);
   assign rng_bit_enable_pfe = mubi4_test_true_strict(mubi_rng_bit_en);
   assign rng_bit_enable_pfa = mubi4_test_invalid(mubi_rng_bit_en);
   assign hw2reg.recov_alert_sts.rng_bit_enable_field_alert.de = rng_bit_enable_pfa;
@@ -768,8 +768,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign markov_active = es_enable;
   assign extht_active = es_enable;
 
-  mubi4_e mubi_ht_clr;
-  assign mubi_ht_clr = mubi4_e'(reg2hw.conf.health_test_clr.q);
+  mubi4_t mubi_ht_clr;
+  assign mubi_ht_clr = mubi4_t'(reg2hw.conf.health_test_clr.q);
   assign health_test_clr_pfe = mubi4_test_true_strict(mubi_ht_clr);
   assign health_test_clr_pfa = mubi4_test_invalid(mubi_ht_clr);
   assign hw2reg.recov_alert_sts.health_test_clr_field_alert.de = health_test_clr_pfa;
@@ -1144,22 +1144,22 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign event_es_health_test_failed = es_main_sm_alert;
   assign event_es_observe_fifo_ready = observe_fifo_thresh_met;
 
-  mubi4_e mubi_es_route;
-  assign mubi_es_route = mubi4_e'(reg2hw.entropy_control.es_route.q);
+  mubi4_t mubi_es_route;
+  assign mubi_es_route = mubi4_t'(reg2hw.entropy_control.es_route.q);
   assign es_route_pfe = mubi4_test_true_strict(mubi_es_route);
   assign es_route_pfa = mubi4_test_invalid(mubi_es_route);
   assign hw2reg.recov_alert_sts.es_route_field_alert.de = es_route_pfa;
   assign hw2reg.recov_alert_sts.es_route_field_alert.d  = es_route_pfa;
 
-  mubi4_e mubi_es_type;
-  assign mubi_es_type = mubi4_e'(reg2hw.entropy_control.es_type.q);
+  mubi4_t mubi_es_type;
+  assign mubi_es_type = mubi4_t'(reg2hw.entropy_control.es_type.q);
   assign es_type_pfe = mubi4_test_true_strict(mubi_es_type);
   assign es_type_pfa = mubi4_test_invalid(mubi_es_type);
   assign hw2reg.recov_alert_sts.es_type_field_alert.de = es_type_pfa;
   assign hw2reg.recov_alert_sts.es_type_field_alert.d  = es_type_pfa;
 
-  mubi4_e mubi_boot_byp_dis;
-  assign mubi_boot_byp_dis = mubi4_e'(reg2hw.conf.boot_bypass_disable.q);
+  mubi4_t mubi_boot_byp_dis;
+  assign mubi_boot_byp_dis = mubi4_t'(reg2hw.conf.boot_bypass_disable.q);
   assign boot_bypass_disable_pfe = mubi4_test_true_strict(mubi_boot_byp_dis);
   assign boot_bypass_disable_pfa = mubi4_test_invalid(mubi_boot_byp_dis);
   assign hw2reg.recov_alert_sts.boot_bypass_disable_field_alert.de = boot_bypass_disable_pfa;

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -83,7 +83,7 @@ module flash_ctrl
 );
 
   import flash_ctrl_reg_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 
   flash_ctrl_core_reg2hw_t reg2hw;
   flash_ctrl_core_hw2reg_t hw2reg;
@@ -859,14 +859,14 @@ module flash_ctrl
   prim_mubi_pkg::mubi4_t flash_disable;
   assign flash_disable = lc_escalate_en == lc_ctrl_pkg::On ?
                          prim_mubi_pkg::MuBi4True :
-                         prim_mubi_pkg::mubi4_e'(reg2hw.dis.q);
+                         prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
 
   assign flash_phy_req.flash_disable = flash_disable;
 
   prim_mubi_pkg::mubi4_t flash_exec_en;
   assign flash_exec_en = lc_escalate_en == lc_ctrl_pkg::On ?
                          prim_mubi_pkg::MuBi4False :
-                         prim_mubi_pkg::mubi4_e'(reg2hw.exec.q);
+                         prim_mubi_pkg::mubi4_t'(reg2hw.exec.q);
 
   //////////////////////////////////////
   // Errors and Interrupts
@@ -1072,7 +1072,7 @@ module flash_ctrl
   // flash phy module
   //////////////////////////////////////
   logic flash_host_req;
-  mubi4_e flash_host_instr_type;
+  mubi4_t flash_host_instr_type;
   logic flash_host_req_rdy;
   logic flash_host_req_done;
   logic flash_host_rderr;

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -387,7 +387,7 @@ package flash_ctrl_pkg;
     logic                 alert_ack;
     jtag_pkg::jtag_req_t  jtag_req;
     logic                 intg_err;
-    prim_mubi_pkg::mubi4_e flash_disable;
+    prim_mubi_pkg::mubi4_t flash_disable;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -83,7 +83,7 @@ module flash_ctrl
 );
 
   import flash_ctrl_reg_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 
   flash_ctrl_core_reg2hw_t reg2hw;
   flash_ctrl_core_hw2reg_t hw2reg;
@@ -860,14 +860,14 @@ module flash_ctrl
   prim_mubi_pkg::mubi4_t flash_disable;
   assign flash_disable = lc_escalate_en == lc_ctrl_pkg::On ?
                          prim_mubi_pkg::MuBi4True :
-                         prim_mubi_pkg::mubi4_e'(reg2hw.dis.q);
+                         prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
 
   assign flash_phy_req.flash_disable = flash_disable;
 
   prim_mubi_pkg::mubi4_t flash_exec_en;
   assign flash_exec_en = lc_escalate_en == lc_ctrl_pkg::On ?
                          prim_mubi_pkg::MuBi4False :
-                         prim_mubi_pkg::mubi4_e'(reg2hw.exec.q);
+                         prim_mubi_pkg::mubi4_t'(reg2hw.exec.q);
 
   //////////////////////////////////////
   // Errors and Interrupts
@@ -1073,7 +1073,7 @@ module flash_ctrl
   // flash phy module
   //////////////////////////////////////
   logic flash_host_req;
-  mubi4_e flash_host_instr_type;
+  mubi4_t flash_host_instr_type;
   logic flash_host_req_rdy;
   logic flash_host_req_done;
   logic flash_host_rderr;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -387,7 +387,7 @@ package flash_ctrl_pkg;
     logic                 alert_ack;
     jtag_pkg::jtag_req_t  jtag_req;
     logic                 intg_err;
-    prim_mubi_pkg::mubi4_e flash_disable;
+    prim_mubi_pkg::mubi4_t flash_disable;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -12,14 +12,14 @@
 
 module flash_phy
   import flash_ctrl_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 
 (
   input clk_i,
   input rst_ni,
   input host_req_i,
   input host_intg_err_i,
-  input mubi4_e host_instr_type_i,
+  input mubi4_t host_instr_type_i,
   input [BusAddrW-1:0] host_addr_i,
   output logic host_req_rdy_o,
   output logic host_req_done_o,

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -11,7 +11,7 @@
 
 module flash_phy_core
   import flash_phy_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 #(
   parameter int unsigned ArbCnt = 4
 ) (
@@ -19,7 +19,7 @@ module flash_phy_core
   input                              rst_ni,
   input                              intg_err_i,
   input                              host_req_i,   // host request - read only
-  input mubi4_e                      host_instr_type_i,
+  input mubi4_t                      host_instr_type_i,
   input                              host_scramble_en_i,
   input                              host_ecc_en_i,
   input [BusBankAddrW-1:0]           host_addr_i,
@@ -76,7 +76,7 @@ module flash_phy_core
   logic [PhyOps-1:0] reqs;
 
   // the type of transaction to flash macro
-  mubi4_e muxed_instr_type;
+  mubi4_t muxed_instr_type;
 
   // host select for address
   logic host_sel;

--- a/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_pkg.sv
@@ -79,7 +79,7 @@ package flash_phy_pkg;
     logic [BankAddrW-1:0] addr;
     logic descramble;
     logic ecc;
-    prim_mubi_pkg::mubi4_e instr_type;
+    prim_mubi_pkg::mubi4_t instr_type;
   } rd_attr_t;
 
   // Flash Operations Supported

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -28,7 +28,7 @@
 
 module flash_phy_rd
   import flash_phy_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 (
   input clk_i,
   input rst_ni,
@@ -39,7 +39,7 @@ module flash_phy_rd
 
   // interface with arbitration unit
   input req_i,
-  input mubi4_e instr_type_i,
+  input mubi4_t instr_type_i,
   input descramble_i,
   input ecc_i,
   input prog_i,

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -29,7 +29,7 @@ class otbn_common_vseq extends otbn_base_vseq;
                          input bit [BUS_DW-1:0]    compare_mask = '1,
                          input bit                 check_exp_data = 1'b0,
                          input bit                 blocking = csr_utils_pkg::default_csr_blocking,
-                         input mubi4_e             instr_type = MuBi4False,
+                         input mubi4_t             instr_type = MuBi4False,
                          tl_sequencer              tl_sequencer_h = p_sequencer.tl_sequencer_h,
                          input tl_intg_err_e       tl_intg_err_type = TlIntgErrNone,
                          input int                 req_abort_pct = 0);

--- a/hw/ip/prim/rtl/prim_mubi_pkg.sv
+++ b/hw/ip/prim/rtl/prim_mubi_pkg.sv
@@ -20,13 +20,10 @@ package prim_mubi_pkg;
   typedef enum logic [MuBi4Width-1:0] {
     MuBi4True = 4'hA, // enabled
     MuBi4False = 4'h5  // disabled
-  } mubi4_e;
-
-  // make a typedef such that this can be used as an intersignal type as well
-  typedef mubi4_e mubi4_t;
+  } mubi4_t;
 
   // Test whether the value is supplied is one of the valid enumerations
-  function automatic logic mubi4_test_invalid(mubi4_e val);
+  function automatic logic mubi4_test_invalid(mubi4_t val);
     return ~(val inside {MuBi4True, MuBi4False});
   endfunction : mubi4_test_invalid
 
@@ -147,13 +144,10 @@ package prim_mubi_pkg;
   typedef enum logic [MuBi8Width-1:0] {
     MuBi8True = 8'h5A, // enabled
     MuBi8False = 8'hA5  // disabled
-  } mubi8_e;
-
-  // make a typedef such that this can be used as an intersignal type as well
-  typedef mubi8_e mubi8_t;
+  } mubi8_t;
 
   // Test whether the value is supplied is one of the valid enumerations
-  function automatic logic mubi8_test_invalid(mubi8_e val);
+  function automatic logic mubi8_test_invalid(mubi8_t val);
     return ~(val inside {MuBi8True, MuBi8False});
   endfunction : mubi8_test_invalid
 
@@ -274,13 +268,10 @@ package prim_mubi_pkg;
   typedef enum logic [MuBi12Width-1:0] {
     MuBi12True = 12'hA5A, // enabled
     MuBi12False = 12'h5A5  // disabled
-  } mubi12_e;
-
-  // make a typedef such that this can be used as an intersignal type as well
-  typedef mubi12_e mubi12_t;
+  } mubi12_t;
 
   // Test whether the value is supplied is one of the valid enumerations
-  function automatic logic mubi12_test_invalid(mubi12_e val);
+  function automatic logic mubi12_test_invalid(mubi12_t val);
     return ~(val inside {MuBi12True, MuBi12False});
   endfunction : mubi12_test_invalid
 
@@ -401,13 +392,10 @@ package prim_mubi_pkg;
   typedef enum logic [MuBi16Width-1:0] {
     MuBi16True = 16'h5A5A, // enabled
     MuBi16False = 16'hA5A5  // disabled
-  } mubi16_e;
-
-  // make a typedef such that this can be used as an intersignal type as well
-  typedef mubi16_e mubi16_t;
+  } mubi16_t;
 
   // Test whether the value is supplied is one of the valid enumerations
-  function automatic logic mubi16_test_invalid(mubi16_e val);
+  function automatic logic mubi16_test_invalid(mubi16_t val);
     return ~(val inside {MuBi16True, MuBi16False});
   endfunction : mubi16_test_invalid
 

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -26,7 +26,7 @@ module prim_generic_flash #(
   input tdi_i,
   input tms_i,
   output logic tdo_o,
-  input prim_mubi_pkg::mubi4_e bist_enable_i,
+  input prim_mubi_pkg::mubi4_t bist_enable_i,
   input prim_mubi_pkg::mubi4_t scanmode_i,
   input scan_en_i,
   input scan_rst_ni,

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -382,7 +382,7 @@ module rstmgr
                          (pwr_i.reset_cause == pwrmgr_pkg::LowPwrEntry);
 
   // software initiated reset request
-  assign sw_rst_req_o = prim_mubi_pkg::mubi4_e'(reg2hw.reset_req.q);
+  assign sw_rst_req_o = prim_mubi_pkg::mubi4_t'(reg2hw.reset_req.q);
 
   // when pwrmgr reset request is received (reset is imminent), clear software
   // request so we are not in an infinite reset loop.

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -443,7 +443,7 @@ module rv_dm
   );
 `endif
 
-  prim_mubi_pkg::mubi4_e en_ifetch;
+  prim_mubi_pkg::mubi4_t en_ifetch;
   assign en_ifetch = (lc_hw_debug_en[EnFetch] == lc_ctrl_pkg::On) ?
                      prim_mubi_pkg::MuBi4True :
                      prim_mubi_pkg::MuBi4False;

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -67,7 +67,7 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
                               input bit                blocking     = $urandom_range(0, 1),
                               input bit                check_rdata  = 0,
                               input bit [TL_DW-1:0]    exp_rdata    = '0,
-                              input mubi4_e            instr_type   = MuBi4False,
+                              input mubi4_t            instr_type   = MuBi4False,
                               output logic [TL_DW-1:0] rdata);
     `DV_CHECK_FATAL((addr inside {[cfg.sram_start_addr : cfg.sram_end_addr]}),
                     $sformatf("addr[0x%0x] is not in range", addr),
@@ -90,7 +90,7 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
                                bit [TL_DW-1:0]  data,
                                bit [TL_DBW-1:0] mask        = get_rand_contiguous_mask(),
                                bit              blocking    = $urandom_range(0, 1),
-                               mubi4_e          instr_type  = MuBi4False);
+                               mubi4_t          instr_type  = MuBi4False);
     `DV_CHECK_FATAL((addr inside {[cfg.sram_start_addr : cfg.sram_end_addr]}),
                     $sformatf("addr[0x%0x] is not in range", addr),
                     `gfn)
@@ -110,7 +110,7 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
                              int num_stress_ops,
                              bit en_ifetch = 0);
     bit [TL_DW-1:0] data;
-    mubi4_e instr_type;
+    mubi4_t instr_type;
 
     `DV_CHECK_FATAL((addr inside {[cfg.sram_start_addr : cfg.sram_end_addr]}),
                     $sformatf("addr[0x%0x] is not in range", addr),
@@ -148,7 +148,7 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
                            bit en_ifetch = 0);
     bit [TL_DW-1:0] data;
     bit [TL_AW-1:0] addr;
-    mubi4_e instr_type;
+    mubi4_t instr_type;
     repeat (num_ops) begin
       bit completed, saw_err;
 

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_executable_vseq.sv
@@ -24,8 +24,8 @@ class sram_ctrl_executable_vseq extends sram_ctrl_multiple_keys_vseq;
   endtask
 
   task randomize_and_drive_ifetch_en();
-    mubi8_e en_sram_ifetch = get_rand_mubi8_val();
-    mubi4_e en_exec_csr = get_rand_mubi4_val();
+    mubi8_t en_sram_ifetch = get_rand_mubi8_val();
+    mubi4_t en_exec_csr = get_rand_mubi4_val();
     lc_ctrl_pkg::lc_tx_e hw_debug_en = get_rand_lc_tx_val();
 
     `uvm_info(`gfn, $sformatf("en_exec_csr: 0b%0b", en_exec_csr), UVM_HIGH)

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -277,18 +277,18 @@ module sram_ctrl
   // SRAM Execution //
   ////////////////////
 
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::MuBi4True;
   import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::mubi8_test_true_strict;
 
-  mubi4_e en_ifetch;
+  mubi4_t en_ifetch;
   if (InstrExec) begin : gen_instr_ctrl
-    mubi4_e lc_ifetch_en;
-    mubi4_e reg_ifetch_en;
+    mubi4_t lc_ifetch_en;
+    mubi4_t reg_ifetch_en;
     assign lc_ifetch_en = (lc_hw_debug_en_i == lc_ctrl_pkg::On) ? MuBi4True :
                                                                   MuBi4False;
-    assign reg_ifetch_en = mubi4_e'(reg2hw.exec.q);
+    assign reg_ifetch_en = mubi4_t'(reg2hw.exec.q);
     assign en_ifetch = (mubi8_test_true_strict(otp_en_sram_ifetch_i)) ? reg_ifetch_en :
                                                                         lc_ifetch_en;
   end else begin : gen_tieoff

--- a/hw/ip/tlul/rtl/tlul_adapter_host.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_host.sv
@@ -23,7 +23,7 @@
 
 module tlul_adapter_host
   import tlul_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 #(
   parameter int unsigned MAX_REQS = 2,
   // TODO(#7966) disable data intgrity overwrite once dv support available
@@ -39,7 +39,7 @@ module tlul_adapter_host
   input  logic [top_pkg::TL_DW-1:0]  wdata_i,
   input  logic [DataIntgWidth-1:0]   wdata_intg_i,
   input  logic [top_pkg::TL_DBW-1:0] be_i,
-  input  mubi4_e                     instr_type_i,
+  input  mubi4_t                     instr_type_i,
 
   output logic                       valid_o,
   output logic [top_pkg::TL_DW-1:0]  rdata_o,

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -19,7 +19,7 @@
  */
 module tlul_adapter_sram
   import tlul_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 #(
   parameter int SramAw            = 12,
   parameter int SramDw            = 32, // Must be multiple of the TL width
@@ -43,11 +43,11 @@ module tlul_adapter_sram
   output  tl_d2h_t          tl_o,
 
   // control interface
-  input   mubi4_e en_ifetch_i,
+  input   mubi4_t en_ifetch_i,
 
   // SRAM interface
   output logic                req_o,
-  output mubi4_e              req_type_o,
+  output mubi4_t              req_type_o,
   input                       gnt_i,
   output logic                we_o,
   output logic [SramAw-1:0]   addr_o,

--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -36,7 +36,7 @@ package tlul_pkg;
 
   typedef struct packed {
     logic [4:0]                 rsvd;
-    prim_mubi_pkg::mubi4_e      instr_type;
+    prim_mubi_pkg::mubi4_t      instr_type;
     logic [H2DCmdIntgWidth-1:0] cmd_intg;
     logic [DataIntgWidth-1:0]   data_intg;
   } tl_a_user_t;
@@ -49,7 +49,7 @@ package tlul_pkg;
   };
 
   typedef struct packed {
-    prim_mubi_pkg::mubi4_e        instr_type;
+    prim_mubi_pkg::mubi4_t        instr_type;
     logic   [top_pkg::TL_AW-1:0]  addr;
     tl_a_op_e                     opcode;
     logic  [top_pkg::TL_DBW-1:0]  mask;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -89,7 +89,7 @@ module flash_ctrl
 );
 
   import flash_ctrl_reg_pkg::*;
-  import prim_mubi_pkg::mubi4_e;
+  import prim_mubi_pkg::mubi4_t;
 
   flash_ctrl_core_reg2hw_t reg2hw;
   flash_ctrl_core_hw2reg_t hw2reg;
@@ -866,14 +866,14 @@ module flash_ctrl
   prim_mubi_pkg::mubi4_t flash_disable;
   assign flash_disable = lc_escalate_en == lc_ctrl_pkg::On ?
                          prim_mubi_pkg::MuBi4True :
-                         prim_mubi_pkg::mubi4_e'(reg2hw.dis.q);
+                         prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
 
   assign flash_phy_req.flash_disable = flash_disable;
 
   prim_mubi_pkg::mubi4_t flash_exec_en;
   assign flash_exec_en = lc_escalate_en == lc_ctrl_pkg::On ?
                          prim_mubi_pkg::MuBi4False :
-                         prim_mubi_pkg::mubi4_e'(reg2hw.exec.q);
+                         prim_mubi_pkg::mubi4_t'(reg2hw.exec.q);
 
   //////////////////////////////////////
   // Errors and Interrupts
@@ -1079,7 +1079,7 @@ module flash_ctrl
   // flash phy module
   //////////////////////////////////////
   logic flash_host_req;
-  mubi4_e flash_host_instr_type;
+  mubi4_t flash_host_instr_type;
   logic flash_host_req_rdy;
   logic flash_host_req_done;
   logic flash_host_rderr;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -393,7 +393,7 @@ package flash_ctrl_pkg;
     logic                 alert_ack;
     jtag_pkg::jtag_req_t  jtag_req;
     logic                 intg_err;
-    prim_mubi_pkg::mubi4_e flash_disable;
+    prim_mubi_pkg::mubi4_t flash_disable;
   } flash_req_t;
 
   // default value of flash_req_t (for dangling ports)

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -804,7 +804,7 @@ module rstmgr
                          (pwr_i.reset_cause == pwrmgr_pkg::LowPwrEntry);
 
   // software initiated reset request
-  assign sw_rst_req_o = prim_mubi_pkg::mubi4_e'(reg2hw.reset_req.q);
+  assign sw_rst_req_o = prim_mubi_pkg::mubi4_t'(reg2hw.reset_req.q);
 
   // when pwrmgr reset request is received (reset is imminent), clear software
   // request so we are not in an infinite reset loop.

--- a/util/design/data/prim_mubi_pkg.sv.tpl
+++ b/util/design/data/prim_mubi_pkg.sv.tpl
@@ -27,13 +27,10 @@ from mubi import prim_mubi
   typedef enum logic [MuBi${nbits}Width-1:0] {
     MuBi${nbits}True = ${nbits}'h${prim_mubi.mubi_value_as_hexstr(True, nbits)}, // enabled
     MuBi${nbits}False = ${nbits}'h${prim_mubi.mubi_value_as_hexstr(False, nbits)}  // disabled
-  } mubi${nbits}_e;
-
-  // make a typedef such that this can be used as an intersignal type as well
-  typedef mubi${nbits}_e mubi${nbits}_t;
+  } mubi${nbits}_t;
 
   // Test whether the value is supplied is one of the valid enumerations
-  function automatic logic mubi${nbits}_test_invalid(mubi${nbits}_e val);
+  function automatic logic mubi${nbits}_test_invalid(mubi${nbits}_t val);
     return ~(val inside {MuBi${nbits}True, MuBi${nbits}False});
   endfunction : mubi${nbits}_test_invalid
 


### PR DESCRIPTION
also do the same for mubi8/16

As discussed with @msfschaffner, there is a convention to use `_t` suffix as a type in topgen.
Right now, design and DV mixed-use both mubi4_e and mubi4_t. It's better to remove mubi4_e
to avoid confusing.

If this looks good, will do the same for lc_tx_e/t

Signed-off-by: Weicai Yang <weicai@google.com>