### PR TITLE
[dv/otp_ctrl] added post_pwr_otp_init to callback and base vseq

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -58,6 +58,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     if (do_otp_ctrl_init && do_apply_reset) otp_ctrl_init();
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
     if (do_otp_pwr_init && do_apply_reset) otp_pwr_init();
+    callback_vseq.post_otp_pwr_init();
   endtask
 
   // Cfg errors are cleared after reset

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_callback_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_callback_vseq.sv
@@ -16,4 +16,7 @@ class otp_ctrl_callback_vseq extends cip_base_vseq #(
     // Do nothing but can be overridden in closed source environment.
   endtask
 
+  virtual task post_otp_pwr_init();
+    // Do nothing but can be overridden in closed source environment.
+  endtask : post_otp_pwr_init
 endclass : otp_ctrl_callback_vseq


### PR DESCRIPTION
Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

A replacement for PR #9104 

Basically, adding a function call for the callback sequence at the end of `dut_init` will prevent a non-blocking implementation in the callback sequence for anything that needs to be configured after the INIT command has finished.