### PR TITLE
[dv/cip_base] Add alert check in post_start

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -137,11 +137,11 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     if (do_clear_all_interrupts) clear_all_interrupts();
 
     if (expect_fatal_alerts) begin
-      // Fatal alert is triggered in this seq. Wait 10_000ns to entire background check
+      // Fatal alert is triggered in this seq. Wait 10_000ns so the background check
       // `check_fatal_alert_nonblocking` has enough time to execute before dut_init.
       // Issue reset if reset is allowed, otherwise, reset will be called in upper vseq.
       #10_000ns;
-      if (do_apply_reset) dut_init();
+      dut_init();
     end else begin
       check_no_fatal_alerts();
     end

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -13,7 +13,6 @@ class keymgr_base_vseq extends cip_base_vseq #(
   // various knobs to enable certain routines
   bit do_keymgr_init = 1'b1;
   bit do_wait_for_init_done = 1'b1;
-  bit do_reset_at_end_of_seq = 1'b0;
   bit seq_check_en = 1'b1;
 
   // do operations at StReset
@@ -291,16 +290,4 @@ class keymgr_base_vseq extends cip_base_vseq #(
       csr_rd_check(.ptr(ral.working_state), .compare_value(keymgr_pkg::StInvalid));
     end
   endtask
-
-  task post_start();
-    super.post_start();
-
-    // If fatal alert will be triggered in this seq, issue reset if reset is allowed, otherwise,
-    // reset will be called in upper vseq
-    if (do_reset_at_end_of_seq) begin
-      #10_000ns;
-      if (do_apply_reset) apply_reset();
-    end
-  endtask
-
 endclass : keymgr_base_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_cmd_invalid_vseq.sv
@@ -66,7 +66,7 @@ class keymgr_cmd_invalid_vseq extends keymgr_lc_disable_vseq;
 
   task post_start();
     // fatal alert will be triggered, need reset to clear it
-    do_reset_at_end_of_seq = 1;
+    expect_fatal_alerts = 1;
     super.post_start();
     cfg.en_scb = 1;
     cfg.keymgr_vif.en_chk = 1;

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -28,12 +28,8 @@ class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
   endfunction
 
   task post_start();
+    expect_fatal_alerts = 1;
     super.post_start();
-
-    // fatal alert will be triggered in this seq. Issue reset if reset is allowed, otherwise, reset
-    // will be called in upper vseq
-    #10_000ns;
-    if (do_apply_reset) apply_reset();
   endtask
 
 endclass : keymgr_hwsw_invalid_input_vseq

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_kmac_rsp_err_vseq.sv
@@ -25,7 +25,7 @@ class keymgr_kmac_rsp_err_vseq extends keymgr_hwsw_invalid_input_vseq;
     cfg.m_keymgr_kmac_agent_cfg.error_rsp_pct = 20;
 
     // fatal alert will be triggered, need reset to clear it
-    do_reset_at_end_of_seq = 1;
+    expect_fatal_alerts = 1;
     super.pre_start();
   endtask
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
@@ -68,7 +68,7 @@ class keymgr_sync_async_fault_cross_vseq extends keymgr_base_vseq;
   endfunction
 
   task post_start();
-    do_reset_at_end_of_seq = 1;
+    expect_fatal_alerts = 1;
     super.post_start();
     cfg.en_scb = 1;
     cfg.keymgr_vif.en_chk = 1;

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_prog_failure_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_prog_failure_vseq.sv
@@ -14,14 +14,7 @@ class lc_ctrl_prog_failure_vseq extends lc_ctrl_smoke_vseq;
   }
 
   virtual task post_start();
-    // trigger dut_init to make sure always on alert is not firing forever
-    if (do_apply_reset) begin
-      dut_init();
-    end else wait(0); // wait until upper seq resets and kills this seq
-
-    // delay to avoid race condition when sending item and checking no item after reset occur
-    // at the same time
-    #1ps;
+    expect_fatal_alerts = 1;
     super.post_start();
   endtask
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
@@ -65,14 +65,7 @@ class otp_ctrl_background_chks_vseq extends otp_ctrl_dai_lock_vseq;
   endtask
 
   virtual task post_start();
-    // Use reset to clear lc interrupt error
-    if (do_apply_reset) begin
-      dut_init();
-    end else wait(0); // wait until upper seq resets and kills this seq
-
-    // delay to avoid race condition when sending item and checking no item after reset occur
-    // at the same time
-    #1ps;
+    expect_fatal_alerts = 1;
     cfg.en_scb = 1;
     super.post_start();
   endtask

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -20,15 +20,6 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
   endtask
 
   virtual task post_start();
-    // Random CSR rw might trigger alert. Some alerts will conintuously be triggered until reset
-    // applied, which will cause alert_monitor phase_ready_to_end timeout.
-    if (do_apply_reset) begin
-      dut_init();
-    end else wait(0); // wait until upper seq resets and kills this seq
-
-    // delay to avoid race condition when sending item and checking no item after reset occur
-    // at the same time
-    #1ps;
     super.post_start();
   endtask
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -45,10 +45,7 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
   endtask
 
   virtual task post_start();
-    apply_reset();
-    // delay to avoid race condition when sending item and checking no item after reset occur
-    // at the same time
-    #1ps;
+    expect_fatal_alerts = 1;
     super.post_start();
   endtask
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -65,15 +65,8 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_lock_vseq;
   endtask
 
   virtual task post_start();
-    // Use reset to clear lc interrupt error
-    if (do_apply_reset) begin
-      cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
-      dut_init();
-    end else wait(0); // wait until upper seq resets and kills this seq
-
-    // delay to avoid race condition when sending item and checking no item after reset occur
-    // at the same time
-    #1ps;
+    expect_fatal_alerts = 1;
+    cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
     super.post_start();
   endtask
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_req_vseq.sv
@@ -33,14 +33,7 @@ class otp_ctrl_parallel_lc_req_vseq extends otp_ctrl_parallel_base_vseq;
   endtask
 
   virtual task post_start();
-    // Use reset to clear lc interrupt error
-    if (do_apply_reset) begin
-      dut_init();
-    end else wait(0); // wait until upper seq resets and kills this seq
-
-    // delay to avoid race condition when sending item and checking no item after reset occur
-    // at the same time
-    #1ps;
+    expect_fatal_alerts = 1;
     super.post_start();
   endtask
 


### PR DESCRIPTION
This PR adds alert checking in post_start in cip_base_vseq：
1). If expect fatal alert - wait 10_000ns and dut_init
2). If does not expect alert - randomly check if alerts ever fire in a random cycles of 200-500.

This PR also includes adopting this change to lc_ctrl, keymgr, and otp_ctrl.