### PR TITLE
[dv/top] Fix Private CI issue - Disable ast assertion in stub_cpu mode

### DIFF
--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -402,6 +402,12 @@ module tb;
       force cpu_d_tl_if.h2d.a_user.instr_type = prim_mubi_pkg::MuBi4False;
       force `CPU_TL_ADAPT_D_HIER.tl_out = cpu_d_tl_if.h2d;
       force cpu_d_tl_if.d2h = `CPU_TL_ADAPT_D_HIER.tl_i;
+
+      // In stub_cpu mode, disable these assertions because writing rand value to clkmgr's CSR
+      // `extclk_sel` can violate these assertions.
+      $assertoff(0, tb.dut.u_ast.u_ast_clks_byp.u_all_clk_byp_req.PrimMubi4SyncCheckTransients_A);
+      $assertoff(0, tb.dut.u_ast.u_ast_clks_byp.u_all_clk_byp_req.PrimMubi4SyncCheckTransients0_A);
+      $assertoff(0, tb.dut.u_ast.u_ast_clks_byp.u_all_clk_byp_req.PrimMubi4SyncCheckTransients1_A);
     end else begin
       // when en_sim_sram == 1, need to make sure the access to sim_sram doesn't appear on
       // cpu_d_tl_if, otherwise, we may have unmapped access as scb doesn't regnize addresses of


### PR DESCRIPTION
Rand write csr `clkexl_sel` would cause this assertion to fail in
top-level. Disable this assertion only in cpu_stub mode.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>