### PR TITLE
[entropy_src, dv] Support for SHA3 conditioning

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim.core
+++ b/hw/ip/entropy_src/dv/entropy_src_sim.core
@@ -13,6 +13,7 @@ filesets:
     depend:
       - lowrisc:dv:entropy_src_test
       - lowrisc:dv:entropy_src_sva
+      - lowrisc:dv:digestpp_dpi:0.1
     files:
       - tb/tb.sv
     file_type: systemVerilogSource

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -100,26 +100,61 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   virtual function string convert2string();
     string str = "";
     str = {str, "\n"};
-    str = {str,  $sformatf("\n\t |**************** entropy_src_env_cfg *****************| \t")                         };
-    str = {str,  $sformatf("\n\t |***** otp_en_es_fw_read           : %12s *****| \t", otp_en_es_fw_read.name())       };
-    str = {str,  $sformatf("\n\t |***** otp_en_es_fw_over           : %12s *****| \t", otp_en_es_fw_over.name())       };
-    str = {str,  $sformatf("\n\t |***** enable                      : %12s *****| \t", enable.name())                  };
-    str = {str,  $sformatf("\n\t |***** route_software              : %12s *****| \t", route_software.name())          };
-    str = {str,  $sformatf("\n\t |***** type_bypass                 : %12s *****| \t", type_bypass.name())             };
-    str = {str,  $sformatf("\n\t |***** entropy_data_reg_enable     : %12s *****| \t", entropy_data_reg_enable.name()) };
-    str = {str,  $sformatf("\n\t |***** boot_bypass_disable         : %12s *****| \t", boot_bypass_disable.name())     };
-    str = {str,  $sformatf("\n\t |***** rng_bit_enable              : %12s *****| \t", rng_bit_enable.name())          };
-    str = {str,  $sformatf("\n\t |***** rng_bit_sel                 : %12d *****| \t", rng_bit_sel)                    };
-    str = {str,  $sformatf("\n\t |----------------- knobs ------------------------------| \t")                         };
-    str = {str,  $sformatf("\n\t |***** otp_en_es_fw_read_pct       : %12d *****| \t", otp_en_es_fw_read_pct)          };
-    str = {str,  $sformatf("\n\t |***** otp_en_es_fw_over_pct       : %12d *****| \t", otp_en_es_fw_over_pct)          };
-    str = {str,  $sformatf("\n\t |***** enable_pct                  : %12d *****| \t", enable_pct)                     };
-    str = {str,  $sformatf("\n\t |***** route_software_pct          : %12d *****| \t", route_software_pct)             };
-    str = {str,  $sformatf("\n\t |***** type_bypass_pct             : %12d *****| \t", type_bypass_pct)                };
-    str = {str,  $sformatf("\n\t |***** entropy_data_reg_enable_pct : %12d *****| \t", entropy_data_reg_enable_pct)    };
-    str = {str,  $sformatf("\n\t |***** boot_bypass_disable_pct     : %12d *****| \t", boot_bypass_disable_pct)        };
-    str = {str,  $sformatf("\n\t |***** rng_bit_enable_pct          : %12d *****| \t", rng_bit_enable_pct)             };
-    str = {str,  $sformatf("\n\t |******************************************************| \t")                         };
+    str = {str, "\n\t |**************** entropy_src_env_cfg *****************| \t"};
+
+    str = {
+        str,
+        $sformatf("\n\t |***** otp_en_es_fw_read           : %12s *****| \t",
+             otp_en_es_fw_read.name()),
+        $sformatf("\n\t |***** otp_en_es_fw_over           : %12s *****| \t",
+                  otp_en_es_fw_over.name()),
+        $sformatf("\n\t |***** enable                      : %12s *****| \t",
+                 enable.name()),
+        $sformatf("\n\t |***** route_software              : %12s *****| \t",
+                  route_software.name()),
+         $sformatf("\n\t |***** type_bypass                 : %12s *****| \t",
+                   type_bypass.name()),
+        $sformatf("\n\t |***** entropy_data_reg_enable     : %12s *****| \t",
+                  entropy_data_reg_enable.name()),
+        $sformatf("\n\t |***** boot_bypass_disable         : %12s *****| \t",
+                  boot_bypass_disable.name()),
+        $sformatf("\n\t |***** rng_bit_enable              : %12s *****| \t",
+                  rng_bit_enable.name()),
+        $sformatf("\n\t |***** rng_bit_sel                 : %12d *****| \t",
+                  rng_bit_sel),
+        $sformatf("\n\t |***** fips_window_size            : %12d *****| \t",
+                  fips_window_size),
+        $sformatf("\n\t |***** bypass_window_size          : %12d *****| \t",
+                  bypass_window_size),
+        $sformatf("\n\t |***** boot_mode_retry_limit       : %12d *****| \t",
+                  boot_mode_retry_limit),
+        $sformatf("\n\t |***** seed_cnt                    : %12d *****| \t",
+                  seed_cnt)
+    };
+
+    str = {str, "\n\t |----------------- knobs ------------------------------| \t"};
+
+    str = {
+        str,
+        $sformatf("\n\t |***** otp_en_es_fw_read_pct       : %12d *****| \t",
+                  otp_en_es_fw_read_pct),
+        $sformatf("\n\t |***** otp_en_es_fw_over_pct       : %12d *****| \t",
+                  otp_en_es_fw_over_pct),
+        $sformatf("\n\t |***** enable_pct                  : %12d *****| \t",
+                  enable_pct),
+        $sformatf("\n\t |***** route_software_pct          : %12d *****| \t",
+                  route_software_pct),
+        $sformatf("\n\t |***** type_bypass_pct             : %12d *****| \t",
+                  type_bypass_pct),
+        $sformatf("\n\t |***** entropy_data_reg_enable_pct : %12d *****| \t",
+                  entropy_data_reg_enable_pct),
+        $sformatf("\n\t |***** boot_bypass_disable_pct     : %12d *****| \t",
+                  boot_bypass_disable_pct),
+        $sformatf("\n\t |***** rng_bit_enable_pct          : %12d *****| \t",
+                  rng_bit_enable_pct)
+    };
+
+    str = {str, "\n\t |******************************************************| \t"};
     str = {str, "\n"};
     return str;
   endfunction

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -13,6 +13,7 @@ package entropy_src_env_pkg;
   import csr_utils_pkg::*;
   import entropy_src_ral_pkg::*;
   import push_pull_agent_pkg::*;
