### PR TITLE
[sw] Fix endianness bit in HMAC DIF.

### DIFF
--- a/sw/device/lib/dif/dif_hmac.c
+++ b/sw/device/lib/dif/dif_hmac.c
@@ -74,10 +74,10 @@ static dif_result_t dif_hmac_calculate_device_config_value(
   bool swap_digest_endianness;
   switch (config.digest_endianness) {
     case kDifHmacEndiannessBig:
-      swap_digest_endianness = false;
+      swap_digest_endianness = true;
       break;
     case kDifHmacEndiannessLittle:
-      swap_digest_endianness = true;
+      swap_digest_endianness = false;
       break;
     default:
       return kDifError;

--- a/sw/device/lib/testing/test_rom/bootstrap.c
+++ b/sw/device/lib/testing/test_rom/bootstrap.c
@@ -69,7 +69,7 @@ static int erase_flash(void) {
 static void compute_sha256(const dif_hmac_t *hmac, const void *data, size_t len,
                            dif_hmac_digest_t *digest) {
   const dif_hmac_transaction_t config = {
-      .digest_endianness = kDifHmacEndiannessBig,
+      .digest_endianness = kDifHmacEndiannessLittle,
       .message_endianness = kDifHmacEndiannessLittle,
   };
   CHECK_DIF_OK(dif_hmac_mode_sha256_start(hmac, config));


### PR DESCRIPTION
According to the [HMAC block specification](https://docs.opentitan.org/hw/ip/hmac/doc/#Reg_cfg), the digest is big-endian when the `digest_swap` bit is 1, and little-endian if it's 0; the DIF had these switched. It's not a surprising mixup, given the `endian_swap` bit for the input message is indeed 1 for little-endian and 0 for big-endian!