### PR TITLE
[dv] Only run registers through one csr_rw sequence at once

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -585,7 +585,8 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
   // override csr_vseq to control adapter to abort transaction
   virtual task run_csr_vseq(string csr_test_type = "",
                             int    num_test_csrs = 0,
-                            bit    do_rand_wr_and_reset = 1);
+                            bit    do_rand_wr_and_reset = 1,
+                            string ral_name = "");
 
     if (csr_access_abort_pct.rand_mode()) begin
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(csr_access_abort_pct)
@@ -599,7 +600,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     // checking the status.
     if (csr_access_abort_pct > 0) csr_utils_pkg::default_csr_check = UVM_NO_CHECK;
     else                          csr_utils_pkg::default_csr_check = UVM_CHECK;
-    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset);
+    super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset, ral_name);
   endtask
 
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -271,7 +271,7 @@ virtual task run_tl_intg_err_vseq_sub(int num_times = 1, string ral_name);
     // run csr_rw seq to send some normal CSR accesses in parallel
     begin
       `uvm_info(`gfn, "Run csr_rw seq", UVM_HIGH)
-      run_csr_vseq("rw");
+      run_csr_vseq(.csr_test_type("rw"), .ral_name(ral_name));
     end
     begin
       issue_tl_access_w_intg_err(ral_name);

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -43,7 +43,8 @@ class keymgr_common_vseq extends keymgr_base_vseq;
 
   virtual task run_csr_vseq(string csr_test_type = "",
                             int    num_test_csrs = 0,
-                            bit    do_rand_wr_and_reset = 1);
+                            bit    do_rand_wr_and_reset = 1,
+                            string ral_name = "");
     csr_vseq_done = 0;
     super.run_csr_vseq(csr_test_type, num_test_csrs, do_rand_wr_and_reset);
     csr_vseq_done = 1;

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -31,7 +31,8 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   // such as `class_clr` and `clr_regwen` registers are not correct.
   virtual task run_csr_vseq(string csr_test_type = "",
                             int    num_test_csrs = 0,
-                            bit    do_rand_wr_and_reset = 1);
+                            bit    do_rand_wr_and_reset = 1,
+                            string ral_name = "");
     if (common_seq_type == "tl_intg_err") begin
       csr_wr(.ptr(ral.loc_alert_regwen[LocalBusIntgFail]), .value(0), .predict(1));
     end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_common_vseq.sv
@@ -31,7 +31,8 @@ class alert_handler_common_vseq extends alert_handler_base_vseq;
   // such as `class_clr` and `clr_regwen` registers are not correct.
   virtual task run_csr_vseq(string csr_test_type = "",
                             int    num_test_csrs = 0,
-                            bit    do_rand_wr_and_reset = 1);
+                            bit    do_rand_wr_and_reset = 1,
+                            string ral_name = "");
     if (common_seq_type == "tl_intg_err") begin
       csr_wr(.ptr(ral.loc_alert_regwen[LocalBusIntgFail]), .value(0), .predict(1));
     end


### PR DESCRIPTION
This is an issue up for blocks with multiple device interfaces. The
default behaviour of `run_csr_vseq` is to grab all of the registers
defined for the block. The `run_tl_intg_err_vseq` task runs in parallel
across the different `ral_name`s, which means we do `run_csr_vseq("rw")`
for each of the interfaces in parallel.

It turns out that the `csr_rw` sequence isn't really "re-entrant". If
you've got two copies running at once then you can see a register `R`
with thread `0` writing it and thread `1` reading it at the same time.
This causes a UVM warning (and causes the test to fail).

This is one of several tweaks needed to get the `rom_ctrl` tests passing. @prajwalaputtappa has been doing most of the work, but I ran into this while trying to validate an RTL change (fixing a genuine RTL bug!).