### PR TITLE
[lc_ctrl/dv] Added state failure test

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -85,7 +85,7 @@
             - Check if lc_state moves to escalation state.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_state_failure"]
     }
     {
       name: lc_errors

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
@@ -13,6 +13,7 @@ package lc_ctrl_dv_utils_pkg;
   import otp_ctrl_pkg::*;
 
   // associative array cannot declare parameter here, so we used const instead
+  // verilog_format: off - avoid bad formatting
   const dec_lc_state_e VALID_NEXT_STATES [dec_lc_state_e][$] = '{
     DecLcStRma:     {DecLcStScrap},
     DecLcStProdEnd: {DecLcStScrap},
@@ -63,6 +64,32 @@ package lc_ctrl_dv_utils_pkg;
   };
 
 
+  // All valid decoded states as int
+  const int ValidDecodedStates[] = '{
+    int'(DecLcStRaw),
+    int'(DecLcStTestUnlocked0),
+    int'(DecLcStTestLocked0),
+    int'(DecLcStTestUnlocked1),
+    int'(DecLcStTestLocked1),
+    int'(DecLcStTestUnlocked2),
+    int'(DecLcStTestLocked2),
+    int'(DecLcStTestUnlocked3),
+    int'(DecLcStTestLocked3),
+    int'(DecLcStTestUnlocked4),
+    int'(DecLcStTestLocked4),
+    int'(DecLcStTestUnlocked5),
+    int'(DecLcStTestLocked5),
+    int'(DecLcStTestUnlocked6),
+    int'(DecLcStTestLocked6),
+    int'(DecLcStTestUnlocked7),
+    int'(DecLcStDev),
+    int'(DecLcStProd),
+    int'(DecLcStProdEnd),
+    int'(DecLcStRma),
+    int'(DecLcStScrap),
+    int'(DecLcStInvalid)
+  };
+
   // Checks whether the current state is a test unlocked state within the given index range.
   function automatic bit is_test_unlocked_state(dec_lc_state_e curr_state, int first, int last);
   begin
@@ -99,6 +126,7 @@ package lc_ctrl_dv_utils_pkg;
     endcase
   end
   endfunction
+  // verilog_format: on
 
   function automatic dec_lc_state_e dec_lc_state(lc_state_e curr_state);
     case (curr_state)
@@ -123,66 +151,271 @@ package lc_ctrl_dv_utils_pkg;
       LcStProdEnd:       return DecLcStProdEnd;
       LcStRma:           return DecLcStRma;
       LcStScrap:         return DecLcStScrap;
-      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_state 0x%0h", curr_state))
+      default:           return DecLcStInvalid;
     endcase
   endfunction
 
   function automatic lc_state_e encode_lc_state(dec_lc_state_e curr_state);
     case (curr_state)
-      DecLcStRaw:           return LcStRaw;
+      DecLcStRaw: return LcStRaw;
       DecLcStTestUnlocked0: return LcStTestUnlocked0;
-      DecLcStTestLocked0:   return LcStTestLocked0;
+      DecLcStTestLocked0: return LcStTestLocked0;
       DecLcStTestUnlocked1: return LcStTestUnlocked1;
-      DecLcStTestLocked1:   return LcStTestLocked1;
+      DecLcStTestLocked1: return LcStTestLocked1;
       DecLcStTestUnlocked2: return LcStTestUnlocked2;
-      DecLcStTestLocked2:   return LcStTestLocked2;
+      DecLcStTestLocked2: return LcStTestLocked2;
       DecLcStTestUnlocked3: return LcStTestUnlocked3;
-      DecLcStTestLocked3:   return LcStTestLocked3;
+      DecLcStTestLocked3: return LcStTestLocked3;
       DecLcStTestUnlocked4: return LcStTestUnlocked4;
-      DecLcStTestLocked4:   return LcStTestLocked4;
+      DecLcStTestLocked4: return LcStTestLocked4;
       DecLcStTestUnlocked5: return LcStTestUnlocked5;
-      DecLcStTestLocked5:   return LcStTestLocked5;
+      DecLcStTestLocked5: return LcStTestLocked5;
       DecLcStTestUnlocked6: return LcStTestUnlocked6;
-      DecLcStTestLocked6:   return LcStTestLocked6;
+      DecLcStTestLocked6: return LcStTestLocked6;
       DecLcStTestUnlocked7: return LcStTestUnlocked7;
-      DecLcStDev:           return LcStDev;
-      DecLcStProd:          return LcStProd;
-      DecLcStProdEnd:       return LcStProdEnd;
-      DecLcStRma:           return LcStRma;
-      DecLcStScrap:         return LcStScrap;
+      DecLcStDev: return LcStDev;
+      DecLcStProd: return LcStProd;
+      DecLcStProdEnd: return LcStProdEnd;
+      DecLcStRma: return LcStRma;
+      DecLcStScrap: return LcStScrap;
       default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_state 0x%0h", curr_state))
     endcase
   endfunction
 
   function automatic int dec_lc_cnt(lc_cnt_e curr_cnt);
     case (curr_cnt)
-      LcCnt0  : return 0;
-      LcCnt1  : return 1;
-      LcCnt2  : return 2;
-      LcCnt3  : return 3;
-      LcCnt4  : return 4;
-      LcCnt5  : return 5;
-      LcCnt6  : return 6;
-      LcCnt7  : return 7;
-      LcCnt8  : return 8;
-      LcCnt9  : return 9;
-      LcCnt10 : return 10;
-      LcCnt11 : return 11;
-      LcCnt12 : return 12;
-      LcCnt13 : return 13;
-      LcCnt14 : return 14;
-      LcCnt15 : return 15;
-      LcCnt16 : return 16;
-      LcCnt17 : return 17;
-      LcCnt18 : return 18;
-      LcCnt19 : return 19;
-      LcCnt20 : return 20;
-      LcCnt21 : return 21;
-      LcCnt22 : return 22;
-      LcCnt23 : return 23;
-      LcCnt24 : return 24;
+      LcCnt0:  return 0;
+      LcCnt1:  return 1;
+      LcCnt2:  return 2;
+      LcCnt3:  return 3;
+      LcCnt4:  return 4;
+      LcCnt5:  return 5;
+      LcCnt6:  return 6;
+      LcCnt7:  return 7;
+      LcCnt8:  return 8;
+      LcCnt9:  return 9;
+      LcCnt10: return 10;
+      LcCnt11: return 11;
+      LcCnt12: return 12;
+      LcCnt13: return 13;
+      LcCnt14: return 14;
+      LcCnt15: return 15;
+      LcCnt16: return 16;
+      LcCnt17: return 17;
+      LcCnt18: return 18;
+      LcCnt19: return 19;
+      LcCnt20: return 20;
+      LcCnt21: return 21;
+      LcCnt22: return 22;
+      LcCnt23: return 23;
+      LcCnt24: return 24;
       default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_cnt 0x%0h", curr_cnt))
     endcase
   endfunction
