### PR TITLE
  [otbn, dv] Added otbn_dmem_err testcase

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -80,7 +80,7 @@
             Inject ECC errors into DMEM and IMEM and expect an alert
             '''
       milestone: V2
-      tests: ["otbn_imem_err"]
+      tests: ["otbn_imem_err", "otbn_dmem_err"]
     }
     {
       name: back_to_back

--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -405,6 +405,10 @@ void ISSWrapper::invalidate_imem() {
   run_command("invalidate_imem\n", nullptr);
 }
 
+void ISSWrapper::invalidate_dmem() {
+  run_command("invalidate_dmem\n", nullptr);
+}
+
 uint32_t ISSWrapper::step_crc(const std::array<uint8_t, 6> &item,
                               uint32_t state) const {
   std::vector<std::string> lines;

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -103,6 +103,9 @@ struct ISSWrapper {
   // Mark all of IMEM as invalid so that any fetch causes an integrity error.
   void invalidate_imem();
 
+  // Mark all of DMEM as invalid so that any load causes an integrity error.
+  void invalidate_dmem();
+
   // Step a CRC calculation with 48 bits of data
   uint32_t step_crc(const std::array<uint8_t, 6> &item, uint32_t state) const;
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -456,6 +456,21 @@ int OtbnModel::invalidate_imem() {
   return 0;
 }
 
+int OtbnModel::invalidate_dmem() {
+  ISSWrapper *iss = ensure_wrapper();
+  if (!iss)
+    return -1;
+
+  try {
+    iss->invalidate_dmem();
+  } catch (const std::exception &err) {
+    std::cerr << "Error when invalidating DMEM in ISS: " << err.what() << "\n";
+    return -1;
+  }
+
+  return 0;
+}
+
 int OtbnModel::step_crc(const svBitVecVal *item /* bit [47:0] */,
                         svBitVecVal *state /* bit [31:0] */) {
   ISSWrapper *iss = ensure_wrapper();
@@ -786,6 +801,11 @@ unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned model_state,
 int otbn_model_invalidate_imem(OtbnModel *model) {
   assert(model);
   return model->invalidate_imem();
+}
+
+int otbn_model_invalidate_dmem(OtbnModel *model) {
+  assert(model);
+  return model->invalidate_dmem();
 }
 
 int otbn_model_step_crc(OtbnModel *model, svBitVecVal *item /* bit [47:0] */,

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -74,6 +74,10 @@ class OtbnModel {
   // error. Returns 0 on success; -1 on failure.
   int invalidate_imem();
 
+  // Mark all of DMEM as invalid so that any load causes an integrity
+  // error. Returns 0 on success; -1 on failure.
+  int invalidate_dmem();
+
   // Step CRC by consuming 48 bits of data.
   //
   // This doesn't actually update any internal state: we're just using the

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -85,6 +85,10 @@ unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned model_state,
 // integrity error. Returns 0 on success or -1 on failure.
 int otbn_model_invalidate_imem(OtbnModel *model);
 
+// Tell the model to mark all of DMEM as invalid so that any load causes an
+// integrity error. Returns 0 on success or -1 on failure.
+int otbn_model_invalidate_dmem(OtbnModel *model);
+
 // Step the CRC calculation for item
 //
 // state is an inout parameter and should be updated in-place. This is

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -48,6 +48,8 @@ package otbn_model_pkg;
                                                   bit [47:0]       item,
                                                   inout bit [31:0] state);
 
+  import "DPI-C" context function int otbn_model_invalidate_dmem(chandle model);
+
   import "DPI-C" function void otbn_model_reset(chandle model);
 
   import "DPI-C" function void otbn_take_loop_warps(chandle model, chandle memutil);

--- a/hw/ip/otbn/dv/otbnsim/sim/insn.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/insn.py
@@ -263,6 +263,10 @@ class LW(OTBNInsn):
         # Stall for a single cycle for memory to respond
         yield
 
+        if result is None:
+            state.stop_at_end_of_cycle(ErrBits.DMEM_INTG_VIOLATION)
+            return
+
         state.gprs.get_reg(self.grd).write_unsigned(result)
 
 
@@ -1080,6 +1084,10 @@ class BNLID(OTBNInsn):
 
         # Stall for a single cycle for memory to respond
         yield
+
+        if value is None:
+            state.stop_at_end_of_cycle(ErrBits.DMEM_INTG_VIOLATION)
+            return
 
         state.wdrs.get_reg(wrd).write_unsigned(value)
 

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -55,6 +55,8 @@ prefixed with "0x" if they are hexadecimal.
 
     invalidate_imem      Mark all of IMEM as having invalid ECC checksums
 
+    invalidate_dmem      Mark all of DMEM as having invalid ECC checksums
+
     set_keymgr_value     Send keymgr data to the model.
 
     step_crc             Step CRC function with 48 bits of data. No actual
@@ -275,18 +277,6 @@ def on_edn_urnd_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
-def on_set_keymgr_value(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
-    if len(args) != 3:
-        raise ValueError('set_keymgr_value expects exactly 1 argument. Got {}.'
-                         .format(args))
-    key0 = read_word('key0', args[0], 384)
-    key1 = read_word('key1', args[1], 384)
-    valid = read_word('valid', args[2], 1) == 1
-    sim.state.set_keymgr_value(key0, key1, valid)
-
-    return None
-
-
 def on_edn_flush(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     if len(args) != 0:
         raise ValueError('edn_flush expects zero arguments. Got {}.'
@@ -319,6 +309,24 @@ def on_invalidate_imem(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     check_arg_count('invalidate_imem', 0, args)
 
     sim.state.invalidate_imem()
+    return None
+
+
+def on_invalidate_dmem(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('invalidate_dmem', 0, args)
+
+    sim.state.dmem.empty_dmem()
+    return None
+
+
+def on_set_keymgr_value(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    if len(args) != 3:
+        raise ValueError('set_keymgr_value expects exactly 1 argument. Got {}.'
+                         .format(args))
+    key0 = read_word('key0', args[0], 384)
+    key1 = read_word('key1', args[1], 384)
+    valid = read_word('valid', args[2], 1) == 1
+    sim.state.set_keymgr_value(key0, key1, valid)
 
     return None
 
@@ -353,6 +361,7 @@ _HANDLERS = {
     'edn_urnd_cdc_done': on_edn_urnd_cdc_done,
     'edn_flush': on_edn_flush,
     'invalidate_imem': on_invalidate_imem,
+    'invalidate_dmem': on_invalidate_dmem,
     'set_keymgr_value': on_set_keymgr_value,
     'step_crc': on_step_crc
 }

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -37,6 +37,7 @@ filesets:
       - seq_lib/otbn_reset_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_sequential_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_imem_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_dmem_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program multiple times and corrupts the
+// dmem registers while the otbn is still running.
+
+class otbn_dmem_err_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_dmem_err_vseq)
+
+  `uvm_object_new
+
+  task body();
+    string elf_path;
+    uvm_reg_data_t act_val;
+    bit [38:0] mask;
+
+    logic [127:0]    key;
+    logic [63:0]     nonce;
+
+    elf_path = pick_elf_path();
+    `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+    load_elf(elf_path, 1'b1);
+
+    // Start OTBN running. When this task returns, we'll be in the middle of a run.
+    start_running_otbn(.check_end_addr(1'b0));
+
+    key = cfg.get_dmem_key();
+    nonce = cfg.get_dmem_nonce();
+
+    // Mask to corrupt 1 to 2 bits of the dmem memory
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
+
+    // Inject error at negedge of clock to avoid racing with second cycle of store instruction.
+    @(cfg.clk_rst_vif.cbn);
+
+    for (int i = 0; i < 2 * otbn_reg_pkg::OTBN_DMEM_SIZE / 32; i++) begin
+      bit[311:0] good_data = cfg.read_dmem_word(i, key, nonce);
+      bit [311:0] bad_data = good_data ^ {8{mask}};
+      cfg.write_dmem_word(i, bad_data, key, nonce);
+    end
+
+    cfg.model_agent_cfg.vif.invalidate_dmem();
+
+    wait (cfg.model_agent_cfg.vif.status != otbn_pkg::StatusBusyExecute);
+
+    // At this point, our status has changed. We're probably actually seeing the alert now, but make
+    // sure that it has gone out in at most 100 cycles.
+    if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked) begin
+      fork
+        begin
+          csr_utils_pkg::csr_rd(.ptr(ral.status), .value(act_val));
+          csr_utils_pkg::csr_rd(.ptr(ral.err_bits), .value(act_val));
+          csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
+        end
+        begin
+          repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
+        end
+      join
+      dut_init("HARD");
+    end
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -10,3 +10,4 @@
 `include "otbn_single_vseq.sv"
 `include "otbn_smoke_vseq.sv"
 `include "otbn_imem_err_vseq.sv"
+`include "otbn_dmem_err_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -57,6 +57,16 @@ interface otbn_model_if
                     "Failed to invalidate IMEM", "otbn_model_if")
   endfunction
 
+  // Mark the entirety of DMEM as invalid
+  //
+  // Call this on a negedge of clk_i to ensure sequencing with the otbn_model_step on the following
+  // posedge.
+  function automatic void invalidate_dmem();
+    `uvm_info("otbn_model_if", "Invalidating DMEM", UVM_HIGH)
+    `DV_CHECK_FATAL(otbn_model_pkg::otbn_model_invalidate_dmem(handle) == 0,
+                    "Failed to invalidate DMEM", "otbn_model_if")
+  endfunction
+
   // Ask the Python model to compute a CRC step for a memory write
   //
   // This doesn't actually update any model state (we pass in the old state and delta, and the

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -185,6 +185,13 @@ name:
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 5
     }
+    {
+      name: "otbn_dmem_err"
+      uvm_test_seq: "otbn_dmem_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
   ]
 
   // List of regressions.
@@ -197,7 +204,7 @@ name:
     {
       name: "core"
       tests: [
-        "otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset", "otbn_multi_err", "otbn_imem_err"
+        "otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset", "otbn_multi_err", "otbn_imem_err", "otbn_dmem_err"
       ]
     }
   ]


### PR DESCRIPTION
[otbn, dv] Added otbn_dmem_err testcase

Following files have been added/ changed in this commit:
1. otbn_dmem_err_vseq.sv - Sequence to inject errors in dmem.
2. otbn_model_if - Added invalidate_dmem pin which tells the ISS model
to trash dmem.
3. otbn_core_model - Calls the invalidate_dmem function in C model.
4. otbn_model.cc/ iss_wrapper.cc - Set the ivalidate_dmem bit in python
code.
5. stepped.py - Calls EmptyDmem function in dmem.
6. dmem.py - Added EmptyDmem function  to trash dmem.

This commit also contains changes to pass a valid bit to specify if the
data in dmem is valid or invalid. This is used in c model to compare
between RTL and ISS model dmem.
