### PR TITLE
[rom_cntrl, dv] Test to verify successful rom check

### DIFF
--- a/hw/dv/sv/kmac_app_agent/seq_lib/kmac_app_device_seq.sv
+++ b/hw/dv/sv/kmac_app_agent/seq_lib/kmac_app_device_seq.sv
@@ -19,14 +19,27 @@ class kmac_app_device_seq extends kmac_app_base_seq;
   endtask
 
   virtual function void randomize_item(REQ item);
+    kmac_pkg::rsp_digest_t rsp_digest_h; 
+    bit set_share;
+    if (cfg.has_user_digest_share()) begin
+      set_share = 1;
+      rsp_digest_h = cfg.get_user_digest_share();
+    end else begin
+      set_share = 0;
+    end
     `DV_CHECK_RANDOMIZE_WITH_FATAL(item,
       if (cfg.zero_delays) {
         rsp_delay == 0;
       } else {
         rsp_delay inside {[cfg.rsp_delay_min : cfg.rsp_delay_max]};
       }
+      if (set_share) {
+        rsp_digest_share0 == rsp_digest_h.digest_share0;
+        rsp_digest_share1 == rsp_digest_h.digest_share1;
+      }
       is_kmac_rsp_err dist {1 :/ cfg.error_rsp_pct,
                             0 :/ 100 - cfg.error_rsp_pct};
     )
   endfunction
+
 endclass

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -278,6 +278,10 @@ package kmac_pkg;
     logic [23:0] info; // Additional Debug info
   } err_t;
 
+  typedef struct packed {
+    logic [AppDigestW-1:0] digest_share0;
+    logic [AppDigestW-1:0] digest_share1;
+  } rsp_digest_t;
   ///////////////////////
   // Library Functions //
   ///////////////////////

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/rom_ctrl_base_vseq.sv: {is_include_file: true}
       - seq_lib/rom_ctrl_common_vseq.sv: {is_include_file: true}
       - seq_lib/rom_ctrl_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/rom_ctrl_chk_successful_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_chk_successful_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_chk_successful_vseq.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// smoke test vseq
+class rom_ctrl_chk_successful_vseq extends rom_ctrl_base_vseq;
+  `uvm_object_utils(rom_ctrl_chk_successful_vseq)
+  `uvm_object_new
+  
+  // Indicates the number of memory accesses to be performed
+  rand int num_mem_reads;
+
+  constraint num_mem_reads_c {
+    num_mem_reads inside {[20 : 50]};
+  }
+
+  task body();
+    set_kmac_digest();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_mem_reads)
+    do_rand_ops(num_mem_reads);
+    read_digest_regs();
+  endtask : body
+
+endclass : rom_ctrl_chk_successful_vseq

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_vseq_list.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_vseq_list.sv
@@ -5,3 +5,4 @@
 `include "rom_ctrl_base_vseq.sv"
 `include "rom_ctrl_smoke_vseq.sv"
 `include "rom_ctrl_common_vseq.sv"
+`include "rom_ctrl_chk_successful_vseq.sv"

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
@@ -54,7 +54,11 @@
       name: rom_ctrl_smoke
       uvm_test_seq: rom_ctrl_smoke_vseq
     }
-
+    {
+      name: successful_rom_chk
+      uvm_test_seq: rom_ctrl_chk_successful_vseq
+    }
+    
     // TODO: add more tests here
   ]
 


### PR DESCRIPTION
Following files have been added/ modified in this commit:
1. rom_ctrl_chk_successful_vseq: Sequence that writes the top 8 address
spaces to ensure we have the expected digest matching with KMAC digest.
2. kmac_app_device_seq: It assigns the rsp_digest_share0/1 fields from the values
present in kmac_app_agent_cfg. Randomization of the rsp_digest_share0/1
fields has been removed.
3. rom_ctrl_env: Sets the value of rsp_digest_share0/1 in
kmac_app_agent_cfg.
4. kmac_app_agent_cfg: rsp_digest_share0/1 fields have been added.