+
+  // Arrays of digit values
+  parameter bit [15:0] A_VALUES[20] = '{
+      lc_ctrl_state_pkg::A0,
+      lc_ctrl_state_pkg::A1,
+      lc_ctrl_state_pkg::A2,
+      lc_ctrl_state_pkg::A3,
+      lc_ctrl_state_pkg::A4,
+      lc_ctrl_state_pkg::A5,
+      lc_ctrl_state_pkg::A6,
+      lc_ctrl_state_pkg::A7,
+      lc_ctrl_state_pkg::A8,
+      lc_ctrl_state_pkg::A9,
+      lc_ctrl_state_pkg::A10,
+      lc_ctrl_state_pkg::A11,
+      lc_ctrl_state_pkg::A12,
+      lc_ctrl_state_pkg::A13,
+      lc_ctrl_state_pkg::A14,
+      lc_ctrl_state_pkg::A15,
+      lc_ctrl_state_pkg::A16,
+      lc_ctrl_state_pkg::A17,
+      lc_ctrl_state_pkg::A18,
+      lc_ctrl_state_pkg::A19
+  };
+
+  parameter bit [15:0] B_VALUES[20] = '{
+      lc_ctrl_state_pkg::B0,
+      lc_ctrl_state_pkg::B1,
+      lc_ctrl_state_pkg::B2,
+      lc_ctrl_state_pkg::B3,
+      lc_ctrl_state_pkg::B4,
+      lc_ctrl_state_pkg::B5,
+      lc_ctrl_state_pkg::B6,
+      lc_ctrl_state_pkg::B7,
+      lc_ctrl_state_pkg::B8,
+      lc_ctrl_state_pkg::B9,
+      lc_ctrl_state_pkg::B10,
+      lc_ctrl_state_pkg::B11,
+      lc_ctrl_state_pkg::B12,
+      lc_ctrl_state_pkg::B13,
+      lc_ctrl_state_pkg::B14,
+      lc_ctrl_state_pkg::B15,
+      lc_ctrl_state_pkg::B16,
+      lc_ctrl_state_pkg::B17,
+      lc_ctrl_state_pkg::B18,
+      lc_ctrl_state_pkg::B19
+  };
+
+  parameter bit [15:0] C_VALUES[24] = '{
+      lc_ctrl_state_pkg::C0,
+      lc_ctrl_state_pkg::C1,
+      lc_ctrl_state_pkg::C2,
+      lc_ctrl_state_pkg::C3,
+      lc_ctrl_state_pkg::C4,
+      lc_ctrl_state_pkg::C5,
+      lc_ctrl_state_pkg::C6,
+      lc_ctrl_state_pkg::C7,
+      lc_ctrl_state_pkg::C8,
+      lc_ctrl_state_pkg::C9,
+      lc_ctrl_state_pkg::C10,
+      lc_ctrl_state_pkg::C11,
+      lc_ctrl_state_pkg::C12,
+      lc_ctrl_state_pkg::C13,
+      lc_ctrl_state_pkg::C14,
+      lc_ctrl_state_pkg::C15,
+      lc_ctrl_state_pkg::C16,
+      lc_ctrl_state_pkg::C17,
+      lc_ctrl_state_pkg::C18,
+      lc_ctrl_state_pkg::C19,
+      lc_ctrl_state_pkg::C20,
+      lc_ctrl_state_pkg::C21,
+      lc_ctrl_state_pkg::C22,
+      lc_ctrl_state_pkg::C23
+  };
+
+  parameter bit [15:0] D_VALUES[24] = '{
+      lc_ctrl_state_pkg::D0,
+      lc_ctrl_state_pkg::D1,
+      lc_ctrl_state_pkg::D2,
+      lc_ctrl_state_pkg::D3,
+      lc_ctrl_state_pkg::D4,
+      lc_ctrl_state_pkg::D5,
+      lc_ctrl_state_pkg::D6,
+      lc_ctrl_state_pkg::D7,
+      lc_ctrl_state_pkg::D8,
+      lc_ctrl_state_pkg::D9,
+      lc_ctrl_state_pkg::D10,
+      lc_ctrl_state_pkg::D11,
+      lc_ctrl_state_pkg::D12,
+      lc_ctrl_state_pkg::D13,
+      lc_ctrl_state_pkg::D14,
+      lc_ctrl_state_pkg::D15,
+      lc_ctrl_state_pkg::D16,
+      lc_ctrl_state_pkg::D17,
+      lc_ctrl_state_pkg::D18,
+      lc_ctrl_state_pkg::D19,
+      lc_ctrl_state_pkg::D20,
+      lc_ctrl_state_pkg::D21,
+      lc_ctrl_state_pkg::D22,
+      lc_ctrl_state_pkg::D23
+  };
+
+  // Binary representation of state and count types
+  typedef bit [NumLcStateValues - 1 : 0] lc_state_bin_t;
+  typedef bit [NumLcCountValues - 1 : 0] lc_count_bin_t;
+
+
+
+  //Convert an lc_state to a binary representation 0=Axx 1=Bxx
+  function static lc_state_bin_t lc_state_to_bin(bit [LcStateWidth-1:0] val);
+    lc_state_to_bin = 0;
+    for (int i = 0; i < $size(A_VALUES); i++) begin
+      if (val[i*16+:16] == A_VALUES[i]) begin
+        lc_state_to_bin[i] = 0;
+      end else if (val[i*16+:16] == B_VALUES[i]) begin
+        lc_state_to_bin[i] = 1;
+      end else begin
+        $fatal(0, "lc_ctrl_dv_utils_pkg lc_state_to_bin: state %x not valid", val);
+      end
+    end
+  endfunction
+
+  //Convert a binary representation to a lc_state representation 0=Axx 1=Bxx
+  function static bit [LcStateWidth-1:0] bin_to_lc_state(lc_state_bin_t val);
+    bin_to_lc_state = 0;
+    for (int i = 0; i < $size(A_VALUES); i++) begin
+      bin_to_lc_state[i*16+:16] = val[i] ? B_VALUES[i] : A_VALUES[i];
+    end
+  endfunction
+
+  //Convert an lc_count to a binary representation 0=Cxx 1=Dxx
+  function static lc_count_bin_t lc_count_to_bin(bit [LcCountWidth-1:0] val);
+    lc_count_to_bin = 0;
+    for (int i = 0; i < $size(C_VALUES); i++) begin
+      if (val[i*16+:16] == C_VALUES[i]) begin
+        lc_count_to_bin[i] = 0;
+      end else if (val[i*16+:16] == D_VALUES[i]) begin
+        lc_count_to_bin[i] = 1;
+      end else begin
+        $fatal(0, "lc_ctrl_dv_utils_pkg lc_count_to_bin: count %x not valid", val);
+      end
+    end
+  endfunction
+
+  //Convert a binary representation to a lc_count representation 0=Cxx 1=Cxx
+  function static bit [LcCountWidth-1:0] bin_to_lc_count(lc_count_bin_t val);
+    bin_to_lc_count = 0;
+    for (int i = 0; i < $size(A_VALUES); i++) begin
+      bin_to_lc_count[i*16+:16] = val[i] ? B_VALUES[i] : A_VALUES[i];
+    end
+  endfunction
+
+  // Array of valid LC states in binary representation
+  parameter lc_state_bin_t ValidLcStatesBin[NumLcStates] = '{
+      lc_state_to_bin(LcStRaw),
+      lc_state_to_bin(LcStTestUnlocked0),
+      lc_state_to_bin(LcStTestLocked0),
+      lc_state_to_bin(LcStTestUnlocked1),
+      lc_state_to_bin(LcStTestLocked1),
+      lc_state_to_bin(LcStTestUnlocked2),
+      lc_state_to_bin(LcStTestLocked2),
+      lc_state_to_bin(LcStTestUnlocked3),
+      lc_state_to_bin(LcStTestLocked3),
+      lc_state_to_bin(LcStTestUnlocked4),
+      lc_state_to_bin(LcStTestLocked4),
+      lc_state_to_bin(LcStTestUnlocked5),
+      lc_state_to_bin(LcStTestLocked5),
+      lc_state_to_bin(LcStTestUnlocked6),
+      lc_state_to_bin(LcStTestLocked6),
+      lc_state_to_bin(LcStTestUnlocked7),
+      lc_state_to_bin(LcStDev),
+      lc_state_to_bin(LcStProd),
+      lc_state_to_bin(LcStProdEnd),
+      lc_state_to_bin(LcStRma),
+      lc_state_to_bin(LcStScrap)
+  };
+
+  // Array of valid LC states in binary representation
+  parameter lc_count_bin_t ValidLcCountsBin[NumLcCountStates] = '{
+      lc_count_to_bin(LcCnt0),
+      lc_count_to_bin(LcCnt1),
+      lc_count_to_bin(LcCnt2),
+      lc_count_to_bin(LcCnt3),
+      lc_count_to_bin(LcCnt4),
+      lc_count_to_bin(LcCnt5),
+      lc_count_to_bin(LcCnt6),
+      lc_count_to_bin(LcCnt7),
+      lc_count_to_bin(LcCnt8),
+      lc_count_to_bin(LcCnt9),
+      lc_count_to_bin(LcCnt10),
+      lc_count_to_bin(LcCnt11),
+      lc_count_to_bin(LcCnt12),
+      lc_count_to_bin(LcCnt13),
+      lc_count_to_bin(LcCnt14),
+      lc_count_to_bin(LcCnt15),
+      lc_count_to_bin(LcCnt16),
+      lc_count_to_bin(LcCnt17),
+      lc_count_to_bin(LcCnt18),
+      lc_count_to_bin(LcCnt19),
+      lc_count_to_bin(LcCnt20),
+      lc_count_to_bin(LcCnt21),
+      lc_count_to_bin(LcCnt22),
+      lc_count_to_bin(LcCnt23),
+      lc_count_to_bin(LcCnt24)
+  };
 
 endpackage

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/lc_ctrl_common_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_prog_failure_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_state_failure_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_errors_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -24,6 +24,17 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   // Use JTAG for register accesses
   // TODO: use multiple address maps
   bit jtag_csr;
