### PR TITLE
[dif] Fix autogenerated init unit tests

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -28,13 +28,11 @@ class AdcCtrlTest : public Test, public MmioTest {
 class InitTest : public AdcCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_adc_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_adc_ctrl_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_adc_ctrl_init({.base_addr = dev().region()}, &adc_ctrl_),
-            kDifOk);
+  EXPECT_EQ(dif_adc_ctrl_init(dev().region(), &adc_ctrl_), kDifOk);
 }
 
 class AlertForceTest : public AdcCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
@@ -28,11 +28,11 @@ class AesTest : public Test, public MmioTest {
 class InitTest : public AesTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_aes_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_aes_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_aes_init({.base_addr = dev().region()}, &aes_), kDifOk);
+  EXPECT_EQ(dif_aes_init(dev().region(), &aes_), kDifOk);
 }
 
 class AlertForceTest : public AesTest {};

--- a/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_alert_handler_autogen_unittest.cc
@@ -28,14 +28,11 @@ class AlertHandlerTest : public Test, public MmioTest {
 class InitTest : public AlertHandlerTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_alert_handler_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_alert_handler_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(
-      dif_alert_handler_init({.base_addr = dev().region()}, &alert_handler_),
-      kDifOk);
+  EXPECT_EQ(dif_alert_handler_init(dev().region(), &alert_handler_), kDifOk);
 }
 
 class IrqGetStateTest : public AlertHandlerTest {};

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -28,13 +28,11 @@ class AonTimerTest : public Test, public MmioTest {
 class InitTest : public AonTimerTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_aon_timer_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_aon_timer_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_aon_timer_init({.base_addr = dev().region()}, &aon_timer_),
-            kDifOk);
+  EXPECT_EQ(dif_aon_timer_init(dev().region(), &aon_timer_), kDifOk);
 }
 
 class AlertForceTest : public AonTimerTest {};

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
@@ -28,12 +28,11 @@ class ClkmgrTest : public Test, public MmioTest {
 class InitTest : public ClkmgrTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_clkmgr_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_clkmgr_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_clkmgr_init({.base_addr = dev().region()}, &clkmgr_), kDifOk);
+  EXPECT_EQ(dif_clkmgr_init(dev().region(), &clkmgr_), kDifOk);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -28,11 +28,11 @@ class CsrngTest : public Test, public MmioTest {
 class InitTest : public CsrngTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_csrng_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_csrng_init({.base_addr = dev().region()}, &csrng_), kDifOk);
+  EXPECT_EQ(dif_csrng_init(dev().region(), &csrng_), kDifOk);
 }
 
 class AlertForceTest : public CsrngTest {};

--- a/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_edn_autogen_unittest.cc
@@ -28,11 +28,11 @@ class EdnTest : public Test, public MmioTest {
 class InitTest : public EdnTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_edn_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_edn_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_edn_init({.base_addr = dev().region()}, &edn_), kDifOk);
+  EXPECT_EQ(dif_edn_init(dev().region(), &edn_), kDifOk);
 }
 
 class AlertForceTest : public EdnTest {};

--- a/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_entropy_src_autogen_unittest.cc
@@ -28,13 +28,11 @@ class EntropySrcTest : public Test, public MmioTest {
 class InitTest : public EntropySrcTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_entropy_src_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_entropy_src_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_entropy_src_init({.base_addr = dev().region()}, &entropy_src_),
-            kDifOk);
+  EXPECT_EQ(dif_entropy_src_init(dev().region(), &entropy_src_), kDifOk);
 }
 
 class AlertForceTest : public EntropySrcTest {};

--- a/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_flash_ctrl_autogen_unittest.cc
@@ -28,13 +28,11 @@ class FlashCtrlTest : public Test, public MmioTest {
 class InitTest : public FlashCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_flash_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_flash_ctrl_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_flash_ctrl_init({.base_addr = dev().region()}, &flash_ctrl_),
-            kDifOk);
+  EXPECT_EQ(dif_flash_ctrl_init(dev().region(), &flash_ctrl_), kDifOk);
 }
 
 class AlertForceTest : public FlashCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -28,11 +28,11 @@ class GpioTest : public Test, public MmioTest {
 class InitTest : public GpioTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_gpio_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_gpio_init({.base_addr = dev().region()}, &gpio_), kDifOk);
+  EXPECT_EQ(dif_gpio_init(dev().region(), &gpio_), kDifOk);
 }
 
 class AlertForceTest : public GpioTest {};

--- a/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_hmac_autogen_unittest.cc
@@ -28,11 +28,11 @@ class HmacTest : public Test, public MmioTest {
 class InitTest : public HmacTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_hmac_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_hmac_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_hmac_init({.base_addr = dev().region()}, &hmac_), kDifOk);
+  EXPECT_EQ(dif_hmac_init(dev().region(), &hmac_), kDifOk);
 }
 
 class AlertForceTest : public HmacTest {};

