### PR TITLE
[kmac/entropy_src] sparse fsm encoding (8982)

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -329,4 +329,13 @@ module entropy_src
     u_entropy_src_core.u_entropy_src_ack_sm.u_state_regs,
     alert_tx_o[1])
 
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(SHA3FsmCheck_A,
+    u_entropy_src_core.u_sha3.u_state_regs, alert_tx_o[1])
+
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(KeccakRoundFsmCheck_A,
+    u_entropy_src_core.u_sha3.u_keccak.u_state_regs, alert_tx_o[1])
+
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(SHA3padFsmCheck_A,
+    u_entropy_src_core.u_sha3.u_pad.u_state_regs, alert_tx_o[1])
+
 endmodule

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -367,7 +367,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     sha3_done;
   logic                     sha3_absorbed;
   logic                     sha3_squeezing;
-  logic [2:0]               sha3_fsm;
+ // logic [sha3_pkg::StateWidth-1:0] sha3_fsm;
   logic [32:0]              sha3_err;
   logic                     cs_aes_halt_req;
   logic                     sha3_msg_rdy;
@@ -390,6 +390,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                    unused_sha3_state;
   logic                    unused_entropy_data;
   logic                    unused_fw_ov_rd_data;
+
+  logic                    sha3_state_error;
 
   // flops
   logic [RngBusWidth-1:0] ht_esbus_dly_q, ht_esbus_dly_d;
@@ -572,7 +574,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
                                              sfifo_esfinal_err_sum ||
                                              es_ack_sm_err_sum ||
                                              es_main_sm_err_sum)) ||
-                                             es_cntr_err_sum; // prim_count err is always active
+                                             es_cntr_err_sum || // prim_count err is always active
+                                             sha3_state_error;
 
   // set fifo errors that are single instances of source
   assign sfifo_esrng_err_sum = (|sfifo_esrng_err) ||
@@ -654,7 +657,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   // set the debug status reg
   assign hw2reg.debug_status.entropy_fifo_depth.d = sfifo_esfinal_depth;
-  assign hw2reg.debug_status.sha3_fsm.d = sha3_fsm;
+  assign hw2reg.debug_status.sha3_fsm.d = '0;
   assign hw2reg.debug_status.sha3_block_pr.d = sha3_block_processed;
   assign hw2reg.debug_status.sha3_squeezing.d = sha3_squeezing;
   assign hw2reg.debug_status.sha3_absorbed.d = sha3_absorbed;
@@ -2074,12 +2077,14 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
     .block_processed_o (sha3_block_processed),
 
-    .sha3_fsm_o (sha3_fsm),
+   // .sha3_fsm_o (sha3_fsm),
+    .sha3_fsm_o(),
 
     .state_valid_o (sha3_state_vld),
     .state_o       (sha3_state),
 
-    .error_o (sha3_err)
+    .error_o (sha3_err),
+    .sparse_fsm_error_o (sha3_state_error)
   );
 
 

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -367,7 +367,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     sha3_done;
   logic                     sha3_absorbed;
   logic                     sha3_squeezing;
- // logic [sha3_pkg::StateWidth-1:0] sha3_fsm;
+  logic [2:0]               sha3_fsm;
   logic [32:0]              sha3_err;
   logic                     cs_aes_halt_req;
   logic                     sha3_msg_rdy;
@@ -657,7 +657,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   // set the debug status reg
   assign hw2reg.debug_status.entropy_fifo_depth.d = sfifo_esfinal_depth;
-  assign hw2reg.debug_status.sha3_fsm.d = '0;
+  assign hw2reg.debug_status.sha3_fsm.d = sha3_fsm;
   assign hw2reg.debug_status.sha3_block_pr.d = sha3_block_processed;
   assign hw2reg.debug_status.sha3_squeezing.d = sha3_squeezing;
   assign hw2reg.debug_status.sha3_absorbed.d = sha3_absorbed;
@@ -2077,8 +2077,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
     .block_processed_o (sha3_block_processed),
 
-   // .sha3_fsm_o (sha3_fsm),
-    .sha3_fsm_o(),
+    .sha3_fsm_o (sha3_fsm),
 
     .state_valid_o (sha3_state_vld),
     .state_o       (sha3_state),

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:arbiter
       - lowrisc:prim:lfsr
       - lowrisc:prim:assert