+  // Error injection configuration
+  lc_ctrl_err_inj_t err_inj;
+
+  // Alert events - these are triggered in the scoreboard
+  event fatal_prog_error_ev;
+  event fatal_state_error_ev;
+  event fatal_bus_integ_error_ev;
+  // Test phase - used to synchronise scoreboard
+  lc_ctrl_test_phase_e test_phase;
+  // Max delay for alerts in clocks
+  uint alert_max_delay;
 
   `uvm_object_utils_begin(lc_ctrl_env_cfg)
   `uvm_object_utils_end
@@ -73,11 +84,20 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
     // Set base address for JTAG map
     ral.set_base_addr(ral.default_map.get_base_addr(), jtag_riscv_map);
 
+    alert_max_delay = 500;
   endfunction
 
   protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
     // Clone the resister map for JTAG
     jtag_riscv_map = clone_reg_map("jtag_riscv_map", ral.default_map);
+  endfunction
+
+  virtual function void set_test_phase(lc_ctrl_test_phase_e test_phase);
+    this.test_phase = test_phase;
+  endfunction
+
+  virtual function lc_ctrl_test_phase_e get_test_phase();
+    return (this.test_phase);
   endfunction
 
   // Use these functions to propagate in_reset to JTAG RISCV agents

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
@@ -8,25 +8,36 @@
  * Covergroups may also be wrapped inside helper classes if needed.
  */
 
-class lc_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(lc_ctrl_env_cfg));
+class lc_ctrl_env_cov extends cip_base_env_cov #(
+  .CFG_T(lc_ctrl_env_cfg)
+);
   `uvm_component_utils(lc_ctrl_env_cov)
 
   // the base class provides the following handles for use:
   // lc_ctrl_env_cfg: cfg
 
   // covergroups
-  // [add covergroups here]
+
+  // State error injections
+  covergroup err_inj_cg;
+    clk_byp_error_rsp_cp: coverpoint cfg.err_inj.clk_byp_error_rsp;
+    flash_rma_error_rsp_cp: coverpoint cfg.err_inj.flash_rma_error_rsp;
+    otp_prog_err_cp: coverpoint cfg.err_inj.otp_prog_err;
+    token_mismatch_err_cp: coverpoint cfg.err_inj.token_mismatch_err;
+    state_err_cp: coverpoint cfg.err_inj.state_err;
+    state_backdoor_err_cp: coverpoint cfg.err_inj.state_backdoor_err;
+    count_err_cp: coverpoint cfg.err_inj.count_err;
+    count_backdoor_err_cp: coverpoint cfg.err_inj.count_backdoor_err;
+    transition_err_cp: coverpoint cfg.err_inj.transition_err;
+  endgroup
 
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // [instantiate covergroups here]
+    err_inj_cg = new();
   endfunction : new
 
-  virtual function void build_phase(uvm_phase phase);
-    super.build_phase(phase);
-    // [or instantiate covergroups here]
-    // Please instantiate sticky_intr_cov array of objects for all interrupts that are sticky
-    // See cip_base_env_cov for details
+  virtual function void sample_cov();
+    err_inj_cg.sample();
   endfunction
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -52,7 +52,37 @@ package lc_ctrl_env_pkg;
     lc_ctrl_pkg::lc_tx_t lc_escalate_en_o;
   } lc_outputs_t;
 
-  // verilog_format: off - avoid bad reformatting
+  // error injection
+  typedef struct packed {
+    bit clk_byp_error_rsp;
+    bit flash_rma_error_rsp;
+    bit otp_prog_err;
+    bit token_mismatch_err;
+    // Invalid state driven via OTP interface
+    bit state_err;
+    // Invalid count driven via OTP interface
+    bit count_err;
+    // Invalid fsm state - via force in lc_ctrl_if
+    bit state_backdoor_err;
+    // Invalid count      - via force in lc_ctrl_if
+    bit count_backdoor_err;
+    bit transition_err;
+  } lc_ctrl_err_inj_t;
+
+  // Test phase - used to synchronise the scoreboard
+  typedef enum {
+    LcCtrlTestInit,
+    LcCtrlIterStart,
+    LcCtrlDutReady,
+    LcCtrlWaitTransition,
+    LcCtrlTransitionComplete,
+    LcCtrlReadState1,
+    LcCtrlEscalate,
+    LcCtrlReadState2,
+    LcCtrlPostStart
+  } lc_ctrl_test_phase_e;
+
+  // verilog_format: off
   const lc_outputs_t EXP_LC_OUTPUTS[NUM_STATES] = {
     // Raw (fixed size array index 0)
     {Off, Off, Off, Off, Off, Off, Off, Off, Off, Off, Off},

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -3,61 +3,81 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // interface for input data from OTP
-interface lc_ctrl_if(input clk, input rst_n);
+
+`ifndef LC_CTRL_FSM_STATE_REGS_PATH
+`define LC_CTRL_FSM_STATE_REGS_PATH \
+    tb.dut.u_lc_ctrl_fsm.u_fsm_state_regs.gen_generic.u_impl_generic.d_i
+`endif
+
+`ifndef LC_CTRL_FSM_COUNT_REGS_PATH
+`define LC_CTRL_FSM_COUNT_REGS_PATH \
+    tb.dut.u_lc_ctrl_fsm.u_cnt_regs.gen_generic.u_impl_generic.d_i
+`endif
+
+
+interface lc_ctrl_if (
+  input clk,
+  input rst_n
+);
 
   import lc_ctrl_pkg::*;
   import lc_ctrl_state_pkg::*;
   import otp_ctrl_pkg::*;
   import otp_ctrl_part_pkg::*;
 
-  logic tdo_oe; // TODO: add assertions
-  otp_lc_data_t otp_i;
-  otp_device_id_t otp_device_id_i;
-  otp_device_id_t otp_manuf_state_i;
-  lc_token_t    hashed_token;
+  logic               tdo_oe;  // TODO: add assertions
+  otp_lc_data_t       otp_i;
+  otp_device_id_t     otp_device_id_i;
+  otp_device_id_t     otp_manuf_state_i;
+  lc_token_t          hashed_token;
 
-  lc_tx_t lc_dft_en_o;
-  lc_tx_t lc_nvm_debug_en_o;
-  lc_tx_t lc_hw_debug_en_o;
-  lc_tx_t lc_cpu_en_o;
-  lc_tx_t lc_creator_seed_sw_rw_en_o;
-  lc_tx_t lc_owner_seed_sw_rw_en_o;
-  lc_tx_t lc_iso_part_sw_rd_en_o;
-  lc_tx_t lc_iso_part_sw_wr_en_o;
-  lc_tx_t lc_seed_hw_rd_en_o;
-  lc_tx_t lc_keymgr_en_o;
-  lc_tx_t lc_escalate_en_o;
-  lc_tx_t lc_check_byp_en_o;
+  lc_tx_t             lc_dft_en_o;
+  lc_tx_t             lc_nvm_debug_en_o;
+  lc_tx_t             lc_hw_debug_en_o;
+  lc_tx_t             lc_cpu_en_o;
+  lc_tx_t             lc_creator_seed_sw_rw_en_o;
+  lc_tx_t             lc_owner_seed_sw_rw_en_o;
+  lc_tx_t             lc_iso_part_sw_rd_en_o;
+  lc_tx_t             lc_iso_part_sw_wr_en_o;
+  lc_tx_t             lc_seed_hw_rd_en_o;
+  lc_tx_t             lc_keymgr_en_o;
+  lc_tx_t             lc_escalate_en_o;
+  lc_tx_t             lc_check_byp_en_o;
 
-  lc_tx_t clk_byp_req_o;
-  lc_tx_t clk_byp_ack_i;
-  lc_tx_t flash_rma_req_o;
-  lc_tx_t flash_rma_ack_i;
+  lc_tx_t             clk_byp_req_o;
+  lc_tx_t             clk_byp_ack_i;
+  lc_tx_t             flash_rma_req_o;
+  lc_tx_t             flash_rma_ack_i;
 
   lc_keymgr_div_t     keymgr_div_o;
   lc_flash_rma_seed_t flash_rma_seed_o;
 
-  task automatic init(lc_state_e lc_state = LcStRaw,
-                      lc_cnt_e   lc_cnt = LcCnt0,
-                      lc_tx_t    clk_byp_ack = Off,
-                      lc_tx_t    flash_rma_ack = Off);
-    otp_i.valid = 1;
-    otp_i.error = 0;
-    otp_i.state = lc_state;
-    otp_i.count = lc_cnt;
+  event               fsm_backdoor_state_write_ev;
+  event               fsm_backdoor_state_read_ev;
+  event               fsm_backdoor_count_write_ev;
+  event               fsm_backdoor_count_read_ev;
+
+  task automatic init(lc_state_e lc_state = LcStRaw, lc_cnt_e lc_cnt = LcCnt0,
+                      lc_tx_t clk_byp_ack = Off, lc_tx_t flash_rma_ack = Off);
+    otp_i.valid             = 1;
+    otp_i.error             = 0;
+    otp_i.state             = lc_state;
+    otp_i.count             = lc_cnt;
     otp_i.test_unlock_token = lc_ctrl_env_pkg::get_random_token();
     otp_i.test_exit_token   = lc_ctrl_env_pkg::get_random_token();
     otp_i.rma_token         = lc_ctrl_env_pkg::get_random_token();
     // TODO: need to randomize this,
-    otp_i.secrets_valid = Off;
+    otp_i.secrets_valid     = Off;
     otp_i.test_tokens_valid = On;
-    otp_i.rma_token_valid = On;
+    otp_i.rma_token_valid   = On;
 
-    otp_device_id_i = 0;
-    otp_manuf_state_i = 0;
+    otp_device_id_i         = 0;
+    otp_manuf_state_i       = 0;
 
-    clk_byp_ack_i = clk_byp_ack;
-    flash_rma_ack_i = flash_rma_ack;
+    clk_byp_ack_i           = clk_byp_ack;
+    flash_rma_ack_i         = flash_rma_ack;
+
+    release `LC_CTRL_FSM_STATE_REGS_PATH;
   endtask
 
   task automatic set_clk_byp_ack(lc_tx_t val);
