### PR TITLE
[csrng/doc] align otp input names

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -125,7 +125,7 @@
             desc: '''
                   Setting this field to kMuBi4True will enable reading from the !!GENBITS register.
                   This application interface for software (register based) will be enabled
-                  only if the efuse_sw_app_enable input is set.
+                  only if the otp_en_csrng_sw_app_read input vector is set to the enable encoding.
                   '''
           resval: false
         },
@@ -134,9 +134,9 @@
             name: "READ_INT_STATE",
             mubi: true
             desc: '''
-                  Setting this field to kMuBi4True will enable reading from the INT_STATE_VAL register.
+                  Setting this field to kMuBi4True will enable reading from the !!INT_STATE_VAL register.
                   Reading the internal state of the enable instances will be enabled
-                  only if the efuse_sw_app_enable input is set.
+                  only if the otp_en_csrng_sw_app_read input vector is set to the enable encoding.
                   '''
           resval: false
         },


### PR DESCRIPTION
The otp efuse name has been changed in the hjson register description to match the input name.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>