### PR TITLE
[bazel] Support dispatching tests to the CW310 board.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -54,3 +54,12 @@ clang_format_check(
     ],
     mode = "fix",
 )
+
+filegroup(
+    name = "cores",
+    srcs = [
+        "check_tool_requirements.core",
+        "topgen.core",
+        "topgen-reg-only.core",
+    ],
+)

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -1,3 +1,87 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+load("//rules:fusesoc.bzl", "fusesoc_build")
+
+package(default_visibility = ["//visibility:public"])
+
+fusesoc_build(
+    name = "verilator",
+    srcs = [
+        "//hw:all_files",
+    ],
+    cores = [
+        "//:cores",
+    ],
+    systems = ["lowrisc:dv:chip_verilator_sim"],
+    target = "sim",
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]) + [
+        "//hw/ip/otp_ctrl/data:all_files",
+        "//hw/ip/otp_ctrl:all_files",
+        "//hw/ip/hmac/data:all_files",
+        "//hw/ip/hmac:all_files",
+        "//hw/ip/otbn/data:all_files",
+        "//hw/ip/otbn:all_files",
+        "//hw/ip/sram_ctrl/data:all_files",
+        "//hw/ip/sram_ctrl:all_files",
+        "//hw/ip/lc_ctrl/data:all_files",
+        "//hw/ip/lc_ctrl:all_files",
+        "//hw/ip/rv_timer/data:all_files",
+        "//hw/ip/rv_timer:all_files",
+        "//hw/ip/usbdev/data:all_files",
+        "//hw/ip/usbdev:all_files",
+        "//hw/ip/kmac/data:all_files",
+        "//hw/ip/kmac:all_files",
+        "//hw/ip/flash_ctrl/data:all_files",
+        "//hw/ip/csrng/data:all_files",
+        "//hw/ip/csrng:all_files",
+        "//hw/ip/sysrst_ctrl/data:all_files",
+        "//hw/ip/spi_device/data:all_files",
+        "//hw/ip/spi_device:all_files",
+        "//hw/ip/keymgr/data:all_files",
+        "//hw/ip/keymgr:all_files",
+        "//hw/ip/pattgen/data:all_files",
+        "//hw/ip/gpio/data:all_files",
+        "//hw/ip/gpio:all_files",
+        "//hw/ip/pinmux/data:all_files",
+        "//hw/ip/uart/data:all_files",
+        "//hw/ip/uart:all_files",
+        "//hw/ip/adc_ctrl/data:all_files",
+        "//hw/ip/entropy_src/data:all_files",
+        "//hw/ip/entropy_src:all_files",
+        "//hw/ip/edn/data:all_files",
+        "//hw/ip/edn:all_files",
+        "//hw/ip/aes/data:all_files",
+        "//hw/ip/aes:all_files",
+        "//hw/ip/aon_timer/data:all_files",
+        "//hw/ip/aon_timer:all_files",
+        "//hw/ip:all_files",
+        "//hw/ip/i2c/data:all_files",
+        "//hw/ip/i2c:all_files",
+        "//hw/ip/spi_host/data:all_files",
+        "//hw/top_earlgrey/sw/autogen:all_files",
+        "//hw/top_earlgrey/sw:all_files",
+        "//hw/top_earlgrey/ip/rstmgr/data/autogen:all_files",
+        "//hw/top_earlgrey/ip/rstmgr/data:all_files",
+        "//hw/top_earlgrey/ip/rstmgr:all_files",
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:all_files",
+        "//hw/top_earlgrey/ip/flash_ctrl/data:all_files",
+        "//hw/top_earlgrey/ip/flash_ctrl:all_files",
+        "//hw/top_earlgrey/ip/clkmgr/data/autogen:all_files",
+        "//hw/top_earlgrey/ip/clkmgr/data:all_files",
+        "//hw/top_earlgrey/ip/clkmgr:all_files",
+        "//hw/top_earlgrey/ip/pinmux/data/autogen:all_files",
+        "//hw/top_earlgrey/ip/pinmux/data:all_files",
+        "//hw/top_earlgrey/ip/pinmux:all_files",
+        "//hw/top_earlgrey/ip:all_files",
+        "//hw/top_earlgrey/ip/pwrmgr/data/autogen:all_files",
+        "//hw/top_earlgrey/ip/pwrmgr/data:all_files",
+        "//hw/top_earlgrey/ip/pwrmgr:all_files",
+        "//hw/top_earlgrey:all_files",
+    ],
+)

