### PR TITLE
[dv/alert_esc_agent] support lpg in alert_esc_agent

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -13,6 +13,7 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   bit is_async        = 0;
   bit en_ping_cov     = 1;
   bit alert_init_done = 0;
+  bit en_alert_lpg    = 0;
 
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
@@ -17,6 +17,11 @@ interface alert_handler_if(input clk, input rst_n);
     lpg_rst_en = '{default: MuBi4False};
   endfunction
 
+  function automatic bit get_lpg_status(int index);
+    check_lpg_index(index);
+    return (lpg_cg_en[index] == MuBi4True || lpg_rst_en[index] == MuBi4True);
+  endfunction
+
   // TODO: randomize all values outside of the mubi4 enum.
   function automatic void set_lpg_cg_en(int index);
     check_lpg_index(index);

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
@@ -22,10 +22,6 @@ class alert_handler_lpg_vseq extends alert_handler_entropy_vseq;
     esc_ping_timeout   == 0;
   }
 
-  constraint alert_trigger_c {
-    alert_trigger == 0;
-  }
-
   // disable interrupt timeout
   constraint esc_intr_timeout_c {
     foreach (intr_timeout_cyc[i]) {intr_timeout_cyc[i] == 0;}
@@ -37,19 +33,11 @@ class alert_handler_lpg_vseq extends alert_handler_entropy_vseq;
     verbosity = UVM_HIGH;
   endfunction
 
-  function void disable_lpg_group(bit [NUM_ALERTS-1:0] alert_en_i);
-    foreach (alert_en_i[i]) begin
-      int index = alert_handler_reg_pkg::LpgMap[i];
-      if ($urandom_range(0, 1)) cfg.alert_handler_vif.set_lpg_cg_en(index);
-      if ($urandom_range(0, 1)) cfg.alert_handler_vif.set_lpg_rst_en(index);
-    end
-  endfunction
-
   task body();
     fork
       begin : isolation_fork
         trigger_non_blocking_seqs();
-        disable_lpg_group(alert_en);
+        enable_lpg_group(alert_en);
         run_smoke_seq();
         disable fork; // disable non-blocking seqs for stress_all tests
       end // end fork

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
@@ -17,6 +17,11 @@ interface alert_handler_if(input clk, input rst_n);
     lpg_rst_en = '{default: MuBi4False};
   endfunction
 
+  function automatic bit get_lpg_status(int index);
+    check_lpg_index(index);
+    return (lpg_cg_en[index] == MuBi4True || lpg_rst_en[index] == MuBi4True);
+  endfunction
+
   // TODO: randomize all values outside of the mubi4 enum.
   function automatic void set_lpg_cg_en(int index);
     check_lpg_index(index);

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_lpg_vseq.sv
@@ -22,10 +22,6 @@ class alert_handler_lpg_vseq extends alert_handler_entropy_vseq;
     esc_ping_timeout   == 0;
   }
 
-  constraint alert_trigger_c {
-    alert_trigger == 0;
-  }
-
   // disable interrupt timeout
   constraint esc_intr_timeout_c {
     foreach (intr_timeout_cyc[i]) {intr_timeout_cyc[i] == 0;}
@@ -37,19 +33,11 @@ class alert_handler_lpg_vseq extends alert_handler_entropy_vseq;
     verbosity = UVM_HIGH;
   endfunction
 
-  function void disable_lpg_group(bit [NUM_ALERTS-1:0] alert_en_i);
-    foreach (alert_en_i[i]) begin
-      int index = alert_handler_reg_pkg::LpgMap[i];
-      if ($urandom_range(0, 1)) cfg.alert_handler_vif.set_lpg_cg_en(index);
-      if ($urandom_range(0, 1)) cfg.alert_handler_vif.set_lpg_rst_en(index);
-    end
-  endfunction
-
   task body();
     fork
       begin : isolation_fork
         trigger_non_blocking_seqs();
-        disable_lpg_group(alert_en);
+        enable_lpg_group(alert_en);
         run_smoke_seq();
         disable fork; // disable non-blocking seqs for stress_all tests
       end // end fork


### PR DESCRIPTION
This PR supports lpg in alert_esc_agent. In alert_handler testbench, if
lpg is enabled and alert triggered from the alert sender side,
alert_handler testbench needs to ignore the alert.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>