### PR TITLE
[edn / csrng / entropy_src] swap to dv streamlined sparse_fsm

### DIFF
--- a/hw/ip/csrng/csrng.core
+++ b/hw/ip/csrng/csrng.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:count
       - lowrisc:prim:assert
       - lowrisc:prim:lc_sync
+      - lowrisc:prim:sparse_fsm
       - lowrisc:ip:tlul
       - lowrisc:ip:aes
       - lowrisc:ip:otp_ctrl_pkg
@@ -73,5 +74,3 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
-
-

--- a/hw/ip/csrng/rtl/csrng.sv
+++ b/hw/ip/csrng/rtl/csrng.sv
@@ -163,7 +163,26 @@ module csrng
     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck_A,
       u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.u_prim_count_cmd_gen_cntr,
       alert_tx_o[1])
+
+    `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(DrbgCmdFsmCheck_A,
+      u_csrng_core.gen_cmd_stage[i].u_csrng_cmd_stage.u_state_regs,
+      alert_tx_o[1])
   end
 
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlMainFsmCheck_A,
+    u_csrng_core.u_csrng_main_sm.u_state_regs,
+    alert_tx_o[1])
+
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(DrbgGenFsmCheck_A,
+    u_csrng_core.u_csrng_ctr_drbg_gen.u_state_regs,
+    alert_tx_o[1])
+
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(DrbgUpdBlkEncFsmCheck_A,
+    u_csrng_core.u_csrng_ctr_drbg_upd.u_blk_enc_state_regs,
+    alert_tx_o[1])
+
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(DrbgUpdOutBlkFsmCheck_A,
+    u_csrng_core.u_csrng_ctr_drbg_upd.u_outblk_state_regs,
+    alert_tx_o[1])
 
 endmodule

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -237,14 +237,15 @@ module csrng_cmd_stage import csrng_pkg::*; #(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(Idle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_raw_q )
+    .state_i ( state_d ),
+    .state_o ( state_raw_q )
   );
 
   assign state_q = state_e'(state_raw_q);

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -218,14 +218,15 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(ReqIdle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_raw_q )
+    .state_i ( state_d ),
+    .state_o ( state_raw_q )
   );
 
   assign state_q = state_e'(state_raw_q);

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -186,14 +186,15 @@ module csrng_ctr_drbg_upd #(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(blk_enc_state_e),
     .Width(BlkEncStateWidth),
     .ResetValue(BlkEncStateWidth'(ReqIdle))
   ) u_blk_enc_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( blk_enc_state_d ),
-    .q_o ( blk_enc_state_raw_q )
+    .state_i ( blk_enc_state_d ),
+    .state_o ( blk_enc_state_raw_q )
   );
 
   assign blk_enc_state_q = blk_enc_state_e'(blk_enc_state_raw_q);
@@ -232,14 +233,15 @@ module csrng_ctr_drbg_upd #(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(outblk_state_e),
     .Width(OutBlkStateWidth),
     .ResetValue(OutBlkStateWidth'(AckIdle))
   ) u_outblk_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( outblk_state_d ),
-    .q_o ( outblk_state_raw_q )
+    .state_i ( outblk_state_d ),
+    .state_o ( outblk_state_raw_q )
   );
 
   assign outblk_state_q = outblk_state_e'(outblk_state_raw_q);

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -76,14 +76,15 @@ module csrng_main_sm import csrng_pkg::*; (
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(Idle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_raw_q )
+    .state_i ( state_d ),
+    .state_o ( state_raw_q )
   );
 
   assign state_q = state_e'(state_raw_q);

--- a/hw/ip/edn/edn.core
+++ b/hw/ip/edn/edn.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:prim:all
       - lowrisc:prim:count
       - lowrisc:prim:assert
+      - lowrisc:prim:sparse_fsm
       - lowrisc:ip:tlul
       - lowrisc:ip:edn_pkg
     files:

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -133,5 +133,14 @@ module edn
     u_edn_core.u_prim_count_max_reqs_cntr,
     alert_tx_o[1])
 
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(MainFsmCheck_A,
+    u_edn_core.u_edn_main_sm.u_state_regs,
+    alert_tx_o[1])
+
+  for (genvar i = 0; i < NumEndPoints; i = i+1) begin : gen_edn_fsm_asserts
+    `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(AckFsmCheck_A,
+      u_edn_core.gen_ep_blk[i].u_edn_ack_sm_ep.u_state_regs,
+      alert_tx_o[1])
+  end
 
 endmodule

--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -51,14 +51,15 @@ module edn_ack_sm (
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(Idle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_raw_q )
+    .state_i ( state_d ),
+    .state_o ( state_raw_q )
   );
 
   assign state_q = state_e'(state_raw_q);

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -62,14 +62,15 @@ module edn_main_sm (
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
 
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(Idle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_raw_q )
+    .state_i ( state_d ),
+    .state_o ( state_raw_q )
   );
 
   assign state_q = state_e'(state_raw_q);

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:prim:count
       - lowrisc:prim:assert
       - lowrisc:prim:lfsr
+      - lowrisc:prim:sparse_fsm
       - lowrisc:ip:tlul
       - lowrisc:ip:sha3
       - lowrisc:ip:otp_ctrl_pkg

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -321,4 +321,12 @@ module entropy_src
     u_entropy_src_core.u_entropy_src_repcnts_ht.u_prim_count_test_cnt,
     alert_tx_o[1])
 
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlMainFsmCheck_A,
+    u_entropy_src_core.u_entropy_src_main_sm.u_state_regs,
+    alert_tx_o[1])
+
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlAckFsmCheck_A,
+    u_entropy_src_core.u_entropy_src_ack_sm.u_state_regs,
+    alert_tx_o[1])
+
 endmodule

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -52,14 +52,15 @@ module entropy_src_ack_sm (
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
 
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(Idle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_raw_q )
+    .state_i ( state_d ),
+    .state_o ( state_raw_q )
   );
 
   assign state_q = state_e'(state_raw_q);

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -82,14 +82,15 @@ module entropy_src_main_sm #(
 
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
-  prim_flop #(
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
     .Width(StateWidth),
     .ResetValue(StateWidth'(Idle))
   ) u_state_regs (
     .clk_i,
     .rst_ni,
-    .d_i ( state_d ),
-    .q_o ( state_raw_q )
+    .state_i ( state_d ),
+    .state_o ( state_raw_q )
   );
 
   assign state_q = state_e'(state_raw_q);


### PR DESCRIPTION
- no functional changes
- part of #9447 for these blocks

Signed-off-by: Timothy Chen <timothytim@google.com>