+  import entropy_src_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -34,7 +35,7 @@ package entropy_src_env_pkg;
   } entropy_src_intr_e;
 
   typedef enum { BOOT, STARTUP, CONTINUOUS } entropy_phase_e;
-  typedef bit[entropy_src_pkg::RNG_BUS_WIDTH-1:0] rng_val_t;
+  typedef bit [RNG_BUS_WIDTH-1:0] rng_val_t;
   typedef rng_val_t queue_of_rng_val_t[$];
 
   //
@@ -88,6 +89,14 @@ package entropy_src_env_pkg;
     return (bypass || phase == BOOT) ? entropy_src_pkg::CSRNG_BUS_WIDTH : fips_window_size;
 
   endfunction
+
+  // return zero if this next set of rng values would cause a health check failure,
+  // based on the currently configured thresholds.
+  function automatic bit health_check_rng_data(queue_of_rng_val_t sample);
+    // TODO: Implement this
+    return 0;
+  endfunction
+
 
   // package sources
   `include "entropy_src_env_cfg.sv"

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -12,10 +12,11 @@ class entropy_src_scoreboard extends cip_base_scoreboard
 
   `uvm_component_utils(entropy_src_scoreboard)
 
+  // used by collect_entropy to determine the FSMs phase
+  int seed_idx           = 0;
   int entropy_data_reads = 0;
 
   // local variables
-  push_pull_item#(.HostDataWidth(RNG_BUS_WIDTH))  rng_item;
   bit [31:0]                       entropy_data_q[$];
   bit [FIPS_CSRNG_BUS_WIDTH - 1:0] fips_csrng_q[$];
 
@@ -147,6 +148,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard
           "entropy_data": begin
             bit [31:0] ed_pred_data = entropy_data_q.pop_front();
             `uvm_info(`gfn, $sformatf("entropy_data_prediction: %08h\n", ed_pred_data), UVM_MEDIUM)