@@ -68,4 +88,49 @@ interface lc_ctrl_if(input clk, input rst_n);
     flash_rma_ack_i = val;
   endtask
 
+  // This must be static because of the force statement
+  function static void fsm_state_backdoor_write(input logic [FsmStateWidth-1:0] val = 'hdead,
+                                                input int delay_clocks = 0,
+                                                input int force_clocks = 5);
+    `dv_info($sformatf("Backdoor write to state registers"))
+    fork
+      begin : force_state_proc
+        repeat (delay_clocks) @(posedge clk);
+        ->fsm_backdoor_state_write_ev;
+        force `LC_CTRL_FSM_STATE_REGS_PATH = val;
+        repeat (force_clocks) @(posedge clk);
+        release `LC_CTRL_FSM_STATE_REGS_PATH;
+      end : force_state_proc
+    join_none
+  endfunction
+
+  function automatic logic [FsmStateWidth-1:0] fsm_state_backdoor_read();
+    ->fsm_backdoor_state_read_ev;
+    return `LC_CTRL_FSM_STATE_REGS_PATH;
+  endfunction
+
+  // This must be static because of the force statement
+  function static void fsm_count_backdoor_write(input logic [LcCountWidth-1:0] val = 'hdead,
+                                                input int delay_clocks = 0,
+                                                input int force_clocks = 5);
+    `dv_info($sformatf("Backdoor write to state registers"))
+    fork
+      begin : force_count_proc
+        repeat (delay_clocks) @(posedge clk);
+        ->fsm_backdoor_count_write_ev;
+        force `LC_CTRL_FSM_COUNT_REGS_PATH = val;
+        repeat (force_clocks) @(posedge clk);
+        release `LC_CTRL_FSM_COUNT_REGS_PATH;
+      end : force_count_proc
+    join_none
+  endfunction
+
+  function automatic logic [LcCountWidth-1:0] fsm_count_backdoor_read();
+    ->fsm_backdoor_count_read_ev;
+    return `LC_CTRL_FSM_COUNT_REGS_PATH;
+  endfunction
+
 endinterface
