### PR TITLE
[sw/silicon_creator] ROM anti-rollback

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -18,7 +18,7 @@
 // Values of `flash_ctrl_partition_t` constants must be distinct from each
 // other, and `kFlashCtrlRegionInfo* >> 1` should give the correct
 // CONTROL.INFO_SEL value.
-static_assert(kFlashCtrlPartitionData == 0u,
+static_assert(kFlashCtrlPartitionData == 0,
               "Incorrect enum value for kFlashCtrlRegionData");
 static_assert(kFlashCtrlPartitionInfo0 >> 1 == 0,
               "Incorrect enum value for kFlashCtrlRegionInfo0");
@@ -166,8 +166,7 @@ static rom_error_t write(uint32_t addr, flash_ctrl_partition_t partition,
                          uint32_t word_count, const uint32_t *data,
                          rom_error_t error) {
   enum {
-    kWindowWordCount =
-        FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES / sizeof(uint32_t),
+    kWindowWordCount = FLASH_CTRL_PARAM_REG_BUS_PGM_RES_BYTES / sizeof(uint32_t)
   };
 
   // Find the number of words that can be written in the first window.

--- a/sw/device/silicon_creator/lib/mock_boot_data.h
+++ b/sw/device/silicon_creator/lib/mock_boot_data.h
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_BOOT_DATA_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_BOOT_DATA_H_
+
+#include "sw/device/silicon_creator/lib/boot_data.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for boot_data.
+ */
+class MockBootData : public GlobalMock<MockBootData> {
+ public:
+  MOCK_METHOD(rom_error_t, Read,
+              (lifecycle_state_t lc_state, boot_data_t *boot_data));
+  MOCK_METHOD(rom_error_t, Write, (const boot_data_t *boot_data));
+};
+
+}  // namespace internal
+
+using MockBootData = testing::StrictMock<internal::MockBootData>;
+
+extern "C" {
+
+rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data) {
+  return MockBootData::Instance().Read(lc_state, boot_data);
+}
+
+rom_error_t boot_data_write(const boot_data_t *boot_data) {
+  return MockBootData::Instance().Write(boot_data);
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_BOOT_DATA_H_

--- a/sw/device/silicon_creator/mask_rom/boot_policy.h
+++ b/sw/device/silicon_creator/mask_rom/boot_policy.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOT_POLICY_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOT_POLICY_H_
 
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 
@@ -51,10 +52,12 @@ boot_policy_manifests_t boot_policy_manifests_get(void);
  * that its `identifier` is correct, and its `security_version` is greater than
  * or equal to the minimum required security version.
  *
+ * @param lc_state Life cycle state of the device.
  * @param manifest A ROM_EXT manifest.
  * @return Result of the operation.
  */
-rom_error_t boot_policy_manifest_check(const manifest_t *manifest);
+rom_error_t boot_policy_manifest_check(lifecycle_state_t lc_state,
+                                       const manifest_t *manifest);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/mask_rom/boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/boot_policy_unittest.cc
@@ -5,41 +5,49 @@
 #include "sw/device/silicon_creator/mask_rom/boot_policy.h"
 
 #include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/mock_boot_data.h"
 #include "sw/device/silicon_creator/lib/mock_manifest.h"
 #include "sw/device/silicon_creator/mask_rom/mock_boot_policy_ptrs.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 namespace manifest_unittest {
 namespace {
+using ::testing::DoAll;
+using ::testing::NotNull;
 using ::testing::Return;
+using ::testing::SetArgPointee;
 
 class BootPolicyTest : public mask_rom_test::MaskRomTest {
  protected:
   mask_rom_test::MockBootPolicyPtrs boot_policy_ptrs_;
   mask_rom_test::MockManifest mock_manifest_;
+  mask_rom_test::MockBootData mock_boot_data_;
 };
 
-TEST_F(BootPolicyTest, ManifestCheck) {
+class ManifestCheckLengthTest : public BootPolicyTest,
+                                public testing::WithParamInterface<uint32_t> {};
+
+TEST_P(ManifestCheckLengthTest, ManifestCheckGood) {
   manifest_t manifest{};
   manifest.identifier = MANIFEST_IDENTIFIER_ROM_EXT;
-
-  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MIN;
+  manifest.length = GetParam();
+  boot_data_t boot_data{};
   EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
-  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorOk);
+  EXPECT_CALL(mock_boot_data_, Read(kLcStateProd, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<1>(boot_data), Return(kErrorOk)));
 
-  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX >> 1;
-  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
-  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorOk);
-
-  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX;
-  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
-  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorOk);
+  EXPECT_EQ(boot_policy_manifest_check(kLcStateProd, &manifest), kErrorOk);
 }
+
+INSTANTIATE_TEST_SUITE_P(GoodLengths, ManifestCheckLengthTest,
+                         testing::Values(MANIFEST_LENGTH_FIELD_ROM_EXT_MIN,
+                                         MANIFEST_LENGTH_FIELD_ROM_EXT_MAX >> 1,
+                                         MANIFEST_LENGTH_FIELD_ROM_EXT_MAX));
 
 TEST_F(BootPolicyTest, ManifestCheckBadIdentifier) {
   manifest_t manifest{};
 
-  EXPECT_EQ(boot_policy_manifest_check(&manifest),
+  EXPECT_EQ(boot_policy_manifest_check(kLcStateProd, &manifest),
             kErrorBootPolicyBadIdentifier);
 }
 
@@ -48,10 +56,49 @@ TEST_F(BootPolicyTest, ManifestCheckBadLength) {
   manifest.identifier = MANIFEST_IDENTIFIER_ROM_EXT;
 
   manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MIN - 1;
-  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorBootPolicyBadLength);
+  EXPECT_EQ(boot_policy_manifest_check(kLcStateProd, &manifest),
+            kErrorBootPolicyBadLength);
 
   manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX + 1;
-  EXPECT_EQ(boot_policy_manifest_check(&manifest), kErrorBootPolicyBadLength);
+  EXPECT_EQ(boot_policy_manifest_check(kLcStateProd, &manifest),
+            kErrorBootPolicyBadLength);
+}
+
+TEST_F(BootPolicyTest, ManifestCheckBadManifest) {
+  manifest_t manifest{};
+  manifest.identifier = MANIFEST_IDENTIFIER_ROM_EXT;
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX;
+
+  EXPECT_CALL(mock_manifest_, Check(&manifest))
+      .WillOnce(Return(kErrorManifestBadEntryPoint));
+  EXPECT_EQ(boot_policy_manifest_check(kLcStateProd, &manifest),
+            kErrorManifestBadEntryPoint);
+}
+
+TEST_F(BootPolicyTest, ManifestCheckBadBootData) {
+  manifest_t manifest{};
+  manifest.identifier = MANIFEST_IDENTIFIER_ROM_EXT;
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX;
+
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+  EXPECT_CALL(mock_boot_data_, Read(kLcStateProd, NotNull()))
+      .WillOnce(Return(kErrorBootDataNotFound));
+  EXPECT_EQ(boot_policy_manifest_check(kLcStateProd, &manifest),
+            kErrorBootDataNotFound);
+}
+
+TEST_F(BootPolicyTest, ManifestCheckRollback) {
+  manifest_t manifest{};
+  manifest.identifier = MANIFEST_IDENTIFIER_ROM_EXT;
+  manifest.length = MANIFEST_LENGTH_FIELD_ROM_EXT_MAX;
+  boot_data_t boot_data{};
+  boot_data.min_security_version_rom_ext = 1;
+
+  EXPECT_CALL(mock_manifest_, Check(&manifest)).WillOnce(Return(kErrorOk));
+  EXPECT_CALL(mock_boot_data_, Read(kLcStateProd, NotNull()))
+      .WillOnce(DoAll(SetArgPointee<1>(boot_data), Return(kErrorOk)));
+  EXPECT_EQ(boot_policy_manifest_check(kLcStateProd, &manifest),
+            kErrorBootPolicyRollback);
 }
 
 struct ManifestOrderTestCase {

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -13,7 +13,6 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/pinmux.h"
-#include "sw/device/lib/runtime/hart.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
@@ -110,7 +109,7 @@ static rom_error_t mask_rom_init(void) {
  * @return Result of the operation.
  */
 static rom_error_t mask_rom_verify(const manifest_t *manifest) {
-  RETURN_IF_ERROR(boot_policy_manifest_check(manifest));
+  RETURN_IF_ERROR(boot_policy_manifest_check(lc_state, manifest));
 
   const sigverify_rsa_key_t *key;
   RETURN_IF_ERROR(sigverify_rsa_key_get(

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -39,6 +39,7 @@ sw_silicon_creator_mask_rom_boot_policy = declare_dependency(
     ],
     dependencies: [
       sw_silicon_creator_lib_manifest,
+      sw_silicon_creator_lib_boot_data,
     ],
   ),
 )


### PR DESCRIPTION
This PR integrates `boot_data` to `boot_policy` to enable anti-rollback protection and updates `boot_policy` unittests.

Resolves #7879