### PR TITLE
[mmio] fix ptr types to avoid arithmetic warnings

### DIFF
--- a/sw/device/lib/base/mmio.c
+++ b/sw/device/lib/base/mmio.c
@@ -31,8 +31,8 @@ static ptrdiff_t misalignment32_of(uintptr_t addr) {
  * @param from_mmio if true, copy from MMIO to main memory. Otherwise, copy from
  * main memory to MMIO.
  */
-static void mmio_region_memcpy32(mmio_region_t base, uint32_t offset, void *buf,
-                                 size_t len, bool from_mmio) {
+static void mmio_region_memcpy32(mmio_region_t base, uint32_t offset,
+                                 uint8_t *buf, size_t len, bool from_mmio) {
   if (len == 0) {
     return;
   }


### PR DESCRIPTION
In mmio_region_memcpy32() the pointer buf, is operated on as a byte
sized pointer, and shouldn't be specified as a void ptr.

Signed-off-by: Drew Macrae <drewmacrae@google.com>