### PR TITLE
[clkmgr] Change external clock switch qualifying condition

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -70,7 +70,7 @@
 
     { struct:  "lc_tx",
       type:    "uni",
-      name:    "lc_dft_en",
+      name:    "lc_hw_debug_en",
       act:     "rcv",
       package: "lc_ctrl_pkg",
     },

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -51,7 +51,7 @@
   input [${len(typed_clocks.hint_clks)-1}:0] idle_i,
 
   // life cycle state output
-  input lc_tx_t lc_dft_en_i,
+  input lc_tx_t lc_hw_debug_en_i,
 
   // clock bypass control with lc_ctrl
   input lc_tx_t lc_clk_byp_req_i,
@@ -206,7 +206,7 @@
   ) u_clkmgr_byp (
     .clk_i,
     .rst_ni,
-    .en_i(lc_dft_en_i),
+    .en_i(lc_hw_debug_en_i),
     .lc_clk_byp_req_i,
     .lc_clk_byp_ack_o,
     .byp_req_i(mubi4_t'(reg2hw.extclk_ctrl.sel.q)),

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -31,7 +31,7 @@ interface clkmgr_if (
   prim_mubi_pkg::mubi4_t scanmode_i;
 
   // Life cycle enables clock bypass functionality.
-  lc_ctrl_pkg::lc_tx_t lc_dft_en_i;
+  lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i;
 
   // Life cycle clock bypass request and clkmgr ack.
   lc_ctrl_pkg::lc_tx_t lc_clk_byp_req;
@@ -107,8 +107,8 @@ interface clkmgr_if (
     scanmode_i = value;
   endfunction
 
-  function automatic void update_lc_dft_en(lc_ctrl_pkg::lc_tx_t value);
-    lc_dft_en_i = value;
+  function automatic void update_lc_debug_en(lc_ctrl_pkg::lc_tx_t value);
+    lc_hw_debug_en_i = value;
   endfunction
 
   function automatic void update_lc_clk_byp_req(lc_ctrl_pkg::lc_tx_t value);
@@ -143,12 +143,12 @@ interface clkmgr_if (
   endfunction
 
   task automatic init(logic [NUM_TRANS-1:0] idle, prim_mubi_pkg::mubi4_t scanmode,
-                      lc_ctrl_pkg::lc_tx_t lc_dft_en = lc_ctrl_pkg::Off,
+                      lc_ctrl_pkg::lc_tx_t lc_debug_en = lc_ctrl_pkg::Off,
                       lc_ctrl_pkg::lc_tx_t lc_clk_byp_req = lc_ctrl_pkg::Off);
     `uvm_info("clkmgr_if", "In clkmgr_if init", UVM_MEDIUM)
     update_idle(idle);
     update_lc_clk_byp_req(lc_clk_byp_req);
-    update_lc_dft_en(lc_dft_en);
+    update_lc_debug_en(lc_debug_en);
     update_scanmode(scanmode);
   endtask
 
@@ -268,7 +268,7 @@ interface clkmgr_if (
   clocking clk_cb @(posedge clk);
     input extclk_ctrl_csr_sel;
     input extclk_ctrl_csr_step_down;
-    input lc_dft_en_i;
+    input lc_hw_debug_en_i;
     input io_clk_byp_req;
     input lc_clk_byp_req;
     input step_down = step_down_ff;

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -53,13 +53,13 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         end
         if (cfg.clk_rst_vif.rst_n) begin
           if ((cfg.clkmgr_vif.clk_cb.extclk_ctrl_csr_sel == On) &&
-              (cfg.clkmgr_vif.clk_cb.lc_dft_en_i == On)) begin
+              (cfg.clkmgr_vif.clk_cb.lc_hw_debug_en_i == On)) begin
             `DV_CHECK_EQ(cfg.clkmgr_vif.all_clk_byp_req, On, "Expected all_clk_byp_req to be On")
           end
           if (cfg.en_cov) begin
             cov.extclk_cg.sample(cfg.clkmgr_vif.clk_cb.extclk_ctrl_csr_sel,
                                  cfg.clkmgr_vif.clk_cb.extclk_ctrl_csr_step_down,
-                                 cfg.clkmgr_vif.clk_cb.lc_dft_en_i,
+                                 cfg.clkmgr_vif.clk_cb.lc_hw_debug_en_i,
                                  cfg.clkmgr_vif.clk_cb.lc_clk_byp_req, cfg.clkmgr_vif.scanmode_i);
           end
         end
@@ -83,7 +83,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
           if (cfg.en_cov) begin
             cov.extclk_cg.sample(cfg.clkmgr_vif.clk_cb.extclk_ctrl_csr_sel,
                                  cfg.clkmgr_vif.clk_cb.extclk_ctrl_csr_step_down,
-                                 cfg.clkmgr_vif.clk_cb.lc_dft_en_i,
+                                 cfg.clkmgr_vif.clk_cb.lc_hw_debug_en_i,
                                  cfg.clkmgr_vif.clk_cb.lc_clk_byp_req, cfg.clkmgr_vif.scanmode_i);
           end
         end

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -107,7 +107,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "In clkmgr_if initialize_on_start", UVM_MEDIUM)
     idle = '1;
     scanmode = prim_mubi_pkg::MuBi4False;
-    cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode), .lc_dft_en(Off));
+    cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode), .lc_debug_en(Off));
     io_ip_clk_en   = 1'b1;
     main_ip_clk_en = 1'b1;
     usb_ip_clk_en  = 1'b1;
