### PR TITLE
[dv/clkmgr] Prepare for V2

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -94,27 +94,26 @@
 
             - External clock is enabled if the `lc_clk_byp_req_i` input from
               `lc_ctrl` is `lc_ctrl_pkg::On`.
-            - External clock is also be enabled when CSR `extclk_sel` is set to
+            - External clock is also be enabled when CSR `extclk_ctrl.sel` is
+              set to
               `lc_ctrl_pkg::On` and the `lc_dtl_en_i` input from `lc_ctrl` is
               `lc_ctrl_pkg::On`.
-            - Notice writes to the `extclk_sel` register are ignored unless the
-              CSR `extclk_sel_regwen` is 1.
+            - Notice writes to the `extclk_ctrl.sel` register are ignored unless
+              the CSR `extclk_ctrl_regwen` is 1.
             - A successful switch to external clocks due to `lc_clk_byl_req_i`
               will cause the clkmgr to undo a divide by 2 for io_div4 and
               io_div2 clocks except when `(scanmode_i == lc_ctrl_pkg::On)`.
             - A software triggered switch to external clock will undo divides
-              by 2 if `extclk_ctrl.step_down` is set to `lc_ctrl_pkg::On`.
+              by 2 if `extclk_ctrl.low_speed_sel` is set to `lc_ctrl_pkg::On`.
 
             **Stimulus**:
-            - CSR writes to `extclk_sel` and `extclk_sel_regwen`.
-            - Setting `lc_dft_en_i`, `lc_clk_byp_req_i`, and the handshake to
+            - CSR writes to `extclk_ctrl` and `extclk_ctrl_regwen`.
+            - Setting `lc_hw_debug_en_i`, `lc_clk_byp_req_i`, and the handshake to
               ast via `ast_clk_byp_req_o` and `ast_clk_byp_ack_i`.
             - Setting `scanmode_i`.
 
             **Checks**:
-            Clock divider checks: since `scanmode_i` is asynchronous, the checks
-            are performed in behavioral code in the scoreboard; SVA assertions
-            will be added, conditioned on scanmode being off.
+            Clock divider checks are done with SVA assertions.
             - When the external clock is selected (and not defeated by
               `scanmode_i` for scoreboard checks):
               - The `clk_io_div2_powerup` output matches the `clk_io_powerup`
