### PR TITLE
[sw, otbn] Create specialized wrappers for RSA

### DIFF
--- a/sw/otbn/crypto/meson.build
+++ b/sw/otbn/crypto/meson.build
@@ -118,6 +118,12 @@ sw_otbn_sources += {
     'rsa_verify_test_exp3.s',
     'rsa_verify.s',
   ),
+  'run_rsa_verify_3072': files(
+    'run_rsa_verify_3072.s',
+    'rsa_verify_3072.s',
+    'rsa_verify_3072_m0inv.s',
+    'rsa_verify_3072_rr.s',
+  ),
   'run_rsa_verify_3072_rr_modexp': files(
     'run_rsa_verify_3072_rr_modexp.s',
     'rsa_verify_3072_rr.s',

--- a/sw/otbn/crypto/meson.build
+++ b/sw/otbn/crypto/meson.build
@@ -118,4 +118,9 @@ sw_otbn_sources += {
     'rsa_verify_test_exp3.s',
     'rsa_verify.s',
   ),
+  'run_rsa_verify_3072_rr_modexp': files(
+    'run_rsa_verify_3072_rr_modexp.s',
+    'rsa_verify_3072_rr.s',
+    'rsa_verify_3072.s',
+  ),
 }

--- a/sw/otbn/crypto/run_rsa_verify_3072.s
+++ b/sw/otbn/crypto/run_rsa_verify_3072.s
@@ -1,0 +1,116 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+/**
+ * Standalone embeddable wrapper for 3072 bit RSA signature verification.
+ * Performs either computation of Montgomery constants or modular
+ * exponentiation, depending on mode.
+ */
+run_rsa_verify_3072:
+  /* Get the mode input value: x3 <= mode */
+  la       x2, mode
+  lw       x3, 0(x2)
+
+  /* if mode=1, compute constants (ends in ecall) */
+  li       x2, 1
+  beq      x3, x2, compute_constants
+
+  /* if mode=2, run modexp (ends in ecall) */
+  li       x2, 2
+  beq      x3, x2, modexp
+
+  /* Unexpected mode; fail */
+  unimp
+
+/**
+ * Compute the two Montgomery constants for the given modulus.
+ *
+ * @param[in] dmem[in_mod]: Modulus of the RSA public key
+ * @param[out] dmem[rr]: Montgomery constant R^2 = (2^3072)^2 mod M
+ * @param[out] dmem[m0inv]: Montgomery constant m0_inv = (-(M^-1)) mod 2^256
+*/
+compute_constants:
+  jal       x1, compute_rr
+  jal       x1, compute_m0_inv
+  ecall
+
+/**
+ * Run RSA-3072 modular exponentiation.
+ *
+ * Computes msg=(sig^e) mod M, where
+ *          e is the public key exponent
+ *          M is the public key modulus
+ *          sig is the signature
+ *
+ * The result, msg, is the recovered message digest.
+ *
+ * @param[in] dmem[in_exp]: Exponent of the RSA public key (must be 3 or F4=65537)
+ * @param[in] dmem[in_mod]: Modulus of the RSA public key
+ * @param[in] dmem[in_buf]: Signature to check against
+ * @param[in] dmem[rr]: Montgomery constant R^2
+ * @param[in] dmem[m0inv]: Montgomery constant m0_inv
+ * @param[out] dmem[out_buf]: Recovered message digest (msg)
+*/
+modexp:
+  /* Get the exponent: x3 <= dmem[in_exp] */
+  la       x2, in_exp
+  lw       x3, 0(x2)
+
+  /* Call a modexp implementation matching the exponent.
+     Both modexp implementations end in ecall. */
+  li       x2, 3
+  beq      x3, x2, modexp_3
+  li       x2, 65537
+  beq      x3, x2, modexp_f4
+
+  /* Unexpected exponent; fail */
+  unimp
+
+modexp_f4:
+  /* run modular exponentiation */
+  jal      x1, modexp_var_3072_f4
+  ecall
+
+modexp_3:
+  /* e=3 exponentiation is unimplemented */
+  unimp
+
+.data
+
+/* Mode (1=constants, 2=modexp) */
+.globl mode
+.balign 4
+mode:
+.zero 4
+
+/* Exponent of the RSA-3072 key. Accepted values: 3 or F4=65537 */
+.globl in_exp
+.balign 4
+in_exp:
+.zero 4
+
+/* Modulus of RSA-3072 key */
+.globl in_mod
+.balign 32
+in_mod:
+.zero 384
+
+/* Montgomery constant m0' */
+.globl m0inv
+.balign 32
+m0inv:
+.zero 32
+
+/* Squared Mongomery Radix RR = (2^3072)^2 mod N */
+.globl rr
+.balign 32
+rr:
+.zero 384
+
+/* signature */
+.globl in_buf
+in_buf:
+.zero 384

