### PR TITLE
[spi_device] rx timeout test and testplan mapping

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -70,9 +70,34 @@
       tests: ["spi_device_dummy_item_extra_dly"]
     }
     {
-      name: async_fifo_reset
-      desc: '''Reset async fifo when SPI interface is idle
-            TODO: fifo may be fetching data from SRAM? What is the actual usage?'''
+      name: tx_async_fifo_reset
+      desc: '''
+            Reset TX async fifo when SPI interface is idle
+
+            - Fill TX SRAM FIFO with some data, which will be transfered to TX async FIFO
+            - Write 0 into read and write point of TX SRAM FIFO
+            - Program `rst_txfifo` to reset the async FIFO
+            - Check `async_fifo_level.txlvl` is 0
+            - Fill TX SRAM FIFO with some other data and enable SPI transfer
+            - Check SPI device sends and receives the correct data
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: rx_async_fifo_reset
+      desc: '''
+            Reset RX async fifo when SPI interface is idle
+
+            - Configure RX SRAM FIFO with a small size, so that it's easy to fill up
+            - Start SPI transfers to fill up the RX SRAM FIFO and at least part of the RX async
+              FIFO
+            - Program `rst_rxfifo` to reset the async FIFO
+            - Check `async_fifo_level.rxlvl` is 0
+            - Write 0 into read and write point of RX SRAM FIFO
+            - Fill TX SRAM FIFO with some other data and start another SPI transfers
+            - Check SPI device sends and receives the correct data
+            '''
       milestone: V2
       tests: []
     }
@@ -98,7 +123,7 @@
       name: byte_transfer_on_spi
       desc: '''send spi transfer on byte granularity, and make sure the timer never expires'''
       milestone: V2
-      tests: []
+      tests: ["spi_device_byte_transfer"]
     }
     {
       name: rx_timeout
@@ -108,7 +133,7 @@
               model the timer feature
             - Note: Timeout only for RX'''
       milestone: V2
-      tests: []
+      tests: ["spi_device_rx_timeout"]
     }
     {
       name: bit_transfer_on_spi
@@ -126,25 +151,10 @@
       tests: ["spi_device_extreme_fifo_size"]
     }
     {
-      name: mode
-      desc: '''TODO :only support fw mode now'''
-      milestone: V2
-      tests: []
-    }
-    {
-      name: mem_ecc
-      desc: '''
-            Backdoor hack memory data to test basic memory ECC behavior limitation:
-            - Just cover basic functionality and connectivity
-            - Complete verification will be done by PFV'''
-      milestone: V2
-      tests: []
-    }
-    {
       name: perf
       desc: '''Run spi_device_fifi_full_vseq with very small delays'''
       milestone: V2
-      tests: []
+      tests: ["spi_device_perf"]
     }
     {
       name: tpm_read

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_byte_transfer_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_byte_transfer_vseq.sv
@@ -3,51 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Byte Access test to verify proper byte data transfer without timeout expiring
-class spi_device_byte_transfer_vseq extends spi_device_base_vseq;
+class spi_device_byte_transfer_vseq extends spi_device_rx_timeout_vseq;
   `uvm_object_utils(spi_device_byte_transfer_vseq)
   `uvm_object_new
 
-  constraint num_trans_c {
-    num_trans == 20;
+  constraint timeout_place_c {
+    timeout_place == 0;
   }
 
-  virtual task body();
-    bit [31:0] host_data;
-    bit [31:0] device_data;
-    bit [7:0] device_data_exp[$];
-    uint       avail_bytes;
-    uint       avail_data;
-
-    spi_device_init();
-    ral.cfg.timer_v.set(8'hFF);
-    csr_update(.csr(ral.cfg));
-
-    for (int i = 1; i <= num_trans; i++) begin
-      `uvm_info(`gfn, $sformatf("starting sequence %0d/%0d", i, num_trans), UVM_LOW)
-      `DV_CHECK_RANDOMIZE_FATAL(this)
-      repeat ($urandom_range(2, 10)) begin
-        bit [31:0] host_data_exp_q[$];
-        `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)
-        `DV_CHECK_STD_RANDOMIZE_FATAL(device_data)
-        // check if tx sram full and wait for at least a word to become available
-        wait_for_tx_avail_bytes(SRAM_WORD_SIZE, SramSpaceAvail, avail_bytes);
-        write_device_words_to_send({device_data});
-        wait_for_tx_filled_rx_space_bytes(SRAM_WORD_SIZE, avail_bytes);
-        spi_host_xfer_byte(host_data[7:0], device_data_exp[0]);
-        read_rx_avail_bytes(SramDataAvail, avail_data);
-        `DV_CHECK_CASE_EQ(avail_data, 0)
-        spi_host_xfer_byte(host_data[15:8], device_data_exp[1]);
-        spi_host_xfer_byte(host_data[23:16], device_data_exp[2]);
-        spi_host_xfer_byte(host_data[31:24], device_data_exp[3]);
-        // check if rx sram is empty and wait for at least a word to arrive
-        wait_for_rx_avail_bytes(SRAM_WORD_SIZE, SramDataAvail, avail_bytes);
-        read_host_words_rcvd(1, host_data_exp_q);
-        `DV_CHECK_CASE_EQ(host_data, host_data_exp_q[0])
-        `DV_CHECK_CASE_EQ(device_data,
-            {device_data_exp[3], device_data_exp[2], device_data_exp[1], device_data_exp[0]})
-        check_for_tx_rx_idle();
-      end
-    end
-  endtask : body
+  constraint num_trans_c {
+    num_trans == 10;
+  }
 
 endclass : spi_device_byte_transfer_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_timeout_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_rx_timeout_vseq.sv
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Byte Access test to verify proper byte data transfer with timeout expiring
+class spi_device_rx_timeout_vseq extends spi_device_base_vseq;
+  `uvm_object_utils(spi_device_rx_timeout_vseq)
+  `uvm_object_new
+
+  rand bit [7:0] timeout;       // Timeout value to be configured
+  rand bit [2:0] timeout_place; // Dictates bytes after which timeout will take place
+
+  constraint timeout_c {
+    timeout >= 100;
+  }
+
+  constraint num_trans_c {
+    num_trans == 20;
+  }
+
+  virtual task transfer_check_byte(bit [1:0] byte_n, bit [7:0] tout,
+    bit [2:0] tout_place, bit [7:0] host_b, ref bit [7:0] device_d);
+    uint available_data;
+    bit [7:0] transfer_byte;
+    spi_host_xfer_byte(host_b, device_d);
+    if (tout_place == 3'd0 && byte_n < 3) begin
+      read_rx_avail_bytes(SramDataAvail, available_data);
+      `DV_CHECK_CASE_EQ(available_data, 0)
+    end
+    if (tout_place[byte_n] == 1'b1) begin
+      cfg.clk_rst_vif.wait_clks(tout + 10);
+      read_rx_avail_bytes(SramDataAvail, available_data);
+      `DV_CHECK_CASE_EQ(available_data, byte_n + 1)
+    end
+  endtask
+
+  virtual task body();
+    bit [31:0] host_data;
+    bit [31:0] device_data;
+    bit [7:0] device_data_exp[$];
+    bit [7:0] device_byte;
+    uint       avail_bytes;
+    uint       avail_data;
+
+    spi_device_init();
+
+    for (int i = 1; i <= num_trans; i++) begin
+      `uvm_info(`gfn, $sformatf("starting sequence %0d/%0d", i, num_trans), UVM_LOW)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      ral.cfg.timer_v.set(timeout);
+      csr_update(.csr(ral.cfg));
+      repeat ($urandom_range(2, 10)) begin
+        bit [31:0] host_data_exp_q[$];
+        `DV_CHECK_STD_RANDOMIZE_FATAL(host_data)
+        `DV_CHECK_STD_RANDOMIZE_FATAL(device_data)
+        // check if tx sram full and wait for at least a word to become available
+        wait_for_tx_avail_bytes(SRAM_WORD_SIZE, SramSpaceAvail, avail_bytes);
+        write_device_words_to_send({device_data});
+        wait_for_tx_filled_rx_space_bytes(SRAM_WORD_SIZE, avail_bytes);
+        for (int i = 0; i <= 3; i++) begin
+          transfer_check_byte(i, timeout, timeout_place, host_data[i * 8 + 7 -: 8], device_byte);
+          device_data_exp[i] = device_byte;
+        end
+        cfg.clk_rst_vif.wait_clks(10);
+        read_rx_avail_bytes(SramDataAvail, avail_data);
+        `DV_CHECK_CASE_EQ(avail_data, 4)
+        read_host_words_rcvd(1, host_data_exp_q);
+        `DV_CHECK_CASE_EQ(host_data, host_data_exp_q[0])
+        `DV_CHECK_CASE_EQ(device_data,
+            {device_data_exp[3], device_data_exp[2], device_data_exp[1], device_data_exp[0]})
+        check_for_tx_rx_idle();
+      end
+    end
+  endtask : body
+
+endclass : spi_device_rx_timeout_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -12,4 +12,5 @@
 `include "spi_device_dummy_item_extra_dly_vseq.sv"
 `include "spi_device_intr_vseq.sv"
 `include "spi_device_perf_vseq.sv"
+`include "spi_device_rx_timeout_vseq.sv"
 `include "spi_device_byte_transfer_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -29,6 +29,7 @@ filesets:
       - seq_lib/spi_device_intr_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_perf_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_byte_transfer_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_rx_timeout_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -91,6 +91,11 @@
       name: spi_device_byte_transfer
       uvm_test_seq: spi_device_byte_transfer_vseq
     }
+    
+    {
+      name: spi_device_rx_timeout
+      uvm_test_seq: spi_device_rx_timeout_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
Added rx-timeout scenario. Randomized timeout value and randomized byte position after which timeout will occur. Checking number of available bytes to ensure proper bytes were written. Checking full word integrity at the end so see timeout-induced writes did not damage data.
Added implemented test mappings into test plan hjson file.

Signed-off-by: kosta-kojdic <kosta.kojdic@ensilica.com>