### PR TITLE
[aon_timer,dv] Improvements on AON timer smoke test

### DIFF
--- a/hw/ip/aon_timer/dv/env/aon_timer_env.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.sv
@@ -14,7 +14,6 @@ class aon_timer_env extends cip_base_env #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-
     // get the vifs from config db
     if (!uvm_config_db#(virtual clk_rst_if)::
         get(this, "", "aon_clk_rst_vif", cfg.aon_clk_rst_vif)) begin

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_smoke_vseq.sv
@@ -9,7 +9,30 @@ class aon_timer_smoke_vseq extends aon_timer_base_vseq;
   `uvm_object_new
 
   task body();
-    `uvm_error(`gfn, "FIXME")
+    // Register Read from the thresholds
+    bit [31:0] wkup_thold;
+    bit [31:0] bark_thold;
+    bit [31:0] bite_thold;
+
+    aon_timer_init();
+    csr_utils_pkg::csr_rd(.ptr(ral.wkup_thold), .value(wkup_thold));
+    `uvm_info(`gfn,
+              $sformatf("\n\t ---| reading 0x%0h from WKUP_THOLD", wkup_thold),
+              UVM_HIGH)
+
+    csr_utils_pkg::csr_rd(.ptr(ral.wdog_bark_thold), .value(bark_thold));
+    `uvm_info(`gfn,
+              $sformatf("\n\t ---| reading 0x%0h from WDOG_BARK_THOLD", bark_thold),
+              UVM_HIGH)
+
+    csr_utils_pkg::csr_rd(.ptr(ral.wdog_bite_thold), .value(bite_thold));
+    `uvm_info(`gfn,
+              $sformatf("\n\t ---| reading 0x%0h from WDOG_BITE_THOLD", bite_thold),
+              UVM_HIGH)
+
+    `uvm_info(`gfn, "\n\t ----| Waiting for AON Timer to finish (interrupt)", UVM_LOW)
+    wait_for_interrupt();
+    aon_timer_shutdown();
   endtask : body
 
 endclass : aon_timer_smoke_vseq

--- a/hw/ip/aon_timer/dv/tb.sv
+++ b/hw/ip/aon_timer/dv/tb.sv
@@ -58,6 +58,7 @@ module tb;
     .lc_escalate_en_i          (lc_escalate_en),
     .intr_wkup_timer_expired_o (wkup_expired),
     .intr_wdog_timer_bark_o    (wdog_bark),
+    .nmi_wdog_timer_bark_o     (/*TODO*/),
     .wkup_req_o                (wkup_req),
     .aon_timer_rst_req_o       (rst_req),
     .sleep_mode_i              (sleep)


### PR DESCRIPTION
This commit includes some DV enhancements of AON timer module.
Which includes:
- A proper initialization and shutdown tasks.
- A core interface to see the timer counts.
- A wait for interrupt so that we would only exit when any
meaningful thing happens.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>