### PR TITLE
Revert "[dv/aon_timer] Temp fix regression error"

### DIFF
--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_base_vseq.sv
@@ -16,9 +16,7 @@ class aon_timer_base_vseq extends cip_base_vseq #(
   // If this is set, the AON clock starts first and then the fast clock starts sometime later. If
   // not, they start in parallel. Since the fast clock is *much* quicker, the practical result is
   // that it starts first.
-  // TODO: Issue #6821: temp set to 1 to avoid assertion error.
-  // rand bit reset_aon_first;
-  bit reset_aon_first = 1;
+  rand bit reset_aon_first;
 
   // Should the escalation signal be enabled at the start of time?
   rand bit initial_lc_escalate_en;


### PR DESCRIPTION
Reverts lowRISC/opentitan#6823

Per Tom's comment on issue #6821, we are going to revert this temp fix and see if we can reproduce the assertion error.