### PR TITLE
[CI_private/rv_core_ibex] Change fatal alert order

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -576,7 +576,7 @@ module rv_core_ibex
   assign alert_test[3] = reg2hw.alert_test.recov_hw_err.q &
                          reg2hw.alert_test.recov_hw_err.qe;
 
-  localparam bit [NumAlerts-1:0] AlertFatal = '{1, 0, 1, 0};
+  localparam bit [NumAlerts-1:0] AlertFatal = '{1'b0, 1'b1, 1'b0, 1'b1};
 
   logic [NumAlerts-1:0] alert_events;
   logic [NumAlerts-1:0] alert_acks;


### PR DESCRIPTION
Fix the order of fatal alert vector. This will fix the `chip_csr_rw` error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>