### PR TITLE
[ entropy_src, dv ] Support for all phases of entropy generation

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -4,15 +4,17 @@
 
 class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_block));
 
+  import entropy_src_pkg::*;
+
   `uvm_object_utils_begin(entropy_src_env_cfg)
   `uvm_object_utils_end
 
   `uvm_object_new
 
   // Ext component cfgs
-  rand push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))
+  rand push_pull_agent_cfg#(.HostDataWidth(RNG_BUS_WIDTH))
        m_rng_agent_cfg;
-  rand push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))
+  rand push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))
        m_csrng_agent_cfg;
 
   virtual pins_if#(8)   otp_en_es_fw_read_vif;
@@ -30,6 +32,10 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   rand prim_mubi_pkg::mubi4_t   enable, route_software, type_bypass,
                                 boot_bypass_disable, entropy_data_reg_enable,
                                 rng_bit_enable;
+
+  // TODO: randomize
+  uint fips_window_size, bypass_window_size, boot_mode_retry_limit;
+  int  seed_cnt;
 
   rand prim_mubi_pkg::mubi8_t   otp_en_es_fw_read, otp_en_es_fw_over;
 
@@ -77,9 +83,9 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
     super.initialize(csr_base_addr);
 
     // create agent config objs
-    m_rng_agent_cfg   = push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::RNG_BUS_WIDTH))::
+    m_rng_agent_cfg   = push_pull_agent_cfg#(.HostDataWidth(RNG_BUS_WIDTH))::
                         type_id::create("m_rng_agent_cfg");
-    m_csrng_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH))::
+    m_csrng_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))::
                         type_id::create("m_csrng_agent_cfg");
 
     // set num_interrupts & num_alerts

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -11,7 +11,11 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   `uvm_object_utils(entropy_src_base_vseq)
 
   rand bit [3:0]   rng_val;
-  rand uint        num_reqs;
+
+  // The actual number of seeds that should be expected out
+  // of the current sequence (given predicted health check failures)
+  uint        seed_cnt_actual;
+
   push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)          m_rng_push_seq;
   push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)   m_csrng_pull_seq;
 
@@ -36,7 +40,8 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     cfg.otp_en_es_fw_read_vif.drive(.val(cfg.otp_en_es_fw_read));
     cfg.otp_en_es_fw_over_vif.drive(.val(cfg.otp_en_es_fw_over));
 
-    // Register write enable 
+    // Register write enable
+    // TODO Do we need to check main_sm_idle before writing DUT registers?
     csr_wr(.ptr(ral.regwen), .value(cfg.regwen));
 
     // Controls
@@ -52,6 +57,92 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     ral.conf.rng_bit_sel.set(cfg.rng_bit_sel);
     csr_update(.csr(ral.conf));
 
+  endtask
+
+  virtual function queue_of_rng_val_t generate_rng_data(int quad_cnt);
+    queue_of_rng_val_t result;
+
+    `uvm_fatal(`gtn, "Need to override this when you extend from this class!")
+
+    return result;
+  endfunction
+
+  // return zero if this next set of rng values would cause a health check failure,
+  // based on the currently configured thresholds.
+  virtual function bit health_check_rng_data(queue_of_rng_val_t sample);
+    // TODO: Implement this
+    return 0;
+  endfunction
+
+  // Load enough data into the rng_push_seq to create the next seed.
+  //
+  // This function needs to take into account the current configuation
+  // (is SHA3 always bypassed? Is boot bypass disabled?) as well as
+  // the fact that some data may be discarded due to health check failures.
+
+  // In the case of anticipated health check failures, the failing
+  // data is loaded anyway, but more data is created to extend the sequence.
+  //
+  // Returns 1 on failure, 0 otherwise.
+  virtual function bit load_rng_push_seq_single_seed(int seed_idx);
+
+    int window_size;
+    entropy_phase_e phase;
+    int retry_limit, retry_cnt;
+    bit status;
+    queue_of_rng_val_t window_sample;
+
+    phase = convert_seed_idx_to_phase(seed_idx,
+                                      cfg.boot_bypass_disable == prim_mubi_pkg::MuBi4True);
+    window_size = rng_window_size(seed_idx,
+                                  cfg.type_bypass == prim_mubi_pkg::MuBi4True,
+                                  cfg.boot_bypass_disable == prim_mubi_pkg::MuBi4True,
+                                  cfg.fips_window_size);
+
+    retry_limit = (phase == BOOT) ? cfg.boot_mode_retry_limit :
+                  (phase == STARTUP) ? 2 :
+                  0; // CONTINUOUS PHASE: No retries necessary.
+                     // Occasional failing data is passed on.
+    retry_cnt   = 0;
+
+    do begin
+      // TODO: properly handle rng bit-select config
+      window_sample = generate_rng_data(window_size / 4);
+      status = health_check_rng_data(window_sample);
+      retry_cnt++;
+      if(retry_limit && retry_cnt >= retry_limit) break;
+    end while(status);
+
+    if(status) begin
+      return status;
+    end
+
+    do begin
+      m_rng_push_seq.num_trans++;
+      cfg.m_rng_agent_cfg.add_h_user_data(window_sample.pop_front());
+    end while(window_sample.size() > 0);
+
+    return status;
+
+  endfunction : load_rng_push_seq_single_seed
+
+  virtual function int load_rng_push_seq();
+    int seed_cnt = 0;
+
+    m_rng_push_seq.num_trans = 0;
+    for (int i = 0; i < cfg.seed_cnt; i++) begin
+      seed_cnt += (load_rng_push_seq_single_seed(i) == 0);
+    end
+
+    return seed_cnt;
+  endfunction
+
+  virtual task init_rng_push_seq();
+    // Create and start rng host sequence
+    m_rng_push_seq = push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
+        create("m_rng_push_seq");
+    seed_cnt_actual = load_rng_push_seq();
+    m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
   endtask
 
 endclass : entropy_src_base_vseq

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -8,18 +8,21 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   `uvm_object_new
 
+  // TODO: This variable currently overlaps with cfg.seed_cnt
+  rand int num_seeds_requested;
+
   task body();
     // Create rng host sequence
     m_rng_push_seq = push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
          create("m_rng_push_seq");
-    // TODO: num_reqs > 4 (fifo_full). Will drop without reqs, need to predict.
-    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_reqs, num_reqs inside {[1:4]};)
+    // TODO: num_seeds_requested > 4 (fifo_full). Will drop without reqs, need to predict.
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_seeds_requested, num_seeds_requested inside {[1:4]};)
     if (cfg.rng_bit_enable == prim_mubi_pkg::MuBi4True) begin
-      m_rng_push_seq.num_trans = (4 * num_reqs *
+      m_rng_push_seq.num_trans = (4 * num_seeds_requested *
            (entropy_src_pkg::CSRNG_BUS_WIDTH/entropy_src_pkg::RNG_BUS_WIDTH + 1));
     end
     else begin
-      m_rng_push_seq.num_trans =  num_reqs *
+      m_rng_push_seq.num_trans =  num_seeds_requested *
            entropy_src_pkg::CSRNG_BUS_WIDTH/entropy_src_pkg::RNG_BUS_WIDTH;
     end
     for (int i = 0; i < m_rng_push_seq.num_trans; i++) begin
@@ -30,10 +33,10 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     // Create csrng host sequence
     m_csrng_pull_seq = push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::type_id::
          create("m_csrng_pull_seq");
-    m_csrng_pull_seq.num_trans = num_reqs;
+    m_csrng_pull_seq.num_trans = num_seeds_requested;
     // TODO: Enhance seq to work for hardware or software entropy consumer
 
-    // Start sequences 
+    // Start sequences
     fork
       m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
       m_csrng_pull_seq.start(p_sequencer.csrng_sequencer_h);

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
@@ -7,16 +7,22 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
 
   `uvm_object_new
 
