### PR TITLE
[dv/rstmgr] Add sw_rst test to the testplan

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr_testplan.hjson
+++ b/hw/ip/rstmgr/data/rstmgr_testplan.hjson
@@ -75,7 +75,7 @@
             - Check the `reset_info`, `cpu_info`, and `alert_info` CSRs are not modified.
             '''
       milestone: V2
-      tests: []
+      tests: ["rstmgr_sw_rst"]
     }
     {
       name: reset_info

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -57,6 +57,9 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     !(scanmode_other inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off});
   }
 
+  rand logic [NumSwResets-1:0] sw_rst_regwen;
+  rand logic [NumSwResets-1:0] sw_rst_ctrl_n;
+
   bit reset_once;
 
   pwrmgr_pkg::pwr_rst_req_t pwr_i;

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_por_stretcher_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_por_stretcher_vseq.sv
@@ -29,6 +29,7 @@ class rstmgr_por_stretcher_vseq extends rstmgr_base_vseq;
   task body();
     cfg.aon_clk_rst_vif.wait_clks(AON_CYCLES_BEFORE_START);
     for (int i = 0; i < num_trans; ++i) begin
+      `DV_CHECK_RANDOMIZE_FATAL(this)
       cfg.rstmgr_vif.por_n = 1'b1;
       cfg.aon_clk_rst_vif.wait_clks(glitch_separation_cycles);
       cfg.rstmgr_vif.por_n = 1'b0;

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -12,8 +12,6 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
   rand ibex_pkg::crash_dump_t cpu_dump;
   rand alert_pkg::alert_crashdump_t alert_dump;
   rand logic [pwrmgr_pkg::HwResetWidth-1:0] rstreqs;
-  rand logic [NumSwResets-1:0] sw_rst_regwen;
-  rand logic [NumSwResets-1:0] sw_rst_ctrl_n;
 
   constraint rstreqs_non_zero_c {rstreqs != '0;}
   constraint sw_rst_regwen_non_trivial_c {sw_rst_regwen != '0 && sw_rst_regwen != '1;}
@@ -81,8 +79,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
                    .err_msg("expected no reset on"));
       csr_wr(.ptr(ral.sw_rst_regwen[0]), .value(sw_rst_regwen));
       `uvm_info(`gfn, $sformatf("sw_rst_regwen set to 0x%0h", sw_rst_regwen), UVM_LOW)
-      csr_rd_check(.ptr(ral.sw_rst_regwen[0]), .compare_value(sw_rst_regwen),
-                   .err_msg("Expected sw_rst_regwen to reflect rw0c"));
+      csr_rd_check(.ptr(ral.sw_rst_regwen[0]), .compare_value(sw_rst_regwen));
 
       // Check sw_rst_regwen can not be set to all ones again because it is rw0c.
       csr_wr(.ptr(ral.sw_rst_regwen[0]), .value('1));

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
@@ -13,12 +13,13 @@ class rstmgr_sw_rst_vseq extends rstmgr_base_vseq;
 
   `uvm_object_new
 
-  rand bit [NumSwResets-1:0] sw_rst_ctrl_n;
-
   task body();
     bit [NumSwResets-1:0] exp_ctrl_n;
     bit [NumSwResets-1:0] sw_rst_regwen = '1;
-    set_alert_and_cpu_info_for_capture(.alert_dump('1), .cpu_dump('1));
+    alert_pkg::alert_crashdump_t bogus_alert_dump = '1;
+    ibex_pkg::crash_dump_t bogus_cpu_dump = '1;
+    set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
+
     for (int i = 0; i < num_trans; ++i) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
       check_sw_rst_ctrl_n(sw_rst_ctrl_n, sw_rst_regwen, i % 2);

--- a/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
@@ -43,8 +43,8 @@ module rstmgr_bind;
 
   bind rstmgr rstmgr_attrs_sva_if rstmgr_attrs_sva_if (
     .rst_ni,
-    .actual_alert_info_attr(hw2reg.alert_info_attr),
-    .actual_cpu_info_attr(hw2reg.cpu_info_attr),
+    .actual_alert_info_attr({'0, hw2reg.alert_info_attr}),
+    .actual_cpu_info_attr({'0, hw2reg.cpu_info_attr}),
     .expected_alert_info_attr(($bits(alert_dump_i) + 31) / 32),
     .expected_cpu_info_attr(($bits(cpu_dump_i) + 31) / 32)
   );


### PR DESCRIPTION
This test was developed some time ago but was not registered with the
testplan.
This also fixes randomization of rstmgr_por_stretcher test.

Signed-off-by: Guillermo Maturana <maturana@google.com>