### PR TITLE
[sram/dv] Configure main sram Exec=1, ret sram Exec=0

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -381,9 +381,13 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
         valid_hw_debug_en = detected_hw_debug_en;
         valid_en_sram_ifetch = detected_en_sram_ifetch;
 
-        allow_ifetch = (valid_en_sram_ifetch == prim_mubi_pkg::MuBi8True) ?
-                       (valid_csr_exec == prim_mubi_pkg::MuBi4True)           :
-                       (valid_hw_debug_en == lc_ctrl_pkg::On);
+        if (`INSTR_EXEC) begin
+          allow_ifetch = (valid_en_sram_ifetch == prim_mubi_pkg::MuBi8True) ?
+                         (valid_csr_exec == prim_mubi_pkg::MuBi4True)       :
+                         (valid_hw_debug_en == lc_ctrl_pkg::On);
+        end else begin
+          allow_ifetch = 0;
+        end
 
         if (!cfg.en_scb) continue;
 

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -61,11 +61,13 @@
   build_modes: [
     {
       name: sram_ctrl_main
-      build_opts: ["+define+SRAM_ADDR_WIDTH=15"]
+      build_opts: ["+define+SRAM_ADDR_WIDTH=15",
+                   "+define+INSTR_EXEC=1"]
     }
     {
       name: sram_ctrl_ret
-      build_opts: ["+define+SRAM_ADDR_WIDTH=10"]
+      build_opts: ["+define+SRAM_ADDR_WIDTH=10",
+                   "+define+INSTR_EXEC=0"]
     }
   ]
 

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -64,7 +64,8 @@ module tb;
 
   sram_ctrl #(
     // memory size in bytes
-    .MemSizeRam(4 * 2 ** `SRAM_ADDR_WIDTH)
+    .MemSizeRam(4 * 2 ** `SRAM_ADDR_WIDTH),
+    .InstrExec(`INSTR_EXEC)
   ) dut (
     // main clock
     .clk_i               (clk                       ),


### PR DESCRIPTION
To align with #8973, only main sram supports instruction fetch

Signed-off-by: Weicai Yang <weicai@google.com>