### PR TITLE
[bazel] Build mask_rom with bazel 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,9 +6,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 git_repository(
     name = "bazel_embedded",
-    commit = "f7299c20ea6182e164adabc336ba2a7c0d8caa71",
+    commit = "b4faaec60b07b11fe3d1fc6b40f22baf31a54690",
     remote = "https://github.com/lowRISC/bazel-embedded.git",
-    shallow_since = "1628013051 +0000",
+    shallow_since = "1639417565 -0800"
 )
 
 load("@bazel_embedded//:bazel_embedded_deps.bzl", "bazel_embedded_deps")

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -16,6 +16,7 @@ fusesoc_build(
     ],
     systems = ["lowrisc:dv:chip_verilator_sim"],
     target = "sim",
+    data = ["//hw/ip/otbn:all_files"],
 )
 
 # TODO(lowRISC/opentitan#7972): Globbing all of the //hw/... hierarchy together

--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -42,7 +42,7 @@ def _fusesoc_build_impl(ctx):
     )
     return [DefaultInfo(
         files = depset([out_dir]),
-        data_runfiles = ctx.runfiles(files = [out_dir]),
+        data_runfiles = ctx.runfiles(files = [out_dir] + ctx.files.data),
     )]
 
 fusesoc_build = rule(
@@ -50,6 +50,7 @@ fusesoc_build = rule(
     attrs = {
         "cores": attr.label_list(allow_files = True, doc = "FuseSoC core specification files"),
         "srcs": attr.label_list(allow_files = True, doc = "Source files"),
+        "data": attr.label_list(allow_files = True, doc = "Files needed at runtime"),
         "target": attr.string(mandatory = True, doc = "Target name (e.g. 'sim')"),
         "systems": attr.string_list(mandatory = True, doc = "Systems to build"),
     },

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -1,0 +1,122 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:opentitan.bzl", "OPENTITAN_PLATFORM", "opentitan_transition")
+load("//rules:bugfix.bzl", "find_cc_toolchain")
+
+def _otbn_binary(ctx):
+    """The build process for otbn resources currently invokes
+    `//hw/ip/otbn/util/otbn-{as,ld,...}` to build the otbn resource.
+    These programs are python scripts which translate otbn special
+    instructions into the proper opcode sequences and _then_ invoke the normal
+    `rv32-{as,ld,...}` programs to produce the resource.  These "native"
+    otbn resources are the `otbn_objs` and `elf` output groups.
+
+    In order to make the otbn resource useful to the the main CPU, the
+    otbn resource needs to be included as a blob of data that the main
+    CPU can dump into the otbn `imem` area and ask otbn to execute it.
+    `util/otbn-build.py` does this with some objcopy-fu, emitting
+    `foo.rv32embed.o`.  Bazel's `cc_*` rules really want dependency objects
+    expressed as archives rather than raw object files, so I've modified
+    `otbn-build` to also emit an archive file.
+
+    _Morally_, the otbn resource is a data dependency.  However the
+    practical meaning of a `data` dependency in bazel is a file made
+    available at runtime, which is not how we're using the otbn resource.
+    The closest analog is something like `cc_embed_data`, which is like
+    a data dependency that needs to be linked into the main program.
+    We achieve by having `otbn-build` emit a conventional RV32I library
+    that other rules can depend on in their `deps`.
+    """
+    cc_toolchain = find_cc_toolchain(ctx)
+    objs = [
+        ctx.actions.declare_file(src.basename.replace("." + src.extension, ".o"))
+        for src in ctx.files.srcs
+    ]
+    elf = ctx.actions.declare_file(ctx.attr.name + ".elf")
+    rv32embed = ctx.actions.declare_file(ctx.attr.name + ".rv32embed.o")
+    archive = ctx.actions.declare_file(ctx.attr.name + ".rv32embed.a")
+    outputs = objs + [elf, rv32embed, archive]
+
+    # Note: the toolchain config doesn"t appear to have a good way to get
+    # access to the assembler.  We should be able to access it via the
+    # the compiler, but I had trouble with //hw/ip/otbn/util/otbn-as invoking
+    # the compiler as assembler.
+    assembler = [f for f in cc_toolchain.all_files.to_list() if f.basename.endswith("as")][0]
+
+    ctx.actions.run(
+        outputs = outputs,
+        inputs = (ctx.files.srcs +
+                  cc_toolchain.all_files.to_list() +
+                  ctx.files._otbn_as +
+                  ctx.files._otbn_ld +
+                  ctx.files._otbn_data +
+                  ctx.files._wrapper),
+        env = {
+            "OTBN_AS": ctx.file._otbn_as.path,
+            "OTBN_LD": ctx.file._otbn_ld.path,
+            "RV32_TOOL_AS": assembler.path,
+            "RV32_TOOL_AR": cc_toolchain.ar_executable,
+            "RV32_TOOL_LD": cc_toolchain.ld_executable,
+            "RV32_TOOL_OBJCOPY": cc_toolchain.objcopy_executable,
+        },
+        arguments = [
+            "--app-name={}".format(ctx.attr.name),
+            "--archive",
+            "--out-dir={}".format(elf.dirname),
+        ] + [src.path for src in ctx.files.srcs],
+        executable = ctx.file._wrapper,
+    )
+
+    feature_configuration = cc_common.configure_features(
+        ctx = ctx,
+        cc_toolchain = cc_toolchain,
+        requested_features = ctx.features,
+        unsupported_features = ctx.disabled_features,
+    )
+
+    return [
+        DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs)),
+        OutputGroupInfo(
+            otbn_objs = depset(objs),
+            elf = depset([elf]),
+            rv32embed = depset([rv32embed]),
+            archive = depset([archive]),
+        ),
+        # Emit a CcInfo provider so that this rule can be a dependency in other
+        # cc_* rules.
+        CcInfo(
+            linking_context = cc_common.create_linking_context(
+                linker_inputs = depset([cc_common.create_linker_input(
+                    owner = ctx.label,
+                    libraries = depset([cc_common.create_library_to_link(
+                        actions = ctx.actions,
+                        feature_configuration = feature_configuration,
+                        cc_toolchain = cc_toolchain,
+                        static_library = archive,
+                    )]),
+                )]),
+            ),
+        ),
+    ]
+
+otbn_binary = rule(
+    implementation = _otbn_binary,
+    cfg = opentitan_transition,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "platform": attr.string(default = OPENTITAN_PLATFORM),
+        "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+        "_otbn_as": attr.label(default = "//hw/ip/otbn/util:otbn-as", allow_single_file = True),
+        "_otbn_ld": attr.label(default = "//hw/ip/otbn/util:otbn-ld", allow_single_file = True),
+        "_otbn_data": attr.label(default = "//hw/ip/otbn/data:all_files", allow_files = True),
+        "_wrapper": attr.label(default = "//util:otbn_build.py", allow_single_file = True),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    fragments = ["cpp"],
+    toolchains = ["@rules_cc//cc:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
+)

--- a/sw/device/boot_rom/BUILD
+++ b/sw/device/boot_rom/BUILD
@@ -88,11 +88,5 @@ opentitan_functest(
         "boot_rom_test.c",
     ],
     deps = [
-        "//sw/device/exts/common",
-        "//sw/device/lib/arch:device",
-        "//sw/device/lib/crt",
-        "//sw/device/lib/testing/test_framework",
-        "//sw/device/lib/testing/test_framework:main",
-        "//sw/device/lib/testing/test_framework:ottf_isrs",
     ],
 )

