### PR TITLE
[sw/ottf] Decouple OTTF ISRs into separate lib.

### DIFF
--- a/sw/device/lib/testing/test_framework/freertos_port.S
+++ b/sw/device/lib/testing/test_framework/freertos_port.S
@@ -2,354 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// Ibex does not implement additional registers beyond the RV32I spec.
-#define PORT_WORD_SIZE 4
-#define PORT_HALF_WORD_SIZE (PORT_WORD_SIZE / 2)
-#define PORT_CONTEXT_SIZE (30 * PORT_WORD_SIZE)
+#include "sw/device/lib/testing/test_framework/ottf_macros.h"
 
 .extern pxCurrentTCB
-.extern xISRStackTop
-.extern ottf_exception_handler
-.extern ottf_software_isr
-.extern ottf_timer_isr
-.extern ottf_external_isr
 
-// -----------------------------------------------------------------------------
-
-/**
- * Save MEPC to the stack.
- *
- * NOTE: this IRQ is synchronous, therefore, we must update the ISR return
- * address to point to the instruction after the one that triggered this IRQ.
- * Since we support the RISC-V compressed instructions extension, we need to
- * check if the two least significant bits of the instruction are
- * b11 (0x3), which means that the trapped instruction is not compressed,
- * i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
- * instruction is 16bits = 2bytes.
- */
-
-.balign 4
-.type process_mepc_on_synchronous_irq, @function
-process_mepc_on_synchronous_irq:
-  csrr t0, mepc
-  li t1, 0x3
-  and t2, t0, t1
-  beq t2, t1, L_32bit_trap_instr
-  addi t0, t0, PORT_HALF_WORD_SIZE
-  ret
-L_32bit_trap_instr:
-  addi t0, t0, PORT_WORD_SIZE
-  ret
-
-  // Set size so this function can be disassembled.
-  .size process_mepc_on_synchronous_irq, .-process_mepc_on_synchronous_irq
-
-// -----------------------------------------------------------------------------
-
-/**
- * Exception handler.
- */
-.balign 4
-.global handler_exception
-.type handler_exception, @function
-handler_exception:
-  // Save all registers to the stack.
-  addi sp, sp, -PORT_CONTEXT_SIZE
-  sw   ra,  1 * PORT_WORD_SIZE(sp)
-  sw   t0,  2 * PORT_WORD_SIZE(sp)
-  sw   t1,  3 * PORT_WORD_SIZE(sp)
-  sw   t2,  4 * PORT_WORD_SIZE(sp)
-  sw   s0,  5 * PORT_WORD_SIZE(sp)
-  sw   s1,  6 * PORT_WORD_SIZE(sp)
-  sw   a0,  7 * PORT_WORD_SIZE(sp)
-  sw   a1,  8 * PORT_WORD_SIZE(sp)
-  sw   a2,  9 * PORT_WORD_SIZE(sp)
-  sw   a3, 10 * PORT_WORD_SIZE(sp)
-  sw   a4, 11 * PORT_WORD_SIZE(sp)
-  sw   a5, 12 * PORT_WORD_SIZE(sp)
-  sw   a6, 13 * PORT_WORD_SIZE(sp)
-  sw   a7, 14 * PORT_WORD_SIZE(sp)
-  sw   s2, 15 * PORT_WORD_SIZE(sp)
-  sw   s3, 16 * PORT_WORD_SIZE(sp)
-  sw   s4, 17 * PORT_WORD_SIZE(sp)
-  sw   s5, 18 * PORT_WORD_SIZE(sp)
-  sw   s6, 19 * PORT_WORD_SIZE(sp)
-  sw   s7, 20 * PORT_WORD_SIZE(sp)
-  sw   s8, 21 * PORT_WORD_SIZE(sp)
-  sw   s9, 22 * PORT_WORD_SIZE(sp)
-  sw  s10, 23 * PORT_WORD_SIZE(sp)
-  sw  s11, 24 * PORT_WORD_SIZE(sp)
-  sw   t3, 25 * PORT_WORD_SIZE(sp)
-  sw   t4, 26 * PORT_WORD_SIZE(sp)
-  sw   t5, 27 * PORT_WORD_SIZE(sp)
-  sw   t6, 28 * PORT_WORD_SIZE(sp)
-
-  // Save MSTATUS for the MPIE bit.
-  csrr t0, mstatus
-  sw t0, 29 * PORT_WORD_SIZE(sp)
-
-  // Save MEPC to the stack after updating it to the next instruction (since
-  // this is a synchronous IRQ).
-  jal process_mepc_on_synchronous_irq
-  sw t0, 0(sp)
-
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
-
-  // Jump to the exception handler.
-  jal ottf_exception_handler
-
-  // Return from ISR.
-  j freertosIrqExit
-
-  // Set size so this function can be disassembled.
-  .size handler_exception, .-handler_exception
-
-// -----------------------------------------------------------------------------
-
-/**
- * Software IRQ handler.
- */
-.balign 4
-.global handler_irq_software
-.type handler_irq_software, @function
-handler_irq_software:
-  // Save all registers to the stack.
-  addi sp, sp, -PORT_CONTEXT_SIZE
-  sw   ra,  1 * PORT_WORD_SIZE(sp)
-  sw   t0,  2 * PORT_WORD_SIZE(sp)
-  sw   t1,  3 * PORT_WORD_SIZE(sp)
-  sw   t2,  4 * PORT_WORD_SIZE(sp)
-  sw   s0,  5 * PORT_WORD_SIZE(sp)
-  sw   s1,  6 * PORT_WORD_SIZE(sp)
-  sw   a0,  7 * PORT_WORD_SIZE(sp)
-  sw   a1,  8 * PORT_WORD_SIZE(sp)
-  sw   a2,  9 * PORT_WORD_SIZE(sp)
-  sw   a3, 10 * PORT_WORD_SIZE(sp)
-  sw   a4, 11 * PORT_WORD_SIZE(sp)
-  sw   a5, 12 * PORT_WORD_SIZE(sp)
-  sw   a6, 13 * PORT_WORD_SIZE(sp)
-  sw   a7, 14 * PORT_WORD_SIZE(sp)
-  sw   s2, 15 * PORT_WORD_SIZE(sp)
-  sw   s3, 16 * PORT_WORD_SIZE(sp)
-  sw   s4, 17 * PORT_WORD_SIZE(sp)
-  sw   s5, 18 * PORT_WORD_SIZE(sp)
-  sw   s6, 19 * PORT_WORD_SIZE(sp)
-  sw   s7, 20 * PORT_WORD_SIZE(sp)
-  sw   s8, 21 * PORT_WORD_SIZE(sp)
-  sw   s9, 22 * PORT_WORD_SIZE(sp)
-  sw  s10, 23 * PORT_WORD_SIZE(sp)
-  sw  s11, 24 * PORT_WORD_SIZE(sp)
-  sw   t3, 25 * PORT_WORD_SIZE(sp)
-  sw   t4, 26 * PORT_WORD_SIZE(sp)
-  sw   t5, 27 * PORT_WORD_SIZE(sp)
-  sw   t6, 28 * PORT_WORD_SIZE(sp)
-
-  // Save MSTATUS for the MPIE bit.
-  csrr t0, mstatus
-  sw t0, 29 * PORT_WORD_SIZE(sp)
-
-  // Save MEPC to the stack after updating it to the next instruction (since
-  // this is a synchronous IRQ).
-  jal process_mepc_on_synchronous_irq
-  sw t0, 0(sp)
-
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
-
-  // Jump to the software ISR.
-  jal ottf_software_isr
-
-  // Return from ISR.
-  j freertosIrqExit
-
-  // Set size so this function can be disassembled.
-  .size handler_irq_software, .-handler_irq_software
-
-// -----------------------------------------------------------------------------
-
-/**
- * Timer IRQ handler.
- */
-.balign 4
-.global handler_irq_timer
-.type handler_irq_timer, @function
-handler_irq_timer:
-  // Save all registers to the stack.
-  addi sp, sp, -PORT_CONTEXT_SIZE
-  sw   ra,  1 * PORT_WORD_SIZE(sp)
-  sw   t0,  2 * PORT_WORD_SIZE(sp)
-  sw   t1,  3 * PORT_WORD_SIZE(sp)
-  sw   t2,  4 * PORT_WORD_SIZE(sp)
-  sw   s0,  5 * PORT_WORD_SIZE(sp)
-  sw   s1,  6 * PORT_WORD_SIZE(sp)
-  sw   a0,  7 * PORT_WORD_SIZE(sp)
-  sw   a1,  8 * PORT_WORD_SIZE(sp)
-  sw   a2,  9 * PORT_WORD_SIZE(sp)
-  sw   a3, 10 * PORT_WORD_SIZE(sp)
-  sw   a4, 11 * PORT_WORD_SIZE(sp)
-  sw   a5, 12 * PORT_WORD_SIZE(sp)
-  sw   a6, 13 * PORT_WORD_SIZE(sp)
-  sw   a7, 14 * PORT_WORD_SIZE(sp)
-  sw   s2, 15 * PORT_WORD_SIZE(sp)
-  sw   s3, 16 * PORT_WORD_SIZE(sp)
-  sw   s4, 17 * PORT_WORD_SIZE(sp)
-  sw   s5, 18 * PORT_WORD_SIZE(sp)
-  sw   s6, 19 * PORT_WORD_SIZE(sp)
-  sw   s7, 20 * PORT_WORD_SIZE(sp)
-  sw   s8, 21 * PORT_WORD_SIZE(sp)
-  sw   s9, 22 * PORT_WORD_SIZE(sp)
-  sw  s10, 23 * PORT_WORD_SIZE(sp)
-  sw  s11, 24 * PORT_WORD_SIZE(sp)
-  sw   t3, 25 * PORT_WORD_SIZE(sp)
-  sw   t4, 26 * PORT_WORD_SIZE(sp)
-  sw   t5, 27 * PORT_WORD_SIZE(sp)
-  sw   t6, 28 * PORT_WORD_SIZE(sp)
-
-  // Save MSTATUS for the MPIE bit.
-  csrr t0, mstatus
-  sw t0, 29 * PORT_WORD_SIZE(sp)
-
-  // Save MEPC to the stack.
-  // NOTE: this IRQ is asynchronous, therefore, we do not need to modify MEPC.
-  csrr t0, mepc
-  sw t0, 0(sp)
-
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
-
-  // Jump to timer ISR.
-  jal ottf_timer_isr
-
-  // Return from ISR.
-  j freertosIrqExit
-
-  // Set size so this function can be disassembled.
-  .size handler_irq_timer, .-handler_irq_timer
-
-// -----------------------------------------------------------------------------
-
-/**
- * External IRQ handler.
- */
-.balign 4
-.global handler_irq_external
-.type handler_irq_external, @function
-handler_irq_external:
-  // Save all registers to the stack.
-  addi sp, sp, -PORT_CONTEXT_SIZE
-  sw   ra,  1 * PORT_WORD_SIZE(sp)
-  sw   t0,  2 * PORT_WORD_SIZE(sp)
-  sw   t1,  3 * PORT_WORD_SIZE(sp)
-  sw   t2,  4 * PORT_WORD_SIZE(sp)
-  sw   s0,  5 * PORT_WORD_SIZE(sp)
-  sw   s1,  6 * PORT_WORD_SIZE(sp)
-  sw   a0,  7 * PORT_WORD_SIZE(sp)
-  sw   a1,  8 * PORT_WORD_SIZE(sp)
-  sw   a2,  9 * PORT_WORD_SIZE(sp)
-  sw   a3, 10 * PORT_WORD_SIZE(sp)
-  sw   a4, 11 * PORT_WORD_SIZE(sp)
-  sw   a5, 12 * PORT_WORD_SIZE(sp)
-  sw   a6, 13 * PORT_WORD_SIZE(sp)
-  sw   a7, 14 * PORT_WORD_SIZE(sp)
-  sw   s2, 15 * PORT_WORD_SIZE(sp)
-  sw   s3, 16 * PORT_WORD_SIZE(sp)
-  sw   s4, 17 * PORT_WORD_SIZE(sp)
-  sw   s5, 18 * PORT_WORD_SIZE(sp)
-  sw   s6, 19 * PORT_WORD_SIZE(sp)
-  sw   s7, 20 * PORT_WORD_SIZE(sp)
-  sw   s8, 21 * PORT_WORD_SIZE(sp)
-  sw   s9, 22 * PORT_WORD_SIZE(sp)
-  sw  s10, 23 * PORT_WORD_SIZE(sp)
-  sw  s11, 24 * PORT_WORD_SIZE(sp)
-  sw   t3, 25 * PORT_WORD_SIZE(sp)
-  sw   t4, 26 * PORT_WORD_SIZE(sp)
-  sw   t5, 27 * PORT_WORD_SIZE(sp)
-  sw   t6, 28 * PORT_WORD_SIZE(sp)
-
-  // Save MSTATUS for the MPIE bit.
-  csrr t0, mstatus
-  sw t0, 29 * PORT_WORD_SIZE(sp)
-
-  // Save MEPC to the stack.
-  // NOTE: this IRQ is asynchronous, therefore, we do not need to modify MEPC.
-  csrr t0, mepc
-  sw t0, 0(sp)
-
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
-
-  // Jump to external ISR.
-  jal ottf_external_isr
-
-  // Return from ISR.
-  j freertosIrqExit
-
-  // Set size so this function can be disassembled.
-  .size handler_irq_external, .-handler_irq_external
-
-// -----------------------------------------------------------------------------
-
-/**
- * ISR exit sub-routine restores registers from the stack.
- */
-.balign 4
-.global freertosIrqExit
-.type freertosIrqExit, @function
-freertosIrqExit:
-  // Load the stack pointer for the current TCB.
-	lw  t1, pxCurrentTCB
-	lw  sp, 0(t1)
-
-  // Load the correct MEPC for the next instruction in the current task.
-	lw t0, 0(sp)
-	csrw mepc, t0
-
-  // Load MSTATUS for the MPIE bit.
-	lw  t0, 29 * PORT_WORD_SIZE(sp)
-	csrw mstatus, t0
-
-  // Restore all registers from the stack.
-  lw   ra,  1 * PORT_WORD_SIZE(sp)
-  lw   t0,  2 * PORT_WORD_SIZE(sp)
-  lw   t1,  3 * PORT_WORD_SIZE(sp)
-  lw   t2,  4 * PORT_WORD_SIZE(sp)
-  lw   s0,  5 * PORT_WORD_SIZE(sp)
-  lw   s1,  6 * PORT_WORD_SIZE(sp)
-  lw   a0,  7 * PORT_WORD_SIZE(sp)
-  lw   a1,  8 * PORT_WORD_SIZE(sp)
-  lw   a2,  9 * PORT_WORD_SIZE(sp)
-  lw   a3, 10 * PORT_WORD_SIZE(sp)
-  lw   a4, 11 * PORT_WORD_SIZE(sp)
-  lw   a5, 12 * PORT_WORD_SIZE(sp)
-  lw   a6, 13 * PORT_WORD_SIZE(sp)
-  lw   a7, 14 * PORT_WORD_SIZE(sp)
-  lw   s2, 15 * PORT_WORD_SIZE(sp)
-  lw   s3, 16 * PORT_WORD_SIZE(sp)
-  lw   s4, 17 * PORT_WORD_SIZE(sp)
-  lw   s5, 18 * PORT_WORD_SIZE(sp)
-  lw   s6, 19 * PORT_WORD_SIZE(sp)
-  lw   s7, 20 * PORT_WORD_SIZE(sp)
-  lw   s8, 21 * PORT_WORD_SIZE(sp)
-  lw   s9, 22 * PORT_WORD_SIZE(sp)
-  lw  s10, 23 * PORT_WORD_SIZE(sp)
-  lw  s11, 24 * PORT_WORD_SIZE(sp)
-  lw   t3, 25 * PORT_WORD_SIZE(sp)
-  lw   t4, 26 * PORT_WORD_SIZE(sp)
-  lw   t5, 27 * PORT_WORD_SIZE(sp)
-  lw   t6, 28 * PORT_WORD_SIZE(sp)
-  addi sp, sp, PORT_CONTEXT_SIZE
-
-  // This exits the ISR completely, and does not return control flow to the ISR
-  // that called this sub-routine.
-  mret
-
-  // Set size so this function can be disassembled.
-  .size freertosIrqExit, .-freertosIrqExit
 // -----------------------------------------------------------------------------
 
 /**
@@ -370,44 +26,44 @@ xPortStartFirstTask:
   lw  ra, 0(sp)
 
   // Restore registers initialized on task start.
-  lw   t1,  3 * PORT_WORD_SIZE(sp)
-  lw   t2,  4 * PORT_WORD_SIZE(sp)
-  lw   s0,  5 * PORT_WORD_SIZE(sp)
-  lw   s1,  6 * PORT_WORD_SIZE(sp)
-  lw   a0,  7 * PORT_WORD_SIZE(sp) // task parameters (pvParameters)
-  lw   a1,  8 * PORT_WORD_SIZE(sp)
-  lw   a2,  9 * PORT_WORD_SIZE(sp)
-  lw   a3, 10 * PORT_WORD_SIZE(sp)
-  lw   a4, 11 * PORT_WORD_SIZE(sp)
-  lw   a5, 12 * PORT_WORD_SIZE(sp)
-  lw   a6, 13 * PORT_WORD_SIZE(sp)
-  lw   a7, 14 * PORT_WORD_SIZE(sp)
-  lw   s2, 15 * PORT_WORD_SIZE(sp)
-  lw   s3, 16 * PORT_WORD_SIZE(sp)
-  lw   s4, 17 * PORT_WORD_SIZE(sp)
-  lw   s5, 18 * PORT_WORD_SIZE(sp)
-  lw   s6, 19 * PORT_WORD_SIZE(sp)
-  lw   s7, 20 * PORT_WORD_SIZE(sp)
-  lw   s8, 21 * PORT_WORD_SIZE(sp)
-  lw   s9, 22 * PORT_WORD_SIZE(sp)
-  lw  s10, 23 * PORT_WORD_SIZE(sp)
-  lw  s11, 24 * PORT_WORD_SIZE(sp)
-  lw   t3, 25 * PORT_WORD_SIZE(sp)
-  lw   t4, 26 * PORT_WORD_SIZE(sp)
-  lw   t5, 27 * PORT_WORD_SIZE(sp)
-  lw   t6, 28 * PORT_WORD_SIZE(sp)
+  lw   t1,  3 * OTTF_WORD_SIZE(sp)
+  lw   t2,  4 * OTTF_WORD_SIZE(sp)
+  lw   s0,  5 * OTTF_WORD_SIZE(sp)
+  lw   s1,  6 * OTTF_WORD_SIZE(sp)
+  lw   a0,  7 * OTTF_WORD_SIZE(sp) // task parameters (pvParameters)
+  lw   a1,  8 * OTTF_WORD_SIZE(sp)
+  lw   a2,  9 * OTTF_WORD_SIZE(sp)
+  lw   a3, 10 * OTTF_WORD_SIZE(sp)
+  lw   a4, 11 * OTTF_WORD_SIZE(sp)
+  lw   a5, 12 * OTTF_WORD_SIZE(sp)
+  lw   a6, 13 * OTTF_WORD_SIZE(sp)
+  lw   a7, 14 * OTTF_WORD_SIZE(sp)
+  lw   s2, 15 * OTTF_WORD_SIZE(sp)
+  lw   s3, 16 * OTTF_WORD_SIZE(sp)
+  lw   s4, 17 * OTTF_WORD_SIZE(sp)
+  lw   s5, 18 * OTTF_WORD_SIZE(sp)
+  lw   s6, 19 * OTTF_WORD_SIZE(sp)
+  lw   s7, 20 * OTTF_WORD_SIZE(sp)
+  lw   s8, 21 * OTTF_WORD_SIZE(sp)
+  lw   s9, 22 * OTTF_WORD_SIZE(sp)
+  lw  s10, 23 * OTTF_WORD_SIZE(sp)
+  lw  s11, 24 * OTTF_WORD_SIZE(sp)
+  lw   t3, 25 * OTTF_WORD_SIZE(sp)
+  lw   t4, 26 * OTTF_WORD_SIZE(sp)
+  lw   t5, 27 * OTTF_WORD_SIZE(sp)
+  lw   t6, 28 * OTTF_WORD_SIZE(sp)
 
   // Initialize t0 to the value of MSTATUS with global interrupts enabled, which
   // is required because this returns with ret, not eret.
-  lw t0, 29 * PORT_WORD_SIZE(sp) // Load the MSTATUS state from the stack.
+  lw t0, 29 * OTTF_WORD_SIZE(sp) // Load the MSTATUS state from the stack.
   ori t0, t0, 1<<3               // Set MIE field.
   csrw mstatus, t0               // Ibex interrupts enabled from here!
 
   // Restore t0 register from the stack (after using it to manipulate MSTATUS).
-  lw t0, 2 * PORT_WORD_SIZE(sp)
+  lw t0, 2 * OTTF_WORD_SIZE(sp)
 
   // Update the stack pointer (shrinking the stack).
-  addi sp, sp, PORT_CONTEXT_SIZE
+  addi sp, sp, OTTF_CONTEXT_SIZE
 
   ret
 
@@ -490,14 +146,14 @@ pxPortInitialiseStack:
   or t0, t0, t1
 
   // Setup the stack frame detailed above (a0 holds the task stack pointer).
-  addi a0, a0, -PORT_CONTEXT_SIZE
+  addi a0, a0, -OTTF_CONTEXT_SIZE
   // Push MSTATUS onto the stack.
-  sw t0, 29 * PORT_WORD_SIZE(a0)
+  sw t0, 29 * OTTF_WORD_SIZE(a0)
 
   // Push task parameters (pvParameters that is in x12/a2, on the stack.
-  sw a2, 7 * PORT_WORD_SIZE(a0)
+  sw a2, 7 * OTTF_WORD_SIZE(a0)
   // Push 0 for the portTASK_RETURN_ADDRESS for now.
-  sw zero, 1 * PORT_WORD_SIZE(a0)
+  sw zero, 1 * OTTF_WORD_SIZE(a0)
   // Push the pointer to the task's entry point (pxCode) onto the stack. This
   // will be loaded into either ra (in xPortStartFirstTask) or mepc (in
   // freertosIrqExit), so that when ret/mret is called control flow will be

--- a/sw/device/lib/testing/test_framework/freertos_port.c
+++ b/sw/device/lib/testing/test_framework/freertos_port.c
@@ -4,7 +4,6 @@
 
 #include "sw/device/lib/dif/dif_rv_timer.h"
 #include "sw/device/lib/irq.h"
-#include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"

--- a/sw/device/lib/testing/test_framework/meson.build
+++ b/sw/device/lib/testing/test_framework/meson.build
@@ -75,40 +75,61 @@ freertos_root = '@0@/@1@'.format(meson.source_root(), 'sw/vendor/freertos_freert
 freertos_memmang_path = '@0@/@1@'.format(freertos_root, 'portable/MemMang')
 freertos_portable_path = '@0@/@1@'.format(freertos_root, 'portable/GCC/RISC-V')
 
-# OpenTitan Test Framework (OTTF) sources & includes.
-ottf_sources = [
-  'ottf.c',
-  'ottf_isrs.c',
-  'freertos_hooks.c',
-  'freertos_port.S',
-  'freertos_port.c',
-  join_paths(freertos_root ,'tasks.c'),
-  join_paths(freertos_root ,'queue.c'),
-  join_paths(freertos_root ,'list.c'),
-  join_paths(freertos_memmang_path,'heap_1.c'),
-]
+# OTTF include directories.
 ottf_incdirs = include_directories(
   '../../../../vendor/freertos_freertos_kernel/include',
   '../../../../vendor/freertos_freertos_kernel/portable/GCC/RISC-V')
+
+# OTTF (Default) Interrupt Service Routines
+#
+# ottf_isrs.c contains various definitions with weak linkage, for interrupt
+# service routine symbols referenced from riscv_crt.
+#
+# To override any default ISRs, implement the declarations in ottf_isrs.h,
+# you intend to override, and link this library or the OTTF below (depending if
+# your tests intends to make use of the OTTF or not).
+sw_lib_testing_ottf_isrs = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_ottf_isrs',
+    sources: [
+      'ottf_isrs.c',
+      'ottf_isrs.S',
+    ],
+    dependencies: [
+      sw_lib_mem,
+      sw_lib_runtime_hart,
+      sw_lib_runtime_ibex,
+      sw_lib_runtime_log,
+    ],
+  )
+)
 
 # OpenTitan Test Framework (OTTF)
 sw_lib_testing_ottf = declare_dependency(
   link_with: static_library(
     'sw_lib_testing_ottf',
-    sources: ottf_sources,
+    sources: [
+      'ottf.c',
+      'freertos_hooks.c',
+      'freertos_port.S',
+      'freertos_port.c',
+      join_paths(freertos_root ,'tasks.c'),
+      join_paths(freertos_root ,'queue.c'),
+      join_paths(freertos_root ,'list.c'),
+      join_paths(freertos_memmang_path,'heap_1.c'),
+    ],
     include_directories: ottf_incdirs,
     c_args: [
       '-D__riscv_float_abi_soft',
     ],
     dependencies: [
-      sw_lib_mem,
-      sw_lib_runtime_ibex,
-      sw_lib_runtime_hart,
-      sw_lib_runtime_log,
-      sw_lib_runtime_print,
       sw_lib_irq,
+      sw_lib_mem,
       sw_lib_dif_uart,
       sw_lib_dif_rv_timer,
+      sw_lib_runtime_log,
+      sw_lib_runtime_print,
+      sw_lib_testing_ottf_isrs,
       sw_lib_testing_test_status,
       sw_lib_testing_test_coverage,
     ],

--- a/sw/device/lib/testing/test_framework/ottf.h
+++ b/sw/device/lib/testing/test_framework/ottf.h
@@ -7,6 +7,8 @@
 
 #include <stdbool.h>
 
+// This private header is included here so that OTTF users can include a single
+// header in their test application (the `ottf.h` header).
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 
 /**

--- a/sw/device/lib/testing/test_framework/ottf_isrs.S
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.S
@@ -1,0 +1,351 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/test_framework/ottf_macros.h"
+
+.extern pxCurrentTCB
+.extern ottf_exception_handler
+.extern ottf_software_isr
+.extern ottf_timer_isr
+.extern ottf_external_isr
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Compute the MEPC to that will be saved to the stack by the associated ISR
+ * handler sub-routine below.
+ *
+ * This subroutine is only invoked for IRQs that are synchronous. Specifically,
+ * this subroutine updates the ISR return address to point to the instruction
+ * after the trapped instruction to prevent an endless interrupt cycle.
+ *
+ * Since we support the RISC-V compressed instructions extension, we need to
+ * check if the two least significant bits of the instruction are
+ * b11 (0x3), which means that the trapped instruction is not compressed,
+ * i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
+ * instruction is 16bits = 2bytes.
+ */
+
+.balign 4
+.type compute_mepc_on_synchronous_irq, @function
+compute_mepc_on_synchronous_irq:
+  csrr t0, mepc
+  li t1, 0x3
+  and t2, t0, t1
+  beq t2, t1, L_32bit_trap_instr
+  addi t0, t0, OTTF_HALF_WORD_SIZE
+  ret
+L_32bit_trap_instr:
+  addi t0, t0, OTTF_WORD_SIZE
+  ret
+
+  // Set size so this function can be disassembled.
+  .size compute_mepc_on_synchronous_irq, .-compute_mepc_on_synchronous_irq
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Exception handler.
+ */
+.balign 4
+.global handler_exception
+.type handler_exception, @function
+handler_exception:
+  // Save all registers to the stack.
+  addi sp, sp, -OTTF_CONTEXT_SIZE
+  sw   ra,  1 * OTTF_WORD_SIZE(sp)
+  sw   t0,  2 * OTTF_WORD_SIZE(sp)
+  sw   t1,  3 * OTTF_WORD_SIZE(sp)
+  sw   t2,  4 * OTTF_WORD_SIZE(sp)
+  sw   s0,  5 * OTTF_WORD_SIZE(sp)
+  sw   s1,  6 * OTTF_WORD_SIZE(sp)
+  sw   a0,  7 * OTTF_WORD_SIZE(sp)
+  sw   a1,  8 * OTTF_WORD_SIZE(sp)
+  sw   a2,  9 * OTTF_WORD_SIZE(sp)
+  sw   a3, 10 * OTTF_WORD_SIZE(sp)
+  sw   a4, 11 * OTTF_WORD_SIZE(sp)
+  sw   a5, 12 * OTTF_WORD_SIZE(sp)
+  sw   a6, 13 * OTTF_WORD_SIZE(sp)
+  sw   a7, 14 * OTTF_WORD_SIZE(sp)
+  sw   s2, 15 * OTTF_WORD_SIZE(sp)
+  sw   s3, 16 * OTTF_WORD_SIZE(sp)
+  sw   s4, 17 * OTTF_WORD_SIZE(sp)
+  sw   s5, 18 * OTTF_WORD_SIZE(sp)
+  sw   s6, 19 * OTTF_WORD_SIZE(sp)
+  sw   s7, 20 * OTTF_WORD_SIZE(sp)
+  sw   s8, 21 * OTTF_WORD_SIZE(sp)
+  sw   s9, 22 * OTTF_WORD_SIZE(sp)
+  sw  s10, 23 * OTTF_WORD_SIZE(sp)
+  sw  s11, 24 * OTTF_WORD_SIZE(sp)
+  sw   t3, 25 * OTTF_WORD_SIZE(sp)
+  sw   t4, 26 * OTTF_WORD_SIZE(sp)
+  sw   t5, 27 * OTTF_WORD_SIZE(sp)
+  sw   t6, 28 * OTTF_WORD_SIZE(sp)
+
+  // Save MSTATUS for the MPIE bit.
+  csrr t0, mstatus
+  sw t0, 29 * OTTF_WORD_SIZE(sp)
+
+  // Save MEPC to the stack after updating it to the next instruction (since
+  // this is a synchronous IRQ).
+  jal compute_mepc_on_synchronous_irq
+  sw t0, 0(sp)
+
+  // Store stack pointer to current TCB.
+  lw t0, pxCurrentTCB
+  sw sp, 0(t0)
+
+  // Jump to the exception handler.
+  jal ottf_exception_handler
+
+  // Return from ISR.
+  j ottf_isr_exit
+
+  // Set size so this function can be disassembled.
+  .size handler_exception, .-handler_exception
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Software IRQ handler.
+ */
+.balign 4
+.global handler_irq_software
+.type handler_irq_software, @function
+handler_irq_software:
+  // Save all registers to the stack.
+  addi sp, sp, -OTTF_CONTEXT_SIZE
+  sw   ra,  1 * OTTF_WORD_SIZE(sp)
+  sw   t0,  2 * OTTF_WORD_SIZE(sp)
+  sw   t1,  3 * OTTF_WORD_SIZE(sp)
+  sw   t2,  4 * OTTF_WORD_SIZE(sp)
+  sw   s0,  5 * OTTF_WORD_SIZE(sp)
+  sw   s1,  6 * OTTF_WORD_SIZE(sp)
+  sw   a0,  7 * OTTF_WORD_SIZE(sp)
+  sw   a1,  8 * OTTF_WORD_SIZE(sp)
+  sw   a2,  9 * OTTF_WORD_SIZE(sp)
+  sw   a3, 10 * OTTF_WORD_SIZE(sp)
+  sw   a4, 11 * OTTF_WORD_SIZE(sp)
+  sw   a5, 12 * OTTF_WORD_SIZE(sp)
+  sw   a6, 13 * OTTF_WORD_SIZE(sp)
+  sw   a7, 14 * OTTF_WORD_SIZE(sp)
+  sw   s2, 15 * OTTF_WORD_SIZE(sp)
+  sw   s3, 16 * OTTF_WORD_SIZE(sp)
+  sw   s4, 17 * OTTF_WORD_SIZE(sp)
+  sw   s5, 18 * OTTF_WORD_SIZE(sp)
+  sw   s6, 19 * OTTF_WORD_SIZE(sp)
+  sw   s7, 20 * OTTF_WORD_SIZE(sp)
+  sw   s8, 21 * OTTF_WORD_SIZE(sp)
+  sw   s9, 22 * OTTF_WORD_SIZE(sp)
+  sw  s10, 23 * OTTF_WORD_SIZE(sp)
+  sw  s11, 24 * OTTF_WORD_SIZE(sp)
+  sw   t3, 25 * OTTF_WORD_SIZE(sp)
+  sw   t4, 26 * OTTF_WORD_SIZE(sp)
+  sw   t5, 27 * OTTF_WORD_SIZE(sp)
+  sw   t6, 28 * OTTF_WORD_SIZE(sp)
+
+  // Save MSTATUS for the MPIE bit.
+  csrr t0, mstatus
+  sw t0, 29 * OTTF_WORD_SIZE(sp)
+
+  // Save MEPC to the stack after updating it to the next instruction (since
+  // this is a synchronous IRQ).
+  jal compute_mepc_on_synchronous_irq
+  sw t0, 0(sp)
+
+  // Store stack pointer to current TCB.
+  lw t0, pxCurrentTCB
+  sw sp, 0(t0)
+
+  // Jump to the software ISR.
+  jal ottf_software_isr
+
+  // Return from ISR.
+  j ottf_isr_exit
+
+  // Set size so this function can be disassembled.
+  .size handler_irq_software, .-handler_irq_software
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Timer IRQ handler.
+ */
+.balign 4
+.global handler_irq_timer
+.type handler_irq_timer, @function
+handler_irq_timer:
+  // Save all registers to the stack.
+  addi sp, sp, -OTTF_CONTEXT_SIZE
+  sw   ra,  1 * OTTF_WORD_SIZE(sp)
+  sw   t0,  2 * OTTF_WORD_SIZE(sp)
+  sw   t1,  3 * OTTF_WORD_SIZE(sp)
+  sw   t2,  4 * OTTF_WORD_SIZE(sp)
+  sw   s0,  5 * OTTF_WORD_SIZE(sp)
+  sw   s1,  6 * OTTF_WORD_SIZE(sp)
+  sw   a0,  7 * OTTF_WORD_SIZE(sp)
+  sw   a1,  8 * OTTF_WORD_SIZE(sp)
+  sw   a2,  9 * OTTF_WORD_SIZE(sp)
+  sw   a3, 10 * OTTF_WORD_SIZE(sp)
+  sw   a4, 11 * OTTF_WORD_SIZE(sp)
+  sw   a5, 12 * OTTF_WORD_SIZE(sp)
+  sw   a6, 13 * OTTF_WORD_SIZE(sp)
+  sw   a7, 14 * OTTF_WORD_SIZE(sp)
+  sw   s2, 15 * OTTF_WORD_SIZE(sp)
+  sw   s3, 16 * OTTF_WORD_SIZE(sp)
+  sw   s4, 17 * OTTF_WORD_SIZE(sp)
+  sw   s5, 18 * OTTF_WORD_SIZE(sp)
+  sw   s6, 19 * OTTF_WORD_SIZE(sp)
+  sw   s7, 20 * OTTF_WORD_SIZE(sp)
+  sw   s8, 21 * OTTF_WORD_SIZE(sp)
+  sw   s9, 22 * OTTF_WORD_SIZE(sp)
+  sw  s10, 23 * OTTF_WORD_SIZE(sp)
+  sw  s11, 24 * OTTF_WORD_SIZE(sp)
+  sw   t3, 25 * OTTF_WORD_SIZE(sp)
+  sw   t4, 26 * OTTF_WORD_SIZE(sp)
+  sw   t5, 27 * OTTF_WORD_SIZE(sp)
+  sw   t6, 28 * OTTF_WORD_SIZE(sp)
+
+  // Save MSTATUS for the MPIE bit.
+  csrr t0, mstatus
+  sw t0, 29 * OTTF_WORD_SIZE(sp)
+
+  // Save MEPC to the stack.
+  // NOTE: this IRQ is asynchronous, therefore, we do not need to modify MEPC.
+  csrr t0, mepc
+  sw t0, 0(sp)
+
+  // Store stack pointer to current TCB.
+  lw t0, pxCurrentTCB
+  sw sp, 0(t0)
+
+  // Jump to timer ISR.
+  jal ottf_timer_isr
+
+  // Return from ISR.
+  j ottf_isr_exit
+
+  // Set size so this function can be disassembled.
+  .size handler_irq_timer, .-handler_irq_timer
+
+// -----------------------------------------------------------------------------
+
+/**
+ * External IRQ handler.
+ */
+.balign 4
+.global handler_irq_external
+.type handler_irq_external, @function
+handler_irq_external:
+  // Save all registers to the stack.
+  addi sp, sp, -OTTF_CONTEXT_SIZE
+  sw   ra,  1 * OTTF_WORD_SIZE(sp)
+  sw   t0,  2 * OTTF_WORD_SIZE(sp)
+  sw   t1,  3 * OTTF_WORD_SIZE(sp)
+  sw   t2,  4 * OTTF_WORD_SIZE(sp)
+  sw   s0,  5 * OTTF_WORD_SIZE(sp)
+  sw   s1,  6 * OTTF_WORD_SIZE(sp)
+  sw   a0,  7 * OTTF_WORD_SIZE(sp)
+  sw   a1,  8 * OTTF_WORD_SIZE(sp)
+  sw   a2,  9 * OTTF_WORD_SIZE(sp)
+  sw   a3, 10 * OTTF_WORD_SIZE(sp)
+  sw   a4, 11 * OTTF_WORD_SIZE(sp)
+  sw   a5, 12 * OTTF_WORD_SIZE(sp)
+  sw   a6, 13 * OTTF_WORD_SIZE(sp)
+  sw   a7, 14 * OTTF_WORD_SIZE(sp)
+  sw   s2, 15 * OTTF_WORD_SIZE(sp)
+  sw   s3, 16 * OTTF_WORD_SIZE(sp)
+  sw   s4, 17 * OTTF_WORD_SIZE(sp)
+  sw   s5, 18 * OTTF_WORD_SIZE(sp)
+  sw   s6, 19 * OTTF_WORD_SIZE(sp)
+  sw   s7, 20 * OTTF_WORD_SIZE(sp)
+  sw   s8, 21 * OTTF_WORD_SIZE(sp)
+  sw   s9, 22 * OTTF_WORD_SIZE(sp)
+  sw  s10, 23 * OTTF_WORD_SIZE(sp)
+  sw  s11, 24 * OTTF_WORD_SIZE(sp)
+  sw   t3, 25 * OTTF_WORD_SIZE(sp)
+  sw   t4, 26 * OTTF_WORD_SIZE(sp)
+  sw   t5, 27 * OTTF_WORD_SIZE(sp)
+  sw   t6, 28 * OTTF_WORD_SIZE(sp)
+
+  // Save MSTATUS for the MPIE bit.
+  csrr t0, mstatus
+  sw t0, 29 * OTTF_WORD_SIZE(sp)
+
+  // Save MEPC to the stack.
+  // NOTE: this IRQ is asynchronous, therefore, we do not need to modify MEPC.
+  csrr t0, mepc
+  sw t0, 0(sp)
+
+  // Store stack pointer to current TCB.
+  lw t0, pxCurrentTCB
+  sw sp, 0(t0)
+
+  // Jump to external ISR.
+  jal ottf_external_isr
+
+  // Return from ISR.
+  j ottf_isr_exit
+
+  // Set size so this function can be disassembled.
+  .size handler_irq_external, .-handler_irq_external
+
+// -----------------------------------------------------------------------------
+
+/**
+ * ISR exit sub-routine restores registers from the stack.
+ */
+.balign 4
+.global ottf_isr_exit
+.type ottf_isr_exit, @function
+ottf_isr_exit:
+  // Load the stack pointer for the current TCB.
+	lw  t1, pxCurrentTCB
+	lw  sp, 0(t1)
+
+  // Load the correct MEPC for the next instruction in the current task.
+	lw t0, 0(sp)
+	csrw mepc, t0
+
+  // Load MSTATUS for the MPIE bit.
+	lw  t0, 29 * OTTF_WORD_SIZE(sp)
+	csrw mstatus, t0
+
+  // Restore all registers from the stack.
+  lw   ra,  1 * OTTF_WORD_SIZE(sp)
+  lw   t0,  2 * OTTF_WORD_SIZE(sp)
+  lw   t1,  3 * OTTF_WORD_SIZE(sp)
+  lw   t2,  4 * OTTF_WORD_SIZE(sp)
+  lw   s0,  5 * OTTF_WORD_SIZE(sp)
+  lw   s1,  6 * OTTF_WORD_SIZE(sp)
+  lw   a0,  7 * OTTF_WORD_SIZE(sp)
+  lw   a1,  8 * OTTF_WORD_SIZE(sp)
+  lw   a2,  9 * OTTF_WORD_SIZE(sp)
+  lw   a3, 10 * OTTF_WORD_SIZE(sp)
+  lw   a4, 11 * OTTF_WORD_SIZE(sp)
+  lw   a5, 12 * OTTF_WORD_SIZE(sp)
+  lw   a6, 13 * OTTF_WORD_SIZE(sp)
+  lw   a7, 14 * OTTF_WORD_SIZE(sp)
+  lw   s2, 15 * OTTF_WORD_SIZE(sp)
+  lw   s3, 16 * OTTF_WORD_SIZE(sp)
+  lw   s4, 17 * OTTF_WORD_SIZE(sp)
+  lw   s5, 18 * OTTF_WORD_SIZE(sp)
+  lw   s6, 19 * OTTF_WORD_SIZE(sp)
+  lw   s7, 20 * OTTF_WORD_SIZE(sp)
+  lw   s8, 21 * OTTF_WORD_SIZE(sp)
+  lw   s9, 22 * OTTF_WORD_SIZE(sp)
+  lw  s10, 23 * OTTF_WORD_SIZE(sp)
+  lw  s11, 24 * OTTF_WORD_SIZE(sp)
+  lw   t3, 25 * OTTF_WORD_SIZE(sp)
+  lw   t4, 26 * OTTF_WORD_SIZE(sp)
+  lw   t5, 27 * OTTF_WORD_SIZE(sp)
+  lw   t6, 28 * OTTF_WORD_SIZE(sp)
+  addi sp, sp, OTTF_CONTEXT_SIZE
+
+  // This exits the ISR completely, and does not return control flow to the ISR
+  // that called this sub-routine.
+  mret
+
+  // Set size so this function can be disassembled.
+  .size ottf_isr_exit, .-ottf_isr_exit

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -9,7 +9,6 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 
 void ottf_exception_handler(void) {
   uint32_t mcause = ibex_mcause_read();

--- a/sw/device/lib/testing/test_framework/ottf_macros.h
+++ b/sw/device/lib/testing/test_framework/ottf_macros.h
@@ -1,0 +1,12 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_MACROS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_MACROS_H_
+
+#define OTTF_WORD_SIZE 4
+#define OTTF_HALF_WORD_SIZE (OTTF_WORD_SIZE / 2)
+#define OTTF_CONTEXT_SIZE (OTTF_WORD_SIZE * 30)
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_FRAMEWORK_OTTF_MACROS_H_


### PR DESCRIPTION
Previously, all default ISRs were contained in the single OTTF build target. This made using the default OTTF ISRs in a standalone bare metal test application that does not make use of the OTTF impossible.

This commit isolates the OTTF default ISRs into a separate library, so they can be used similar to the existing `sw/device/lib/handler.<c,h>` ISRs, since those will be deprecated in the near future when all chip-level tests migrate to the OTTF.

This partially addresses a larger issue (#8015) of developing the OpenTitan Test Framework (OTTF).
 
Signed-off-by: Timothy Trippel <ttrippel@google.com>