--- a/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_i2c_autogen_unittest.cc
@@ -28,11 +28,11 @@ class I2cTest : public Test, public MmioTest {
 class InitTest : public I2cTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_i2c_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_i2c_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_i2c_init({.base_addr = dev().region()}, &i2c_), kDifOk);
+  EXPECT_EQ(dif_i2c_init(dev().region(), &i2c_), kDifOk);
 }
 
 class AlertForceTest : public I2cTest {};

--- a/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_keymgr_autogen_unittest.cc
@@ -28,12 +28,11 @@ class KeymgrTest : public Test, public MmioTest {
 class InitTest : public KeymgrTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_keymgr_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_keymgr_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_keymgr_init({.base_addr = dev().region()}, &keymgr_), kDifOk);
+  EXPECT_EQ(dif_keymgr_init(dev().region(), &keymgr_), kDifOk);
 }
 
 class AlertForceTest : public KeymgrTest {};

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -28,11 +28,11 @@ class KmacTest : public Test, public MmioTest {
 class InitTest : public KmacTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_kmac_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_kmac_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_kmac_init({.base_addr = dev().region()}, &kmac_), kDifOk);
+  EXPECT_EQ(dif_kmac_init(dev().region(), &kmac_), kDifOk);
 }
 
 class AlertForceTest : public KmacTest {};

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
@@ -28,12 +28,11 @@ class LcCtrlTest : public Test, public MmioTest {
 class InitTest : public LcCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_lc_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_lc_ctrl_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_lc_ctrl_init({.base_addr = dev().region()}, &lc_ctrl_), kDifOk);
+  EXPECT_EQ(dif_lc_ctrl_init(dev().region(), &lc_ctrl_), kDifOk);
 }
 
 class AlertForceTest : public LcCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -28,11 +28,11 @@ class OtbnTest : public Test, public MmioTest {
 class InitTest : public OtbnTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_otbn_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_otbn_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_otbn_init({.base_addr = dev().region()}, &otbn_), kDifOk);
+  EXPECT_EQ(dif_otbn_init(dev().region(), &otbn_), kDifOk);
 }
 
 class AlertForceTest : public OtbnTest {};

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -28,13 +28,11 @@ class OtpCtrlTest : public Test, public MmioTest {
 class InitTest : public OtpCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_otp_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_otp_ctrl_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_otp_ctrl_init({.base_addr = dev().region()}, &otp_ctrl_),
-            kDifOk);
+  EXPECT_EQ(dif_otp_ctrl_init(dev().region(), &otp_ctrl_), kDifOk);
 }
 
 class AlertForceTest : public OtpCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
@@ -28,12 +28,11 @@ class PattgenTest : public Test, public MmioTest {
 class InitTest : public PattgenTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_pattgen_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_pattgen_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_pattgen_init({.base_addr = dev().region()}, &pattgen_), kDifOk);
+  EXPECT_EQ(dif_pattgen_init(dev().region(), &pattgen_), kDifOk);
 }
 
 class AlertForceTest : public PattgenTest {};

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
@@ -28,12 +28,11 @@ class PinmuxTest : public Test, public MmioTest {
 class InitTest : public PinmuxTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_pinmux_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_pinmux_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_pinmux_init({.base_addr = dev().region()}, &pinmux_), kDifOk);
+  EXPECT_EQ(dif_pinmux_init(dev().region(), &pinmux_), kDifOk);
 }
 
 class AlertForceTest : public PinmuxTest {};

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -28,12 +28,11 @@ class PwrmgrTest : public Test, public MmioTest {
 class InitTest : public PwrmgrTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_pwrmgr_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_pwrmgr_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_pwrmgr_init({.base_addr = dev().region()}, &pwrmgr_), kDifOk);
+  EXPECT_EQ(dif_pwrmgr_init(dev().region(), &pwrmgr_), kDifOk);
 }
 
 class IrqGetStateTest : public PwrmgrTest {};

--- a/sw/device/lib/dif/autogen/dif_rom_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rom_ctrl_autogen_unittest.cc
@@ -28,13 +28,11 @@ class RomCtrlTest : public Test, public MmioTest {
 class InitTest : public RomCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rom_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_rom_ctrl_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rom_ctrl_init({.base_addr = dev().region()}, &rom_ctrl_),
-            kDifOk);
+  EXPECT_EQ(dif_rom_ctrl_init(dev().region(), &rom_ctrl_), kDifOk);
 }
 
 class AlertForceTest : public RomCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
@@ -28,12 +28,11 @@ class RstmgrTest : public Test, public MmioTest {
 class InitTest : public RstmgrTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rstmgr_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_rstmgr_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rstmgr_init({.base_addr = dev().region()}, &rstmgr_), kDifOk);
