### PR TITLE
[otbn, doc] Add information-flow data to OTBN ISA YAML.

### DIFF
--- a/hw/ip/otbn/data/base-insns.yml
+++ b/hw/ip/otbn/data/base-insns.yml
@@ -287,6 +287,9 @@
     type: mem-load
     target: [offset, grs1]
     bytes: 4
+  iflow:
+    - to: [grd]
+      from: [dmem]
 
 - mnemonic: sw
   rv32i: true
@@ -316,6 +319,9 @@
     type: mem-store
     target: [offset, grs1]
     bytes: 4
+  iflow:
+    - to: [dmem]
+      from: [grs2]
 
 - mnemonic: beq
   rv32i: true
@@ -406,6 +412,9 @@
       funct3: b000
       rd: grd
       opcode: b11001
+  iflow:
+    - to: [grd]
+      from: []
 
 - mnemonic: csrrs
   rv32i: true
@@ -432,6 +441,43 @@
   lsu:
     type: csr
     target: [csr]
+  iflow:
+    - to: [grd]
+      from: []
+    - test:
+        - csr == 0x7c0
+      to: [fg0-all]
+      from: [fg0-all, grs1]
+    - test:
+        - csr == 0x7c0
+      to: [grd]
+      from: [fg0-all]
+    - test:
+        - csr == 0x7c1
+      to: [fg1-all]
+      from: [fg1-all, grs1]
+    - test:
+        - csr == 0x7c1
+      to: [grd]
+      from: [fg1-all]
+    - test:
+        - csr == 0x7c8
+      to: [fg0-all, fg1-all]
+      from: [fg0-all, fg1-all, grs1]
+    - test:
+        - csr == 0x7c8
+      to: [grd]
+      from: [fg0-all, fg1-all]
+    - test:
+        - csr >= 0x7d0
+        - csr <= 0x7d8
+      to: [mod]
+      from: [mod, grs1]
+    - test:
+        - csr >= 0x7d0
+        - csr <= 0x7d8
+      to: [grd]
+      from: [mod]
 
 - mnemonic: csrrw
   rv32i: true
@@ -459,6 +505,51 @@
   lsu:
     type: csr
     target: [csr]
+  iflow:
+    - to: [grd]
+      from: []
+    - test:
+        - grd != 0
+        - csr == 0x7c0
+      to: [fg0-all]
+      from: [grs1]
+    - test:
+        - grd != 0
+        - csr == 0x7c0
+      to: [grd]
+      from: [fg0-all]
+    - test:
+        - grd != 0
+        - csr == 0x7c1
+      to: [fg1-all]
+      from: [grs1]
+    - test:
+        - grd != 0
+        - csr == 0x7c1
+      to: [grd]
+      from: [fg1-all]
+    - test:
+        - grd != 0
+        - csr == 0x7c8
+      to: [fg0-all, fg1-all]
+      from: [grs1]
+    - test:
+        - grd != 0
+        - csr == 0x7c8
+      to: [grd]
+      from: [fg0-all, fg1-all]
+    - test:
+        - grd != 0
+        - csr >= 0x7d0
+        - csr <= 0x7d8
+      to: [mod]
+      from: [mod, grs1]
+    - test:
+        - grd != 0
+        - csr >= 0x7d0
+        - csr <= 0x7d8
+      to: [grd]
+      from: [mod]
 
 - mnemonic: ecall
   rv32i: true

--- a/hw/ip/otbn/data/bignum-insns.yml
+++ b/hw/ip/otbn/data/bignum-insns.yml
@@ -38,6 +38,9 @@
     flags. The content of the second source WDR can be shifted by an unsigned
     immediate before it is consumed by the operation.
   errs: []
+  iflow:
+    - to: [wrd, flags-all]
+      from: [wrs1, wrs2]
   encoding:
     scheme: bnaf
     mapping:
@@ -59,6 +62,9 @@
     WDR can be shifted by an unsigned immediate before it is consumed by the
     operation.
   errs: []
+  iflow:
+    - to: [wrd, flags-all]
+      from: [wrs1, wrs2, flags-c]
   encoding:
     scheme: bnaf
     mapping:
