### PR TITLE
[sram/dv] Fix mem data check

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -144,10 +144,6 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     if (cfg.en_scb_tl_err_chk) begin
       if (predict_tl_err(item, AddrChannel, ral_name)) return;
     end
-    if (cfg.en_scb_mem_chk && item.is_write() && is_mem_addr(item, ral_name)) begin
-      process_mem_write(item, ral_name);
-    end
-
     if (!cfg.en_scb) return;
 
     process_tl_access(item, AddrChannel, ral_name);
@@ -161,8 +157,12 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       void'(item.is_ok());
       if (predict_tl_err(item, DataChannel, ral_name)) return;
     end
-    if (cfg.en_scb_mem_chk && !item.is_write() && is_mem_addr(item, ral_name)) begin
-      process_mem_read(item, ral_name);
+    if (cfg.en_scb_mem_chk && is_mem_addr(item, ral_name)) begin
+      if (item.is_write()) begin
+        process_mem_write(item, ral_name);
+      end else begin
+        process_mem_read(item, ral_name);
+      end
     end
 
     if (!cfg.en_scb) return;

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -52,6 +52,9 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
     ral.ctrl.init.set(1);
     csr_update(.csr(ral.ctrl));
     csr_spinwait(.ptr(ral.status.init_done), .exp_data(1));
+
+    // initialize mem_model
+    cfg.scb.init_mem();
   endtask
 
   // Request a new scrambling key from the OTP interface.

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
@@ -46,6 +46,8 @@ class sram_ctrl_env #(parameter int AddrWidth = 10) extends cip_base_env #(
     uvm_config_db#(push_pull_agent_cfg#(.DeviceDataWidth(KDI_DATA_SIZE)))::set(
       this, "m_kdi_agent", "cfg", cfg.m_kdi_cfg);
     cfg.m_kdi_cfg.en_cov = cfg.en_cov;
+
+    cfg.scb = scoreboard;
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -25,6 +25,10 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
   // Represent the lower and upper bounds of the SRAM memory region
   bit [TL_AW-1:0] sram_start_addr, sram_end_addr;
 
+  // Store the scb handle for seq. When seq initializes the mem, we should initialize mem_model in
+  // scb as well.
+  sram_ctrl_scoreboard#(AddrWidth) scb;
+
   // otp clk freq
   rand uint otp_freq_mhz;
 

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
@@ -59,6 +59,8 @@ package sram_ctrl_env_pkg;
     SramCtrlInitDone        = 5
   } sram_ctrl_status_e;
 
+  typedef class sram_ctrl_scoreboard;
+
   // package sources
   `include "sram_ctrl_env_cfg.sv"
   `include "sram_ctrl_env_cov.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -101,6 +101,11 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
   bit in_raw_hazard = 0;
 
+  // initialize mem to remove all the previous written data
+  function void init_mem();
+    exp_mem[cfg.sram_ral_name].init();
+  endfunction
+
   // utility function to word-align an input TL address
   // (SRAM is indexed at word granularity)
   function bit [TL_AW-1:0] word_align_addr(bit [TL_AW-1:0] addr);


### PR DESCRIPTION
1. Fixed data check in mem model didn't work
2. Moved updating exp mem write value after data phase is done, as the
2nd address may finish before the data phase of the 1st item when it
supports 2+ outstanding items
3. Avoided frontdoor checking read value if the location hasn't been
written (check against backdoor will be still applied)
4. Added knob for seq to initialize the mem and do it during sram_ctrl_init

Signed-off-by: Weicai Yang <weicai@google.com>