### PR TITLE
[dv/prim_alert] Clean up alert test

### DIFF
--- a/hw/ip/prim/rtl/prim_alert_receiver.sv
+++ b/hw/ip/prim/rtl/prim_alert_receiver.sv
@@ -272,6 +272,9 @@ module prim_alert_receiver
   // shift sequence two cycles to the right to avoid reset effects.
   `ASSERT(PingDiffOk_A, ##2 $past(send_init) ^ alert_rx_o.ping_p ^ alert_rx_o.ping_n)
   `ASSERT(AckDiffOk_A, ##2 $past(send_init) ^ alert_rx_o.ack_p ^ alert_rx_o.ack_n)
+  `ASSERT(InitReq_A, mubi4_test_true_strict(init_trig_i) &&
+          !(state_q inside {InitReq, InitAckWait}) |=> send_init)
+
   // ping request at input -> need to see encoded ping request
   `ASSERT(PingRequest0_A, ##1 $rose(ping_req_i) && !send_init |=> $changed(alert_rx_o.ping_p))
   // ping response implies it has been requested


### PR DESCRIPTION
This PR cleans up prim_alert test:
1). Remove redundant differential signal checks in tb. They are proned
to erros, hard to debug, and RTL assertions already covered them.
2). Add more alert_init request or dut_init request to cover FSM
coverages.
3). Add a few more assertions in design.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>