### PR TITLE
[entropy_src/doc] uninstantiate command update

### DIFF
--- a/hw/ip/csrng/doc/_index.md
+++ b/hw/ip/csrng/doc/_index.md
@@ -378,6 +378,7 @@ The actions performed by each command, as well as which flags are supported, are
          Values in the instance are zeroed out.
          When the <tt>uninstantiate</tt> comand is completed, the <tt>active</tt> bit in the CSRNG working state will be cleared.
          Uninstantiating an instance effectively resets it, clearing any errors that it may have encountered due to bad command syntax or entropy source failures.
+         Only a value of zero should be used for clen, since any additional data will be ignored.
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
The documentation has been updated to restrict the clen of an uninstantiate command to be zero.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>