### PR TITLE
[sw/silicon_creator] Add boot_data_functest to CI and DVSim

### DIFF
--- a/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
@@ -210,6 +210,10 @@
       name: sw_silicon_creator_lib_driver_watchdog_functest
       sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_watchdog_functest:1"]
     }
+    {
+      name: sw_silicon_creator_lib_boot_data_functest
+      sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_boot_data_functest:1"]
+    }
   ]
 
   // List of regressions.

--- a/test/systemtest/earlgrey/config.py
+++ b/test/systemtest/earlgrey/config.py
@@ -168,4 +168,8 @@ TEST_APPS_SELFCHECKING = [
         # verilator for now.
         "targets": ["sim_verilator"],
     },
+    {
+        "name": "sw_silicon_creator_lib_boot_data_functest",
+        "test_dir": "sw/device/silicon_creator/testing",
+    },
 ]


### PR DESCRIPTION
This PR adds boot_data_functest to CI and DVSim.

Signed-off-by: Alphan Ulusoy <alphan@google.com>