### PR TITLE
[bazel] add entries for bazel to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,13 @@
 *.c                 @moidx
 *.h                 @moidx
 
+
+# Bazel build rules
+*.bzl               @cfrantz @drewmacrae
+BUILD               @cfrantz @drewmacrae
+/WORKSPACE          @cfrantz @drewmacrae
+/.bazelrc           @cfrantz @drewmacrae
+
 # Utils: reggen, topgen, tlgen
 util/*.py           @asb
 util/*gen/          @msfschaffner @tjaychen


### PR DESCRIPTION
Assign codeownership for
* BUILD
* WORKSPACE
* *.bzl
* .bazelrc
files to drewmacrae and cfrantz to help automate reviewing.

Signed-off-by: Drew Macrae <drewmacrae@google.com>