@@ -143,22 +142,17 @@
     {
       name: clk_status
       desc: '''
-            This tests the `pwr_o.clk_status` output port.
+            This tests the three `pwr_o.<clk>_status` output ports, for the
+            `io`, `main`, and `usb` clocks.
 
-            The `pwr_o.clk_status` output must track the `pwr_i.ip_clk_en`
-            input once the clock outputs are enabled when ip_clk_en is active,
-            or disabled when ip_clk_en goes inactive.
+            The `pwr_o.<clk>_status` output must track the correspponding
+            `pwr_i.<clk>_ip_clk_en` input.
 
             **Stimulus**:
-            - Randomize the `pwr_i.ip_clk_en` setting.
-            - Randomize the various pwrmgr clock controls per settings in
-              the pwrmgr `control` CSR.
-            - This will trigger cases where the usb clock is inactive with
-              `ip_clk_en` enabled.
+            - Randomize the `pwr_i.<clk>_ip_clk_en` setting for each clock.
 
             **Check**:
-            - The sequence checks that `pwr_o.clk_status` tracks
-              `pwr_i.ip_clk_en`.
+            - The checks are done in SVA at `clkmbf_pwrmgr_sva_if.sv`.
             '''
       milestone: V2
       tests: ["clkmgr_clk_status"]
@@ -270,14 +264,8 @@
             Collects coverage for the external clock selection.
 
             The external clock selection depends on the `extclk_sel` CSR,
-            and the `lc_dft_en_i`, `lc_clk_byp_req_i`, and `scanmode_i`
+            and the `lc_hw_debug_en_i`, `lc_clk_byp_req_i`, and `scanmode_i`
             input pins. This covergroup collects their cross.
-            '''
-    }
-    {
-      name: jitter_cg
-      desc: '''
-            Collects coverage of the `jitter` CSR.
             '''
     }
     {

--- a/hw/ip/clkmgr/doc/checklist.md
+++ b/hw/ip/clkmgr/doc/checklist.md
@@ -173,21 +173,21 @@ Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Not Started |
-Documentation | [DV_DOC_COMPLETED][]                    | Not Started |
-Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Not Started |
-Testbench     | [ALL_INTERFACES_EXERCISED][]            | Not Started |
-Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Not Started |
-Testbench     | [SIM_TB_ENV_COMPLETED][]                | Not Started |
-Tests         | [SIM_ALL_TESTS_PASSING][]               | Not Started |
-Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | Not Started |
-Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | Not Started |
-Tests         | [SIM_FW_SIMULATED][]                    | Not Started |
-Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Not Started |
-Coverage      | [SIM_CODE_COVERAGE_V2][]                | Not Started |
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Not Started |
-Coverage      | [FPV_CODE_COVERAGE_V2][]                | Not Started |
-Coverage      | [FPV_COI_COVERAGE_V2][]                 | Not Started |
+Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Done        |
+Documentation | [DV_DOC_COMPLETED][]                    | Done        |
+Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
+Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        |
+Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
+Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
+Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |
+Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | NA          |
+Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | NA          |
+Tests         | [SIM_FW_SIMULATED][]                    | Done        |
+Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
+Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        |
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
+Coverage      | [FPV_CODE_COVERAGE_V2][]                | NA          |
+Coverage      | [FPV_COI_COVERAGE_V2][]                 | NA          |
 Code Quality  | [TB_LINT_PASS][]                        | Not Started |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | Not Started |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Not Started |

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -29,6 +29,9 @@ package clkmgr_env_pkg;
   localparam int NUM_PERI = 4;
   localparam int NUM_TRANS = 5;
 
+  typedef logic [NUM_PERI-1:0] peri_enables_t;
+  typedef logic [NUM_TRANS-1:0] hintables_t;
+
   localparam int MainClkHz = 100_000_000;
   localparam int IoClkHz = 96_000_000;
   localparam int UsbClkHz = 48_000_000;

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -38,6 +38,7 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
       monitor_jitter_en();
       sample_peri_covs();
       sample_trans_covs();
+      sample_freq_measurement_covs();
     join_none
   endtask
 
@@ -179,12 +180,65 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
   endtask
 
   task sample_trans_covs();
-    for (int i = 0; i < NUM_TRANS; ++i) begin
+    for (int i = 0; i < $bits(hintables_t); ++i) begin
       fork
         automatic int trans_index = i;
         sample_trans_cov(trans_index);
       join_none
     end
+  endtask
+
+  task sample_freq_measurement_covs();
+    fork
+      forever
+        @(posedge cfg.clkmgr_vif.io_freq_measurement.valid) begin
+          if (cfg.en_cov) begin
+            cov.freq_measure_cg_wrap[ClkMesrIo].sample(
+                !cfg.clkmgr_vif.io_freq_measurement.slow &&
+                !cfg.clkmgr_vif.io_freq_measurement.fast,
+                cfg.clkmgr_vif.io_freq_measurement.slow, cfg.clkmgr_vif.io_freq_measurement.fast);
+          end
+        end
+      forever
+        @(posedge cfg.clkmgr_vif.io_div2_freq_measurement.valid) begin
+          if (cfg.en_cov) begin
+            cov.freq_measure_cg_wrap[ClkMesrIoDiv2].sample(
+                !cfg.clkmgr_vif.io_div2_freq_measurement.slow &&
+                !cfg.clkmgr_vif.io_div2_freq_measurement.fast,
+                cfg.clkmgr_vif.io_div2_freq_measurement.slow,
+                cfg.clkmgr_vif.io_div2_freq_measurement.fast);
+          end
+        end
+      forever
+        @(posedge cfg.clkmgr_vif.io_div4_freq_measurement.valid) begin
+          if (cfg.en_cov) begin
+            cov.freq_measure_cg_wrap[ClkMesrIoDiv4].sample(
+                !cfg.clkmgr_vif.io_div4_freq_measurement.slow &&
+                !cfg.clkmgr_vif.io_div4_freq_measurement.fast,
+                cfg.clkmgr_vif.io_div4_freq_measurement.slow,
+                cfg.clkmgr_vif.io_div4_freq_measurement.fast);
+          end
+        end
+      forever
+        @(posedge cfg.clkmgr_vif.main_freq_measurement.valid) begin
+          if (cfg.en_cov) begin
+            cov.freq_measure_cg_wrap[ClkMesrMain].sample(
+                !cfg.clkmgr_vif.main_freq_measurement.slow &&
+                !cfg.clkmgr_vif.main_freq_measurement.fast,
+                cfg.clkmgr_vif.main_freq_measurement.slow,
+                cfg.clkmgr_vif.main_freq_measurement.fast);
+          end
+        end
+      forever
+        @(posedge cfg.clkmgr_vif.usb_freq_measurement.valid) begin
+          if (cfg.en_cov) begin
+            cov.freq_measure_cg_wrap[ClkMesrUsb].sample(
+                !cfg.clkmgr_vif.usb_freq_measurement.slow &&
+                !cfg.clkmgr_vif.usb_freq_measurement.fast,
+                cfg.clkmgr_vif.usb_freq_measurement.slow, cfg.clkmgr_vif.usb_freq_measurement.fast);
+          end
+        end
+    join_none
   endtask
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
@@ -266,29 +320,14 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         if (addr_phase_write) measure_ctrl_regwen = item.a_data;
       end
       "io_measure_ctrl": begin
-        if (cfg.en_cov) begin
-          // TODO(maturana) Insert coverage.
-        end
       end
       "io_div2_measure_ctrl": begin
-        if (cfg.en_cov) begin
-          // TODO(maturana) Insert coverage.
-        end
       end
       "io_div4_measure_ctrl": begin
-        if (cfg.en_cov) begin
-          // TODO(maturana) Insert coverage.
-        end
       end
       "main_measure_ctrl": begin
-        if (cfg.en_cov) begin
-          // TODO(maturana) Insert coverage.
-        end
       end
       "usb_measure_ctrl": begin
-        if (cfg.en_cov) begin
-          // TODO(maturana) Insert coverage.
-        end
       end
       "recov_err_code": begin
         do_read_check = 1'b0;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -28,7 +28,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   rand bit                 main_ip_clk_en;
   rand bit                 usb_ip_clk_en;
 
-  rand bit [NUM_TRANS-1:0] idle;
+  rand hintables_t       idle;
 
   mubi4_t                  scanmode;
   int                      scanmode_on_weight         = 8;
@@ -82,7 +82,6 @@ class clkmgr_base_vseq extends cip_base_vseq #(
 
   virtual task dut_shutdown();
     // check for pending clkmgr operations and wait for them to complete
-    // TODO
   endtask
 
   task start_aon_clk();
@@ -112,6 +111,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     end else begin
       cfg.io_clk_rst_vif.start_clk();
       cfg.clkmgr_vif.pwr_i.io_ip_clk_en = io_ip_clk_en;
+      // There is a check that the RTL generates in a bounded number of cycles, so if this posedge
+      // never occurs we wont timeout.
       @(posedge cfg.clkmgr_vif.pwr_o.io_status);
     end
     `uvm_info(`gfn, "controlling io clock done", UVM_LOW)

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
@@ -13,8 +13,11 @@ class clkmgr_clk_status_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
-  // And disable scanmode since it is not interesting.
-  constraint scanmode_c {scanmode == lc_ctrl_pkg::Off;}
+  function void post_randomize();
+    super.post_randomize();
+    // Disable scanmode since it is not interesting.
+    scanmode = prim_mubi_pkg::MuBi4False;
+  endfunction
 
   task body();
     update_csrs_with_reset_values();

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -11,10 +11,11 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
 
   // This is measured in aon clocks, and is pretty tight.
   localparam int CyclesToGetOneMeasurement = 2;
-  // This is measured in clkmgr clk_i clocks. It is set to cover worse case delays.
+
+  // This is measured in clkmgr clk_i clocks. It is set to cover worst case delays.
   // The clk_i frequency is randomized for IPs, but the clkmgr is hooked to io_div4, which would
-  // allow a tighter number of cycles.
-  // TODO(maturana) Connect clkmgr's clk_i to the powerup io_div4 clock, as is in the chip.
+  // allow a tighter number of cycles. Leaving the clk_i random probably provides more cases,
+  // so leaving it as is.
   localparam int CyclesForErrUpdate = 16;
 
   // The min ands max offsets from the expected counts. Notice the count occasionally matches

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -11,7 +11,7 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
-  rand logic [NUM_PERI-1:0] initial_enables;
+  rand peri_enables_t initial_enables;
 
   // The clk_enables CSR cannot be manipulated in low power mode.
   constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
@@ -21,7 +21,7 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
   task body();
     update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
-      logic [NUM_PERI-1:0] flipped_enables;
+      peri_enables_t flipped_enables;
       `DV_CHECK_RANDOMIZE_FATAL(this)
       cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode));
       control_ip_clocks();

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -37,8 +37,8 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
   // via assertions in clkmgr_if.sv and behavioral code in the scoreboard.
   task test_peri_clocks();
     // Flip all bits of clk_enables.
-    logic [NUM_PERI-1:0] value = ral.clk_enables.get();
-    logic [NUM_PERI-1:0] flipped_value;
+    peri_enables_t value = ral.clk_enables.get();
+    peri_enables_t flipped_value;
     csr_rd(.ptr(ral.clk_enables), .value(value));
     flipped_value = value ^ ((1 << ral.clk_enables.get_n_bits()) - 1);
     csr_wr(.ptr(ral.clk_enables), .value(flipped_value));
@@ -57,7 +57,7 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
     trans_e trans;
     logic bit_value;
     logic [TL_DW-1:0] value;
-    logic [NUM_TRANS-1:0] idle;
+    hintables_t idle;
     typedef struct {
       trans_e unit;
       uvm_reg_field hint_bit;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -17,7 +17,7 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
-  rand bit [NUM_TRANS-1:0] initial_hints;
+  rand hintables_t initial_hints;
 
   // The clk_hints CSR cannot be manipulated in low power mode.
   constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
@@ -28,7 +28,7 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
     update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
       logic bit_value;
-      logic [NUM_TRANS-1:0] value;
+      hintables_t value;
 
       `DV_CHECK_RANDOMIZE_FATAL(this)
       cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode));


### PR DESCRIPTION
Add frequency measurement covergroups.
Update the dv documentation and checklist.
Fix clkmgr_clk_status_vseq constraint.

Signed-off-by: Guillermo Maturana <maturana@google.com>