+            `uvm_info(`gfn, $sformatf("Actual value:            %08h", item.d_data), UVM_HIGH)
             `DV_CHECK_FATAL(csr.predict(.value(ed_pred_data), .kind(UVM_PREDICT_READ)))
             entropy_data_reads++;
             `uvm_info(`gfn, $sformatf("entropy_data_reads: %3d\n", entropy_data_reads), UVM_MEDIUM);
@@ -168,25 +170,77 @@ class entropy_src_scoreboard extends cip_base_scoreboard
     return fips_csrng[0 +: CSRNG_BUS_WIDTH];
   endfunction
 
-  function bit [FIPS_CSRNG_BUS_WIDTH - 1:0] predict_fips_csrng(
-      bit [RNG_BUS_WIDTH - 1:0] data_q[$]);
+  // Note: this routine is destructive in that it empties the input argument
+  function bit [FIPS_CSRNG_BUS_WIDTH - 1:0] predict_fips_csrng(queue_of_rng_val_t sample);
     bit [FIPS_CSRNG_BUS_WIDTH - 1:0] fips_csrng_data;
     bit [CSRNG_BUS_WIDTH - 1:0]      csrng_data;
     bit [FIPS_BUS_WIDTH - 1:0]       fips_data;
+    entropy_phase_e                  dut_phase;
+    bit                              predict_conditioned;
 
-    // TODO: Add SHA3 prediction
-    if (cfg.type_bypass) begin
-      fips_data = '0;
+    int                              sample_rng_frames;
+    int                              pass_cnt_threshold;
+    int                              pass_cnt;
+
+    dut_phase = convert_seed_idx_to_phase(seed_idx,
+                                          cfg.boot_bypass_disable == prim_mubi_pkg::MuBi4True);
+
+    sample_rng_frames = sample.size();
+
+    `uvm_info(`gfn, $sformatf("processing %01d frames", sample_rng_frames), UVM_FULL)
+
+    predict_conditioned = (cfg.type_bypass != prim_mubi_pkg::MuBi4True) && (dut_phase != BOOT);
+
+    // TODO: for now assume that data is fips certified if it has been conditioned
+    //       need to check that no other conditions apply for released data.
+    fips_data    = predict_conditioned;
+
+    if (predict_conditioned) begin
+      int rng_per_byte = 8 / RNG_BUS_WIDTH;
+
+      bit [7:0] sha_msg[];
+      bit [7:0] sha_digest[CSRNG_BUS_WIDTH / 8];
+      longint msg_len = 0;
+
+      sha_msg = new[sample.size() / rng_per_byte];
+
+      while (sample.size() > 0) begin
+        bit [7:0] sha_byte = '0;
+        for (int i = 0; i < rng_per_byte; i++) begin
+          sha_byte = (sha_byte >> RNG_BUS_WIDTH);
+          sha_byte = sha_byte | (sample.pop_front() << (8 - RNG_BUS_WIDTH));
+        end
+        `uvm_info(`gfn, $sformatf("msglen: %04h, byte: %02h", msg_len, sha_byte), UVM_FULL)
+        sha_msg[msg_len] = sha_byte;
+        msg_len++;
+      end
+
+      `uvm_info(`gfn, $sformatf("DIGESTION COMMENCING of %d bytes", msg_len), UVM_FULL)
+
+      digestpp_dpi_pkg::c_dpi_sha3_384(sha_msg, msg_len, sha_digest);
+
+      `uvm_info(`gfn, "DIGESTING COMPLETE", UVM_FULL)
+
+      csrng_data = '0;
+      for(int i = 0; i < CSRNG_BUS_WIDTH / 8; i++) begin
+        bit [7:0] sha_byte = sha_digest[i];
+
+        `uvm_info(`gfn, $sformatf("repacking: %02d", i), UVM_FULL)
+
+        csrng_data = (csrng_data >> 8) | (sha_byte << (CSRNG_BUS_WIDTH - 8));
+      end
+      `uvm_info(`gfn, $sformatf("Conditioned data: %096h", csrng_data), UVM_HIGH)
+
     end else begin
-      // TODO: support Boot mode entropy
-      // Will require some changes from #9451
-      fips_data = '1;
-    end
 
-    for (int i = data_q.size() - 1; i >= 0 ; i--) begin
-      // Since the queue is read from back to front
-      // earlier rng bits occupy the less significant bits of csrng_data
-      csrng_data = (csrng_data << 4) + data_q[i];
+      while (sample.size() > 0) begin
+        rng_val_t rng_val = sample.pop_back();
+        // Since the queue is read from back to front
+        // earlier rng bits occupy the less significant bits of csrng_data
+        csrng_data = (csrng_data << RNG_BUS_WIDTH) + rng_val;
+      end
+      `uvm_info(`gfn, $sformatf("Unconditioned data: %096h", csrng_data), UVM_HIGH)
+
     end
     fips_csrng_data = {fips_data, csrng_data};
 
@@ -194,55 +248,133 @@ class entropy_src_scoreboard extends cip_base_scoreboard
   endfunction
 
   task collect_entropy();
-    bit [15:0]              window_size;
-    bit [RNG_BUS_WIDTH - 1:0] rng_data, rng_data_q[$];
-    bit                     first_call;
-    int                     rng_frames_per_window;
 
-    first_call = 1'b1;
+    bit [15:0]                window_size;
+    entropy_phase_e           dut_fsm_phase;
+    push_pull_item#(.HostDataWidth(RNG_BUS_WIDTH))  rng_item;
+    rng_val_t                 rng_val;
+    // TODO rename window to "sample"
+    queue_of_rng_val_t        window;
+    queue_of_rng_val_t        sample;
+    int                       window_rng_frames;
+    int                       pass_requirement, pass_cnt;
+    int                       retry_limit, retry_cnt;
 
-    // TODO: Read window size from register
-    if (cfg.type_bypass || first_call)
-      window_size = CSRNG_BUS_WIDTH;
-    else
-      window_size = 2048;
+    retry_cnt = 0;
+    pass_cnt  = 0;
 
-    // TODO: RNG bit-select
-    rng_frames_per_window = window_size/RNG_BUS_WIDTH;
+    window.delete();
+    sample.delete();
 
-    forever begin
-      if (cfg.rng_bit_enable == prim_mubi_pkg::MuBi4True) begin
-        for (int i = 0; i < RNG_BUS_WIDTH; i++) begin
-          rng_fifo.get(rng_item);
-          rng_data[i] = rng_item.h_data[cfg.rng_bit_sel];
+    forever begin : collect_entropy_loop
+
+      dut_fsm_phase = convert_seed_idx_to_phase(seed_idx,
+          cfg.boot_bypass_disable == prim_mubi_pkg::MuBi4True);
+
+      case (dut_fsm_phase)
+        BOOT: begin
+          pass_requirement = 1;
+          retry_limit = cfg.boot_mode_retry_limit;
         end
-      end
-      else begin
-        rng_fifo.get(rng_item);
-        rng_data = rng_item.h_data;
-      end
-      rng_data_q.push_back(rng_data);
+        STARTUP: begin
+          pass_requirement = 2;
+          retry_limit = 2;
+        end
+        CONTINUOUS: begin
+          pass_requirement = 0;
+          retry_limit = 2;
+        end
+        default: begin
+          `uvm_fatal(`gfn, "Invalid predicted dut state (bug in environment)")
+        end
+      endcase
 
-      if (rng_data_q.size() == rng_frames_per_window) begin
+      `uvm_info(`gfn, $sformatf("phase: %s\n", dut_fsm_phase.name), UVM_HIGH)
+
+      window_size = rng_window_size(seed_idx, cfg.type_bypass == prim_mubi_pkg::MuBi4True,
+                                    cfg.boot_bypass_disable == prim_mubi_pkg::MuBi4True,
+                                    cfg.fips_window_size);
+
+      `uvm_info(`gfn, $sformatf("window_size: %08d\n", window_size), UVM_HIGH)
+
+      // Note on RNG bit enable and window frame count:
+      // When rng_bit_enable is selected, the function below repacks the data so that
+      // the selected bit fills a whole frame.
+      // This mirrors the DUT's behavior of repacking the data before the health checks
+      //
+      // Thus the number of (repacked) window frames is the same regardless of whether
+      // the bit select is enabled.
+
+      window_rng_frames = window_size / RNG_BUS_WIDTH;
+
+      window.delete();
+      if(dut_fsm_phase != STARTUP) begin
+        sample.delete();
+      end
+
+      while (window.size() < window_rng_frames) begin
+        if (cfg.rng_bit_enable == prim_mubi_pkg::MuBi4True) begin
+          for (int i = 0; i < RNG_BUS_WIDTH; i++) begin
+            rng_fifo.get(rng_item);
+            rng_val[i] = rng_item.h_data[cfg.rng_bit_sel];
+          end
+        end else begin
+          rng_fifo.get(rng_item);
+          rng_val = rng_item.h_data;
+        end
+        window.push_back(rng_val);
+      end
+
+
+     `uvm_info(`gfn, "FULL_WINDOW", UVM_FULL)
+      if (health_check_rng_data(window)) begin
+        retry_cnt++;
+        pass_cnt = 0;
+      end else begin
+        retry_cnt = 0;
+        pass_cnt++;
+      end
+
+      // Now that the window has been tested, add it to the running sample.
+      while(window.size() > 0) begin
+        sample.push_back(window.pop_front());
+      end
+
+      `uvm_info(`gfn, $sformatf("pass_cnt: %01d, retry_cnt: %01d", pass_cnt, retry_cnt), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("pass_requirement: %01d", pass_requirement), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("retry_limit: %01d", retry_limit), UVM_HIGH)
+      `uvm_info(`gfn, $sformatf("sample.size: %01d", sample.size()), UVM_HIGH)
+
+      // TODO: Update health check stats.
+      if (retry_cnt >= retry_limit) begin
+        // TODO: Alert state
+        `uvm_info(`gfn, "TODO: manage alerts", UVM_FULL)
+      end else if (pass_cnt >= pass_requirement) begin
         bit [FIPS_CSRNG_BUS_WIDTH - 1:0] fips_csrng;
-        fips_csrng = predict_fips_csrng(rng_data_q);
+
+        fips_csrng = predict_fips_csrng(sample);
+
+        // update counters for processing next seed:
+        retry_cnt = 0;
+        pass_cnt  = 0;
+        seed_idx++;
+
+        // package data for routing to SW or to CSRNG:
         if (cfg.route_software == prim_mubi_pkg::MuBi4True) begin
           bit [CSRNG_BUS_WIDTH - 1:0] csrng_seed = get_csrng_seed(fips_csrng);
-          for (int i = 0; i < CSRNG_BUS_WIDTH/TL_DW; i++) begin
-            bit [TL_DW - 1:0] entropy_slice = csrng_seed[i*TL_DW +: TL_DW];
+          for (int i = 0; i < CSRNG_BUS_WIDTH / TL_DW; i++) begin
+            bit [TL_DW - 1:0] entropy_slice = csrng_seed[i * TL_DW +: TL_DW];
             entropy_data_q.push_back(entropy_slice);
           end
         end else if (cfg.route_software == prim_mubi_pkg::MuBi4False) begin
           fips_csrng_q.push_back(fips_csrng);
-        end else begin
-          // TODO: invalid MuBi value for route_software: What where does data go?
         end
-        for (int i = 0; i < rng_frames_per_window; i++) begin
-          rng_data_q.delete();
-        end
+      end else begin
+        // Inconsequential health check failure
       end
-      first_call = 1'b0;
-    end
+
+    end : collect_entropy_loop
+
   endtask
 
   virtual task process_csrng();

--- a/hw/ip/kmac/dv/dpi/digestpp_dpi_pkg.sv
+++ b/hw/ip/kmac/dv/dpi/digestpp_dpi_pkg.sv
@@ -12,27 +12,27 @@ package digestpp_dpi_pkg;
 
   // DPI-C imports
   import "DPI-C" context function void c_dpi_sha3_224(
-    input bit[7:0]      msg[],
-    input int unsigned  msg_len,
-    output bit[7:0]     digest[]
+    input bit[7:0]          msg[],
+    input longint unsigned  msg_len,
+    output bit[7:0]         digest[]
   );
 
   import "DPI-C" context function void c_dpi_sha3_256(
-    input bit[7:0]      msg[],
-    input int unsigned  msg_len,
-    output bit[7:0]     digest[]
+    input bit[7:0]          msg[],
+    input longint unsigned  msg_len,
+    output bit[7:0]         digest[]
   );
 
   import "DPI-C" context function void c_dpi_sha3_384(
-    input bit[7:0]      msg[],
-    input int unsigned  msg_len,
-    output bit[7:0]     digest[]
+    input bit[7:0]          msg[],
+    input longint unsigned  msg_len,
+    output bit[7:0]         digest[]
   );
 
   import "DPI-C" context function void c_dpi_sha3_512(
-    input bit[7:0]      msg[],
-    input int unsigned  msg_len,
-    output bit[7:0]     digest[]
+    input bit[7:0]          msg[],
+    input longint unsigned  msg_len,
+    output bit[7:0]         digest[]
   );
 
   import "DPI-C" context function void c_dpi_shake128(


### PR DESCRIPTION
- Uses digestpp DPI routine for predicting SHA3 outputs
    - Fixes bug in digestpp package where msg_len was originally
      only a 32-bit int.  Makes it now a 64-bit longint to match
      C++ implementation below
- Establishes proper support for independent retry and pass counts
  for health checks.  (Startup phase needs 2 consecutive passes to
  complete)
    - Analogous changes made to the entropy_src_base_vseq
- In startup mode, the conditioning sample can now accumulate accross
  multiple widows.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>