### PR TITLE
[build] give one arg for each Variadic macro

### DIFF
--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -15,15 +15,15 @@
 #include "sw/device/lib/testing/check.h"
 
 void demo_gpio_startup(dif_gpio_t *gpio) {
-  LOG_INFO("Watch the LEDs!");
+  LOG_INFO("Watch the LEDs!", "");
 
   // Give a LED pattern as startup indicator for 5 seconds.
-  CHECK_DIF_OK(dif_gpio_write_all(gpio, 0xff00));
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, 0xff00), "");
   for (int i = 0; i < 32; ++i) {
     usleep(5 * 1000);  // 5 ms
-    CHECK_DIF_OK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2));
+    CHECK_DIF_OK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2), "");
   }
-  CHECK_DIF_OK(dif_gpio_write_all(gpio, 0x0000));  // All LEDs off.
+  CHECK_DIF_OK(dif_gpio_write_all(gpio, 0x0000), "");  // All LEDs off.
 }
 
 /**
@@ -39,7 +39,7 @@ static const uint32_t kFtdiMask = 0x10000;
 
 uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   uint32_t gpio_state;
-  CHECK_DIF_OK(dif_gpio_read_all(gpio, &gpio_state));
+  CHECK_DIF_OK(dif_gpio_read_all(gpio, &gpio_state), "");
   gpio_state &= kGpioMask;
 
   uint32_t state_delta = prev_gpio_state ^ gpio_state;
@@ -53,9 +53,9 @@ uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
 
   if ((state_delta & kFtdiMask) != 0) {
     if ((gpio_state & kFtdiMask) != 0) {
-      LOG_INFO("FTDI control changed. Enable JTAG.");
+      LOG_INFO("FTDI control changed. Enable JTAG.", "");
     } else {
-      LOG_INFO("FTDI control changed. Enable JTAG.");
+      LOG_INFO("FTDI control changed. Enable JTAG.", "");
     }
   }
 
@@ -67,12 +67,14 @@ void demo_spi_to_log_echo(const dif_spi_device_t *spi,
   uint32_t spi_buf[8];
   size_t spi_len;
   CHECK_DIF_OK(
-      dif_spi_device_recv(spi, spi_config, spi_buf, sizeof(spi_buf), &spi_len));
+      dif_spi_device_recv(spi, spi_config, spi_buf, sizeof(spi_buf), &spi_len),
+      "");
   if (spi_len > 0) {
     uint32_t echo_word = spi_buf[0] ^ 0x01010101;
-    CHECK_DIF_OK(dif_spi_device_send(spi, spi_config, &echo_word,
-                                     sizeof(uint32_t),
-                                     /*bytes_sent=*/NULL));
+    CHECK_DIF_OK(
+        dif_spi_device_send(spi, spi_config, &echo_word, sizeof(uint32_t),
+                            /*bytes_sent=*/NULL),
+        "");
     LOG_INFO("SPI: %z", spi_len, spi_buf);
   }
 }
@@ -86,8 +88,8 @@ void demo_uart_to_uart_and_gpio_echo(dif_uart_t *uart, dif_gpio_t *gpio) {
     }
 
     uint8_t rcv_char;
-    CHECK_DIF_OK(dif_uart_bytes_receive(uart, 1, &rcv_char, NULL));
-    CHECK_DIF_OK(dif_uart_byte_send_polled(uart, rcv_char));
-    CHECK_DIF_OK(dif_gpio_write_all(gpio, rcv_char << 8));
+    CHECK_DIF_OK(dif_uart_bytes_receive(uart, 1, &rcv_char, NULL), "");
+    CHECK_DIF_OK(dif_uart_byte_send_polled(uart, rcv_char), "");
+    CHECK_DIF_OK(dif_gpio_write_all(gpio, rcv_char << 8), "");
   }
 }

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -22,21 +22,25 @@ static dif_spi_device_config_t spi_config;
 static dif_uart_t uart;
 
 int main(int argc, char **argv) {
-  CHECK_DIF_OK(dif_uart_init(
-      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart));
   CHECK_DIF_OK(
-      dif_uart_configure(&uart, (dif_uart_config_t){
-                                    .baudrate = kUartBaudrate,
-                                    .clk_freq_hz = kClockFreqPeripheralHz,
-                                    .parity_enable = kDifToggleDisabled,
-                                    .parity = kDifUartParityEven,
-                                }));
+      dif_uart_init(mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart),
+      "");
+  CHECK_DIF_OK(dif_uart_configure(&uart,
+                                  (dif_uart_config_t){
+                                      .baudrate = kUartBaudrate,
+                                      .clk_freq_hz = kClockFreqPeripheralHz,
+                                      .parity_enable = kDifToggleDisabled,
+                                      .parity = kDifUartParityEven,
+                                  }),
+               "");
   base_uart_stdout(&uart);
 
   pinmux_init();
 
-  CHECK_DIF_OK(dif_spi_device_init(
-      mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR), &spi));
+  CHECK_DIF_OK(
+      dif_spi_device_init(
+          mmio_region_from_addr(TOP_EARLGREY_SPI_DEVICE_BASE_ADDR), &spi),
+      "");
   spi_config.clock_polarity = kDifSpiDeviceEdgePositive;
   spi_config.data_phase = kDifSpiDeviceEdgeNegative;
   spi_config.tx_order = kDifSpiDeviceBitOrderMsbToLsb;
