### PR TITLE
[dv/chip] Drive LC test_locked state to unlocked state 

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
@@ -9,6 +9,9 @@ class jtag_riscv_agent_cfg extends dv_base_agent_cfg;
   jtag_agent_cfg m_jtag_agent_cfg;
   jtag_sequencer jtag_sequencer_h;
 
+  // Allows JTAG to return error status.
+  bit allow_errors = 0;
+
   // status to return if we assert in_reset
   logic [DMI_OPW-1:0] status_in_reset;
 

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
@@ -77,4 +77,13 @@ package jtag_riscv_agent_pkg;
     csr_val = jtag_csr_seq.data;
   endtask
 
-endpackage : jtag_riscv_agent_pkg
+  task automatic jtag_write_csr(bit [bus_params_pkg::BUS_AW-1:0] csr_addr,
+                                jtag_riscv_sequencer             seqr,
+                                bit [bus_params_pkg::BUS_DW-1:0] csr_val);
+    jtag_riscv_csr_seq jtag_csr_seq = jtag_riscv_csr_seq::type_id::create("jtag_csr_seq");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(jtag_csr_seq, addr == csr_addr; do_write == 1; data == csr_val;,
+                                   , msg_id)
+    jtag_csr_seq.start(seqr);
+  endtask
+
+endpackage: jtag_riscv_agent_pkg

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_monitor.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_monitor.sv
@@ -66,7 +66,11 @@ class jtag_riscv_monitor extends dv_base_monitor #(
                       "Got busy status (%s) - op:%s(%h) addr:%h", status.name, op.name, op, addr),
                       UVM_MEDIUM)
           end else begin
-            `uvm_error(`gfn, $sformatf("Bad status - %s(%h) ", status.name, status))
+            if (!cfg.allow_errors) begin
+              `uvm_error(`gfn, $sformatf("Bad status - %s(%h) ", status.name, status))
+            end else begin
+              `uvm_info(`gfn, $sformatf("Bad status - %s(%h) ", status.name, status), UVM_MEDIUM)
+            end
           end
         end else begin
           `uvm_error(`gfn, $sformatf("Bad op - %s(%h) ", op_trans.name, op_trans))

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1231,7 +1231,7 @@
             X-ref'ed with chip_kmac_lc_req.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
       name: chip_sw_lc_ctrl_kmac_reset

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -20,6 +20,9 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
   // Local queue for holding received UART TX data.
   byte uart_tx_data_q[$];
 
+  // Default value to drive JTAG tap during pre_start().
+  chip_tap_type_e select_jtag = SelectRVJtagTap;
+
   `uvm_object_new
 
   task post_start();
@@ -70,7 +73,7 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
 
     // Drive strap signals at the start.
     if (do_strap_pins_init) begin
-      cfg.tap_straps_vif.drive(SelectRVJtagTap); // Select JTAG.
+      cfg.tap_straps_vif.drive(select_jtag);
       cfg.dft_straps_vif.drive(2'b00);
       cfg.sw_straps_vif.drive({2'b00, cfg.use_spi_load_bootstrap});
     end

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -8,26 +8,31 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   `uvm_object_new
 
   // LC sends two 64-bit msg as input token.
-  localparam uint ExitTokenWidthBit  = kmac_pkg::MsgWidth * 2;
-  localparam uint ExitTokenWidthByte = ExitTokenWidthBit / 8;
+  localparam uint TokenWidthBit  = kmac_pkg::MsgWidth * 2;
+  localparam uint TokenWidthByte = TokenWidthBit / 8;
 
-  rand bit [7:0] lc_exit_token[ExitTokenWidthByte];
+  rand bit [7:0] lc_exit_token[TokenWidthByte];
+  rand bit [7:0] lc_unlock_token[TokenWidthByte];
 
   constraint num_trans_c {
     num_trans inside {[2:3]};
   }
 
