### PR TITLE
[sw/silicon_creator] Use flash_ctrl_info_mp_set() in boot_data and update functest

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -383,4 +383,5 @@ void flash_ctrl_info_mp_set(flash_ctrl_info_page_t info_page,
       reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_SHADOWED_0_ERASE_EN_0_BIT,
       perms.erase == kHardenedBoolTrue);
   sec_mmio_write32_shadowed(addr, reg);
+  sec_mmio_write_increment(1);
 }


### PR DESCRIPTION
This PR has two commits: the first commit adds a missing `sec_mmio_write_increment()` call to `flash_ctrl_info_mp_set()` and the second commit adds calls to `flash_ctrl_info_mp_set()` to `boot_data.c` and updates `boot_data_functest.c`.