### PR TITLE
[rtl] Handle integrity errors properly for bus devices with no regs

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_mem_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_mem_reg_top.sv
@@ -23,6 +23,9 @@ module flash_ctrl_mem_reg_top (
   import flash_ctrl_reg_pkg::* ;
 
 
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
+
 
   // incoming payload check
   logic intg_err;
@@ -54,43 +57,16 @@ module flash_ctrl_mem_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
+  tlul_err_resp #(
+    .EnableDataIntgGen(0)
+  ) u_err (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
+    .tl_h_i (tl_reg_h2d),
+    .tl_h_o (tl_reg_d2h)
   );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -23,6 +23,9 @@ module flash_ctrl_prim_reg_top (
   import flash_ctrl_reg_pkg::* ;
 
 
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
+
 
   // incoming payload check
   logic intg_err;
@@ -54,43 +57,16 @@ module flash_ctrl_prim_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
+  tlul_err_resp #(
+    .EnableDataIntgGen(0)
+  ) u_err (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
+    .tl_h_i (tl_reg_h2d),
+    .tl_h_o (tl_reg_d2h)
   );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -84,7 +84,7 @@ module hmac_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -84,7 +84,7 @@ module otp_ctrl_core_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -23,6 +23,9 @@ module otp_ctrl_prim_reg_top (
   import otp_ctrl_reg_pkg::* ;
 
 
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
+
 
   // incoming payload check
   logic intg_err;
@@ -54,43 +57,16 @@ module otp_ctrl_prim_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
+  tlul_err_resp #(
+    .EnableDataIntgGen(0)
+  ) u_err (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
+    .tl_h_i (tl_reg_h2d),
+    .tl_h_o (tl_reg_d2h)
   );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
