### PR TITLE
[ci] Add CW310 mask ROM splicing

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -430,6 +430,7 @@ jobs:
 
       cp "$OBJ_DIR/hw/synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.bit" \
         "$BIN_DIR/hw/top_earlgrey"
+      cp "$OBJ_DIR/hw/synth-vivado/rom.mmi" "$BIN_DIR/hw/top_earlgrey"
     displayName: Build bitstream with Vivado
   - bash: |
       . util/build_consts.sh
@@ -443,9 +444,42 @@ jobs:
   - template: ci/upload-artifacts-template.yml
     parameters:
       includePatterns:
-        - "/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
+        - "/hw/***"
   - publish: "$(Build.ArtifactStagingDirectory)"
     artifact: chip_earlgrey_cw310-build-out
+    displayName: Upload all Vivado artifacts for CW310
+    condition: failed()
+
+- job: chip_earlgrey_cw310_splice_mask_rom
+  displayName: Splice mask ROM binary into CW310 bitstream using Vivado
+  dependsOn:
+    - chip_earlgrey_cw310
+    - sw_build
+  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
+  pool: ci-public
+  timeoutInMinutes: 10
+  steps:
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_earlgrey_cw310
+        - sw_build
+  - bash: |
+      set -e
+      . util/build_consts.sh
+
+      module load "xilinx/vivado/$(VIVADO_VERSION)"
+
+      util/fpga/splice_rom.sh -t cw310 -T earlgrey -b PROD
+
+    displayName: Splicing bitstream with Vivado
+  - template: ci/upload-artifacts-template.yml
+    parameters:
+      includePatterns:
+        - "/hw/***"
+  - publish: "$(Build.ArtifactStagingDirectory)"
+    artifact: chip_earlgrey_cw310-splice-mask-rom-build-out
     displayName: Upload all Vivado artifacts for CW310
     condition: failed()
 

--- a/util/fpga/splice_rom.sh
+++ b/util/fpga/splice_rom.sh
@@ -97,9 +97,8 @@ TARGET_FILE_EXT=".scr.39.vmem"
 TARGET_EXPORT="${TARGET_PREFIX}_export_fpga_${TARGET_BOARD}"
 TARGET="${BIN_DIR}/${TARGET_PREFIX}_fpga_${TARGET_BOARD}"
 
-FPGA_BUILD_DIR=${OBJ_DIR}/hw/synth-vivado
-FPGA_MMI_PATH=${FPGA_BUILD_DIR}/lowrisc_systems_chip_${TARGET_TOP}_${TARGET_BOARD}_0.1.runs/impl_1
-FPGA_BIT_NAME=lowrisc_systems_chip_${TARGET_TOP}_${TARGET_BOARD}_0.1
+FPGA_BIN_DIR="${BIN_DIR}/hw/top_${TARGET_TOP}"
+FPGA_BIT_NAME="lowrisc_systems_chip_${TARGET_TOP}_${TARGET_BOARD}_0.1"
 
 # Create the Vivado image for splicing.
 hw/ip/rom_ctrl/util/gen_vivado_mem_image.py \
@@ -113,11 +112,11 @@ hw/ip/rom_ctrl/util/gen_vivado_mem_image.py \
 # the implemented design in Vivado and then inspecting the cell properties of
 # the corresponding BRAM cells. This information is very useful when debugging
 # the splicing flow.
-updatemem -force --meminfo "${FPGA_BUILD_DIR}/rom.mmi" \
+updatemem -force --meminfo "${FPGA_BIN_DIR}/rom.mmi" \
   --data "${TARGET}.updatemem.mem" \
-  --bit "${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit"  --proc dummy \
-  --out "${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.splice.bit" \
+  --bit "${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit"  --proc dummy \
+  --out "${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.splice.bit" \
   --debug
 
-mv ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit.orig
-mv ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.splice.bit ${FPGA_BUILD_DIR}/${FPGA_BIT_NAME}.bit
+mv ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit.orig
+mv ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.splice.bit ${FPGA_BIN_DIR}/${FPGA_BIT_NAME}.bit


### PR DESCRIPTION
CW310 ROM splicing with the mask_rom binary enables the execution of
end-to-end test cases for secure boot.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>