### PR TITLE
[prim_ram_1p_scr] Removing prim:all dependency

### DIFF
--- a/hw/ip/prim/prim_ram_1p_scr.core
+++ b/hw/ip/prim/prim_ram_1p_scr.core
@@ -12,7 +12,8 @@ filesets:
       - lowrisc:prim:util
       - lowrisc:prim:ram_1p_adv
       - lowrisc:prim:lfsr
-      - lowrisc:prim:all
+      - lowrisc:prim:buf
+      - lowrisc:prim:cipher
       - lowrisc:prim:util_get_scramble_params
       - lowrisc:dv_verilator:memutil_dpi_scrambled
     files:


### PR DESCRIPTION
This commit includes addition of necessary primitives to the `.core` file of prim_ram_1p_scr module and removing
 `prim:all` dependency.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>