--- a/sw/device/lib/BUILD
+++ b/sw/device/lib/BUILD
@@ -43,3 +43,13 @@ cc_library(
         "//sw/device/lib/base",
     ],
 )
+
+cc_library(
+    name = "irq",
+    srcs = ["irq.c"],
+    hdrs = ["irq.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base",
+    ],
+)

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -30,6 +30,9 @@ cc_library(
 
 cc_library(
     name = "mmio",
+    hdrs = [
+        "mmio.h",
+    ],
     srcs = [
         "mmio.c",
     ],

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -31,6 +31,85 @@ cc_library(
     ],
 )
 
+# TODO(lowRISC/opentitan#7972): clean up check.h after completing the
+# migration to bazel.
+cc_library(
+    name = "check",
+    hdrs = [
+        "test_status.h",
+        "//sw/device/lib/testing:check",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+cc_library(
+    name = "freertos_config",
+    hdrs = [
+        "FreeRTOSConfig.h",
+    ],
+    # FreeRTOS sources don't follow our project's include-path standard,
+    # and just include via the bare filename.
+    includes = ["."],
+    deps = [
+        "//sw/device/lib/arch:device",
+    ],
+)
+
+cc_library(
+    name = "freertos_port",
+    srcs = [
+        "freertos_hooks.c",
+        "freertos_port.S",
+        "freertos_port.c",
+    ],
+    hdrs = [
+        "ottf_macros.h",
+    ],
+    deps = [
+        ":check",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib:irq",
+        "//sw/device/lib/base",
+        "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/vendor/freertos_freertos_kernel:kernel",
+    ],
+)
+
+cc_library(
+    name = "ottf",
+    srcs = [
+        "ottf.c",
+    ],
+    hdrs = [
+        "ottf.h",
+        "//sw/device/lib/testing:check",
+    ],
+    linkopts = [
+        # Make the linker keep resolving references between these
+        # targets until satisfied.
+        "-Wl,--start-group",
+        "$(location :freertos_port)",
+        "$(location //sw/device/lib:irq)",
+        "$(location //sw/vendor/freertos_freertos_kernel:kernel)",
+        "-Wl,--end-group",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":freertos_port",
+        ":test_framework",
+        "//sw/device/lib:irq",
+        "//sw/device/lib/base",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/vendor/freertos_freertos_kernel:kernel",
+    ],
+)
+
 cc_library(
     name = "ottf_isrs",
     srcs = [
@@ -39,13 +118,9 @@ cc_library(
     ],
     hdrs = [
         "ottf_isrs.h",
-        "ottf_macros.h",
     ],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
-        "//sw/device/lib/base",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/lib/runtime:ibex",
-        "//sw/device/lib/runtime:log",
+        ":freertos_port",
     ],
 )

--- a/sw/device/silicon_creator/BUILD
+++ b/sw/device/silicon_creator/BUILD
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -1,0 +1,430 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_functest", "verilator_params")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boot_data_intf",
+    hdrs = ["boot_data.h"],
+    deps = [
+        ":error",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+    ],
+)
+
+cc_library(
+    name = "boot_data",
+    srcs = ["boot_data.c"],
+    deps = [
+        ":boot_data_intf",
+        ":error",
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+    ],
+)
+
+cc_library(
+    name = "mock_boot_data",
+    testonly = True,
+    hdrs = ["mock_boot_data.h"],
+    deps = [
+        ":boot_data_intf",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+opentitan_functest(
+    name = "boot_data_functest",
+    srcs = ["boot_data_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        ":boot_data",
+        ":test_main",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+    ],
+)
+
+cc_library(
+    name = "epmp_intf",
+    hdrs = [
+        "epmp.h",
+        "epmp_defs.h",
+    ],
+    deps = [
+        ":error",
+    ],
+)
+
+cc_library(
+    name = "epmp",
+    srcs = ["epmp.c"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":epmp_intf",
+        ":error",
+        "//sw/device/lib/base",
+    ],
+)
+
+cc_test(
+    name = "epmp_unittest",
+    srcs = [
+        "epmp_unittest.cc",
+        # sources included here because we need MOCK_CSR.
+        "epmp.c",
+        "epmp.h",
+    ],
+    deps = [
+        ":epmp_intf",
+        ":error",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_csr",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "epmp_test_unlock",
+    srcs = ["epmp_test_unlock.c"],
+    hdrs = ["epmp_test_unlock.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":epmp_intf",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+    ],
+)
+
+cc_library(
+    name = "error",
+    srcs = ["absl_status.h"],
+    hdrs = ["error.h"],
+    deps = [
+        "//sw/device/lib/base",
+    ],
+)
+
+cc_test(
+    name = "error_unittest",
+    srcs = ["error_unittest.cc"],
+    deps = [
+        ":error",
+        "//sw/device/lib/base",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "irq_asm",
+    srcs = ["irq_asm.S"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/ip/aon_timer/data:aon_timer_regs",
+        "//hw/top_earlgrey/ip/pwrmgr/data/autogen:pwrmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+    ],
+)
+
+opentitan_functest(
+    name = "irq_asm_functest",
+    srcs = ["irq_asm_functest.c"],
+    deps = [
+        ":error",
+        ":irq_asm",
+        ":test_main",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:watchdog",
+    ],
+)
+
+cc_library(
+    name = "keymgr_binding",
+    hdrs = ["keymgr_binding_value.h"],
+)
+
+cc_library(
+    name = "log",
+    srcs = ["log.c"],
+    hdrs = ["log.h"],
+    deps = [
+        ":error",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+    ],
+)
+
+cc_test(
+    name = "log_unittest",
+    srcs = ["log_unittest.cc"],
+    deps = [
+        ":error",
+        ":log",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "manifest_intf",
+    hdrs = [
+        "manifest.h",
+        "manifest_size.h",
+    ],
+    deps = [
+        ":epmp_intf",
+        ":error",
+        ":keymgr_binding",
+        ":sigverify_internal",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+    ],
+)
+
+cc_library(
+    name = "manifest",
+    srcs = ["manifest.c"],
+    deps = [
+        ":manifest_intf",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+    ],
+)
+
+cc_library(
+    name = "mock_manifest",
+    testonly = True,
+    hdrs = ["mock_manifest.h"],
+    deps = [
+        ":manifest_intf",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "manifest_unittest",
+    srcs = [
+        "manifest_unittest.cc",
+    ],
+    defines = ["MOCK_CSR"],
+    deps = [
+        ":epmp_intf",
+        ":error",
+        ":keymgr_binding",
+        ":manifest_intf",
+        ":sigverify_internal",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_csr",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "otbn_util",
+    srcs = ["otbn_util.c"],
+    hdrs = ["otbn_util.h"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/drivers:otbn",
+    ],
+)
+
+cc_library(
+    name = "shutdown",
+    srcs = ["shutdown.c"],
+    hdrs = ["shutdown.h"],
+    deps = [
+        ":error",
+        ":log",
+        "//hw/ip/keymgr/data:keymgr_regs",
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/ip/sram_ctrl/data:sram_ctrl_regs",
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/drivers:alert",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+    ],
+)
+
+cc_test(
+    name = "shutdown_unittest",
+    srcs = [
+        "shutdown.c",
+        "shutdown.h",
+        "shutdown_unittest.cc",
+    ],
+    defines = [
+        "OT_OFF_TARGET_TEST",
+    ],
+    deps = [
+        ":error",
+        ":log",
+        "//hw/ip/keymgr/data:keymgr_regs",
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/ip/sram_ctrl/data:sram_ctrl_regs",
+        "//hw/top_earlgrey:alert_handler_regs",
+        "//hw/top_earlgrey/ip/flash_ctrl/data/autogen:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:mock_alert",
+        "//sw/device/silicon_creator/lib/drivers:mock_otp",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "sigverify_internal",
+    hdrs = [
+        "sigverify_mod_exp.h",
+        "sigverify_rsa_key.h",
+    ],
+    deps = [
+        ":error",
+    ],
+)
+
+cc_library(
+    name = "sigverify_intf",
+    hdrs = ["sigverify.h"],
+    deps = [
+        ":error",
+        ":manifest_intf",
+        ":sigverify_internal",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+    ],
+)
+
+cc_library(
+    name = "sigverify",
+    srcs = ["sigverify.c"],
+    deps = [
+        ":sigverify_internal",
+        ":sigverify_intf",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+    ],
+)
+
+cc_test(
+    name = "sigverify_unittest",
+    srcs = ["sigverify_unittest.cc"],
+    deps = [
+        ":mock_sigverify",
+        ":sigverify",
+        ":sigverify_intf",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:mock_otp",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "sigverify_functest",
+    srcs = ["sigverify_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+        tags = [
+            "manual",
+            "verilator",
+        ],
+    ),
+    deps = [
+        ":sigverify",
+        ":sigverify_intf",
+        ":sigverify_mod_exp_ibex",
+        ":sigverify_mod_exp_otbn",
+        ":test_main",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_library(
+    name = "sigverify_mod_exp_ibex",
+    srcs = ["sigverify_mod_exp_ibex.c"],
+    deps = [
+        ":sigverify_internal",
+        "//sw/device/lib/base",
+    ],
+)
+
+cc_library(
+    name = "sigverify_mod_exp_otbn",
+    srcs = ["sigverify_mod_exp_otbn.c"],
+    deps = [
+        ":error",
+        ":otbn_util",
+        ":sigverify_internal",
+        "//sw/device/silicon_creator/lib/drivers:otbn",
+        "//sw/otbn/crypto:run_rsa_verify_3072_rr_modexp",
+    ],
+)
+
+cc_library(
+    name = "mock_sigverify",
+    testonly = True,
+    hdrs = [
+        "mock_sigverify_mod_exp_ibex.h",
+        "mock_sigverify_mod_exp_otbn.h",
+    ],
+    deps = [
+        ":sigverify_internal",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "sigverify_mod_exp_ibex_unittest",
+    srcs = ["sigverify_mod_exp_ibex_unittest.cc"],
+    deps = [
+        ":sigverify_internal",
+        ":sigverify_intf",
+        ":sigverify_mod_exp_ibex",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "test_main",
+    hdrs = ["test_main.h"],
+    deps = [
+        ":error",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf",
+    ],
+)

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -1,0 +1,84 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["static_critical.ld"])
+
+cc_library(
+    name = "mock_csr",
+    testonly = True,
+    srcs = ["mock_csr.cc"],
+    hdrs = ["mock_csr.h"],
+    defines = ["MOCK_CSR"],
+    deps = [
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "mock_csr_test",
+    srcs = ["mock_csr_test.cc"],
+    deps = [
+        ":mock_csr",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "abs_mmio",
+    srcs = ["abs_mmio.c"],
+    hdrs = ["abs_mmio.h"],
+    deps = [
+        "//sw/device/lib/base",
+    ],
+)
+
+cc_library(
+    name = "mock_abs_mmio",
+    testonly = True,
+    hdrs = ["mock_abs_mmio.h"],
+    deps = [
+        ":abs_mmio",
+        "//sw/device/lib/base/testing",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "sec_mmio",
+    srcs = ["sec_mmio.c"],
+    hdrs = ["sec_mmio.h"],
+    deps = [
+        ":abs_mmio",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+    ],
+)
+
+cc_library(
+    name = "mock_sec_mmio",
+    testonly = True,
+    hdrs = ["mock_sec_mmio.h"],
+    deps = [
+        ":sec_mmio",
+        "//sw/device/lib/base/testing",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "sec_mmio_unittest",
+    srcs = ["sec_mmio_unittest.cc"],
+    deps = [
+        ":mock_abs_mmio",
+        ":sec_mmio",
+        "//sw/device/silicon_creator/lib:error",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -1,0 +1,434 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_functest")
+
+cc_library(
+    name = "alert",
+    srcs = ["alert.c"],
+    hdrs = ["alert.h"],
+    deps = [
+        "//hw/top_earlgrey:alert_handler_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_library(
+    name = "mock_alert",
+    testonly = True,
+    hdrs = ["mock_alert.h"],
+    deps = [
+        ":alert",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "alert_unittest",
+    srcs = ["alert_unittest.cc"],
+    deps = [
+        ":alert",
+        "//hw/top_earlgrey:alert_handler_regs",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "alert_functest",
+    srcs = ["alert_functest.c"],
+    deps = [
+        ":alert",
+        ":rstmgr",
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey:alert_handler_regs",
+        "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib:test_main",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_library(
+    name = "flash_ctrl",
+    srcs = ["flash_ctrl.c"],
+    hdrs = ["flash_ctrl.h"],
+    deps = [
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_test(
+    name = "flash_ctrl_unittest",
+    srcs = ["flash_ctrl_unittest.cc"],
+    deps = [
+        ":flash_ctrl",
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//sw/device/lib/base",
+        "//sw/device/lib/base/testing",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "hmac",
+    srcs = ["hmac.c"],
+    hdrs = ["hmac.h"],
+    deps = [
+        "//hw/ip/hmac/data:hmac_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+    ],
+)
+
+cc_library(
+    name = "mock_hmac",
+    testonly = True,
+    hdrs = ["mock_hmac.h"],
+    deps = [
+        ":hmac",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "hmac_unittest",
+    srcs = ["hmac_unittest.cc"],
+    deps = [
+        ":hmac",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "hmac_functest",
+    srcs = ["hmac_functest.c"],
+    deps = [
+        ":hmac",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:test_main",
+    ],
+)
+
+cc_library(
+    name = "keymgr",
+    srcs = ["keymgr.c"],
+    hdrs = ["keymgr.h"],
+    deps = [
+        "//hw/ip/keymgr/data:keymgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/lib/base/freestanding",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:keymgr_binding",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_test(
+    name = "keymgr_unittest",
+    srcs = ["keymgr_unittest.cc"],
+    deps = [
+        ":keymgr",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "keymgr_functest",
+    srcs = ["keymgr_functest.c"],
+    # FIXME: currently, the FPGA doesn't wake up from low-power mode.
+    # For now, run the test only in verilator.
+    targets = ["verilator"],
+    deps = [
+        ":keymgr",
+        ":lifecycle",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib:flash_ctrl",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:keymgr_binding",
+        "//sw/device/silicon_creator/lib:test_main",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_library(
+    name = "lifecycle",
+    srcs = ["lifecycle.c"],
+    hdrs = ["lifecycle.h"],
+    deps = [
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_library(
+    name = "mock_lifecycle",
+    testonly = True,
+    hdrs = ["mock_lifecycle.h"],
+    deps = [
+        ":lifecycle",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "otbn",
+    srcs = ["otbn.c"],
+    hdrs = ["otbn.h"],
+    deps = [
+        "//hw/ip/otbn/data:otbn_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+    ],
+)
+
+cc_test(
+    name = "otbn_unittest",
+    srcs = ["otbn_unittest.cc"],
+    deps = [
+        ":otbn",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "otp",
+    srcs = ["otp.c"],
+    hdrs = ["otp.h"],
+    deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_library(
+    name = "mock_otp",
+    testonly = True,
+    hdrs = ["mock_otp.h"],
+    deps = [
+        ":otp",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "otp_unittest",
+    srcs = ["otp_unittest.cc"],
+    deps = [
+        ":otp",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "pinmux",
+    srcs = ["pinmux.c"],
+    hdrs = ["pinmux.h"],
+    deps = [
+        "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+    ],
+)
+
+cc_test(
+    name = "pinmux_unittest",
+    srcs = ["pinmux_unittest.cc"],
+    deps = [
+        ":pinmux",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "retention_sram",
+    srcs = ["retention_sram.c"],
+    hdrs = ["retention_sram.h"],
+    deps = [
+        "//hw/ip/sram_ctrl/data:sram_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+    ],
+)
+
+cc_test(
+    name = "retention_sram_unittest",
+    srcs = ["retention_sram_unittest.cc"],
+    deps = [
+        ":retention_sram",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "retention_sram_functest",
+    srcs = ["retention_sram_functest.c"],
+    deps = [
+        ":retention_sram",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:test_main",
+    ],
+)
+
+cc_library(
+    name = "rstmgr",
+    srcs = ["rstmgr.c"],
+    hdrs = ["rstmgr.h"],
+    deps = [
+        "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_test(
+    name = "rstmgr_unittest",
+    srcs = ["rstmgr_unittest.cc"],
+    deps = [
+        ":rstmgr",
+        "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "uart",
+    srcs = ["uart.c"],
+    hdrs = ["uart.h"],
+    deps = [
+        "//hw/ip/uart/data:uart_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+    ],
+)
+
+cc_test(
+    name = "uart_unittest",
+    srcs = ["uart_unittest.cc"],
+    deps = [
+        ":uart",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "uart_functest",
+    srcs = ["uart_functest.c"],
+    deps = [
+        ":uart",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:test_main",
+    ],
+)
+
+cc_library(
+    name = "watchdog",
+    srcs = ["watchdog.c"],
+    hdrs = ["watchdog.h"],
+    deps = [
+        "//hw/ip/aon_timer/data:aon_timer_regs",
+        "//hw/top_earlgrey/ip/pwrmgr/data/autogen:pwrmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+    ],
+)
+
+cc_test(
+    name = "watchdog_unittest",
+    srcs = ["watchdog_unittest.cc"],
+    deps = [
+        ":watchdog",
+        "//hw/ip/aon_timer/data:aon_timer_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "watchdog_functest",
+    srcs = ["watchdog_functest.c"],
+    deps = [
+        ":retention_sram",
+        ":rstmgr",
+        ":watchdog",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:test_main",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+    ],
+)

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
+
 #include "sw/device/silicon_creator/lib/drivers/otbn.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/otbn_util.h"

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -1,0 +1,253 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_functest", "verilator_params")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "boot_policy",
+    srcs = ["boot_policy.c"],
+    hdrs = [
+        "boot_policy.h",
+        "boot_policy_ptrs.h",
+    ],
+    deps = [
+        "//sw/device/silicon_creator/lib:boot_data",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:manifest_intf",
+    ],
+)
+
+cc_library(
+    name = "mock_boot_policy_ptrs",
+    testonly = True,
+    hdrs = ["mock_boot_policy_ptrs.h"],
+    deps = [
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_test(
+    name = "boot_policy_unittest",
+    srcs = [
+        "boot_policy.c",
+        "boot_policy.h",
+        "boot_policy_ptrs.h",
+        "boot_policy_unittest.cc",
+    ],
+    defines = ["OT_OFF_TARGET_TEST"],
+    deps = [
+        ":mock_boot_policy_ptrs",
+        "//sw/device/silicon_creator/lib:mock_boot_data",
+        "//sw/device/silicon_creator/lib:mock_manifest",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_binary(
+    name = "mask_rom",
+    srcs = [
+        "mask_rom.c",
+        "mask_rom.h",
+        "mask_rom_start.S",
+    ],
+    linkopts = [
+        "-T $(location mask_rom.ld)",
+    ],
+    output_scrambled = True,
+    deps = [
+        "mask_rom.ld",
+        ":boot_policy",
+        ":mask_rom_epmp",
+        ":primitive_bootstrap",
+        ":sigverify_keys",
+        "//hw/ip/csrng/data:csrng_regs",
+        "//hw/ip/edn/data:edn_regs",
+        "//hw/ip/entropy_src/data:entropy_src_regs",
+        "//hw/ip/sram_ctrl/data:sram_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:linker_script",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device:info_sections",
+        "//sw/device/lib:pinmux",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/silicon_creator/lib:epmp",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:irq_asm",
+        "//sw/device/silicon_creator/lib:log",
+        "//sw/device/silicon_creator/lib:shutdown",
+        "//sw/device/silicon_creator/lib:sigverify",
+        "//sw/device/silicon_creator/lib:sigverify_intf",
+        "//sw/device/silicon_creator/lib:sigverify_mod_exp_ibex",
+        "//sw/device/silicon_creator/lib:sigverify_mod_exp_otbn",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/base:static_critical.ld",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:keymgr",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:retention_sram",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+    ],
+)
+
+cc_library(
+    name = "mask_rom_epmp",
+    srcs = [
+        "mask_rom_epmp.S",
+        "mask_rom_epmp.c",
+    ],
+    hdrs = ["mask_rom_epmp.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:epmp_intf",
+    ],
+)
+
+opentitan_functest(
+    name = "mask_rom_epmp_test",
+    srcs = [
+        "mask_rom_epmp_test.c",
+        "mask_rom_start.S",
+    ],
+    linkopts = [
+        "-T $(location mask_rom.ld)",
+    ],
+    # This test doesn't use the OTTF.
+    ottf = [],
+    output_scrambled = True,
+    targets = ["verilator"],  # Can only run in verilator right now.
+    verilator = verilator_params(
+        rom = ":mask_rom_epmp_test_prog_verilator_scr",
+    ),
+    deps = [
+        "mask_rom.ld",
+        ":mask_rom_epmp",
+        "//hw/ip/csrng/data:csrng_regs",
+        "//hw/ip/edn/data:edn_regs",
+        "//hw/ip/entropy_src/data:entropy_src_regs",
+        "//hw/ip/sram_ctrl/data:sram_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:linker_script",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device:info_sections",
+        "//sw/device/lib:pinmux",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/crt",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing/test_framework",
+        "//sw/device/silicon_creator/lib:epmp",
+        "//sw/device/silicon_creator/lib:epmp_test_unlock",
+        "//sw/device/silicon_creator/lib:irq_asm",
+        "//sw/device/silicon_creator/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/base:static_critical.ld",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:uart",
+    ],
+)
+
+cc_library(
+    name = "primitive_bootstrap",
+    srcs = ["primitive_bootstrap.c"],
+    hdrs = ["primitive_bootstrap.h"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/boot_rom:bootstrap",
+        "//sw/device/lib:flash_ctrl",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:log",
+        "//sw/device/silicon_creator/lib/drivers:hmac",
+    ],
+)
+
+cc_library(
+    name = "sigverify_keys_ptrs",
+    hdrs = ["sigverify_keys_ptrs.h"],
+)
+
+cc_library(
+    name = "mock_sigverify_keys_ptrs",
+    testonly = True,
+    hdrs = ["mock_sigverify_keys_ptrs.h"],
+    deps = [
+        ":sigverify_keys_ptrs",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "sigverify_keys",
+    srcs = ["sigverify_keys.c"],
+    hdrs = ["sigverify_keys.h"],
+    deps = [
+        ":sigverify_keys_ptrs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:sigverify_internal",
+        "//sw/device/silicon_creator/lib:sigverify_intf",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/mask_rom/keys:test_keys",
+    ],
+)
+
+cc_test(
+    name = "sigverify_keys_unittest",
+    srcs = [
+        "sigverify_keys.c",
+        "sigverify_keys.h",
+        "sigverify_keys_unittest.cc",
+    ],
+    defines = ["OT_OFF_TARGET_TEST"],
+    deps = [
+        ":mock_sigverify_keys_ptrs",
+        ":sigverify_keys",
+        ":sigverify_keys_ptrs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:mock_sigverify",
+        "//sw/device/silicon_creator/lib:sigverify",
+        "//sw/device/silicon_creator/lib:sigverify_internal",
+        "//sw/device/silicon_creator/lib:sigverify_intf",
+        "//sw/device/silicon_creator/lib:sigverify_mod_exp_ibex",
+        "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:mock_otp",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
+opentitan_functest(
+    name = "mask_rom_test",
+    srcs = [
+        "mask_rom_test.c",
+    ],
+    targets = ["verilator"],  # Can only run in verilator right now.
+    verilator = verilator_params(
+        args = [
+            "console",
+            # This test program is not signed, so a boot fault is the expected behavior.
+            "--exit-success='boot_fault: 0x0142500d'",
+        ],
+        rom = ":mask_rom_verilator_scr",
+    ),
+)

--- a/sw/device/silicon_creator/mask_rom/keys/BUILD
+++ b/sw/device/silicon_creator/mask_rom/keys/BUILD
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "test_keys",
+    hdrs = [
+        "test_key_0_rsa_3072_exp_f4.h",
+        "test_key_1_rsa_3072_exp_3.h",
+    ],
+)

--- a/sw/device/silicon_creator/mask_rom/mask_rom_test.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_test.c
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+const test_config_t kTestConfig;
+
+bool test_main(void) { return true; }

--- a/sw/device/silicon_creator/testing/BUILD
+++ b/sw/device/silicon_creator/testing/BUILD
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mask_rom_test",
+    testonly = True,
+    hdrs = ["mask_rom_test.h"],
+)

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:otbn.bzl", "otbn_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+otbn_binary(
+    name = "run_rsa_verify_3072_rr_modexp",
+    srcs = [
+        "rsa_verify_3072.s",
+        "rsa_verify_3072_rr.s",
+        "run_rsa_verify_3072_rr_modexp.s",
+    ],
+)

--- a/sw/vendor/freertos_freertos_kernel/BUILD
+++ b/sw/vendor/freertos_freertos_kernel/BUILD
@@ -1,0 +1,52 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "portmacro",
+    includes = ["portable/GCC/RISC-V"],
+    hdrs = [
+        "portable/GCC/RISC-V/portmacro.h",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+)
+
+cc_library(
+    name = "kernel",
+    srcs = [
+        "tasks.c",
+        "queue.c",
+        "list.c",
+        "portable/MemMang/heap_1.c",
+        "include/deprecated_definitions.h",
+    ],
+    includes = ["include"],
+    hdrs = [
+        "include/atomic.h",
+        "include/croutine.h",
+        "include/event_groups.h",
+        "include/FreeRTOS.h",
+        "include/list.h",
+        "include/message_buffer.h",
+        "include/mpu_prototypes.h",
+        "include/mpu_wrappers.h",
+        "include/portable.h",
+        "include/projdefs.h",
+        "include/queue.h",
+        "include/semphr.h",
+        "include/stack_macros.h",
+        "include/StackMacros.h",
+        "include/stream_buffer.h",
+        "include/task.h",
+        "include/timers.h",
+    ],
+    deps = [
+        ":portmacro",
+        "//sw/device/lib/base",
+        "//sw/device/lib/testing/test_framework:freertos_config",
+    ],
+)

--- a/sw/vendor/patches/freertos_freertos_kernel/build_with_bazel.patch
+++ b/sw/vendor/patches/freertos_freertos_kernel/build_with_bazel.patch
@@ -1,0 +1,58 @@
+diff --git b/BUILD a/BUILD
+new file mode 100644
+index 000000000..7a3961010
+--- /dev/null
++++ a/BUILD
+@@ -0,0 +1,52 @@
++# Copyright lowRISC contributors.
++# Licensed under the Apache License, Version 2.0, see LICENSE for details.
++# SPDX-License-Identifier: Apache-2.0
++
++package(default_visibility = ["//visibility:public"])
++
++load("//rules:opentitan.bzl", "OPENTITAN_CPU")
++
++cc_library(
++    name = "portmacro",
++    includes = ["portable/GCC/RISC-V"],
++    hdrs = [
++        "portable/GCC/RISC-V/portmacro.h",
++    ],
++    target_compatible_with = [OPENTITAN_CPU],
++)
++
++cc_library(
++    name = "kernel",
++    srcs = [
++        "tasks.c",
++        "queue.c",
++        "list.c",
++        "portable/MemMang/heap_1.c",
++        "include/deprecated_definitions.h",
++    ],
++    includes = ["include"],
++    hdrs = [
++        "include/atomic.h",
++        "include/croutine.h",
++        "include/event_groups.h",
++        "include/FreeRTOS.h",
++        "include/list.h",
++        "include/message_buffer.h",
++        "include/mpu_prototypes.h",
++        "include/mpu_wrappers.h",
++        "include/portable.h",
++        "include/projdefs.h",
++        "include/queue.h",
++        "include/semphr.h",
++        "include/stack_macros.h",
++        "include/StackMacros.h",
++        "include/stream_buffer.h",
++        "include/task.h",
++        "include/timers.h",
++    ],
++    deps = [
++        ":portmacro",
++        "//sw/device/lib/base",
++        "//sw/device/lib/testing/test_framework:freertos_config",
++    ],
++)

--- a/util/opentitantool_test_runner.sh
+++ b/util/opentitantool_test_runner.sh
@@ -8,5 +8,6 @@
 
 set -e
 
+readonly REPO_TOP="$TEST_SRCDIR/$TEST_WORKSPACE"
 readonly OPENTITANTOOL="sw/host/opentitantool/opentitantool"
 RUST_BACKTRACE=1 ${OPENTITANTOOL} "$@"


### PR DESCRIPTION
1. Add a bazel rule to build otbn programs.
2. Add bazel rules for all silicon_creator sources.
3. Add bazel rules for all silicon_creator tests.

Signed-off-by: Chris Frantz <cfrantz@google.com>