### PR TITLE
[chip, dv] Do OTP image generation as DVSim orchestrated step

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -413,20 +413,25 @@
   end
 `endif
 
-// This macro converts a string input from plusarg to an enum variable
-// ENUM_: the name of enum type
-// PLUSARG_: the name of the plusargs, which is also the name of the enum variable
-// CHECK_EXIST_: set to 1, `$value$plusargs()` should return true
+// Retrieves a plusarg value representing an enum literal.
+//
+// The plusarg is parsed as a string, which needs to be converted into the enum literal whose name
+// matches the string. This functionality is provided by the UVM helper function below.
+//
+// ENUM_: The enum type.
+// VAR_: The enum variable to which the plusarg value will be set (must be declared already).
+// PLUSARG_: the name of the plusarg (as raw text). This is typically the same as the enum variable.
+// CHECK_EXISTS_: Throws a fatal error if the plusarg is not set.
 `ifndef DV_GET_ENUM_PLUSARG
-`define DV_GET_ENUM_PLUSARG(ENUM_, PLUSARG_, CHECK_EXIST_ = 0, ID_ = `gfn) \
+`define DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_ = VAR_, CHECK_EXISTS_ = 0, ID_ = `gfn) \
   begin \
     string str; \
     if ($value$plusargs("``PLUSARG_``=%0s", str)) begin \
