### PR TITLE
[ottf,mask_rom] Migrate all mask ROM func tests to OTTF.

### DIFF
--- a/sw/device/silicon_creator/lib/test_main.h
+++ b/sw/device/silicon_creator/lib/test_main.h
@@ -6,7 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_TEST_MAIN_H_
 
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/test_framework/test_main.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
 /**

--- a/sw/device/silicon_creator/testing/meson.build
+++ b/sw/device/silicon_creator/testing/meson.build
@@ -22,8 +22,7 @@ foreach mask_rom_test_name, mask_rom_test_info : mask_rom_tests
         riscv_crt,
         device_lib,
         mask_rom_test_info['library'],
-        sw_lib_irq_handlers,
-        sw_lib_testing_test_main,
+        sw_lib_testing_ottf,
       ],
     )
 

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -856,8 +856,7 @@ foreach sw_test_name, sw_test_info : sw_rom_ext_tests
         rom_ext_slot_libs['rom_ext_slot_a'],
         device_lib,
         sw_test_info['library'],
-        sw_lib_irq_handlers,
-        sw_lib_testing_test_main,
+        sw_lib_testing_ottf,
       ],
     )
 


### PR DESCRIPTION
This PR migrates all mask ROM func tests to the OTTF, from the old (soon to be deprecated) on-device test framework.

This partially addresses #8015.

~**_This PR depends on #9414. Duplicate commit will be removed when #9414 merges._**~

Signed-off-by: Timothy Trippel <ttrippel@google.com>