### PR TITLE
[rom_ctrl, dv] Fix for rom_ctrl_tl_errors regression failures

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_scoreboard.sv
@@ -185,6 +185,14 @@ class rom_ctrl_scoreboard extends cip_base_scoreboard #(
       return;
     end
 
+    // if access was to a valid csr, get the csr handle
+    if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
+      csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
+      `DV_CHECK_NE_FATAL(csr, null)
+    end else begin
+      `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
+    end
+
     // If we get here, then the access was on the register channel. If it was to an invalid CSR,
     // there's nothing more to do. The base classes should already predict an error response.
     if (csr == null)


### PR DESCRIPTION
Following changes are made in this commit:
1. cip_base_vseq__tl_errors: Dafault sequencer has been removed in
create_tl_access_error_case as it introduced unwanted bugs by running on
default sequencer.
tl_write_ro_mem_err is made to run on corresponding RAL model's
sequencer
2. rom_ctrl_scoreboard: If an invalid address is picked, the scoreboard
is taught not to generate errors.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>