+      - lowrisc:prim:sparse_fsm
       - lowrisc:ip:tlul
       - lowrisc:ip:keymgr_pkg
       - lowrisc:ip:sha3

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -129,44 +129,71 @@ module keccak_round #(
   // state inputs
   assign rnd_eq_end = (int'(round) == MaxRound - 1);
 
-  typedef enum logic [2:0] {
-      StIdle,
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 6 -n 6 \
+  //      -s 1363425333 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||||||||||| (53.33%)
+  //  4: ||||||||||||||| (40.00%)
+  //  5: || (6.67%)
+  //  6: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 5
+  // Minimum Hamming weight: 1
+  // Maximum Hamming weight: 5
+  //
+  localparam int StateWidth = 6;
+  typedef enum logic [StateWidth-1:0] {
+      StIdle = 6'b100010,
 
       // Active state is used in Unmasked version only.
       // It handles keccak round in a cycle
-      StActive,
+      StActive = 6'b111101,
 
       // Phase1 --> Phase2 --> Phase3
       // Activated only in Masked version.
       // Phase1 processes Theta, Rho, Pi steps in a cycle and stores the states
       // into storage. It unconditionally moves to Phase2.
-      StPhase1,
+      StPhase1 = 6'b011011,
 
       // First half part of Chi step. It waits random value is ready
       // then move to Phase 3.
-      StPhase2,
+      StPhase2 = 6'b000111,
 
       // Second half of Chi step and Iota step.
       // This state doesn't require random value as it is XORed into the states
       // in Phase2. If round is reached to the end (MaxRound -1) then it
       // completes the process and goes back to Idle. If not, repeats the Phase
       // again.
-      StPhase3,
+      StPhase3 = 6'b001000,
 
       // Error state. Not clearly defined yet.
       // Intention is if any unexpected input in the process, state moves to
       // here and report through the error fifo with debugging information.
-      StError
+      StError = 6'b010100
   } keccak_st_e;
   keccak_st_e keccak_st, keccak_st_d;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      keccak_st <= StIdle;
-    end else begin
-      keccak_st <= keccak_st_d;
-    end
-  end
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign keccak_st = keccak_st_e'(state_raw_q);
+  prim_sparse_fsm_flop #(
+    .StateEnumT(keccak_st_e),
+    .Width(StateWidth),
+    .ResetValue(StateWidth'(StIdle))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .state_i ( keccak_st_d ),
+    .state_o ( state_raw_q )
+  );
 
   // Next state logic and output logic
   always_comb begin
@@ -272,6 +299,7 @@ module keccak_round #(
 
       default: begin
         keccak_st_d = StError;
+        //ToDO: alert signal?
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -51,6 +51,8 @@ module keccak_round #(
   // State out. This can be used as Digest
   output logic [Width-1:0] state_o [Share],
 
+  output logic             sparse_fsm_error_o,
+
   input                    clear_i     // Clear internal state to '0
 );
 
@@ -213,6 +215,8 @@ module keccak_round #(
 
     complete_d = 1'b 0;
 
+    sparse_fsm_error_o = 1'b 0;
+
     unique case (keccak_st)
       StIdle: begin
         if (valid_i) begin
@@ -294,12 +298,13 @@ module keccak_round #(
       end
 
       StError: begin
-        keccak_st_d = StIdle;
+        keccak_st_d = StError;
+        sparse_fsm_error_o = 1'b 1;
       end
 
       default: begin
         keccak_st_d = StError;
-        //ToDO: alert signal?
+        sparse_fsm_error_o = 1'b 1;
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -299,11 +299,11 @@ module keccak_round #(
 
       StError: begin
         keccak_st_d = StError;
-        sparse_fsm_error_o = 1'b 1;
       end
 
       default: begin
-        keccak_st_d = StError;
+        //this state is terminal
+        keccak_st_d = keccak_st;
         sparse_fsm_error_o = 1'b 1;
       end
     endcase

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -81,21 +81,41 @@ module kmac
   /////////////////
   // This state machine is to track the current process based on SW input and
   // KMAC operation.
-  typedef enum logic [2:0] {
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 5 -n 6 \
+  //      -s 4015776642 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||||||||||| (50.00%)
+  //  4: |||||||||||||||| (40.00%)
+  //  5: |||| (10.00%)
+  //  6: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 5
+  // Minimum Hamming weight: 1
+  // Maximum Hamming weight: 5
+  //
+  localparam int StateWidth = 6;
+  typedef enum logic [StateWidth-1:0] {
     // Idle state
-    KmacIdle,
+    KmacIdle = 6'b001000,
 
     // When software writes CmdStart @ KmacIdle and kmac_en, FSM moves to this
-    KmacPrefix,
+    KmacPrefix = 6'b100110,
 
     // When SHA3 engine processes Key block, FSM moves to here.
-    KmacKeyBlock,
+    KmacKeyBlock = 6'b111101,
 
     // Message Feed
-    KmacMsgFeed,
+    KmacMsgFeed = 6'b010010,
 
     // Complete and squeeze
-    KmacDigest
+    KmacDigest = 6'b100001
 
   } kmac_st_e;
   kmac_st_e kmac_st, kmac_st_d;
@@ -586,12 +606,13 @@ module kmac
   logic sparse_fsm_error;
   logic sha3_state_error, kmac_errchk_state_error;
   logic kmac_core_state_error, kmac_app_state_error;
-  logic kmac_entropy_state_error;
+  logic kmac_entropy_state_error, kmac_state_error;
   assign sparse_fsm_error = sha3_state_error
                           | kmac_errchk_state_error
                           | kmac_core_state_error
                           | kmac_app_state_error
-                          | kmac_entropy_state_error;
+                          | kmac_entropy_state_error
+                          | kmac_state_error;
 
   prim_intr_hw #(.Width(1)) intr_kmac_err (
     .clk_i,
@@ -610,19 +631,26 @@ module kmac
   // State Machine //
   ///////////////////
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      kmac_st <= KmacIdle;
-    end else begin
-      kmac_st <= kmac_st_d;
-    end
-  end
+  // State FF
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  prim_sparse_fsm_flop #(
+    .StateEnumT(kmac_st_e),
+    .Width(StateWidth),
+    .ResetValue(StateWidth'(KmacIdle))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .state_i ( kmac_st_d ),
+    .state_o ( kmac_st   )
+  );
 
   always_comb begin
     // Default value
     kmac_st_d = KmacIdle;
 
     entropy_in_keyblock = 1'b 0;
+    kmac_state_error = 1'b 0;
 
     unique case (kmac_st)
       KmacIdle: begin
@@ -681,7 +709,9 @@ module kmac
       end
 
       default: begin
-        kmac_st_d = KmacIdle;
+        //this state is terminal
+        kmac_st_d = kmac_st;
+        kmac_state_error = 1'b 1;
       end
     endcase
   end
@@ -1213,6 +1243,7 @@ module kmac
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(KeccackFsmCheck_A, u_sha3.u_keccak.u_state_regs,
                                        alert_tx_o[0])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(ErrorCheckFsmCheck_A, u_errchk.u_state_regs, alert_tx_o[0])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(KmacFsmCheck_A, u_state_regs, alert_tx_o[0])
 
   // prim is only instantiated if masking is enabled
   if (EnMasking == 1) begin : g_testassertion

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -104,7 +104,9 @@ module kmac_app
   input err_processed_i,
 
   // error_o value is pushed to Error FIFO at KMAC/SHA3 top and reported to SW
-  output kmac_pkg::err_t error_o
+  output kmac_pkg::err_t error_o,
+
+  output logic sparse_fsm_error_o
 );
 
   /////////////////
@@ -374,6 +376,7 @@ module kmac_app
 
     // Error
     fsm_err = '{valid: 1'b 0, code: ErrNone, info: '0};
+    sparse_fsm_error_o = 1'b 0;
 
     // If error happens, FSM asserts data ready but discard incoming msg
     fsm_data_ready = 1'b 0;
@@ -498,7 +501,8 @@ module kmac_app
       end
 
       default: begin
-        st_d = StIdle;
+        sparse_fsm_error_o = 1'b 1;
+        st_d = StError;
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -501,8 +501,9 @@ module kmac_app
       end
 
       default: begin
+        // this state is terminal
+        st_d = st;
         sparse_fsm_error_o = 1'b 1;
-        st_d = StError;
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -341,16 +341,19 @@ module kmac_app
   /////////
 
   // State register
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
   logic [StateWidth-1:0] st_raw;
   assign st = st_e'(st_raw);
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(st_e),
     .Width      (StateWidth),
     .ResetValue (StateWidth'(StIdle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( st_d   ),
-    .q_o ( st_raw )
+    .state_i ( st_d   ),
+    .state_o ( st_raw )
   );
 
   // Next State & output logic

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -224,7 +224,8 @@ module kmac_core
       end
 
       default: begin
-        st_d = StKmacIdle;
+        // this state is terminal
+        st_d = st;
         sparse_fsm_error_o = 1'b 1;
       end
     endcase

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -47,7 +47,9 @@ module kmac_core
   input done_i,
 
   // Control to SHA3 core
-  output logic process_o
+  output logic process_o,
+
+  output logic sparse_fsm_error_o
 );
 
   import sha3_pkg::KeccakMsgAddrW;
