### PR TITLE
[otbn,dv] Fix up DMEM size for DV code

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -16,11 +16,6 @@ module otbn_core_model
   import otbn_model_pkg::*;
   import edn_pkg::*;
 #(
-  // Size of the instruction memory, in bytes
-  parameter int ImemSizeByte = 4096,
-  // Size of the data memory, in bytes
-  parameter int DmemSizeByte = 4096,
-
   // The scope that contains the instruction and data memory (for DPI)
   parameter string MemScope = "",
 
@@ -56,13 +51,10 @@ module otbn_core_model
   output bit             err_o // something went wrong
 );
 
-  localparam int ImemSizeWords = ImemSizeByte / 4;
-  localparam int DmemSizeWords = DmemSizeByte / (WLEN / 8);
-
   // Create and destroy an object through which we can talk to the ISS.
   chandle model_handle;
   initial begin
-    model_handle = otbn_model_init(MemScope, DesignScope, ImemSizeWords, DmemSizeWords);
+    model_handle = otbn_model_init(MemScope, DesignScope);
     assert(model_handle != null);
   end
   final begin

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -220,12 +220,8 @@ static std::vector<T> get_stack(const std::string &stack_scope) {
 }
 
 OtbnModel::OtbnModel(const std::string &mem_scope,
-                     const std::string &design_scope, unsigned imem_size_words,
-                     unsigned dmem_size_words)
-    : mem_util_(mem_scope),
-      design_scope_(design_scope),
-      imem_size_words_(imem_size_words),
-      dmem_size_words_(dmem_size_words) {}
+                     const std::string &design_scope)
+    : mem_util_(mem_scope), design_scope_(design_scope) {}
 
 OtbnModel::~OtbnModel() {}
 
@@ -638,10 +634,9 @@ bool OtbnModel::check_call_stack(ISSWrapper &iss) const {
   return good;
 }
 
-OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope,
-                           unsigned imem_words, unsigned dmem_words) {
+OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope) {
   assert(mem_scope && design_scope);
-  return new OtbnModel(mem_scope, design_scope, imem_words, dmem_words);
+  return new OtbnModel(mem_scope, design_scope);
 }
 
 void otbn_model_destroy(OtbnModel *model) { delete model; }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -16,8 +16,7 @@ class ISSWrapper;
 
 class OtbnModel {
  public:
-  OtbnModel(const std::string &mem_scope, const std::string &design_scope,
-            unsigned imem_size_words, unsigned dmem_size_words);
+  OtbnModel(const std::string &mem_scope, const std::string &design_scope);
   ~OtbnModel();
 
   // Replace any current loop warps with those from memutil. Returns 0
@@ -109,7 +108,6 @@ class OtbnModel {
   std::unique_ptr<ISSWrapper> iss_;
   OtbnMemUtil mem_util_;
   std::string design_scope_;
-  unsigned imem_size_words_, dmem_size_words_;
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_MODEL_H_

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -16,8 +16,7 @@
 extern "C" {
 
 // Create an OtbnModel object. Will always succeed.
-OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope,
-                           unsigned imem_words, unsigned dmem_words);
+OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope);
 
 // Delete an OtbnModel
 void otbn_model_destroy(OtbnModel *model);

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -10,9 +10,7 @@ package otbn_model_pkg;
   import otbn_pkg::WLEN;
 
   import "DPI-C" context function chandle otbn_model_init(string mem_scope,
-                                                          string design_scope,
-                                                          int unsigned imem_words,
-                                                          int unsigned dmem_words);
+                                                          string design_scope);
 
   import "DPI-C" function void otbn_model_destroy(chandle model);
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -11,7 +11,7 @@
 class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
   `uvm_component_utils(otbn_env_cov)
 
-  localparam int DmemSizeByte = int'(otbn_reg_pkg::OTBN_DMEM_SIZE);
+  localparam int DmemSizeByte = 2 * int'(otbn_reg_pkg::OTBN_DMEM_SIZE);
   localparam int ImemSizeByte = int'(otbn_reg_pkg::OTBN_IMEM_SIZE);
 
   // A field for each known mnemonic, cast to a mnem_str_t. We have to do this because VCS (at

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -96,7 +96,7 @@ package otbn_env_pkg;
   typedef class otbn_scoreboard;
 
   parameter int ImemIndexWidth = vbits(int'(otbn_reg_pkg::OTBN_IMEM_SIZE) / 4);
-  parameter int DmemIndexWidth = vbits(int'(otbn_reg_pkg::OTBN_DMEM_SIZE) / 32);
+  parameter int DmemIndexWidth = vbits(2 * int'(otbn_reg_pkg::OTBN_DMEM_SIZE) / 32);
 
   // package sources
   `include "otbn_env_cfg.sv"

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -73,7 +73,8 @@ class otbn_base_vseq extends cip_base_vseq #(
 
   protected function automatic void
   get_queue_entries(bit for_imem, ref otbn_loaded_word entries[$]);