@@ -87,6 +93,9 @@
     Adds a zero-extended unsigned immediate to the value of a WDR, writes the
     result to the destination WDR, and updates the flags.
   errs: []
+  iflow:
+    - to: [wrd, flags-all]
+      from: [wrs]
   encoding:
     scheme: bnai
     mapping:
@@ -112,6 +121,9 @@
 
     Flags are not used or saved.
   errs: []
+  iflow:
+    - to: [wrd]
+      from: [wrs1, wrs2, mod]
   encoding:
     scheme: bnam
     mapping:
@@ -173,6 +185,13 @@
 
     For versions of the instruction with writeback, see `BN.MULQACC.WO` and `BN.MULQACC.SO`.
   errs: []
+  iflow:
+    - to: [acc]
+      from: [wrs1, wrs2]
+    - test:
+        - zero_acc == 0
+      to: [acc]
+      from: [acc]
   encoding:
     scheme: bnaq
     mapping:
@@ -207,6 +226,13 @@
     Multiplies two `WLEN/4` WDR values, shifts the product by `acc_shift_imm` bits, and adds the result to the accumulator.
     Writes the resulting accumulator to `wrd`.
   errs: []
+  iflow:
+    - to: [acc, wrd, flags-m, flags-l, flags-z]
+      from: [wrs1, wrs2]
+    - test:
+        - zero_acc == 0
+      to: [acc, wrd, flags-m, flags-l, flags-z]
+      from: [acc]
   encoding:
     scheme: bnaq
     mapping:
@@ -258,6 +284,33 @@
     The `M` flag is set iff the top bit of the shifted-out result is zero.
     The `Z` flag is left unchanged if the shifted-out result is zero and cleared if not.
   errs: []
+  iflow:
+    - to: [acc, wrd]
+      from: [wrs1, wrs2]
+    - test:
+        - zero_acc == 0
+        - wrd_hwsel == 0
+      to: [acc, wrd, flags-l, flags-z]
+      from: [acc, wrs1, wrs2]
+    - test:
+        - zero_acc == 0
+        - wrd_hwsel == 1
+      to: [acc, wrd, flags-m, flags-z]
+      from: [acc, wrs1, wrs2]
+    - test:
+        - zero_acc == 1
+        - wrd_hwsel == 0
+      to: [flags-l, flags-z]
+      from: [wrs1, wrs2]
+    - test:
+        - zero_acc == 1
+        - wrd_hwsel == 1
+      to: [flags-m, flags-z]
+      from: [wrs1, wrs2]
+    - test:
+        - wrd_hwsel == 1
+      to: [flags-z]
+      from: [flags-z]
   encoding:
     scheme: bnaq
     mapping:
@@ -289,6 +342,9 @@
     Subtracts the second WDR value from the first one, writes the result to the destination WDR and updates flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
   errs: []
+  iflow:
+    - to: [wrd, flags-all]
+      from: [wrs1, wrs2]
   encoding:
     scheme: bnaf
     mapping:
@@ -307,6 +363,9 @@
   doc: |
     Subtracts the second WDR value and the Carry from the first one, writes the result to the destination WDR, and updates the flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
+  iflow:
+    - to: [wrd, flags-all]
+      from: [wrs1, wrs2, flags-c]
   encoding:
     scheme: bnaf
     mapping:
@@ -334,6 +393,9 @@
     Subtracts a zero-extended unsigned immediate from the value of a WDR,
     writes the result to the destination WDR, and updates the flags.
   errs: []
+  iflow:
+    - to: [wrd, flags-all]
+      from: [wrs]
   encoding:
     scheme: bnai
     mapping:
@@ -359,6 +421,9 @@
 
     Flags are not used or saved.
   errs: []
+  iflow:
+    - to: [wrd]
+      from: [wrs1, wrs2, mod]
   encoding:
     scheme: bnam
     mapping:
@@ -388,6 +453,9 @@
     The content of the second source register can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group `flag_group` are updated with the result of the operation.
   errs: []
+  iflow: &bn-and-iflow
+    - to: [wrd, flags-m, flags-l, flags-z]
+      from: [wrs1, wrs2]
   encoding:
     scheme: bna
     mapping:
@@ -409,6 +477,7 @@
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group `flag_group` are updated with the result of the operation.
   errs: []
