### PR TITLE
[sram/dv] Fix access_during_key_req

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -29,6 +29,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   local bit is_fatal_alert[string];
   local int alert_chk_max_delay[string];
 
+  // intg check
+  bit en_d_user_intg_chk = 1;
+
   // covergroups
   tl_errors_cg_wrap   tl_errors_cgs_wrap[string];
   tl_intg_err_cg_wrap tl_intg_err_cgs_wrap[string];
@@ -359,7 +362,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       uint num_cmd_err_bits, num_data_err_bits;
 
       // integrity at d_user is from DUT, which should be always correct
-      void'(item.is_d_chan_intg_ok(.throw_error(1)));
+      if (en_d_user_intg_chk) void'(item.is_d_chan_intg_ok(.throw_error(1)));
 
       // sample covergroup
       `downcast(cip_item, item)

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_base_vseq.sv
@@ -52,9 +52,6 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
     ral.ctrl.init.set(1);
     csr_update(.csr(ral.ctrl));
     csr_spinwait(.ptr(ral.status.init_done), .exp_data(1));
-
-    // initialize mem_model
-    cfg.scb.init_mem();
   endtask
 
   // Request a new scrambling key from the OTP interface.
@@ -64,9 +61,6 @@ class sram_ctrl_base_vseq #(parameter int AddrWidth = `SRAM_ADDR_WIDTH) extends 
     ral.ctrl.renew_scr_key.set(1);
     csr_update(.csr(ral.ctrl));
     csr_spinwait(.ptr(ral.status.scr_key_valid), .exp_data(1));
-
-    // initialize mem_model
-    cfg.scb.init_mem();
   endtask
 
   // Task to perform a single SRAM read at the specified location

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -102,6 +102,8 @@
     {
       name: "{variant}_access_during_key_req"
       uvm_test_seq: sram_ctrl_access_during_key_req_vseq
+      // Need to make sure no sram access when we just request new key or init, so use zero_delays
+      run_opts: ["+zero_delays=1"]
     }
     {
       name: "{variant}_executable"


### PR DESCRIPTION
1. updated seq and scb to avoid timing precise check
2. moved mem_init to scb
3. disabled intg check if we only request key update without init

Signed-off-by: Weicai Yang <weicai@google.com>