-    // Get the size of this memory (to make sure the number of loaded words makes sense)
+    // Get the bus-accessible size of this memory (to make sure the number of loaded words makes
+    // sense)
     int unsigned mem_size = for_imem ? OTBN_IMEM_SIZE : OTBN_DMEM_SIZE;
 
     // Iterate over the segments for this memory

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -196,8 +196,6 @@ module tb;
   bit [31:0] model_insn_cnt;
 
   otbn_core_model #(
-    .DmemSizeByte (otbn_reg_pkg::OTBN_DMEM_SIZE),
-    .ImemSizeByte (otbn_reg_pkg::OTBN_IMEM_SIZE),
     .MemScope     ("..dut"),
     .DesignScope  ("..dut.u_otbn_core")
   ) u_model (
@@ -266,6 +264,7 @@ module tb;
 
   initial begin
     mem_bkdr_util imem_util, dmem_util;
+    int unsigned real_dmem_size, dmem_depth;
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
@@ -303,11 +302,16 @@ module tb;
                     .depth (otbn_reg_pkg::OTBN_IMEM_SIZE / 4),
                     .n_bits (otbn_reg_pkg::OTBN_IMEM_SIZE / 4 * 39),
                     .err_detection_scheme (mem_bkdr_util_pkg::Ecc_39_32));
+
+    // DMEM is twice as big as the bus-accessible part
+    real_dmem_size = 2 * otbn_reg_pkg::OTBN_DMEM_SIZE;
+    dmem_depth = real_dmem_size / 32;
+
     dmem_util = new(.name ("dmem_util"),
                     .path ({"tb.dut.u_dmem.u_prim_ram_1p_adv.",
                             "u_mem.gen_generic.u_impl_generic.mem"}),
-                    .depth (otbn_reg_pkg::OTBN_DMEM_SIZE / 32),
-                    .n_bits (otbn_reg_pkg::OTBN_DMEM_SIZE / 32 * 312),
+                    .depth (dmem_depth),
+                    .n_bits (dmem_depth * 312),
                     .err_detection_scheme (mem_bkdr_util_pkg::Ecc_39_32));
 
     uvm_config_db#(mem_bkdr_util)::set(null, "*.env", imem_util.get_name(), imem_util);

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -292,8 +292,6 @@ module otbn_top_sim (
   bit        otbn_model_err;
 
   otbn_core_model #(
-    .DmemSizeByte    ( DmemSizeByte ),
-    .ImemSizeByte    ( ImemSizeByte ),
     .MemScope        ( ".." ),
     .DesignScope     ( DesignScope )
   ) u_otbn_core_model (

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -800,8 +800,6 @@ module otbn
     assign edn_urnd_data_valid = edn_urnd_req & edn_urnd_ack;
 
     otbn_core_model #(
-      .DmemSizeByte(DmemSizeByte),
-      .ImemSizeByte(ImemSizeByte),
       .MemScope(".."),
       .DesignScope("")
     ) u_otbn_core_model (


### PR DESCRIPTION
Commit 9535680 halves the bus-accessible size of DMEM. One side effect
is that the auto-generated `otbn_reg_pkg::OTBN_DMEM_SIZE` gets
halved (even though the memory doesn't actually change size). Put the
factor of 2 back in where needed.

Also, drop the IMEM/DMEM size parameters completely from the model,
since they aren't needed anyway (the Python ignores them and gets its
sizes directly from the hjson).
