### PR TITLE
[bazel] Generate HTML coverage reports

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -16,3 +16,7 @@ build --incompatible_enable_cc_toolchain_resolution
 # This lets us generate key/value pairs for the workspace which can be
 # accessed like we do in util/BUILD
 build --workspace_status_command=util/get_workspace_status.sh
+
+# Generate coverage in lcov format, which can be post-processed by lcov
+# into html-formatted reports.
+coverage --combined_report=lcov --instrument_test_targets --experimental_cc_coverage

--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
-load("//rules:quality.bzl", "clang_format_check", "license_check")
+load("//rules:quality.bzl", "clang_format_check", "html_coverage_report", "license_check")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -53,6 +53,10 @@ clang_format_check(
         "./build/**",
     ],
     mode = "fix",
+)
+
+html_coverage_report(
+    name = "html_coverage_report",
 )
 
 filegroup(

--- a/apt-requirements.txt
+++ b/apt-requirements.txt
@@ -24,6 +24,7 @@ flex
 g++
 git
 golang
+lcov
 libelf1
 libelf-dev
 libftdi1-2

--- a/rules/quality.bzl
+++ b/rules/quality.bzl
@@ -111,3 +111,29 @@ clang_format_check = rule(
     },
     executable = True,
 )
+
+def _html_coverage_report_impl(ctx):
+    out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
+    substitutions = {}
+    ctx.actions.expand_template(
+        template = ctx.file._runner,
+        output = out_file,
+        substitutions = substitutions,
+        is_executable = True,
+    )
+
+    return DefaultInfo(
+        files = depset([out_file]),
+        executable = out_file,
+    )
+
+html_coverage_report = rule(
+    implementation = _html_coverage_report_impl,
+    attrs = {
+        "_runner": attr.label(
+            default = "//rules/scripts:html_coverage_report.template.sh",
+            allow_single_file = True,
+        ),
+    },
+    executable = True,
+)

--- a/rules/scripts/html_coverage_report.template.sh
+++ b/rules/scripts/html_coverage_report.template.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+if [[ $# == 0 ]]; then
+    ARGS=("//...")
+else
+    ARGS="$@"
+fi
+
+if ! cd "$BUILD_WORKSPACE_DIRECTORY"; then
+    echo "Unable to change to workspace (BUILD_WORKSPACE_DIRECTORY: ${BUILD_WORKSPACE_DIRECTORY})"
+    exit 1
+fi
+
+bazel coverage "${ARGS[@]}"
+genhtml -o bazel-out/_coverage/ bazel-out/_coverage/_coverage_report.dat
+echo "Coverage report: file://$(pwd)/bazel-out/_coverage/index.html"


### PR DESCRIPTION
1. Add `lcov` to `apt-requirements.txt` to generate HTML coverage reports.
2. Set up the coverage options in `.bazelrc`.
3. Write a script to generate coverage and emit an HTML report.

This PR does not add coverage support for on-chip tests; that will be added
in a follow-up PR.

Signed-off-by: Chris Frantz <cfrantz@google.com>