### PR TITLE
[sw/silicon_creator] Separate mask ROM specific RSA subroutines.

### DIFF
--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/meson.build
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/meson.build
@@ -8,6 +8,10 @@ sw_lib_crypto_rsa_3072_otbn_sources = {
     'rsa_3072_verify.s',
     'rsa_3072.s',
   ),
+  'rsa_3072_modexp': files(
+    'rsa_3072_modexp.s',
+    'rsa_3072.s',
+  ),
 }
 
 # OTBN BUILD procedure
@@ -60,6 +64,20 @@ foreach app_name, app_sources : sw_lib_crypto_rsa_3072_otbn_sources
   )
 
 endforeach
+
+# C wrapper for RSA-3072 modexp
+sw_silicon_creator_lib_crypto_rsa_3072_verify = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_crypto_rsa_3072_modexp',
+    sources: [
+      'rsa_3072_modexp.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_otbn_util,
+      sw_lib_crypto_rsa_3072_otbn['rsa_3072_modexp']['rv32embed_dependency'],
+    ],
+  ),
+)
 
 # C wrapper for RSA-3072 verify
 sw_silicon_creator_lib_crypto_rsa_3072_verify = declare_dependency(

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_modexp.c
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_modexp.c
@@ -1,0 +1,97 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_modexp.h"
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+#include "sw/device/silicon_creator/lib/otbn_util.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+OTBN_DECLARE_APP_SYMBOLS(rsa_3072_modexp);  // The OTBN RSA-3072 verify app.
+OTBN_DECLARE_PTR_SYMBOL(rsa_3072_modexp, out_buf);  // Output buffer (message).
+OTBN_DECLARE_PTR_SYMBOL(rsa_3072_modexp, in_mod);   // The RSA modulus (n).
+OTBN_DECLARE_PTR_SYMBOL(rsa_3072_modexp, in_buf);   // The signature (s).
+OTBN_DECLARE_PTR_SYMBOL(rsa_3072_modexp,
+                        in_m0inv);  // The Montgomery constant m0_inv.
+
+static const otbn_app_t kOtbnAppRsa = OTBN_APP_T_INIT(rsa_3072_modexp);
+static const otbn_ptr_t kOtbnVarRsaOutBuf =
+    OTBN_PTR_T_INIT(rsa_3072_modexp, out_buf);
+static const otbn_ptr_t kOtbnVarRsaInMod =
+    OTBN_PTR_T_INIT(rsa_3072_modexp, in_mod);
+static const otbn_ptr_t kOtbnVarRsaInBuf =
+    OTBN_PTR_T_INIT(rsa_3072_modexp, in_buf);
+static const otbn_ptr_t kOtbnVarRsaInM0Inv =
+    OTBN_PTR_T_INIT(rsa_3072_modexp, in_m0inv);
+
+/**
+ * Copies a 3072-bit number from the CPU memory to OTBN data memory.
+ *
+ * @param otbn The OTBN context object.
+ * @param src Source of the data to copy.
+ * @param dst Pointer to the destination in OTBN's data memory.
+ * @return The result of the operation.
+ */
+static otbn_error_t write_rsa_3072_int_to_otbn(otbn_t *otbn,
+                                               const rsa_3072_int_t *src,
+                                               otbn_ptr_t dst) {
+  return otbn_copy_data_to_otbn(otbn, kRsa3072NumWords, src->data, dst);
+}
+
+/**
+ * Copies a 3072-bit number from OTBN data memory to CPU memory.
+ *
+ * @param otbn The OTBN context object.
+ * @param src The pointer in OTBN data memory to copy from.
+ * @param dst The destination of the copied data in main memory (preallocated).
+ * @return The result of the operation.
+ */
+static otbn_error_t read_rsa_3072_int_from_otbn(otbn_t *otbn,
+                                                const otbn_ptr_t src,
+                                                rsa_3072_int_t *dst) {
+  return otbn_copy_data_from_otbn(otbn, kRsa3072NumWords, src, dst->data);
+}
+
+otbn_error_t run_otbn_rsa_3072_modexp(const rsa_3072_int_t *signature,
+                                      const rsa_3072_public_key_t *public_key,
+                                      const uint32_t *m0_inv,
+                                      rsa_3072_int_t *recovered_message) {
+  otbn_t otbn;
+
+  // For now, only the F4 modulus is supported.
+  if (public_key->e != 65537) {
+    return kOtbnErrorInvalidArgument;
+  }
+
+  // Initialize OTBN and load the RSA app.
+  otbn_init(&otbn);
+  OTBN_RETURN_IF_ERROR(otbn_load_app(&otbn, kOtbnAppRsa));
+
+  // Set the modulus (n).
+  OTBN_RETURN_IF_ERROR(
+      write_rsa_3072_int_to_otbn(&otbn, &public_key->n, kOtbnVarRsaInMod));
+
+  // Set the signature.
+  OTBN_RETURN_IF_ERROR(
+      write_rsa_3072_int_to_otbn(&otbn, signature, kOtbnVarRsaInBuf));
+
+  // Set the precomputed constant m0_inv.
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(&otbn, kOtbnWideWordNumWords,
+                                              m0_inv, kOtbnVarRsaInM0Inv));
+
+  // Start the OTBN routine.
+  OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
+
+  // Spin here waiting for OTBN to complete.
+  OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
+
+  // Read recovered message out of OTBN dmem.
+  OTBN_RETURN_IF_ERROR(
+      read_rsa_3072_int_from_otbn(&otbn, kOtbnVarRsaOutBuf, recovered_message));
+
+  return kOtbnErrorOk;
+}

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_modexp.h
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_modexp.h
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CRYPTO_RSA_3072_RSA_3072_MODEXP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CRYPTO_RSA_3072_RSA_3072_MODEXP_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/otbn_util.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /* Length of the RSA-3072 modulus is 3072 bits */
+  kRsa3072NumBits = 3072,
+  /* Length of the RSA-3072 modulus in words */
+  kRsa3072NumWords = kRsa3072NumBits / (sizeof(uint32_t) * 8),
+};
+
+/**
+ * A type that holds an element of the RSA-3072 finite field (i.e. a 3072-bit
+ * number).
+ *
+ * This type can be used for RSA-3072 signatures, keys, and intermediate values
+ * during modular exponentiation.
+ */
+typedef struct rsa_3072_int_t {
+  uint32_t data[kRsa3072NumWords];
+} rsa_3072_int_t;
+
+/**
+ * A type that holds an RSA-3072 public key.
+ *
+ * The public key consists of a 3072-bit modulus n and a public exponent e.
+ */
+typedef struct rsa_3072_public_key_t {
+  rsa_3072_int_t n;
+  uint32_t e;
+} rsa_3072_public_key_t;
+
+/**
+ * Performs modular exponentiation for signature verification.
+ *
+ * Computes (signature^e) mod n, where e and n are the exponent and modulus in
+ * the public key respectively.
+ *
+ * Currently, only e=65537 is supported.
+ *
+ * @param signature Signature to be verified.
+ * @param public_key Key to check the signature against.
+ * @param m0_inv Precomputed Montgomery constant ((-(n^-1)) mod 2^256)
+ * @param recoveredMessage Buffer in which to store output
+ * @return Result of the operation (OK or error).
+ */
+otbn_error_t run_otbn_rsa_3072_modexp(const rsa_3072_int_t *signature,
+                                      const rsa_3072_public_key_t *public_key,
+                                      const uint32_t *m0_inv,
+                                      rsa_3072_int_t *recovered_message);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_CRYPTO_RSA_3072_RSA_3072_MODEXP_H_

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_modexp.s
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_modexp.s
@@ -1,0 +1,55 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+
+.section .text.start
+
+/**
+ * OTBN app to compute R^2 and then run RSA-3072 modexp.
+ *
+ * Expects the RSA signature (in_buf), constant m0_inv (in_m0inv) and modulus
+ * (in_mod) to be pre-populated. Recovered message will be stored in out_buf.
+ */
+run_rsa_3072:
+  /* Compute R^2 and store in in_rr */
+  jal      x1, precomp_rr
+
+  /* Run modular exponentiation and store the result in out_buf */
+  jal      x1, modexp_var_3072_f4
+
+  ecall
+
+.text
+
+.data
+
+/* Output buffer for the resulting, recovered message. */
+.globl out_buf
+.balign 32
+out_buf:
+  .zero 384
+
+/* Input buffer for the modulus. */
+.globl in_mod
+.balign 32
+in_mod:
+  .zero 384
+
+/* Input buffer for the signature. */
+.globl in_buf
+.balign 32
+in_buf:
+  .zero 384
+
+/* Working buffer for the Montgomery transformation constant R^2. */
+.globl in_rr
+.balign 32
+in_rr:
+  .zero 384
+
+/* Input buffer for the Montgomery constant. */
+.globl in_m0inv
+.balign 32
+in_m0inv:
+  .zero 32


### PR DESCRIPTION
Part of #9303 

Create a separate interface for RSA-3072 that has only the subroutines mask ROM needs, and write a separate C wrapper for that interface.

The `rsa_3072_modexp` C wrapper is very, very similar to the `rsa_3072_verify` version in the same directory, just stripped down to include only `modexp` and computing the constant R^2. Next, the `rsa_3072_verify` version (which includes a more standard interface for signature verification with all the bells and whistles, rather than just modexp and R^2) will be moved out of `silicon_creator` entirely.