### PR TITLE
[rom_ctrl] Update checklist to match current status

### DIFF
--- a/hw/ip/rom_ctrl/doc/checklist.md
+++ b/hw/ip/rom_ctrl/doc/checklist.md
@@ -44,14 +44,14 @@ RTL           | [FEATURE_COMPLETE][]    | Done        |
 RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
 RTL           | [ARCHITECTURE_FROZEN][] | Done        |
-RTL           | [REVIEW_TODO][]         | Partial     | Remaining TODOs are related to FI hardening
+RTL           | [REVIEW_TODO][]         | Done        | Remaining TODOs are related to FI hardening (tracked in D2S)
 RTL           | [STYLE_X][]             | Done        |
-Code Quality  | [LINT_PASS][]           | Not Started |
+Code Quality  | [LINT_PASS][]           | Done        |
 Code Quality  | [CDC_SETUP][]           | N/A         | rom_ctrl has only one clock
 Code Quality  | [FPGA_TIMING][]         | Done        |
 Code Quality  | [CDC_SYNCMACRO][]       | N/A         | rom_ctrl has only one clock
 Security      | [SEC_CM_DOCUMENTED][]   | Not Started |
-Security      | [SEC_RND_CNST][]        | Not Started |
+Security      | [SEC_RND_CNST][]        | Done        |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new_features" >}}
 [BLOCK_DIAGRAM]:       {{<relref "/doc/project/checklist.md#block_diagram" >}}


### PR DESCRIPTION
Everything is done for D2 except the planning/implementation of
FI hardening and countermeasures.

The `LINT_PASS` item includes a review of lint waivers. There's exactly
one such waiver, which silences AscentLint about a signal that's
intentionally driven to a constant, one cycle after reset (the world's
simplest FSM!)
