### PR TITLE
[dw/pwrmgr] Add aborted low power entry test

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -101,7 +101,7 @@
       tests: ["pwrmgr_wakeup"]
     }
     {
-      name: aborted_lowpower
+      name: aborted_low_power
       desc: '''
             Test aborted low power transitions.
 
@@ -127,7 +127,7 @@
               `abort` events when capture is enabled.
             '''
       milestone: V2
-      tests: []
+      tests: ["pwrmgr_aborted_low_power"]
     }
     {
       name: reset

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
@@ -19,6 +19,7 @@ filesets:
       - pwrmgr_env.sv: {is_include_file: true}
       - seq_lib/pwrmgr_vseq_list.sv: {is_include_file: true}
       - seq_lib/pwrmgr_base_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_aborted_low_power_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_reset_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_smoke_vseq.sv: {is_include_file: true}

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -103,7 +103,7 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
       wakeup_intr_cg_wrap[i] = new({wakeup.name, "_intr_cg"});
     end
     control_cg = new();
-    reset_cg = new();
+    reset_cg   = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -146,7 +146,8 @@ interface pwrmgr_if (
     rstreqs_i = resets;
   endfunction
 
-  function automatic void update_reset_en(logic [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_en_value);
+  function automatic void update_reset_en(
+      logic [pwrmgr_reg_pkg::NumRstReqs-1:0] reset_en_value);
     reset_en = reset_en_value;
   endfunction
 
@@ -168,8 +169,7 @@ interface pwrmgr_if (
   endfunction
 
   function automatic void update_control_enables(pwrmgr_env_pkg::control_enables_t value);
-    `uvm_info("pwrmgr_if", $sformatf("Updating control enables to 0x%x", value),
-              UVM_MEDIUM)
+    `uvm_info("pwrmgr_if", $sformatf("Updating control enables to 0x%x", value), UVM_MEDIUM)
     control_enables = value;
   endfunction
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_aborted_low_power_vseq.sv
@@ -1,0 +1,95 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The aborted low power test causes low power transitions to abort for CPU interrupts and nvms not
+// idle. It randomly enables wakeups, info capture, and interrupts, and sends wakeups at random
+// times, but causes a test failure if they are not aborted.
+class pwrmgr_aborted_low_power_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_aborted_low_power_vseq)
+
+  `uvm_object_new
+
+  // If set causes an abort because the CPU gets an interrupt, which shows up as
+  // pwr_cpu.core_sleeping being low when the fast FSM is in FastPwrStateFallThrough.
+  rand bit cpu_interrupt;
+  rand bit flash_idle;
+  rand bit lc_idle;
+  rand bit otp_idle;
+  constraint idle_c {
+    solve cpu_interrupt before flash_idle, lc_idle, otp_idle;
+    if (!cpu_interrupt) {flash_idle & lc_idle & otp_idle == 1'b0;}
+  }
+
+  constraint wakeups_c {wakeups != 0;}
+
+  constraint wakeup_en_c {
+    solve wakeups before wakeups_en;
+    |(wakeups_en & wakeups) == 1'b1;
+  }
+
+  // Make sure wakeup capture is enabled to check the abort happened.
+  constraint enable_wakeup_capture_c {disable_wakeup_capture == 1'b0;}
+
+  task body();
+    logic [TL_DW-1:0] value;
+    wakeups_t enabled_wakeups;
+
+    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
+    csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(0));
+    set_nvms_idle();
+    for (int i = 0; i < num_trans; ++i) begin
+      `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      // Enable wakeups.
+      enabled_wakeups = wakeups_en & wakeups;
+      `DV_CHECK(enabled_wakeups, $sformatf(
+                "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
+      `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
+      csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
+      `uvm_info(`gfn, $sformatf("%0sabling wakeup capture", disable_wakeup_capture ? "Dis" : "En"),
+                UVM_MEDIUM)
+      csr_wr(.ptr(ral.wake_info_capture_dis), .value(disable_wakeup_capture));
+
+      update_control_enables(1'b1);
+
+      wait_for_csr_to_propagate_to_slow_domain();
+
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
+
+      // Defeat the low power entry.
+      if (cpu_interrupt) begin
+        // The transition back to cpu active must be soon enough.
+        `uvm_info(`gfn, "Expecting a fall_through (0x40)", UVM_MEDIUM)
+        set_nvms_idle();
+        cfg.clk_rst_vif.wait_clks(2);
+        cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
+      end else begin
+        `uvm_info(`gfn, "Expecting an abort (0x80)", UVM_MEDIUM)
+        set_nvms_idle(flash_idle, lc_idle, otp_idle);
+      end
+      // Wait enough time for the clocks to be turned off and then wait for them to go back on,
+      // indicating the fast fsm is active again.
+      cfg.clk_rst_vif.wait_clks(2);
+      wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);
+
+      // Check there was no reset.
+      csr_rd_check(.ptr(ral.reset_status[0]), .compare_value(0),
+                   .err_msg("failed reset_status check"));
+
+      // No wakeups, but check abort and fall_through.
+      if (cpu_interrupt) begin
+        check_wake_info(.reasons('0), .fall_through(1'b1), .abort(1'b0));
+      end else begin
+        check_wake_info(.reasons('0), .fall_through(1'b0), .abort(1'b1));
+      end
+      clear_wake_info();
+
+      // Get ready for another round.
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
+      set_nvms_idle();
+    end
+    `uvm_info(`gfn, "Test done", UVM_MEDIUM)
+  endtask
+
+endclass : pwrmgr_aborted_low_power_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
@@ -63,7 +63,7 @@ class pwrmgr_reset_vseq extends pwrmgr_base_vseq;
       wait_for_fast_fsm_active();
       `uvm_info(`gfn, "Back from reset", UVM_MEDIUM)
 
-      check_wake_info('0, .fall_through(1'b0), .abort(1'b0));
+      check_wake_info(.reasons('0), .fall_through(1'b0), .abort(1'b0));
 
       cfg.slow_clk_rst_vif.wait_clks(4);
       csr_rd_check(.ptr(ral.reset_status[0]), .compare_value('0));

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
@@ -21,6 +21,7 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
     logic [TL_DW-1:0] value;
     wakeups_t wakeup_en;
     resets_t reset_en;
+    set_nvms_idle();
     cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
     csr_rd_check(.ptr(ral.wake_status[0]), .compare_value(0));
     csr_rd_check(.ptr(ral.reset_status[0]), .compare_value(0));
@@ -34,7 +35,6 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
     // Initiate low power transition.
     csr_wr(.ptr(ral.control.low_power_hint), .value(1'b1));
     cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
-    fast_to_low_power();
     if (ral.control.main_pd_n.get_mirrored_value() == 1'b0) begin
       wait_for_reset_cause(pwrmgr_pkg::LowPwrEntry);
     end
@@ -59,7 +59,6 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
     // Trigger a reset.
     cfg.pwrmgr_vif.update_resets(resets);
     cfg.slow_clk_rst_vif.wait_clks(2);
-    fast_to_low_power();
     wait_for_reset_cause(pwrmgr_pkg::HwReq);
 
     // Now bring it back: the slow fsm doesn't participate on this, so we cannot
@@ -72,7 +71,6 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
 
     // Wait for interrupt to be generated whether or not it is enabled.
     cfg.slow_clk_rst_vif.wait_clks(10);
-    `uvm_info(`gfn, "Ending smoke test", UVM_LOW)
   endtask
 
 endclass : pwrmgr_smoke_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 `include "pwrmgr_base_vseq.sv"
+`include "pwrmgr_aborted_low_power_vseq.sv"
 `include "pwrmgr_reset_vseq.sv"
 `include "pwrmgr_smoke_vseq.sv"
 `include "pwrmgr_wakeup_vseq.sv"

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -69,6 +69,10 @@
       uvm_test_seq: pwrmgr_wakeup_vseq
       run_opts: ["+test_timeout_ns=1000000"]
     }
+    {
+      name: pwrmgr_aborted_low_power
+      uvm_test_seq: pwrmgr_aborted_low_power_vseq
+    }
 
     // TODO: add more tests here
   ]


### PR DESCRIPTION
Add testing of a wakeup with a prior wakeup pending.
Randomize some delay cycle counts once only to avoid inconsistent
pipelining for slow responder.
Add uvm info for objection mechanism.
Enhance nvms idle updates to enable aborted low power entry testing.

Signed-off-by: Guillermo Maturana <maturana@google.com>