### PR TITLE
[sw/silicon_creator] Use sec_mmio for FLASH_CTRL_EXEC_REG in flash_ctrl

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -315,7 +315,8 @@ rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
 
 void flash_ctrl_exec_set(flash_ctrl_exec_t enable) {
   // Enable or disable flash execution.
-  abs_mmio_write32(kBase + FLASH_CTRL_EXEC_REG_OFFSET, (uint32_t)enable);
+  sec_mmio_write32(kBase + FLASH_CTRL_EXEC_REG_OFFSET, (uint32_t)enable);
+  sec_mmio_write_increment(1);
 }
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -21,6 +21,7 @@ class FlashCtrlTest : public mask_rom_test::MaskRomTest {
  protected:
   uint32_t base_ = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR;
   mask_rom_test::MockAbsMmio mmio_;
+  mask_rom_test::MockSecMmio sec_mmio_;
 };
 
 class InitTest : public FlashCtrlTest {};
@@ -187,13 +188,15 @@ TEST_F(TransferTest, TransferInternalError) {
 class ExecTest : public FlashCtrlTest {};
 
 TEST_F(ExecTest, Enable) {
-  EXPECT_ABS_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET, kMultiBitBool4True);
+  EXPECT_SEC_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET, kMultiBitBool4True);
+  EXPECT_SEC_WRITE_INCREMENT(1);
   flash_ctrl_exec_set(kFlashCtrlExecEnable);
 }
 
 TEST_F(ExecTest, Disable) {
   // Note: any value that is not `0xa` will disable execution.
-  EXPECT_ABS_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET, kMultiBitBool4False);
+  EXPECT_SEC_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET, kMultiBitBool4False);
+  EXPECT_SEC_WRITE_INCREMENT(1);
   flash_ctrl_exec_set(kFlashCtrlExecDisable);
 }
 

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
@@ -62,6 +62,15 @@ typedef enum exception {
 } exception_t;
 
 /**
+ * sec_mmio callback.
+ *
+ * @param error sec_mmio error.
+ */
+static void sec_mmio_callback(rom_error_t error) {
+  LOG_ERROR("sec_mmio error: 0x%x", error);
+}
+
+/**
  * Get the value of the `mcause` register.
  *
  * @returns The encoded interrupt or exception cause.
@@ -366,6 +375,9 @@ static void test_unlock_exec_eflash(epmp_state_t *epmp) {
 }
 
 void mask_rom_main(void) {
+  // Initialize sec_mmio.
+  sec_mmio_init(sec_mmio_callback);
+
   // Initialize pinmux configuration so we can use the UART.
   pinmux_init();
 


### PR DESCRIPTION
Fixes #9287

Signed-off-by: Alphan Ulusoy <alphan@google.com>