-      if (!uvm_enum_wrapper#(ENUM_)::from_name(str, PLUSARG_)) begin \
-        `uvm_fatal(ID_, $sformatf("Cannot find %s from enum ``ENUM_``", PLUSARG_.name)) \
+      if (!uvm_enum_wrapper#(ENUM_)::from_name(str, VAR_)) begin \
+        `uvm_fatal(ID_, $sformatf("Cannot find %s from enum ``ENUM_``", VAR_.name())) \
       end \
-    end else if (CHECK_EXIST_) begin \
-      `uvm_fatal(ID_, "Can't find plusargs ``PLUSARG_``") \
+    end else if (CHECK_EXISTS_) begin \
+      `uvm_fatal(ID_, "Please pass the plusarg +``PLUSARG_``=<``ENUM_``-literal>") \
     end \
   end
 `endif

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -107,24 +107,44 @@
                    "{tool}_otbn_tracer_build_opts",
                    "{tool}_memutil_dpi_scrambled_build_opts"]
 
+  // Setup for generating OTP images.
+  gen_otp_images_cfg_dir: "{proj_root}/hw/ip/otp_ctrl/data"
+  gen_otp_images_cmd: "{proj_root}/util/design/gen-otp-img.py"
+  gen_otp_images_cmd_opts: ["--quiet", "--seed {seed}"]
+
   // Add run modes.
   run_modes: [
-    { // This base mode initializes the OTP / life cycle with the DEV state
-      name: base_otp_lc_dev_mode
-      sw_images: ["sw/device/otp_img/otp_img:3"],
-      run_opts: ["+sw_build_bin_dir={sw_build_dir}/build-bin",
-                 "+sw_build_device={sw_build_device}",
-                 // Separate individual SW images supplied to +sw_images plusarg by comma.
-                 "+sw_images={eval_cmd} echo {sw_images} | sed -E 's/\\s+/,/g'"]
+    // Generates OTP images with different LC states with cannonical values,
+    // pseudo-randomized with the same test seed.
+    {
+      name: gen_otp_images_mode
+      pre_run_cmds: [
+        '''{gen_otp_images_cmd} {gen_otp_images_cmd_opts} \
+               --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_raw.hjson \
+               --out {run_dir}/otp_ctrl_img_raw.vmem
+        ''',
+        '''{gen_otp_images_cmd} {gen_otp_images_cmd_opts} \
+               --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_dev.hjson \
+               --out {run_dir}/otp_ctrl_img_dev.vmem
+        ''',
+        '''{gen_otp_images_cmd} {gen_otp_images_cmd_opts} \
+               --img-cfg {gen_otp_images_cfg_dir}/otp_ctrl_img_rma.hjson \
+               --out {run_dir}/otp_ctrl_img_rma.vmem
+        ''',
+      ]
     }
     {
       name: sw_test_mode
       sw_images: ["sw/device/boot_rom/boot_rom:0"]
-      en_run_modes: ["base_otp_lc_dev_mode"]
+      run_opts: ["+sw_build_bin_dir={sw_build_dir}/build-bin",
+                 "+sw_build_device={sw_build_device}",
+                 // Separate individual SW images supplied to +sw_images plusarg by comma.
+                 "+sw_images={eval_cmd} echo {sw_images} | sed -E 's/\\s+/,/g'"]
+      en_run_modes: ["gen_otp_images_mode"]
     }
     {
       name: stub_cpu_mode
-      en_run_modes: ["base_otp_lc_dev_mode"]
+      en_run_modes: ["gen_otp_images_mode"]
       run_opts: ["+stub_cpu=1"]
     }
     {
@@ -140,7 +160,7 @@
     }
     {
       name: xbar_mode
-      en_run_modes: ["base_otp_lc_dev_mode"]
+      en_run_modes: ["gen_otp_images_mode"]
       run_opts: ["+xbar_mode=1"]
       reseed: 100
     }
@@ -161,7 +181,6 @@
   // - 0 for boot_rom,
   // - 1 for SW test,
   // - 2 for OTBN test,
-  // - 3 for OTP and so on
   // This allows an arbitrary number of SW images to be supplied to the TB.
   tests: [
     {

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -31,11 +31,11 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
   // sw related
   // Directory from where to pick up the SW test images -default to PWD {run_dir}.
-  string              sw_build_bin_dir = ".";
+  string sw_build_bin_dir = ".";
 
   // In OpenTitan, the same SW test image can be built for DV, Verilator and FPGA. SW build for
   // other platforms can be run on DV as well. We allow that by specifying the SW build device.
-  string              sw_build_device = "sim_dv";
+  string sw_build_device = "sim_dv";
 
   // Types of SW images used in the test.
   //
@@ -52,8 +52,12 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   //
   // The ~resolve_sw_image_paths()~ function does the job of prefixing this path with
   // ~sw_build_bin_dir and suffixing with ~sw_build_device~.
-  string              sw_images[sw_type_e];
-  string              sw_image_flags[sw_type_e][$];
+  string sw_images[sw_type_e];
+  string sw_image_flags[sw_type_e][$];
+
+  // Maintain a list of generated OTP images.
+  lc_ctrl_state_pkg::lc_state_e use_otp_image = lc_ctrl_state_pkg::LcStRma;
+  string otp_images[lc_ctrl_state_pkg::lc_state_e];
 
   uint                sw_test_timeout_ns = 5_000_000; // 5ms
   sw_logger_vif       sw_logger_vif;
@@ -109,7 +113,11 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     sw_images[SwTypeRom] = "./rom";
     sw_images[SwTypeTest] = "./sw";
     sw_images[SwTypeOtbn] = "./otbn";
-    sw_images[SwTypeOtp] = "./otp";
+
+    // By default, assume these OTP image paths.
+    otp_images[lc_ctrl_state_pkg::LcStRaw] = "otp_ctrl_img_raw.vmem";
+    otp_images[lc_ctrl_state_pkg::LcStDev] = "otp_ctrl_img_dev.vmem";
+    otp_images[lc_ctrl_state_pkg::LcStRma] = "otp_ctrl_img_rma.vmem";
 
     `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)
     `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -19,6 +19,7 @@ package chip_env_pkg;
   import flash_ctrl_pkg::*;
   import jtag_riscv_agent_pkg::*;
   import kmac_pkg::*;
+  import lc_ctrl_state_pkg::*;
   import mem_bkdr_util_pkg::*;
   import otp_ctrl_pkg::*;
   import spi_agent_pkg::*;
@@ -72,8 +73,7 @@ package chip_env_pkg;
   typedef enum {
     SwTypeRom,  // Ibex SW - first stage boot ROM.
     SwTypeTest, // Ibex SW - actual test SW.
-    SwTypeOtbn, // Otbn SW.
-    SwTypeOtp   // OTP image.
+    SwTypeOtbn  // Otbn SW.
   } sw_type_e;
 
   typedef enum bit [1:0] {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -49,7 +49,7 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
     cfg.mem_bkdr_util_h[FlashBank0Info].set_mem();
     cfg.mem_bkdr_util_h[FlashBank1Info].set_mem();
     // Backdoor load the OTP image.
-    cfg.mem_bkdr_util_h[Otp].load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
+    cfg.mem_bkdr_util_h[Otp].load_mem_from_file(cfg.otp_images[cfg.use_otp_image]);
     // Randomize the ROM image. Subclasses that have an actual ROM image will load it later.
     cfg.mem_bkdr_util_h[Rom].randomize_mem();
     // Bring the chip out of reset.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -35,7 +35,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
   virtual task apply_reset(string kind = "HARD");
     super.apply_reset(kind);
     // Backdoor load the OTP image.
-    cfg.mem_bkdr_util_h[Otp].load_mem_from_file({cfg.sw_images[SwTypeOtp], ".vmem"});
+    cfg.mem_bkdr_util_h[Otp].load_mem_from_file(cfg.otp_images[cfg.use_otp_image]);
     wait (cfg.rst_n_mon_vif.pins[0] === 1);
     cfg.clk_rst_vif.wait_clks(100);
   endtask

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -18,6 +18,8 @@ class chip_base_test extends cip_base_test #(
 
   virtual function void build_phase(uvm_phase phase);
     string sw_images_plusarg;
+    string use_otp_image_plusarg;
+
     super.build_phase(phase);
 
     // TL integrity gen is in the design data path, no need to generate it in the agent
@@ -63,6 +65,12 @@ class chip_base_test extends cip_base_test #(
     if ($value$plusargs("sw_images=%0s", sw_images_plusarg)) begin
       cfg.parse_sw_images_string(sw_images_plusarg);
     end
+
+    // Knob to select the OTP image based on LC state.
+    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::lc_state_e, cfg.use_otp_image, use_otp_image)
+    `DV_CHECK_FATAL(cfg.otp_images.exists(cfg.use_otp_image),
+                    $sformatf({"Unsupported plusarg value: +use_otp_image=%0s. An image associated",
+                               "with this LC state needs to be created first."}, cfg.use_otp_image))
   endfunction : build_phase
 
 endclass : chip_base_test

