### PR TITLE
[spi_agent/spi_device] Host driver capability of driving less than a byte

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -15,6 +15,8 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   bit device_bit_dir;     // 1 - lsb -> msb, 0 - msb -> lsb
   bit sck_on;             // keep sck on
   bit [1:0] csb_sel;      // Select active CSB
+  bit partial_byte;       // Transfering less than byte
+  bit [2:0] bits_to_transfer; // Bits to transfer if using less than byte
 
   // spi mode knob
   spi_mode_e spi_mode;
@@ -47,6 +49,8 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (host_bit_dir,   UVM_DEFAULT)
     `uvm_field_int (device_bit_dir, UVM_DEFAULT)
     `uvm_field_int (csb_sel,        UVM_DEFAULT)
+    `uvm_field_int (partial_byte,   UVM_DEFAULT)
+    `uvm_field_int (bits_to_transfer,             UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_sck,         UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_sck,     UVM_DEFAULT)
     `uvm_field_int (extra_dly_chance_pc_btw_sck,  UVM_DEFAULT)

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -98,6 +98,7 @@ class spi_host_driver extends spi_driver;
         cfg.vif.sio[0] <= host_byte[which_bit];
         // wait for sampling edge to sample sio (half cycle)
         cfg.wait_sck_edge(SamplingEdge);
+        if (cfg.partial_byte == 1 && j >= cfg.bits_to_transfer) break;
         which_bit = cfg.device_bit_dir ? j : 7 - j;
         device_byte[which_bit] = cfg.vif.sio[1];
         // wait for driving edge to complete 1 cycle

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -130,6 +130,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     cfg.m_spi_agent_cfg.host_bit_dir = host_bit_dir;
     cfg.m_spi_agent_cfg.device_bit_dir = device_bit_dir;
     cfg.m_spi_agent_cfg.csb_sel = 0;
+    cfg.m_spi_agent_cfg.partial_byte = 0;
     // update device rtl
     ral.control.mode.set(spi_mode);
     csr_update(.csr(ral.control));


### PR DESCRIPTION
Added configurable partial_byte and number_of_bits to the spi_agent configuration. If enabled, host_driver will break from sending normal byte after issuing certain number of bits. In spi_device, spi_init sets this config to 0 and default mode is normal byte flow. This will be used for bit access test.

Signed-off-by: kosta-kojdic <kosta.kojdic@ensilica.com>