@@ -116,7 +116,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
 
   task pre_start();
     update_csrs_with_reset_values();
-    cfg.clkmgr_vif.init(.idle('1), .scanmode(scanmode), .lc_dft_en(Off));
+    cfg.clkmgr_vif.init(.idle('1), .scanmode(scanmode), .lc_debug_en(Off));
     cfg.clkmgr_vif.update_io_ip_clk_en(1'b0);
     cfg.clkmgr_vif.update_main_ip_clk_en(1'b0);
     cfg.clkmgr_vif.update_usb_ip_clk_en(1'b0);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
@@ -12,18 +12,18 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
   // When extclk_ctrl_regwen is clear it is not possible to select external clocks.
   // This is tested in regular csr_rw, so here this register is simply set to 1.
 
-  // lc_dft_en is set according to sel_lc_dft_en, which is randomized with weights.
-  lc_tx_t            lc_dft_en;
-  rand lc_tx_t       lc_dft_en_other;
-  rand lc_tx_t_sel_e sel_lc_dft_en;
+  // lc_debug_en is set according to sel_lc_debug_en, which is randomized with weights.
+  lc_tx_t            lc_debug_en;
+  rand lc_tx_t       lc_debug_en_other;
+  rand lc_tx_t_sel_e sel_lc_debug_en;
 
-  constraint lc_dft_en_c {
-    sel_lc_dft_en dist {
+  constraint lc_debug_en_c {
+    sel_lc_debug_en dist {
       LcTxTSelOn    := 8,
       LcTxTSelOff   := 2,
       LcTxTSelOther := 2
     };
-    !(lc_dft_en_other inside {On, Off});
+    !(lc_debug_en_other inside {On, Off});
   }
 
   // lc_clk_byp_req is set according to sel_lc_clk_byp_req, which is randomized with weights.
@@ -66,7 +66,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
 
   function void post_randomize();
     super.post_randomize();
-    lc_dft_en = get_lc_tx_t_from_sel(sel_lc_dft_en, lc_dft_en_other);
+    lc_debug_en = get_lc_tx_t_from_sel(sel_lc_debug_en, lc_debug_en_other);
     lc_clk_byp_req = get_lc_tx_t_from_sel(sel_lc_clk_byp_req, lc_clk_byp_req_other);
   endfunction
 
@@ -111,7 +111,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       // Init needs to be synchronous.
       @cfg.clk_rst_vif.cb begin
-        cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode), .lc_dft_en(lc_dft_en));
+        cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode), .lc_debug_en(lc_debug_en));
         control_ip_clocks();
       end
       fork
@@ -126,11 +126,11 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
       join
       `uvm_info(`gfn, $sformatf(
                 {"extclk_ctrl_sel=0x%0x, extclk_ctrl_low_speed_sel=0x%0x, lc_clk_byp_req=0x%0x, ",
-                 "lc_dft_en=0x%0x, scanmode=0x%0x"},
+                 "lc_debug_en=0x%0x, scanmode=0x%0x"},
                 extclk_ctrl_sel,
                 extclk_ctrl_low_speed_sel,
                 lc_clk_byp_req,
-                lc_dft_en,
+                lc_debug_en,
                 scanmode
                 ), UVM_MEDIUM)
       csr_rd_check(.ptr(ral.extclk_ctrl),

--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -110,7 +110,7 @@ module clkmgr_bind;
     .maybe_divided_clk(clocks_o.clk_io_div2_powerup),
     .lc_step_down_ctrl(lc_clk_byp_req_i == lc_ctrl_pkg::On),
     .lc_step_down_ack(io_clk_byp_ack_i == prim_mubi_pkg::MuBi4True),
-    .sw_step_down_ctrl(lc_dft_en_i == lc_ctrl_pkg::On &&
+    .sw_step_down_ctrl(lc_hw_debug_en_i == lc_ctrl_pkg::On &&
                        reg2hw.extclk_ctrl.sel.q == prim_mubi_pkg::MuBi4True &&
                        reg2hw.extclk_ctrl.low_speed_sel.q == prim_mubi_pkg::MuBi4True),
     .sw_step_down_ack(all_clk_byp_ack_i == prim_mubi_pkg::MuBi4True),
@@ -127,7 +127,7 @@ module clkmgr_bind;
     .maybe_divided_clk(clocks_o.clk_io_div4_powerup),
     .lc_step_down_ctrl(lc_clk_byp_req_i == lc_ctrl_pkg::On),
     .lc_step_down_ack(io_clk_byp_ack_i == prim_mubi_pkg::MuBi4True),
-    .sw_step_down_ctrl(lc_dft_en_i == lc_ctrl_pkg::On &&
+    .sw_step_down_ctrl(lc_hw_debug_en_i == lc_ctrl_pkg::On &&
                        reg2hw.extclk_ctrl.sel.q == prim_mubi_pkg::MuBi4True &&
                        reg2hw.extclk_ctrl.low_speed_sel.q == prim_mubi_pkg::MuBi4True),
     .sw_step_down_ack(all_clk_byp_ack_i == prim_mubi_pkg::MuBi4True),

--- a/hw/ip/clkmgr/dv/tb.sv
+++ b/hw/ip/clkmgr/dv/tb.sv
@@ -99,7 +99,7 @@ module tb;
     .scanmode_i(clkmgr_if.scanmode_i),
     .idle_i    (clkmgr_if.idle_i),
 
-    .lc_dft_en_i      (clkmgr_if.lc_dft_en_i),
+    .lc_hw_debug_en_i (clkmgr_if.lc_hw_debug_en_i),
     .all_clk_byp_req_o(clkmgr_if.all_clk_byp_req),
     .all_clk_byp_ack_i(clkmgr_if.all_clk_byp_ack),
     .io_clk_byp_req_o (clkmgr_if.io_clk_byp_req),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2851,7 +2851,7 @@
           index: -1
         }
         {
-          name: lc_dft_en
+          name: lc_hw_debug_en
           struct: lc_tx
           package: lc_ctrl_pkg
           type: uni
@@ -2859,7 +2859,7 @@
           width: 1
           inst_name: clkmgr_aon
           default: ""
-          top_signame: lc_ctrl_lc_dft_en
+          top_signame: lc_ctrl_lc_hw_debug_en
           index: -1
         }
         {
@@ -7221,7 +7221,6 @@
         otp_ctrl.lc_dft_en
         pinmux_aon.lc_dft_en
         ast.lc_dft_en
-        clkmgr_aon.lc_dft_en
       ]
       lc_ctrl.lc_nvm_debug_en:
       [
@@ -7234,6 +7233,7 @@
         pinmux_aon.lc_hw_debug_en
         csrng.lc_hw_debug_en
         rv_dm.lc_hw_debug_en
+        clkmgr_aon.lc_hw_debug_en
       ]
       lc_ctrl.lc_cpu_en:
       [
@@ -15419,7 +15419,7 @@
         index: -1
       }
       {
-        name: lc_dft_en
+        name: lc_hw_debug_en
         struct: lc_tx
         package: lc_ctrl_pkg
         type: uni
@@ -15427,7 +15427,7 @@
         width: 1
         inst_name: clkmgr_aon
         default: ""
-        top_signame: lc_ctrl_lc_dft_en
+        top_signame: lc_ctrl_lc_hw_debug_en
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -857,15 +857,15 @@
       // LC function control signal broadcast
       'lc_ctrl.lc_dft_en'          : ['otp_ctrl.lc_dft_en',
                                       'pinmux_aon.lc_dft_en',
-                                      'ast.lc_dft_en',
-                                      'clkmgr_aon.lc_dft_en'
+                                      'ast.lc_dft_en'
                                      ],
       'lc_ctrl.lc_nvm_debug_en'    : ['flash_ctrl.lc_nvm_debug_en'],
       'lc_ctrl.lc_hw_debug_en'     : ['sram_ctrl_main.lc_hw_debug_en',
                                       'sram_ctrl_ret_aon.lc_hw_debug_en',
                                       'pinmux_aon.lc_hw_debug_en',
                                       'csrng.lc_hw_debug_en',
-                                      'rv_dm.lc_hw_debug_en'],
+                                      'rv_dm.lc_hw_debug_en',
+                                      'clkmgr_aon.lc_hw_debug_en'],
       'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en'],
       'lc_ctrl.lc_keymgr_en'       : ['keymgr.lc_keymgr_en'],
       'lc_ctrl.lc_escalate_en'     : ['aes.lc_escalate_en',

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -76,7 +76,7 @@
 
     { struct:  "lc_tx",
       type:    "uni",
-      name:    "lc_dft_en",
+      name:    "lc_hw_debug_en",
       act:     "rcv",
       package: "lc_ctrl_pkg",
     },

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -60,7 +60,7 @@
   input [4:0] idle_i,
 
   // life cycle state output
-  input lc_tx_t lc_dft_en_i,
+  input lc_tx_t lc_hw_debug_en_i,
 
   // clock bypass control with lc_ctrl
   input lc_tx_t lc_clk_byp_req_i,
@@ -238,7 +238,7 @@
   ) u_clkmgr_byp (
     .clk_i,
     .rst_ni,
-    .en_i(lc_dft_en_i),
+    .en_i(lc_hw_debug_en_i),
     .lc_clk_byp_req_i,
     .lc_clk_byp_ack_o,
     .byp_req_i(mubi4_t'(reg2hw.extclk_ctrl.sel.q)),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1732,7 +1732,7 @@ module top_earlgrey #(
       // Inter-module signals
       .clocks_o(clkmgr_aon_clocks),
       .cg_en_o(clkmgr_aon_cg_en),
-      .lc_dft_en_i(lc_ctrl_lc_dft_en),
+      .lc_hw_debug_en_i(lc_ctrl_lc_hw_debug_en),
       .io_clk_byp_req_o(io_clk_byp_req_o),
       .io_clk_byp_ack_i(io_clk_byp_ack_i),
       .all_clk_byp_req_o(all_clk_byp_req_o),


### PR DESCRIPTION
- Fixes #9294
- Now software is able to request external clock during TEST_UNLOCKED,
  DEV and RMA states.

Signed-off-by: Timothy Chen <timothytim@google.com>