### PR TITLE
[rv_core_ibex] Fix recov_alert behavior

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -309,62 +309,48 @@
   regwidth: "32",
   registers: {
     cfg: [
-      { multireg: {
-          cname: "SW_ALERTS_REGWEN",
-          name: "SW_ALERT_REGWEN",
-          desc: "Software alert regwen.",
-          count: "NumSwAlerts",
-          swaccess: "rw0c",
-          hwaccess: "none",
-          compact: false,
-          fields: [
-            { bits: "0",
-              name: "EN",
-              resval: "1",
-              desc: "Software alert write-enable.  Once set to 0, it can longer be configured to 1",
-              enum: [
-                { value: "0",
-                  name: "Software alert locked",
-                  desc: '''
-                          Software alert can no longer be configured until next reset.
-                          '''
-                },
-                { value: "1",
-                  name: "Software alert enabled",
-                  desc: '''
-                          Software alert can still be configured.
-                          '''
-                },
-              ]
-            },
-          ],
-        },
+      { name: "SW_RECOV_ERR",
+        desc: '''
+          Software recoverable error
+        ''',
+        swaccess: "rw",
+        hwaccess: "hrw",
+        fields: [
+          { bits: "3:0",
+            mubi: true,
+            name: "VAL",
+            resval: false,
+            desc: '''
+              Software recoverable alert.
+              When set to any value other than kMultiBitBool4False, a recoverable alert is sent.
+              Once the alert is sent, the field is then reset to kMultiBitBool4False.
+            '''
+          },
+        ],
+        tags: [// This register will self clear when set
+        "excl:CsrNonInitTests:CsrExclWriteCheck"],
       },
 
-      { multireg: {
-          cname: "SW_ALERTS",
-          name: "SW_ALERT",
-          regwen: "SW_ALERT_REGWEN",
-          regwen_multi: true,
-          desc: '''
-                  Software trigger alerts.
-                  When set to 1, triggers an alert to the alert handler
-                                          ''',
-                                          count: "NumSwAlerts",
-          compact: false,
-          swaccess: "rw",
-          hwaccess: "hro",
-          fields: [
-            { bits: "1:0",
-              name: "VAL",
-              desc: '''
-                      Software alert trigger value.
-                      Any value NOT 1 will trigger an alert.
-                      ''',
-                      resval: "1"
-            },
-          ],
-        },
+      { name: "SW_FATAL_ERR",
+        desc: '''
+          Software fatal error
+        ''',
+        swaccess: "rw0c",
+        hwaccess: "hro",
+        fields: [
+          { bits: "3:0",
+            mubi: true,
+            name: "VAL",
+            resval: false,
+            desc: '''
+              Software fatal alert.
+              When set to any value other than kMultiBitBool4False, a fatal alert is sent.
+              Note, this field once cleared cannot be set and will continuously cause alert events.
+            '''
+          },
+        ]
+        tags: [// This register is sticky and cannot be cleared after being set
+        "excl:CsrNonInitTests:CsrExclWrite"],
       },
 
       { multireg: {

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -113,18 +113,12 @@ module rv_core_ibex_cfg_reg_top (
   logic alert_test_recov_sw_err_wd;
   logic alert_test_fatal_hw_err_wd;
   logic alert_test_recov_hw_err_wd;
-  logic sw_alert_regwen_0_we;
-  logic sw_alert_regwen_0_qs;
-  logic sw_alert_regwen_0_wd;
-  logic sw_alert_regwen_1_we;
-  logic sw_alert_regwen_1_qs;
-  logic sw_alert_regwen_1_wd;
-  logic sw_alert_0_we;
-  logic [1:0] sw_alert_0_qs;
-  logic [1:0] sw_alert_0_wd;
-  logic sw_alert_1_we;
-  logic [1:0] sw_alert_1_qs;
-  logic [1:0] sw_alert_1_wd;
+  logic sw_recov_err_we;
+  logic [3:0] sw_recov_err_qs;
+  logic [3:0] sw_recov_err_wd;
+  logic sw_fatal_err_we;
+  logic [3:0] sw_fatal_err_qs;
+  logic [3:0] sw_fatal_err_wd;
   logic ibus_regwen_0_we;
   logic ibus_regwen_0_qs;
   logic ibus_regwen_0_wd;
@@ -255,100 +249,44 @@ module rv_core_ibex_cfg_reg_top (
   );
 
 
-  // Subregister 0 of Multireg sw_alert_regwen
-  // R[sw_alert_regwen_0]: V(False)
+  // R[sw_recov_err]: V(False)
   prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
-  ) u_sw_alert_regwen_0 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (sw_alert_regwen_0_we),
-    .wd     (sw_alert_regwen_0_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (sw_alert_regwen_0_qs)
-  );
-
-
-  // Subregister 1 of Multireg sw_alert_regwen
-  // R[sw_alert_regwen_1]: V(False)
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW0C),
-    .RESVAL  (1'h1)
-  ) u_sw_alert_regwen_1 (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (sw_alert_regwen_1_we),
-    .wd     (sw_alert_regwen_1_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (sw_alert_regwen_1_qs)
-  );
-
-
-  // Subregister 0 of Multireg sw_alert
-  // R[sw_alert_0]: V(False)
-  prim_subreg #(
-    .DW      (2),
+    .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h1)
-  ) u_sw_alert_0 (
+    .RESVAL  (4'h5)
+  ) u_sw_recov_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_alert_0_we & sw_alert_regwen_0_qs),
-    .wd     (sw_alert_0_wd),
+    .we     (sw_recov_err_we),
+    .wd     (sw_recov_err_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
+    .de     (hw2reg.sw_recov_err.de),
+    .d      (hw2reg.sw_recov_err.d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_alert[0].q),
+    .q      (reg2hw.sw_recov_err.q),
 
     // to register interface (read)
-    .qs     (sw_alert_0_qs)
+    .qs     (sw_recov_err_qs)
   );
 
 
-  // Subregister 1 of Multireg sw_alert
-  // R[sw_alert_1]: V(False)
+  // R[sw_fatal_err]: V(False)
   prim_subreg #(
-    .DW      (2),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (2'h1)
-  ) u_sw_alert_1 (
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (4'h5)
+  ) u_sw_fatal_err (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (sw_alert_1_we & sw_alert_regwen_1_qs),
-    .wd     (sw_alert_1_wd),
+    .we     (sw_fatal_err_we),
+    .wd     (sw_fatal_err_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -356,10 +294,10 @@ module rv_core_ibex_cfg_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.sw_alert[1].q),
+    .q      (reg2hw.sw_fatal_err.q),
 
     // to register interface (read)
-    .qs     (sw_alert_1_qs)
+    .qs     (sw_fatal_err_qs)
   );
 
 
@@ -1043,35 +981,33 @@ module rv_core_ibex_cfg_reg_top (
 
 
 
-  logic [25:0] addr_hit;
+  logic [23:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == RV_CORE_IBEX_ALERT_TEST_OFFSET);
-    addr_hit[ 1] = (reg_addr == RV_CORE_IBEX_SW_ALERT_REGWEN_0_OFFSET);
-    addr_hit[ 2] = (reg_addr == RV_CORE_IBEX_SW_ALERT_REGWEN_1_OFFSET);
-    addr_hit[ 3] = (reg_addr == RV_CORE_IBEX_SW_ALERT_0_OFFSET);
-    addr_hit[ 4] = (reg_addr == RV_CORE_IBEX_SW_ALERT_1_OFFSET);
-    addr_hit[ 5] = (reg_addr == RV_CORE_IBEX_IBUS_REGWEN_0_OFFSET);
-    addr_hit[ 6] = (reg_addr == RV_CORE_IBEX_IBUS_REGWEN_1_OFFSET);
-    addr_hit[ 7] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_EN_0_OFFSET);
-    addr_hit[ 8] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_EN_1_OFFSET);
-    addr_hit[ 9] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_OFFSET);
-    addr_hit[10] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_OFFSET);
-    addr_hit[11] = (reg_addr == RV_CORE_IBEX_IBUS_REMAP_ADDR_0_OFFSET);
-    addr_hit[12] = (reg_addr == RV_CORE_IBEX_IBUS_REMAP_ADDR_1_OFFSET);
-    addr_hit[13] = (reg_addr == RV_CORE_IBEX_DBUS_REGWEN_0_OFFSET);
-    addr_hit[14] = (reg_addr == RV_CORE_IBEX_DBUS_REGWEN_1_OFFSET);
-    addr_hit[15] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_EN_0_OFFSET);
-    addr_hit[16] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_EN_1_OFFSET);
-    addr_hit[17] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_OFFSET);
-    addr_hit[18] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_OFFSET);
-    addr_hit[19] = (reg_addr == RV_CORE_IBEX_DBUS_REMAP_ADDR_0_OFFSET);
-    addr_hit[20] = (reg_addr == RV_CORE_IBEX_DBUS_REMAP_ADDR_1_OFFSET);
-    addr_hit[21] = (reg_addr == RV_CORE_IBEX_NMI_ENABLE_OFFSET);
-    addr_hit[22] = (reg_addr == RV_CORE_IBEX_NMI_STATE_OFFSET);
-    addr_hit[23] = (reg_addr == RV_CORE_IBEX_ERR_STATUS_OFFSET);
-    addr_hit[24] = (reg_addr == RV_CORE_IBEX_RND_DATA_OFFSET);
-    addr_hit[25] = (reg_addr == RV_CORE_IBEX_RND_STATUS_OFFSET);
+    addr_hit[ 1] = (reg_addr == RV_CORE_IBEX_SW_RECOV_ERR_OFFSET);
+    addr_hit[ 2] = (reg_addr == RV_CORE_IBEX_SW_FATAL_ERR_OFFSET);
+    addr_hit[ 3] = (reg_addr == RV_CORE_IBEX_IBUS_REGWEN_0_OFFSET);
+    addr_hit[ 4] = (reg_addr == RV_CORE_IBEX_IBUS_REGWEN_1_OFFSET);
+    addr_hit[ 5] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_EN_0_OFFSET);
+    addr_hit[ 6] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_EN_1_OFFSET);
+    addr_hit[ 7] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_OFFSET);
+    addr_hit[ 8] = (reg_addr == RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_OFFSET);
+    addr_hit[ 9] = (reg_addr == RV_CORE_IBEX_IBUS_REMAP_ADDR_0_OFFSET);
+    addr_hit[10] = (reg_addr == RV_CORE_IBEX_IBUS_REMAP_ADDR_1_OFFSET);
+    addr_hit[11] = (reg_addr == RV_CORE_IBEX_DBUS_REGWEN_0_OFFSET);
+    addr_hit[12] = (reg_addr == RV_CORE_IBEX_DBUS_REGWEN_1_OFFSET);
+    addr_hit[13] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_EN_0_OFFSET);
+    addr_hit[14] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_EN_1_OFFSET);
+    addr_hit[15] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_OFFSET);
+    addr_hit[16] = (reg_addr == RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_OFFSET);
+    addr_hit[17] = (reg_addr == RV_CORE_IBEX_DBUS_REMAP_ADDR_0_OFFSET);
+    addr_hit[18] = (reg_addr == RV_CORE_IBEX_DBUS_REMAP_ADDR_1_OFFSET);
+    addr_hit[19] = (reg_addr == RV_CORE_IBEX_NMI_ENABLE_OFFSET);
+    addr_hit[20] = (reg_addr == RV_CORE_IBEX_NMI_STATE_OFFSET);
+    addr_hit[21] = (reg_addr == RV_CORE_IBEX_ERR_STATUS_OFFSET);
+    addr_hit[22] = (reg_addr == RV_CORE_IBEX_RND_DATA_OFFSET);
+    addr_hit[23] = (reg_addr == RV_CORE_IBEX_RND_STATUS_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1102,9 +1038,7 @@ module rv_core_ibex_cfg_reg_top (
                (addr_hit[20] & (|(RV_CORE_IBEX_CFG_PERMIT[20] & ~reg_be))) |
                (addr_hit[21] & (|(RV_CORE_IBEX_CFG_PERMIT[21] & ~reg_be))) |
                (addr_hit[22] & (|(RV_CORE_IBEX_CFG_PERMIT[22] & ~reg_be))) |
-               (addr_hit[23] & (|(RV_CORE_IBEX_CFG_PERMIT[23] & ~reg_be))) |
-               (addr_hit[24] & (|(RV_CORE_IBEX_CFG_PERMIT[24] & ~reg_be))) |
-               (addr_hit[25] & (|(RV_CORE_IBEX_CFG_PERMIT[25] & ~reg_be)))));
+               (addr_hit[23] & (|(RV_CORE_IBEX_CFG_PERMIT[23] & ~reg_be)))));
   end
   assign alert_test_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -1115,77 +1049,71 @@ module rv_core_ibex_cfg_reg_top (
   assign alert_test_fatal_hw_err_wd = reg_wdata[2];
 
   assign alert_test_recov_hw_err_wd = reg_wdata[3];
-  assign sw_alert_regwen_0_we = addr_hit[1] & reg_we & !reg_error;
+  assign sw_recov_err_we = addr_hit[1] & reg_we & !reg_error;
 
-  assign sw_alert_regwen_0_wd = reg_wdata[0];
-  assign sw_alert_regwen_1_we = addr_hit[2] & reg_we & !reg_error;
+  assign sw_recov_err_wd = reg_wdata[3:0];
+  assign sw_fatal_err_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign sw_alert_regwen_1_wd = reg_wdata[0];
-  assign sw_alert_0_we = addr_hit[3] & reg_we & !reg_error;
-
-  assign sw_alert_0_wd = reg_wdata[1:0];
-  assign sw_alert_1_we = addr_hit[4] & reg_we & !reg_error;
-
-  assign sw_alert_1_wd = reg_wdata[1:0];
-  assign ibus_regwen_0_we = addr_hit[5] & reg_we & !reg_error;
+  assign sw_fatal_err_wd = reg_wdata[3:0];
+  assign ibus_regwen_0_we = addr_hit[3] & reg_we & !reg_error;
 
   assign ibus_regwen_0_wd = reg_wdata[0];
-  assign ibus_regwen_1_we = addr_hit[6] & reg_we & !reg_error;
+  assign ibus_regwen_1_we = addr_hit[4] & reg_we & !reg_error;
 
   assign ibus_regwen_1_wd = reg_wdata[0];
-  assign ibus_addr_en_0_we = addr_hit[7] & reg_we & !reg_error;
+  assign ibus_addr_en_0_we = addr_hit[5] & reg_we & !reg_error;
 
   assign ibus_addr_en_0_wd = reg_wdata[0];
-  assign ibus_addr_en_1_we = addr_hit[8] & reg_we & !reg_error;
+  assign ibus_addr_en_1_we = addr_hit[6] & reg_we & !reg_error;
 
   assign ibus_addr_en_1_wd = reg_wdata[0];
-  assign ibus_addr_matching_0_we = addr_hit[9] & reg_we & !reg_error;
+  assign ibus_addr_matching_0_we = addr_hit[7] & reg_we & !reg_error;
 
   assign ibus_addr_matching_0_wd = reg_wdata[31:0];
-  assign ibus_addr_matching_1_we = addr_hit[10] & reg_we & !reg_error;
+  assign ibus_addr_matching_1_we = addr_hit[8] & reg_we & !reg_error;
 
   assign ibus_addr_matching_1_wd = reg_wdata[31:0];
-  assign ibus_remap_addr_0_we = addr_hit[11] & reg_we & !reg_error;
+  assign ibus_remap_addr_0_we = addr_hit[9] & reg_we & !reg_error;
 
   assign ibus_remap_addr_0_wd = reg_wdata[31:0];
-  assign ibus_remap_addr_1_we = addr_hit[12] & reg_we & !reg_error;
+  assign ibus_remap_addr_1_we = addr_hit[10] & reg_we & !reg_error;
 
   assign ibus_remap_addr_1_wd = reg_wdata[31:0];
-  assign dbus_regwen_0_we = addr_hit[13] & reg_we & !reg_error;
+  assign dbus_regwen_0_we = addr_hit[11] & reg_we & !reg_error;
 
   assign dbus_regwen_0_wd = reg_wdata[0];
-  assign dbus_regwen_1_we = addr_hit[14] & reg_we & !reg_error;
+  assign dbus_regwen_1_we = addr_hit[12] & reg_we & !reg_error;
 
   assign dbus_regwen_1_wd = reg_wdata[0];
-  assign dbus_addr_en_0_we = addr_hit[15] & reg_we & !reg_error;
+  assign dbus_addr_en_0_we = addr_hit[13] & reg_we & !reg_error;
 
   assign dbus_addr_en_0_wd = reg_wdata[0];
-  assign dbus_addr_en_1_we = addr_hit[16] & reg_we & !reg_error;
+  assign dbus_addr_en_1_we = addr_hit[14] & reg_we & !reg_error;
 
   assign dbus_addr_en_1_wd = reg_wdata[0];
-  assign dbus_addr_matching_0_we = addr_hit[17] & reg_we & !reg_error;
+  assign dbus_addr_matching_0_we = addr_hit[15] & reg_we & !reg_error;
 
   assign dbus_addr_matching_0_wd = reg_wdata[31:0];
-  assign dbus_addr_matching_1_we = addr_hit[18] & reg_we & !reg_error;
+  assign dbus_addr_matching_1_we = addr_hit[16] & reg_we & !reg_error;
 
   assign dbus_addr_matching_1_wd = reg_wdata[31:0];
-  assign dbus_remap_addr_0_we = addr_hit[19] & reg_we & !reg_error;
+  assign dbus_remap_addr_0_we = addr_hit[17] & reg_we & !reg_error;
 
   assign dbus_remap_addr_0_wd = reg_wdata[31:0];
-  assign dbus_remap_addr_1_we = addr_hit[20] & reg_we & !reg_error;
+  assign dbus_remap_addr_1_we = addr_hit[18] & reg_we & !reg_error;
 
   assign dbus_remap_addr_1_wd = reg_wdata[31:0];
-  assign nmi_enable_we = addr_hit[21] & reg_we & !reg_error;
+  assign nmi_enable_we = addr_hit[19] & reg_we & !reg_error;
 
   assign nmi_enable_alert_en_wd = reg_wdata[0];
 
   assign nmi_enable_wdog_en_wd = reg_wdata[1];
-  assign nmi_state_we = addr_hit[22] & reg_we & !reg_error;
+  assign nmi_state_we = addr_hit[20] & reg_we & !reg_error;
 
   assign nmi_state_alert_wd = reg_wdata[0];
 
   assign nmi_state_wdog_wd = reg_wdata[1];
-  assign err_status_we = addr_hit[23] & reg_we & !reg_error;
+  assign err_status_we = addr_hit[21] & reg_we & !reg_error;
 
   assign err_status_reg_intg_err_wd = reg_wdata[0];
 
@@ -1194,7 +1122,7 @@ module rv_core_ibex_cfg_reg_top (
   assign err_status_fatal_core_err_wd = reg_wdata[9];
 
   assign err_status_recov_core_err_wd = reg_wdata[10];
-  assign rnd_status_re = addr_hit[25] & reg_re & !reg_error;
+  assign rnd_status_re = addr_hit[23] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -1208,107 +1136,99 @@ module rv_core_ibex_cfg_reg_top (
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[0] = sw_alert_regwen_0_qs;
+        reg_rdata_next[3:0] = sw_recov_err_qs;
       end
 
       addr_hit[2]: begin
-        reg_rdata_next[0] = sw_alert_regwen_1_qs;
+        reg_rdata_next[3:0] = sw_fatal_err_qs;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[1:0] = sw_alert_0_qs;
-      end
-
-      addr_hit[4]: begin
-        reg_rdata_next[1:0] = sw_alert_1_qs;
-      end
-
-      addr_hit[5]: begin
         reg_rdata_next[0] = ibus_regwen_0_qs;
       end
 
-      addr_hit[6]: begin
+      addr_hit[4]: begin
         reg_rdata_next[0] = ibus_regwen_1_qs;
       end
 
-      addr_hit[7]: begin
+      addr_hit[5]: begin
         reg_rdata_next[0] = ibus_addr_en_0_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[6]: begin
         reg_rdata_next[0] = ibus_addr_en_1_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[7]: begin
         reg_rdata_next[31:0] = ibus_addr_matching_0_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[8]: begin
         reg_rdata_next[31:0] = ibus_addr_matching_1_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[9]: begin
         reg_rdata_next[31:0] = ibus_remap_addr_0_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[10]: begin
         reg_rdata_next[31:0] = ibus_remap_addr_1_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[11]: begin
         reg_rdata_next[0] = dbus_regwen_0_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = dbus_regwen_1_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[13]: begin
         reg_rdata_next[0] = dbus_addr_en_0_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[14]: begin
         reg_rdata_next[0] = dbus_addr_en_1_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[15]: begin
         reg_rdata_next[31:0] = dbus_addr_matching_0_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[16]: begin
         reg_rdata_next[31:0] = dbus_addr_matching_1_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[17]: begin
         reg_rdata_next[31:0] = dbus_remap_addr_0_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[18]: begin
         reg_rdata_next[31:0] = dbus_remap_addr_1_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[19]: begin
         reg_rdata_next[0] = nmi_enable_alert_en_qs;
         reg_rdata_next[1] = nmi_enable_wdog_en_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[20]: begin
         reg_rdata_next[0] = nmi_state_alert_qs;
         reg_rdata_next[1] = nmi_state_wdog_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[21]: begin
         reg_rdata_next[0] = err_status_reg_intg_err_qs;
         reg_rdata_next[8] = err_status_fatal_intg_err_qs;
         reg_rdata_next[9] = err_status_fatal_core_err_qs;
         reg_rdata_next[10] = err_status_recov_core_err_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[22]: begin
         reg_rdata_next[31:0] = rnd_data_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = rnd_status_qs;
       end
 

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
@@ -7,13 +7,6 @@
 
 package rv_core_ibex_pkg;
 
-  typedef enum logic [1:0] {
-    EventOn = 2'b10,
-    EventOff = 2'b01
-  } alert_event_e;
-
-  typedef alert_event_e alert_event_t;
-
   typedef struct packed {
     logic en;
     logic [31:0] matching_region;

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -38,8 +38,12 @@ package rv_core_ibex_reg_pkg;
   } rv_core_ibex_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
-    logic [1:0]  q;
-  } rv_core_ibex_reg2hw_sw_alert_mreg_t;
+    logic [3:0]  q;
+  } rv_core_ibex_reg2hw_sw_recov_err_reg_t;
+
+  typedef struct packed {
+    logic [3:0]  q;
+  } rv_core_ibex_reg2hw_sw_fatal_err_reg_t;
 
   typedef struct packed {
     logic        q;
@@ -84,6 +88,11 @@ package rv_core_ibex_reg_pkg;
   } rv_core_ibex_reg2hw_nmi_state_reg_t;
 
   typedef struct packed {
+    logic [3:0]  d;
+    logic        de;
+  } rv_core_ibex_hw2reg_sw_recov_err_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -124,8 +133,9 @@ package rv_core_ibex_reg_pkg;
 
   // Register -> HW type for cfg interface
   typedef struct packed {
-    rv_core_ibex_reg2hw_alert_test_reg_t alert_test; // [275:268]
-    rv_core_ibex_reg2hw_sw_alert_mreg_t [1:0] sw_alert; // [267:264]
+    rv_core_ibex_reg2hw_alert_test_reg_t alert_test; // [279:272]
+    rv_core_ibex_reg2hw_sw_recov_err_reg_t sw_recov_err; // [271:268]
+    rv_core_ibex_reg2hw_sw_fatal_err_reg_t sw_fatal_err; // [267:264]
     rv_core_ibex_reg2hw_ibus_addr_en_mreg_t [1:0] ibus_addr_en; // [263:262]
     rv_core_ibex_reg2hw_ibus_addr_matching_mreg_t [1:0] ibus_addr_matching; // [261:198]
     rv_core_ibex_reg2hw_ibus_remap_addr_mreg_t [1:0] ibus_remap_addr; // [197:134]
@@ -138,6 +148,7 @@ package rv_core_ibex_reg_pkg;
 
   // HW -> register type for cfg interface
   typedef struct packed {
+    rv_core_ibex_hw2reg_sw_recov_err_reg_t sw_recov_err; // [50:46]
     rv_core_ibex_hw2reg_nmi_state_reg_t nmi_state; // [45:42]
     rv_core_ibex_hw2reg_err_status_reg_t err_status; // [41:34]
     rv_core_ibex_hw2reg_rnd_data_reg_t rnd_data; // [33:1]
@@ -146,31 +157,29 @@ package rv_core_ibex_reg_pkg;
 
   // Register offsets for cfg interface
   parameter logic [CfgAw-1:0] RV_CORE_IBEX_ALERT_TEST_OFFSET = 7'h 0;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_ALERT_REGWEN_0_OFFSET = 7'h 4;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_ALERT_REGWEN_1_OFFSET = 7'h 8;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_ALERT_0_OFFSET = 7'h c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_ALERT_1_OFFSET = 7'h 10;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_0_OFFSET = 7'h 14;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_1_OFFSET = 7'h 18;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_0_OFFSET = 7'h 1c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_1_OFFSET = 7'h 20;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_OFFSET = 7'h 24;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_OFFSET = 7'h 28;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_0_OFFSET = 7'h 2c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_1_OFFSET = 7'h 30;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_0_OFFSET = 7'h 34;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_1_OFFSET = 7'h 38;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_0_OFFSET = 7'h 3c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_1_OFFSET = 7'h 40;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_OFFSET = 7'h 44;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_OFFSET = 7'h 48;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_0_OFFSET = 7'h 4c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_1_OFFSET = 7'h 50;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_ENABLE_OFFSET = 7'h 54;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_STATE_OFFSET = 7'h 58;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ERR_STATUS_OFFSET = 7'h 5c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_DATA_OFFSET = 7'h 60;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_STATUS_OFFSET = 7'h 64;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_RECOV_ERR_OFFSET = 7'h 4;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_FATAL_ERR_OFFSET = 7'h 8;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_0_OFFSET = 7'h c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_1_OFFSET = 7'h 10;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_0_OFFSET = 7'h 14;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_1_OFFSET = 7'h 18;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_OFFSET = 7'h 1c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_OFFSET = 7'h 20;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_0_OFFSET = 7'h 24;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_1_OFFSET = 7'h 28;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_0_OFFSET = 7'h 2c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_1_OFFSET = 7'h 30;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_0_OFFSET = 7'h 34;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_1_OFFSET = 7'h 38;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_OFFSET = 7'h 3c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_OFFSET = 7'h 40;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_0_OFFSET = 7'h 44;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_1_OFFSET = 7'h 48;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_ENABLE_OFFSET = 7'h 4c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_STATE_OFFSET = 7'h 50;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ERR_STATUS_OFFSET = 7'h 54;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_DATA_OFFSET = 7'h 58;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_STATUS_OFFSET = 7'h 5c;
 
   // Reset values for hwext registers and their fields for cfg interface
   parameter logic [3:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 4'h 0;
@@ -184,10 +193,8 @@ package rv_core_ibex_reg_pkg;
   // Register index for cfg interface
   typedef enum int {
     RV_CORE_IBEX_ALERT_TEST,
-    RV_CORE_IBEX_SW_ALERT_REGWEN_0,
-    RV_CORE_IBEX_SW_ALERT_REGWEN_1,
-    RV_CORE_IBEX_SW_ALERT_0,
-    RV_CORE_IBEX_SW_ALERT_1,
+    RV_CORE_IBEX_SW_RECOV_ERR,
+    RV_CORE_IBEX_SW_FATAL_ERR,
     RV_CORE_IBEX_IBUS_REGWEN_0,
     RV_CORE_IBEX_IBUS_REGWEN_1,
     RV_CORE_IBEX_IBUS_ADDR_EN_0,
@@ -212,33 +219,31 @@ package rv_core_ibex_reg_pkg;
   } rv_core_ibex_cfg_id_e;
 
   // Register width information to check illegal writes for cfg interface
-  parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [26] = '{
+  parameter logic [3:0] RV_CORE_IBEX_CFG_PERMIT [24] = '{
     4'b 0001, // index[ 0] RV_CORE_IBEX_ALERT_TEST
-    4'b 0001, // index[ 1] RV_CORE_IBEX_SW_ALERT_REGWEN_0
-    4'b 0001, // index[ 2] RV_CORE_IBEX_SW_ALERT_REGWEN_1
-    4'b 0001, // index[ 3] RV_CORE_IBEX_SW_ALERT_0
-    4'b 0001, // index[ 4] RV_CORE_IBEX_SW_ALERT_1
-    4'b 0001, // index[ 5] RV_CORE_IBEX_IBUS_REGWEN_0
-    4'b 0001, // index[ 6] RV_CORE_IBEX_IBUS_REGWEN_1
-    4'b 0001, // index[ 7] RV_CORE_IBEX_IBUS_ADDR_EN_0
-    4'b 0001, // index[ 8] RV_CORE_IBEX_IBUS_ADDR_EN_1
-    4'b 1111, // index[ 9] RV_CORE_IBEX_IBUS_ADDR_MATCHING_0
-    4'b 1111, // index[10] RV_CORE_IBEX_IBUS_ADDR_MATCHING_1
-    4'b 1111, // index[11] RV_CORE_IBEX_IBUS_REMAP_ADDR_0
-    4'b 1111, // index[12] RV_CORE_IBEX_IBUS_REMAP_ADDR_1
-    4'b 0001, // index[13] RV_CORE_IBEX_DBUS_REGWEN_0
-    4'b 0001, // index[14] RV_CORE_IBEX_DBUS_REGWEN_1
-    4'b 0001, // index[15] RV_CORE_IBEX_DBUS_ADDR_EN_0
-    4'b 0001, // index[16] RV_CORE_IBEX_DBUS_ADDR_EN_1
-    4'b 1111, // index[17] RV_CORE_IBEX_DBUS_ADDR_MATCHING_0
-    4'b 1111, // index[18] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1
-    4'b 1111, // index[19] RV_CORE_IBEX_DBUS_REMAP_ADDR_0
-    4'b 1111, // index[20] RV_CORE_IBEX_DBUS_REMAP_ADDR_1
-    4'b 0001, // index[21] RV_CORE_IBEX_NMI_ENABLE
-    4'b 0001, // index[22] RV_CORE_IBEX_NMI_STATE
-    4'b 0011, // index[23] RV_CORE_IBEX_ERR_STATUS
-    4'b 1111, // index[24] RV_CORE_IBEX_RND_DATA
-    4'b 0001  // index[25] RV_CORE_IBEX_RND_STATUS
+    4'b 0001, // index[ 1] RV_CORE_IBEX_SW_RECOV_ERR
+    4'b 0001, // index[ 2] RV_CORE_IBEX_SW_FATAL_ERR
+    4'b 0001, // index[ 3] RV_CORE_IBEX_IBUS_REGWEN_0
+    4'b 0001, // index[ 4] RV_CORE_IBEX_IBUS_REGWEN_1
+    4'b 0001, // index[ 5] RV_CORE_IBEX_IBUS_ADDR_EN_0
+    4'b 0001, // index[ 6] RV_CORE_IBEX_IBUS_ADDR_EN_1
+    4'b 1111, // index[ 7] RV_CORE_IBEX_IBUS_ADDR_MATCHING_0
+    4'b 1111, // index[ 8] RV_CORE_IBEX_IBUS_ADDR_MATCHING_1
+    4'b 1111, // index[ 9] RV_CORE_IBEX_IBUS_REMAP_ADDR_0
+    4'b 1111, // index[10] RV_CORE_IBEX_IBUS_REMAP_ADDR_1
+    4'b 0001, // index[11] RV_CORE_IBEX_DBUS_REGWEN_0
+    4'b 0001, // index[12] RV_CORE_IBEX_DBUS_REGWEN_1
+    4'b 0001, // index[13] RV_CORE_IBEX_DBUS_ADDR_EN_0
+    4'b 0001, // index[14] RV_CORE_IBEX_DBUS_ADDR_EN_1
+    4'b 1111, // index[15] RV_CORE_IBEX_DBUS_ADDR_MATCHING_0
+    4'b 1111, // index[16] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1
+    4'b 1111, // index[17] RV_CORE_IBEX_DBUS_REMAP_ADDR_0
+    4'b 1111, // index[18] RV_CORE_IBEX_DBUS_REMAP_ADDR_1
+    4'b 0001, // index[19] RV_CORE_IBEX_NMI_ENABLE
+    4'b 0001, // index[20] RV_CORE_IBEX_NMI_STATE
+    4'b 0011, // index[21] RV_CORE_IBEX_ERR_STATUS
+    4'b 1111, // index[22] RV_CORE_IBEX_RND_DATA
+    4'b 0001  // index[23] RV_CORE_IBEX_RND_STATUS
   };
 
 endpackage


### PR DESCRIPTION
- Fixes #9415
- Make software alerts mubi types and make recoverable error self clearing

Signed-off-by: Timothy Chen <timothytim@google.com>