### PR TITLE
[prim] Fix prim_packer_fifo when ClearOnRead is false

### DIFF
--- a/hw/ip/prim/rtl/prim_packer_fifo.sv
+++ b/hw/ip/prim/rtl/prim_packer_fifo.sv
@@ -107,7 +107,7 @@ module prim_packer_fifo #(
            depth_q;
 
     assign data_d = clear_data ? '0 :
-           load_data ? (data_q | wdata_shifted) :
+           load_data ? (wdata_shifted | (depth_q == 0 ? '0 : data_q)) :
            data_q;
 
     // set outputs


### PR DESCRIPTION
When we take the first part of an output word, we need to zero the
existing contents.

This is causing lots of tests (~60%) in the OTBN nightlies to fail.

As a more general point, I'm interested to know why the packer is built like this. Wouldn't a shift register with a "word reversal" at the end have been easier? You wouldn't need to do the ugly "zero the whole thing when you take a word" dance.