@@ -173,6 +175,8 @@ module kmac_core
     kmac_valid = 1'b 0;
     kmac_process = 1'b 0;
 
+    sparse_fsm_error_o = 1'b 0;
+
     unique case (st)
       StKmacIdle: begin
         if (kmac_en_i && start_i) begin
@@ -221,7 +225,7 @@ module kmac_core
 
       default: begin
         st_d = StKmacIdle;
-        //ToDO add alert
+        sparse_fsm_error_o = 1'b 1;
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -58,6 +58,7 @@ module kmac_entropy
 
   // Error output
   output err_t err_o,
+  output logic sparse_fsm_error_o,
   input        err_processed_i
 );
 
@@ -392,6 +393,7 @@ module kmac_entropy
   // State: Next State and Output Logic
   always_comb begin
     st_d = StRandReset;
+    sparse_fsm_error_o = 1'b 0;
 
     // Default Timer values
     timer_enable = 1'b 0;
@@ -592,6 +594,7 @@ module kmac_entropy
 
       default: begin
         st_d = StRandReset;
+        sparse_fsm_error_o = 1'b 1;
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -376,14 +376,17 @@ module kmac_entropy
   assign st = rand_st_e'(st_raw_q);
 
   // State FF
-  prim_flop #(
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  prim_sparse_fsm_flop #(
+    .StateEnumT(rand_st_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(StRandReset))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( st_d     ),
-    .q_o ( st_raw_q )
+    .state_i ( st_d     ),
+    .state_o ( st_raw_q )
   );
 
   // State: Next State and Output Logic

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -593,7 +593,8 @@ module kmac_entropy
       end
 
       default: begin
