### PR TITLE
[lc_ctrl/doc] Update the lc_cnt limit

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -834,8 +834,8 @@
           name: "CNT"
           desc: '''
           Number of total life cycle state transition attempts.
-          The life cycle controller allows up to 16 transition attempts.
-          If this counter is equal to 16, the !!LC_STATE is considered
+          The life cycle controller allows up to 24 transition attempts.
+          If this counter is equal to 24, the !!LC_STATE is considered
           to be invalid and will read as SCRAP.
 
           If the counter state is invalid, the counter will have the


### PR DESCRIPTION
LC_CNT limit is updated to 24 instead of 16.
@msfschaffner please correct me if it is wrong.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>