### PR TITLE
[rom_ctrl] Correctly wire up fatal alerts from bus integrity errors

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -375,7 +375,7 @@ module rom_ctrl
                                   reg2hw.alert_test.qe;
 
   logic [NumAlerts-1:0] alerts;
-  assign alerts[AlertFatal] = reg_integrity_error | checker_alert | mux_alert;
+  assign alerts[AlertFatal] = bus_integrity_error | checker_alert | mux_alert;
 
   for (genvar i = 0; i < NumAlerts; i++) begin: gen_alert_tx
     prim_alert_sender #(


### PR DESCRIPTION
Way back in April (da74794), I fixed up the connections so that
`FATAL_ALERT_CAUSE` would reflect a bus integrity error even when it
didn't come from the register interface. Unfortunately, I didn't make
the corresponding change in the trigger for the alert itself. Oops.

Caught by Prajwala debugging failures in the `tl_intg_err` tests. Nice!
