### PR TITLE
[chip, dv] Randomize SRAM

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -11,7 +11,6 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   bit                 en_uart_logger;
   uart_agent_pkg::baud_rate_e uart_baud_rate = uart_agent_pkg::BaudRate1Mbps;
   bit                 use_gpio_for_sw_test_status;
-  bit                 initialize_ram;
 
   // Write logs from sw test to separate log file as well, in addition to the simulator log file.
   bit                 write_sw_logs_to_file = 1'b1;

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -353,7 +353,7 @@ module tb;
                                       .path  (`DV_STRINGIFY(`RAM_MAIN_MEM_HIER)),
                                       .depth ($size(`RAM_MAIN_MEM_HIER)),
                                       .n_bits($bits(`RAM_MAIN_MEM_HIER)),
-                                      .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
+                                      .err_detection_scheme(mem_bkdr_util_pkg::Ecc_39_32));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamMain0], `RAM_MAIN_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init RAM RET", UVM_MEDIUM)
@@ -361,7 +361,7 @@ module tb;
                                      .path  (`DV_STRINGIFY(`RAM_RET_MEM_HIER)),
                                      .depth ($size(`RAM_RET_MEM_HIER)),
                                      .n_bits($bits(`RAM_RET_MEM_HIER)),
-                                     .err_detection_scheme(mem_bkdr_util_pkg::ParityOdd));
+                                     .err_detection_scheme(mem_bkdr_util_pkg::Ecc_39_32));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[RamRet0], `RAM_RET_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init ROM", UVM_MEDIUM)

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -47,9 +47,6 @@ class chip_base_test extends cip_base_test #(
     // Knob to set the sw_test_timeout_ns (set to 5ms by default).
     void'($value$plusargs("sw_test_timeout_ns=%0d", cfg.sw_test_timeout_ns));
 
-    // Knob to pre-initialize RAM to 0s (disabled by default).
-    void'($value$plusargs("initialize_ram=%0b", cfg.initialize_ram));
-
     // Knob to use SPI to load image via ROM bootstrap.
     void'($value$plusargs("use_spi_load_bootstrap=%0b", cfg.use_spi_load_bootstrap));
 


### PR DESCRIPTION
Fixes private CI.
Unconditionally initialize the SRAM with garbage data on reset for chip
level SW based tests.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>