### PR TITLE
[dv] mubi related coverage

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -28,12 +28,28 @@ begin tgl
 end
 
 begin assert
-  // These three assertions in prim_lc_sync check when `lc_ctrl_pkg::lc_tx_t` input is neither `On`
-  // or `Off`, it is interrupted to the correct `On` or `Off` after one clock cycle. This behavior
-  // is implemented outside of IP level design thus these assertions are not covered in IP level
-  // testbenchs.
+  // These three assertions in prim_lc_sync and prim_mubi* check when `lc_ctrl_pkg::lc_tx_t` or
+  // `mubi*_t` input are neither `On` or `Off`, it is interrupted to the correct `On` or `Off`
+  // after one clock cycle. This behavior is implemented outside of IP level design thus these
+  // assertions are not covered in IP level testbenchs.
   // TODO: check these assertions in top-level or FPV.
   -assert PrimLcSyncCheckTransients_A
   -assert PrimLcSyncCheckTransients0_A
   -assert PrimLcSyncCheckTransients1_A
+
+  -assert PrimMubi4SyncCheckTransients_A
+  -assert PrimMubi4SyncCheckTransients0_A
+  -assert PrimMubi4SyncCheckTransients1_A
+
+  -assert PrimMubi8SyncCheckTransients_A
+  -assert PrimMubi8SyncCheckTransients0_A
+  -assert PrimMubi8SyncCheckTransients1_A
+
+  -assert PrimMubi12SyncCheckTransients_A
+  -assert PrimMubi12SyncCheckTransients0_A
+  -assert PrimMubi12SyncCheckTransients1_A
+
+  -assert PrimMubi16SyncCheckTransients_A
+  -assert PrimMubi16SyncCheckTransients0_A
+  -assert PrimMubi16SyncCheckTransients1_A
 end

--- a/hw/dv/tools/xcelium/cover.ccf
+++ b/hw/dv/tools/xcelium/cover.ccf
@@ -24,3 +24,28 @@ select_coverage -toggle -module prim_esc_sender
 select_coverage -toggle -module prim_esc_receiver
 select_coverage -toggle -module prim_prince
 select_coverage -toggle -module prim_lfsr
+
+// These three assertions in prim_lc_sync and prim_mubi* check when `lc_ctrl_pkg::lc_tx_t` or
+// `mubi*_t` input are neither `On` or `Off`, it is interrupted to the correct `On` or `Off`
+// after one clock cycle. This behavior is implemented outside of IP level design thus these
+// assertions are not covered in IP level testbenchs.
+// TODO: check these assertions in top-level or FPV.
+deselect_coverage -assertion *.PrimLcSyncCheckTransients_A
+deselect_coverage -assertion *.PrimLcSyncCheckTransients0_A
+deselect_coverage -assertion *.PrimLcSyncCheckTransients1_A
+
+deselect_coverage -assertion *.PrimMubi4SyncCheckTransients_A
+deselect_coverage -assertion *.PrimMubi4SyncCheckTransients0_A
+deselect_coverage -assertion *.PrimMubi4SyncCheckTransients1_A
+
+deselect_coverage -assertion PrimMubi8SyncCheckTransients_A
+deselect_coverage -assertion PrimMubi8SyncCheckTransients0_A
+deselect_coverage -assertion PrimMubi8SyncCheckTransients1_A
+
+deselect_coverage -assertion PrimMubi12SyncCheckTransients_A
+deselect_coverage -assertion PrimMubi12SyncCheckTransients0_A
+deselect_coverage -assertion PrimMubi12SyncCheckTransients1_A
+
+deselect_coverage -assertion PrimMubi16SyncCheckTransients_A
+deselect_coverage -assertion PrimMubi16SyncCheckTransients0_A
+deselect_coverage -assertion PrimMubi16SyncCheckTransients1_A

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
@@ -6,6 +6,7 @@
 interface alert_handler_if(input clk, input rst_n);
   import alert_pkg::*;
   import prim_mubi_pkg::*;
+  import cip_base_pkg::*;
 
   mubi4_t [NLpg-1:0] lpg_cg_en;
   mubi4_t [NLpg-1:0] lpg_rst_en;
@@ -13,8 +14,9 @@ interface alert_handler_if(input clk, input rst_n);
   string msg_id = "alert_handler_if";
 
   function automatic void init();
-    lpg_cg_en = '{default: MuBi4False};
-    lpg_rst_en = '{default: MuBi4False};
+    mubi4_t mubi_false_val = get_rand_mubi4_val(0, 1, 1);
+    lpg_cg_en = '{default: mubi_false_val};
+    lpg_rst_en = '{default: mubi_false_val};
   endfunction
 
   function automatic bit get_lpg_status(int index);

