### PR TITLE
[chip/dv] Generate TLUL data intg for top-level CSR tests

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env.sv
@@ -22,7 +22,7 @@ class cip_base_env #(type CFG_T               = cip_base_env_cfg,
 
     // use cip_tl_seq_item to create tl_seq_item with correct integrity values and obtain integrity
     // related functions
-    if (cfg.en_tl_intg_gen) tl_seq_item::type_id::set_type_override(cip_tl_seq_item::get_type());
+    tl_seq_item::type_id::set_type_override(cip_tl_seq_item::get_type());
 
     // Retrieve the virtual interfaces from uvm_config_db.
     if (!uvm_config_db#(intr_vif)::get(this, "", "intr_vif", cfg.intr_vif) &&

--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -25,10 +25,6 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   uvm_reg_data_t      shadow_update_err_status_fields[dv_base_reg_field];
   uvm_reg_data_t      shadow_storage_err_status_fields[dv_base_reg_field];
 
-  // Enables TL integrity generation & checking with *_user bits.
-  // Assume ALL TL agents have integrity check enabled or disabled altogether.
-  bit                 en_tl_intg_gen = 1;
-
   alert_esc_agent_cfg m_alert_agent_cfg[string];
   push_pull_agent_cfg#(.DeviceDataWidth(EDN_DATA_WIDTH)) m_edn_pull_agent_cfg[];
 

--- a/hw/dv/sv/cip_lib/doc/index.md
+++ b/hw/dv/sv/cip_lib/doc/index.md
@@ -85,8 +85,6 @@ virtual function void initialize(bit [31:0] csr_base_addr = '1);
   super.initialize(csr_base_addr); // ral model is created in `super.initialize`
   tl_intg_alert_fields[ral.a_status_reg.a_field] = value;
 ```
-* **en_tl_intg_gen**: Controls whether the TLUL integrity error is generated in
-  sequences / checked by the scoreboard.
 
 Apart from these, there are several common settings such as `zero_delays`,
 `clk_freq_mhz`, which are randomized as well as knobs such as `en_scb` and
@@ -277,10 +275,7 @@ class cip_base_test #(type CFG_T = cip_base_env_cfg,
 
 ### cip_tl_seq_item
 This is extended class of tl_seq_item to generate correct integrity values in
-a_user and d_user. If DUT relies on the agent to generate integrity for TLUL, set
-`cfg.en_tl_intg_gen = 1`, cip_tl_seq_item will override tl_seq_item, and integrity
-values will be generated. If TLUL integrity is handled in the DUT, set
-`cfg.en_tl_intg_gen = 0`, then `a_user` and `d_user` will be fully randomized.
+`a_user` and `d_user`.
 
 ## Extending from CIP library classes
 Let's say we are verifying an actual comportable IP `uart` which has `uart_tx`

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -266,8 +266,6 @@ virtual task run_tl_intg_err_vseq(int num_times = 1);
 endtask
 
 virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
-  `DV_CHECK_EQ(cfg.en_tl_intg_gen, 1)
-
   fork
     // run csr_rw seq to send some normal CSR accesses in parallel
     begin
@@ -283,7 +281,6 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
       check_tl_intg_error_response();
     end
   join
-
 endtask
 
 virtual task issue_tl_access_w_intg_err(string ral_name);

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -12,8 +12,8 @@ class cip_tl_seq_item extends tl_seq_item;
   int                 max_ecc_errors = MAX_TL_ECC_ERRORS;
 
   `uvm_object_utils_begin(cip_tl_seq_item)
-    `uvm_field_enum(tl_intg_err_e,          tl_intg_err_type, UVM_DEFAULT)
-    `uvm_field_int(max_ecc_errors,                            UVM_DEFAULT)
+    `uvm_field_enum(tl_intg_err_e, tl_intg_err_type, UVM_DEFAULT)
+    `uvm_field_int(max_ecc_errors,                   UVM_DEFAULT)
   `uvm_object_utils_end
 
   function void post_randomize();
@@ -54,8 +54,8 @@ class cip_tl_seq_item extends tl_seq_item;
 
     user.rsvd = '0;
     user.instr_type = instr_type;
-    user.cmd_intg = cmd_with_intg[H2DCmdFullWidth -1 -: H2DCmdIntgWidth];
-    user.data_intg = data_with_intg[DataFullWidth -1 -: DataIntgWidth];
+    user.cmd_intg  = cmd_with_intg[H2DCmdFullWidth - 1 -: H2DCmdIntgWidth];
+    user.data_intg = data_with_intg[DataFullWidth - 1 -: DataIntgWidth];
     return user;
   endfunction : compute_a_user
 

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -209,7 +209,9 @@ module lc_ctrl
   );
 
   // DMI to TL-UL transducing
-  tlul_adapter_host u_tap_tlul_host (
+  tlul_adapter_host #(
+    .EnableDataIntgGen(1)
+  ) u_tap_tlul_host (
     .clk_i,
     .rst_ni,
     // do not make a request unless there is room for the response

--- a/hw/ip/rv_dm/rtl/rv_dm.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm.sv
@@ -304,6 +304,7 @@ module rv_dm
   end
 
   tlul_adapter_host #(
+    .EnableDataIntgGen(1),
     .MAX_REQS(1)
   ) tl_adapter_host_sba (
     .clk_i,

--- a/hw/ip/tlul/rtl/tlul_adapter_host.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_host.sv
@@ -26,8 +26,7 @@ module tlul_adapter_host
   import prim_mubi_pkg::mubi4_t;
 #(
   parameter int unsigned MAX_REQS = 2,
-  // TODO(#7966) disable data intgrity overwrite once dv support available
-  parameter bit EnableDataIntgGen = 1
+  parameter bit EnableDataIntgGen = 0
 ) (
   input clk_i,
   input rst_ni,
@@ -107,7 +106,6 @@ module tlul_adapter_host
     d_ready:   1'b1
   };
 
-  // TODO #7966 disable data intgrity overwrite once dv support available
   tlul_cmd_intg_gen #(.EnableDataIntgGen (EnableDataIntgGen)) u_cmd_intg_gen (
     .tl_i(tl_out),
     .tl_o(tl_o)

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -22,9 +22,6 @@ class chip_base_test extends cip_base_test #(
 
     super.build_phase(phase);
 
-    // TL integrity gen is in the design data path, no need to generate it in the agent
-    cfg.en_tl_intg_gen = 0;
-
     // Knob to en/dis stubbing cpu (disabled by default).
     void'($value$plusargs("stub_cpu=%0b", cfg.stub_cpu));
     // Set tl_agent's is_active bit based on the retrieved stub_cpu value.


### PR DESCRIPTION
Addressed #7966
In chip level stub_cpu mode, TB needs to generate data intg as data intg
is generated in Ibex and we bypass the Ibex to drive the TL interface.

Signed-off-by: Weicai Yang <weicai@google.com>