### PR TITLE
[sw/ottf] Fix bugs saving/restoring stack pointer in ISRs.

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf.c
+++ b/sw/device/lib/testing/test_framework/ottf.c
@@ -4,6 +4,9 @@
 
 #include "sw/device/lib/testing/test_framework/ottf.h"
 
+#include <assert.h>
+#include <stddef.h>
+
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/log.h"
@@ -18,6 +21,15 @@
 
 // TODO: make this toplevel agnostic.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// Check layout of test configuration struct since OTTF ISR asm code requires a
+// specific layout.
+static_assert(offsetof(test_config_t, enable_concurrency) == 0,
+              "Expected enable_concurrency field to be at offset zero within "
+              "test configuration struct.");
+static_assert(sizeof(((test_config_t){0}).enable_concurrency) == 1,
+              "Expected enable_concurrency field in test configuration struct "
+              "to be one byte.");
 
 // UART for communication with host.
 static dif_uart_t uart0;

--- a/sw/device/lib/testing/test_framework/ottf.h
+++ b/sw/device/lib/testing/test_framework/ottf.h
@@ -22,18 +22,16 @@
  * This type represents configuration values for an on-device test, which allow
  * tests to configure the behavior of the OpenTitan Test Framework (OTTF).
  *
- * New fields can be safely added to this struct without affecting any tests;
- * the "default" value of all fields should be zero (or NULL, or equivalent).
+ * WARNING: DO NOT REARRANGE THE MEMBERS IN THIS STRUCT. THE FIRST MEMBER IS
+ * ACCESSED BY OTTF ISR ASSEMBLY WHICH EXPECTS A SPECIFIC CONFIGURATION.
+ *
+ * However, new fields can be safely added to this struct without affecting any
+ * tests; the "default" value of all fields should be zero (or NULL, or
+ * equivalent).
  *
  * See `kTestConfig`.
  */
 typedef struct test_config {
-  /**
-   * Indicates that `test_main()` does something non-trivial to the UART
-   * device. Setting this to true will make `test_main()` guard against this
-   * by resetting the UART device before printing debug information.
-   */
-  bool can_clobber_uart;
   /**
    * If true, `test_main()` is run as a FreeRTOS task, enabling test writers to
    * to spawn additional (concurrent) FreeRTOS tasks within the `test_main()`
@@ -44,6 +42,12 @@ typedef struct test_config {
    * not require concurrency, and seek to minimize simulation runtime.
    */
   bool enable_concurrency;
+  /**
+   * Indicates that `test_main()` does something non-trivial to the UART
+   * device. Setting this to true will make `test_main()` guard against this
+   * by resetting the UART device before printing debug information.
+   */
+  bool can_clobber_uart;
 } test_config_t;
 
 /**

--- a/sw/device/lib/testing/test_framework/ottf_isrs.S
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.S
@@ -5,6 +5,7 @@
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 
 .extern pxCurrentTCB
+.extern kTestConfig
 .extern ottf_exception_handler
 .extern ottf_software_isr
 .extern ottf_timer_isr
@@ -33,15 +34,39 @@ compute_mepc_on_synchronous_irq:
   csrr t0, mepc
   li t1, 0x3
   and t2, t0, t1
-  beq t2, t1, L_32bit_trap_instr
+  beq t2, t1, .L_32bit_trap_instr
   addi t0, t0, OTTF_HALF_WORD_SIZE
   ret
-L_32bit_trap_instr:
+.L_32bit_trap_instr:
   addi t0, t0, OTTF_WORD_SIZE
   ret
 
   // Set size so this function can be disassembled.
   .size compute_mepc_on_synchronous_irq, .-compute_mepc_on_synchronous_irq
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Store stack pointer to current Task Control Block (TCB) ONLY if concurrency
+ * is enabled for a given test, i.e., the test that triggers an IRQ is running
+ * as a FreeRTOS task. This is because for bare-metal tests, the current
+ * FreeRTOS TCB pointer (pxCurrentTCB) will be NULL, which will result in an
+ * exception, if we attempt to perform a store to said address.
+ */
+.balign 4
+.type save_current_sp_to_tcb, @function
+save_current_sp_to_tcb:
+  la t0, kTestConfig  // Load the pointer to the test configuration struct.
+  lb t1, 0(t0)        // Load the first byte of the test_config struct, which
+                      // contains the `enable_concurrency` field to check.
+  beqz t1, .L_skip_sp_save
+  lw t2, pxCurrentTCB
+  sw sp, 0(t2)
+.L_skip_sp_save:
+  ret
+
+  // Set size so this function can be disassembled.
+  .size save_current_sp_to_tcb, .-save_current_sp_to_tcb
 
 // -----------------------------------------------------------------------------
 
@@ -92,9 +117,9 @@ handler_exception:
   jal compute_mepc_on_synchronous_irq
   sw t0, 0(sp)
 
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
+  // Store stack pointer to current TCB (only if concurrency is enabled, i.e.,
+  // the test that triggers this is running as a FreeRTOS task).
+  jal save_current_sp_to_tcb
 
   // Jump to the exception handler.
   jal ottf_exception_handler
