### PR TITLE
[dv] Fix intg_err test

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_host_single_seq.sv
@@ -16,8 +16,11 @@ class cip_tl_host_single_seq extends tl_host_single_seq #(cip_tl_seq_item);
 
   virtual function void randomize_req(REQ req, int idx);
     super.randomize_req(req, idx);
-    req.set_instr_type(instr_type);
+
+    // set tl_intg_err_type first, as set_instr_type will trigger re-calculating integrity based on
+    // the TLUL info and err_type
     req.tl_intg_err_type = tl_intg_err_type;
+    req.set_instr_type(instr_type);
   endfunction
 
 endclass


### PR DESCRIPTION
This addressed the regression failures in all the intg_err test which is
due to the update from #9243

Signed-off-by: Weicai Yang <weicai@google.com>