### PR TITLE
[otbn,dv] Bug-fix: First Insn uses faulty URND

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -137,6 +137,7 @@ class OTBNSim:
             self.state.ext_regs.write('INSN_CNT', 0, True)
             return (None, changes)
 
+        self.state.wsrs.URND.commit()
         self.state.wsrs.URND.step()
 
         if self.state.fsm_state == FsmState.POST_EXEC:

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -160,6 +160,7 @@ class URNDWSR(WSR):
                       4 * [0], 4 * [0]]
         self.out = 4 * [0]
         self._next_value = None  # type: Optional[int]
+        self._value = None  # type: Optional[int]
         self.running = False
 
     # Function to left rotate a 64b number n by d bits
@@ -175,6 +176,7 @@ class URNDWSR(WSR):
         return
 
     def read_unsigned(self) -> int:
+        assert self._value is not None
         return self._value
 
     def state_update(self, data_in: List[int]) -> List[int]:


### PR DESCRIPTION
The bug was happening when the first executed
instruction tried to use `URND`. Since first step
did not resulted with a change in `_value` it was
generating a None assignment.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>