### PR TITLE
[spi_device] Connect Readbuffer flip event to interrupt

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -283,12 +283,6 @@ module spi_device
   logic intr_readbuf_watermark, intr_readbuf_flip;
   logic flash_sck_readbuf_watermark, flash_sck_readbuf_flip;
 
-  // TODO: Implement
-  assign intr_readbuf_flip             = 1'b 0;
-
-  logic  unused_flip_event;
-  assign unused_flip_event = flash_sck_readbuf_flip;
-
   // TPM ===============================================================
   localparam int unsigned TpmFifoDepth    = 4; // 4B
   localparam int unsigned TpmFifoPtrW     = $clog2(TpmFifoDepth+1);
@@ -611,6 +605,14 @@ module spi_device
     .intr_o                 (intr_readbuf_watermark_o              )
   );
 
+  prim_pulse_sync u_flash_readbuf_flip_pulse_sync (
+    .clk_src_i   (clk_spi_in_buf        ),
+    .rst_src_ni  (rst_ni                ),
+    .src_pulse_i (flash_sck_readbuf_flip),
+    .clk_dst_i   (clk_i                 ),
+    .rst_dst_ni  (rst_ni                ),
+    .dst_pulse_o (intr_readbuf_flip     )
+  );
   prim_intr_hw #(.Width(1)) u_intr_readbuf_flip (
     .clk_i,
     .rst_ni,

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -677,19 +677,12 @@ module spi_readcmd
   //- END:   Main state machine -----------------------------------------------
 
   // Events: register
-  // watermark, flip are pulse signals. watermark pulse width is 1 SCK. flip
-  // pulse width varies (2 to 32).
-  // They are not registered (output of comb logic). Register the signal then
-  // pulse sync at TOP
-  always_ff @(posedge clk_i or negedge sys_rst_ni) begin
-    if (!sys_rst_ni) begin
-      sck_read_watermark_o <= 1'b 0;
-      sck_read_flip_o      <= 1'b 0;
-    end else begin
-      sck_read_watermark_o <= read_watermark;
-      sck_read_flip_o      <= read_flip;
-    end
-  end
+  // watermark, flip are pulse signals. watermark pulse width is 1 SCK.
+  // flip pulse width varies inside readbuffer and changed into 1 SCK width.
+  // They are not registered (output of comb logic).
+  // As these signals goes into prim_pulse_sync, no need to register here.
+  assign sck_read_watermark_o = read_watermark;
+  assign sck_read_flip_o      = read_flip;
 
   ///////////////
   // Instances //

--- a/hw/ip/spi_device/rtl/spid_readbuffer.sv
+++ b/hw/ip/spi_device/rtl/spid_readbuffer.sv
@@ -114,8 +114,15 @@ module spid_readbuffer #(
   assign current_buffer_idx = current_address_i[31:OneBufferAw];
   assign flip = current_buffer_idx == next_buffer_addr;
 
-  // TODO: Make event_flip_o pulse signal
-  assign event_flip_o = active && flip;
+  // make flip event single cycle pulse signal
+  // It will be synchronized into the bus clock domain using prim_pulse_sync
+  logic flip_q;
+  always_ff @(posedge clk_i or negedge sys_rst_ni) begin
+    if (!sys_rst_ni) flip_q <= 1'b 0;
+    else             flip_q <= flip;
+  end
+
+  assign event_flip_o = active && flip && !flip_q;
 
   // TODO: Consider the case if host jumps the address? (report error?)
 


### PR DESCRIPTION
This commit connects the readbuf flip event into the interrupt line.
The flip event may be high for multiple SCK cycles. The logic converts
the signal into single cycle pulse to use prim_pulse_sync.