### PR TITLE
[entropy/rtl] added count pkg to fix lint errors

### DIFF
--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
+      - lowrisc:prim:count
       - lowrisc:prim:assert
       - lowrisc:prim:lfsr
       - lowrisc:ip:tlul


### PR DESCRIPTION
The prim_count package needs to be added to the core file to fix lint errors.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>