### PR TITLE
[adc_ctrl] Officially move adc_ctrl to D2

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.prj.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.prj.hjson
@@ -9,7 +9,7 @@
     hw_checklist:       "../doc/checklist",
     version:            "1.0",
     life_stage:         "L1",
-    design_stage:       "D0",
+    design_stage:       "D2",
     verification_stage: "V0",
     notes:              "DV resource allocation pending.",
 }

--- a/hw/ip/adc_ctrl/doc/checklist.md
+++ b/hw/ip/adc_ctrl/doc/checklist.md
@@ -52,7 +52,7 @@ RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        |
 RTL           | [STYLE_X][]             | Done        |
 Code Quality  | [LINT_PASS][]           | Done        |
-Code Quality  | [CDC_SETUP][]           | In progress |
+Code Quality  | [CDC_SETUP][]           | NA          | CDC setup not yet available
 Code Quality  | [FPGA_TIMING][]         | Done        |
 Code Quality  | [CDC_SYNCMACRO][]       | Done        |
 Security      | [SEC_CM_DOCUMENTED][]   | NA          |


### PR DESCRIPTION
- This was simply neglected after the last round of changes.

Signed-off-by: Timothy Chen <timothytim@google.com>