### PR TITLE
[flash_ctrl] Merge generic memories and update backdoor load

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -67,6 +67,8 @@ package flash_ctrl_env_pkg;
                                             FlashPageWidth - 1;
   parameter uint FlashMemAddrBankMsbBit   = FlashDataByteWidth + FlashWordLineWidth +
                                             FlashPageWidth + FlashBankWidth - 1;
+  // Need to create a design parameter for this
+  parameter uint FlashFullDataWidth       = flash_ctrl_pkg::DataWidth + 4;
 
   // types
   typedef enum int {

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -183,7 +183,7 @@ module tb;
                               .path  (`FLASH_DATA_MEM_HIER_STR(i)),
                               .depth ($size(`FLASH_DATA_MEM_HIER(i))),
                               .n_bits($bits(`FLASH_DATA_MEM_HIER(i))),
-                              .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_72_64));
+                              .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
         uvm_config_db#(mem_bkdr_util)::set(null, "*.env", m_mem_bkdr_util.get_name(),
                                            m_mem_bkdr_util);
         part = part.next();
@@ -196,7 +196,7 @@ module tb;
                                 .path  (`FLASH_INFO_MEM_HIER_STR(i, j)),
                                 .depth ($size(`FLASH_INFO_MEM_HIER(i, j))),
                                 .n_bits($bits(`FLASH_INFO_MEM_HIER(i, j))),
-                                .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_72_64));
+                                .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
           uvm_config_db#(mem_bkdr_util)::set(null, "*.env", m_mem_bkdr_util.get_name(),
                                              m_mem_bkdr_util);
           part = part.next();

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -310,7 +310,7 @@ module tb;
           .path  (`DV_STRINGIFY(`FLASH0_DATA_MEM_HIER)),
           .depth ($size(`FLASH0_DATA_MEM_HIER)),
           .n_bits($bits(`FLASH0_DATA_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_72_64));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Data], `FLASH0_DATA_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init flash 0 info", UVM_MEDIUM)
@@ -319,7 +319,7 @@ module tb;
           .path  (`DV_STRINGIFY(`FLASH0_INFO_MEM_HIER)),
           .depth ($size(`FLASH0_INFO_MEM_HIER)),
           .n_bits($bits(`FLASH0_INFO_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_72_64));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank0Info], `FLASH0_INFO_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init flash 1 data", UVM_MEDIUM)
@@ -328,7 +328,7 @@ module tb;
           .path  (`DV_STRINGIFY(`FLASH1_DATA_MEM_HIER)),
           .depth ($size(`FLASH1_DATA_MEM_HIER)),
           .n_bits($bits(`FLASH1_DATA_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_72_64));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Data], `FLASH0_DATA_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init flash 0 info", UVM_MEDIUM)
@@ -337,7 +337,7 @@ module tb;
           .path  (`DV_STRINGIFY(`FLASH1_INFO_MEM_HIER)),
           .depth ($size(`FLASH1_INFO_MEM_HIER)),
           .n_bits($bits(`FLASH1_INFO_MEM_HIER)),
-          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_72_64));
+          .err_detection_scheme(mem_bkdr_util_pkg::EccHamming_76_68));
       `MEM_BKDR_UTIL_FILE_OP(m_mem_bkdr_util[FlashBank1Info], `FLASH1_INFO_MEM_HIER)
 
       `uvm_info("tb.sv", "Backdoor init OTP", UVM_MEDIUM)


### PR DESCRIPTION
- Should address #9397
- Merge the separate flash data / metadata memories back into one
- Update the backdoor path to use the full 76_68 ECC scheme
- Update flash backdoor load to create the extra 4-bits of integrity
  ECC for the purposes of backdoor load.  The flash routine is 
  responsible for the integrity ECC, and the mem_bkdr_util routine
  is responsible for the reliability ECC.

- In the future, the same routine that creates the 4-bit integrity
  ECC will also be responsible for scramble, the final backdoor load
  will only be aware of the 8-bit reliability ECC.