-  task body();
-    // Create and start rng host sequence
-    m_rng_push_seq = push_pull_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
-         create("m_rng_push_seq");
-    m_rng_push_seq.num_trans = entropy_src_pkg::CSRNG_BUS_WIDTH/entropy_src_pkg::RNG_BUS_WIDTH;
-    for (int i = 0; i < m_rng_push_seq.num_trans; i++) begin
-      rng_val = i % 16;
-      cfg.m_rng_agent_cfg.add_h_user_data(rng_val);
+  int rng_count = 0;
+
+  virtual function queue_of_rng_val_t generate_rng_data(int quad_cnt);
+    queue_of_rng_val_t result;
+
+    for (int i = 0; i < quad_cnt; i++) begin
+      result.push_back(4'(rng_count));
+      rng_count++;
     end
-    m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
+
+    return result;
+  endfunction
+
+  task body();
+
+    init_rng_push_seq;
 
     // Wait for entropy_valid interrupt
     csr_spinwait(.ptr(ral.intr_state.es_entropy_valid), .exp_data(1'b1));

--- a/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_base_test.sv
@@ -27,6 +27,8 @@ class entropy_src_base_test extends cip_base_test #(
   // Overrides should happen in the specific testcase.
 
   virtual function void configure_env();
+    // TODO: randomize seed_cnt
+    cfg.seed_cnt               = 1;
     cfg.otp_en_es_fw_read_pct  = 100;
     cfg.otp_en_es_fw_over_pct  = 100;
     cfg.regwen_pct             = 100;

--- a/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
@@ -12,6 +12,9 @@ class entropy_src_smoke_test extends entropy_src_base_test;
 
     // TODO: Enable scoreboard
     cfg.en_scb                      = 0;
+    cfg.fips_window_size            = 2048;
+    cfg.bypass_window_size          = 384;
+    cfg.boot_mode_retry_limit       = 10;
     cfg.route_software_pct          = 100;
     cfg.entropy_data_reg_enable_pct = 100;
 


### PR DESCRIPTION
Now supports conditioning bypass, boot phase, startup phase & continuous phase.

- This commit adds functionality to the entropy_source environment to predicte the
current phase of entropy_src operation: BOOT, STARTUP or CONTINUOUS. Tracking
this phase is essential both for scoreboarding and for planning sequences.

- RNG Sequence generation is redesigned to assign certain AST-RNG outputs to
particular entropy_src output seeds.  Each seed is tracked by a particular "seed
index", which can be used to predict what phase the entropy source will be in
when it receives that seed.  Knowing the phase is important, as it also indicates
how much RNG data must be provided to generate the this seed..

- The progression from one phase to another can be halted by health test failures.
Therefore this commit introduces a stub of a function to predict whether a particular
RNG sub-sequence will fail a health-check.  This function is currently unimplemented.
For the purposes of sequence generation, it is not important to know which health test
will fail, only that _some_ health test will fail.  Thus it is envisioned that
the stub that is currently in entropy_src_base_vseq.sv will eventually be constructed
from smaller functions, one for each type of health check.
  - Note: these fine-grain health check functions will be needed for both
    scoreboarding and sequence generation purposes.

- Includes various configuration registers which will be useful for controlling
the size of the health-check windows, via CSRs.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>