### PR TITLE
[reggen] generate defines of type unsigned ints

### DIFF
--- a/util/reggen/gen_cheader.py
+++ b/util/reggen/gen_cheader.py
@@ -205,7 +205,7 @@ def gen_cdefines_module_param(outstr: TextIO,
                               existing_defines: Set[str]) -> None:
     # Presently there is only one type (int), however if the new types are
     # added, they potentially need to be handled differently.
-    known_types = ["int"]
+    known_types = ["int", "int unsigned"]
     if param.param_type not in known_types:
         warnings.warn("Cannot generate a module define of type {}"
                       .format(param.param_type))
@@ -217,7 +217,7 @@ def gen_cdefines_module_param(outstr: TextIO,
     # otherwise, assume StudlyCaps and covert it to snake_case.
     param_name = param.name if '_' in param.name else to_snake_case(param.name)
     define_name = as_define(module_name + '_PARAM_' + param_name)
-    if param.param_type == "int":
+    if param.param_type == "int" or param.param_type == "int unsigned":
         define = gen_define(define_name, [], param.value,
                             existing_defines)
 


### PR DESCRIPTION
Wrote a few lines so gen_cheader.py could generate defines for fields
with unsigned values.

Prevents warnings like the following:
```/usr/local/google/home/drewmacrae/opentitan/util/reggen/gen_cheader.py:210:
UserWarning: Cannot generate a module define of type int unsigned```

Signed-off-by: Drew Macrae <drewmacrae@google.com>