### PR TITLE
[sw/silicon_creator] Add flash_ctrl_info_mp_set() and migrate boot_data_functest.c to silicon_creator flash_ctrl driver

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -99,15 +99,6 @@ typedef enum flash_crtl_partition {
   X(kFlashCtrlInfoPageOwnerReserved1,     INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 7)), \
   X(kFlashCtrlInfoPageOwnerReserved2,     INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 8)), \
   X(kFlashCtrlInfoPageOwnerReserved3,     INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 9)), \
-  /*
-   * Bank 0 information partition type 1 pages.
-   */ \
-  X(kFlashCtrlInfoPageBank0Type1Page0,    INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo1, 0)), \
-  /**
-   * Bank 0 information parititon type 2 pages.
-   */ \
-  X(kFlashCtrlInfoPageBank0Type2Page0,    INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo2, 0)), \
-  X(kFlashCtrlInfoPageBank0Type2Page1,    INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo2, 1)), \
   /**
    * Bank 1 information partition type 0 pages.
    */ \
@@ -121,15 +112,6 @@ typedef enum flash_crtl_partition {
   X(kFlashCtrlInfoPageBootServices,       INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 7)), \
   X(kFlashCtrlInfoPageOwnerCerificate0,   INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 8)), \
   X(kFlashCtrlInfoPageOwnerCerificate1,   INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 9)), \
-  /*
-   * Bank 1 information partition type 1 pages.
-   */ \
-  X(kFlashCtrlInfoPageBank1Type1Page0,    INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo1, 0)), \
-  /**
-   * Bank 1 information parititon type 2 pages.
-   */ \
-  X(kFlashCtrlInfoPageBank1Type2Page0,    INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo2, 0)), \
-  X(kFlashCtrlInfoPageBank1Type2Page1,    INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo2, 1)),
 // clang-format on
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -5,6 +5,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_FLASH_CTRL_H_
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
@@ -282,6 +283,36 @@ rom_error_t flash_ctrl_data_erase(uint32_t addr,
  */
 rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
                                   flash_ctrl_erase_type_t erase_type);
+
+/**
+ * A struct for specifying access permissions.
+ */
+typedef struct flash_ctrl_mp {
+  /**
+   * Read.
+   */
+  hardened_bool_t read;
+  /**
+   * Write.
+   */
+  hardened_bool_t write;
+  /**
+   * Erase.
+   */
+  hardened_bool_t erase;
+} flash_ctrl_mp_t;
+
+/**
+ * Sets access permissions for an info page.
+ *
+ * A permission is enabled only if the corresponding field in `perms` is
+ * `kHardenedBoolTrue`.
+ *
+ * @param info_page An information page.
+ * @param perms New permissions.
+ */
+void flash_ctrl_info_mp_set(flash_ctrl_info_page_t info_page,
+                            flash_ctrl_mp_t perms);
 
 typedef enum flash_ctrl_exec {
   kFlashCtrlExecDisable = kMultiBitBool4False,

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
 #include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 #include "flash_ctrl_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -463,7 +463,8 @@ sw_silicon_creator_lib_driver_flash_ctrl = declare_dependency(
       'flash_ctrl.c',
     ],
     dependencies: [
-      sw_lib_mmio,
+      sw_silicon_creator_lib_base_abs_mmio,
+      sw_silicon_creator_lib_base_sec_mmio,
     ],
   ),
 )
@@ -478,10 +479,11 @@ test('sw_silicon_creator_lib_driver_flash_ctrl_unittest', executable(
     dependencies: [
       sw_vendor_gtest,
       sw_silicon_creator_lib_base_mock_abs_mmio,
+      sw_silicon_creator_lib_base_mock_sec_mmio,
     ],
     native: true,
-    c_args: ['-DMOCK_ABS_MMIO'],
-    cpp_args: ['-DMOCK_ABS_MMIO'],
+    c_args: ['-DMOCK_ABS_MMIO', '-DMOCK_SEC_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO', '-DMOCK_SEC_MMIO'],
   ),
   suite: 'mask_rom',
 )

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -282,7 +282,7 @@ sw_silicon_creator_lib_boot_data_functest = declare_dependency(
       'boot_data_functest.c'
     ],
     dependencies: [
-      sw_lib_flash_ctrl,
+      sw_silicon_creator_lib_driver_flash_ctrl,
       sw_silicon_creator_lib_boot_data,
     ],
   ),


### PR DESCRIPTION
This PR adds `flash_ctrl_info_mp_set()` to the flash_ctrl driver (using `sec_mmio`) and migrates `boot_data_functest.c` to silicon_creator flash_ctrl driver. I'll add unit tests for the new function if we are happy with the interface in this PR.

This PR also removes enum constants for info pages of type 1 and 2 since silicon_creator won't need to access them.