### PR TITLE
[kmac] Use Empty signal from FIFO

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1859,7 +1859,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
               // after its depth has been greater than 0 to prevent random assertions
               @(fifo_wr_ptr, fifo_rd_ptr);
               #1;
-              if (fifo_wr_ptr > fifo_rd_ptr) begin
+              if (fifo_wr_ptr >= fifo_rd_ptr) begin
                 `uvm_info(`gfn, "fifo_wr_ptr is greater than fifo_rd_ptr", UVM_HIGH)
                 while (fifo_wr_ptr != fifo_rd_ptr) begin
                   cfg.clk_rst_vif.wait_clks(1);

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -159,7 +159,7 @@ module kmac_msgfifo
   assign msg_data_o  = fifo_rdata.data;
   assign msg_strb_o  = fifo_rdata.strb;
 
-  assign fifo_empty_o = fifo_depth_o == '0;
+  assign fifo_empty_o = !fifo_rvalid;
 
   // Flush (process from outside) handling
   flush_st_e flush_st, flush_st_d;


### PR DESCRIPTION
The issue has been discussed in #9202

KMAC MsgFIFO sees the FIFO depth to calculate the empty status of SYNC
FIFO. When the logic writes data and the receiver acked the read data at
the same time and the FIFO has been empty already, the empty status
won't be de-asserted as the `depth` wont be increased.

The issue is that SW will not get the fifo empty event due to the
behavior described above if the receiver logic is faster than the SW.

This commit revises the msgfifo logic to see the `rvalid` as an
inversion of the empty status. The scenario above will lower the `empty`
signal with the fix.
