### PR TITLE
[lc_ctrl] Make the life cycle state CSR multibit

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -64,7 +64,7 @@
     { name:    "CsrLcStateWidth",
       desc:    "Number of life cycle state enum bits.",
       type:    "int"
-      default: "5",
+      default: "30", // 6 * 5bit
       local:   "true"
     }
     { name:    "CsrLcCountWidth",
@@ -76,7 +76,7 @@
     { name:    "CsrLcIdStateWidth",
       desc:    "Number of life cycle id state enum bits.",
       type:    "int"
-      default: "2",
+      default: "32",
       local:   "true"
     }
     { name:    "CsrOtpTestCtrlWidth",
@@ -555,6 +555,10 @@
         { bits: "CsrLcStateWidth-1:0"
           name: "STATE"
           desc: '''
+                This field encodes the target life cycle state in a redundant enum format.
+                The 5bit state enum is repeated 6x so that it fills the entire 32bit register.
+                The encoding is straightforward replication: [val, val, val, val, val, val].
+
                 Note that this register is shared with the life cycle TAP interface.
                 In order to have exclusive access to this register, SW must first claim the associated
                 hardware mutex via !!CLAIM_TRANSITION_IF.
@@ -563,87 +567,87 @@
                   // CLAIM_TRANSITION_IF, so can not auto predict its value.
                   "excl:CsrNonInitTests:CsrExclCheck"],
           enum: [
-            { value: "0",
+            { value: "0b00000_00000_00000_00000_00000_00000", // 0
               name:  "RAW",
               desc:  "Raw life cycle state after fabrication where all functions are disabled."
             }
-            { value: "1",
+            { value: "0b00001_00001_00001_00001_00001_00001", // 1
               name:  "TEST_UNLOCKED0",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "2",
+            { value: "0b00010_00010_00010_00010_00010_00010", // 2
               name:  "TEST_LOCKED0",
               desc:  "Locked test state where where all functions are disabled."
             }
-            { value: "3",
+            { value: "0b00011_00011_00011_00011_00011_00011", // 3
               name:  "TEST_UNLOCKED1",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "4",
+            { value: "0b00100_00100_00100_00100_00100_00100", // 4
               name:  "TEST_LOCKED1",
               desc:  "Locked test state where where all functions are disabled."
             }
-            { value: "5",
+            { value: "0b00101_00101_00101_00101_00101_00101", // 5
               name:  "TEST_UNLOCKED2",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "6",
+            { value: "0b00110_00110_00110_00110_00110_00110", // 6
               name:  "TEST_LOCKED2",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "7",
+            { value: "0b00111_00111_00111_00111_00111_00111", // 7
               name:  "TEST_UNLOCKED3",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "8",
+            { value: "0b01000_01000_01000_01000_01000_01000", // 8
               name:  "TEST_LOCKED3",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "9",
+            { value: "0b01001_01001_01001_01001_01001_01001", // 9
               name:  "TEST_UNLOCKED4",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "10",
+            { value: "0b01010_01010_01010_01010_01010_01010", // 10
               name:  "TEST_LOCKED4",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "11",
+            { value: "0b01011_01011_01011_01011_01011_01011", // 11
               name:  "TEST_UNLOCKED5",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "12",
+            { value: "0b01100_01100_01100_01100_01100_01100", // 12
               name:  "TEST_LOCKED5",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "13",
+            { value: "0b01101_01101_01101_01101_01101_01101", // 13
               name:  "TEST_UNLOCKED6",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "14",
+            { value: "0b01110_01110_01110_01110_01110_01110", // 14
               name:  "TEST_LOCKED6",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "15",
+            { value: "0b01111_01111_01111_01111_01111_01111", // 15
               name:  "TEST_UNLOCKED7",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "16",
+            { value: "0b10000_10000_10000_10000_10000_10000", // 16
               name:  "DEV",
               desc:  "Development life cycle state where limited debug functionality is available."
             }
-            { value: "17",
+            { value: "0b10001_10001_10001_10001_10001_10001", // 17
               name:  "PROD",
               desc:  "Production life cycle state."
             }
-            { value: "18",
+            { value: "0b10010_10010_10010_10010_10010_10010", // 18
               name:  "PROD_END",
               desc:  "Same as PROD, but transition into RMA is not possible from this state."
             }
-            { value: "19",
+            { value: "0b10011_10011_10011_10011_10011_10011", // 19
               name:  "RMA",
               desc:  "RMA life cycle state."
             }
-            { value: "20",
+            { value: "0b10100_10100_10100_10100_10100_10100", // 20
               name:  "SCRAP",
               desc:  "SCRAP life cycle state where all functions are disabled."
             }
@@ -707,102 +711,106 @@
       fields: [
         { bits: "CsrLcStateWidth-1:0"
           name: "STATE"
-          desc: ""
+          desc: '''
+                This field exposes the decoded life cycle state in a redundant enum format.
+                The 5bit state enum is repeated 6x so that it fills the entire 32bit register.
+                The encoding is straightforward replication: [val, val, val, val, val, val].
+                '''
           enum: [
-            { value: "0",
+            { value: "0b00000_00000_00000_00000_00000_00000", // 0
               name:  "RAW",
               desc:  "Raw life cycle state after fabrication where all functions are disabled."
             }
-            { value: "1",
+            { value: "0b00001_00001_00001_00001_00001_00001", // 1
               name:  "TEST_UNLOCKED0",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "2",
+            { value: "0b00010_00010_00010_00010_00010_00010", // 2
               name:  "TEST_LOCKED0",
               desc:  "Locked test state where where all functions are disabled."
             }
-            { value: "3",
+            { value: "0b00011_00011_00011_00011_00011_00011", // 3
               name:  "TEST_UNLOCKED1",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "4",
+            { value: "0b00100_00100_00100_00100_00100_00100", // 4
               name:  "TEST_LOCKED1",
               desc:  "Locked test state where where all functions are disabled."
             }
-            { value: "5",
+            { value: "0b00101_00101_00101_00101_00101_00101", // 5
               name:  "TEST_UNLOCKED2",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "6",
+            { value: "0b00110_00110_00110_00110_00110_00110", // 6
               name:  "TEST_LOCKED2",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "7",
+            { value: "0b00111_00111_00111_00111_00111_00111", // 7
               name:  "TEST_UNLOCKED3",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "8",
+            { value: "0b01000_01000_01000_01000_01000_01000", // 8
               name:  "TEST_LOCKED3",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "9",
+            { value: "0b01001_01001_01001_01001_01001_01001", // 9
               name:  "TEST_UNLOCKED4",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "10",
+            { value: "0b01010_01010_01010_01010_01010_01010", // 10
               name:  "TEST_LOCKED4",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "11",
+            { value: "0b01011_01011_01011_01011_01011_01011", // 11
               name:  "TEST_UNLOCKED5",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "12",
+            { value: "0b01100_01100_01100_01100_01100_01100", // 12
               name:  "TEST_LOCKED5",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "13",
+            { value: "0b01101_01101_01101_01101_01101_01101", // 13
               name:  "TEST_UNLOCKED6",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "14",
+            { value: "0b01110_01110_01110_01110_01110_01110", // 14
               name:  "TEST_LOCKED6",
               desc:  "Locked test state where debug all functions are disabled."
             }
-            { value: "15",
+            { value: "0b01111_01111_01111_01111_01111_01111", // 15
               name:  "TEST_UNLOCKED7",
               desc:  "Unlocked test state where debug functions are enabled."
             }
-            { value: "16",
+            { value: "0b10000_10000_10000_10000_10000_10000", // 16
               name:  "DEV",
               desc:  "Development life cycle state where limited debug functionality is available."
             }
-            { value: "17",
+            { value: "0b10001_10001_10001_10001_10001_10001", // 17
               name:  "PROD",
               desc:  "Production life cycle state."
             }
-            { value: "18",
+            { value: "0b10010_10010_10010_10010_10010_10010", // 18
               name:  "PROD_END",
               desc:  "Same as PROD, but transition into RMA is not possible from this state."
             }
-            { value: "19",
+            { value: "0b10011_10011_10011_10011_10011_10011", // 19
               name:  "RMA",
               desc:  "RMA life cycle state."
             }
-            { value: "20",
+            { value: "0b10100_10100_10100_10100_10100_10100", // 20
               name:  "SCRAP",
               desc:  "SCRAP life cycle state where all functions are disabled."
             }
             // The following states are temporary.
-            { value: "21",
+            { value: "0b10101_10101_10101_10101_10101_10101", // 21
               name:  "POST_TRANSITION",
               desc:  "This state is temporary and behaves the same way as SCRAP."
             }
-            { value: "22",
+            { value: "0b10110_10110_10110_10110_10110_10110", // 22
               name:  "ESCALATE",
               desc:  "This state is temporary and behaves the same way as SCRAP."
             }
-            { value: "23",
+            { value: "0b10111_10111_10111_10111_10111_10111", // 23
               name:  "INVALID",
               desc:   '''
                       This state is reported when the life cycle state encoding is invalid.
@@ -845,19 +853,19 @@
       tags: [ // Life cycle internal HW will update status so can not auto-predict its value.
               "excl:CsrAllTests:CsrExclCheck"],
       fields: [
-        { bits: "1:0"
+        { bits: "CsrLcIdStateWidth-1:0"
           name: "STATE"
           desc: ""
           enum: [
-            { value: "0",
+            { value: "0x0",
               name:  "BLANK",
               desc:  "The device has not yet been personalized."
             }
-            { value: "1",
+            { value: "0x11111111",
               name:  "PERSONALIZED",
               desc:  "The device has been personalized."
             }
-            { value: "2",
+            { value: "0x22222222",
               name:  "INVALID",
               desc:  "The state is not valid."
             }

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -66,7 +66,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
         check_lc_outputs(exp_lc_o, err_msg);
 
         // predict LC state and cnt csr
-        void'(ral.lc_state.predict(lc_state));
+        void'(ral.lc_state.predict({DecLcStateNumRep{lc_state[DecLcStateWidth-1:0]}}));
         void'(ral.lc_transition_cnt.predict(dec_lc_cnt(cfg.lc_ctrl_vif.otp_i.count)));
       end
     end

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -107,7 +107,7 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
     bit trigger_alert;
     bit [TL_DW-1:0] status_val;
     csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
-    csr_wr(ral.transition_target, next_lc_state);
+    csr_wr(ral.transition_target, {DecLcStateNumRep{next_lc_state[DecLcStateWidth-1:0]}});
     foreach (ral.transition_token[i]) begin
       csr_wr(ral.transition_token[i], token_val[TL_DW-1:0]);
       token_val = token_val >> TL_DW;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -38,7 +38,7 @@ module lc_ctrl_fsm
   input  lc_tx_t                rma_token_valid_i,
   // Transition trigger interface.
   input                         trans_cmd_i,
-  input  dec_lc_state_e         trans_target_i,
+  input  ext_dec_lc_state_t     trans_target_i,
   // Decoded life cycle state for CSRs.
   output dec_lc_state_e         dec_lc_state_o,
   output dec_lc_cnt_t           dec_lc_cnt_o,
@@ -322,7 +322,7 @@ module lc_ctrl_fsm
       // Flash RMA state. Note that we check the flash response again
       // two times later below.
       FlashRmaSt: begin
-        if (trans_target_i == DecLcStRma) begin
+        if (trans_target_i == {DecLcStateNumRep{DecLcStRma}}) begin
           lc_flash_rma_req = On;
           if (lc_flash_rma_ack[0] == On) begin
             fsm_state_d = TokenCheck0St;
@@ -342,10 +342,10 @@ module lc_ctrl_fsm
         end else begin
           // If any of these RMA are conditions are true,
           // all of them must be true at the same time.
-          if ((trans_target_i != DecLcStRma &&
+          if ((trans_target_i != {DecLcStateNumRep{DecLcStRma}} &&
                lc_flash_rma_req_o == Off    &&
                lc_flash_rma_ack[1] == Off)   ||
-              (trans_target_i == DecLcStRma &&
+              (trans_target_i == {DecLcStateNumRep{DecLcStRma}} &&
                lc_flash_rma_req_o == On     &&
                lc_flash_rma_ack[1] == On)) begin
             if (hashed_token_i == hashed_token_mux &&
@@ -496,7 +496,7 @@ module lc_ctrl_fsm
     hashed_tokens_valid[InvalidTokenIdx]    = 1'b0; // always invalid
   end
 
-  assign token_idx = TransTokenIdxMatrix[dec_lc_state_o][trans_target_i];
+  assign token_idx = TransTokenIdxMatrix[dec_lc_state_o][trans_target_i[0]];
   assign hashed_token_mux = hashed_tokens[token_idx];
   assign hashed_token_valid_mux = hashed_tokens_valid[token_idx];
 

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_pkg.sv
@@ -8,9 +8,9 @@ package lc_ctrl_reg_pkg;
 
   // Param list
   parameter int NumTokenWords = 4;
-  parameter int CsrLcStateWidth = 5;
+  parameter int CsrLcStateWidth = 30;
   parameter int CsrLcCountWidth = 5;
-  parameter int CsrLcIdStateWidth = 2;
+  parameter int CsrLcIdStateWidth = 32;
   parameter int CsrOtpTestCtrlWidth = 32;
   parameter int CsrOtpTestStatusWidth = 32;
   parameter int NumDeviceIdWords = 8;
@@ -60,7 +60,7 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_reg2hw_transition_token_mreg_t;
 
   typedef struct packed {
-    logic [4:0]  q;
+    logic [29:0] q;
     logic        qe;
   } lc_ctrl_reg2hw_transition_target_reg_t;
 
@@ -119,7 +119,7 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_transition_token_mreg_t;
 
   typedef struct packed {
-    logic [4:0]  d;
+    logic [29:0] d;
   } lc_ctrl_hw2reg_transition_target_reg_t;
 
   typedef struct packed {
@@ -131,7 +131,7 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_otp_vendor_test_status_reg_t;
 
   typedef struct packed {
-    logic [4:0]  d;
+    logic [29:0] d;
   } lc_ctrl_hw2reg_lc_state_reg_t;
 
   typedef struct packed {
@@ -139,7 +139,7 @@ package lc_ctrl_reg_pkg;
   } lc_ctrl_hw2reg_lc_transition_cnt_reg_t;
 
   typedef struct packed {
-    logic [1:0]  d;
+    logic [31:0] d;
   } lc_ctrl_hw2reg_lc_id_state_reg_t;
 
   typedef struct packed {
@@ -152,28 +152,28 @@ package lc_ctrl_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [189:184]
-    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [183:175]
-    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [174:173]
-    lc_ctrl_reg2hw_transition_ctrl_reg_t transition_ctrl; // [172:171]
-    lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [170:39]
-    lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [38:33]
+    lc_ctrl_reg2hw_alert_test_reg_t alert_test; // [214:209]
+    lc_ctrl_reg2hw_claim_transition_if_reg_t claim_transition_if; // [208:200]
+    lc_ctrl_reg2hw_transition_cmd_reg_t transition_cmd; // [199:198]
+    lc_ctrl_reg2hw_transition_ctrl_reg_t transition_ctrl; // [197:196]
+    lc_ctrl_reg2hw_transition_token_mreg_t [3:0] transition_token; // [195:64]
+    lc_ctrl_reg2hw_transition_target_reg_t transition_target; // [63:33]
     lc_ctrl_reg2hw_otp_vendor_test_ctrl_reg_t otp_vendor_test_ctrl; // [32:0]
   } lc_ctrl_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    lc_ctrl_hw2reg_status_reg_t status; // [740:731]
-    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [730:723]
-    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [722:722]
-    lc_ctrl_hw2reg_transition_ctrl_reg_t transition_ctrl; // [721:721]
-    lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [720:593]
-    lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [592:588]
-    lc_ctrl_hw2reg_otp_vendor_test_ctrl_reg_t otp_vendor_test_ctrl; // [587:556]
-    lc_ctrl_hw2reg_otp_vendor_test_status_reg_t otp_vendor_test_status; // [555:524]
-    lc_ctrl_hw2reg_lc_state_reg_t lc_state; // [523:519]
-    lc_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [518:514]
-    lc_ctrl_hw2reg_lc_id_state_reg_t lc_id_state; // [513:512]
+    lc_ctrl_hw2reg_status_reg_t status; // [820:811]
+    lc_ctrl_hw2reg_claim_transition_if_reg_t claim_transition_if; // [810:803]
+    lc_ctrl_hw2reg_transition_regwen_reg_t transition_regwen; // [802:802]
+    lc_ctrl_hw2reg_transition_ctrl_reg_t transition_ctrl; // [801:801]
+    lc_ctrl_hw2reg_transition_token_mreg_t [3:0] transition_token; // [800:673]
+    lc_ctrl_hw2reg_transition_target_reg_t transition_target; // [672:643]
+    lc_ctrl_hw2reg_otp_vendor_test_ctrl_reg_t otp_vendor_test_ctrl; // [642:611]
+    lc_ctrl_hw2reg_otp_vendor_test_status_reg_t otp_vendor_test_status; // [610:579]
+    lc_ctrl_hw2reg_lc_state_reg_t lc_state; // [578:549]
+    lc_ctrl_hw2reg_lc_transition_cnt_reg_t lc_transition_cnt; // [548:544]
+    lc_ctrl_hw2reg_lc_id_state_reg_t lc_id_state; // [543:512]
     lc_ctrl_hw2reg_device_id_mreg_t [7:0] device_id; // [511:256]
     lc_ctrl_hw2reg_manuf_state_mreg_t [7:0] manuf_state; // [255:0]
   } lc_ctrl_hw2reg_t;
@@ -228,12 +228,12 @@ package lc_ctrl_reg_pkg;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_1_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_2_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_TRANSITION_TOKEN_3_RESVAL = 32'h 0;
-  parameter logic [4:0] LC_CTRL_TRANSITION_TARGET_RESVAL = 5'h 0;
+  parameter logic [29:0] LC_CTRL_TRANSITION_TARGET_RESVAL = 30'h 0;
   parameter logic [31:0] LC_CTRL_OTP_VENDOR_TEST_CTRL_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_OTP_VENDOR_TEST_STATUS_RESVAL = 32'h 0;
-  parameter logic [4:0] LC_CTRL_LC_STATE_RESVAL = 5'h 0;
+  parameter logic [29:0] LC_CTRL_LC_STATE_RESVAL = 30'h 0;
   parameter logic [4:0] LC_CTRL_LC_TRANSITION_CNT_RESVAL = 5'h 0;
-  parameter logic [1:0] LC_CTRL_LC_ID_STATE_RESVAL = 2'h 0;
+  parameter logic [31:0] LC_CTRL_LC_ID_STATE_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_DEVICE_ID_0_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_DEVICE_ID_1_RESVAL = 32'h 0;
   parameter logic [31:0] LC_CTRL_DEVICE_ID_2_RESVAL = 32'h 0;
@@ -299,12 +299,12 @@ package lc_ctrl_reg_pkg;
     4'b 1111, // index[ 7] LC_CTRL_TRANSITION_TOKEN_1
     4'b 1111, // index[ 8] LC_CTRL_TRANSITION_TOKEN_2
     4'b 1111, // index[ 9] LC_CTRL_TRANSITION_TOKEN_3
-    4'b 0001, // index[10] LC_CTRL_TRANSITION_TARGET
+    4'b 1111, // index[10] LC_CTRL_TRANSITION_TARGET
     4'b 1111, // index[11] LC_CTRL_OTP_VENDOR_TEST_CTRL
     4'b 1111, // index[12] LC_CTRL_OTP_VENDOR_TEST_STATUS
-    4'b 0001, // index[13] LC_CTRL_LC_STATE
+    4'b 1111, // index[13] LC_CTRL_LC_STATE
     4'b 0001, // index[14] LC_CTRL_LC_TRANSITION_CNT
-    4'b 0001, // index[15] LC_CTRL_LC_ID_STATE
+    4'b 1111, // index[15] LC_CTRL_LC_ID_STATE
     4'b 1111, // index[16] LC_CTRL_DEVICE_ID_0
     4'b 1111, // index[17] LC_CTRL_DEVICE_ID_1
     4'b 1111, // index[18] LC_CTRL_DEVICE_ID_2

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -153,8 +153,8 @@ module lc_ctrl_reg_top (
   logic [31:0] transition_token_3_wd;
   logic transition_target_re;
   logic transition_target_we;
-  logic [4:0] transition_target_qs;
-  logic [4:0] transition_target_wd;
+  logic [29:0] transition_target_qs;
+  logic [29:0] transition_target_wd;
   logic otp_vendor_test_ctrl_re;
   logic otp_vendor_test_ctrl_we;
   logic [31:0] otp_vendor_test_ctrl_qs;
@@ -162,11 +162,11 @@ module lc_ctrl_reg_top (
   logic otp_vendor_test_status_re;
   logic [31:0] otp_vendor_test_status_qs;
   logic lc_state_re;
-  logic [4:0] lc_state_qs;
+  logic [29:0] lc_state_qs;
   logic lc_transition_cnt_re;
   logic [4:0] lc_transition_cnt_qs;
   logic lc_id_state_re;
-  logic [1:0] lc_id_state_qs;
+  logic [31:0] lc_id_state_qs;
   logic device_id_0_re;
   logic [31:0] device_id_0_qs;
   logic device_id_1_re;
@@ -513,7 +513,7 @@ module lc_ctrl_reg_top (
 
   // R[transition_target]: V(True)
   prim_subreg_ext #(
-    .DW    (5)
+    .DW    (30)
   ) u_transition_target (
     .re     (transition_target_re),
     .we     (transition_target_we & transition_regwen_qs),
@@ -558,7 +558,7 @@ module lc_ctrl_reg_top (
 
   // R[lc_state]: V(True)
   prim_subreg_ext #(
-    .DW    (5)
+    .DW    (30)
   ) u_lc_state (
     .re     (lc_state_re),
     .we     (1'b0),
@@ -588,7 +588,7 @@ module lc_ctrl_reg_top (
 
   // R[lc_id_state]: V(True)
   prim_subreg_ext #(
-    .DW    (2)
+    .DW    (32)
   ) u_lc_id_state (
     .re     (lc_id_state_re),
     .we     (1'b0),
@@ -972,7 +972,7 @@ module lc_ctrl_reg_top (
   assign transition_target_re = addr_hit[10] & reg_re & !reg_error;
   assign transition_target_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign transition_target_wd = reg_wdata[4:0];
+  assign transition_target_wd = reg_wdata[29:0];
   assign otp_vendor_test_ctrl_re = addr_hit[11] & reg_re & !reg_error;
   assign otp_vendor_test_ctrl_we = addr_hit[11] & reg_we & !reg_error;
 
@@ -1054,7 +1054,7 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[4:0] = transition_target_qs;
+        reg_rdata_next[29:0] = transition_target_qs;
       end
 
       addr_hit[11]: begin
@@ -1066,7 +1066,7 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[4:0] = lc_state_qs;
+        reg_rdata_next[29:0] = lc_state_qs;
       end
 
       addr_hit[14]: begin
@@ -1074,7 +1074,7 @@ module lc_ctrl_reg_top (
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[1:0] = lc_id_state_qs;
+        reg_rdata_next[31:0] = lc_id_state_qs;
       end
 
       addr_hit[16]: begin

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv
@@ -22,6 +22,9 @@ package lc_ctrl_state_pkg;
   parameter int LcStateWidth = NumLcStateValues * LcValueWidth;
   parameter int NumLcStates = 21;
   parameter int DecLcStateWidth = vbits(NumLcStates);
+  // Redundant version used in the CSRs.
+  parameter int DecLcStateNumRep = 32/DecLcStateWidth;
+  parameter int ExtDecLcStateWidth = DecLcStateNumRep*DecLcStateWidth;
 
   parameter int NumLcCountValues = 24;
   parameter int LcCountWidth = NumLcCountValues * LcValueWidth;
@@ -33,6 +36,9 @@ package lc_ctrl_state_pkg;
   // is declared here for exposure through the CSR interface.
   parameter int NumLcIdStates = 2;
   parameter int DecLcIdStateWidth = vbits(NumLcIdStates+1);
+  // Redundant version used in the CSRs.
+  parameter int DecLcIdStateNumRep = 32/DecLcIdStateWidth;
+  parameter int ExtDecLcIdStateWidth = DecLcIdStateNumRep*DecLcIdStateWidth;
 
   /////////////////////////////////////////////
   // Life cycle manufacturing state encoding //
@@ -301,6 +307,8 @@ package lc_ctrl_state_pkg;
     DecLcStEscalate = 22,
     DecLcStInvalid = 23
   } dec_lc_state_e;
+
+  typedef dec_lc_state_e [DecLcStateNumRep-1:0] ext_dec_lc_state_t;
 
   typedef enum logic [DecLcIdStateWidth-1:0] {
     DecLcIdBlank,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_pkg.sv.tpl
@@ -78,6 +78,9 @@ package lc_ctrl_state_pkg;
   parameter int LcStateWidth = NumLcStateValues * LcValueWidth;
   parameter int NumLcStates = ${len(lc_st_enc.config['lc_state'])};
   parameter int DecLcStateWidth = vbits(NumLcStates);
+  // Redundant version used in the CSRs.
+  parameter int DecLcStateNumRep = 32/DecLcStateWidth;
+  parameter int ExtDecLcStateWidth = DecLcStateNumRep*DecLcStateWidth;
 
   parameter int NumLcCountValues = ${lc_st_enc.config['num_lc_cnt_words']};
   parameter int LcCountWidth = NumLcCountValues * LcValueWidth;
@@ -89,6 +92,9 @@ package lc_ctrl_state_pkg;
   // is declared here for exposure through the CSR interface.
   parameter int NumLcIdStates = 2;
   parameter int DecLcIdStateWidth = vbits(NumLcIdStates+1);
+  // Redundant version used in the CSRs.
+  parameter int DecLcIdStateNumRep = 32/DecLcIdStateWidth;
+  parameter int ExtDecLcIdStateWidth = DecLcIdStateNumRep*DecLcIdStateWidth;
 
   /////////////////////////////////////////////
   // Life cycle manufacturing state encoding //
@@ -153,6 +159,8 @@ ${_print_state_enum('LcCnt', 'lc_cnt', lc_st_enc.config)}
     DecLcStEscalate = ${len(lc_st_enc.config['lc_state']) + 1},
     DecLcStInvalid = ${len(lc_st_enc.config['lc_state']) + 2}
   } dec_lc_state_e;
+
+  typedef dec_lc_state_e [DecLcStateNumRep-1:0] ext_dec_lc_state_t;
 
   typedef enum logic [DecLcIdStateWidth-1:0] {
     DecLcIdBlank,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_transition.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_transition.sv
@@ -10,20 +10,20 @@ module lc_ctrl_state_transition
   import lc_ctrl_state_pkg::*;
 (
   // Life cycle state vector.
-  input  lc_state_e        lc_state_i,
-  input  lc_cnt_e          lc_cnt_i,
+  input  lc_state_e         lc_state_i,
+  input  lc_cnt_e           lc_cnt_i,
   // Main FSM state.
-  input  fsm_state_e       fsm_state_i,
+  input  fsm_state_e        fsm_state_i,
   // Decoded lc state input
-  input  dec_lc_state_e    dec_lc_state_i,
+  input  dec_lc_state_e     dec_lc_state_i,
   // Transition target.
-  input  dec_lc_state_e    trans_target_i,
+  input  ext_dec_lc_state_t trans_target_i,
   // Updated state vector.
-  output lc_state_e        next_lc_state_o,
-  output lc_cnt_e          next_lc_cnt_o,
+  output lc_state_e         next_lc_state_o,
+  output lc_cnt_e           next_lc_cnt_o,
   // If the transition counter is maxed out
-  output logic             trans_cnt_oflw_error_o,
-  output logic             trans_invalid_error_o
+  output logic              trans_cnt_oflw_error_o,
+  output logic              trans_invalid_error_o
 );
 
   //////////////////////////
@@ -80,7 +80,7 @@ module lc_ctrl_state_transition
       endcase // lc_cnt_i
 
       // In case the transition target is SCRAP, max out the counter.
-      if (trans_target_i == DecLcStScrap) begin
+      if (trans_target_i == {DecLcStateNumRep{DecLcStScrap}}) begin
         next_lc_cnt_o = LcCnt24;
       end
     end
@@ -91,39 +91,39 @@ module lc_ctrl_state_transition
                             TransProgSt}) begin
       // Check that the decoded transition indexes are valid
       // before indexing the state transition matrix.
-      if (dec_lc_state_i <= DecLcStScrap ||
-          trans_target_i <= DecLcStScrap) begin
+      if (dec_lc_state_i    <= DecLcStScrap &&
+          trans_target_i[0] <= DecLcStScrap) begin
         // Check the state transition token matrix in order to see whether this
         // transition is valid. All transitions have a token index value different
         // from InvalidTokenIdx.
-        if (TransTokenIdxMatrix[dec_lc_state_i][trans_target_i] != InvalidTokenIdx) begin
+        if (TransTokenIdxMatrix[dec_lc_state_i][trans_target_i[0]] != InvalidTokenIdx) begin
           // Encode the target state.
           // Note that the life cycle encoding itself also ensures that only certain transitions are
           // possible. So even if this logic here is tampered with, the encoding values won't allow
           // an invalid transition (instead, the programming operation will fail and leave the life
           // cycle state corrupted/invalid).
           unique case (trans_target_i)
-            DecLcStRaw:           next_lc_state_o = LcStRaw;
-            DecLcStTestUnlocked0: next_lc_state_o = LcStTestUnlocked0;
-            DecLcStTestLocked0:   next_lc_state_o = LcStTestLocked0;
-            DecLcStTestUnlocked1: next_lc_state_o = LcStTestUnlocked1;
-            DecLcStTestLocked1:   next_lc_state_o = LcStTestLocked1;
-            DecLcStTestUnlocked2: next_lc_state_o = LcStTestUnlocked2;
-            DecLcStTestLocked2:   next_lc_state_o = LcStTestLocked2;
-            DecLcStTestUnlocked3: next_lc_state_o = LcStTestUnlocked3;
-            DecLcStTestLocked3:   next_lc_state_o = LcStTestLocked3;
-            DecLcStTestUnlocked4: next_lc_state_o = LcStTestUnlocked4;
-            DecLcStTestLocked4:   next_lc_state_o = LcStTestLocked4;
-            DecLcStTestUnlocked5: next_lc_state_o = LcStTestUnlocked5;
-            DecLcStTestLocked5:   next_lc_state_o = LcStTestLocked5;
-            DecLcStTestUnlocked6: next_lc_state_o = LcStTestUnlocked6;
-            DecLcStTestLocked6:   next_lc_state_o = LcStTestLocked6;
-            DecLcStTestUnlocked7: next_lc_state_o = LcStTestUnlocked7;
-            DecLcStDev:           next_lc_state_o = LcStDev;
-            DecLcStProd:          next_lc_state_o = LcStProd;
-            DecLcStProdEnd:       next_lc_state_o = LcStProdEnd;
-            DecLcStRma:           next_lc_state_o = LcStRma;
-            DecLcStScrap:         next_lc_state_o = LcStScrap;
+            {DecLcStateNumRep{DecLcStRaw}}:           next_lc_state_o = LcStRaw;
+            {DecLcStateNumRep{DecLcStTestUnlocked0}}: next_lc_state_o = LcStTestUnlocked0;
+            {DecLcStateNumRep{DecLcStTestLocked0}}:   next_lc_state_o = LcStTestLocked0;
+            {DecLcStateNumRep{DecLcStTestUnlocked1}}: next_lc_state_o = LcStTestUnlocked1;
+            {DecLcStateNumRep{DecLcStTestLocked1}}:   next_lc_state_o = LcStTestLocked1;
+            {DecLcStateNumRep{DecLcStTestUnlocked2}}: next_lc_state_o = LcStTestUnlocked2;
+            {DecLcStateNumRep{DecLcStTestLocked2}}:   next_lc_state_o = LcStTestLocked2;
+            {DecLcStateNumRep{DecLcStTestUnlocked3}}: next_lc_state_o = LcStTestUnlocked3;
+            {DecLcStateNumRep{DecLcStTestLocked3}}:   next_lc_state_o = LcStTestLocked3;
+            {DecLcStateNumRep{DecLcStTestUnlocked4}}: next_lc_state_o = LcStTestUnlocked4;
+            {DecLcStateNumRep{DecLcStTestLocked4}}:   next_lc_state_o = LcStTestLocked4;
+            {DecLcStateNumRep{DecLcStTestUnlocked5}}: next_lc_state_o = LcStTestUnlocked5;
+            {DecLcStateNumRep{DecLcStTestLocked5}}:   next_lc_state_o = LcStTestLocked5;
+            {DecLcStateNumRep{DecLcStTestUnlocked6}}: next_lc_state_o = LcStTestUnlocked6;
+            {DecLcStateNumRep{DecLcStTestLocked6}}:   next_lc_state_o = LcStTestLocked6;
+            {DecLcStateNumRep{DecLcStTestUnlocked7}}: next_lc_state_o = LcStTestUnlocked7;
+            {DecLcStateNumRep{DecLcStDev}}:           next_lc_state_o = LcStDev;
+            {DecLcStateNumRep{DecLcStProd}}:          next_lc_state_o = LcStProd;
+            {DecLcStateNumRep{DecLcStProdEnd}}:       next_lc_state_o = LcStProdEnd;
+            {DecLcStateNumRep{DecLcStRma}}:           next_lc_state_o = LcStRma;
+            {DecLcStateNumRep{DecLcStScrap}}:         next_lc_state_o = LcStScrap;
             default:              trans_invalid_error_o = 1'b1;
           endcase // trans_target_i
         end else begin

--- a/sw/device/lib/dif/dif_lc_ctrl.c
+++ b/sw/device/lib/dif/dif_lc_ctrl.c
@@ -188,7 +188,7 @@ dif_result_t dif_lc_ctrl_get_id_state(const dif_lc_ctrl_t *lc,
 
   uint32_t reg =
       mmio_region_read32(lc->base_addr, LC_CTRL_LC_ID_STATE_REG_OFFSET);
-  switch (bitfield_field32_read(reg, LC_CTRL_LC_ID_STATE_STATE_FIELD)) {
+  switch (reg) {
     case LC_CTRL_LC_ID_STATE_STATE_VALUE_BLANK:
       *state = kDifLcCtrlIdStateBlank;
       break;

--- a/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_lc_ctrl_unittest.cc
@@ -125,8 +125,7 @@ TEST_F(StateTest, GetIdState) {
   for (auto pair : states) {
     dif_lc_ctrl_id_state_t state;
 
-    EXPECT_READ32(LC_CTRL_LC_ID_STATE_REG_OFFSET,
-                  {{LC_CTRL_LC_ID_STATE_STATE_OFFSET, pair.first}});
+    EXPECT_READ32(LC_CTRL_LC_ID_STATE_REG_OFFSET, pair.first);
     EXPECT_EQ(dif_lc_ctrl_get_id_state(&lc_, &state), kDifOk);
     EXPECT_EQ(state, pair.second);
   }

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.h
@@ -18,105 +18,105 @@ typedef enum LcState {
   /**
    * Raw life cycle state after fabrication where all functions are disabled.
    */
-  kLcStateRaw,
+  kLcStateRaw = 0x0,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked0,
+  kLcStateTestUnlocked0 = 1 * 0x2108421,
   /**
    * Locked test state where where all functions are disabled.
    */
-  kLcStateTestLocked0,
+  kLcStateTestLocked0 = 2 * 0x2108421,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked1,
+  kLcStateTestUnlocked1 = 3 * 0x2108421,
   /**
    * Locked test state where where all functions are disabled.
    */
-  kLcStateTestLocked1,
+  kLcStateTestLocked1 = 4 * 0x2108421,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked2,
+  kLcStateTestUnlocked2 = 5 * 0x2108421,
   /**
    * Locked test state where debug all functions are disabled.
    */
-  kLcStateTestLocked2,
+  kLcStateTestLocked2 = 6 * 0x2108421,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked3,
+  kLcStateTestUnlocked3 = 7 * 0x2108421,
   /**
    * Locked test state where debug all functions are disabled.
    */
-  kLcStateTestLocked3,
+  kLcStateTestLocked3 = 8 * 0x2108421,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked4,
+  kLcStateTestUnlocked4 = 9 * 0x2108421,
   /**
    * Locked test state where debug all functions are disabled.
    */
-  kLcStateTestLocked4,
+  kLcStateTestLocked4 = 10 * 0x2108421,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked5,
+  kLcStateTestUnlocked5 = 11 * 0x2108421,
   /**
    * Locked test state where debug all functions are disabled.
    */
-  kLcStateTestLocked5,
+  kLcStateTestLocked5 = 12 * 0x2108421,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked6,
+  kLcStateTestUnlocked6 = 13 * 0x2108421,
   /**
    * Locked test state where debug all functions are disabled.
    */
-  kLcStateTestLocked6,
+  kLcStateTestLocked6 = 14 * 0x2108421,
   /**
    * Unlocked test state where debug functions are enabled.
    */
-  kLcStateTestUnlocked7,
+  kLcStateTestUnlocked7 = 15 * 0x2108421,
   /**
    * Development life cycle state where limited debug functionality is
    * available.
    */
-  kLcStateDev,
+  kLcStateDev = 16 * 0x2108421,
   /**
    * Production life cycle state.
    */
-  kLcStateProd,
+  kLcStateProd = 17 * 0x2108421,
   /**
    * Same as PROD, but transition into RMA is not possible from this state.
    */
-  kLcStateProdEnd,
+  kLcStateProdEnd = 18 * 0x2108421,
   /**
    * RMA life cycle state.
    */
-  kLcStateRma,
+  kLcStateRma = 19 * 0x2108421,
   /**
    * SCRAP life cycle state where all functions are disabled.
    */
-  kLcStateScrap,
+  kLcStateScrap = 20 * 0x2108421,
   /**
    * This state is temporary and behaves the same way as SCRAP.
    */
-  kLcStatePostTransition,
+  kLcStatePostTransition = 21 * 0x2108421,
   /**
    * This state is temporary and behaves the same way as SCRAP.
    */
-  kLcStateEscalate,
+  kLcStateEscalate = 22 * 0x2108421,
   /**
    * This state is reported when the life cycle state encoding is invalid.
    * This state is temporary and behaves the same way as SCRAP.
    */
-  kLcStateInvalid,
+  kLcStateInvalid = 23 * 0x2108421,
   /**
    * This is not a state - it is the total number of states.
    */
-  kLcStateNumStates,
+  kLcStateNumStates = 24,
 } lifecycle_state_t;
 
 enum {


### PR DESCRIPTION
In order to harden the ROM code, we need the life cycle state information exposed in the `lc_ctrl` CSRs to be multibit.

To that end, the 5bit life cycle enum is repeated 6x in order to span the entire 32bit register.
Likewise, the 2bit provisioning state is repeated in order to span 32bit.

@moidx let me know if this works.

(Note: This was done in this way in order to keep the design impact within bounds. A complete translation to a randomized multibit enum would require more work, as we would have to add a translation LUT to the design.)

Signed-off-by: Michael Schaffner <msf@opentitan.org>