+  iflow: *bn-and-iflow
   encoding:
     scheme: bna
     mapping:
@@ -437,6 +506,9 @@
     The source value can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group `flag_group` are updated with the result of the operation.
   errs: []
+  iflow:
+    - to: [wrd, flags-m, flags-l, flags-z]
+      from: [wrs]
   encoding:
     scheme: bnan
     mapping:
@@ -457,6 +529,7 @@
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group `flag_group` are updated with the result of the operation.
   errs: []
+  iflow: *bn-and-iflow
   encoding:
     scheme: bna
     mapping:
@@ -519,6 +592,25 @@
   doc: |
     Returns in the destination WDR the value of the first source WDR if the flag in the chosen flag group is set, otherwise returns the value of the second source WDR.
   errs: []
+  iflow:
+    - to: [wrd]
+      from: [wrs1, wrs2]
+    - test:
+        - flag == 0
+      to: [wrd]
+      from: [flags-c]
+    - test:
+        - flag == 1
+      to: [wrd]
+      from: [flags-m]
+    - test:
+        - flag == 2
+      to: [wrd]
+      from: [flags-l]
+    - test:
+        - flag == 3
+      to: [wrd]
+      from: [flags-z]
   encoding:
     scheme: bns
     mapping:
@@ -544,6 +636,9 @@
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUB, except that no result register is written.
   errs: []
+  iflow:
+    - to: [flags-all]
+      from: [wrs1, wrs2]
   encoding:
     scheme: bnc
     mapping:
@@ -562,6 +657,9 @@
     Subtracts the second WDR value from the first one and updates flags.
     This instruction is identical to BN.SUBB, except that no result register is written.
   errs: []
+  iflow:
+    - to: [flags-all]
+      from: [wrs1, wrs2, flags-c]
   encoding:
     scheme: bnc
     mapping:
@@ -630,6 +728,17 @@
     - An `ILLEGAL_INSN` error if both `grd_inc` and `grs1_inc` are set.
     - An `ILLEGAL_INSN` error if the value in GPR `grd` is greater than 31.
     - &data-addr A `BAD_DATA_ADDR` error if the computed address is not a valid DMEM address aligned to WLEN bits.
+  iflow:
+    - to: [wref-grd]
+      from: [dmem]
+    - test:
+        - grd_inc == 1
+      to: [grd]
+      from: [grd]
+    - test:
+        - grs1_inc == 1
+      to: [grs1]
+      from: [grs1]
   encoding:
     scheme: bnxid
     mapping:
@@ -693,6 +802,17 @@
     type: mem-store
     target: [offset, grs1]
     bytes: 32
+  iflow:
+    - to: [dmem]
+      from: [wref-grs2]
+    - test:
+        - grs1_inc == 1
+      to: [grs1]
+      from: [grs1]
+    - test:
+        - grs2_inc == 1
+      to: [grs2]
+      from: [grs2]
   encoding:
     scheme: bnxid
     mapping:
@@ -750,6 +870,17 @@
     - A `CALL_STACK` error from using `x1` as `grs` or `grd` when the call stack is empty.
     - An `ILLEGAL_INSN` error if either the value in GPR `grd` or the value in GPR `grs` is greater than 31.
     - An `ILLEGAL_INSN` error if both `grs_inc` and `grd_inc` are set.
+  iflow:
+    - to: [wref-grd]
+      from: [wref-grs]
+    - test:
+        - grd_inc == 1
+      to: [grd]
+      from: [grd]
+    - test:
+        - grs_inc == 1
+      to: [grs]
+      from: [grs]
   encoding:
     scheme: bnmovr
     mapping:
@@ -770,6 +901,17 @@
     If `wsr` isn't the index of a valid WSR, this results in an error (setting bit `illegal_insn` in `ERR_BITS`).
   errs:
     - &bad-wsr An `ILLEGAL_INSN` error if `wsr` doesn't name a valid WSR.
+  iflow:
+    - to: [wrd]
+      from: []
+    - test:
+        - wsr == 0x0
+      to: [wrd]
+      from: [mod]
+    - test:
+        - wsr == 0x3
+      to: [wrd]
+      from: [acc]
   encoding:
     scheme: wcsr
     mapping:
