### PR TITLE
[top] Enable pwrmgr_smoketest in FPGA

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -722,8 +722,6 @@ module chip_earlgrey_asic (
   tlul_pkg::tl_h2d_t base_ast_bus;
   tlul_pkg::tl_d2h_t ast_base_bus;
 
-  assign ast_base_pwr.main_pok = ast_pwst.main_pok;
-
   // synchronization clocks / rests
   clkmgr_pkg::clkmgr_out_t clkmgr_aon_clocks;
   rstmgr_pkg::rstmgr_out_t rstmgr_aon_resets;
@@ -841,6 +839,8 @@ module chip_earlgrey_asic (
   //////////////////////////////////
 
 
+
+  assign ast_base_pwr.main_pok = ast_pwst.main_pok;
 
   logic [ast_pkg::UsbCalibWidth-1:0] usb_io_pu_cal;
 

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -1033,23 +1033,6 @@ module chip_earlgrey_cw310 #(
   //////////////////////
   // Top-level design //
   //////////////////////
-  pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;
-  ast_pkg::ast_alert_req_t ast_base_alerts;
-  ast_pkg::ast_status_t ast_base_status;
-
-  assign ast_base_pwr.slow_clk_val = 1'b1;
-  assign ast_base_pwr.core_clk_val = 1'b1;
-  assign ast_base_pwr.io_clk_val   = 1'b1;
-  assign ast_base_pwr.usb_clk_val  = 1'b1;
-  assign ast_base_pwr.main_pok     = 1'b1;
-
-  ast_pkg::ast_dif_t silent_alert = '{
-                                       p: 1'b0,
-                                       n: 1'b1
-                                     };
-
-  assign ast_base_alerts.alerts = {ast_pkg::NumAlerts{silent_alert}};
-  assign ast_base_status.io_pok = {ast_pkg::NumIoRails{1'b1}};
 
   // the rst_ni pin only goes to AST
   // the rest of the logic generates reset based on the 'pok' signal.

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -741,8 +741,6 @@ module chip_earlgrey_cw310 #(
   tlul_pkg::tl_h2d_t base_ast_bus;
   tlul_pkg::tl_d2h_t ast_base_bus;
 
-  assign ast_base_pwr.main_pok = ast_pwst.main_pok;
-
   // synchronization clocks / rests
   clkmgr_pkg::clkmgr_out_t clkmgr_aon_clocks;
   rstmgr_pkg::rstmgr_out_t rstmgr_aon_resets;
@@ -863,6 +861,8 @@ module chip_earlgrey_cw310 #(
   // TODO: Hook this up when FPGA pads are updated
   assign ext_clk = '0;
   assign pad2ast = '0;
+
+  assign ast_base_pwr.main_pok = base_ast_pwr.main_pd_n;
 
   logic clk_main, clk_usb_48mhz, clk_aon, rst_n;
   clkgen_xil7series # (

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -985,23 +985,6 @@ module chip_earlgrey_nexysvideo #(
   //////////////////////
   // Top-level design //
   //////////////////////
-  pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;
-  ast_pkg::ast_alert_req_t ast_base_alerts;
-  ast_pkg::ast_status_t ast_base_status;
-
-  assign ast_base_pwr.slow_clk_val = 1'b1;
-  assign ast_base_pwr.core_clk_val = 1'b1;
-  assign ast_base_pwr.io_clk_val   = 1'b1;
-  assign ast_base_pwr.usb_clk_val  = 1'b1;
-  assign ast_base_pwr.main_pok     = 1'b1;
-
-  ast_pkg::ast_dif_t silent_alert = '{
-                                       p: 1'b0,
-                                       n: 1'b1
-                                     };
-
-  assign ast_base_alerts.alerts = {ast_pkg::NumAlerts{silent_alert}};
-  assign ast_base_status.io_pok = {ast_pkg::NumIoRails{1'b1}};
 
   // the rst_ni pin only goes to AST
   // the rest of the logic generates reset based on the 'pok' signal.

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -693,8 +693,6 @@ module chip_earlgrey_nexysvideo #(
   tlul_pkg::tl_h2d_t base_ast_bus;
   tlul_pkg::tl_d2h_t ast_base_bus;
 
-  assign ast_base_pwr.main_pok = ast_pwst.main_pok;
-
   // synchronization clocks / rests
   clkmgr_pkg::clkmgr_out_t clkmgr_aon_clocks;
   rstmgr_pkg::rstmgr_out_t rstmgr_aon_resets;
@@ -815,6 +813,8 @@ module chip_earlgrey_nexysvideo #(
   // TODO: Hook this up when FPGA pads are updated
   assign ext_clk = '0;
   assign pad2ast = '0;
+
+  assign ast_base_pwr.main_pok = base_ast_pwr.main_pd_n;
 
   logic clk_main, clk_usb_48mhz, clk_aon, rst_n;
   clkgen_xil7series # (

--- a/test/systemtest/earlgrey/config.py
+++ b/test/systemtest/earlgrey/config.py
@@ -71,7 +71,7 @@ TEST_APPS_SELFCHECKING = [
     },
     {
         "name": "pwrmgr_smoketest",
-        "targets": ["sim_verilator"],
+        "targets": ["sim_verilator", "fpga_cw310"],
     },
     {
         "name": "rstmgr_smoketest",

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -551,8 +551,6 @@ module chip_${top["name"]}_${target["name"]} (
   tlul_pkg::tl_h2d_t base_ast_bus;
   tlul_pkg::tl_d2h_t ast_base_bus;
 
-  assign ast_base_pwr.main_pok = ast_pwst.main_pok;
-
   // synchronization clocks / rests
   clkmgr_pkg::clkmgr_out_t clkmgr_aon_clocks;
   rstmgr_pkg::rstmgr_out_t rstmgr_aon_resets;
@@ -677,6 +675,8 @@ module chip_${top["name"]}_${target["name"]} (
 
 % if target["name"] == "asic":
 
+  assign ast_base_pwr.main_pok = ast_pwst.main_pok;
+
   logic [ast_pkg::UsbCalibWidth-1:0] usb_io_pu_cal;
 
   // external clock comes in at a fixed position
@@ -706,6 +706,8 @@ module chip_${top["name"]}_${target["name"]} (
   // TODO: Hook this up when FPGA pads are updated
   assign ext_clk = '0;
   assign pad2ast = '0;
+
+  assign ast_base_pwr.main_pok = base_ast_pwr.main_pd_n;
 
   logic clk_main, clk_usb_48mhz, clk_aon, rst_n;
   clkgen_xil7series # (

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1136,23 +1136,6 @@ module chip_${top["name"]}_${target["name"]} (
   //////////////////////
   // Top-level design //
   //////////////////////
-  pwrmgr_pkg::pwr_ast_rsp_t ast_base_pwr;
-  ast_pkg::ast_alert_req_t ast_base_alerts;
-  ast_pkg::ast_status_t ast_base_status;
-
-  assign ast_base_pwr.slow_clk_val = 1'b1;
-  assign ast_base_pwr.core_clk_val = 1'b1;
-  assign ast_base_pwr.io_clk_val   = 1'b1;
-  assign ast_base_pwr.usb_clk_val  = 1'b1;
-  assign ast_base_pwr.main_pok     = 1'b1;
-
-  ast_pkg::ast_dif_t silent_alert = '{
-                                       p: 1'b0,
-                                       n: 1'b1
-                                     };
-
-  assign ast_base_alerts.alerts = {ast_pkg::NumAlerts{silent_alert}};
-  assign ast_base_status.io_pok = {ast_pkg::NumIoRails{1'b1}};
 
   // the rst_ni pin only goes to AST
   // the rest of the logic generates reset based on the 'pok' signal.


### PR DESCRIPTION
- Various top level fixes to enable `pwrmgr_smoke_test` in FPGA.
- This should unblock certain FPGA development activities.
- As part of this PR, part of the power okay signaling is bypassed, pending more investigation (#9507 )