@@ -44,28 +48,30 @@ int main(int argc, char **argv) {
   spi_config.rx_fifo_timeout = 63;
   spi_config.rx_fifo_len = kDifSpiDeviceBufferLen / 2;
   spi_config.tx_fifo_len = kDifSpiDeviceBufferLen / 2;
-  CHECK_DIF_OK(dif_spi_device_configure(&spi, &spi_config));
+  CHECK_DIF_OK(dif_spi_device_configure(&spi, &spi_config), "");
 
   CHECK_DIF_OK(
-      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));
+      dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio),
+      "");
   // Enable GPIO: 0-7 and 16 is input; 8-15 is output.
-  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00));
+  CHECK_DIF_OK(dif_gpio_output_set_enabled_all(&gpio, 0x0ff00), "");
 
   // Add DATE and TIME because I keep fooling myself with old versions
-  LOG_INFO("Hello World!");
-  LOG_INFO("Built at: " __DATE__ ", " __TIME__);
+  LOG_INFO("Hello World!", "");
+  LOG_INFO("Built at: " __DATE__ ", " __TIME__, "");
 
   demo_gpio_startup(&gpio);
 
   // Now have UART <-> Buttons/LEDs demo
   // all LEDs off
-  CHECK_DIF_OK(dif_gpio_write_all(&gpio, 0x0000));
-  LOG_INFO("Try out the switches on the board");
-  LOG_INFO("or type anything into the console window.");
-  LOG_INFO("The LEDs show the ASCII code of the last character.");
+  CHECK_DIF_OK(dif_gpio_write_all(&gpio, 0x0000), "");
+  LOG_INFO("Try out the switches on the board", "");
+  LOG_INFO("or type anything into the console window.", "");
+  LOG_INFO("The LEDs show the ASCII code of the last character.", "");
 
   CHECK_DIF_OK(dif_spi_device_send(&spi, &spi_config, "SPI!", 4,
-                                   /*bytes_sent=*/NULL));
+                                   /*bytes_sent=*/NULL),
+               "");
 
   uint32_t gpio_state = 0;
   while (true) {

--- a/sw/device/lib/handler.c
+++ b/sw/device/lib/handler.c
@@ -66,19 +66,19 @@ __attribute__((weak)) void handler_exception(void) {
 }
 
 __attribute__((weak)) void handler_irq_software(void) {
-  LOG_INFO("Software IRQ triggered!");
+  LOG_INFO("Software IRQ triggered!", "");
   while (1) {
   }
 }
 
 __attribute__((weak)) void handler_irq_timer(void) {
-  LOG_INFO("Timer IRQ triggered!");
+  LOG_INFO("Timer IRQ triggered!", "");
   while (1) {
   }
 }
 
 __attribute__((weak)) void handler_irq_external(void) {
-  LOG_INFO("External IRQ triggered!");
+  LOG_INFO("External IRQ triggered!", "");
   while (1) {
   }
 }
@@ -107,7 +107,7 @@ __attribute__((weak)) void handler_lsu_fault(void) {
 }
 
 __attribute__((weak)) void handler_ecall(void) {
-  LOG_INFO("Environment call encountered");
+  LOG_INFO("Environment call encountered", "");
   while (1) {
   }
 }

--- a/sw/device/lib/testing/check.h
+++ b/sw/device/lib/testing/check.h
@@ -100,9 +100,9 @@
          only one of the below string constants           \
          will be included in the final binary.*/          \
       if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("DIF-fail: " #dif_call);                \
+        LOG_ERROR("DIF-fail: " #dif_call, "");            \
       } else {                                            \
-        LOG_ERROR("DIF-fail: " __VA_ARGS__);              \
+        LOG_ERROR("DIF-fail: " __VA_ARGS__, "");          \
       }                                                   \
       /* Currently, this macro will call into             \
          the test failure code, which logs                \

--- a/sw/device/lib/testing/test_framework/test_status.c
+++ b/sw/device/lib/testing/test_framework/test_status.c
@@ -25,13 +25,13 @@ static void test_status_device_write(test_status_t test_status) {
 void test_status_set(test_status_t test_status) {
   switch (test_status) {
     case kTestStatusPassed: {
-      LOG_INFO("PASS!");
+      LOG_INFO("PASS!", "");
       test_status_device_write(test_status);
       abort();
       break;
     }
     case kTestStatusFailed: {
-      LOG_INFO("FAIL!");
+      LOG_INFO("FAIL!", "");
       test_status_device_write(test_status);
       abort();
       break;


### PR DESCRIPTION
To build with the -pedantic flag set without warnings, we need to pass
one argument to all variadic macros. This commit addresses all the ones
in the project that bazel builds so far. Later this will be important if
we want to endable building under other compilers than gcc.

Signed-off-by: Drew Macrae <drewmacrae@google.com>

Please let me know if there's a preferred way to do this. This is the lowest impact way I could come up with to do it.