### PR TITLE
[dv/chip] Fix private CI issue

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -181,6 +181,9 @@
       regwen: "EXTCLK_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      tags: [ // Write non-Mubi4True or non-Mubi4False value will cause AST clks_byp's
+              // PrimMubi4SyncCheckTransients_A assertion to fail.
+              "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         {
           bits: "3:0",

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -179,6 +179,9 @@
       regwen: "EXTCLK_CTRL_REGWEN",
       swaccess: "rw",
       hwaccess: "hro",
+      tags: [ // Write non-Mubi4True or non-Mubi4False value will cause AST clks_byp's
+              // PrimMubi4SyncCheckTransients_A assertion to fail.
+              "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         {
           bits: "3:0",


### PR DESCRIPTION
This PR fixes a private CI assertion issue triggered by writing
non-Mubi4True or False value to the `extclk_ctrl` CSR.
This will eventually trigger an assertion error in AST.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>