### PR TITLE
[sw/silicon_creator] Clean up flash disable in shutdown

### DIFF
--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -294,7 +294,8 @@ SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_keymgr_kill(void)) {
 
 SHUTDOWN_FUNC(NO_MODIFIERS, shutdown_flash_kill(void)) {
   enum { kBase = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR };
-  abs_mmio_write32(kBase + FLASH_CTRL_DIS_REG_OFFSET, 1);
+  // Setting DIS (rw0c) to a value other than 5 will disable flash permanently.
+  abs_mmio_write32(kBase + FLASH_CTRL_DIS_REG_OFFSET, 0);
 }
 
 SHUTDOWN_FUNC(noreturn, shutdown_hang(void)) {

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -605,7 +605,7 @@ TEST_F(ShutdownTest, ShutdownFinalize) {
 
 TEST_F(ShutdownTest, FlashKill) {
   EXPECT_ABS_WRITE32(
-      TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR + FLASH_CTRL_DIS_REG_OFFSET, 1);
+      TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR + FLASH_CTRL_DIS_REG_OFFSET, 0);
   unmocked_shutdown_flash_kill();
 }
 


### PR DESCRIPTION
The flash disable register was originally rw1c but is now rw0c. Writing 1 to the register does actually work because the reset value of the register is 5 but writing 0 to the register is cleaner.