### PR TITLE
[flash_ctrl] Remove oob handling altogether

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -516,13 +516,15 @@
         hwaccess: "hro",
         resval: "0",
         fields: [
-          { bits: "31:0",
+          { bits: "19:0",
             name: "START",
             desc: '''
-              Start address of a flash transaction.  Software should supply the full byte address.
-              The flash controller will then truncate the address as needed.  For read operations,
-              the flash controller will truncate to the closest, lower word aligned address.  For
-              example, if 0x13 is supplied, the controller will perform a read at address 0x10.
+              Start address of a flash transaction.  This is a byte address relative to the flash
+              only.  Ie, an address of 0 will access address 0 of the requested partition.
+
+              For read operations, the flash controller will truncate to the closest, lower word
+              aligned address.  For example, if 0x13 is supplied, the controller will perform a
+              read at address 0x10.
 
               Program operations behave similarly, the controller does not have read modified write
               support.
@@ -1437,13 +1439,6 @@
         swaccess: "rw1c",
         hwaccess: "hwo",
         fields: [
-          { bits: "0",
-            name: "oob_err",
-            desc: '''
-              The supplied address !!ADDR is invalid and out of bounds.
-              This is a synchronous error.
-            '''
-          },
           { bits: "1",
             name: "mp_err",
             desc: '''
@@ -1503,12 +1498,6 @@
         swaccess: "ro",
         hwaccess: "hrw",
         fields: [
-          { bits: "0",
-            name: "oob_err",
-            desc: '''
-              The flash hardware interface supplied an out of bound value.
-            '''
-          },
           { bits: "1",
             name: "mp_err",
             desc: '''
@@ -1572,7 +1561,7 @@
         swaccess: "ro",
         hwaccess: "hwo",
         fields: [
-          { bits: "31:0",
+          { bits: "19:0",
             resval: 0,
           },
         ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -513,13 +513,15 @@
         hwaccess: "hro",
         resval: "0",
         fields: [
-          { bits: "31:0",
+          { bits: "${total_byte_width-1}:0",
             name: "START",
             desc: '''
-              Start address of a flash transaction.  Software should supply the full byte address.
-              The flash controller will then truncate the address as needed.  For read operations,
-              the flash controller will truncate to the closest, lower word aligned address.  For
-              example, if 0x13 is supplied, the controller will perform a read at address 0x10.
+              Start address of a flash transaction.  This is a byte address relative to the flash
+              only.  Ie, an address of 0 will access address 0 of the requested partition.
+
+              For read operations, the flash controller will truncate to the closest, lower word
+              aligned address.  For example, if 0x13 is supplied, the controller will perform a
+              read at address 0x10.
 
               Program operations behave similarly, the controller does not have read modified write
               support.
@@ -938,13 +940,6 @@
         swaccess: "rw1c",
         hwaccess: "hwo",
         fields: [
-          { bits: "0",
-            name: "oob_err",
-            desc: '''
-              The supplied address !!ADDR is invalid and out of bounds.
-              This is a synchronous error.
-            '''
-          },
           { bits: "1",
             name: "mp_err",
             desc: '''
@@ -1004,12 +999,6 @@
         swaccess: "ro",
         hwaccess: "hrw",
         fields: [
-          { bits: "0",
-            name: "oob_err",
-            desc: '''
-              The flash hardware interface supplied an out of bound value.
-            '''
-          },
           { bits: "1",
             name: "mp_err",
             desc: '''
@@ -1073,7 +1062,7 @@
         swaccess: "ro",
         hwaccess: "hwo",
         fields: [
-          { bits: "31:0",
+          { bits: "${total_byte_width-1}:0",
             resval: 0,
           },
         ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -7,9 +7,6 @@
 
 package flash_ctrl_pkg;
 
-  // End address of flash
-  parameter logic [top_pkg::TL_AW-1:0] EndAddr = 'h${format(int(cfg.end_addr), "x")};
-
   // design parameters that can be altered through topgen
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
   parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
@@ -60,8 +57,10 @@ package flash_ctrl_pkg;
   parameter int BusWordsPerPage = WordsPerPage * WidthMultiple;
   parameter int BusWordW        = prim_util_pkg::vbits(BusWordsPerPage);
   parameter int BusAddrW        = BankW + PageW + BusWordW;
+  parameter int BusAddrByteW    = BusAddrW + BusByteWidth;
   parameter int BusBankAddrW    = PageW + BusWordW;
   parameter int PhyAddrStart    = BusWordW - WordW;
+
 
   // fifo parameters
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);

--- a/hw/ip/flash_ctrl/doc/_index.md
+++ b/hw/ip/flash_ctrl/doc/_index.md
@@ -185,14 +185,6 @@ Each page can be configured with access privileges.
 As a result, software does not need to define a start and end page for information partitions.
 See {{< regref "BANK0_INFO_PAGE_CFG0" >}} as an example.
 
-#### Address Out of Bounds Check
-In addition to memory protection, the flash controller also explicitly checks to ensure the supplied input is not too large.
-Normally, if software supplies an address that is larger than the flash, the address bits are truncated and the operation wraps.
-However, this can lead to unintentional side effects where it seems like the controller is erasing, programming or reading the wrong location.
-
-Instead the controller explicitly creates an error when the address is out of bounds.
-This terminates the transaction immediately and notifies software of the error.
-
 #### Memory Protection for Key Manager and Life Cycle
 
 While memory protection is largely under software control, certain behavior is hardwired to support key manager secret partitions and life cycle functions.

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -205,7 +205,7 @@ module flash_ctrl
   flash_key_t rand_data_key;
   flash_ctrl_reg2hw_control_reg_t hw_ctrl;
   logic hw_req;
-  logic [top_pkg::TL_AW-1:0] hw_addr;
+  logic [BusAddrByteW-1:0] hw_addr;
   logic hw_done;
   flash_ctrl_err_t hw_err;
   logic hw_rvalid;
@@ -224,13 +224,11 @@ module flash_ctrl
 
   // Flash control muxed connections
   flash_ctrl_reg2hw_control_reg_t muxed_ctrl;
-  logic [top_pkg::TL_AW-1:0] muxed_addr;
+  logic [BusAddrByteW-1:0] muxed_addr;
   logic op_start;
   logic [11:0] op_num_words;
   logic [BusAddrW-1:0] op_addr;
   logic [BusAddrW-1:0] ctrl_err_addr;
-  // SW or HW supplied address is out of bounds
-  logic op_addr_oob;
   flash_op_e op_type;
   flash_part_e op_part;
   logic [InfoTypesWidth-1:0] op_info_sel;
@@ -370,9 +368,6 @@ module flash_ctrl
   assign op_erase_type = flash_erase_e'(muxed_ctrl.erase_sel.q);
   assign op_prog_type  = flash_prog_e'(muxed_ctrl.prog_sel.q);
   assign op_addr       = muxed_addr[BusByteWidth +: BusAddrW];
-  // The supplied address by software is completely beyond the flash
-  // and will wrap.  Instead of allowing this, explicitly error back.
-  assign op_addr_oob   = muxed_addr >= EndAddr;
   assign op_type       = flash_op_e'(muxed_ctrl.op.q);
   assign op_part       = flash_part_e'(muxed_ctrl.partition_sel.q);
   assign op_info_sel   = muxed_ctrl.info_sel.q;
@@ -509,7 +504,7 @@ module flash_ctrl
     .op_done_o      (prog_done),
     .op_err_o       (prog_err),
     .op_addr_i      (op_addr),
-    .op_addr_oob_i  (op_addr_oob),
+    .op_addr_oob_i  ('0),
     .op_type_i      (op_prog_type),
     .type_avail_i   (prog_type_en),
     .op_err_addr_o  (prog_err_addr),
@@ -595,7 +590,7 @@ module flash_ctrl
     .op_err_o       (rd_err),
     .op_err_addr_o  (rd_err_addr),
     .op_addr_i      (op_addr),
-    .op_addr_oob_i  (op_addr_oob),
+    .op_addr_oob_i  ('0),
 
     // FIFO Interface
     .data_rdy_i     (rd_fifo_wready),
@@ -622,7 +617,7 @@ module flash_ctrl
     .op_done_o      (erase_done),
     .op_err_o       (erase_err),
     .op_addr_i      (op_addr),
-    .op_addr_oob_i  (op_addr_oob),
+    .op_addr_oob_i  ('0),
     .op_err_addr_o  (erase_err_addr),
 
     // Flash Macro Interface
@@ -874,27 +869,24 @@ module flash_ctrl
   //////////////////////////////////////
 
   // all software interface errors are treated as synchronous errors
-  assign hw2reg.err_code.oob_err.d        = 1'b1;
   assign hw2reg.err_code.mp_err.d         = 1'b1;
   assign hw2reg.err_code.rd_err.d         = 1'b1;
   assign hw2reg.err_code.prog_win_err.d   = 1'b1;
   assign hw2reg.err_code.prog_type_err.d  = 1'b1;
   assign hw2reg.err_code.flash_phy_err.d  = 1'b1;
   assign hw2reg.err_code.update_err.d     = 1'b1;
-  assign hw2reg.err_code.oob_err.de       = sw_ctrl_err.oob_err;
   assign hw2reg.err_code.mp_err.de        = sw_ctrl_err.mp_err;
   assign hw2reg.err_code.rd_err.de        = sw_ctrl_err.rd_err;
   assign hw2reg.err_code.prog_win_err.de  = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de = sw_ctrl_err.prog_type_err;
   assign hw2reg.err_code.flash_phy_err.de = sw_ctrl_err.phy_err;
   assign hw2reg.err_code.update_err.de    = update_err;
-  assign hw2reg.err_addr.d                = {reg2hw.addr.q[31:BusAddrW],ctrl_err_addr};
+  assign hw2reg.err_addr.d                = {ctrl_err_addr, {BusByteWidth{1'h0}}};
   assign hw2reg.err_addr.de               = sw_ctrl_err.mp_err |
                                             sw_ctrl_err.rd_err |
                                             sw_ctrl_err.phy_err;
 
   // all hardware interface errors are considered faults
-  assign hw2reg.fault_status.oob_err.d        = 1'b1;
   assign hw2reg.fault_status.mp_err.d         = 1'b1;
   assign hw2reg.fault_status.rd_err.d         = 1'b1;
   assign hw2reg.fault_status.prog_win_err.d   = 1'b1;
@@ -904,7 +896,6 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.lcmgr_err.d      = 1'b1;
   assign hw2reg.fault_status.storage_err.d    = 1'b1;
-  assign hw2reg.fault_status.oob_err.de       = hw_err.oob_err;
   assign hw2reg.fault_status.mp_err.de        = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de        = hw_err.rd_err;
   assign hw2reg.fault_status.prog_win_err.de  = hw_err.prog_win_err;
@@ -1060,12 +1051,10 @@ module flash_ctrl
 
   // Unused bits
   logic [BusByteWidth-1:0] unused_byte_sel;
-  logic [top_pkg::TL_AW-1-BusAddrW:0] unused_higher_addr_bits;
   logic [top_pkg::TL_AW-1:0] unused_scratch;
 
   // Unused signals
   assign unused_byte_sel = muxed_addr[BusByteWidth-1:0];
-  assign unused_higher_addr_bits = muxed_addr[top_pkg::TL_AW-1:BusAddrW];
   assign unused_scratch = reg2hw.scratch;
 
 
@@ -1161,9 +1150,6 @@ module flash_ctrl
   // This is used only for assertions
   logic unused_op_valid;
   assign unused_op_valid = prog_op_valid | rd_op_valid | erase_op_valid;
-
-  // if there is an out of bounds error, flash request should never assert
-  `ASSERT(OutofBoundsReq_A, unused_op_valid & op_addr_oob |-> ~flash_phy_req.req)
 
   // add more assertions
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PageCntAlertCheck_A, u_flash_hw_if.u_page_cnt,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
@@ -21,7 +21,7 @@ module flash_ctrl_arb import flash_ctrl_pkg::*; (
 
   // software interface to rd_ctrl / erase_ctrl
   input flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t sw_ctrl_i,
-  input [31:0] sw_addr_i,
+  input [BusAddrByteW-1:0] sw_addr_i,
   output logic sw_ack_o,
   output flash_ctrl_err_t sw_err_o,
 
@@ -38,7 +38,7 @@ module flash_ctrl_arb import flash_ctrl_pkg::*; (
   input hw_req_i,
   input flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t hw_ctrl_i,
   input flash_lcmgr_phase_e hw_phase_i,
-  input [31:0] hw_addr_i,
+  input [BusAddrByteW-1:0] hw_addr_i,
   output logic hw_ack_o,
   output flash_ctrl_err_t hw_err_o,
 
@@ -53,7 +53,7 @@ module flash_ctrl_arb import flash_ctrl_pkg::*; (
 
   // muxed interface to rd_ctrl / erase_ctrl
   output flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t muxed_ctrl_o,
-  output logic [31:0] muxed_addr_o,
+  output logic [BusAddrByteW-1:0] muxed_addr_o,
   input prog_ack_i,
   input flash_ctrl_err_t prog_err_i,
   input [BusAddrW-1:0] prog_err_addr_i,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -225,8 +225,8 @@ module flash_ctrl_core_reg_top (
   logic [11:0] control_num_qs;
   logic [11:0] control_num_wd;
   logic addr_we;
-  logic [31:0] addr_qs;
-  logic [31:0] addr_wd;
+  logic [19:0] addr_qs;
+  logic [19:0] addr_wd;
   logic prog_type_en_we;
   logic prog_type_en_normal_qs;
   logic prog_type_en_normal_wd;
@@ -947,8 +947,6 @@ module flash_ctrl_core_reg_top (
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
   logic err_code_we;
-  logic err_code_oob_err_qs;
-  logic err_code_oob_err_wd;
   logic err_code_mp_err_qs;
   logic err_code_mp_err_wd;
   logic err_code_rd_err_qs;
@@ -961,7 +959,6 @@ module flash_ctrl_core_reg_top (
   logic err_code_flash_phy_err_wd;
   logic err_code_update_err_qs;
   logic err_code_update_err_wd;
-  logic fault_status_oob_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
   logic fault_status_prog_win_err_qs;
@@ -971,7 +968,7 @@ module flash_ctrl_core_reg_top (
   logic fault_status_phy_intg_err_qs;
   logic fault_status_lcmgr_err_qs;
   logic fault_status_storage_err_qs;
-  logic [31:0] err_addr_qs;
+  logic [19:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_wd;
@@ -1698,9 +1695,9 @@ module flash_ctrl_core_reg_top (
 
   // R[addr]: V(False)
   prim_subreg #(
-    .DW      (32),
+    .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (20'h0)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11153,31 +11150,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_code]: V(False)
-  //   F[oob_err]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_err_code_oob_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (err_code_we),
-    .wd     (err_code_oob_err_wd),
-
-    // from internal hardware
-    .de     (hw2reg.err_code.oob_err.de),
-    .d      (hw2reg.err_code.oob_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (err_code_oob_err_qs)
-  );
-
   //   F[mp_err]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -11330,31 +11302,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[fault_status]: V(False)
-  //   F[oob_err]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
-  ) u_fault_status_oob_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.fault_status.oob_err.de),
-    .d      (hw2reg.fault_status.oob_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.fault_status.oob_err.q),
-
-    // to register interface (read)
-    .qs     (fault_status_oob_err_qs)
-  );
-
   //   F[mp_err]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -11583,9 +11530,9 @@ module flash_ctrl_core_reg_top (
 
   // R[err_addr]: V(False)
   prim_subreg #(
-    .DW      (32),
+    .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (20'h0)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12278,7 +12225,7 @@ module flash_ctrl_core_reg_top (
   assign control_num_wd = reg_wdata[27:16];
   assign addr_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign addr_wd = reg_wdata[31:0];
+  assign addr_wd = reg_wdata[19:0];
   assign prog_type_en_we = addr_hit[10] & reg_we & !reg_error;
 
   assign prog_type_en_normal_wd = reg_wdata[0];
@@ -12995,8 +12942,6 @@ module flash_ctrl_core_reg_top (
   assign op_status_err_wd = reg_wdata[1];
   assign err_code_we = addr_hit[85] & reg_we & !reg_error;
 
-  assign err_code_oob_err_wd = reg_wdata[0];
-
   assign err_code_mp_err_wd = reg_wdata[1];
 
   assign err_code_rd_err_wd = reg_wdata[2];
@@ -13099,7 +13044,7 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[9]: begin
-        reg_rdata_next[31:0] = addr_qs;
+        reg_rdata_next[19:0] = addr_qs;
       end
 
       addr_hit[10]: begin
@@ -13635,7 +13580,6 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[85]: begin
-        reg_rdata_next[0] = err_code_oob_err_qs;
         reg_rdata_next[1] = err_code_mp_err_qs;
         reg_rdata_next[2] = err_code_rd_err_qs;
         reg_rdata_next[3] = err_code_prog_win_err_qs;
@@ -13645,7 +13589,6 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[86]: begin
-        reg_rdata_next[0] = fault_status_oob_err_qs;
         reg_rdata_next[1] = fault_status_mp_err_qs;
         reg_rdata_next[2] = fault_status_rd_err_qs;
         reg_rdata_next[3] = fault_status_prog_win_err_qs;
@@ -13658,7 +13601,7 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[87]: begin
-        reg_rdata_next[31:0] = err_addr_qs;
+        reg_rdata_next[19:0] = err_addr_qs;
       end
 
       addr_hit[88]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -23,7 +23,7 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; #(
   // interface to ctrl arb control ports
   output flash_ctrl_reg_pkg::flash_ctrl_reg2hw_control_reg_t ctrl_o,
   output logic req_o,
-  output logic [top_pkg::TL_AW-1:0] addr_o,
+  output logic [BusAddrByteW-1:0] addr_o,
   input done_i,
   input flash_ctrl_err_t err_i,
 
@@ -684,8 +684,8 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; #(
   assign ctrl_o.info_sel.q = seed_phase ? info_sel : rma_info_sel;
   assign ctrl_o.num = seed_phase ? num_words : rma_num_words;
   // address is consistent with software width format (full bus)
-  assign addr_o = seed_phase ? top_pkg::TL_AW'({addr, {BusByteWidth{1'b0}}}) :
-                               top_pkg::TL_AW'({rma_addr, {BusByteWidth{1'b0}}});
+  assign addr_o = seed_phase ? {addr, {BusByteWidth{1'b0}}} :
+                               {rma_addr, {BusByteWidth{1'b0}}};
   assign init_busy_o = seed_phase;
   assign req_o = seed_phase | rma_phase;
   assign rready_o = 1'b1;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -7,9 +7,6 @@
 
 package flash_ctrl_pkg;
 
-  // End address of flash
-  parameter logic [top_pkg::TL_AW-1:0] EndAddr = 'h20100000;
-
   // design parameters that can be altered through topgen
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
   parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
@@ -60,8 +57,10 @@ package flash_ctrl_pkg;
   parameter int BusWordsPerPage = WordsPerPage * WidthMultiple;
   parameter int BusWordW        = prim_util_pkg::vbits(BusWordsPerPage);
   parameter int BusAddrW        = BankW + PageW + BusWordW;
+  parameter int BusAddrByteW    = BusAddrW + BusByteWidth;
   parameter int BusBankAddrW    = PageW + BusWordW;
   parameter int PhyAddrStart    = BusWordW - WordW;
+
 
   // fifo parameters
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -148,7 +148,7 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_reg2hw_control_reg_t;
 
   typedef struct packed {
-    logic [31:0] q;
+    logic [19:0] q;
   } flash_ctrl_reg2hw_addr_reg_t;
 
   typedef struct packed {
@@ -482,9 +482,6 @@ package flash_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-    } oob_err;
-    struct packed {
-      logic        q;
     } mp_err;
     struct packed {
       logic        q;
@@ -627,10 +624,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } oob_err;
-    struct packed {
-      logic        d;
-      logic        de;
     } mp_err;
     struct packed {
       logic        d;
@@ -655,10 +648,6 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_hw2reg_err_code_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } oob_err;
     struct packed {
       logic        d;
       logic        de;
@@ -698,7 +687,7 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
-    logic [31:0] d;
+    logic [19:0] d;
     logic        de;
   } flash_ctrl_hw2reg_err_addr_reg_t;
 
@@ -729,33 +718,33 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [561:556]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [555:550]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [549:538]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [537:534]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [533:530]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [529:526]
-    flash_ctrl_reg2hw_init_reg_t init; // [525:525]
-    flash_ctrl_reg2hw_control_reg_t control; // [524:505]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [504:473]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [472:471]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [470:470]
-    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [469:262]
-    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [261:256]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [548:543]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [542:537]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [536:525]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [524:521]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [520:517]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [516:513]
+    flash_ctrl_reg2hw_init_reg_t init; // [512:512]
+    flash_ctrl_reg2hw_control_reg_t control; // [511:492]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [491:472]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [471:470]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [469:469]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [468:261]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [260:255]
     flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank0_info0_page_cfg_shadowed; // [255:186]
+        bank0_info0_page_cfg_shadowed; // [254:185]
     flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank0_info1_page_cfg_shadowed; // [185:179]
+        bank0_info1_page_cfg_shadowed; // [184:178]
     flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank0_info2_page_cfg_shadowed; // [178:165]
+        bank0_info2_page_cfg_shadowed; // [177:164]
     flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank1_info0_page_cfg_shadowed; // [164:95]
+        bank1_info0_page_cfg_shadowed; // [163:94]
     flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank1_info1_page_cfg_shadowed; // [94:88]
+        bank1_info1_page_cfg_shadowed; // [93:87]
     flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank1_info2_page_cfg_shadowed; // [87:74]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [73:72]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [71:62]
+        bank1_info2_page_cfg_shadowed; // [86:73]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [72:71]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:62]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [61:46]
     flash_ctrl_reg2hw_phy_err_cfg_reg_t phy_err_cfg; // [45:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -766,15 +755,15 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [163:152]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [151:151]
-    flash_ctrl_hw2reg_control_reg_t control; // [150:149]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [148:147]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [146:143]
-    flash_ctrl_hw2reg_status_reg_t status; // [142:133]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [132:119]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [118:99]
-    flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [98:66]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [147:136]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [135:135]
+    flash_ctrl_hw2reg_control_reg_t control; // [134:133]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [132:131]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [130:127]
+    flash_ctrl_hw2reg_status_reg_t status; // [126:117]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [116:105]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [104:87]
+    flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [86:66]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [65:48]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [47:6]
     flash_ctrl_hw2reg_phy_status_reg_t phy_status; // [5:0]
@@ -1013,7 +1002,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[ 6] FLASH_CTRL_INIT
     4'b 0001, // index[ 7] FLASH_CTRL_CTRL_REGWEN
     4'b 1111, // index[ 8] FLASH_CTRL_CONTROL
-    4'b 1111, // index[ 9] FLASH_CTRL_ADDR
+    4'b 0111, // index[ 9] FLASH_CTRL_ADDR
     4'b 0001, // index[10] FLASH_CTRL_PROG_TYPE_EN
     4'b 0001, // index[11] FLASH_CTRL_ERASE_SUSPEND
     4'b 0001, // index[12] FLASH_CTRL_REGION_CFG_REGWEN_0
@@ -1091,7 +1080,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[84] FLASH_CTRL_STATUS
     4'b 0001, // index[85] FLASH_CTRL_ERR_CODE
     4'b 0011, // index[86] FLASH_CTRL_FAULT_STATUS
-    4'b 1111, // index[87] FLASH_CTRL_ERR_ADDR
+    4'b 0111, // index[87] FLASH_CTRL_ERR_ADDR
     4'b 0011, // index[88] FLASH_CTRL_ECC_SINGLE_ERR_CNT
     4'b 0111, // index[89] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0
     4'b 0111, // index[90] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -522,13 +522,15 @@
         hwaccess: "hro",
         resval: "0",
         fields: [
-          { bits: "31:0",
+          { bits: "19:0",
             name: "START",
             desc: '''
-              Start address of a flash transaction.  Software should supply the full byte address.
-              The flash controller will then truncate the address as needed.  For read operations,
-              the flash controller will truncate to the closest, lower word aligned address.  For
-              example, if 0x13 is supplied, the controller will perform a read at address 0x10.
+              Start address of a flash transaction.  This is a byte address relative to the flash
+              only.  Ie, an address of 0 will access address 0 of the requested partition.
+
+              For read operations, the flash controller will truncate to the closest, lower word
+              aligned address.  For example, if 0x13 is supplied, the controller will perform a
+              read at address 0x10.
 
               Program operations behave similarly, the controller does not have read modified write
               support.
@@ -1443,13 +1445,6 @@
         swaccess: "rw1c",
         hwaccess: "hwo",
         fields: [
-          { bits: "0",
-            name: "oob_err",
-            desc: '''
-              The supplied address !!ADDR is invalid and out of bounds.
-              This is a synchronous error.
-            '''
-          },
           { bits: "1",
             name: "mp_err",
             desc: '''
@@ -1509,12 +1504,6 @@
         swaccess: "ro",
         hwaccess: "hrw",
         fields: [
-          { bits: "0",
-            name: "oob_err",
-            desc: '''
-              The flash hardware interface supplied an out of bound value.
-            '''
-          },
           { bits: "1",
             name: "mp_err",
             desc: '''
@@ -1578,7 +1567,7 @@
         swaccess: "ro",
         hwaccess: "hwo",
         fields: [
-          { bits: "31:0",
+          { bits: "19:0",
             resval: 0,
           },
         ]

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -211,7 +211,7 @@ module flash_ctrl
   flash_key_t rand_data_key;
   flash_ctrl_reg2hw_control_reg_t hw_ctrl;
   logic hw_req;
-  logic [top_pkg::TL_AW-1:0] hw_addr;
+  logic [BusAddrByteW-1:0] hw_addr;
   logic hw_done;
   flash_ctrl_err_t hw_err;
   logic hw_rvalid;
@@ -230,13 +230,11 @@ module flash_ctrl
 
   // Flash control muxed connections
   flash_ctrl_reg2hw_control_reg_t muxed_ctrl;
-  logic [top_pkg::TL_AW-1:0] muxed_addr;
+  logic [BusAddrByteW-1:0] muxed_addr;
   logic op_start;
   logic [11:0] op_num_words;
   logic [BusAddrW-1:0] op_addr;
   logic [BusAddrW-1:0] ctrl_err_addr;
-  // SW or HW supplied address is out of bounds
-  logic op_addr_oob;
   flash_op_e op_type;
   flash_part_e op_part;
   logic [InfoTypesWidth-1:0] op_info_sel;
@@ -376,9 +374,6 @@ module flash_ctrl
   assign op_erase_type = flash_erase_e'(muxed_ctrl.erase_sel.q);
   assign op_prog_type  = flash_prog_e'(muxed_ctrl.prog_sel.q);
   assign op_addr       = muxed_addr[BusByteWidth +: BusAddrW];
-  // The supplied address by software is completely beyond the flash
-  // and will wrap.  Instead of allowing this, explicitly error back.
-  assign op_addr_oob   = muxed_addr >= EndAddr;
   assign op_type       = flash_op_e'(muxed_ctrl.op.q);
   assign op_part       = flash_part_e'(muxed_ctrl.partition_sel.q);
   assign op_info_sel   = muxed_ctrl.info_sel.q;
@@ -515,7 +510,7 @@ module flash_ctrl
     .op_done_o      (prog_done),
     .op_err_o       (prog_err),
     .op_addr_i      (op_addr),
-    .op_addr_oob_i  (op_addr_oob),
+    .op_addr_oob_i  ('0),
     .op_type_i      (op_prog_type),
     .type_avail_i   (prog_type_en),
     .op_err_addr_o  (prog_err_addr),
@@ -601,7 +596,7 @@ module flash_ctrl
     .op_err_o       (rd_err),
     .op_err_addr_o  (rd_err_addr),
     .op_addr_i      (op_addr),
-    .op_addr_oob_i  (op_addr_oob),
+    .op_addr_oob_i  ('0),
 
     // FIFO Interface
     .data_rdy_i     (rd_fifo_wready),
@@ -628,7 +623,7 @@ module flash_ctrl
     .op_done_o      (erase_done),
     .op_err_o       (erase_err),
     .op_addr_i      (op_addr),
-    .op_addr_oob_i  (op_addr_oob),
+    .op_addr_oob_i  ('0),
     .op_err_addr_o  (erase_err_addr),
 
     // Flash Macro Interface
@@ -880,27 +875,24 @@ module flash_ctrl
   //////////////////////////////////////
 
   // all software interface errors are treated as synchronous errors
-  assign hw2reg.err_code.oob_err.d        = 1'b1;
   assign hw2reg.err_code.mp_err.d         = 1'b1;
   assign hw2reg.err_code.rd_err.d         = 1'b1;
   assign hw2reg.err_code.prog_win_err.d   = 1'b1;
   assign hw2reg.err_code.prog_type_err.d  = 1'b1;
   assign hw2reg.err_code.flash_phy_err.d  = 1'b1;
   assign hw2reg.err_code.update_err.d     = 1'b1;
-  assign hw2reg.err_code.oob_err.de       = sw_ctrl_err.oob_err;
   assign hw2reg.err_code.mp_err.de        = sw_ctrl_err.mp_err;
   assign hw2reg.err_code.rd_err.de        = sw_ctrl_err.rd_err;
   assign hw2reg.err_code.prog_win_err.de  = sw_ctrl_err.prog_win_err;
   assign hw2reg.err_code.prog_type_err.de = sw_ctrl_err.prog_type_err;
   assign hw2reg.err_code.flash_phy_err.de = sw_ctrl_err.phy_err;
   assign hw2reg.err_code.update_err.de    = update_err;
-  assign hw2reg.err_addr.d                = {reg2hw.addr.q[31:BusAddrW],ctrl_err_addr};
+  assign hw2reg.err_addr.d                = {ctrl_err_addr, {BusByteWidth{1'h0}}};
   assign hw2reg.err_addr.de               = sw_ctrl_err.mp_err |
                                             sw_ctrl_err.rd_err |
                                             sw_ctrl_err.phy_err;
 
   // all hardware interface errors are considered faults
-  assign hw2reg.fault_status.oob_err.d        = 1'b1;
   assign hw2reg.fault_status.mp_err.d         = 1'b1;
   assign hw2reg.fault_status.rd_err.d         = 1'b1;
   assign hw2reg.fault_status.prog_win_err.d   = 1'b1;
@@ -910,7 +902,6 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_intg_err.d   = 1'b1;
   assign hw2reg.fault_status.lcmgr_err.d      = 1'b1;
   assign hw2reg.fault_status.storage_err.d    = 1'b1;
-  assign hw2reg.fault_status.oob_err.de       = hw_err.oob_err;
   assign hw2reg.fault_status.mp_err.de        = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de        = hw_err.rd_err;
   assign hw2reg.fault_status.prog_win_err.de  = hw_err.prog_win_err;
@@ -1066,12 +1057,10 @@ module flash_ctrl
 
   // Unused bits
   logic [BusByteWidth-1:0] unused_byte_sel;
-  logic [top_pkg::TL_AW-1-BusAddrW:0] unused_higher_addr_bits;
   logic [top_pkg::TL_AW-1:0] unused_scratch;
 
   // Unused signals
   assign unused_byte_sel = muxed_addr[BusByteWidth-1:0];
-  assign unused_higher_addr_bits = muxed_addr[top_pkg::TL_AW-1:BusAddrW];
   assign unused_scratch = reg2hw.scratch;
 
 
@@ -1167,9 +1156,6 @@ module flash_ctrl
   // This is used only for assertions
   logic unused_op_valid;
   assign unused_op_valid = prog_op_valid | rd_op_valid | erase_op_valid;
-
-  // if there is an out of bounds error, flash request should never assert
-  `ASSERT(OutofBoundsReq_A, unused_op_valid & op_addr_oob |-> ~flash_phy_req.req)
 
   // add more assertions
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PageCntAlertCheck_A, u_flash_hw_if.u_page_cnt,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -225,8 +225,8 @@ module flash_ctrl_core_reg_top (
   logic [11:0] control_num_qs;
   logic [11:0] control_num_wd;
   logic addr_we;
-  logic [31:0] addr_qs;
-  logic [31:0] addr_wd;
+  logic [19:0] addr_qs;
+  logic [19:0] addr_wd;
   logic prog_type_en_we;
   logic prog_type_en_normal_qs;
   logic prog_type_en_normal_wd;
@@ -947,8 +947,6 @@ module flash_ctrl_core_reg_top (
   logic status_prog_empty_qs;
   logic status_init_wip_qs;
   logic err_code_we;
-  logic err_code_oob_err_qs;
-  logic err_code_oob_err_wd;
   logic err_code_mp_err_qs;
   logic err_code_mp_err_wd;
   logic err_code_rd_err_qs;
@@ -961,7 +959,6 @@ module flash_ctrl_core_reg_top (
   logic err_code_flash_phy_err_wd;
   logic err_code_update_err_qs;
   logic err_code_update_err_wd;
-  logic fault_status_oob_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
   logic fault_status_prog_win_err_qs;
@@ -971,7 +968,7 @@ module flash_ctrl_core_reg_top (
   logic fault_status_phy_intg_err_qs;
   logic fault_status_lcmgr_err_qs;
   logic fault_status_storage_err_qs;
-  logic [31:0] err_addr_qs;
+  logic [19:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_wd;
@@ -1698,9 +1695,9 @@ module flash_ctrl_core_reg_top (
 
   // R[addr]: V(False)
   prim_subreg #(
-    .DW      (32),
+    .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
+    .RESVAL  (20'h0)
   ) u_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -11153,31 +11150,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[err_code]: V(False)
-  //   F[oob_err]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessW1C),
-    .RESVAL  (1'h0)
-  ) u_err_code_oob_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (err_code_we),
-    .wd     (err_code_oob_err_wd),
-
-    // from internal hardware
-    .de     (hw2reg.err_code.oob_err.de),
-    .d      (hw2reg.err_code.oob_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (err_code_oob_err_qs)
-  );
-
   //   F[mp_err]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -11330,31 +11302,6 @@ module flash_ctrl_core_reg_top (
 
 
   // R[fault_status]: V(False)
-  //   F[oob_err]: 0:0
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h0)
-  ) u_fault_status_oob_err (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.fault_status.oob_err.de),
-    .d      (hw2reg.fault_status.oob_err.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.fault_status.oob_err.q),
-
-    // to register interface (read)
-    .qs     (fault_status_oob_err_qs)
-  );
-
   //   F[mp_err]: 1:1
   prim_subreg #(
     .DW      (1),
@@ -11583,9 +11530,9 @@ module flash_ctrl_core_reg_top (
 
   // R[err_addr]: V(False)
   prim_subreg #(
-    .DW      (32),
+    .DW      (20),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (32'h0)
+    .RESVAL  (20'h0)
   ) u_err_addr (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
@@ -12278,7 +12225,7 @@ module flash_ctrl_core_reg_top (
   assign control_num_wd = reg_wdata[27:16];
   assign addr_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign addr_wd = reg_wdata[31:0];
+  assign addr_wd = reg_wdata[19:0];
   assign prog_type_en_we = addr_hit[10] & reg_we & !reg_error;
 
   assign prog_type_en_normal_wd = reg_wdata[0];
@@ -12995,8 +12942,6 @@ module flash_ctrl_core_reg_top (
   assign op_status_err_wd = reg_wdata[1];
   assign err_code_we = addr_hit[85] & reg_we & !reg_error;
 
-  assign err_code_oob_err_wd = reg_wdata[0];
-
   assign err_code_mp_err_wd = reg_wdata[1];
 
   assign err_code_rd_err_wd = reg_wdata[2];
@@ -13099,7 +13044,7 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[9]: begin
-        reg_rdata_next[31:0] = addr_qs;
+        reg_rdata_next[19:0] = addr_qs;
       end
 
       addr_hit[10]: begin
@@ -13635,7 +13580,6 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[85]: begin
-        reg_rdata_next[0] = err_code_oob_err_qs;
         reg_rdata_next[1] = err_code_mp_err_qs;
         reg_rdata_next[2] = err_code_rd_err_qs;
         reg_rdata_next[3] = err_code_prog_win_err_qs;
@@ -13645,7 +13589,6 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[86]: begin
-        reg_rdata_next[0] = fault_status_oob_err_qs;
         reg_rdata_next[1] = fault_status_mp_err_qs;
         reg_rdata_next[2] = fault_status_rd_err_qs;
         reg_rdata_next[3] = fault_status_prog_win_err_qs;
@@ -13658,7 +13601,7 @@ module flash_ctrl_core_reg_top (
       end
 
       addr_hit[87]: begin
-        reg_rdata_next[31:0] = err_addr_qs;
+        reg_rdata_next[19:0] = err_addr_qs;
       end
 
       addr_hit[88]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -13,9 +13,6 @@
 
 package flash_ctrl_pkg;
 
-  // End address of flash
-  parameter logic [top_pkg::TL_AW-1:0] EndAddr = 'h20100000;
-
   // design parameters that can be altered through topgen
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
   parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
@@ -66,8 +63,10 @@ package flash_ctrl_pkg;
   parameter int BusWordsPerPage = WordsPerPage * WidthMultiple;
   parameter int BusWordW        = prim_util_pkg::vbits(BusWordsPerPage);
   parameter int BusAddrW        = BankW + PageW + BusWordW;
+  parameter int BusAddrByteW    = BusAddrW + BusByteWidth;
   parameter int BusBankAddrW    = PageW + BusWordW;
   parameter int PhyAddrStart    = BusWordW - WordW;
+
 
   // fifo parameters
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -148,7 +148,7 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_reg2hw_control_reg_t;
 
   typedef struct packed {
-    logic [31:0] q;
+    logic [19:0] q;
   } flash_ctrl_reg2hw_addr_reg_t;
 
   typedef struct packed {
@@ -482,9 +482,6 @@ package flash_ctrl_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
-    } oob_err;
-    struct packed {
-      logic        q;
     } mp_err;
     struct packed {
       logic        q;
@@ -627,10 +624,6 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } oob_err;
-    struct packed {
-      logic        d;
-      logic        de;
     } mp_err;
     struct packed {
       logic        d;
@@ -655,10 +648,6 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_hw2reg_err_code_reg_t;
 
   typedef struct packed {
-    struct packed {
-      logic        d;
-      logic        de;
-    } oob_err;
     struct packed {
       logic        d;
       logic        de;
@@ -698,7 +687,7 @@ package flash_ctrl_reg_pkg;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
-    logic [31:0] d;
+    logic [19:0] d;
     logic        de;
   } flash_ctrl_hw2reg_err_addr_reg_t;
 
@@ -729,33 +718,33 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [561:556]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [555:550]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [549:538]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [537:534]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [533:530]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [529:526]
-    flash_ctrl_reg2hw_init_reg_t init; // [525:525]
-    flash_ctrl_reg2hw_control_reg_t control; // [524:505]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [504:473]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [472:471]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [470:470]
-    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [469:262]
-    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [261:256]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [548:543]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [542:537]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [536:525]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [524:521]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [520:517]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [516:513]
+    flash_ctrl_reg2hw_init_reg_t init; // [512:512]
+    flash_ctrl_reg2hw_control_reg_t control; // [511:492]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [491:472]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [471:470]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [469:469]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [468:261]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [260:255]
     flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank0_info0_page_cfg_shadowed; // [255:186]
+        bank0_info0_page_cfg_shadowed; // [254:185]
     flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank0_info1_page_cfg_shadowed; // [185:179]
+        bank0_info1_page_cfg_shadowed; // [184:178]
     flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank0_info2_page_cfg_shadowed; // [178:165]
+        bank0_info2_page_cfg_shadowed; // [177:164]
     flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank1_info0_page_cfg_shadowed; // [164:95]
+        bank1_info0_page_cfg_shadowed; // [163:94]
     flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank1_info1_page_cfg_shadowed; // [94:88]
+        bank1_info1_page_cfg_shadowed; // [93:87]
     flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank1_info2_page_cfg_shadowed; // [87:74]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [73:72]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [71:62]
+        bank1_info2_page_cfg_shadowed; // [86:73]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [72:71]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:62]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [61:46]
     flash_ctrl_reg2hw_phy_err_cfg_reg_t phy_err_cfg; // [45:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -766,15 +755,15 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [163:152]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [151:151]
-    flash_ctrl_hw2reg_control_reg_t control; // [150:149]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [148:147]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [146:143]
-    flash_ctrl_hw2reg_status_reg_t status; // [142:133]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [132:119]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [118:99]
-    flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [98:66]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [147:136]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [135:135]
+    flash_ctrl_hw2reg_control_reg_t control; // [134:133]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [132:131]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [130:127]
+    flash_ctrl_hw2reg_status_reg_t status; // [126:117]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [116:105]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [104:87]
+    flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [86:66]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [65:48]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [47:6]
     flash_ctrl_hw2reg_phy_status_reg_t phy_status; // [5:0]
@@ -1013,7 +1002,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[ 6] FLASH_CTRL_INIT
     4'b 0001, // index[ 7] FLASH_CTRL_CTRL_REGWEN
     4'b 1111, // index[ 8] FLASH_CTRL_CONTROL
-    4'b 1111, // index[ 9] FLASH_CTRL_ADDR
+    4'b 0111, // index[ 9] FLASH_CTRL_ADDR
     4'b 0001, // index[10] FLASH_CTRL_PROG_TYPE_EN
     4'b 0001, // index[11] FLASH_CTRL_ERASE_SUSPEND
     4'b 0001, // index[12] FLASH_CTRL_REGION_CFG_REGWEN_0
@@ -1091,7 +1080,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[84] FLASH_CTRL_STATUS
     4'b 0001, // index[85] FLASH_CTRL_ERR_CODE
     4'b 0011, // index[86] FLASH_CTRL_FAULT_STATUS
-    4'b 1111, // index[87] FLASH_CTRL_ERR_ADDR
+    4'b 0111, // index[87] FLASH_CTRL_ERR_ADDR
     4'b 0011, // index[88] FLASH_CTRL_ECC_SINGLE_ERR_CNT
     4'b 0111, // index[89] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_0
     4'b 0111, // index[90] FLASH_CTRL_ECC_SINGLE_ERR_ADDR_1


### PR DESCRIPTION
The current oob handling is not complete.  It only handles an upper bound
check but does not check the lower bound.  This means the original issue
that caused this error can still happen as long as someone supplies a
lower address (such as 0x0).

After talking it through with the @a-will, the utility of this feature
just seems very minor.  It also complicates things by pulling a system
address map into a peripheral, which really does not seem like the right
way to go about this.

As a result, I have removed this feature altogether, and will instead rely
on software to make sure the addresses being fed to flash_ctrl are within
bounds.

Fixes #9444

Signed-off-by: Timothy Chen <timothytim@google.com>