### PR TITLE
[flash_ctrl/dv] Checking fix of bug #8934 and small addition to seq_cfg

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -188,9 +188,22 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(flash_ctrl_core_reg_b
       flash_ctrl_pkg::FlashEraseBank: begin
         // This address is relative to the bank it's in.
         erase_check_addr = 0;
-        num_words = FlashNumBusWordsPerBank;
         // No need to state page for bank erase.
         erase_page_num_msg = "";
+        case (flash_op.partition)
+          FlashPartData: begin
+            num_words = FlashNumBusWordsPerBank;
+          end
+          FlashPartInfo: begin
+            num_words = InfoTypeBusWords[0];
+          end
+          default: begin
+            `uvm_fatal(`gfn, $sformatf({"Invalid partition for bank_erase: %0s. ",
+                                        "Bank erase is only valid in the data partition ",
+                                        "(FlashPartData) and the first info partition ",
+                                        "(FlashPartInfo)."}, flash_op.partition.name()))
+          end
+        endcase
       end
       default: begin
         `uvm_fatal(`gfn, $sformatf("Invalid erase_type: %0s", flash_op.erase_type.name()))

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -46,6 +46,12 @@ package flash_ctrl_env_pkg;
   parameter uint FlashNumBusWordsPerBank  = FlashNumBusWords / flash_ctrl_pkg::NumBanks;
   parameter uint FlashNumBusWordsPerPage  = FlashNumBusWordsPerBank / flash_ctrl_pkg::PagesPerBank;
 
+  parameter uint InfoTypeBusWords [flash_ctrl_pkg::InfoTypes] = '{
+    flash_ctrl_pkg::InfoTypeSize[0] * FlashNumBusWordsPerPage,
+    flash_ctrl_pkg::InfoTypeSize[1] * FlashNumBusWordsPerPage,
+    flash_ctrl_pkg::InfoTypeSize[2] * FlashNumBusWordsPerPage
+  };
+
   parameter uint FlashBankBytesPerWord    = flash_ctrl_pkg::DataWidth / 8;
 
   parameter uint FlashDataByteWidth       = $clog2(FlashBankBytesPerWord);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -70,6 +70,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Poll fifo status before writing to prog_fifo / reading from rd_fifo.
   uint poll_fifo_status_pc;
 
+  // Chances to start flash with all 1s and not with random values (default is 30%).
+  uint flash_init_set_pc;
+
   //  Set by a higher level vseq that invokes this vseq 
   bit external_cfg;
 
@@ -148,6 +151,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
     op_allow_invalid = 1'b0;
 
     poll_fifo_status_pc = 30;
+
+    flash_init_set_pc = 30;
 
     external_cfg = 1'b0;
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -18,6 +18,17 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   `uvm_object_new
 
+  // Determine post-reset initialization method.
+  rand flash_mem_init_e flash_init;
+
+  // By default, in 30% of the times initialize flash as in initial state (all 1s),
+  //  while in 70% of the times the initialization will be randomized (simulating working flash).
+  constraint flash_init_c {
+    flash_init dist {
+      FlashMemInitSet       :/ cfg.seq_cfg.flash_init_set_pc,
+      FlashMemInitRandomize :/ 100 - cfg.seq_cfg.flash_init_set_pc
+    };
+  }
 
   // Vseq to do some initial post-reset actions. Can be overriden by extending envs.
   flash_ctrl_callback_vseq callback_vseq;
@@ -42,7 +53,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     // Set all flash partitions to 1s.
     flash_dv_part_e part = part.first();
     do begin
-      cfg.flash_mem_bkdr_init(part, FlashMemInitSet);
+      cfg.flash_mem_bkdr_init(part, flash_init);
       part = part.next();
     end while (part != part.first());
     // Wait for flash_ctrl to finish initializing on every reset


### PR DESCRIPTION
Hi,
This PR includes:
* Add missing support for back-door check of bank erase in info partition. Required to verify the fix to bug #8934.
* Make the flash to be initialized most of the times to random values rather then pure initial state (all 1s).
   This will be controllable by a field in the sequence config instance.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>