--- a/hw/ip/BUILD
+++ b/hw/ip/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/adc_ctrl/data/BUILD
+++ b/hw/ip/adc_ctrl/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "adc_ctrl.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/aes/BUILD
+++ b/hw/ip/aes/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/aes/data/BUILD
+++ b/hw/ip/aes/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "aes.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/aon_timer/BUILD
+++ b/hw/ip/aon_timer/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/aon_timer/data/BUILD
+++ b/hw/ip/aon_timer/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "aon_timer.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/csrng/BUILD
+++ b/hw/ip/csrng/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/csrng/data/BUILD
+++ b/hw/ip/csrng/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "csrng.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/edn/BUILD
+++ b/hw/ip/edn/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/edn/data/BUILD
+++ b/hw/ip/edn/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "edn.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/entropy_src/BUILD
+++ b/hw/ip/entropy_src/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/entropy_src/data/BUILD
+++ b/hw/ip/entropy_src/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "entropy_src.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/flash_ctrl/data/BUILD
+++ b/hw/ip/flash_ctrl/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "flash_ctrl.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/gpio/BUILD
+++ b/hw/ip/gpio/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/gpio/data/BUILD
+++ b/hw/ip/gpio/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "gpio.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/hmac/BUILD
+++ b/hw/ip/hmac/BUILD
@@ -1,3 +1,9 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/hmac/data/BUILD
+++ b/hw/ip/hmac/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "hmac.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/i2c/BUILD
+++ b/hw/ip/i2c/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/i2c/data/BUILD
+++ b/hw/ip/i2c/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "i2c.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/keymgr/BUILD
+++ b/hw/ip/keymgr/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/keymgr/data/BUILD
+++ b/hw/ip/keymgr/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "keymgr.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/kmac/BUILD
+++ b/hw/ip/kmac/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/kmac/data/BUILD
+++ b/hw/ip/kmac/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "kmac.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/lc_ctrl/BUILD
+++ b/hw/ip/lc_ctrl/BUILD
@@ -1,3 +1,9 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/lc_ctrl/data/BUILD
+++ b/hw/ip/lc_ctrl/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "lc_ctrl.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/otbn/BUILD
+++ b/hw/ip/otbn/BUILD
@@ -1,3 +1,9 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/otbn/data/BUILD
+++ b/hw/ip/otbn/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "otbn.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/otp_ctrl/BUILD
+++ b/hw/ip/otp_ctrl/BUILD
@@ -1,3 +1,9 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -4,12 +4,21 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:autogen.bzl", "autogen_hjson_header")
+load("//rules:autogen.bzl", "autogen_hjson_header", "otp_image")
 
 autogen_hjson_header(
     name = "otp_ctrl_regs",
     srcs = [
         "otp_ctrl.hjson",
+    ],
+)
+
+otp_image(
+    name = "rma_image_verilator",
+    src = "otp_ctrl_img_rma.hjson",
+    deps = [
+        "otp_ctrl_mmap.hjson",
+        "//hw/ip/lc_ctrl/data:lc_ctrl_state.hjson",
     ],
 )
 

