### PR TITLE
[sw/ottf] Rename OTTF exception handlers.

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -11,33 +11,33 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
 
-OT_ATTR_WEAK void ottf_exception_handler(void) {
+void ottf_exception_handler(void) {
   uint32_t mcause = ibex_mcause_read();
 
   switch ((ottf_exc_id_t)(mcause & kIdMax)) {
     case kInstrMisaligned:
-      ottf_instr_misaligned_fault();
+      ottf_instr_misaligned_fault_handler();
       break;
     case kInstrAccessFault:
-      ottf_instr_access_fault();
+      ottf_instr_access_fault_handler();
       break;
     case kIllegalInstrFault:
-      ottf_illegal_instr_fault();
+      ottf_illegal_instr_fault_handler();
       break;
     case kBreakpoint:
-      ottf_breakpoint();
+      ottf_breakpoint_handler();
       break;
     case kLoadAccessFault:
-      ottf_load_store_fault();
+      ottf_load_store_fault_handler();
       break;
     case kStoreAccessFault:
-      ottf_load_store_fault();
+      ottf_load_store_fault_handler();
       break;
     case kMachineECall:
-      ottf_machine_ecall();
+      ottf_machine_ecall_handler();
       break;
     case kUserECall:
-      ottf_user_ecall();
+      ottf_user_ecall_handler();
       break;
     default:
       LOG_INFO("Unknown exception triggered!");
@@ -45,42 +45,42 @@ OT_ATTR_WEAK void ottf_exception_handler(void) {
   }
 }
 
-OT_ATTR_WEAK void ottf_instr_misaligned_fault(void) {
+OT_ATTR_WEAK void ottf_instr_misaligned_fault_handler(void) {
   LOG_INFO("Misaligned instruction, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_instr_access_fault(void) {
+OT_ATTR_WEAK void ottf_instr_access_fault_handler(void) {
   LOG_INFO("Instruction access fault, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_illegal_instr_fault(void) {
+OT_ATTR_WEAK void ottf_illegal_instr_fault_handler(void) {
   LOG_INFO("Illegal instruction fault, mtval shows the faulting instruction.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_breakpoint(void) {
+OT_ATTR_WEAK void ottf_breakpoint_handler(void) {
   LOG_INFO("Breakpoint triggered, mtval holds the breakpoint address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_load_store_fault(void) {
+OT_ATTR_WEAK void ottf_load_store_fault_handler(void) {
   LOG_INFO("Load/Store fault, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_machine_ecall(void) {
+OT_ATTR_WEAK void ottf_machine_ecall_handler(void) {
   LOG_INFO("Machine-mode environment call (syscall).");
   abort();
 }
 
-OT_ATTR_WEAK void ottf_user_ecall(void) {
+OT_ATTR_WEAK void ottf_user_ecall_handler(void) {
   LOG_INFO("User-mode environment call (syscall).");
   abort();
 }

--- a/sw/device/lib/testing/test_framework/ottf_isrs.h
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.h
@@ -25,8 +25,11 @@ typedef enum ottf_exc_id {
 /**
  * OTTF exception handler.
  *
- * `ottf_isrs.c` provides a weak definition of this symbol, which can be
- * overriden at link-time by providing an additional non-weak definition.
+ * The `ottf_isrs.c` definition of this symbol is NOT weak, and therefore cannot
+ * be overriden. However, the sub-handlers this function invokes are weak, and
+ * therefore can be overriden at link-time by providing an additional non-weak
+ * definition. See the implementation of this function (in `ottf_isrs.c`) for
+ * which sub-handlers are invoked.
  */
 void ottf_exception_handler(void);
 
@@ -39,7 +42,7 @@ void ottf_exception_handler(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overriden at link-time by providing an additional non-weak definition.
  */
-void ottf_instr_misaligned_fault(void);
+void ottf_instr_misaligned_fault_handler(void);
 
 /**
  * OTTF instruction access fault handler.
@@ -50,7 +53,7 @@ void ottf_instr_misaligned_fault(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overriden at link-time by providing an additional non-weak definition.
  */
-void ottf_instr_access_fault(void);
+void ottf_instr_access_fault_handler(void);
 
 /**
  * OTTF illegal instruction fault handler.
@@ -61,7 +64,7 @@ void ottf_instr_access_fault(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overriden at link-time by providing an additional non-weak definition.
  */
-void ottf_illegal_instr_fault(void);
+void ottf_illegal_instr_fault_handler(void);
 
 /**
  * OTTF breakpoint handler.
@@ -72,7 +75,7 @@ void ottf_illegal_instr_fault(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overriden at link-time by providing an additional non-weak definition.
  */
-void ottf_breakpoint(void);
+void ottf_breakpoint_handler(void);
 
 /**
  * OTTF load/store fault handler.
@@ -83,7 +86,7 @@ void ottf_breakpoint(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overriden at link-time by providing an additional non-weak definition.
  */
-void ottf_load_store_fault(void);
+void ottf_load_store_fault_handler(void);
 
 /**
  * OTTF machine-mode evironment call handler.
@@ -94,7 +97,7 @@ void ottf_load_store_fault(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overriden at link-time by providing an additional non-weak definition.
  */
-void ottf_machine_ecall(void);
+void ottf_machine_ecall_handler(void);
 
 /**
  * OTTF user-mode evironment call handler.
@@ -105,7 +108,7 @@ void ottf_machine_ecall(void);
  * `ottf_isrs.c` provides a weak definition of this symbol, which can be
  * overriden at link-time by providing an additional non-weak definition.
  */
-void ottf_user_ecall(void);
+void ottf_user_ecall_handler(void);
 
 /**
  * OTTF software IRQ handler.


### PR DESCRIPTION
This commit adds the suffix `_handler` to each default exception handling function that is invoked by the main OTTF exception handler.

Additionally, this commit makes the main OTTF exection handler a strong symbol, since test developers that use the OTTF should override the appropriate OTTF exception **_SUB_**-handler function for the functionality they are trying to test.

Signed-off-by: Timothy Trippel <ttrippel@google.com>