### PR TITLE
[otbn, rtl] Asserts to conform with X usage guidance

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -969,6 +969,9 @@ module otbn
   `ASSERT_KNOWN(EdnUrndOKnown_A, edn_urnd_o, clk_edn_i, !rst_edn_ni)
   `ASSERT_KNOWN(OtbnOtpKeyO_A, otbn_otp_key_o, clk_otp_i, !rst_otp_ni)
 
+  // Incoming key must be valid (other inputs go via prim modules that handle the X checks).
+  `ASSERT_KNOWN(KeyMgrKeyValid_A, keymgr_key_i.valid)
+
   // In locked state, the readable registers INSN_CNT, IMEM, and DMEM are expected to always read 0
   // when accessed from the bus. For INSN_CNT, we use "|=>" so that the assertion lines up with
   // "status.q" (a signal that isn't directly accessible here).

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -657,4 +657,9 @@ module otbn_core
   // Keep the EDN requests active until they are acknowledged.
   `ASSERT(EdnRndReqStable_A, edn_rnd_req_o & ~edn_rnd_ack_i |=> edn_rnd_req_o)
   `ASSERT(EdnUrndReqStable_A, edn_urnd_req_o & ~edn_urnd_ack_i |=> edn_urnd_req_o)
+
+  `ASSERT(OnlyWriteLoadDataBaseWhenDMemValid_A,
+    rf_bignum_wr_en_ctrl & insn_dec_bignum.rf_wdata_sel == RfWdSelLsu |-> dmem_rvalid_i)
+  `ASSERT(OnlyWriteLoadDataBignumWhenDMemValid_A,
+    rf_base_wr_en_ctrl & insn_dec_base.rf_wdata_sel == RfWdSelLsu |-> dmem_rvalid_i)
 endmodule

--- a/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
+++ b/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
@@ -142,4 +142,5 @@ module otbn_instruction_fetch
   // We should always get prefetches correct, the check exists as an integrity check only
   `ASSERT(NoAddressMismatch,
           imem_rvalid_i && insn_fetch_req_valid_i |-> insn_fetch_req_addr_i == insn_prefetch_addr)
+  `ASSERT(FetchEnOnlyIfValidIMem, insn_fetch_en |-> imem_rvalid_i)
 endmodule


### PR DESCRIPTION
The style guide recommends adding asserts where valid signals are used
to ensure actions they ultimately cause are only happening when the
valids are asserted.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>