-        st_d = StRandReset;
+        // this state is terminal
+        st_d = st;
         sparse_fsm_error_o = 1'b 1;
       end
     endcase

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -115,6 +115,18 @@ module kmac_errchk
   } st_e;
   st_e st, st_d;
 
+  localparam int StateWidthL = 3;
+  typedef enum logic [StateWidthL-1:0] {
+    StIdleL,
+    StMsgFeedL,
+    StProcessingL,
+    StAbsorbedL,
+    StSqueezingL,
+    StErrorL
+  } st_logical_e;
+  st_logical_e stL;
+
+
   /////////////
   // Signals //
   /////////////
@@ -216,6 +228,16 @@ module kmac_errchk
     end
   end : check_prefix
 
+  always_comb begin : recode_st
+    unique case (st)
+      StIdle       : stL = StIdleL;
+      StMsgFeed    : stL = StMsgFeedL;
+      StProcessing : stL = StProcessingL;
+      StAbsorbed   : stL = StAbsorbedL;
+      StSqueezing  : stL = StSqueezingL;
+      default      : stL = StErrorL;
+    endcase
+  end : recode_st
 
   // Return error code
   err_t err;
@@ -228,7 +250,8 @@ module kmac_errchk
                  code: ErrSwCmdSequence,
                  info: {5'h0,
                         {err_swsequence, err_modestrength, err_prefix},
-                        {6'b0, st, sw_cmd_i}
+                        8'h 0,
+                        {1'b0, stL, sw_cmd_i}
                        }
                };
       end

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -67,7 +67,8 @@ module kmac_errchk
   input sha3_absorbed_i,
   input keccak_done_i,
 
-  output err_t error_o
+  output err_t error_o,
+  output logic sparse_fsm_error_o
 );
 
   // sha3_pkg::sha3_mode_e
@@ -138,6 +139,7 @@ module kmac_errchk
   // info field: Current state, Received command
   always_comb begin
     err_swsequence = 1'b 0;
+    sparse_fsm_error_o = 1'b 0;
 
     unique case (st)
       StIdle: begin
@@ -175,6 +177,7 @@ module kmac_errchk
 
       default: begin
         err_swsequence = 1'b 0;
+        sparse_fsm_error_o = 1'b 1;
       end
     endcase
   end

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -351,8 +351,8 @@ module kmac_errchk
       end
 
       default: begin
-        st_d = StIdle;
-        //ToDo: add alert
+        // this state is terminal
+        st_d = st;
       end
     endcase
   end : next_state

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -165,10 +165,21 @@ module sha3
   ///////////////////
 
   // State Register
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) st <= StIdle;
-    else         st <= st_d;
-  end
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  logic [StateWidth-1:0] state_raw_q;
+  assign st = sha3_st_e'(state_raw_q);
+  prim_sparse_fsm_flop #(
+    .StateEnumT(sha3_st_e),
+    .Width(StateWidth),
+    .ResetValue(StateWidth'(StIdle))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .state_i ( st_d        ),
+    .state_o ( state_raw_q )
+  );
+
 
   // Next State and Output Logic
   // Mainly the FSM controls the input signal access
