### PR TITLE
Non-homogeneous multiregs

### DIFF
--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -244,20 +244,17 @@ def gen_cdefines_module_params(outstr: TextIO,
 
 def gen_multireg_field_defines(outstr: TextIO,
                                regname: str,
-                               field: Field,
+                               fields: List[Field],
                                subreg_num: int,
                                regwidth: int,
                                existing_defines: Set[str]) -> None:
-    field_width = field.bits.width()
-    fields_per_reg = regwidth // field_width
 
-    define_name = regname + '_' + as_define(field.name + "_FIELD_WIDTH")
-    define = gen_define(define_name, [], str(field_width), existing_defines)
-    genout(outstr, define)
+    for each_field in fields:
+        field_width = each_field.bits.width()
 
-    define_name = regname + '_' + as_define(field.name + "_FIELDS_PER_REG")
-    define = gen_define(define_name, [], str(fields_per_reg), existing_defines)
-    genout(outstr, define)
+        define_name = regname + '_' + as_define(each_field.name + "_FIELD_WIDTH")
+        define = gen_define(define_name, [], str(field_width), existing_defines)
+        genout(outstr, define)
 
     define_name = regname + "_MULTIREG_COUNT"
     define = gen_define(define_name, [], str(subreg_num), existing_defines)
@@ -274,12 +271,12 @@ def gen_cdefine_multireg(outstr: TextIO,
                          existing_defines: Set[str]) -> None:
     comment = multireg.reg.desc + " (common parameters)"
     genout(outstr, format_comment(first_line(comment)))
-    if len(multireg.reg.fields) == 1:
+    if len(multireg.reg.fields) >= 1:
         regname = as_define(component + '_' + multireg.reg.name)
-        gen_multireg_field_defines(outstr, regname, multireg.reg.fields[0],
+        gen_multireg_field_defines(outstr, regname, multireg.reg.fields,
                                    len(multireg.regs), regwidth, existing_defines)
     else:
-        log.warn("Non-homogeneous multireg " + multireg.reg.name +
+        log.warn("Fieldless multireg " + multireg.reg.name +
                  " skip multireg specific data generation.")
 
     for subreg in multireg.regs:


### PR DESCRIPTION
I ran into a couple problems chasing a non-homogeneous multireg warning and doing my best to solve it. We can generate the fileds that are being properly generated anyway. I don't generate the NUMBER_OF_*_PER_REG fields because even homogeneous multiregs don't appear to uniformly fill registers with as many copies of a field that will fit most of the time (which is what the code appears to have assumed was the behavior.) 

I was making the lowest impact edit I could and I didn't find any evidence that we intended to avoid non-homogeneous multiregs in the future.