### PR TITLE
[pwrmgr/dv] Fix intg_err

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -27,6 +27,7 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
     list_of_alerts = pwrmgr_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
     num_interrupts = ral.intr_state.get_n_used_bits();
+    tl_intg_alert_fields[ral.fault_status.reg_intg_err] = 1;
   endfunction
 
 endclass


### PR DESCRIPTION
Need to provide the csr that is affected by intg_error in the env cfg

Refer to [docs](https://github.com/lowRISC/opentitan/blob/master/hw/dv/sv/cip_lib/doc/index.md) 
and search `tl_intg_alert_fields` for details

Signed-off-by: Weicai Yang <weicai@google.com>