### PR TITLE
[otbn,dv] Correctly model timing for IMEM integrity errors

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -154,11 +154,7 @@ class OTBNSim:
             self.state.ext_regs.write('INSN_CNT', 0, True)
             return (None, changes)
 
-        if self.state.fsm_state == FsmState.POST_EXEC:
-            return (None, self._on_stall(verbose, fetch_next=False))
-
-        if self.state.fsm_state == FsmState.LOCKING:
-            self.state.ext_regs.write('INSN_CNT', 0, True)
+        if self.state.fsm_state in [FsmState.POST_EXEC, FsmState.LOCKING]:
             return (None, self._on_stall(verbose, fetch_next=False))
 
         assert self.state.fsm_state == FsmState.EXEC

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -291,7 +291,7 @@ def on_edn_rnd_cdc_done(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 def on_invalidate_imem(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     check_arg_count('invalidate_imem', 0, args)
 
-    sim.state.invalidated_imem = True
+    sim.state.invalidate_imem()
 
     return None
 


### PR DESCRIPTION
This was broken by 0ac448a (adding the prefetch stage) because the RTL
now caches IMEM contents for a cycle, meaning that injected IMEM
integrity errors arrive a cycle later.

We also slightly re-jig the timing for where INSN_CNT gets zeroed to
match the new behaviour.