-  virtual function void backdoor_override_otp();
-    bit [otp_ctrl_reg_pkg::TestUnlockTokenSize-1:0] rand_unlock_token;
-    `DV_CHECK_STD_RANDOMIZE_FATAL(rand_unlock_token)
+  // Reassign `select_jtag` variable to drive LC JTAG tap at start,
+  // because LC_CTRL's TestLock state can only sample strap once at boot.
+  virtual task pre_start();
+    select_jtag = SelectLCJtagTap;
+    super.pre_start();
+  endtask
 
-    // Override the LC partition to TestUnlocked2.
-    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition(lc_ctrl_state_pkg::LcStTestUnlocked2);
+  virtual function void backdoor_override_otp();
+    // Override the LC partition to TestLocked1 state.
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition(LcStTestLocked1);
 
     // Override the test exit token to match SW test's input token.
     cfg.mem_bkdr_util_h[Otp].otp_write_secret0_partition(
-        .unlock_token(rand_unlock_token),
-        .exit_token(get_otp_exit_token(lc_exit_token)));
+        .unlock_token(get_otp_token(lc_unlock_token)),
+        .exit_token(get_otp_token(lc_exit_token)));
   endfunction
 
   virtual task dut_init(string reset_kind = "HARD");
@@ -38,25 +43,25 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   // This function takes the token value from LC_CTRL token CSRs, then runs through cshake128 to
   // get a 768-bit XORed token output.
   // The first 128 bits of the decoded token should match the OTP's secret0 paritition's
-  // descrambled exit token value.
-  virtual function bit [ExitTokenWidthBit-1:0] get_otp_exit_token(
-      bit [7:0] token_in[ExitTokenWidthByte]);
+  // descrambled tokens value.
+  virtual function bit [TokenWidthBit-1:0] get_otp_token(
+      bit [7:0] token_in[TokenWidthByte]);
 
     bit [7:0]                      dpi_digest[kmac_pkg::AppDigestW/8];
     bit [kmac_pkg::AppDigestW-1:0] digest_bits;
 
-    digestpp_dpi_pkg::c_dpi_cshake128(token_in, "", "LC_CTRL", ExitTokenWidthByte,
+    digestpp_dpi_pkg::c_dpi_cshake128(token_in, "", "LC_CTRL", TokenWidthByte,
                                       kmac_pkg::AppDigestW/8, dpi_digest);
 
     digest_bits = {<< byte {dpi_digest}};
-    return (digest_bits[ExitTokenWidthBit-1:0]);
+    return (digest_bits[TokenWidthBit-1:0]);
   endfunction
 
   virtual task body();
     super.body();
 
     for (int trans_i = 1; trans_i <= num_trans; trans_i++) begin
-      // sw_symbol_backdoor_overwrite takes an array as the input
+      // sw_symbol_backdoor_overwrite takes an array as the input.
       bit [7:0] trans_i_array[] = {trans_i};
       sw_symbol_backdoor_overwrite("kTestIterationCount", trans_i_array);
 
@@ -68,33 +73,77 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
       // Override the C test kLcExitToken with random data.
       sw_symbol_backdoor_overwrite("kLcExitToken", lc_exit_token);
 
+      // In this test, LC_CTRL will enter the TestLocked state which only allows TAP selection once
+      // per boot. Because testbench does not know the exact time when TAP selection happens, we
+      // continuously issue LC JTAG read until it returns valid value.
+      // In the meantime, TAP selection could happen in between a transaction and might return an
+      // error. This error is permitted and can be ignored.
+      cfg.m_jtag_riscv_agent_cfg.allow_errors = 1;
+
+      // Wait until LC_CTRL is ready.
+      wait_lc_status(LcReady);
+
+      // Once TAP selection finishes, does not expect any JTAG errors.
+      cfg.m_jtag_riscv_agent_cfg.allow_errors = 0;
+
+      // Use JTAG interface to transit LC_CTRL from TestLock to TestUnlock state.
+      `uvm_info(`gfn, "Start LC transition request to TestUnlock state", UVM_LOW)
+      jtag_riscv_agent_pkg::jtag_write_csr(ral.lc_ctrl.claim_transition_if.get_offset(),
+                                           p_sequencer.jtag_sequencer_h,
+                                           prim_mubi_pkg::MuBi8True);
+      begin
+        bit [TL_DW-1:0] unlock_token_csr_vals[4] = {<< 32 {{<< 8 {lc_unlock_token}}}};
+        foreach (unlock_token_csr_vals[index]) begin
+          jtag_riscv_agent_pkg::jtag_write_csr(ral.lc_ctrl.transition_token[index].get_offset(),
+                                               p_sequencer.jtag_sequencer_h,
+                                               unlock_token_csr_vals[index]);
+        end
+      end
+      jtag_riscv_agent_pkg::jtag_write_csr(ral.lc_ctrl.transition_target.get_offset(),
+                                           p_sequencer.jtag_sequencer_h,
+                                           {DecLcStateNumRep{DecLcStTestUnlocked2}});
+      jtag_riscv_agent_pkg::jtag_write_csr(ral.lc_ctrl.transition_cmd.get_offset(),
+                                           p_sequencer.jtag_sequencer_h,
+                                           1);
+      `uvm_info(`gfn, "Sent LC transition request", UVM_LOW)
+
+      wait_lc_status(LcTransitionSuccessful);
+
+      // LC state transition requires a chip reset.
+      apply_reset();
+
       // Wait for SW to finish power on set up.
       wait (cfg.sw_logger_vif.printed_log == "Start LC_CTRL transition test.");
 
-      // Select LC jtag.
-      cfg.tap_straps_vif.drive(SelectLCJtagTap);
+      // Wait for LC_CTRL state trasition finish from TLUL interface.
+      wait_lc_status(LcTransitionSuccessful);
 
-      while(1) begin
-        bit [TL_DW-1:0]  status_val;
-        lc_ctrl_status_e dummy;
-        cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
-        jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.status.get_offset(),
-                                            p_sequencer.jtag_sequencer_h,
-                                            status_val);
-
-        // Ensure that none of the other status bits are set.
-        `DV_CHECK_EQ(status_val >> dummy.num(), 0,
-                     $sformatf("Unexpected status error %0h", status_val))
-        if (status_val[LcTransitionSuccessful]) break;
-      end
-
-      // LC state transition requires a chip reset.
+      // LC_CTRL state transition requires a chip reset.
       apply_reset();
 
       // Wait for SW test finishes with a pass/fail status.
       wait (cfg.sw_test_status_vif.sw_test_status inside {SwTestStatusPassed,
                                                           SwTestStatusFailed});
       `uvm_info(`gfn, $sformatf("Sequence %0d/%0d finished!", trans_i, num_trans), UVM_LOW)
+    end
+  endtask
+
+  virtual task wait_lc_status(lc_ctrl_status_e expect_status);
+    while(1) begin
+      bit [TL_DW-1:0]  status_val;
+      lc_ctrl_status_e dummy;
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
+      jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.status.get_offset(),
+                                          p_sequencer.jtag_sequencer_h,
+                                          status_val);
+
+      // Ensure that none of the other status bits are set.
+      `DV_CHECK_EQ(status_val >> dummy.num(), 0,
+                   $sformatf("Unexpected status error %0h", status_val))
+      if (status_val[expect_status]) begin
+        `uvm_info(`gfn, $sformatf("LC status %0s.", expect_status.name), UVM_LOW)
+        break;
+      end
     end
   endtask
 


### PR DESCRIPTION
 This PR based on previous lc_ctrl_transtition sequence and added one                                
 more state transition:                                                                              
 TestLocked1 -> TestUnlocked2                                                                        
 
With this transition, we covered all the toggle coverage for                                     
 `test_unlock_token` between LC and KMAC interface. 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>