### PR TITLE
[otbn,dv] Fix byte order in otbn_model.cc's words_to_bytes

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -98,7 +98,7 @@ static std::vector<uint8_t> words_to_bytes(
     }
 
     for (int j = 0; j < 4; ++j) {
-      ret.push_back((w32 >> 8 * j) & 0xff);
+      ret.push_back((w32 >> 8 * (3 - j)) & 0xff);
     }
   }
   return ret;


### PR DESCRIPTION
The words were being extracted with the wrong endianness.
