### PR TITLE
[sw/silicon_creator] Add lifecycle_state_name_get()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -279,7 +279,7 @@ bool test_main(void) {
 
   // This test is expected to run in DEV, PROD or PROD_END states.
   lifecycle_state_t lc_state = lifecycle_state_get();
-  LOG_INFO("lifecycle state: %s", lifecycle_state_name[lc_state]);
+  LOG_INFO("lifecycle state: %s", lifecycle_state_name_get(lc_state));
 
   // Initialize pwrmgr
   dif_pwrmgr_t pwrmgr;

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -14,7 +14,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "lc_ctrl_regs.h"
 
-const char *const lifecycle_state_name[] = {
+static const char *const kStateNames[] = {
     // clang-format off
     "RAW",
     "TEST_UNLOCKED0",
@@ -43,8 +43,8 @@ const char *const lifecycle_state_name[] = {
     // clang-format on
 };
 
-static_assert(ARRAYSIZE(lifecycle_state_name) == kLcStateNumStates,
-              "length of the lifecycle_state_name array doesn't match the "
+static_assert(ARRAYSIZE(kStateNames) == kLcStateNumStates,
+              "length of the kStateNames array doesn't match the "
               "number of states.");
 
 #define LC_ASSERT(a, b) static_assert(a == b, "Bad value for " #a)
@@ -82,6 +82,17 @@ lifecycle_state_t lifecycle_state_get(void) {
       sec_mmio_read32(kBase + LC_CTRL_LC_STATE_REG_OFFSET),
       LC_CTRL_LC_STATE_STATE_FIELD);
   return (lifecycle_state_t)value;
+}
+
+const char *lifecycle_state_name_get(lifecycle_state_t lc_state) {
+  // Life cycle state value (`lc_state`) is a 32-bit value that repeats the
+  // 5-bit life cycle state index 6 times.
+  enum { kStateIndexMask = 0x1f };
+  size_t state_index = (uint32_t)lc_state & kStateIndexMask;
+  if (state_index >= kLcStateNumStates) {
+    state_index = kLcStateInvalid & kStateIndexMask;
+  }
+  return kStateNames[state_index];
 }
 
 void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.h
@@ -133,17 +133,20 @@ typedef struct lifecycle_device_id {
   uint32_t device_id[kLifecycleDeviceIdNumWords];
 } lifecycle_device_id_t;
 
-/*
- * An array of human-readable life cycle state names.
- */
-extern const char *const lifecycle_state_name[];
-
 /**
  * Get the life cycle state.
  *
  * @return Life cycle state.
  */
 lifecycle_state_t lifecycle_state_get(void);
+
+/**
+ * Get the human-readable name for a life cycle state.
+ *
+ * @param lc_state Life cycle state.
+ * @return Name of the given state.
+ */
+const char *lifecycle_state_name_get(lifecycle_state_t lc_state);
 
 /**
  * Get the device identifier.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -197,7 +197,7 @@ void mask_rom_main(void) {
   // TODO(lowrisc/opentitan#7894): What (if anything) should we print at
   // startup?
   log_printf("OpenTitan: \"version-tag\"\r\n");
-  log_printf("lc_state: %s\r\n", lifecycle_state_name[lc_state]);
+  log_printf("lc_state: %s\r\n", lifecycle_state_name_get(lc_state));
 
   // TODO(lowrisc/opentitan#1513): Switch to EEPROM SPI device bootstrap
   // protocol.


### PR DESCRIPTION
Life cycle state values were updated in #9319. This change adds
a utility function for getting human-readable state names using the new
state values.

Resolves #9429

Signed-off-by: Alphan Ulusoy <alphan@google.com>