@@ -154,9 +179,9 @@ handler_irq_software:
   jal compute_mepc_on_synchronous_irq
   sw t0, 0(sp)
 
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
+  // Store stack pointer to current TCB (only if concurrency is enabled, i.e.,
+  // the test that triggers this is running as a FreeRTOS task).
+  jal save_current_sp_to_tcb
 
   // Jump to the software ISR.
   jal ottf_software_isr
@@ -216,9 +241,9 @@ handler_irq_timer:
   csrr t0, mepc
   sw t0, 0(sp)
 
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
+  // Store stack pointer to current TCB (only if concurrency is enabled, i.e.,
+  // the test that triggers this is running as a FreeRTOS task).
+  jal save_current_sp_to_tcb
 
   // Jump to timer ISR.
   jal ottf_timer_isr
@@ -278,9 +303,9 @@ handler_irq_external:
   csrr t0, mepc
   sw t0, 0(sp)
 
-  // Store stack pointer to current TCB.
-  lw t0, pxCurrentTCB
-  sw sp, 0(t0)
+  // Store stack pointer to current TCB (only if concurrency is enabled, i.e.,
+  // the test that triggers this is running as a FreeRTOS task).
+  jal save_current_sp_to_tcb
 
   // Jump to external ISR.
   jal ottf_external_isr
@@ -300,17 +325,26 @@ handler_irq_external:
 .global ottf_isr_exit
 .type ottf_isr_exit, @function
 ottf_isr_exit:
-  // Load the stack pointer for the current TCB.
-	lw  t1, pxCurrentTCB
-	lw  sp, 0(t1)
+  // Load the stack pointer for the current task control block (TCB), only if
+  // the `enable_concurrency` flag is set in the test configuration struct,
+  // meaning a test is run as a FreeRTOS task, where each task maintains its own
+  // stack. Otherwise, the test is run on bare-metal, and there is no TCB, and
+  // only a single stack/stack pointer.
+  la t0, kTestConfig  // Load the pointer to the test configuration struct.
+  lb t1, 0(t0)        // Load the first byte of the test_config struct, which
+                      // contains the `enable_concurrency` field to check.
+  beqz t1, .L_skip_sp_restore
+  lw  t2, pxCurrentTCB
+  lw  sp, 0(t2)
+.L_skip_sp_restore:
 
   // Load the correct MEPC for the next instruction in the current task.
-	lw t0, 0(sp)
-	csrw mepc, t0
+  lw t0, 0(sp)
+  csrw mepc, t0
 
   // Load MSTATUS for the MPIE bit.
-	lw  t0, 29 * OTTF_WORD_SIZE(sp)
-	csrw mstatus, t0
+  lw  t0, 29 * OTTF_WORD_SIZE(sp)
+  csrw mstatus, t0
 
   // Restore all registers from the stack.
   lw   ra,  1 * OTTF_WORD_SIZE(sp)

--- a/sw/device/tests/ottf_example_bare_metal_test.c
+++ b/sw/device/tests/ottf_example_bare_metal_test.c
@@ -6,8 +6,8 @@
 #include "sw/device/lib/testing/test_framework/ottf.h"
 
 const test_config_t kTestConfig = {
-    .can_clobber_uart = false,
     .enable_concurrency = false,
+    .can_clobber_uart = false,
 };
 
 bool test_main(void) {

--- a/sw/device/tests/ottf_example_concurrency_test.c
+++ b/sw/device/tests/ottf_example_concurrency_test.c
@@ -6,8 +6,8 @@
 #include "sw/device/lib/testing/test_framework/ottf.h"
 
 const test_config_t kTestConfig = {
-    .can_clobber_uart = false,
     .enable_concurrency = true,
+    .can_clobber_uart = false,
 };
 
 bool test_main(void) {


### PR DESCRIPTION
The OTTF was optimized in #9158 to allow running bare-metal tests (in place of running each test as a FreeRTOS "task") if the test did NOT require spawning (additional) concurrenct tasks.

This introduced a bug in the ISR assembly that saves/restores the current execution context to the stack upon entry/exit from the ISR. For tests run as a FreeRTOS task, i.e., tests that set the `enable_concurrency` flag in the test configuration struct (see `test_config_t` in `sw/device/lib/testing/test_framework/ottf.h`), the current stack pointer must be saved/restored from the current Task Control Block (TCB) because each FreeRTOS task maintains a separate stack and a context switch could happen in an exception handler (task yield) or ISR (preemption).

However, for bare-metal tests, the current TCB pointer (which is initialized and maintained by FreeRTOS) is NULL. Therefore attempting to dereference said pointer results in a store access fault.

This commit fixes this bug by checking the test mode (bare-metal vs. concurrency) in the ISR entry/exit assembly to store/load the proper execution context state.