--- a/hw/ip_templates/alert_handler/dv/tb/tb.sv
+++ b/hw/ip_templates/alert_handler/dv/tb/tb.sv
@@ -8,6 +8,7 @@ module tb;
   import dv_utils_pkg::*;
   import alert_handler_env_pkg::*;
   import alert_handler_test_pkg::*;
+  import alert_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -92,6 +93,38 @@ module tb;
     .esc_rx_i             ( esc_rx        ),
     .esc_tx_o             ( esc_tx        )
   );
+
+  `define LPG_MUBI_PATH tb.dut.u_alert_handler_lpg_ctrl
+  for (genvar k = 0; k < NLpg; k++) begin : gen_lpgs_asserts_disable
+    // These SVA checks the lpg inputs are either Off or On, we will use more than these 2 values.
+    // If it's not On, it should be Off.
+    initial begin
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_rst_en.PrimMubi4SyncCheckTransients_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_rst_en.PrimMubi4SyncCheckTransients0_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_rst_en.PrimMubi4SyncCheckTransients1_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_cg_en.PrimMubi4SyncCheckTransients_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_cg_en.PrimMubi4SyncCheckTransients0_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_cg_en.PrimMubi4SyncCheckTransients1_A);
+    end
+  end
+
+  for (genvar k=0; k < NAlerts; k++) begin : gen_alert_map_asserts_disable
+    initial begin
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_alert_map[k].u_prim_mubi4_sync_lpg_en.PrimMubi4SyncCheckTransients_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_alert_map[k].u_prim_mubi4_sync_lpg_en.PrimMubi4SyncCheckTransients0_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_alert_map[k].u_prim_mubi4_sync_lpg_en.PrimMubi4SyncCheckTransients1_A);
+    end
+  end
+  `undef LPG_MUBI_HIER_PATH
 
   initial begin
     // drive clk and rst_n from clk_if

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
@@ -6,6 +6,7 @@
 interface alert_handler_if(input clk, input rst_n);
   import alert_pkg::*;
   import prim_mubi_pkg::*;
+  import cip_base_pkg::*;
 
   mubi4_t [NLpg-1:0] lpg_cg_en;
   mubi4_t [NLpg-1:0] lpg_rst_en;
@@ -13,8 +14,9 @@ interface alert_handler_if(input clk, input rst_n);
   string msg_id = "alert_handler_if";
 
   function automatic void init();
-    lpg_cg_en = '{default: MuBi4False};
-    lpg_rst_en = '{default: MuBi4False};
+    mubi4_t mubi_false_val = get_rand_mubi4_val(0, 1, 1);
+    lpg_cg_en = '{default: mubi_false_val};
+    lpg_rst_en = '{default: mubi_false_val};
   endfunction
 
   function automatic bit get_lpg_status(int index);

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/tb/tb.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/tb/tb.sv
@@ -8,6 +8,7 @@ module tb;
   import dv_utils_pkg::*;
   import alert_handler_env_pkg::*;
   import alert_handler_test_pkg::*;
+  import alert_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -92,6 +93,38 @@ module tb;
     .esc_rx_i             ( esc_rx        ),
     .esc_tx_o             ( esc_tx        )
   );
+
+  `define LPG_MUBI_PATH tb.dut.u_alert_handler_lpg_ctrl
+  for (genvar k = 0; k < NLpg; k++) begin : gen_lpgs_asserts_disable
+    // These SVA checks the lpg inputs are either Off or On, we will use more than these 2 values.
+    // If it's not On, it should be Off.
+    initial begin
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_rst_en.PrimMubi4SyncCheckTransients_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_rst_en.PrimMubi4SyncCheckTransients0_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_rst_en.PrimMubi4SyncCheckTransients1_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_cg_en.PrimMubi4SyncCheckTransients_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_cg_en.PrimMubi4SyncCheckTransients0_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_lpgs[k].u_prim_mubi4_sync_cg_en.PrimMubi4SyncCheckTransients1_A);
+    end
+  end
+
+  for (genvar k=0; k < NAlerts; k++) begin : gen_alert_map_asserts_disable
+    initial begin
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_alert_map[k].u_prim_mubi4_sync_lpg_en.PrimMubi4SyncCheckTransients_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_alert_map[k].u_prim_mubi4_sync_lpg_en.PrimMubi4SyncCheckTransients0_A);
+      $assertoff(0,
+          `LPG_MUBI_PATH.gen_alert_map[k].u_prim_mubi4_sync_lpg_en.PrimMubi4SyncCheckTransients1_A);
+    end
+  end
+  `undef LPG_MUBI_HIER_PATH
 
   initial begin
     // drive clk and rst_n from clk_if


### PR DESCRIPTION
This PR has two commits:
1). For alert_handler, randomize mubi4_false type to include random values that is not mubi4_true.
2). For coverage exclusion, similar as lc_sync_check, we exclude mubi trans assertions because they will be checked outside of IP level.