+  EXPECT_EQ(dif_rstmgr_init(dev().region(), &rstmgr_), kDifOk);
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
@@ -28,12 +28,11 @@ class RvPlicTest : public Test, public MmioTest {
 class InitTest : public RvPlicTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rv_plic_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_rv_plic_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rv_plic_init({.base_addr = dev().region()}, &rv_plic_), kDifOk);
+  EXPECT_EQ(dif_rv_plic_init(dev().region(), &rv_plic_), kDifOk);
 }
 
 class AlertForceTest : public RvPlicTest {};

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -28,13 +28,11 @@ class RvTimerTest : public Test, public MmioTest {
 class InitTest : public RvTimerTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rv_timer_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_rv_timer_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rv_timer_init({.base_addr = dev().region()}, &rv_timer_),
-            kDifOk);
+  EXPECT_EQ(dif_rv_timer_init(dev().region(), &rv_timer_), kDifOk);
 }
 
 class AlertForceTest : public RvTimerTest {};

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -28,13 +28,11 @@ class SpiDeviceTest : public Test, public MmioTest {
 class InitTest : public SpiDeviceTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_spi_device_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_spi_device_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_spi_device_init({.base_addr = dev().region()}, &spi_device_),
-            kDifOk);
+  EXPECT_EQ(dif_spi_device_init(dev().region(), &spi_device_), kDifOk);
 }
 
 class AlertForceTest : public SpiDeviceTest {};

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
@@ -28,13 +28,11 @@ class SpiHostTest : public Test, public MmioTest {
 class InitTest : public SpiHostTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_spi_host_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_spi_host_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_spi_host_init({.base_addr = dev().region()}, &spi_host_),
-            kDifOk);
+  EXPECT_EQ(dif_spi_host_init(dev().region(), &spi_host_), kDifOk);
 }
 
 class AlertForceTest : public SpiHostTest {};

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
@@ -28,13 +28,11 @@ class SramCtrlTest : public Test, public MmioTest {
 class InitTest : public SramCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_sram_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_sram_ctrl_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_sram_ctrl_init({.base_addr = dev().region()}, &sram_ctrl_),
-            kDifOk);
+  EXPECT_EQ(dif_sram_ctrl_init(dev().region(), &sram_ctrl_), kDifOk);
 }
 
 class AlertForceTest : public SramCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen_unittest.cc
@@ -28,13 +28,11 @@ class SysrstCtrlTest : public Test, public MmioTest {
 class InitTest : public SysrstCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_sysrst_ctrl_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_sysrst_ctrl_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_sysrst_ctrl_init({.base_addr = dev().region()}, &sysrst_ctrl_),
-            kDifOk);
+  EXPECT_EQ(dif_sysrst_ctrl_init(dev().region(), &sysrst_ctrl_), kDifOk);
 }
 
 class AlertForceTest : public SysrstCtrlTest {};

--- a/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_uart_autogen_unittest.cc
@@ -28,11 +28,11 @@ class UartTest : public Test, public MmioTest {
 class InitTest : public UartTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_uart_init({.base_addr = dev().region()}, nullptr), kDifBadArg);
+  EXPECT_EQ(dif_uart_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_uart_init({.base_addr = dev().region()}, &uart_), kDifOk);
+  EXPECT_EQ(dif_uart_init(dev().region(), &uart_), kDifOk);
 }
 
 class AlertForceTest : public UartTest {};

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -28,12 +28,11 @@ class UsbdevTest : public Test, public MmioTest {
 class InitTest : public UsbdevTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_usbdev_init({.base_addr = dev().region()}, nullptr),
-            kDifBadArg);
+  EXPECT_EQ(dif_usbdev_init(dev().region(), nullptr), kDifBadArg);
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_usbdev_init({.base_addr = dev().region()}, &usbdev_), kDifOk);
+  EXPECT_EQ(dif_usbdev_init(dev().region(), &usbdev_), kDifOk);
 }
 
 class AlertForceTest : public UsbdevTest {};

--- a/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
@@ -40,14 +40,14 @@ namespace {
 
   TEST_F(InitTest, NullArgs) {
     EXPECT_EQ(dif_${ip.name_snake}_init(
-        {.base_addr = dev().region()},
+        dev().region(),
         nullptr),
       kDifBadArg);
   }
 
   TEST_F(InitTest, Success) {
     EXPECT_EQ(dif_${ip.name_snake}_init(
-        {.base_addr = dev().region()},
+        dev().region(),
         &${ip.name_snake}_),
       kDifOk);
   }


### PR DESCRIPTION
The first parameter of `dif_*_init()` functions is a `mmio_region_t` but autogenerated unit tests pass `{.base_addr = dev().region()}` instead of simply passing the return value of `dev().region()`, which is a `mmio_region_t`. Caught this while trying to measure off-target coverage using `clang-13`. I'm not sure why this builds without any warnings using `gcc`, could be a bug, at least the lack of any warnings.

Signed-off-by: Alphan Ulusoy <alphan@google.com>