@@ -246,6 +257,7 @@ module sha3
 
       default: begin
         st_d = StIdle;
+        //TODO error
       end
 
     endcase

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -269,7 +269,8 @@ module sha3
       end
 
       default: begin
-        st_d = StIdle_sparse;
+        //this state is terminal
+        st_d = st;
         sha3_state_error = 1'b 1;
       end
 

--- a/hw/ip/kmac/rtl/sha3_pkg.sv
+++ b/hw/ip/kmac/rtl/sha3_pkg.sv
@@ -100,15 +100,35 @@ package sha3_pkg;
   // SHA3 core state. This state value is used in sha3core module
   // and also in KMAC top module and the register interface for sw to track the
   // sha3 status.
-  typedef enum logic [2:0] {
-    StIdle,
+  // Encoding generated with:
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 6 -n 6 \
+  //      -s 4082450958 --language=sv
+  //
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: |||||||||||||||||||| (53.33%)
+  //  4: ||||||||||||||| (40.00%)
+  //  5: || (6.67%)
+  //  6: --
+  //
+  // Minimum Hamming distance: 3
+  // Maximum Hamming distance: 5
+  // Minimum Hamming weight: 2
+  // Maximum Hamming weight: 5
+  //
+  localparam int StateWidth = 6;
+  typedef enum logic [StateWidth-1:0] {
+    StIdle = 6'b101100,
 
     // Absorb stage receives the message bitstream and computes the keccak
     // rounds. This internal operation is mainly done inside sha3pad module
     // not sha3core. The core module and this state machine observe the status
     // of the process and mainly waits until all the sponge absorbing is
     // completed. The main indicator is `absorbed` signal.
-    StAbsorb,
+    StAbsorb = 6'b100111,
 
     // TODO: Implement StAbort later after context-switching discussion.
     // Abort stage can be moved from StAbsorb stage. It basically holds the
@@ -116,23 +136,23 @@ package sha3_pkg;
     // software. This stage is for the software to pause current operation and
     // store the internal state elsewhere then initiates new KMAC/SHA3 process.
     // StAbort only can be moved to _StFlush_.
-    //StAbort,
+    //StAbort = 6'b110000,
 
     // Squeeze stage allows the software to read the internal state.
     // If `EnMasking`, it opens the read permission of two share of the state.
     // The squeezing in SHA3 specification describes the software to read up to
     // the rate of SHA3 algorithm but this logic opens up the entire 1600 bits
     // of the state (3200bits if `EnMasking`).
-    StSqueeze,
+    StSqueeze = 6'b001010,
 
     // ManualRun stage initiaties the keccak round and waits the completion.
     // This state is moved from Squeeze state by writing 1 to manual_run CSR.
     // When keccak round is completed, it goes back to Squeeze state.
-    StManualRun,
+    StManualRun = 6'b111011,
 
     // Flush stage, the core clears out the internal variables and also
     // submodules' variables too. Then moves back to Idle state.
-    StFlush
+    StFlush =  6'b010101
   } sha3_st_e;
 
   //////////////////

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -463,7 +463,8 @@ module sha3pad
       end
 
       default: begin
-        st_d = StPadIdle;
+        // this state is terminal
+        st_d = st;
         sparse_fsm_error_o = 1'b 1;
       end
 

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -60,7 +60,10 @@ module sha3pad
   // Indication of the Keccak Sponge Absorbing is complete, it is time for SW to
   // control the Keccak-round if it needs more digest, or complete by asserting
   // `done_i`
-  output logic absorbed_o
+  output logic absorbed_o,
+
+  // Indication that there was a fault in the sparse encoding
+  output logic sparse_fsm_error_o
 );
 
   /////////////////
@@ -298,6 +301,8 @@ module sha3pad
 
     absorbed_d = 1'b 0;
 
+    sparse_fsm_error_o = 1'b 0;
+
     unique case (st)
 
       // In Idle state, the FSM checks if the software (or upper FSM) initiates
@@ -459,6 +464,7 @@ module sha3pad
 
       default: begin
         st_d = StPadIdle;
+        sparse_fsm_error_o = 1'b 1;
       end
 
     endcase


### PR DESCRIPTION
This PR addresses the sparse encoding of the FSM in #8982 
It also partially addresses #9447 