### PR TITLE
[keymgr/dv] Disable assertion data stable check

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -234,8 +234,10 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
         get_operation() inside {keymgr_pkg::OpAdvance, keymgr_pkg::OpDisable}) begin
       current_cdi = get_adv_cdi_type();
       if (current_cdi > 0 && current_internal_key[current_cdi] > 0) begin
+        bit good_key = get_is_kmac_key_correct();
+        bit good_data = good_key && !get_sw_invalid_input() && !get_hw_invalid_input();
         cfg.keymgr_vif.update_kdf_key(current_internal_key[current_cdi], current_state,
-                                      get_is_kmac_key_correct());
+                                      good_key, good_data);
       end
     end
   endfunction
@@ -591,6 +593,8 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
               end
               default: begin // other than StReset and StDisabled
                 bit good_key = get_is_kmac_key_correct();
+                bit good_data = good_key && !get_sw_invalid_input() && !get_hw_invalid_input();
+
                 bit skip_clean_kmac_key = 0;
 
                 if (current_state != keymgr_pkg::StReset &&
@@ -607,7 +611,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
                 // update kmac key for check
                 if (current_internal_key[current_cdi] > 0) begin
                   cfg.keymgr_vif.update_kdf_key(current_internal_key[current_cdi], current_state,
-                                                good_key);
+                                                good_key, good_data);
                 end
               end
             endcase

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -171,7 +171,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
                               current_state.name, operation.name, is_good_op), UVM_MEDIUM)
 
     // wait for status to get out of OpWip and check
-    csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip), .timeout_ns(100_000),
+    csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip), .timeout_ns(1000_000),
                  .compare_op(CompareOpNe), .spinwait_delay_ns($urandom_range(0, 100)));
 
     exp_status = is_good_op ? keymgr_pkg::OpDoneSuccess : keymgr_pkg::OpDoneFail;

--- a/hw/ip/keymgr/dv/tb.sv
+++ b/hw/ip/keymgr/dv/tb.sv
@@ -89,16 +89,4 @@ module tb;
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
-
-  // TODO (#9324): Disable h_data stability assertion when keymgr is in disabled state.
-  initial begin
-    forever @tb.dut.u_ctrl.state_q begin
-      if (tb.dut.u_ctrl.state_q == 10'b1010101000) begin // StCtrlDisabled
-        $assertoff(0, tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A);
-      end else begin
-        $asserton(0, tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A);
-      end
-    end
-  end
-
 endmodule


### PR DESCRIPTION
Addressed #9324
Disabled the assertion when it's in StDisabled/StInvalid, LC is off or
SW/HW input is invalid

Also increased the spinwait delay for op_status as push_pull agent 
delay issue is fixed and it may take longer time to complete the operation

Signed-off-by: Weicai Yang <weicai@google.com>