### PR TITLE
[hw,uart] Change the uart0 pins 

### DIFF
--- a/hw/top_earlgrey/data/pins_cw310.xdc
+++ b/hw/top_earlgrey/data/pins_cw310.xdc
@@ -63,13 +63,13 @@ set_property -dict { PACKAGE_PIN AE11 IOSTANDARD LVCMOS18 } [get_ports { SPI_HOS
 
 ## OTHER IO
 set_property -dict { PACKAGE_PIN A8  IOSTANDARD LVCMOS33 } [get_ports { IOC2 }]; #USERIOB-9
-set_property -dict { PACKAGE_PIN B9  IOSTANDARD LVCMOS33 } [get_ports { IOC3 }]; #USERIOB-11
-set_property -dict { PACKAGE_PIN A9  IOSTANDARD LVCMOS33 } [get_ports { IOC4 }]; #USERIOB-15
 set_property -dict { PACKAGE_PIN E10 IOSTANDARD LVCMOS33 } [get_ports { IOC5 }]; #USERIOB-14
 set_property -dict { PACKAGE_PIN D8  IOSTANDARD LVCMOS33 } [get_ports { IOC6 }]; #USERIOB-16
 set_property -dict { PACKAGE_PIN D9  IOSTANDARD LVCMOS33 } [get_ports { IOC7 }]; #USERIOB-18
 #set_property -dict { PACKAGE_PIN C9  IOSTANDARD LVCMOS33 } [get_ports { IOC8 }]; #USERIOB-24
 #set_property -dict { PACKAGE_PIN D10 IOSTANDARD LVCMOS33 } [get_ports { IOC9 }]; #USERIOB-26
+set_property -dict { PACKAGE_PIN B9  IOSTANDARD LVCMOS33 } [get_ports { IOC10 }]; #USERIOB-11
+set_property -dict { PACKAGE_PIN A9  IOSTANDARD LVCMOS33 } [get_ports { IOC11 }]; #USERIOB-15
 
 ## ChipWhisperer 20-Pin Connector (J14)
 set_property -dict { PACKAGE_PIN AF25 IOSTANDARD LVCMOS33 } [get_ports { IOC9 }];       #J14 PIN 12 CWIO_IO2 - OpenTitan UART1 TX
@@ -97,8 +97,8 @@ set_property -dict { PACKAGE_PIN A12   IOSTANDARD LVCMOS33 } [get_ports { IO_USB
 set_property -dict { PACKAGE_PIN A13   IOSTANDARD LVCMOS33 } [get_ports { IO_USB_DPPULLUP0 }]; #USERIOB-27
 
 ## UART
-set_property -dict { PACKAGE_PIN AA22 IOSTANDARD LVCMOS33 } [get_ports { IOC11 }]; #UART1RXD - OpenTitan UART0 TX
-set_property -dict { PACKAGE_PIN W24  IOSTANDARD LVCMOS33 } [get_ports { IOC10 }]; #UART1TXD - OpenTitan UART0 RX
+set_property -dict { PACKAGE_PIN AA22 IOSTANDARD LVCMOS33 } [get_ports { IOC4 }]; #UART1RXD - OpenTitan UART0 TX
+set_property -dict { PACKAGE_PIN W24  IOSTANDARD LVCMOS33 } [get_ports { IOC3 }]; #UART1TXD - OpenTitan UART0 RX
 
 ## Configuration options, can be used for all designs
 set_property CONFIG_VOLTAGE 3.3 [current_design]

--- a/hw/top_earlgrey/data/pins_nexysvideo.xdc
+++ b/hw/top_earlgrey/data/pins_nexysvideo.xdc
@@ -116,13 +116,13 @@ set_property -dict { PACKAGE_PIN M17  IOSTANDARD LVCMOS12 } [get_ports { IOA7 }]
 
 ## Pmod header JA
 set_property -dict { PACKAGE_PIN AB22  IOSTANDARD LVCMOS33 } [get_ports { IOC2 }]; #IO_L10N_T1_D15_14 Sch=ja[1]
-set_property -dict { PACKAGE_PIN AB21  IOSTANDARD LVCMOS33 } [get_ports { IOC3 }]; #IO_L10P_T1_D14_14 Sch=ja[2]
-set_property -dict { PACKAGE_PIN AB20  IOSTANDARD LVCMOS33 } [get_ports { IOC4 }]; #IO_L15N_T2_DQS_DOUT_CSO_B_14 Sch=ja[3]
 set_property -dict { PACKAGE_PIN AB18  IOSTANDARD LVCMOS33 } [get_ports { IOC5 }]; #IO_L17N_T2_A13_D29_14 Sch=ja[4]
 set_property -dict { PACKAGE_PIN Y21   IOSTANDARD LVCMOS33 } [get_ports { IOC6 }]; #IO_L9P_T1_DQS_14 Sch=ja[7]
 set_property -dict { PACKAGE_PIN AA21  IOSTANDARD LVCMOS33 } [get_ports { IOC7 }]; #IO_L8N_T1_D12_14 Sch=ja[8]
 set_property -dict { PACKAGE_PIN AA20  IOSTANDARD LVCMOS33 } [get_ports { IOC8 }]; #IO_L8P_T1_D11_14 Sch=ja[9]
 set_property -dict { PACKAGE_PIN AA18  IOSTANDARD LVCMOS33 } [get_ports { IOC9 }]; #IO_L17P_T2_A14_D30_14 Sch=ja[10]
+set_property -dict { PACKAGE_PIN AB21  IOSTANDARD LVCMOS33 } [get_ports { IOC10 }]; #IO_L10P_T1_D14_14 Sch=ja[2]
+set_property -dict { PACKAGE_PIN AB20  IOSTANDARD LVCMOS33 } [get_ports { IOC11 }]; #IO_L15N_T2_DQS_DOUT_CSO_B_14 Sch=ja[3]
 
 
 ## Pmod header JB
@@ -176,8 +176,8 @@ set_property -dict { PACKAGE_PIN AB6   IOSTANDARD LVCMOS33 } [get_ports { IO_UPH
 
 
 ## UART
-set_property -dict { PACKAGE_PIN AA19  IOSTANDARD LVCMOS33 } [get_ports { IOC11 }]; #IO_L15P_T2_DQS_RDWR_B_14 Sch=uart_rx_out
-set_property -dict { PACKAGE_PIN V18   IOSTANDARD LVCMOS33 } [get_ports { IOC10 }]; #IO_L14P_T2_SRCC_14 Sch=uart_tx_in
+set_property -dict { PACKAGE_PIN AA19  IOSTANDARD LVCMOS33 } [get_ports { IOC4 }]; #IO_L15P_T2_DQS_RDWR_B_14 Sch=uart_rx_out
+set_property -dict { PACKAGE_PIN V18   IOSTANDARD LVCMOS33 } [get_ports { IOC3 }]; #IO_L14P_T2_SRCC_14 Sch=uart_tx_in
 
 
 ## Ethernet

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -92,15 +92,16 @@ module chip_earlgrey_verilator (
 
   always_comb begin : assign_mio_in
     mio_in = '0;
-    mio_in[32] = cio_uart_rx_p2d_i;
     mio_in[31:0] = cio_gpio_p2d_i;
+    mio_in[25] = cio_uart_rx_p2d_i;
   end
 
-  assign cio_gpio_d2p_o       = mio_out[31:0];
-  assign cio_gpio_en_d2p_o    = mio_oe[31:0];
-  assign cio_uart_tx_d2p_o    = mio_out[33];
-  assign cio_uart_tx_en_d2p_o = mio_oe[33];
-
+  assign cio_gpio_d2p_o[25:0]       = mio_out[25:0];
+  assign cio_gpio_en_d2p_o[25:0]    = mio_oe[25:0];
+  assign cio_gpio_d2p_o[31:27]      = mio_out[31:27];
+  assign cio_gpio_en_d2p_o[31:27]   = mio_oe[31:27];
+  assign cio_uart_tx_d2p_o    = mio_out[26];
+  assign cio_uart_tx_en_d2p_o = mio_oe[26];
 
   ////////////////////////////////
   // AST - Custom for Verilator //

--- a/hw/top_englishbreakfast/data/pins_cw305.xdc
+++ b/hw/top_englishbreakfast/data/pins_cw305.xdc
@@ -54,8 +54,8 @@ set_property -dict { PACKAGE_PIN G16 IOSTANDARD LVCMOS33 } [get_ports { IO_UTX_D
 
 ## 20-Pin Connector (JP1)
 
-set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports { IOC11 }];      #JP1 PIN 12 TIO2    - OpenTitan UART0 TX
-set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports { IOC10 }];      #JP1 PIN 10 TIO1    - OpenTitan UART0 RX
+set_property -dict { PACKAGE_PIN R16 IOSTANDARD LVCMOS33 } [get_ports { IOC4 }];      #JP1 PIN 12 TIO2    - OpenTitan UART0 TX
+set_property -dict { PACKAGE_PIN P16 IOSTANDARD LVCMOS33 } [get_ports { IOC3 }];      #JP1 PIN 10 TIO1    - OpenTitan UART0 RX
 set_property -dict { PACKAGE_PIN T14 IOSTANDARD LVCMOS33 } [get_ports { IO_TRIGGER }]; #JP1 PIN 16 TIO4    - Capture Trigger
 set_property -dict { PACKAGE_PIN M16 IOSTANDARD LVCMOS33 } [get_ports { IO_CLKOUT }];  #JP1 PIN  4 TIO_HS1 - Target clock
 

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -882,7 +882,7 @@
           'FLASH_TEST_VOLT',
           'FLASH_TEST_MODE0', 'FLASH_TEST_MODE1',
           'IOB10', 'IOB11', 'IOB12',
-          'IOC0', 'IOC1', 'IOC2', 'IOC3', 'IOC4', 'IOC5', 'IOC6', 'IOC7', 'IOC8', 'IOC9', 'IOC12',
+          'IOC0', 'IOC1', 'IOC2', 'IOC5', 'IOC6', 'IOC7', 'IOC8', 'IOC9', 'IOC10', 'IOC11', 'IOC12',
           'IOR0', 'IOR1', 'IOR2', 'IOR3', 'IOR4', 'IOR5', 'IOR6', 'IOR7', 'IOR10', 'IOR11', 'IOR12', 'IOR13'
         ],
 

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -71,14 +71,16 @@ module chip_englishbreakfast_verilator (
 
   always_comb begin : assign_mio_in
     mio_in = '0;
-    mio_in[32] = cio_uart_rx_p2d;
     mio_in[31:0] = cio_gpio_p2d;
+    mio_in[25] = cio_uart_rx_p2d;
   end
 
-  assign cio_gpio_d2p       = mio_out[31:0];
-  assign cio_gpio_en_d2p    = mio_oe[31:0];
-  assign cio_uart_tx_d2p    = mio_out[33];
-  assign cio_uart_tx_en_d2p = mio_oe[33];
+  assign cio_gpio_d2p[25:0]       = mio_out[25:0];
+  assign cio_gpio_en_d2p[25:0]    = mio_oe[25:0];
+  assign cio_gpio_d2p[31:27]      = mio_out[31:27];
+  assign cio_gpio_en_d2p[31:27]   = mio_oe[31:27];
+  assign cio_uart_tx_d2p    = mio_out[26];
+  assign cio_uart_tx_en_d2p = mio_oe[26];
 
   // dummy ast connections
   pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -3,7 +3,7 @@ index 8861f54ba..8442bb896 100644
 --- a/sw/device/lib/pinmux.c
 +++ b/sw/device/lib/pinmux.c
 @@ -60,24 +60,4 @@ void pinmux_init(void) {
-   reg_offset = kTopEarlgreyPinmuxMioOutIoc11 << 2;
+   reg_offset = kTopEarlgreyPinmuxMioOutIoc4 << 2;
    mask = PINMUX_MIO_OUTSEL_0_OUT_0_MASK;
    mmio_region_write32(reg32, reg_offset, reg_value & mask);
 -

--- a/sw/device/lib/pinmux.c
+++ b/sw/device/lib/pinmux.c
@@ -41,23 +41,23 @@ void pinmux_init(void) {
                  PINMUX_MIO_OUTSEL_0_OUT_0_MASK,
                  PINMUX_PERIPH_OUTSEL_IDX_OFFSET);
 
-  // Configure UART0 RX input to connect to MIO pad IOC10
+  // Configure UART0 RX input to connect to MIO pad IOC3
   mmio_region_t reg32 = mmio_region_from_addr(
       PINMUX0_BASE_ADDR + PINMUX_MIO_PERIPH_INSEL_0_REG_OFFSET);
-  uint32_t reg_value = kTopEarlgreyPinmuxInselIoc10;
+  uint32_t reg_value = kTopEarlgreyPinmuxInselIoc3;
   // We've got one insel configuration field per register. Hence, we have to
   // convert the enumeration index into a byte address using << 2.
   uint32_t reg_offset = kTopEarlgreyPinmuxPeripheralInUart0Rx << 2;
   uint32_t mask = PINMUX_MIO_PERIPH_INSEL_0_IN_0_MASK;
   mmio_region_write32(reg32, reg_offset, reg_value & mask);
 
-  // Configure UART0 TX output to connect to MIO pad IOC11
+  // Configure UART0 TX output to connect to MIO pad IOC4
   reg32 =
       mmio_region_from_addr(PINMUX0_BASE_ADDR + PINMUX_MIO_OUTSEL_0_REG_OFFSET);
   reg_value = kTopEarlgreyPinmuxOutselUart0Tx;
   // We've got one insel configuration field per register. Hence, we have to
   // convert the enumeration index into a byte address using << 2.
-  reg_offset = kTopEarlgreyPinmuxMioOutIoc11 << 2;
+  reg_offset = kTopEarlgreyPinmuxMioOutIoc4 << 2;
   mask = PINMUX_MIO_OUTSEL_0_OUT_0_MASK;
   mmio_region_write32(reg32, reg_offset, reg_value & mask);
 

--- a/sw/device/silicon_creator/lib/drivers/pinmux.c
+++ b/sw/device/silicon_creator/lib/drivers/pinmux.c
@@ -34,7 +34,7 @@ static const pinmux_input_t kPinmuxInputs[] = {
      */
     {
         .periph = kTopEarlgreyPinmuxPeripheralInUart0Rx,
-        .pad = kTopEarlgreyPinmuxInselIoc10,
+        .pad = kTopEarlgreyPinmuxInselIoc3,
     },
 };
 
@@ -53,7 +53,7 @@ static const pinmux_output_t kPinmuxOutputs[] = {
     /**
      * UART
      */
-    {.pad = kTopEarlgreyPinmuxMioOutIoc11,
+    {.pad = kTopEarlgreyPinmuxMioOutIoc4,
      .periph = kTopEarlgreyPinmuxOutselUart0Tx},
 };
 

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -63,10 +63,10 @@ TEST_F(InitTest, Initialize) {
   EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio17),
                      kTopEarlgreyPinmuxInselIob8)
   EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInUart0Rx),
-                     kTopEarlgreyPinmuxInselIoc10);
+                     kTopEarlgreyPinmuxInselIoc3);
 
   // The outputs that will be configured.
-  EXPECT_ABS_WRITE32(RegOut(kTopEarlgreyPinmuxMioOutIoc11),
+  EXPECT_ABS_WRITE32(RegOut(kTopEarlgreyPinmuxMioOutIoc4),
                      kTopEarlgreyPinmuxOutselUart0Tx);
 
   pinmux_init();

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -500,8 +500,8 @@ bool test_main(void) {
 
   // TODO, remove thse once pinout configuration is provided
   pinmux_connect_uart_to_pads(
-      kTopEarlgreyPinmuxInselIoc10, kTopEarlgreyPinmuxPeripheralInUart0Rx,
-      kTopEarlgreyPinmuxMioOutIoc11, kTopEarlgreyPinmuxOutselUart0Tx);
+      kTopEarlgreyPinmuxInselIoc3, kTopEarlgreyPinmuxPeripheralInUart0Rx,
+      kTopEarlgreyPinmuxMioOutIoc4, kTopEarlgreyPinmuxOutselUart0Tx);
   pinmux_connect_uart_to_pads(
       kTopEarlgreyPinmuxInselIor5, kTopEarlgreyPinmuxPeripheralInUart1Rx,
       kTopEarlgreyPinmuxMioOutIor6, kTopEarlgreyPinmuxOutselUart1Tx);


### PR DESCRIPTION
This PR only changes the UART0 RX/TX pins from IOC10/IOC11 to IOC3/IOC4 in order to match the tapeout.

Closes #8355