### PR TITLE
[otbn, dv] Connecting keymgr_key interface with ISS model

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -355,6 +355,24 @@ void ISSWrapper::edn_urnd_step(uint32_t edn_urnd_data) {
   run_command(oss.str(), nullptr);
 }
 
+void ISSWrapper::set_keymgr_value(const std::array<uint32_t, 12> &key0_arr,
+                                  const std::array<uint32_t, 12> &key1_arr,
+                                  bool valid) {
+  std::ostringstream oss;
+
+  oss << "set_keymgr_value 0x" << std::hex << std::setfill('0');
+  for (int i = 0; i < 12; ++i) {
+    oss << std::setw(8) << key0_arr[11 - i];
+  }
+  oss << " 0x";
+  for (int i = 0; i < 12; ++i) {
+    oss << std::setw(8) << key1_arr[11 - i];
+  }
+  oss << " " << valid << "\n";
+
+  run_command(oss.str(), nullptr);
+}
+
 int ISSWrapper::step(bool gen_trace) {
   std::vector<std::string> lines;
   bool error = false;

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -75,6 +75,10 @@ struct ISSWrapper {
   // also RTL signals CDC is done.
   void edn_urnd_step(uint32_t edn_urnd_data);
 
+  // Provide keymgr values to model
+  void set_keymgr_value(const std::array<uint32_t, 12> &key0_arr,
+                        const std::array<uint32_t, 12> &key1_arr, bool valid);
+
   // Signals 256b EDN random number for RND is valid in the RTL.
   void edn_rnd_cdc_done();
 

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -15,6 +15,7 @@ module otbn_core_model
   import otbn_pkg::*;
   import otbn_model_pkg::*;
   import edn_pkg::*;
+  import keymgr_pkg::otbn_key_req_t;
 #(
   // Size of the instruction memory, in bytes
   parameter int ImemSizeByte = 4096,
@@ -50,6 +51,8 @@ module otbn_core_model
   output bit [31:0]      insn_cnt_o, // INSN_CNT register
 
   input logic            invalidate_imem_i, // Trash contents of IMEM (causing integrity errors)
+
+  input keymgr_pkg::otbn_key_req_t keymgr_key_i,
 
   output bit             done_rr_o,
 
@@ -196,6 +199,19 @@ module otbn_core_model
     end
   end
 
+  always_ff @(posedge clk_i or posedge rst_ni)
+  begin
+    if (rst_ni) begin
+      if (!$stable(keymgr_key_i) || $rose(rst_ni)) begin
+        otbn_model_set_keymgr_value(model_handle, keymgr_key_i.key[0], keymgr_key_i.key[1],
+                                    keymgr_key_i.valid);
+      end
+    end
+  end
+  // Assertion to ensure that keymgr key valid is never unknown.
+  `ASSERT_KNOWN(KeyValidIsKnownChk_A, keymgr_key_i.valid)
+  // Assertion to ensure that keymgr key values are never unknown if valid is high.
+  `ASSERT_KNOWN_IF(KeyIsKnownChk_A, keymgr_key_i.valid, {keymgr_key_i.key[0], keymgr_key_i.key[1]})
   assign unused_raw_err_bits = ^raw_err_bits_q[31:$bits(err_bits_t)];
   assign unused_edn_rsp_fips = edn_rnd_i.edn_fips & edn_urnd_i.edn_fips;
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -306,6 +306,22 @@ void OtbnModel::edn_urnd_step(svLogicVecVal *edn_urnd_data /* logic [31:0] */) {
   iss->edn_urnd_step(edn_urnd_data->aval);
 }
 
+void OtbnModel::set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
+                                 svLogicVecVal *key1 /* logic [383:0] */,
+                                 unsigned char valid) {
+  ISSWrapper *iss = ensure_wrapper();
+
+  std::array<uint32_t, 12> key0_arr;
+  std::array<uint32_t, 12> key1_arr;
+  assert(valid == 0 || valid == 1);
+  for (int i = 0; i < 12; i++) {
+    key0_arr[i] = key0[i].aval;
+    key1_arr[i] = key1[i].aval;
+  }
+
+  iss->set_keymgr_value(key0_arr, key1_arr, valid != 0);
+}
+
 void OtbnModel::edn_urnd_cdc_done() {
   ISSWrapper *iss = ensure_wrapper();
   iss->edn_urnd_cdc_done();
@@ -760,4 +776,10 @@ void otbn_model_reset(OtbnModel *model) {
 void otbn_take_loop_warps(OtbnModel *model, OtbnMemUtil *memutil) {
   assert(model && memutil);
   model->take_loop_warps(*memutil);
+}
+
+void otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
+                                 svLogicVecVal *key1, unsigned char valid) {
+  assert(model && key0 && key1);
+  model->set_keymgr_value(key0, key1, valid);
 }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -39,6 +39,10 @@ class OtbnModel {
   // EDN Step sends ISS the RND data when ACK signal is high.
   void edn_rnd_step(svLogicVecVal *edn_rnd_data /* logic [31:0] */);
 
+  void set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
+                        svLogicVecVal *key1 /* logic [383:0] */,
+                        unsigned char valid);
+
   // EDN Step sends ISS the URND related EDN data when ACK signal is high.
   void edn_urnd_step(svLogicVecVal *edn_urnd_data /* logic [31:0] */);
 

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -39,6 +39,10 @@ void edn_model_rnd_cdc_done(OtbnModel *model);
 // Signal RTL is finished processing EDN data for URND to Model
 void edn_model_urnd_cdc_done(OtbnModel *model);
 
+// Pass keymgr data to model
+void otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
+                                 svLogicVecVal *key1, unsigned char valid);
+
 // The main entry point to the OTBN model, exported from here and used in
 // otbn_core_model.sv.
 //

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -28,6 +28,10 @@ package otbn_model_pkg;
     void edn_model_urnd_cdc_done(chandle model);
 
   import "DPI-C" function
+    void otbn_model_set_keymgr_value(chandle model, logic [383:0] key0,
+                                     logic [383:0] key1, bit valid);
+
+  import "DPI-C" function
     void edn_model_rnd_cdc_done(chandle model);
 
   import "DPI-C" context function

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -153,6 +153,9 @@ class OTBNState:
         # signal from RTL
         self.urnd_256b_counter = 0
 
+    def set_keymgr_value(self, key0: int, key1: int, valid: bool) -> None:
+        return None
+
     def edn_rnd_step(self, rnd_data: int) -> None:
         # Take the new data
         assert 0 <= rnd_data < (1 << 32)

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -55,6 +55,8 @@ prefixed with "0x" if they are hexadecimal.
 
     invalidate_imem      Mark all of IMEM as having invalid ECC checksums
 
+    set_keymgr_value     Send keymgr data to the model.
+
 '''
 
 import sys
@@ -260,6 +262,18 @@ def on_edn_urnd_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
+def on_set_keymgr_value(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    if len(args) != 3:
+        raise ValueError('set_keymgr_value expects exactly 1 argument. Got {}.'
+                         .format(args))
+    key0 = read_word('key0', args[0], 384)
+    key1 = read_word('key1', args[1], 384)
+    valid = read_word('valid', args[2], 1) == 1
+    sim.state.set_keymgr_value(key0, key1, valid)
+
+    return None
+
+
 def on_edn_flush(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     if len(args) != 0:
         raise ValueError('edn_flush expects zero arguments. Got {}.'
@@ -321,7 +335,8 @@ _HANDLERS = {
     'edn_rnd_cdc_done': on_edn_rnd_cdc_done,
     'edn_urnd_cdc_done': on_edn_urnd_cdc_done,
     'edn_flush': on_edn_flush,
-    'invalidate_imem': on_invalidate_imem
+    'invalidate_imem': on_invalidate_imem,
+    'set_keymgr_value': on_set_keymgr_value
 }
 
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.core
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
       - lowrisc:ip:otbn_pkg
+      - lowrisc:ip:keymgr_pkg
     files:
       - otbn_model_if.sv
       - otbn_model_agent_pkg.sv

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -2,14 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface otbn_model_if #(
+interface otbn_model_if
+  import keymgr_pkg::otbn_key_req_t;
+#(
   // Size of the instruction memory, in bytes
   parameter int ImemSizeByte = 4096,
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte)
 ) (
   input logic clk_i,
-  input logic rst_ni
+  input logic rst_ni,
+  input otbn_key_req_t keymgr_key_i
 );
 
   // Inputs to DUT

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -23,6 +23,7 @@ module tb;
   wire clk, rst_n;
   wire idle, intr_done;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  otbn_key_req_t keymgr_key;
 
   // interfaces
   clk_rst_if                    clk_rst_if (.clk(clk), .rst_n(rst_n));
@@ -35,11 +36,16 @@ module tb;
   // needed for sequences that trigger alerts (locking OTBN) without telling the model.
   `DV_ASSERT_CTRL("otbn_status_assert_en", tb.MatchingStatus_A)
 
+  assign keymgr_key.key[0] = {12{32'hDEADBEEF}};
+  assign keymgr_key.key[1] = {12{32'hBAADF00D}};
+  assign keymgr_key.valid  = 1'b1;
+
   otbn_model_if #(
     .ImemSizeByte (otbn_reg_pkg::OTBN_IMEM_SIZE)
   ) model_if (
-    .clk_i  (clk),
-    .rst_ni (rst_n)
+    .clk_i         (clk),
+    .rst_ni        (rst_n),
+    .keymgr_key_i  (keymgr_key)
   );
 
   // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
@@ -89,12 +95,6 @@ module tb;
   assign otp_key_rsp.key = TestScrambleKey;
   assign otp_key_rsp.nonce = TestScrambleNonce;
   assign otp_key_rsp.seed_valid = 1'b0;
-
-  otbn_key_req_t keymgr_key;
-
-  assign keymgr_key.key[0] = {12{32'hDEADBEEF}};
-  assign keymgr_key.key[1] = {12{32'hBAADF00D}};
-  assign keymgr_key.valid  = 1'b1;
 
   // dut
   otbn # (
@@ -225,7 +225,9 @@ module tb;
 
     .done_rr_o    (),
 
-    .err_o        (model_if.err)
+    .err_o        (model_if.err),
+
+    .keymgr_key_i (model_if.keymgr_key_i)
   );
 
   // Pull the final PC and the OtbnModel handle out of the SV model wrapper.

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:otbn
       - lowrisc:dv:otbn_model
       - lowrisc:ip:otbn_tracer
+      - lowrisc:ip:keymgr_pkg
   files_verilator:
     depend:
       - lowrisc:dv:otbn_memutil

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -8,6 +8,7 @@ module otbn_top_sim (
 );
   import otbn_pkg::*;
   import edn_pkg::*;
+  import keymgr_pkg::otbn_key_req_t;
 
   // Size of the instruction memory, in bytes
   parameter int ImemSizeByte = otbn_reg_pkg::OTBN_IMEM_SIZE;
@@ -54,11 +55,13 @@ module otbn_top_sim (
 
   // Instruction counter (feeds into otbn.INSN_CNT in full block)
   logic [31:0]              insn_cnt;
-
   logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares;
-
   assign sideload_key_shares[0] = {12{32'hDEADBEEF}};
   assign sideload_key_shares[1] = {12{32'hBAADF00D}};
+  otbn_key_req_t keymgr_key;
+  assign keymgr_key.key[0] = sideload_key_shares[0];
+  assign keymgr_key.key[1] = sideload_key_shares[1];
+  assign keymgr_key.valid  = 1'b1;
 
   otbn_core #(
     .ImemSizeByte ( ImemSizeByte ),
@@ -321,6 +324,8 @@ module otbn_top_sim (
     .insn_cnt_o            ( otbn_model_insn_cnt ),
 
     .invalidate_imem_i     ( 1'b0 ),
+
+    .keymgr_key_i          ( keymgr_key),
 
     .done_rr_o             ( otbn_model_done_rr ),
 


### PR DESCRIPTION
Following changes have been made in this commit:
1. otbn_model_if.sv - Added keymgr_key pin
2. tb.sv - Connected keymgr_key pin to otbn_model_if and otbn_core_model
   to otbn_model_if.
3. otbn_core_model - Added a function that calls another function in C model
   to set keymgr values in ISS model on reset or change in keymgr_key value.
4. otbn_model - Added a function that calls another function in iss_wrapper
   to pass the keymgr values to python code.
5. iss_wrapper - Added a function that passes the keymgr values as a string
   to python code.
6. stepped.py - Added a function to receive values from iss_wrapper and
   pass to simstate.
7. state.py - Added a placeholder function that will use keymgr data.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>