### PR TITLE
[rom_ctrl] Fix ECC generation in testbench and pass through integrity data properly

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
@@ -100,7 +100,7 @@ virtual function void rom_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:
     // Calculate the scrambled data
     wdata_arr = {<<{integ_data}};
     wdata_arr = sram_scrambler_pkg::encrypt_sram_data(
-        wdata_arr, 39, 0, rom_addr, addr_width, key_arr, nonce_arr
+        wdata_arr, 39, 39, rom_addr, addr_width, key_arr, nonce_arr
     );
     scrambled_data = {<<{wdata_arr}};
   end

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -161,6 +161,7 @@
           name: "ROM"
           items: "8192" // 32 KiB
           swaccess: "ro",
+          data-intg-passthru: "true",
           desc: '''ROM data'''
         }
       }

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_rom_reg_top.sv
@@ -37,7 +37,7 @@ module rom_ctrl_rom_reg_top (
   tlul_pkg::tl_d2h_t tl_o_pre;
   tlul_rsp_intg_gen #(
     .EnableRspIntgGen(1),
-    .EnableDataIntgGen(1)
+    .EnableDataIntgGen(0)
   ) u_rsp_intg_gen (
     .tl_i(tl_o_pre),
     .tl_o(tl_o)

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6354,6 +6354,7 @@
           exec: True
           byte_write: False
           size: 0x8000
+          data_intg_passthru: True
         }
       }
       param_decl:

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -657,11 +657,12 @@
       base_addrs: {rom: "0x00008000", regs: "0x411e0000"}
       memory: {
         rom: {
-          label:      "rom",
-          swaccess:   "ro",
-          exec:       "True",
-          byte_write: "False",
-          size:       "0x8000"
+          label:              "rom",
+          swaccess:           "ro",
+          exec:               "True",
+          byte_write:         "False",
+          size:               "0x8000"
+          data_intg_passthru: "True"
         }
       },
       param_decl: {

--- a/util/topgen/validate.py
+++ b/util/topgen/validate.py
@@ -216,6 +216,10 @@ memory_optional = {
     'size': ['d', 'memory region size in bytes for the linker script, '
                   'xbar and RTL parameterisations'],
     'config': ['d', 'Extra configuration for a particular memory'],
+    'data_intg_passthru': [
+        'pb',
+        'Integrity bits are passed through directly from the memory'
+    ]
 }
 
 memory_added = {


### PR DESCRIPTION
The first two commits fix the DV side (ensuring that the data is randomized in a way that gives valid ECC checksums). This is needed because the smoke test expects those ECC checksums to be valid in TL transactions, but (as of the 3rd commit) we're now passing through whatever was stored in the ROM.

Fixes #9536.