--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "otp_ctrl.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/pattgen/data/BUILD
+++ b/hw/ip/pattgen/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "pattgen.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/pinmux/data/BUILD
+++ b/hw/ip/pinmux/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "pinmux.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/rv_timer/BUILD
+++ b/hw/ip/rv_timer/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/rv_timer/data/BUILD
+++ b/hw/ip/rv_timer/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "rv_timer.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/spi_device/BUILD
+++ b/hw/ip/spi_device/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/spi_device/data/BUILD
+++ b/hw/ip/spi_device/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "spi_device.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/spi_host/data/BUILD
+++ b/hw/ip/spi_host/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "spi_host.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/sram_ctrl/BUILD
+++ b/hw/ip/sram_ctrl/BUILD
@@ -1,3 +1,9 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/sram_ctrl/data/BUILD
+++ b/hw/ip/sram_ctrl/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "sram_ctrl.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/sysrst_ctrl/data/BUILD
+++ b/hw/ip/sysrst_ctrl/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "sysrst_ctrl.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/uart/BUILD
+++ b/hw/ip/uart/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/uart/data/BUILD
+++ b/hw/ip/uart/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "uart.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/usbdev/BUILD
+++ b/hw/ip/usbdev/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/ip/usbdev/data/BUILD
+++ b/hw/ip/usbdev/data/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "usbdev.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/BUILD
+++ b/hw/top_earlgrey/BUILD
@@ -19,3 +19,8 @@ autogen_hjson_header(
         "ip_autogen/alert_handler/data/alert_handler.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/BUILD
+++ b/hw/top_earlgrey/ip/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/clkmgr/BUILD
+++ b/hw/top_earlgrey/ip/clkmgr/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/clkmgr/data/BUILD
+++ b/hw/top_earlgrey/ip/clkmgr/data/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/BUILD
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "clkmgr.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/flash_ctrl/BUILD
+++ b/hw/top_earlgrey/ip/flash_ctrl/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/flash_ctrl/data/BUILD
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/BUILD
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "flash_ctrl.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/pinmux/BUILD
+++ b/hw/top_earlgrey/ip/pinmux/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/pinmux/data/BUILD
+++ b/hw/top_earlgrey/ip/pinmux/data/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/BUILD
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "pinmux.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/pwrmgr/BUILD
+++ b/hw/top_earlgrey/ip/pwrmgr/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/pwrmgr/data/BUILD
+++ b/hw/top_earlgrey/ip/pwrmgr/data/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/BUILD
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "pwrmgr.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/rstmgr/BUILD
+++ b/hw/top_earlgrey/ip/rstmgr/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/rstmgr/data/BUILD
+++ b/hw/top_earlgrey/ip/rstmgr/data/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/BUILD
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/BUILD
@@ -12,3 +12,8 @@ autogen_hjson_header(
         "rstmgr.hjson",
     ],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/sw/BUILD
+++ b/hw/top_earlgrey/sw/BUILD
@@ -1,3 +1,10 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/hw/top_earlgrey/sw/autogen/BUILD
+++ b/hw/top_earlgrey/sw/autogen/BUILD
@@ -19,3 +19,8 @@ cc_library(
     name = "linker_script",
     deps = ["top_earlgrey_memory.ld"],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+)

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -65,3 +65,28 @@ autogen_chip_info = rule(
         "_tool": attr.label(default = "//util:rom_chip_info.py", allow_files = True),
     },
 )
