### PR TITLE
[sw/ottf] Replace duplicate code with existing macros.

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -78,6 +78,17 @@
                 "Unexpected offset for " #type "." #member)
 
 /**
+ * A macro that expands to an assertion for the size of a struct member.
+ *
+ * @param type A struct type.
+ * @param member A member of the struct.
+ * @param size Expected size of the type.
+ */
+#define OT_ASSERT_MEMBER_SIZE(type, member, size)             \
+  static_assert(sizeof(((type){0}).member) == UINT32_C(size), \
+                "Unexpected size for " #type)
+
+/**
  * A macro that expands to an assertion for the size of a type.
  *
  * @param type A type.

--- a/sw/device/lib/testing/test_framework/ottf.c
+++ b/sw/device/lib/testing/test_framework/ottf.c
@@ -24,12 +24,8 @@
 
 // Check layout of test configuration struct since OTTF ISR asm code requires a
 // specific layout.
-static_assert(offsetof(test_config_t, enable_concurrency) == 0,
-              "Expected enable_concurrency field to be at offset zero within "
-              "test configuration struct.");
-static_assert(sizeof(((test_config_t){0}).enable_concurrency) == 1,
-              "Expected enable_concurrency field in test configuration struct "
-              "to be one byte.");
+OT_ASSERT_MEMBER_OFFSET(test_config_t, enable_concurrency, 0);
+OT_ASSERT_MEMBER_SIZE(test_config_t, enable_concurrency, 1);
 
 // UART for communication with host.
 static dif_uart_t uart0;


### PR DESCRIPTION
This commit replaces OTTF static asserts that check the offset and size of the `enable_concurrency` member of the test configuration struct with existing OT macros.

This addresses @alphan's review comment in #9414.

Signed-off-by: Timothy Trippel <ttrippel@google.com>