### PR TITLE
[otbn] Move to D2

### DIFF
--- a/hw/ip/otbn/data/otbn.prj.hjson
+++ b/hw/ip/otbn/data/otbn.prj.hjson
@@ -21,7 +21,7 @@
         {
             version:            "0.2",
             life_stage:         "L1",
-            design_stage:       "D1",
+            design_stage:       "D2",
             verification_stage: "V1",
             dif_stage:          "S1",
         },

--- a/hw/ip/otbn/doc/checklist.md
+++ b/hw/ip/otbn/doc/checklist.md
@@ -35,23 +35,23 @@ Code Quality  | [LINT_SETUP][]                 | Done        |
 
 Type          | Item                    | Resolution  | Note/Collaterals
 --------------|-------------------------|-------------|------------------
-Documentation | [NEW_FEATURES][]        | Not Started |
-Documentation | [BLOCK_DIAGRAM][]       | Not Started |
-Documentation | [DOC_INTERFACE][]       | Not Started |
-Documentation | [MISSING_FUNC][]        | Not Started |
-Documentation | [FEATURE_FROZEN][]      | Not Started |
-RTL           | [FEATURE_COMPLETE][]    | Not Started |
-RTL           | [AREA_CHECK][]          | Not Started |
-RTL           | [PORT_FROZEN][]         | Not Started |
-RTL           | [ARCHITECTURE_FROZEN][] | Not Started |
-RTL           | [REVIEW_TODO][]         | Not Started |
-RTL           | [STYLE_X][]             | Not Started |
-Code Quality  | [LINT_PASS][]           | Not Started |
-Code Quality  | [CDC_SETUP][]           | Not Started |
-Code Quality  | [FPGA_TIMING][]         | Not Started |
-Code Quality  | [CDC_SYNCMACRO][]       | Not Started |
-Security      | [SEC_CM_DOCUMENTED][]   | Not Started |
-Security      | [SEC_RND_CNST][]        | Not Started |
+Documentation | [NEW_FEATURES][]        | Done        | New features are [Key Sideload](https://www.github.com/lowrisc/opentitan/pull/8650), [Private OTBN DMem](https://www.github.com/lowrisc/opentitan/pull/8890), [XoShiRo PRNG](https://www.github.com/lowrisc/opentitan/pull/7944) and [Prefetch Stage](https://www.github.com/lowrisc/opentitan/issues/8898)
+Documentation | [BLOCK_DIAGRAM][]       | Done        |
+Documentation | [DOC_INTERFACE][]       | Done        |
+Documentation | [MISSING_FUNC][]        | Done        | All non security features are documented
+Documentation | [FEATURE_FROZEN][]      | Done        |
+RTL           | [FEATURE_COMPLETE][]    | Done        | Excluding security hardening features
+RTL           | [AREA_CHECK][]          | Done        |
+RTL           | [PORT_FROZEN][]         | Done        |
+RTL           | [ARCHITECTURE_FROZEN][] | Done        |
+RTL           | [REVIEW_TODO][]         | Done        | Remaining TODOs are all security related and will be dealt with for D2S
+RTL           | [STYLE_X][]             | Done        |
+Code Quality  | [LINT_PASS][]           | Done        |
+Code Quality  | [CDC_SETUP][]           | Done        |
+Code Quality  | [FPGA_TIMING][]         | Done        |
+Code Quality  | [CDC_SYNCMACRO][]       | Done        |
+Security      | [SEC_CM_DOCUMENTED][]   | Done        | Two things are not yet documented, this will be done as part of D2S: Blanking, specifying exactly what is blanked. Loop stack hardening, there are a couple of options to discuss.
+Security      | [SEC_RND_CNST][]        | Done        |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new_features" >}}
 [BLOCK_DIAGRAM]:       {{<relref "/doc/project/checklist.md#block_diagram" >}}


### PR DESCRIPTION
The follow PRs must be merged before we can reach D2: https://github.com/lowRISC/opentitan/pull/9219 and https://github.com/lowRISC/opentitan/pull/9560

Please note I am requested we defer the specification of the specifics of blanking and loop stack hardening to D2S. I don't think there's any major points of disagreement about how these will work but we do need to work out some details.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>