### PR TITLE
[rom_ctrl] Check TL command integrity in ROM adapter

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -151,6 +151,7 @@ module rom_ctrl
     .Outstanding(2),
     .ByteAccess(0),
     .ErrOnWrite(1),
+    .CmdIntgCheck(1),
     .EnableRspIntgGen(1),
     .EnableDataIntgGen(SecDisableScrambling),
     .EnableDataIntgPt(!SecDisableScrambling)


### PR DESCRIPTION
This fixes the `rom_ctrl_tl_intg_err` test (where we weren't previously
spotting malformed TL commands sent to the ROM).

See https://github.com/lowRISC/opentitan/pull/9406#discussion_r759558623 for discussion.