--- a/util/design/gen-otp-img.py
+++ b/util/design/gen-otp-img.py
@@ -36,7 +36,6 @@ def _override_seed(args, name, config):
     # Otherwise, we either take it from the .hjson if present, or
     # randomly generate a new seed if not.
     else:
-        random.seed()
         new_seed = random.getrandbits(64)
         if config.setdefault('seed', new_seed) == new_seed:
             log.warning('No {} specified, setting to {}.'.format(
@@ -101,6 +100,10 @@ def main():
     parser.register('action', 'extend', ExtendAction)
     parser.add_argument('--quiet', '-q', action='store_true',
                         help='''Don't print out progress messages.''')
+    parser.add_argument('--seed',
+                        type=int,
+                        metavar='<seed>',
+                        help="Custom seed used for randomization.")
     parser.add_argument('--img-seed',
                         type=int,
                         metavar='<seed>',
@@ -200,6 +203,10 @@ def main():
     log.info('Loading main image configuration file {}'.format(args.img_cfg))
     with open(args.img_cfg, 'r') as infile:
         img_cfg = hjson.load(infile)
+  
+    # Set the initial random seed so that the generated image is 
+    # deterministically randomized.
+    random.seed(args.seed)
 
     # If specified, override the seeds.
     _override_seed(args, 'lc_seed', lc_state_cfg)


### PR DESCRIPTION
Currently, the OTP generation for RMA LC state is done by meson. For DV, this is now handled by DVSim instead. The OTP image generation is now wired up to `pre_run_cmds`. 

The primary motivation of doing so is to allow the closed source foundry database to modify the OTP generation command line so that they can specify a different layout. See #9229 for details. 

The first commit adds a `--seed` switch to OTP image generation script so that we can randomize the generated image for all tests individually and reproducibly. 

The second commit performs the updates described above.
 
Fixes #9229. 