### PR TITLE
[sw/exts] Skip zero-ing stack in testing 2nd boot stage.

### DIFF
--- a/sw/device/exts/common/flash_crt.S
+++ b/sw/device/exts/common/flash_crt.S
@@ -53,11 +53,6 @@ _start:
   la   a1, _bss_end
   call crt_section_clear
 
-  // Zero out the stack
-  la   a0, _stack_start
-  la   a1, _stack_end
-  call crt_section_clear
-
   // Initialize the `.data` segment from the `.idata` segment.
   la   a0, _data_start
   la   a1, _data_end


### PR DESCRIPTION
The testing-only version of the 2nd boot-stage
(`sw/device/exts/common/flash_crt.S`), currently zeros out the stack.
This wastes simulation cycles and is not necessary in this testing-only
code. This addresses a task in #9163.

Signed-off-by: Timothy Trippel <ttrippel@google.com>