+
+`undef LC_CTRL_FSM_STATE_REGS_PATH
+`undef LC_CTRL_FSM_COUNT_REGS_PATH

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -3,20 +3,29 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class lc_ctrl_scoreboard extends cip_base_scoreboard #(
-    .CFG_T(lc_ctrl_env_cfg),
-    .RAL_T(lc_ctrl_reg_block),
-    .COV_T(lc_ctrl_env_cov)
-  );
+  .CFG_T(lc_ctrl_env_cfg),
+  .RAL_T(lc_ctrl_reg_block),
+  .COV_T(lc_ctrl_env_cov)
+);
   `uvm_component_utils(lc_ctrl_scoreboard)
 
   // local variables
   bit is_personalized = 0;
 
+  // Data to program OTP
+  protected otp_ctrl_pkg::lc_otp_program_req_t m_otp_prog_data;
+  // First OTP program instruction count cleared by reset
+  protected uint m_otp_prog_cnt;
+  event check_lc_output_ev;
+
   // TLM agent fifos
-  uvm_tlm_analysis_fifo #(push_pull_item#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
-                        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))) otp_prog_fifo;
-  uvm_tlm_analysis_fifo #(push_pull_item#(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)))
-                        otp_token_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item #(
+    .HostDataWidth  (OTP_PROG_HDATA_WIDTH),
+    .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)
+  )) otp_prog_fifo;
+  uvm_tlm_analysis_fifo #(push_pull_item #(
+    .HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)
+  )) otp_token_fifo;
   uvm_tlm_analysis_fifo #(alert_esc_seq_item) esc_wipe_secrets_fifo;
   uvm_tlm_analysis_fifo #(alert_esc_seq_item) esc_scrap_state_fifo;
   uvm_tlm_analysis_fifo #(jtag_riscv_item) jtag_riscv_fifo;
@@ -54,7 +63,7 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
         // TODO: add coverage
         dec_lc_state_e lc_state = dec_lc_state(cfg.lc_ctrl_vif.otp_i.state);
         lc_outputs_t   exp_lc_o = EXP_LC_OUTPUTS[int'(lc_state)];
-        string         err_msg  = $sformatf("LC_St %0s", lc_state.name);
+        string         err_msg = $sformatf("LC_St %0s", lc_state.name);
         cfg.clk_rst_vif.wait_n_clks(1);
 
         // lc_creator_seed_sw_rw_en_o is ON only when device has NOT been personalized or RMA state
@@ -66,26 +75,58 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
           exp_lc_o.lc_seed_hw_rd_en_o = lc_ctrl_pkg::Off;
         end
 
+        ->check_lc_output_ev;
         check_lc_outputs(exp_lc_o, err_msg);
 
-        // predict LC state and cnt csr
-        void'(ral.lc_state.predict({DecLcStateNumRep{lc_state[DecLcStateWidth-1:0]}}));
-        void'(ral.lc_transition_cnt.predict(dec_lc_cnt(cfg.lc_ctrl_vif.otp_i.count)));
+
+        if (cfg.err_inj.state_err || cfg.err_inj.count_err ||
+            cfg.err_inj.state_backdoor_err || cfg.err_inj.count_backdoor_err
+            ) begin // State/count error expected
+          set_exp_alert(.alert_name("fatal_state_error"), .is_fatal(1),
+                        .max_delay(cfg.alert_max_delay));
+        end
+
       end
     end
   endtask
 
   virtual task process_otp_prog_rsp();
+    otp_ctrl_pkg::lc_otp_program_req_t otp_prog_data_exp;
+    lc_state_e otp_prog_state_act, otp_prog_state_exp;
+    lc_cnt_e otp_prog_count_act, otp_prog_count_exp;
+    const string MsgFmt = "Check failed %s == %s %s [%h] vs %s [%h]";
     forever begin
-      push_pull_item#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
-                      .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)) item_rcv;
+      push_pull_item #(
+        .HostDataWidth  (OTP_PROG_HDATA_WIDTH),
+        .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)
+      ) item_rcv;
       otp_prog_fifo.get(item_rcv);
       if (item_rcv.d_data == 1 && cfg.en_scb) begin
         set_exp_alert(.alert_name("fatal_prog_error"), .is_fatal(1));
       end
+      // Decode and store to use for prediction
+      m_otp_prog_data = otp_ctrl_pkg::lc_otp_program_req_t'(item_rcv.h_data);
+
+      // Increment otp program count
+      m_otp_prog_cnt++;
+
+      // Get expected from model
+      otp_prog_data_exp  = predict_otp_prog_req();
+
+      otp_prog_state_act = lc_state_e'(m_otp_prog_data.state);
+      otp_prog_state_exp = lc_state_e'(otp_prog_data_exp.state);
+      otp_prog_count_exp = lc_cnt_e'(otp_prog_data_exp.count);
+      otp_prog_count_act = lc_cnt_e'(m_otp_prog_data.count);
+
+      `DV_CHECK_EQ(otp_prog_state_act, otp_prog_state_exp, $sformatf(
+                   " - %s vs %s", otp_prog_state_act.name, otp_prog_state_exp.name))
+
+      `DV_CHECK_EQ(otp_prog_count_act, otp_prog_count_exp, $sformatf(
+                   " - %s vs %s", otp_prog_count_act.name, otp_prog_count_exp.name))
     end
   endtask
 
+  // verilog_format: off - avoid bad formatting
   virtual task process_otp_token_rsp();
     forever begin
       push_pull_item#(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)) item_rcv;
@@ -98,19 +139,19 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
       end
     end
   endtask
+  // verilog_format: on
 
   virtual task process_jtag_riscv();
-    jtag_riscv_item jt_item;
-    tl_seq_item     tl_item;
-    const uvm_reg_addr_t jtag_risc_address_mask = ~(2**(DMI_ADDRW+2) - 1);
+    jtag_riscv_item      jt_item;
+    tl_seq_item          tl_item;
+    const uvm_reg_addr_t jtag_risc_address_mask = ~(2 ** (DMI_ADDRW + 2) - 1);
     const uvm_reg_addr_t base_address = cfg.jtag_riscv_map.get_base_addr();
     const uvm_reg_addr_t base_address_masked = base_address & jtag_risc_address_mask;
 
     forever begin
       jtag_riscv_fifo.get(jt_item);
-      `uvm_info(`gfn,{"process_jtag_risc: ",
-          jt_item.sprint(uvm_default_line_printer)}, UVM_MEDIUM)
-      if((jt_item.op === DmiRead || jt_item.op === DmiWrite) && jt_item.status === DmiNoErr) begin
+      `uvm_info(`gfn, {"process_jtag_risc: ", jt_item.sprint(uvm_default_line_printer)}, UVM_MEDIUM)
+      if ((jt_item.op === DmiRead || jt_item.op === DmiWrite) && jt_item.status === DmiNoErr) begin
         `uvm_create_obj(tl_seq_item, tl_item)
         tl_item.a_addr   = base_address_masked | (jt_item.addr << 2);
         tl_item.a_data   = jt_item.data;
@@ -129,82 +170,207 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
   endtask
 
   // check lc outputs, default all off
-  virtual function void check_lc_outputs(lc_outputs_t exp_o = '{default:lc_ctrl_pkg::Off},
-                                         string       msg   = "expect all output OFF");
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_dft_en_o,              exp_o.lc_dft_en_o,              msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_nvm_debug_en_o,        exp_o.lc_nvm_debug_en_o,        msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_hw_debug_en_o,         exp_o.lc_hw_debug_en_o,         msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_cpu_en_o,              exp_o.lc_cpu_en_o,              msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_keymgr_en_o,           exp_o.lc_keymgr_en_o,           msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_escalate_en_o,         exp_o.lc_escalate_en_o,         msg)
+  virtual function void check_lc_outputs(lc_outputs_t exp_o = '{default: lc_ctrl_pkg::Off},
+                                         string msg = "expect all output OFF");
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_dft_en_o, exp_o.lc_dft_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_nvm_debug_en_o, exp_o.lc_nvm_debug_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_hw_debug_en_o, exp_o.lc_hw_debug_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_cpu_en_o, exp_o.lc_cpu_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_keymgr_en_o, exp_o.lc_keymgr_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_escalate_en_o, exp_o.lc_escalate_en_o, msg)
     `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_owner_seed_sw_rw_en_o, exp_o.lc_owner_seed_sw_rw_en_o, msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_rd_en_o,   exp_o.lc_iso_part_sw_rd_en_o,   msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_wr_en_o,   exp_o.lc_iso_part_sw_wr_en_o,   msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_seed_hw_rd_en_o,       exp_o.lc_seed_hw_rd_en_o,       msg)
-    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_creator_seed_sw_rw_en_o,
-                 exp_o.lc_creator_seed_sw_rw_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_rd_en_o, exp_o.lc_iso_part_sw_rd_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_wr_en_o, exp_o.lc_iso_part_sw_wr_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_seed_hw_rd_en_o, exp_o.lc_seed_hw_rd_en_o, msg)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_creator_seed_sw_rw_en_o, exp_o.lc_creator_seed_sw_rw_en_o, msg)
   endfunction
 
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
-    bit     do_read_check   = 1'b0;
-    bit     write           = item.is_write();
+    uvm_reg        csr;
+    bit            do_read_check = 1'b0;
+    bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
-    lc_outputs_t exp        = '{default:lc_ctrl_pkg::Off};
+    lc_outputs_t   exp = '{default: lc_ctrl_pkg::Off};
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AddrChannel);
+    bit            addr_phase_write = (write && channel == AddrChannel);
+    bit            data_phase_read = (!write && channel == DataChannel);
+    bit            data_phase_write = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
-    end
-    else begin
+    end else begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
     // if incoming access is a write to a valid csr, then make updates right away
     if (addr_phase_write) begin
-      `uvm_info(`gfn,{"process_tl_access: write predict ", csr.get_name(), " ",
-          item.sprint(uvm_default_line_printer)}, UVM_MEDIUM)
+      `uvm_info(`gfn, {
+                "process_tl_access: write predict ",
+                csr.get_name(),
+                " ",
+                item.sprint(uvm_default_line_printer)
+                }, UVM_MEDIUM)
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
     end
 
-    // process the csr req
-    // for write, update local variable and fifo at address phase
-    // for read, update predication at address phase and compare at data phase
-    case (csr.get_name())
-      // TODO: temp enable read checking, once do_read_check default set to 1, should not need this.
-      "lc_transition_cnt", "lc_state": do_read_check = 1;
-      "status": begin
-        if (data_phase_read) begin
-          // when lc successfully req a transition, all outputs are turned off.
-          if (item.d_data[ral.status.transition_successful.get_lsb_pos()]) check_lc_outputs(exp);
+    if (addr_phase_read) begin
+      case (csr.get_name())
+        "lc_state": begin
+          // if (cfg.err_inj.state_err) begin // State error expected
+          //   case(cfg.test_phase)
+          //     LcCtrlReadState1: `DV_CHECK_FATAL(
+          //         ral.lc_state.predict(.value(DecLcStInvalid), .kind(UVM_PREDICT_READ)))
+          //     LcCtrlReadState2: `DV_CHECK_FATAL(
+          //         ral.lc_state.predict(.value(DecLcStEscalate), .kind(UVM_PREDICT_READ)))
+          //   endcase
+          `DV_CHECK_FATAL(ral.lc_state.state.predict(
+                          .value(predict_lc_state()), .kind(UVM_PREDICT_READ)))
         end
-      end
-      default: begin
-        // `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
-      end
-    endcase
+
+        "lc_transition_cnt": begin
+          // If we have a state error no transition will take place so
+          // the tarnsition count will be 31
+          if(!cfg.err_inj.count_err && !cfg.err_inj.state_err &&
+              !cfg.err_inj.count_backdoor_err && !cfg.err_inj.state_backdoor_err
+              ) begin
+            `DV_CHECK_FATAL((ral.lc_transition_cnt.predict(
+                            .value(dec_lc_cnt(cfg.lc_ctrl_vif.otp_i.count)), .kind(UVM_PREDICT_READ)
+                            )))
+          end else begin  // State or count error expected
+            `DV_CHECK_FATAL(ral.lc_transition_cnt.predict(.value(31), .kind(UVM_PREDICT_READ)))
+          end
+        end
+
+        default: begin
+          // `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        end
+      endcase
+    end
 
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
     if (data_phase_read) begin
+      if (csr.get_name() inside {"lc_state", "lc_transition_cnt"}) do_read_check = 1;
+
       if (do_read_check) begin
-        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
-                     $sformatf("reg name: %0s", csr.get_full_name()))
+        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data, $sformatf(
+                     "reg name: %0s", csr.get_full_name()))
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
-      `uvm_info(`gfn,{"process_tl_access: read predict ", csr.get_name(), " ",
-          item.sprint(uvm_default_line_printer)}, UVM_MEDIUM)
+      `uvm_info(`gfn, {
+                "process_tl_access: read predict ",
+                csr.get_name(),
+                " ",
+                item.sprint(uvm_default_line_printer)
+                }, UVM_MEDIUM)
+
+      // when lc successfully req a transition, all outputs are turned off.
+      if (cfg.err_inj.state_backdoor_err || cfg.err_inj.count_backdoor_err) begin
+        // Expect escalate
+        exp.lc_escalate_en_o = lc_ctrl_pkg::On;
+      end
+
+      if (ral.status.transition_successful.get()) check_lc_outputs(exp);
     end
   endtask