--- a/sw/otbn/crypto/run_rsa_verify_3072_rr_modexp.s
+++ b/sw/otbn/crypto/run_rsa_verify_3072_rr_modexp.s
@@ -1,0 +1,79 @@
+/* Copyright lowRISC contributors. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+/**
+ * Standalone embeddable wrapper for 3072 bit RSA signature verification.
+ *
+ * Uses the OTBN RSA 3072-bit only modular exponentiation implementation to
+ * obtain the message (digest) from an input signature. Assumes that the
+ * Montgomery constant m0_inv is provided, but computes the RR constant on the
+ * fly.
+ *
+ * @param[in] dmem[in_exp]: Exponent of the RSA public key (must be 3 or F4=65537)
+ * @param[in] dmem[in_mod]: Modulus of the RSA public key
+ * @param[in] dmem[in_buf]: Signature to check against
+ * @param[in] dmem[m0inv]: Montgomery constant (-(M^-1)) mod 2^256
+ * @param[out] dmem[out_buf]: Recovered message digest
+ */
+run_rsa_verify_3072:
+
+  /* Compute R^2 (same for both exponents): dmem[rr] <= R^2 */
+  jal      x1, compute_rr
+
+  /* Get the exponent: x3 <= dmem[in_exp] */
+  la       x2, in_exp
+  lw       x3, 0(x2)
+
+  /* Call a modexp implementation matching the exponent.
+     Both modexp implementations end in ecall. */
+  li       x2, 3
+  beq      x3, x2, modexp_3
+  li       x2, 65537
+  beq      x3, x2, modexp_f4
+
+  /* Unexpected exponent; fail */
+  unimp
+
+modexp_f4:
+  /* run modular exponentiation */
+  jal      x1, modexp_var_3072_f4
+
+  ecall
+
+modexp_3:
+  /* e=3 exponentiation is unimplemented */
+  unimp
+
+.data
+
+/* Exponent of the RSA-3072 key. Accepted values: 3 or F4=65537 */
+.globl in_exp
+.balign 4
+in_exp:
+.zero 4
+
+/* Modulus of RSA-3072 key */
+.globl in_mod
+.balign 32
+in_mod:
+.zero 384
+
+/* Montgomery constant m0' */
+.globl m0inv
+.balign 32
+m0inv:
+.zero 32
+
+/* Squared Mongomery Radix RR = (2^3072)^2 mod N */
+.globl rr
+.balign 32
+rr:
+.zero 384
+
+/* signature */
+.globl in_buf
+in_buf:
+.zero 384


### PR DESCRIPTION
On top of #9349; only the last two commits are part of this change. Draft until #9349 is merged. Part of #9303 

Creates two thin, executable wrappers for RSA-3072 assembly in OTBN:
1. (For sigverify) Computes R^2 and then modexp.
2. (For other applications, such as the OS-visible cryptolib) Takes a "mode" argument and either computes constants (R^2 and m0_inv) or modexp depending on the mode.

The reason for having two separate wrappers is to that the ROM/ROM_EXT sigverify code can be as specialized as possible -- in this case that means not including the code that computes m0_inv at all to minimize binary size (since that constant is precomputed and stored) and also reducing overhead by running modexp immediately after R^2 is computed, so we don't have to read it from DMEM and then pass it back in. This kind of procedure wouldn't normally make sense, since typically R^2 would be computed once and used many times, but in ROM/ROM_EXT it's only used once.

CC @alphan 