### PR TITLE
[tlul] Tweaks to avoid generating unused error responders in tlul_socket_1n

### DIFF
--- a/hw/dv/sv/sim_sram/sim_sram.sv
+++ b/hw/dv/sv/sim_sram/sim_sram.sv
@@ -53,15 +53,16 @@ module sim_sram #(
 
   // Split the incoming access into two.
   tlul_socket_1n #(
-    .N        (2),
-    .HReqPass (1'b1),
-    .HRspPass (1'b1),
-    .DReqPass ({2{1'b1}}),
-    .DRspPass ({2{1'b1}}),
-    .HReqDepth(4'h0),
-    .HRspDepth(4'h0),
-    .DReqDepth({2{4'h0}}),
-    .DRspDepth({2{4'h0}})
+    .N           (2),
+    .HReqPass    (1'b1),
+    .HRspPass    (1'b1),
+    .DReqPass    ({2{1'b1}}),
+    .DRspPass    ({2{1'b1}}),
+    .HReqDepth   (4'h0),
+    .HRspDepth   (4'h0),
+    .DReqDepth   ({2{4'h0}}),
+    .DRspDepth   ({2{4'h0}}),
+    .ExplicitErrs(1'b0)
   ) u_socket (
     .clk_i,
     .rst_ni,
@@ -69,7 +70,7 @@ module sim_sram #(
     .tl_h_o      (tl_in_o),
     .tl_d_o      (tl_socket_h2d),
     .tl_d_i      (tl_socket_d2h),
-    .dev_select_i({1'b0, dev_select})
+    .dev_select_i(dev_select)
   );
 
   // Logic to select SRAM address range.

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -98,15 +98,16 @@ module flash_ctrl_core_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (3),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({3{1'b1}}),
-    .DRspPass   ({3{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({3{4'h0}}),
-    .DRspDepth  ({3{4'h0}})
+    .N            (3),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({3{1'b1}}),
+    .DRspPass     ({3{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({3{4'h0}}),
+    .DRspDepth    ({3{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_mem_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_mem_reg_top.sv
@@ -54,43 +54,8 @@ module flash_ctrl_mem_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
-    .clk_i  (clk_i),
-    .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
-  );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prim_reg_top.sv
@@ -54,43 +54,8 @@ module flash_ctrl_prim_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
-    .clk_i  (clk_i),
-    .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
-  );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -84,7 +84,7 @@ module hmac_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];
@@ -95,15 +95,16 @@ module hmac_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (2),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({2{1'b1}}),
-    .DRspPass   ({2{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({2{4'h0}}),
-    .DRspDepth  ({2{4'h0}})
+    .N            (2),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({2{1'b1}}),
+    .DRspPass     ({2{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({2{4'h0}}),
+    .DRspDepth    ({2{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -97,15 +97,16 @@ module kmac_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (3),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({3{1'b1}}),
-    .DRspPass   ({3{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({3{4'h0}}),
-    .DRspDepth  ({3{4'h0}})
+    .N            (3),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({3{1'b1}}),
+    .DRspPass     ({3{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({3{4'h0}}),
+    .DRspDepth    ({3{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -97,15 +97,16 @@ module otbn_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (3),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({3{1'b1}}),
-    .DRspPass   ({3{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({3{4'h0}}),
-    .DRspDepth  ({3{4'h0}})
+    .N            (3),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({3{1'b1}}),
+    .DRspPass     ({3{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({3{4'h0}}),
+    .DRspDepth    ({3{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -84,7 +84,7 @@ module otp_ctrl_core_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];
@@ -95,15 +95,16 @@ module otp_ctrl_core_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (2),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({2{1'b1}}),
-    .DRspPass   ({2{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({2{4'h0}}),
-    .DRspDepth  ({2{4'h0}})
+    .N            (2),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({2{1'b1}}),
+    .DRspPass     ({2{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({2{4'h0}}),
+    .DRspDepth    ({2{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_prim_reg_top.sv
@@ -54,43 +54,8 @@ module otp_ctrl_prim_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
-    .clk_i  (clk_i),
-    .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
-  );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -84,7 +84,7 @@ module spi_device_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];
@@ -95,15 +95,16 @@ module spi_device_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (2),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({2{1'b1}}),
-    .DRspPass   ({2{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({2{4'h0}}),
-    .DRspDepth  ({2{4'h0}})
+    .N            (2),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({2{1'b1}}),
+    .DRspPass     ({2{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({2{4'h0}}),
+    .DRspDepth    ({2{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -97,15 +97,16 @@ module spi_host_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (3),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({3{1'b1}}),
-    .DRspPass   ({3{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({3{4'h0}}),
-    .DRspDepth  ({3{4'h0}})
+    .N            (3),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({3{1'b1}}),
+    .DRspPass     ({3{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({3{4'h0}}),
+    .DRspDepth    ({3{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_ram_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_ram_reg_top.sv
@@ -54,43 +54,8 @@ module sram_ctrl_ram_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
-    .clk_i  (clk_i),
-    .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
-  );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -200,7 +200,7 @@ module tlul_socket_1n #(
   end
 
   assign tl_u_o[N].a_valid     = tl_t_o.a_valid &
-                                 (dev_select_t == NWD'(N)) &
+                                 (dev_select_t >= NWD'(N)) &
                                  ~hold_all_requests;
   assign tl_u_o[N].a_opcode    = tl_t_o.a_opcode;
   assign tl_u_o[N].a_param     = tl_t_o.a_param;

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -84,7 +84,7 @@ module usbdev_reg_top (
   tlul_pkg::tl_h2d_t tl_socket_h2d [2];
   tlul_pkg::tl_d2h_t tl_socket_d2h [2];
 
-  logic [1:0] reg_steer;
+  logic [0:0] reg_steer;
 
   // socket_1n connection
   assign tl_reg_h2d = tl_socket_h2d[1];
@@ -95,15 +95,16 @@ module usbdev_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (2),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({2{1'b1}}),
-    .DRspPass   ({2{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({2{4'h0}}),
-    .DRspDepth  ({2{4'h0}})
+    .N            (2),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({2{1'b1}}),
+    .DRspPass     ({2{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({2{4'h0}}),
+    .DRspDepth    ({2{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -98,15 +98,16 @@ module flash_ctrl_core_reg_top (
 
   // Create Socket_1n
   tlul_socket_1n #(
-    .N          (3),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({3{1'b1}}),
-    .DRspPass   ({3{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({3{4'h0}}),
-    .DRspDepth  ({3{4'h0}})
+    .N            (3),
+    .HReqPass     (1'b1),
+    .HRspPass     (1'b1),
+    .DReqPass     ({3{1'b1}}),
+    .DRspPass     ({3{1'b1}}),
+    .HReqDepth    (4'h0),
+    .HRspDepth    (4'h0),
+    .DReqDepth    ({3{4'h0}}),
+    .DRspDepth    ({3{4'h0}}),
+    .ExplicitErrs (1'b0)
   ) u_socket (
     .clk_i  (clk_i),
     .rst_ni (rst_ni),

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_mem_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_mem_reg_top.sv
@@ -54,43 +54,8 @@ module flash_ctrl_mem_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
-    .clk_i  (clk_i),
-    .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
-  );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_prim_reg_top.sv
@@ -54,43 +54,8 @@ module flash_ctrl_prim_reg_top (
     .tl_o(tl_o)
   );
 
-  tlul_pkg::tl_h2d_t tl_socket_h2d [0];
-  tlul_pkg::tl_d2h_t tl_socket_d2h [0];
-
-  logic [0:0] reg_steer;
-
-  // socket_1n connection
-
-  // Create Socket_1n
-  tlul_socket_1n #(
-    .N          (0),
-    .HReqPass   (1'b1),
-    .HRspPass   (1'b1),
-    .DReqPass   ({0{1'b1}}),
-    .DRspPass   ({0{1'b1}}),
-    .HReqDepth  (4'h0),
-    .HRspDepth  (4'h0),
-    .DReqDepth  ({0{4'h0}}),
-    .DRspDepth  ({0{4'h0}})
-  ) u_socket (
-    .clk_i  (clk_i),
-    .rst_ni (rst_ni),
-    .tl_h_i (tl_i),
-    .tl_h_o (tl_o_pre),
-    .tl_d_o (tl_socket_h2d),
-    .tl_d_i (tl_socket_d2h),
-    .dev_select_i (reg_steer)
-  );
-
-  // Create steering logic
-  always_comb begin
-    reg_steer = -1;       // Default set to register
-
-    // TODO: Can below codes be unique case () inside ?
-    if (intg_err) begin
-      reg_steer = -1;
-    end
-  end
+  assign tl_reg_h2d = tl_i;
+  assign tl_o_pre   = tl_reg_d2h;
 
   // Unused signal tieoff
   // devmode_i is not used if there are no registers


### PR DESCRIPTION
The first patch is a bugfix.

The later patches only have any effect when the number of devices happens to be a power of 2. The xbar code explicitly needs the error responder functionality. No other use of the module does.

For now, we hide the changes behind a parameter. Once things have bedded down, it might make sense to rip the error responder out of the socket entirely and instantiate it explicitly in the crossbar.

Prompted by discussion at #9462.