### PR TITLE
[sw/silicon_creator] Limit boot_data_functest to CW310 for CI

### DIFF
--- a/test/systemtest/earlgrey/config.py
+++ b/test/systemtest/earlgrey/config.py
@@ -174,5 +174,7 @@ TEST_APPS_SELFCHECKING = [
     {
         "name": "sw_silicon_creator_lib_boot_data_functest",
         "test_dir": "sw/device/silicon_creator/testing",
+        # This test takes a long time to run in simulation.
+        "targets": ["fpga_cw310"],
     },
 ]


### PR DESCRIPTION
This test can be run in verilator but takes a long time to complete and timed out in #9443. This PR restricts to CW310 for faster results.

Signed-off-by: Alphan Ulusoy <alphan@google.com>