@@ -65,7 +65,7 @@ module rom_ctrl_rom_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];
@@ -97,10 +97,9 @@ module rom_ctrl_rom_reg_top (
 
   // Create steering logic
   always_comb begin
-    reg_steer = 1;       // Default set to register
 
     // TODO: Can below codes be unique case () inside ?
-      reg_steer = 0;
+    reg_steer = 0;
     if (intg_err) begin
       reg_steer = 1;
     end

--- a/hw/ip/rv_dm/rtl/rv_dm_rom_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_rom_reg_top.sv
@@ -65,7 +65,7 @@ module rv_dm_rom_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];
@@ -97,10 +97,9 @@ module rv_dm_rom_reg_top (
 
   // Create steering logic
   always_comb begin
-    reg_steer = 1;       // Default set to register
 
     // TODO: Can below codes be unique case () inside ?
-      reg_steer = 0;
+    reg_steer = 0;
     if (intg_err) begin
       reg_steer = 1;
     end

--- a/hw/ip/rv_dm/rtl/rv_dm_rom_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_rom_reg_top.sv
@@ -28,6 +28,9 @@ module rv_dm_rom_reg_top (
   import rv_dm_reg_pkg::* ;
 
 
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
+
 
   // incoming payload check
   logic intg_err;
@@ -59,8 +62,57 @@ module rv_dm_rom_reg_top (
     .tl_o(tl_o)
   );
 
-  assign tl_win_o = tl_i;
-  assign tl_o_pre = tl_win_i;
+  tlul_pkg::tl_h2d_t tl_socket_h2d [2];
+  tlul_pkg::tl_d2h_t tl_socket_d2h [2];
+
+  logic [1:0] reg_steer;
+
+  // socket_1n connection
+  assign tl_reg_h2d = tl_socket_h2d[1];
+  assign tl_socket_d2h[1] = tl_reg_d2h;
+
+  assign tl_win_o = tl_socket_h2d[0];
+  assign tl_socket_d2h[0] = tl_win_i;
+
+  // Create Socket_1n
+  tlul_socket_1n #(
+    .N          (2),
+    .HReqPass   (1'b1),
+    .HRspPass   (1'b1),
+    .DReqPass   ({2{1'b1}}),
+    .DRspPass   ({2{1'b1}}),
+    .HReqDepth  (4'h0),
+    .HRspDepth  (4'h0),
+    .DReqDepth  ({2{4'h0}}),
+    .DRspDepth  ({2{4'h0}})
+  ) u_socket (
+    .clk_i  (clk_i),
+    .rst_ni (rst_ni),
+    .tl_h_i (tl_i),
+    .tl_h_o (tl_o_pre),
+    .tl_d_o (tl_socket_h2d),
+    .tl_d_i (tl_socket_d2h),
+    .dev_select_i (reg_steer)
+  );
+
+  // Create steering logic
+  always_comb begin
+    reg_steer = 1;       // Default set to register
+
+    // TODO: Can below codes be unique case () inside ?
+      reg_steer = 0;
+    if (intg_err) begin
+      reg_steer = 1;
+    end
+  end
+  tlul_err_resp #(
+    .EnableDataIntgGen(0)
+  ) u_err (
+    .clk_i  (clk_i),
+    .rst_ni (rst_ni),
+    .tl_h_i (tl_reg_h2d),
+    .tl_h_o (tl_reg_d2h)
+  );
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -84,7 +84,7 @@ module spi_device_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_ram_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_ram_reg_top.sv
@@ -23,6 +23,9 @@ module sram_ctrl_ram_reg_top (
   import sram_ctrl_reg_pkg::* ;
 
 
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
+
 
   // incoming payload check
   logic intg_err;
@@ -54,43 +57,16 @@ module sram_ctrl_ram_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
+  tlul_err_resp #(
+    .EnableDataIntgGen(0)
+  ) u_err (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
+    .tl_h_i (tl_reg_h2d),
+    .tl_h_o (tl_reg_d2h)
   );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/tlul/lint/tlul_socket_1n.waiver
+++ b/hw/ip/tlul/lint/tlul_socket_1n.waiver
@@ -5,8 +5,6 @@
 # waiver file for TLUL elements lint
 
 # socket 1:N
-waive -rules INVALID_COMPARE   -location {tlul_socket_1n.sv} -regexp {Comparison '.dev_select_t == NWD'.*can never be true} \
-      -comment "lint appears to be confused about the width expansion of NWD'(2)'"
 waive -rules MIXED_SIGN        -location {tlul_socket_1n.sv} -regexp {Unsigned operand .* and signed .NWD} \
       -comment "is there a way to make NWD'(idx)' an unsigned operand?"
 waive -rules HIER_NET_NOT_READ -location {tlul_socket_1n.sv} -regexp {a_(address|data|mask|param|size|user.*)' in module 'tlul_socket_1n'} \

--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -46,7 +46,7 @@ module tlul_socket_1n #(
   parameter bit [3:0]     HRspDepth = 4'h2,
   parameter bit [N*4-1:0] DReqDepth = {N{4'h2}},
   parameter bit [N*4-1:0] DRspDepth = {N{4'h2}},
-  localparam int unsigned NWD       = $clog2(N+1) // derived parameter
+  localparam int unsigned NWD       = $clog2(N) // derived parameter
 ) (
   input                     clk_i,
   input                     rst_ni,

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -84,7 +84,7 @@ module usbdev_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_mem_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_mem_reg_top.sv
@@ -23,6 +23,9 @@ module flash_ctrl_mem_reg_top (
   import flash_ctrl_reg_pkg::* ;
 
 
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
+
 
   // incoming payload check
   logic intg_err;
@@ -54,43 +57,16 @@ module flash_ctrl_mem_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
+  tlul_err_resp #(
+    .EnableDataIntgGen(0)
+  ) u_err (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
+    .tl_h_i (tl_reg_h2d),
+    .tl_h_o (tl_reg_d2h)
   );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
@@ -23,6 +23,9 @@ module flash_ctrl_prim_reg_top (
   import flash_ctrl_reg_pkg::* ;
 
 
+  tlul_pkg::tl_h2d_t tl_reg_h2d;
+  tlul_pkg::tl_d2h_t tl_reg_d2h;
+
 
   // incoming payload check
   logic intg_err;
@@ -54,43 +57,16 @@ module flash_ctrl_prim_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
+  tlul_err_resp #(
+    .EnableDataIntgGen(0)
+  ) u_err (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
+    .tl_h_i (tl_reg_h2d),
+    .tl_h_o (tl_reg_d2h)
   );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -285,9 +285,9 @@ module ${mod_name} (
     .error_i (reg_error)
   );
 
-% if not rb.async_if:
+  % if not rb.async_if:
   // cdc oversampling signals
-  % for clock in rb.clocks.values():
+    % for clock in rb.clocks.values():
   <%
     clk_name = clock.clock_base_name
     tgl_expr = clk_name + "_tgl"
@@ -306,8 +306,8 @@ module ${mod_name} (
     .dst_req_o(sync_${clk_name}_update),
     .dst_ack_i(sync_${clk_name}_update)
   );
-  % endfor
-% endif
+    % endfor
+  % endif
 
   % if block.expose_reg_if:
   assign reg2hw.reg_if.reg_we    = reg_we;
@@ -333,12 +333,12 @@ ${reg_sig_decl(r)}\
 ${field_sig_decl(f, sig_name, r.hwext, r.shadowed, r.async_clk)}\
     % endfor
   % endfor
-% if len(rb.clocks.values()) > 0:
+  % if len(rb.clocks.values()) > 0:
   // Define register CDC handling.
   // CDC handling is done on a per-reg instead of per-field boundary.
-% endif
-% for r in regs_flat:
-  % if r.async_clk:
+  % endif
+  % for r in regs_flat:
+    % if r.async_clk:
 <%
   base_name = r.async_clk.clock_base_name
   r_name = r.name.lower()
@@ -351,35 +351,35 @@ ${field_sig_decl(f, sig_name, r.hwext, r.shadowed, r.async_clk)}\
   dst_re_expr = f"{base_name}_{r_name}_re" if r.needs_re() else ""
   dst_regwen_expr = f"{base_name}_{r_name}_regwen" if r.regwen else ""
 %>
-    % if len(r.fields) > 1:
-      % for f in r.fields:
+      % if len(r.fields) > 1:
+        % for f in r.fields:
   logic ${str_arr_sv(f.bits)} ${base_name}_${r_name}_${f.name.lower()}_qs_int;
-      % endfor
-    % else:
+        % endfor
+      % else:
   logic ${str_arr_sv(r.fields[0].bits)} ${base_name}_${r_name}_qs_int;
-    % endif
+      % endif
   logic [${r.get_width()-1}:0] ${base_name}_${r_name}_d;
-  % if r.needs_we():
+      % if r.needs_we():
   logic [${r.get_width()-1}:0] ${base_name}_${r_name}_wdata;
   logic ${base_name}_${r_name}_we;
   logic unused_${base_name}_${r_name}_wdata;
-  % endif
-  % if r.needs_re():
+      % endif
+      % if r.needs_re():
   logic ${base_name}_${r_name}_re;
-  % endif
-  % if r.regwen:
+      % endif
+      % if r.regwen:
   logic ${base_name}_${r_name}_regwen;
-  % endif
+      % endif
 
   always_comb begin
     ${base_name}_${r_name}_d = '0;
-    % if len(r.fields) > 1:
-      % for f in r.fields:
+      % if len(r.fields) > 1:
+        % for f in r.fields:
     ${base_name}_${r_name}_d[${str_bits_sv(f.bits)}] = ${base_name}_${r_name}_${f.name.lower()}_qs_int;
-      % endfor
-    % else:
+        % endfor
+      % else:
     ${base_name}_${r_name}_d = ${base_name}_${r_name}_qs_int;
-    % endif
+      % endif
   end
 
   prim_reg_cdc #(
@@ -404,11 +404,11 @@ ${field_sig_decl(f, sig_name, r.hwext, r.shadowed, r.async_clk)}\
     .dst_regwen_o (${dst_regwen_expr}),
     .dst_wd_o     (${dst_wd_expr})
   );
-    % if r.needs_we():
+      % if r.needs_we():
   assign unused_${base_name}_${r_name}_wdata = ^${base_name}_${r_name}_wdata;
+      % endif
     % endif
-  % endif
-% endfor
+  % endfor
 
   // Register instances
   % for r in rb.all_regs:
@@ -477,7 +477,7 @@ ${finst_gen(sr, field, finst_name, fsig_name)}
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
 
-% if regs_flat:
+  % if regs_flat:
 <%
     # We want to signal wr_err if reg_be (the byte enable signal) is true for
     # any bytes that aren't supported by a register. That's true if a
@@ -494,9 +494,9 @@ ${finst_gen(sr, field, finst_name, fsig_name)}
     wr_err = (reg_we &
               (${wr_err_expr}));
   end
-% else:
+  % else:
   assign wr_error = 1'b0;
-% endif\
+  % endif\
 
   % for i, r in enumerate(regs_flat):
 ${reg_enable_gen(r, i)}\
@@ -513,25 +513,25 @@ ${field_wd_gen(f, r.name.lower() + "_" + f.name.lower(), r.hwext, r.shadowed, r.
   always_comb begin
     reg_rdata_next = '0;
     unique case (1'b1)
-      % for i, r in enumerate(regs_flat):
-        % if r.async_clk:
+  % for i, r in enumerate(regs_flat):
+    % if r.async_clk:
       addr_hit[${i}]: begin
         reg_rdata_next = DW'(${r.name.lower()}_qs);
       end
-        % elif len(r.fields) == 1:
+    % elif len(r.fields) == 1:
       addr_hit[${i}]: begin
 ${rdata_gen(r.fields[0], r.name.lower())}\
       end
 
-        % else:
+    % else:
       addr_hit[${i}]: begin
-          % for f in r.fields:
+      % for f in r.fields:
 ${rdata_gen(f, r.name.lower() + "_" + f.name.lower())}\
-          % endfor
+      % endfor
       end
 
-        % endif
-      % endfor
+    % endif
+  % endfor
       default: begin
         reg_rdata_next = '1;
       end
@@ -574,13 +574,13 @@ ${rdata_gen(f, r.name.lower() + "_" + f.name.lower())}\
   always_comb begin
     reg_busy_sel = '0;
     unique case (1'b1)
-      % for i, r in enumerate(regs_flat):
-        % if r.async_clk:
+    % for i, r in enumerate(regs_flat):
+      % if r.async_clk:
       addr_hit[${i}]: begin
         reg_busy_sel = ${r.name.lower() + "_busy"};
       end
-        % endif
-      % endfor
+      % endif
+    % endfor
       default: begin
         reg_busy_sel  = '0;
       end


### PR DESCRIPTION
The way we normally handle malformed TL accesses in "`foo_reg_top`" is
that we detect the error, steer the access to the register adapter,
and pass it a flag saying that the access should be responded to with
an error. This is really neat, but (unsurprisingly!) doesn't work if
there are no registers.

This commit adds a new "`tlul_adapter_err`" module that responds to all
accesses with an error. The reg_top code generation is then slightly
rejigged so that we create one of those if we didn't have any
registers.

Thanks to @prajwalaputtappa for finding this bug by debugging why the `rom_ctrl_tl_intg_err` tests were failing. I note that this PR changes quite a few other modules. Have they had their TL bus tests wired up? :-/