+
+  // Predict the value of lc_state register
+  virtual function bit [31:0] predict_lc_state();
+    // Unrepeated lc_state expected - default state from otp_i
+    dec_lc_state_e lc_state_single_exp = dec_lc_state(cfg.lc_ctrl_vif.otp_i.state);
+    bit [31:0] lc_state_exp;
+
+    // Exceptions to default
+    if (cfg.err_inj.state_err || cfg.err_inj.count_err || cfg.err_inj.count_backdoor_err ||
+        cfg.err_inj.state_backdoor_err) begin // State error expected
+      case (cfg.test_phase)
+        LcCtrlReadState1: lc_state_single_exp = DecLcStInvalid;
+        LcCtrlReadState2: lc_state_single_exp = DecLcStEscalate;
+        default: lc_state_single_exp = DecLcStInvalid;
+      endcase
+    end
+    // repeat state to fill the word for hardness
+    lc_state_exp = {DecLcStateNumRep{lc_state_single_exp}};
+
+    `uvm_info(`gfn, $sformatf(
+              "predict_lc_state: lc_state_single_exp=%s(%x) lc_state_exp=%h",
+              lc_state_single_exp.name,
+              lc_state_single_exp,
+              lc_state_exp
+              ), UVM_MEDIUM)
+
+    return lc_state_exp;
+  endfunction
+
+  virtual function otp_ctrl_pkg::lc_otp_program_req_t predict_otp_prog_req();
+    // Convert state and count back to enums
+    const lc_state_e LcStateIn = cfg.lc_ctrl_vif.otp_i.state;
+    const lc_cnt_e LcCntIn = cfg.lc_ctrl_vif.otp_i.count;
+    // Incremented LcCntIn - next() works because of encoding method
+    const lc_cnt_e LcCntInInc = LcCntIn.next();
+    // TODO needs expanding for JTAG registers
+    const
+    lc_state_e
+    LcTargetState = encode_lc_state(
+        cfg.ral.transition_target.get_mirrored_value()
+    );
+    lc_state_e lc_state_exp;
+    lc_cnt_e lc_cnt_exp;
+
+    if (m_otp_prog_cnt == 1) begin
+      // First program transaction just programs the incremented count so state
+      // is the same as input
+      lc_cnt_exp   = LcCntInInc;
+      lc_state_exp = LcStateIn;
+    end else if (m_otp_prog_cnt == 2) begin
+      // Second program transaction programs both the incremented count and
+      // the transition target state in (TRANSITION_TARGET register)
+      lc_cnt_exp   = LcCntInInc;
+      lc_state_exp = LcTargetState;
+    end
+
+    // Transition to SCRAP state always programs LcCnt24
+    if (LcTargetState == LcStScrap) lc_cnt_exp = LcCnt24;
+
+    `uvm_info(`gfn, $sformatf(
+              "predict_otp_prog_req: state=%s count=%s", lc_state_exp.name(), lc_cnt_exp.name),
+              UVM_MEDIUM)
+
+    return ('{state: lc_state_t'(lc_state_exp), count: lc_cnt_t'(lc_cnt_exp), req: 0});
+  endfunction
+
+  // this function check if the triggered alert is expected
+  // to turn off this check, user can set `do_alert_check` to 0
+  // We overload this to trigger events in the config object when an alert is triggered
+  virtual function void process_alert(string alert_name, alert_esc_seq_item item);
+    if (item.alert_handshake_sta == AlertReceived) begin
+      case (alert_name)
+        "fatal_prog_error": begin
+          ->cfg.fatal_prog_error_ev;
+        end
+        "fatal_state_error": begin
+          ->cfg.fatal_state_error_ev;
+        end
+        "fatal_bus_integ_error": begin
+          ->cfg.fatal_bus_integ_error_ev;
+        end
+        default: begin
+          `uvm_fatal(`gfn, {"Unexpected alert received: ", alert_name})
+        end
+      endcase
+    end
+
+    super.process_alert(alert_name, item);
+
+  endfunction
 
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     // reset local fifos queues and variables
+    // Clear OTP program count
+    m_otp_prog_cnt = 0;
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
@@ -4,12 +4,429 @@
 
 // This sequence creates lc transition failures such as token mismatch.
 class lc_ctrl_errors_vseq extends lc_ctrl_smoke_vseq;
-  `uvm_object_utils(lc_ctrl_errors_vseq)
 
+  // Process to handle alerts
+  protected process handle_alerts_process;
+  // Error injection control
+  rand lc_ctrl_err_inj_t err_inj;
+  // Invalid lc_state lc_count as a binary representation
+  rand lc_state_bin_t invalid_lc_state_bin;
+  rand lc_count_bin_t invalid_lc_count_bin;
+  rand bit [DecLcStateWidth-1:0] invalid_next_state;
+  rand bit [FsmStateWidth-1:0] fsm_state_invert_bits;
+  rand bit [LcCountWidth-1:0] fsm_count_invert_bits;
+  rand int unsigned fsm_state_err_inj_delay;
+  rand int unsigned fsm_state_err_inj_period;
+  rand int unsigned fsm_count_err_inj_delay;
+  rand int unsigned fsm_count_err_inj_period;
+
+  `uvm_object_utils_begin(lc_ctrl_errors_vseq)
+    `uvm_field_int(num_trans, UVM_DEFAULT)
+    `uvm_field_int(err_inj, UVM_DEFAULT)
+    `uvm_field_int(invalid_lc_state_bin, UVM_DEFAULT)
+    `uvm_field_int(invalid_lc_count_bin, UVM_DEFAULT)
+    `uvm_field_int(invalid_next_state, UVM_DEFAULT)
+    `uvm_field_int(fsm_state_invert_bits, UVM_DEFAULT)
+    `uvm_field_int(fsm_state_err_inj_delay, UVM_DEFAULT)
+    `uvm_field_int(fsm_state_err_inj_period, UVM_DEFAULT)
+  `uvm_object_utils_end
   `uvm_object_new
 