@@ -794,6 +936,17 @@
     If `wsr` isn't the index of a valid WSR, this results in an error (setting bit `illegal_insn` in `ERR_BITS`).
   errs:
     - *bad-wsr
+  iflow:
+    - to: []
+      from: []
+    - test:
+        - wsr == 0x0
+      to: [mod]
+      from: [wrs]
+    - test:
+        - wsr == 0x3
+      to: [acc]
+      from: [wrs]
   encoding:
     scheme: wcsr
     mapping:

--- a/hw/ip/otbn/data/insns.yml
+++ b/hw/ip/otbn/data/insns.yml
@@ -80,6 +80,14 @@ encoding-schemes: enc-schemes.yml
 #  cycles:    A positive integer, giving the number of cycles that the
 #             instruction takes to execute. Optional, default 1.
 #
+#  iflow:    An optional list of dictionaries. If set, this describes the
+#            information flow properties of the instruction according to the
+#            dictionaries' fields (defined below). The default is to assume all
+#            source registers flow to all destination registers, the new
+#            destination register value does not depend on the old value, and
+#            that there is no information flow to or from memory, flags, or
+#            special registers.
+#
 # The operands field should be a list, corresponding to the operands in the
 # order they will appear in the syntax. Each operand is either a string (the
 # operand name) or a dictionary. In the latter case, it has the following
@@ -162,6 +170,40 @@ encoding-schemes: enc-schemes.yml
 #
 #  bytes:   An integer giving the width of the operation in bytes. This is
 #           required if type is mem-* and cannot be used otherwise.
+#
+#
+# If specified, the iflow field for an instruction should be a list of
+# dictionaries, each specifying an information flow "rule". Rules have the
+# following fields:
+#
+#   to: A list of strings, representing the locations that receive information
+#       from locations in the "from" list (i.e. information-flow sinks). Every
+#       location updated by the instruction should be in the "to" list. Each
+#       string should be either:
+#       - a register operand name such as "grd" or "wrs1"
+#       - "wref-<reg operand name>" for instructions where a WDR is indirectly
+#         accessed via a GPR operand
+#       - "dmem" for memory, which is treated as a monolithic block
+#       - "acc" or "mod" to represent special registers ACC and MOD
+#       - a flag (represented as "<flag group>-<flag>" e.g. fg0-all, flags-c), where:
+#         * <flag group> can be either "fg0", "fg1", or (if the instruction has
+#           a `flag_group` operand) simply "flags" to select that flag group
+#         * <flag> can be l, c, m, z, or "all".
+#
+#   from: List of strings with the same format as the "to" field; represents
+#         the locations that information in this rule is flowing from (i.e.
+#         information-flow sources). If the "from" list is empty, that means
+#         the locations in the "to" list are updated to constants, and their
+#         values no longer depend on their previous values.
+#
+#   test:  Optional list of strings specifying when this rule applies. The rule
+#          only applies if all tests in the list are true. Each list item is a
+#          string of the form "<operand> <comparison> <value>", where:
+#          - <operand> is the name of one of the instruction's operands
+#          - <comparison> is "==", "!=", ">=", or "<="
+#          - <value> is an integer that is within the allowed range of values
+#            for this operand (for instance, for a flag group it would be 0 or 1,
+#            and for a register it would be between 0 and 31).
 
 insn-groups:
   - key: base

--- a/hw/ip/otbn/util/shared/insn_yaml.py
+++ b/hw/ip/otbn/util/shared/insn_yaml.py
@@ -30,7 +30,7 @@ class Insn:
                          'syntax', 'doc', 'errs', 'note',
                          'encoding', 'glued-ops',
                          'literal-pseudo-op', 'python-pseudo-op', 'lsu',
-                         'straight-line'])
+                         'straight-line', 'iflow'])
 
         self.mnemonic = check_str(yd['mnemonic'], 'mnemonic for instruction')
 


### PR DESCRIPTION
As part of the YAML function specifications, write a machine-readable description of how data flows through each instruction, including consideration of flags, memory, indirect references, and special registers.

Information flow to/from DMEM treats memory as a monolithic block. However, the existing `lsu` field already provides information about where memory loads/stores occur and how many bytes they are.