### PR TITLE
[sw, tests] Introduce MAIN SRAM chip level scrambling test

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -139,4 +139,16 @@
  */
 #define OT_RETURN_ADDR() __builtin_return_address(0)
 
+/**
+ * Hints to the compiler that some point is not reachable.
+ *
+ * One use case could be a function that never returns.
+ *
+ * Please not that if the control flow reaches the point of the
+ * __builtin_unreachable, the program is undefined.
+ *
+ * See https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html.
+ */
+#define OT_UNREACHABLE() __builtin_unreachable()
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_MACROS_H_

--- a/sw/device/lib/testing/rstmgr_testutils.c
+++ b/sw/device/lib/testing/rstmgr_testutils.c
@@ -18,6 +18,13 @@ bool rstmgr_testutils_is_reset_info(const dif_rstmgr_t *rstmgr,
   return actual_info == info;
 }
 
+bool rstmgr_testutils_reset_info_any(const dif_rstmgr_t *rstmgr,
+                                     dif_rstmgr_reset_info_bitfield_t info) {
+  dif_rstmgr_reset_info_bitfield_t actual_info;
+  CHECK_DIF_OK(dif_rstmgr_reset_info_get(rstmgr, &actual_info));
+  return (actual_info & info) != 0;
+}
+
 void rstmgr_testutils_compare_alert_info(
     const dif_rstmgr_t *rstmgr,
     dif_rstmgr_alert_info_dump_segment_t *expected_alert_dump,

--- a/sw/device/lib/testing/rstmgr_testutils.h
+++ b/sw/device/lib/testing/rstmgr_testutils.h
@@ -21,6 +21,17 @@ bool rstmgr_testutils_is_reset_info(const dif_rstmgr_t *rstmgr,
                                     dif_rstmgr_reset_info_bitfield_t info);
 
 /**
+ * Determines if the reset info contains any of the reasons in `info`.
+ *
+ * @param rstmgr A reset manager handle.
+ * @param info A bit mask of reset reasons.
+ *
+ * @return True if the reset info contains any of the reasons in `info`.
+ */
+bool rstmgr_testutils_reset_info_any(const dif_rstmgr_t *rstmgr,
+                                     dif_rstmgr_reset_info_bitfield_t info);
+
+/**
  * Compares the given alert dump against the device's.
  *
  * If the dump array is null or its size is zero this check succeeds. It is

--- a/sw/device/lib/testing/sram_ctrl_testutils.c
+++ b/sw/device/lib/testing/sram_ctrl_testutils.c
@@ -11,9 +11,9 @@
 #include "sw/device/lib/testing/check.h"
 
 void sram_ctrl_testutils_write(uintptr_t address,
-                               const sram_ctrl_data_t *data) {
+                               const sram_ctrl_testutils_data_t *data) {
   mmio_region_t region = mmio_region_from_addr(address);
-  for (size_t index = 0; index < SRAM_CTRL_DATA_NUM_WORDS; ++index) {
+  for (size_t index = 0; index < SRAM_CTRL_TESTUTILS_DATA_NUM_WORDS; ++index) {
     mmio_region_write32(region, index, data->words[index]);
   }
 }
@@ -25,9 +25,10 @@ void sram_ctrl_testutils_write(uintptr_t address,
  * Caller can request to check for equality or inequality through `eq`.
  */
 static bool read_from_ram_check(uintptr_t address,
-                                const sram_ctrl_data_t *expected, bool eq) {
+                                const sram_ctrl_testutils_data_t *expected,
+                                bool eq) {
   mmio_region_t region = mmio_region_from_addr(address);
-  for (size_t index = 0; index < SRAM_CTRL_DATA_NUM_WORDS; ++index) {
+  for (size_t index = 0; index < SRAM_CTRL_TESTUTILS_DATA_NUM_WORDS; ++index) {
     uint32_t read_word = mmio_region_read32(region, index);
     if ((read_word == expected->words[index]) != eq) {
       LOG_INFO("READ_WORD[%x], CONTROL_WORD[%x], INDEX = %d", read_word,
@@ -40,8 +41,8 @@ static bool read_from_ram_check(uintptr_t address,
   return true;
 }
 
-bool sram_ctrl_testutils_read_check_eq(uintptr_t address,
-                                       const sram_ctrl_data_t *expected) {
+bool sram_ctrl_testutils_read_check_eq(
+    uintptr_t address, const sram_ctrl_testutils_data_t *expected) {
   if (!read_from_ram_check(address, expected, true)) {
     LOG_INFO("Equality check failure");
     return false;
@@ -50,8 +51,8 @@ bool sram_ctrl_testutils_read_check_eq(uintptr_t address,
   return true;
 }
 
-bool sram_ctrl_testutils_read_check_neq(uintptr_t address,
-                                        const sram_ctrl_data_t *expected) {
+bool sram_ctrl_testutils_read_check_neq(
+    uintptr_t address, const sram_ctrl_testutils_data_t *expected) {
   if (!read_from_ram_check(address, expected, false)) {
     LOG_INFO("Inequality check failure");
     return false;

--- a/sw/device/lib/testing/sram_ctrl_testutils.h
+++ b/sw/device/lib/testing/sram_ctrl_testutils.h
@@ -11,34 +11,40 @@
 #include "sw/device/lib/dif/dif_sram_ctrl.h"
 
 /**
+ * Test buffer size in words and bytes.
+ */
+#define SRAM_CTRL_TESTUTILS_DATA_NUM_WORDS 4
+#define SRAM_CTRL_TESTUTILS_DATA_NUM_BYTES \
+  (SRAM_CTRL_TESTUTILS_DATA_NUM_WORDS * sizeof(uint32_t))
+
+/**
  * A typed representation of the test data.
  */
-#define SRAM_CTRL_DATA_NUM_WORDS 4
-#define SRAM_CTRL_DATA_NUM_BYTES 128
-typedef struct sram_ctrl_data {
-  uint32_t words[SRAM_CTRL_DATA_NUM_WORDS];
-} sram_ctrl_data_t;
+typedef struct sram_ctrl_testutils_data {
+  uint32_t words[SRAM_CTRL_TESTUTILS_DATA_NUM_WORDS];
+} sram_ctrl_testutils_data_t;
 
 /**
  * Writes `data` at the `address` in RAM.
  */
-void sram_ctrl_testutils_write(uintptr_t address, const sram_ctrl_data_t *data);
+void sram_ctrl_testutils_write(uintptr_t address,
+                               const sram_ctrl_testutils_data_t *data);
 
 /**
  * Reads data from `address` in SRAM and compares against `expected`.
  *
  * The data is checked for equality.
  */
-bool sram_ctrl_testutils_read_check_eq(uintptr_t address,
-                                       const sram_ctrl_data_t *expected);
+bool sram_ctrl_testutils_read_check_eq(
+    uintptr_t address, const sram_ctrl_testutils_data_t *expected);
 
 /**
  * Reads data from `address` in SRAM and compares against `expected`.
  *
  * The data is checked for inequality.
  */
-bool sram_ctrl_testutils_read_check_neq(uintptr_t address,
-                                        const sram_ctrl_data_t *expected);
+bool sram_ctrl_testutils_read_check_neq(
+    uintptr_t address, const sram_ctrl_testutils_data_t *expected);
 
 /**
  * Triggers the SRAM scrambling operation.

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -636,6 +636,31 @@ sw_tests += {
   }
 }
 
+# SRAM Controller main scrambled access test.
+sram_ctrl_main_scrambled_access_test_lib = declare_dependency(
+  link_with: static_library(
+    'sram_ctrl_main_scrambled_access_test_lib',
+    sources: [
+      hw_ip_rstmgr_reg_h,
+      hw_ip_sram_ctrl_reg_h,
+      'sram_ctrl_main_scrambled_access_test.c',
+    ],
+    dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_dif_sram_ctrl,
+      sw_lib_runtime_log,
+      sw_lib_testing_rstmgr_testutils,
+      sw_lib_testing_sram_ctrl_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'sram_ctrl_main_scrambled_access_test': {
+    'library': sram_ctrl_main_scrambled_access_test_lib,
+  }
+}
+
 # SRAM Controller execution from Main SRAM test.
 sram_ctrl_execution_test_main_lib = declare_dependency(
   link_with: static_library(

--- a/sw/device/tests/sram_ctrl_execution_test_ret.c
+++ b/sw/device/tests/sram_ctrl_execution_test_ret.c
@@ -93,7 +93,7 @@ typedef void (*sram_ctrl_instruction_fault_function_t)(void);
  * https://github.com/riscv-non-isa/riscv-asm-manual/blob/master/riscv-asm.md
  */
 static void sram_execution_test(void) {
-  memset((void *)kRetRamStartAddr, 0, SRAM_CTRL_DATA_NUM_BYTES);
+  memset((void *)kRetRamStartAddr, 0, SRAM_CTRL_TESTUTILS_DATA_NUM_BYTES);
 
   // Map the function pointer onto the instruction buffer.
   sram_ctrl_instruction_fault_function_t instruction_access_fault_func =

--- a/sw/device/tests/sram_ctrl_main_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_main_scrambled_access_test.c
@@ -1,0 +1,184 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/multibits.h"
+#include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/sram_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/test_main.h"
+#include "sw/device/lib/testing/test_framework/test_status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rstmgr_regs.h"     // Generated.
+#include "sram_ctrl_regs.h"  // Generated.
+
+const test_config_t kTestConfig;
+
+static dif_sram_ctrl_t sram_ctrl;
+
+/**
+ * MAIN SRAM scrambling test buffer.
+ *
+ * This buffer is initialized with a known pattern, which will be overwritten
+ * with a pseudo-random data as the result of MAIN SRAM scrambling.
+ */
+static volatile uint32_t
+    sram_ctrl_main_scramble_buffer[SRAM_CTRL_TESTUTILS_DATA_NUM_WORDS];
+
+/**
+ * Test pattern to be written and read from SRAM.
+ */
+static const sram_ctrl_testutils_data_t kRamTestPattern1 = {
+    .words =
+        {
+            0xA5A5A5A5,
+            0xA5A5A5A5,
+            0xA5A5A5A5,
+            0xA5A5A5A5,
+        },
+};
+
+/**
+ * Test pattern to be written and read from SRAM.
+ */
+static const sram_ctrl_testutils_data_t kRamTestPattern2 = {
+    .words =
+        {
+            0x5A5A5A5A,
+            0x5A5A5A5A,
+            0x5A5A5A5A,
+            0x5A5A5A5A,
+        },
+};
+
+/**
+ * Performs scrambling, saves the test relevant data and resets the system.
+ *
+ * This code is written in assembly because MAIN SRAM addresses will be
+ * scrambled, which has a similar effect to overwriting with pseudo-random
+ * data. This will thrash the SRAM (including .bss, .data segments and the
+ * stack), effectively rendering the C runtime environment invalid.
+ *
+ * This function saves contents of the `sram_ctrl_main_scramble_buffer` in the
+ * RETENTION SRAM, which is kept intact across the system reboot.
+ */
+static noreturn void main_sram_scramble(void) {
+  asm volatile(
+      // Request the new scrambling key for MAIN SRAM.
+      "li t0, 0x1                                                   \n"
+      "sw t0, %[kSramCtrlOffset](%[kSramCtrlRegsBase])              \n"
+
+      // Busy loop - waiting for scrambling to finish.
+      ".L_scrambling_busy_loop:                                     \n"
+      "  lw t0, %[kSramCtrlStatusOffset](%[kSramCtrlRegsBase])      \n"
+      "  andi t0, t0, %[kSramCtrlKeyScrDone]                        \n"
+      "  beqz t0, .L_scrambling_busy_loop                           \n"
+
+      // Copy the buffer contents to the retention SRAM.
+      ".L_buffer_copy_loop:                                         \n"
+      "  lw t0, 0(%[kCopyFromAddr])                                 \n"
+      "  sw t0, 0(%[kCopyToAddr])                                   \n"
+      "  addi %[kCopyFromAddr], %[kCopyFromAddr], 4                 \n"
+      "  addi %[kCopyToAddr], %[kCopyToAddr], 4                     \n"
+      "  blt %[kCopyToAddr], %[kCopyToEndAddr], .L_buffer_copy_loop \n"
+
+      // Trigger the software system reset via the Reset Manager.
+      "li t0, %[kMultiBitTrue]                                      \n"
+      "sw t0, %[kRstMgrResetReq](%[kRstMgrRegsBase])                \n"
+
+      // Satisfy the `noreturn` promise to the compiler.
+      ".L_infinite_loop:                                            \n"
+      "  wfi                                                        \n"
+      "  j .L_infinite_loop"
+      :
+      : [kMultiBitTrue] "I"(kMultiBitBool4True),
+
+        [kSramCtrlRegsBase] "r"(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
+        [kSramCtrlOffset] "I"(SRAM_CTRL_CTRL_REG_OFFSET),
+        [kSramCtrlStatusOffset] "I"(SRAM_CTRL_STATUS_REG_OFFSET),
+        // TODO(lowRISC/opentitan#8546): reading from scrambled but not
+        // initialized SRAM may trigger ECC errors.
+        [kSramCtrlKeyScrDone] "I"(0x1 << SRAM_CTRL_STATUS_SCR_KEY_VALID_BIT),
+
+        [kRstMgrRegsBase] "r"(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR),
+        [kRstMgrResetReq] "I"(RSTMGR_RESET_REQ_REG_OFFSET),
+
+        [kCopyFromAddr] "r"(sram_ctrl_main_scramble_buffer),
+        [kCopyToAddr] "r"(TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR),
+        [kCopyToEndAddr] "r"(TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR +
+                             SRAM_CTRL_TESTUTILS_DATA_NUM_WORDS)
+
+      : "t0");
+
+  OT_UNREACHABLE();
+}
+
+/**
+ * Checks whether the system reset was requested by the software.
+ */
+static bool reentry_after_system_reset(void) {
+  dif_rstmgr_t rstmgr;
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  return rstmgr_testutils_reset_info_any(&rstmgr, kDifRstmgrResetInfoSw);
+}
+
+/**
+ * Prepares the MAIN SRAM and the RETENTION SRAM buffers.
+ *
+ * Makes sure that both buffers can be read and written to, and are initialized
+ * to the opposite patterns.
+ */
+static void prepare_for_scrambling(void) {
+  // Make sure we can write and read to the retention SRAM.
+  sram_ctrl_testutils_write(TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
+                            &kRamTestPattern2);
+  sram_ctrl_testutils_write(TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR,
+                            &kRamTestPattern1);
+  CHECK(sram_ctrl_testutils_read_check_eq(
+      TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR, &kRamTestPattern1));
+
+  // Make sure we can write and read the buffer in MAIN SRAM.
+  sram_ctrl_testutils_write((uintptr_t)&sram_ctrl_main_scramble_buffer,
+                            &kRamTestPattern1);
+  sram_ctrl_testutils_write((uintptr_t)&sram_ctrl_main_scramble_buffer,
+                            &kRamTestPattern2);
+  CHECK(sram_ctrl_testutils_read_check_eq(
+      (uintptr_t)&sram_ctrl_main_scramble_buffer, &kRamTestPattern2));
+}
+
+/**
+ * Executes the MAIN SRAM scrambling test.
+ *
+ * This test is re-entrant. On the first pass the test triggers MAIN SRAM
+ * scrambling, saves the relevant test data in RETENTION SRAM, and triggers the
+ * system reset. On the second pass, it compares the saved test data against
+ * the expected pattern.
+ */
+bool test_main(void) {
+  CHECK_DIF_OK(dif_sram_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
+      &sram_ctrl));
+
+  if (reentry_after_system_reset()) {
+    CHECK(sram_ctrl_testutils_read_check_neq(
+        TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR, &kRamTestPattern1));
+    CHECK(sram_ctrl_testutils_read_check_neq(
+        TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR, &kRamTestPattern2));
+  } else {
+    prepare_for_scrambling();
+    main_sram_scramble();
+  }
+
+  return true;
+}

--- a/sw/device/tests/sram_ctrl_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_scrambled_access_test.c
@@ -27,7 +27,7 @@ static const uintptr_t kRetSramStartAddr =
 /**
  * First test pattern to be written and read from SRAM.
  */
-static const sram_ctrl_data_t kRamTestPattern1 = {
+static const sram_ctrl_testutils_data_t kRamTestPattern1 = {
     .words =
         {
             0xA5A5A5A5,
@@ -40,7 +40,7 @@ static const sram_ctrl_data_t kRamTestPattern1 = {
 /**
  * Second test pattern to be written and read from SRAM.
  */
-static const sram_ctrl_data_t kRamTestPattern2 = {
+static const sram_ctrl_testutils_data_t kRamTestPattern2 = {
     .words =
         {
             0x5A5A5A5A,


### PR DESCRIPTION
This change also consists of some naming clean-up, addition of a helper function to the rstmgr testutils and the main sram scrambling itself.