-  function void pre_randomize();
-    this.token_mismatch_err_c.constraint_mode(0);
+  constraint no_err_rsps_c {
+    err_inj.clk_byp_error_rsp == 0;
+    err_inj.flash_rma_error_rsp == 0;
+  }
+
+  constraint otp_prog_err_c {err_inj.otp_prog_err == 0;}
+
+  constraint token_mismatch_err_c {err_inj.token_mismatch_err == 0;}
+
+  constraint lc_state_failure_c {
+    err_inj.state_err == 0;
+    err_inj.state_backdoor_err == 0;
+    err_inj.count_err == 0;
+    err_inj.count_backdoor_err == 0;
+  }
+
+  constraint lc_errors_c {err_inj.transition_err == 0;}
+
+  constraint invalid_states_bin_c {
+    !(invalid_lc_state_bin inside {ValidLcStatesBin});
+    !(invalid_lc_count_bin inside {ValidLcCountsBin});
+    !(invalid_next_state inside {ValidDecodedStates});
+  }
+
+  constraint fsm_state_invert_bits_c {
+    // Just one bit flipped by default
+    $onehot(fsm_state_invert_bits);
+  }
+
+  constraint fsm_count_invert_bits_c {
+    // Just one bit flipped by default
+    $onehot(fsm_count_invert_bits);
+  }
+
+  constraint fsm_state_err_inj_delay_c {
+    fsm_state_err_inj_delay inside {[1 : 5]};
+    fsm_state_err_inj_period inside {[2 : 4]};
+  }
+
+  constraint fsm_count_err_inj_delay_c {
+    fsm_count_err_inj_delay inside {[1 : 5]};
+    fsm_count_err_inj_period inside {[2 : 4]};
+  }
+
+  virtual task post_start();
+    `uvm_info(`gfn, "post_start: Task called for lc_ctrl_errors_vseq", UVM_MEDIUM)
+
+    // Clear all error injection bits so we end with a clean lc_ state, lc_count etc.
+    err_inj = 0;
+
+    // trigger dut_init to make sure always on alert is not firing forever
+    if (do_apply_reset) begin
+      `uvm_info(`gfn, "post_start: calling dut_init", UVM_MEDIUM)
+      dut_init();
+    end else begin
+      `uvm_info(`gfn, "post_start: waiting to be killed", UVM_MEDIUM)
+      wait(0);  // wait until upper seq resets and kills this seq
+    end
+    // delay to avoid race condition when sending item and checking no item after reset occur
+    // at the same time
+    #1ps;
+    super.post_start();
+
+  endtask
+
+  task body();
+    uvm_reg_data_t rdata;
+    logic [FsmStateWidth-1:0] fsm_state;
+    num_trans.rand_mode(0);
+
+    fork
+      handle_alerts();
+    join_none
+
+    run_clk_byp_rsp_nonblocking(err_inj.clk_byp_error_rsp);
+    run_flash_rma_rsp_nonblocking(err_inj.flash_rma_error_rsp);
+
+    for (int i = 1; i <= num_trans; i++) begin
+      cfg.set_test_phase(LcCtrlIterStart);
+
+      if (i != 1) begin
+        `DV_CHECK_RANDOMIZE_FATAL(this)
+        dut_init();
+      end
+
+      update_err_inj_cfg();
+
+      `uvm_info(`gfn, $sformatf(
+                "starting seq %0d/%0d, init LC_state is %0s, LC_cnt is %0s",
+                i,
+                num_trans,
+                lc_state.name,
+                lc_cnt.name
+                ), UVM_MEDIUM)
+
+      if ($urandom_range(0, 1)) begin
+        csr_rd_check(.ptr(ral.status.ready), .compare_value(1));
+      end
+
+      cfg.set_test_phase(LcCtrlDutReady);
+
+      // Invalid fsm state in registers by "backdoor"
+      if (err_inj.state_backdoor_err) begin
+        fork
+          begin
+            cfg.clk_rst_vif.wait_clks(fsm_state_err_inj_delay);
+            fsm_backdoor_err_inj();
+          end
+        join_none
+      end
+
+      // Invalid fsm state in registers by "backdoor"
+      if (err_inj.count_backdoor_err) begin
+        fork
+          begin
+            cfg.clk_rst_vif.wait_clks(fsm_count_err_inj_delay);
+            count_backdoor_err_inj();
+          end
+        join_none
+      end
+
+      // SW transition request
+      if ((err_inj.state_err || valid_state_for_trans(
+              lc_state
+          )) && (err_inj.count_err || lc_cnt != LcCnt24)) begin
+        lc_ctrl_state_pkg::lc_token_t token_val = get_random_token();
+        randomize_next_lc_state(dec_lc_state(lc_state));
+        `uvm_info(`gfn, $sformatf(
+                  "next_LC_state is %0s, input token is %0h", next_lc_state.name, token_val),
+                  UVM_HIGH)
+
+        set_hashed_token();
+        sw_transition_req(next_lc_state, token_val);
+      end else begin
+        // wait at least two clks for scb to finish checking lc outputs
+        cfg.clk_rst_vif.wait_clks($urandom_range(10, 2));
+      end
+
+      // Allow escalate to be generated if we have received an alert
+      cfg.set_test_phase(LcCtrlReadState1);
+      // Check count and state before escalate is generated
+      rd_lc_state_and_cnt_csrs();
+
+      // Allow escalate to be generated if we have received an alert
+      cfg.set_test_phase(LcCtrlEscalate);
+
+      // Wait before re-checking lc_state to allow escalate to be accepted
+      cfg.clk_rst_vif.wait_clks(100);
+      cfg.set_test_phase(LcCtrlReadState2);
+      // Check count and state after escalate is generated
+      rd_lc_state_and_cnt_csrs();
+
+      // Sample coverage if enabled
+      if (cfg.en_cov) begin
+        sample_cov();
+      end
+
+    end
+
+    // Clear error injection object so we don't get expect alerts etc.
+    cfg.err_inj = 0;
+
+    `uvm_info(`gfn, "body: finished", UVM_MEDIUM)
+  endtask : body
+
+  // smoke test will always return valid next_lc_state
+  // need to randomize here because associative array's index cannot be a rand input in constraint
+  // verilog_format: off - avoid bad formatting
+  virtual function void randomize_next_lc_state(dec_lc_state_e curr_lc_state);
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(next_lc_state,
+        if (!err_inj.transition_err && !err_inj.state_err) {
+          // Valid transition
+          next_lc_state inside {VALID_NEXT_STATES[curr_lc_state]};
+        } else if (!err_inj.state_err) {
+          // Invalid transition
+          !(next_lc_state inside {VALID_NEXT_STATES[curr_lc_state]});
+        })
   endfunction
+  // verilog_format: on - avoid bad formatting
+
+  // This function add otp_program_i's error bit field from the otp_prog_pull_agent device driver.
+  // The pushed data length is (num_trans * 2) because for each transaction, we will have two
+  // otp_program request at most (one for lc_token and one for lc_state)
+  virtual function void add_otp_prog_err_bit();
+    repeat (num_trans * 2) begin
+      bit err_bit = err_inj.otp_prog_err ? $urandom_range(0, 1) : 0;
+      cfg.m_otp_prog_pull_agent_cfg.add_d_user_data(err_bit);
+    end
+  endfunction
+
+  virtual function void set_hashed_token();
+    lc_ctrl_pkg::token_idx_e token_idx = get_exp_token(dec_lc_state(lc_state), next_lc_state);
+
+    // No token for InvalidTokenIdx
+    lc_ctrl_state_pkg::lc_token_t tokens_a[NumTokens-1];
+    tokens_a[ZeroTokenIdx]       = 0;
+    tokens_a[RawUnlockTokenIdx]  = lc_ctrl_state_pkg::RndCnstRawUnlockTokenHashed;
+    tokens_a[TestUnlockTokenIdx] = cfg.lc_ctrl_vif.otp_i.test_unlock_token;
+    tokens_a[TestExitTokenIdx]   = cfg.lc_ctrl_vif.otp_i.test_exit_token;
+    tokens_a[RmaTokenIdx]        = cfg.lc_ctrl_vif.otp_i.rma_token;
+
+    if (!err_inj.state_err && !err_inj.count_err) begin
+      `DV_CHECK_NE(token_idx, InvalidTokenIdx, $sformatf(
+                   "curr_state: %0s, next_state %0s, does not expect InvalidToken",
+                   lc_state.name,
+                   next_lc_state.name
+                   ))
+    end
+
+    // Clear the user_data_q here cause previous data might not be used due to some other lc_ctrl
+    // error: for example: lc_program error
+    cfg.m_otp_token_pull_agent_cfg.clear_d_user_data();
+    if (!err_inj.token_mismatch_err) begin
+      cfg.m_otp_token_pull_agent_cfg.add_d_user_data(tokens_a[token_idx]);
+    end else begin
+      // 50% chance to input other token data, 50% chance let push-pull agent drive random data
+      if ($urandom_range(0, 1)) begin
+        token_idx = token_idx_e'($urandom_range(0, TokenIdxWidth - 2));
+        cfg.m_otp_token_pull_agent_cfg.add_d_user_data(tokens_a[token_idx]);
+      end
+    end
+  endfunction
+
+  // Drive OTP input `lc_state` and `lc_cnt`.
+  virtual task drive_otp_i(bit rand_otp_i = 1);
+    `uvm_info(`gfn, $sformatf("drive_otp_i: started rand_otp_i=%0b err_inj=%p", rand_otp_i, err_inj
+              ), UVM_MEDIUM)
+    if (rand_otp_i) begin
+      if (!err_inj.state_err) begin
+        `DV_CHECK_STD_RANDOMIZE_FATAL(lc_state)
+      end else begin
+        // Force invalid state on input
+        `uvm_info(`gfn, "drive_otp_i: applying invalid state to otp_i", UVM_MEDIUM)
+        lc_state = bin_to_lc_state(invalid_lc_state_bin);
+      end
+
+      if (!err_inj.count_err) begin
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(lc_cnt, (lc_state != LcStRaw) -> (lc_cnt != LcCnt0);)
+      end else begin
+        // Force invalid count on input
+        lc_cnt = bin_to_lc_count(invalid_lc_count_bin);
+      end
+
+    end else begin
+      lc_state = LcStRaw;
+      lc_cnt   = LcCnt0;
+    end
+    cfg.lc_ctrl_vif.init(lc_state, lc_cnt);
+  endtask
+
+  virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*4-1:0] token_val);
+    bit trigger_alert;
+    bit [TL_DW-1:0] status_val;
+    csr_wr(ral.claim_transition_if, CLAIM_TRANS_VAL);
+    csr_wr(ral.transition_target, next_lc_state);
+    foreach (ral.transition_token[i]) begin
+      csr_wr(ral.transition_token[i], token_val[TL_DW-1:0]);
+      token_val = token_val >> TL_DW;
+    end
+    csr_wr(ral.transition_cmd, 'h01);
+    cfg.set_test_phase(LcCtrlWaitTransition);
+    // Wait for status done or terminal errors
+    `DV_SPINWAIT(wait_status(trigger_alert);)
+    cfg.set_test_phase(LcCtrlTransitionComplete);
+    // always on alert, set time delay to make sure alert triggered for at least for one
+    // handshake cycle
+    if (trigger_alert) cfg.clk_rst_vif.wait_clks($urandom_range(50, 20));
+  endtask
+
+  // Wait for status done or terminal errors
+  virtual task wait_status(ref bit expect_alert);
+    bit [TL_DW-1:0] status_val;
+    bit state_error_exp, state_error_act;
+    bit count_error_exp, count_error_act;
+    // verilog_format: off - avoid bad formatting
+    forever begin
+      csr_rd(ral.status, status_val);
+      `uvm_info(`gfn, {"wait_status: ", ral.status.sprint(uvm_default_line_printer)}, UVM_MEDIUM)
+      if (get_field_val(ral.status.transition_successful, status_val)) break;
+      if (get_field_val(ral.status.token_error, status_val)) break;
+      if (get_field_val(ral.status.otp_error, status_val) ||
+          get_field_val(ral.status.state_error, status_val) ||
+          get_field_val(ral.status.bus_integ_error, status_val)) begin
+        expect_alert = 1;
+        break;
+      end
+      // verilog_format: on
+      // Random delay to next read
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 1));
+    end
+
+    // Expected bits
+    state_error_exp = cfg.err_inj.state_err || cfg.err_inj.count_err ||
+        cfg.err_inj.state_backdoor_err || cfg.err_inj.count_backdoor_err;
+
+
+    // Actual bits
+    state_error_act = get_field_val(ral.status.state_error, status_val);
+
+    // Check status against expected from err_inj
+    `DV_CHECK_EQ(state_error_act, state_error_exp)
+
+  endtask
+
+  // checking of these two CSRs are done in scb
+  virtual task rd_lc_state_and_cnt_csrs();
+    bit [TL_DW-1:0] val;
+    csr_rd(ral.lc_state, val);
+    csr_rd(ral.lc_transition_cnt, val);
+  endtask
+
+  // Update the error injection configuration
+  // This is shared with the scoreboard via the environment config object
+  virtual function void update_err_inj_cfg();
+    cfg.err_inj = err_inj;
+    `uvm_info(`gfn, $sformatf("update_err_inj_cfg: %p", cfg.err_inj), UVM_MEDIUM)
+  endfunction
+
+  // Sample the coverage for this sequence
+  virtual function void sample_cov();
+    p_sequencer.cov.sample_cov();
+  endfunction
+
+  // Monitor alert events and trigger handling function
+  virtual task handle_alerts();
+    handle_alerts_process = process::self;
+    fork
+      forever @(cfg.fatal_prog_error_ev) handle_fatal_prog_error();
+      forever @(cfg.fatal_state_error_ev) handle_fatal_state_error();
+      forever @(cfg.fatal_bus_integ_error_ev) handle_fatal_bus_integ_error();
+    join
+  endtask
+
+  // Flip bits in FSM registers
+  protected virtual task fsm_backdoor_err_inj();
+    logic [FsmStateWidth-1:0] fsm_state;
+    fsm_state = cfg.lc_ctrl_vif.fsm_state_backdoor_read();
+    fsm_state ^= fsm_state_invert_bits;
+    cfg.lc_ctrl_vif.fsm_state_backdoor_write(fsm_state, 0, fsm_state_err_inj_period);
+  endtask
+
+  // Flip bits in Count registers
+  protected virtual task count_backdoor_err_inj();
+    logic [LcCountWidth-1:0] fsm_count;
+    fsm_count = cfg.lc_ctrl_vif.fsm_count_backdoor_read();
+    fsm_count ^= fsm_count_invert_bits;
+    cfg.lc_ctrl_vif.fsm_count_backdoor_write(fsm_count, 0, fsm_count_err_inj_period);
+  endtask
+
+  // Send an escalate alert
+  protected virtual task send_escalate(int index, int assert_clocks = 1);
+    // TODO - replace with calls to escalate agent when driver implemented
+    unique case (index)
+      0: begin
+        cfg.m_esc_scrap_state0_agent_cfg.vif.sender_cb.esc_tx_int <= 2'b10;
+        cfg.clk_rst_vif.wait_clks(assert_clocks);
+        cfg.m_esc_scrap_state0_agent_cfg.vif.sender_cb.esc_tx_int <= 2'b01;
+      end
+      1: begin
+        cfg.m_esc_scrap_state1_agent_cfg.vif.sender_cb.esc_tx_int <= 2'b10;
+        cfg.clk_rst_vif.wait_clks(assert_clocks);
+        cfg.m_esc_scrap_state1_agent_cfg.vif.sender_cb.esc_tx_int <= 2'b01;
+      end
+      default: begin
+        `uvm_fatal(`gfn, $sformatf("Invalid index %0d", index))
+      end
+    endcase
+  endtask
+
+  // do_print - do a better job of printing structures etc.
+  virtual function void do_print(uvm_printer printer);
+    super.do_print(printer);
+    // err_inj
+    printer.print_generic(.name("err_inj"), .type_name("lc_ctrl_err_inj_t"), .size($bits(err_inj)),
+                          .value($sformatf("%p", err_inj)));
+
+  endfunction
+
+  // Individual event handlers
+  virtual task handle_fatal_prog_error;
+    `uvm_info(`gfn, $sformatf("handle_fatal_prog_error: alert received"), UVM_MEDIUM)
+    // Only send escalate at correct point of the test
+    if (!(cfg.get_test_phase() inside {LcCtrlEscalate, LcCtrlReadState2})) return;
+    send_escalate(1, 100);
+  endtask
+
+  virtual task handle_fatal_state_error;
+    `uvm_info(`gfn, $sformatf("handle_fatal_state_error: alert received"), UVM_MEDIUM)
+    // Only send an escalate at the correct part of the test
+    if (!(cfg.get_test_phase() inside {LcCtrlEscalate, LcCtrlReadState2})) return;
+    send_escalate(0, 100);
+  endtask
+
+  virtual task handle_fatal_bus_integ_error;
+    `uvm_info(`gfn, $sformatf("handle_fatal_bus_integ_error: alert received"), UVM_MEDIUM)
+  endtask
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_failure_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_failure_vseq.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// State failure test sequence
+class lc_ctrl_state_failure_vseq extends lc_ctrl_errors_vseq;
+  `uvm_object_utils(lc_ctrl_state_failure_vseq)
+
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[50 : 100]};}
+
+  constraint lc_state_failure_c {
+    $onehot(
+        {
+          err_inj.state_err,
+          err_inj.count_err,
+          err_inj.state_backdoor_err,
+          err_inj.count_backdoor_err
+        }
+    );
+  }
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -5,5 +5,6 @@
 `include "lc_ctrl_base_vseq.sv"
 `include "lc_ctrl_smoke_vseq.sv"
 `include "lc_ctrl_common_vseq.sv"
-`include "lc_ctrl_prog_failure_vseq.sv"
 `include "lc_ctrl_errors_vseq.sv"
+`include "lc_ctrl_prog_failure_vseq.sv"
+`include "lc_ctrl_state_failure_vseq.sv"

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -52,6 +52,11 @@
     }
 
     {
+      name: lc_ctrl_state_failure
+      uvm_test_seq: lc_ctrl_state_failure_vseq
+    }
+
+    {
       name: lc_ctrl_prog_failure
       uvm_test_seq: lc_ctrl_prog_failure_vseq
     }
@@ -60,6 +65,7 @@
       name: lc_ctrl_errors
       uvm_test_seq: lc_ctrl_errors_vseq
     }
+
   ]
 
   // List of regressions.


### PR DESCRIPTION
- Error injection via sequence lc_ctrl_errors_vseq
- Added test_phase and err_inj to config object to synchronise
scoreboard to sequence
- Added err_inj to errors sequence (mirrored by cfg)
- Added events to cfg to indicate alerts detected by scoreboard
and synchronise escalate generation by sequence
- Enhanced scoreboard to check OTP programming data against expected.
- Predicting register values in scoreboard depending on error injection
and test phase

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>