+
+def _otp_image(ctx):
+    output = ctx.actions.declare_file(ctx.attr.name + ".vmem")
+    ctx.actions.run(
+        outputs = [output],
+        inputs = ctx.files.src + ctx.files.deps + ctx.files._tool,
+        arguments = [
+            "--quiet",
+            "--img-cfg",
+            ctx.files.src[0].path,
+            "--out",
+            output.path,
+        ],
+        executable = ctx.files._tool[0],
+    )
+    return [DefaultInfo(files = depset([output]), data_runfiles = ctx.runfiles(files = [output]))]
+
+otp_image = rule(
+    implementation = _otp_image,
+    attrs = {
+        "src": attr.label(allow_files = True),
+        "deps": attr.label_list(allow_files = True),
+        "_tool": attr.label(default = "//util:design/gen-otp-img.py", allow_files = True),
+    },
+)

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -1,0 +1,56 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rules for running FuseSoC.
+
+FuseSoC is a package manager and set of build tools for HDL code.
+
+Because we want the output of some FuseSoC built resources to be
+available to bazel (such as the verilated chip model for running
+tests), the `fusesoc_build` rule allows bazel to delegate certain
+targets to FuseSoC.
+
+This rule is not sandboxed, as our current configuration depends
+on FuseSoC and its dependencies (verible, verilator, etc) already
+having been installed.  In the future, we will try to rework our
+dependencies so the FuseSoC rules can be sandboxed.
+"""
+
+def _fusesoc_build_impl(ctx):
+    out_dir = ctx.actions.declare_directory("build.{}".format(ctx.label.name))
+    ctx.actions.run(
+        mnemonic = "FuseSoC",
+        outputs = [out_dir],
+        inputs = ctx.files.srcs + ctx.files.cores,
+        arguments = [
+            "--cores-root={}".format(c.dirname)
+            for c in ctx.files.cores
+        ] + [
+            "run",
+            "--flag=fileset_top",
+            "--target={}".format(ctx.attr.target),
+            "--setup",
+            "--build",
+            "--build-root={}".format(out_dir.path),
+        ] + ctx.attr.systems,
+        executable = "fusesoc",
+        use_default_shell_env = True,
+        execution_requirements = {
+            "no-sandbox": "",
+        },
+    )
+    return [DefaultInfo(
+        files = depset([out_dir]),
+        data_runfiles = ctx.runfiles(files = [out_dir]),
+    )]
+
+fusesoc_build = rule(
+    implementation = _fusesoc_build_impl,
+    attrs = {
+        "cores": attr.label_list(allow_files = True, doc = "FuseSoC core specification files"),
+        "srcs": attr.label_list(allow_files = True, doc = "Source files"),
+        "target": attr.string(mandatory = True, doc = "Target name (e.g. 'sim')"),
+        "systems": attr.string_list(mandatory = True, doc = "Systems to build"),
+    },
+)

--- a/sw/device/boot_rom/BUILD
+++ b/sw/device/boot_rom/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary")
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_functest")
 load("//rules:autogen.bzl", "autogen_chip_info")
 
 autogen_chip_info(
@@ -55,7 +55,7 @@ cc_library(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing",
+        "//sw/device/lib/testing/test_framework",
     ],
 )
 
@@ -78,6 +78,21 @@ cc_library(
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing",
+        "//sw/device/lib/testing/test_framework",
+    ],
+)
+
+opentitan_functest(
+    name = "boot_rom_test",
+    srcs = [
+        "boot_rom_test.c",
+    ],
+    deps = [
+        "//sw/device/exts/common",
+        "//sw/device/lib:irq",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/testing/test_framework",
+        "//sw/device/lib/testing/test_framework:main",
     ],
 )

--- a/sw/device/boot_rom/boot_rom_test.c
+++ b/sw/device/boot_rom/boot_rom_test.c
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/testing/test_framework/test_main.h"
+
+const test_config_t kTestConfig;
+
+bool test_main(void) { return true; }

--- a/sw/device/examples/BUILD
+++ b/sw/device/examples/BUILD
@@ -11,6 +11,6 @@ cc_library(
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
-        "//sw/device/lib/testing",
+        "//sw/device/lib/testing/test_framework",
     ],
 )

--- a/sw/device/examples/hello_world/BUILD
+++ b/sw/device/examples/hello_world/BUILD
@@ -38,6 +38,6 @@ cc_library(
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
-        "//sw/device/lib/testing",
+        "//sw/device/lib/testing/test_framework",
     ],
 )

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -6,27 +6,10 @@ package(default_visibility = ["//visibility:public"])
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 
-# TODO use more specific targets to avoid unnecesary dependencies
-# https://github.com/lowRISC/opentitan/issues/9098
-cc_library(
-    name = "testing",
-    srcs = [
-        "test_framework/test_coverage_none.c",
-        "test_framework/test_status.c",
-    ],
-    hdrs = [
-        "check.h",
-        "test_framework/test_coverage.h",
-        "test_framework/test_status.h",
-    ],
-    target_compatible_with = [OPENTITAN_CPU],
-    deps = [
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/arch:device",
-        "//sw/device/lib/base",
-        "//sw/device/lib/dif:uart",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/lib/runtime:log",
-        "//sw/device/lib/runtime:print",
-    ],
+# TODO: Fix this.  This file isn't useful without test-status.h and should be
+# considered part of the basic test_framework library.  As such, this file
+# _should_ live along side those files.
+filegroup(
+    name = "check",
+    srcs = ["check.h"],
 )

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -1,0 +1,46 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "main",
+    srcs = [
+        "test_main.c",
+    ],
+    hdrs = [
+        "test_main.h",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":test_framework",
+    ],
+)
+
+# TODO use more specific targets to avoid unnecesary dependencies
+# https://github.com/lowRISC/opentitan/issues/9098
+cc_library(
+    name = "test_framework",
+    srcs = [
+        "test_coverage_none.c",
+        "test_status.c",
+    ],
+    hdrs = [
+        "test_coverage.h",
+        "test_status.h",
+        "//sw/device/lib/testing:check",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+    ],
+)

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -13,6 +13,7 @@ rust_library(
         "src/app/command.rs",
         "src/app/conf.rs",
         "src/app/mod.rs",
+        "src/bootstrap/legacy.rs",
         "src/bootstrap/mod.rs",
         "src/bootstrap/primitive.rs",
         "src/io/gpio.rs",

--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -31,3 +31,11 @@ rust_binary(
         "//sw/host/opentitanlib",
     ] + all_crate_deps(),
 )
+
+filegroup(
+    name = "test_resources",
+    srcs = [
+        ":opentitantool",
+        "//sw/host/opentitantool/config",
+    ],
+)

--- a/sw/host/opentitantool/config/BUILD
+++ b/sw/host/opentitantool/config/BUILD
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "config",
+    srcs = glob(["**"]),
+)

--- a/sw/host/opentitantool/config/opentitan_verilator.json
+++ b/sw/host/opentitantool/config/opentitan_verilator.json
@@ -1,0 +1,12 @@
+{
+  "includes": ["opentitan.json"],
+  "interface": "verilator",
+  "pins": [
+  ],
+  "uarts": [
+    {
+      "name": "console",
+      "alias_of": "0"
+    }
+  ]
+}

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -9,3 +9,25 @@ pub mod hello;
 pub mod image;
 pub mod load_bitstream;
 pub mod spi;
+
+use anyhow::Result;
+use erased_serde::Serialize;
+use std::any::Any;
+use structopt::StructOpt;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+
+#[derive(Debug, StructOpt)]
+/// No Operation.
+pub struct NoOp {}
+
+impl CommandDispatch for NoOp {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        Ok(None)
+    }
+}

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -8,12 +8,14 @@ use log::LevelFilter;
 use std::env::{args_os, ArgsOs};
 use std::ffi::OsString;
 use std::io::ErrorKind;
+use std::iter::{IntoIterator, Iterator};
 use std::path::PathBuf;
 use structopt::StructOpt;
 
 mod backend;
 mod command;
 use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
 
 #[derive(Debug, StructOpt, CommandDispatch)]
 enum RootCommandHierarchy {
@@ -23,8 +25,10 @@ enum RootCommandHierarchy {
     Console(command::console::Console),
 
     Gpio(command::gpio::GpioCommand),
+
     Image(command::image::Image),
     LoadBitstream(command::load_bitstream::LoadBitstream),
+    NoOp(command::NoOp),
     Spi(command::spi::SpiCommand),
 
     // Flattened because `Greetings` is a subcommand hierarchy.
@@ -34,6 +38,10 @@ enum RootCommandHierarchy {
 }
 
 #[derive(Debug, StructOpt)]
+#[structopt(
+    name = "opentitantool",
+    about = "A tool for interacting with OpenTitan chips."
+)]
 struct Opts {
     #[structopt(
         long,
@@ -44,6 +52,9 @@ struct Opts {
 
     #[structopt(long, default_value = "off")]
     logging: LevelFilter,
+
+    #[structopt(long, help = "Parse and execute the argument as a command")]
+    exec: Vec<String>,
 
     #[structopt(flatten)]
     backend_opts: backend::BackendOpts,
@@ -107,10 +118,31 @@ fn parse_command_line(opts: Opts, mut args: ArgsOs) -> Result<Opts> {
     Ok(opts)
 }
 
+fn execute<I>(args: I, opts: &Opts, transport: &TransportWrapper) -> Result<()>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let command = RootCommandHierarchy::from_iter(
+        std::iter::once(OsString::from("opentitantool")).chain(args),
+    );
+    if let Some(value) = command.run(opts, transport)? {
+        println!("{}", serde_json::to_string_pretty(&value)?);
+    }
+    Ok(())
+}
+
 fn main() -> Result<()> {
     let opts = parse_command_line(Opts::from_args(), args_os())?;
 
     let transport = backend::create(&opts.backend_opts)?;
+
+    for command in &opts.exec {
+        execute(
+            shellwords::split(command)?.iter().map(OsString::from),
+            &opts,
+            &transport,
+        )?;
+    }
 
     if let Some(value) = opts.command.run(&opts, &transport)? {
         println!("{}", serde_json::to_string_pretty(&value)?);

--- a/util/opentitantool_test_runner.sh
+++ b/util/opentitantool_test_runner.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# A shell script for executing opentitantool as the test harness for
+# functional tests.
+#
+# Currently this script expects only to execute tests via verilator.
+
+set -e
+
+PASS="PASS"
+FAIL="FAIL"
+TIMELIMIT=$((15*60))
+
+for arg in "$@"; do
+  case $arg in
+    --tool=*)
+      OPENTITANTOOL="${arg#*=}"
+      shift
+      ;;
+    --verilator-dir=*)
+      VERILATOR_DIR="${arg#*=}"
+      shift
+      ;;
+    --verilator-rom=*)
+      VERILATOR_ROM="${arg#*=}"
+      shift
+      ;;
+    --verilator-flash=*)
+      VERILATOR_FLASH="${arg#*=}"
+      shift
+      ;;
+    --verilator-otp=*)
+      VERILATOR_OTP="${arg#*=}"
+      shift
+      ;;
+    --pass=*)
+      PASS="${arg#*=}"
+      shift
+      ;;
+    --fail=*)
+      FAIL="${arg#*=}"
+      shift
+      ;;
+    --timeout=*)
+      TIMELIMIT="${arg#*=}"
+      shift
+      ;;
+    *)
+      echo "Unknown argument: $arg"
+      exit 1
+      ;;
+esac
+done
+
+RUST_BACKTRACE=1 ${OPENTITANTOOL} \
+    --rcfile= \
+    --logging=info \
+    --interface=verilator \
+    --verilator-bin="${VERILATOR_DIR}/sim-verilator/Vchip_sim_tb" \
+    --verilator-rom="${VERILATOR_ROM}" \
+    --verilator-flash="${VERILATOR_FLASH}" \
+    --verilator-otp="${VERILATOR_OTP}" \
+    console \
+        --uart=0 \
+        --exit-failure="${FAIL}" \
+        --exit-success="${PASS}" \
+        --timeout="${TIMELIMIT}"


### PR DESCRIPTION
DO_NOT_SUBMIT until #9338 and #9211 are submitted.

1. Update the test runner script to understand the cw310 target.
2. Update the opentitan_functest macro to emit rules for the cw310 target.
3. Tag tests with "verilator" or "cw310" so test execution can be controlled
   with the bazel --test_tag_filters flag.

Signed-off-by: Chris Frantz <cfrantz@google.com>