### PR TITLE
[lint] blackbox ast completely

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -31,7 +31,8 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/chip_earlgrey_asic.waiver
+      - lint/chip_earlgrey_asic.waiver: {file_type: waiver}
+      - lint/chip_earlgrey_ascentlint-config.tcl: {file_type: tclSource}
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/top_earlgrey/lint/chip_earlgrey_ascentlint-config.tcl
+++ b/hw/top_earlgrey/lint/chip_earlgrey_ascentlint-config.tcl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+set ri_blackbox_modules {ast}
+
+
+


### PR DESCRIPTION
This option blackboxes `ast` completely in lint.
The assumption is that `ast` lint is run elsewhere in both open and closed source. 

