### PR TITLE
[mubi] Weaken mubi types to pass around bit vectors instead of an enum

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -27,11 +27,11 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   rand bit         regwen;
   rand bit [1:0]   rng_bit_sel;
 
-  rand prim_mubi_pkg::mubi4_t   enable, route_software, type_bypass,
+  rand prim_mubi_pkg::mubi4_e   enable, route_software, type_bypass,
                                 boot_bypass_disable, entropy_data_reg_enable,
                                 rng_bit_enable;
 
-  rand prim_mubi_pkg::mubi8_t   otp_en_es_fw_read, otp_en_es_fw_over;
+  rand prim_mubi_pkg::mubi8_e   otp_en_es_fw_read, otp_en_es_fw_over;
 
   // Constraints
   constraint c_regwen {regwen dist {

--- a/hw/ip/prim/rtl/prim_mubi_pkg.sv
+++ b/hw/ip/prim/rtl/prim_mubi_pkg.sv
@@ -12,9 +12,9 @@
 
 package prim_mubi_pkg;
 
-  //////////////////////////////////////////////
+  ///////////////////////////////////////
   // 4 Bit Multibit Type and Functions //
-  //////////////////////////////////////////////
+  ///////////////////////////////////////
 
   parameter int MuBi4Width = 4;
   typedef enum logic [MuBi4Width-1:0] {
@@ -29,7 +29,7 @@ package prim_mubi_pkg;
 
   // Convert a 1 input value to a mubi output
   function automatic mubi4_t mubi4_bool_to_mubi(logic val);
-    return (val ? MuBi4True : MuBi4False);
+    return val ? MuBi4True : MuBi4False;
   endfunction : mubi4_bool_to_mubi
 
   // Test whether the multibit value signals an "enabled" condition.
@@ -141,9 +141,9 @@ package prim_mubi_pkg;
     return mubi4_and(a, b, MuBi4False);
   endfunction : mubi4_and_lo
 
-  //////////////////////////////////////////////
+  ///////////////////////////////////////
   // 8 Bit Multibit Type and Functions //
-  //////////////////////////////////////////////
+  ///////////////////////////////////////
 
   parameter int MuBi8Width = 8;
   typedef enum logic [MuBi8Width-1:0] {
@@ -158,7 +158,7 @@ package prim_mubi_pkg;
 
   // Convert a 1 input value to a mubi output
   function automatic mubi8_t mubi8_bool_to_mubi(logic val);
-    return (val ? MuBi8True : MuBi8False);
+    return val ? MuBi8True : MuBi8False;
   endfunction : mubi8_bool_to_mubi
 
   // Test whether the multibit value signals an "enabled" condition.
@@ -270,9 +270,9 @@ package prim_mubi_pkg;
     return mubi8_and(a, b, MuBi8False);
   endfunction : mubi8_and_lo
 
-  //////////////////////////////////////////////
+  ////////////////////////////////////////
   // 12 Bit Multibit Type and Functions //
-  //////////////////////////////////////////////
+  ////////////////////////////////////////
 
   parameter int MuBi12Width = 12;
   typedef enum logic [MuBi12Width-1:0] {
@@ -287,7 +287,7 @@ package prim_mubi_pkg;
 
   // Convert a 1 input value to a mubi output
   function automatic mubi12_t mubi12_bool_to_mubi(logic val);
-    return (val ? MuBi12True : MuBi12False);
+    return val ? MuBi12True : MuBi12False;
   endfunction : mubi12_bool_to_mubi
 
   // Test whether the multibit value signals an "enabled" condition.
@@ -399,9 +399,9 @@ package prim_mubi_pkg;
     return mubi12_and(a, b, MuBi12False);
   endfunction : mubi12_and_lo
 
-  //////////////////////////////////////////////
+  ////////////////////////////////////////
   // 16 Bit Multibit Type and Functions //
-  //////////////////////////////////////////////
+  ////////////////////////////////////////
 
   parameter int MuBi16Width = 16;
   typedef enum logic [MuBi16Width-1:0] {
@@ -416,7 +416,7 @@ package prim_mubi_pkg;
 
   // Convert a 1 input value to a mubi output
   function automatic mubi16_t mubi16_bool_to_mubi(logic val);
-    return (val ? MuBi16True : MuBi16False);
+    return val ? MuBi16True : MuBi16False;
   endfunction : mubi16_bool_to_mubi
 
   // Test whether the multibit value signals an "enabled" condition.

--- a/hw/ip/prim/rtl/prim_mubi_pkg.sv
+++ b/hw/ip/prim/rtl/prim_mubi_pkg.sv
@@ -17,10 +17,16 @@ package prim_mubi_pkg;
   ///////////////////////////////////////
 
   parameter int MuBi4Width = 4;
+
+  // The enum holds the "good" values that we will use. For code in the rest of the design, use
+  // mubi4_t instead. This is a better representation of "4 bits that are hopefully
+  // one of the encoded bools".
   typedef enum logic [MuBi4Width-1:0] {
     MuBi4True = 4'hA, // enabled
     MuBi4False = 4'h5  // disabled
-  } mubi4_t;
+  } mubi4_e;
+
+  typedef logic [MuBi4Width-1:0] mubi4_t;
 
   // Test whether the value is supplied is one of the valid enumerations
   function automatic logic mubi4_test_invalid(mubi4_t val);
@@ -146,10 +152,16 @@ package prim_mubi_pkg;
   ///////////////////////////////////////
 
   parameter int MuBi8Width = 8;
+
+  // The enum holds the "good" values that we will use. For code in the rest of the design, use
+  // mubi8_t instead. This is a better representation of "8 bits that are hopefully
+  // one of the encoded bools".
   typedef enum logic [MuBi8Width-1:0] {
     MuBi8True = 8'h5A, // enabled
     MuBi8False = 8'hA5  // disabled
-  } mubi8_t;
+  } mubi8_e;
+
+  typedef logic [MuBi8Width-1:0] mubi8_t;
 
   // Test whether the value is supplied is one of the valid enumerations
   function automatic logic mubi8_test_invalid(mubi8_t val);
@@ -275,10 +287,16 @@ package prim_mubi_pkg;
   ////////////////////////////////////////
 
   parameter int MuBi12Width = 12;
+
+  // The enum holds the "good" values that we will use. For code in the rest of the design, use
+  // mubi12_t instead. This is a better representation of "12 bits that are hopefully
+  // one of the encoded bools".
   typedef enum logic [MuBi12Width-1:0] {
     MuBi12True = 12'hA5A, // enabled
     MuBi12False = 12'h5A5  // disabled
-  } mubi12_t;
+  } mubi12_e;
+
+  typedef logic [MuBi12Width-1:0] mubi12_t;
 
   // Test whether the value is supplied is one of the valid enumerations
   function automatic logic mubi12_test_invalid(mubi12_t val);
@@ -404,10 +422,16 @@ package prim_mubi_pkg;
   ////////////////////////////////////////
 
   parameter int MuBi16Width = 16;
+
+  // The enum holds the "good" values that we will use. For code in the rest of the design, use
+  // mubi16_t instead. This is a better representation of "16 bits that are hopefully
+  // one of the encoded bools".
   typedef enum logic [MuBi16Width-1:0] {
     MuBi16True = 16'h5A5A, // enabled
     MuBi16False = 16'hA5A5  // disabled
-  } mubi16_t;
+  } mubi16_e;
+
+  typedef logic [MuBi16Width-1:0] mubi16_t;
 
   // Test whether the value is supplied is one of the valid enumerations
   function automatic logic mubi16_test_invalid(mubi16_t val);

--- a/util/design/data/prim_mubi_pkg.sv.tpl
+++ b/util/design/data/prim_mubi_pkg.sv.tpl
@@ -28,6 +28,7 @@ from mubi import prim_mubi
    true_hex = f"{nbits}'h" + prim_mubi.mubi_value_as_hexstr(True, nbits)
    false_hex = f"{nbits}'h" + prim_mubi.mubi_value_as_hexstr(False, nbits)
 
+   enum_type = f'mubi{nbits}_e'
    mubi_type = f'mubi{nbits}_t'
    fun_pfx = f'mubi{nbits}_'
 
@@ -37,10 +38,16 @@ from mubi import prim_mubi
   ${box_slashes}
 
   parameter int ${MuBiWidth} = ${nbits};
+
+  // The enum holds the "good" values that we will use. For code in the rest of the design, use
+  // ${mubi_type} instead. This is a better representation of "${nbits} bits that are hopefully
+  // one of the encoded bools".
   typedef enum logic [${MuBiWidth}-1:0] {
     ${MuBiTrue} = ${true_hex}, // enabled
     ${MuBiFalse} = ${false_hex}  // disabled
-  } ${mubi_type};
+  } ${enum_type};
+
+  typedef logic [${MuBiWidth}-1:0] ${mubi_type};
 
   // Test whether the value is supplied is one of the valid enumerations
   function automatic logic ${fun_pfx}test_invalid(${mubi_type} val);

--- a/util/design/data/prim_mubi_pkg.sv.tpl
+++ b/util/design/data/prim_mubi_pkg.sv.tpl
@@ -18,54 +18,67 @@ from mubi import prim_mubi
 % for n in range(1, n_max_nibbles + 1):
 <%
    nbits = n * 4
-%>\
-  //////////////////////////////////////////////
-  // ${nbits} Bit Multibit Type and Functions //
-  //////////////////////////////////////////////
+   hdr = f'// {nbits} Bit Multibit Type and Functions //'
+   box_slashes = '/' * len(hdr)
 
-  parameter int MuBi${nbits}Width = ${nbits};
-  typedef enum logic [MuBi${nbits}Width-1:0] {
-    MuBi${nbits}True = ${nbits}'h${prim_mubi.mubi_value_as_hexstr(True, nbits)}, // enabled
-    MuBi${nbits}False = ${nbits}'h${prim_mubi.mubi_value_as_hexstr(False, nbits)}  // disabled
-  } mubi${nbits}_t;
+   MuBiWidth = f'MuBi{nbits}Width'
+   MuBiTrue = f'MuBi{nbits}True'
+   MuBiFalse = f'MuBi{nbits}False'
+
+   true_hex = f"{nbits}'h" + prim_mubi.mubi_value_as_hexstr(True, nbits)
+   false_hex = f"{nbits}'h" + prim_mubi.mubi_value_as_hexstr(False, nbits)
+
+   mubi_type = f'mubi{nbits}_t'
+   fun_pfx = f'mubi{nbits}_'
+
+%>\
+  ${box_slashes}
+  ${hdr}
+  ${box_slashes}
+
+  parameter int ${MuBiWidth} = ${nbits};
+  typedef enum logic [${MuBiWidth}-1:0] {
+    ${MuBiTrue} = ${true_hex}, // enabled
+    ${MuBiFalse} = ${false_hex}  // disabled
+  } ${mubi_type};
 
   // Test whether the value is supplied is one of the valid enumerations
-  function automatic logic mubi${nbits}_test_invalid(mubi${nbits}_t val);
-    return ~(val inside {MuBi${nbits}True, MuBi${nbits}False});
-  endfunction : mubi${nbits}_test_invalid
+  function automatic logic ${fun_pfx}test_invalid(${mubi_type} val);
+    return ~(val inside {${MuBiTrue}, ${MuBiFalse}});
+  endfunction : ${fun_pfx}test_invalid
 
   // Convert a 1 input value to a mubi output
-  function automatic mubi${nbits}_t mubi${nbits}_bool_to_mubi(logic val);
-    return (val ? MuBi${nbits}True : MuBi${nbits}False);
-  endfunction : mubi${nbits}_bool_to_mubi
+  function automatic ${mubi_type} ${fun_pfx}bool_to_mubi(logic val);
+    return val ? ${MuBiTrue} : ${MuBiFalse};
+  endfunction : ${fun_pfx}bool_to_mubi
 
   // Test whether the multibit value signals an "enabled" condition.
   // The strict version of this function requires
   // the multibit value to equal True.
-  function automatic logic mubi${nbits}_test_true_strict(mubi${nbits}_t val);
-    return MuBi${nbits}True == val;
-  endfunction : mubi${nbits}_test_true_strict
+  function automatic logic ${fun_pfx}test_true_strict(${mubi_type} val);
+    return ${MuBiTrue} == val;
+  endfunction : ${fun_pfx}test_true_strict
 
   // Test whether the multibit value signals a "disabled" condition.
   // The strict version of this function requires
   // the multibit value to equal False.
-  function automatic logic mubi${nbits}_test_false_strict(mubi${nbits}_t val);
-    return MuBi${nbits}False == val;
-  endfunction : mubi${nbits}_test_false_strict
+  function automatic logic ${fun_pfx}test_false_strict(${mubi_type} val);
+    return ${MuBiFalse} == val;
+  endfunction : ${fun_pfx}test_false_strict
 
   // Test whether the multibit value signals an "enabled" condition.
   // The loose version of this function interprets all
   // values other than False as "enabled".
-  function automatic logic mubi${nbits}_test_true_loose(mubi${nbits}_t val);
-    return MuBi${nbits}False != val;
-  endfunction : mubi${nbits}_test_true_loose
+  function automatic logic ${fun_pfx}test_true_loose(${mubi_type} val);
+    return ${MuBiFalse} != val;
+  endfunction : ${fun_pfx}test_true_loose
 
   // Test whether the multibit value signals a "disabled" condition.
   // The loose version of this function interprets all
   // values other than True as "disabled".
-  function automatic logic mubi${nbits}_test_false_loose(mubi${nbits}_t val);
-    return MuBi${nbits}True != val;
-  endfunction : mubi${nbits}_test_false_loose
+  function automatic logic ${fun_pfx}test_false_loose(${mubi_type} val);
+    return ${MuBiTrue} != val;
+  endfunction : ${fun_pfx}test_false_loose
 
 
   // Performs a logical OR operation between two multibit values.
@@ -79,20 +92,20 @@ from mubi import prim_mubi
   // !act | act  | act
   // act  | act  | act
   //
-  function automatic mubi${nbits}_t mubi${nbits}_or(mubi${nbits}_t a, mubi${nbits}_t b, mubi${nbits}_t act);
-    logic [MuBi${nbits}Width-1:0] a_in, b_in, act_in, out;
+  function automatic ${mubi_type} ${fun_pfx}or(${mubi_type} a, ${mubi_type} b, ${mubi_type} act);
+    logic [${MuBiWidth}-1:0] a_in, b_in, act_in, out;
     a_in = a;
     b_in = b;
     act_in = act;
-    for (int k = 0; k < MuBi${nbits}Width; k++) begin
+    for (int k = 0; k < ${MuBiWidth}; k++) begin
       if (act_in[k]) begin
         out[k] = a_in[k] || b_in[k];
       end else begin
         out[k] = a_in[k] && b_in[k];
       end
     end
-    return mubi${nbits}_t'(out);
-  endfunction : mubi${nbits}_or
+    return ${mubi_type}'(out);
+  endfunction : ${fun_pfx}or
 
   // Performs a logical AND operation between two multibit values.
   // This treats "act" as logical 1, and all other values are
@@ -105,48 +118,48 @@ from mubi import prim_mubi
   // !act | act  | !act
   // act  | act  | act
   //
-  function automatic mubi${nbits}_t mubi${nbits}_and(mubi${nbits}_t a, mubi${nbits}_t b, mubi${nbits}_t act);
-    logic [MuBi${nbits}Width-1:0] a_in, b_in, act_in, out;
+  function automatic ${mubi_type} ${fun_pfx}and(${mubi_type} a, ${mubi_type} b, ${mubi_type} act);
+    logic [${MuBiWidth}-1:0] a_in, b_in, act_in, out;
     a_in = a;
     b_in = b;
     act_in = act;
-    for (int k = 0; k < MuBi${nbits}Width; k++) begin
+    for (int k = 0; k < ${MuBiWidth}; k++) begin
       if (act_in[k]) begin
         out[k] = a_in[k] && b_in[k];
       end else begin
         out[k] = a_in[k] || b_in[k];
       end
     end
-    return mubi${nbits}_t'(out);
-  endfunction : mubi${nbits}_and
+    return ${mubi_type}'(out);
+  endfunction : ${fun_pfx}and
 
   // Performs a logical OR operation between two multibit values.
   // This treats "True" as logical 1, and all other values are
   // treated as 0.
-  function automatic mubi${nbits}_t mubi${nbits}_or_hi(mubi${nbits}_t a, mubi${nbits}_t b);
-    return mubi${nbits}_or(a, b, MuBi${nbits}True);
-  endfunction : mubi${nbits}_or_hi
+  function automatic ${mubi_type} ${fun_pfx}or_hi(${mubi_type} a, ${mubi_type} b);
+    return ${fun_pfx}or(a, b, ${MuBiTrue});
+  endfunction : ${fun_pfx}or_hi
 
   // Performs a logical AND operation between two multibit values.
   // This treats "True" as logical 1, and all other values are
   // treated as 0.
-  function automatic mubi${nbits}_t mubi${nbits}_and_hi(mubi${nbits}_t a, mubi${nbits}_t b);
-    return mubi${nbits}_and(a, b, MuBi${nbits}True);
-  endfunction : mubi${nbits}_and_hi
+  function automatic ${mubi_type} ${fun_pfx}and_hi(${mubi_type} a, ${mubi_type} b);
+    return ${fun_pfx}and(a, b, ${MuBiTrue});
+  endfunction : ${fun_pfx}and_hi
 
   // Performs a logical OR operation between two multibit values.
   // This treats "False" as logical 1, and all other values are
   // treated as 0.
-  function automatic mubi${nbits}_t mubi${nbits}_or_lo(mubi${nbits}_t a, mubi${nbits}_t b);
-    return mubi${nbits}_or(a, b, MuBi${nbits}False);
-  endfunction : mubi${nbits}_or_lo
+  function automatic ${mubi_type} ${fun_pfx}or_lo(${mubi_type} a, ${mubi_type} b);
+    return ${fun_pfx}or(a, b, ${MuBiFalse});
+  endfunction : ${fun_pfx}or_lo
 
   // Performs a logical AND operation between two multibit values.
   // Tlos treats "False" as logical 1, and all other values are
   // treated as 0.
-  function automatic mubi${nbits}_t mubi${nbits}_and_lo(mubi${nbits}_t a, mubi${nbits}_t b);
-    return mubi${nbits}_and(a, b, MuBi${nbits}False);
-  endfunction : mubi${nbits}_and_lo
+  function automatic ${mubi_type} ${fun_pfx}and_lo(${mubi_type} a, ${mubi_type} b);
+    return ${fun_pfx}and(a, b, ${MuBiFalse});
+  endfunction : ${fun_pfx}and_lo
 
 % endfor
 endpackage : prim_mubi_pkg


### PR DESCRIPTION
This patch was originally motivated by the irritation of casting
between bit vectors and the enum type. But it turns out there's a
better reason for doing it: the IEEE spec is very vague about whether
a variable of an enum type can contain values other than the enum
values and, if so, what happens. (For anyone who wants to read along,
the Enumerations section is 6.19 of IEEE 1800-2017, and the only
discussion of this values is at the end of 6.19.5, where an
"out-of-range" value is assigned: whatever that means!)

In practice, I suspect that any sensible tool will just treat e.g. the
old `mubi4_t` as a "`logic [3:0]`", together with a pair of helpful named
values. However, I'm not sure it's actually guaranteed by the
standard, nor was the exact behaviour of a `mubi4_t'(...)` when the
inputs are bogus.

Rather than worrying about such things, let's just use bit
vectors (since that's how we're thinking about these possibly-slippery
objects anyway!). What we'd probably *really* like is akin to
Haskell's "newtype"s, where you'd have an n-bit type that's
interconvertible with an n-bit vector, but needs explicit casts.
Unfortunately, SystemVerilog doesn't support that sort of thing.

Existing code shouldn't need any changes, although it will now have
some unnecessary type-casts. And we can now be sure that an
enthusiastic technically-standards-compliant synthesis tool won't undo
all our hard work!
