### PR TITLE
[sw, tests] MAIN SRAM test refactor

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -115,6 +115,24 @@
 #define OT_ATTR_WEAK __attribute__((weak))
 
 /**
+ * Attribute to construct functions without prologue/epilogue sequences.
+ *
+ * Only basic asm statements can be safely included in naked functions.
+ *
+ * See https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Function-Attributes.html
+ * #RISC-V-Function-Attributes
+ */
+#define OT_ATTR_NAKED __attribute__((naked))
+
+/**
+ * Attribute to place symbols into particular sections.
+ *
+ * See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
+ * #Common-Function-Attributes
+ */
+#define OT_ATTR_SECTION(name) __attribute__((section(name)))
+
+/**
  * Returns the return address of the current function.
  *
  * See https://gcc.gnu.org/onlinedocs/gcc/Return-Address.html.

--- a/sw/device/lib/testing/sram_ctrl_testutils.h
+++ b/sw/device/lib/testing/sram_ctrl_testutils.h
@@ -10,16 +10,6 @@
 
 #include "sw/device/lib/dif/dif_sram_ctrl.h"
 
-/*
- * Adds the first parameter to the second parameter and returns the result.
- *
- * The main use-case is to map this function pointer onto a buffer holding
- * SRAM execution test instructions. The assumption is that this buffer holds
- * instruction[0] = add a0, a1, a0, instruction[1] = jalr zero, 0(ra).
- */
-typedef uint32_t (*sram_ctrl_testutils_exec_function_t)(volatile uint32_t,
-                                                        volatile uint32_t);
-
 /**
  * A typed representation of the test data.
  */

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -644,6 +644,8 @@ sram_ctrl_execution_test_main_lib = declare_dependency(
     dependencies: [
       sw_lib_bitfield,
       sw_lib_dif_sram_ctrl,
+      sw_lib_irq_handlers,
+      sw_lib_runtime_ibex,
       sw_lib_runtime_log,
       sw_lib_testing_lc_ctrl_testutils,
       sw_lib_testing_otp_ctrl_testutils,

--- a/sw/device/tests/sram_ctrl_execution_test_main.c
+++ b/sw/device/tests/sram_ctrl_execution_test_main.c
@@ -6,7 +6,10 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_sram_ctrl.h"
+#include "sw/device/lib/handler.h"
+#include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
 #include "sw/device/lib/testing/lc_ctrl_testutils.h"
@@ -21,8 +24,12 @@ const test_config_t kTestConfig;
 
 static dif_sram_ctrl_t sram_ctrl;
 
-static volatile const uint32_t kExecParam1 = 2;
-static volatile const uint32_t kExecParam2 = 3;
+/**
+ * This flag is used to verify that the execution from SRAM was successful.
+ * Declared as volatile, because it is referenced in the fault handler, as well
+ * as the main test flow.
+ */
+static volatile bool exception_observed;
 
 /**
  * Main SRAM start and end addresses (inclusive).
@@ -42,50 +49,14 @@ static const uint32_t kRamEndAddr = TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_BASE_ADDR +
 static const uint32_t kOtpIfetchHwRelativeOffset = 8;
 
 /**
- * Buffer to hold instructions to be executed.
+ * Executes the return instruction from MAIN SRAM.
  *
- * Because this is the Main SRAM, we let the compiler allocate the buffer
- * instead of using the hard-coded locations from the `sram_ctrl_testutil.c`,
- * in order to prevent clobbering the data used by the program.
- *
- * This can be thought of as the implementation for the `ram_exec_function_t`.
- *
- * NOTE: We explicitly specify the `.data` section, otherwise due to the
- *       `const` qualifier buffer would end up in flash. The implicit
- *       alternative would be to drop the `const` qualifier, making the buffer
- *       go into the `.data` section.
+ * This function will return on success, or cause an exception if the
+ * execution is disabled.
  */
-__attribute__((section(
-    ".data"))) static volatile const uint32_t execution_test_instructions[2] = {
-    /*
-     *   Abstract representation: add rd, rs1, rs2
-     *   +-----------+-------+-------+-------+------+-----------+
-     *   |  0000000  |  rs2  |  rs1  |  000  |  rd  |  0110011  |
-     *   +-----------+-------+-------+-------+------+-----------+
-     *   31        25 24   20 19   15 14   12 11   7 6          0
-     *
-     *   Custom representation: add a0, a1, a0
-     *   +-----------+---------+---------+-------+--------+-----------+
-     *   |  0000000  |  01010  |  01011  |  000  | 01010  |  0110011  |
-     *   +-----------+---------+---------+-------+--------+-----------+
-     *   31        25 24     20 19     15 14   12 11     7 6          0
-     */
-    0x00A58533,
-    /*
-     *   Abstract representation: ret == jalr rd, offset(rs1)
-     *   +----------------+-------+-------+------+-----------+
-     *   |  000000000000  |  rs1  |  000  |  rd  |  1100111  |
-     *   +----------------+-------+-------+------+-----------+
-     *   31             20 19   15 14   12 11   7 6          0
-     *
-     *   Custom representation: jalr zero, 0(ra)
-     *   +----------------+---------+-------+---------+-----------+
-     *   |  000000000000  |  00001  |  000  |  00000  |  1100111  |
-     *   +----------------+---------+-------+---------+-----------+
-     *   31             20 19     15 14   12 11      7 6          0
-     */
-    0x00008067,
-};
+OT_ATTR_NAKED
+OT_ATTR_SECTION(".data")
+void execute_code_in_sram(void) { asm volatile("jalr zero, 0(ra)"); }
 
 static bool otp_ifetch_enabled(void) {
   dif_otp_ctrl_t otp;
@@ -112,30 +83,42 @@ static bool otp_ifetch_enabled(void) {
 }
 
 /**
- * Performs SRAM execution test.
+ * Handles an exception.
  *
- * `ram_exec_function_t` is "mapped" onto the `execution_test_instructions`
- * buffer that holds hand-crafted machine instructions. Effectively, this
- * buffer becomes the function body.
+ * This exception handler only processes the faults that are relevant to this
+ * test. It falls into an infinite `wait_for_interrupt` routine (by calling
+ * `abort()`) for the rest.
  *
- * According to the calling convention the parameters will be passed in the
- * a0 and a1 registers, with a0 also treated as the return value register.
+ * The controlled fault originates in the retention SRAM, which means that
+ * normally the return address would be calculated relative to the trapped
+ * instruction. However, due to execution from retention SRAM being permanently
+ * disabled, this approach would not work.
+ *
+ * Instead the control flow needs to be returned to the caller. In other words,
+ * sram_execution_test -> retention_sram -> exception_handler
+ * -> sram_execution_test.
  */
-static void sram_execution_test(void) {
-  // Map the function pointer onto the instruction buffer.
-  sram_ctrl_testutils_exec_function_t func =
-      (sram_ctrl_testutils_exec_function_t)execution_test_instructions;
+void handler_exception(void) {
+  uintptr_t ret_addr = (uintptr_t)OT_RETURN_ADDR();
+  LOG_INFO("Fault address: mepc = %p, return address = %p", ibex_mepc_read(),
+           ret_addr);
 
-  uintptr_t func_address = (uintptr_t)func;
-  CHECK(func_address >= kRamStartAddr && func_address <= kRamEndAddr,
-        "Test code resides outside of the Main SRAM: function address = %x",
-        func_address);
-
-  uint32_t expected_result = kExecParam1 + kExecParam2;
-  uint32_t result = func(kExecParam1, kExecParam2);
-  CHECK(result == expected_result,
-        "SRAM Execution expected %d + %d = %d, got %d", kExecParam1,
-        kExecParam2, expected_result, result);
+  exc_id_t exception_id = ibex_mcause_read();
+  switch (exception_id) {
+    case kInstAccFault:
+      LOG_INFO("Instruction access fault handler");
+      exception_observed = true;
+      ibex_mepc_write(ret_addr);
+      break;
+    case kInstIllegalFault:
+      LOG_INFO("Illegal instruction fault handler");
+      exception_observed = true;
+      ibex_mepc_write(ret_addr);
+      break;
+    default:
+      LOG_FATAL("Unexpected exception id = 0x%x", exception_id);
+      abort();
+  }
 }
 
 /**
@@ -147,6 +130,11 @@ static void sram_execution_test(void) {
  * determines whether the execution from SRAM is enabled.
  */
 bool test_main(void) {
+  uintptr_t func_address = (uintptr_t)execute_code_in_sram;
+  CHECK(func_address >= kRamStartAddr && func_address <= kRamEndAddr,
+        "Test code resides outside of the Main SRAM: function address = %x",
+        func_address);
+
   CHECK_DIF_OK(dif_sram_ctrl_init(
       mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR),
       &sram_ctrl));
@@ -167,10 +155,16 @@ bool test_main(void) {
       CHECK_DIF_OK(
           dif_sram_ctrl_exec_set_enabled(&sram_ctrl, kDifToggleEnabled));
 
-      sram_execution_test();
+      exception_observed = false;
+      execute_code_in_sram();
+      CHECK(!exception_observed,
+            "Exception observed whilst executing from SRAM!");
     }
   } else if (lc_ctrl_testutils_debug_func_enabled(&lc)) {
-    sram_execution_test();
+    exception_observed = false;
+    execute_code_in_sram();
+    CHECK(!exception_observed,
+          "Exception observed whilst executing from SRAM!");
   } else {
     LOG_FATAL("Execution from SRAM cannot be enabled, cannot run the test");
   }


### PR DESCRIPTION
- Make test failure controlled (if execution from SRAM is disabled, we catch it in the exception handler and report a test failure).
- Substitute hand-crafted instruction buffer for SRAM execution testing for a naked function.
- Simplify the SRAM execution test (simply contains `jalr` that return to the caller).