### PR TITLE
Revert "[kmac] Use Empty signal from FIFO"

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -1859,7 +1859,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
               // after its depth has been greater than 0 to prevent random assertions
               @(fifo_wr_ptr, fifo_rd_ptr);
               #1;
-              if (fifo_wr_ptr >= fifo_rd_ptr) begin
+              if (fifo_wr_ptr > fifo_rd_ptr) begin
                 `uvm_info(`gfn, "fifo_wr_ptr is greater than fifo_rd_ptr", UVM_HIGH)
                 while (fifo_wr_ptr != fifo_rd_ptr) begin
                   cfg.clk_rst_vif.wait_clks(1);

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -159,7 +159,7 @@ module kmac_msgfifo
   assign msg_data_o  = fifo_rdata.data;
   assign msg_strb_o  = fifo_rdata.strb;
 
-  assign fifo_empty_o = !fifo_rvalid;
+  assign fifo_empty_o = fifo_depth_o == '0;
 
   // Flush (process from outside) handling
   flush_st_e flush_st, flush_st_d;


### PR DESCRIPTION
This reverts commit 0e0c1a99f5a45584017d42bc8cba0aa376745908.

The change appears to have broken the CW310 CI tests

Signed-off-by: Greg Chadwick <gac@lowrisc.org>