### PR TITLE
[ottf,tests] Migrate sram_ctrl_main_scrambled_access_test to OTTF.

### DIFF
--- a/sw/device/tests/sram_ctrl_main_scrambled_access_test.c
+++ b/sw/device/tests/sram_ctrl_main_scrambled_access_test.c
@@ -14,7 +14,7 @@
 #include "sw/device/lib/testing/check.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/sram_ctrl_testutils.h"
-#include "sw/device/lib/testing/test_framework/test_main.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
 #include "sw/device/lib/testing/test_framework/test_status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"


### PR DESCRIPTION
An sram_ctrl chip-level test merged just before #9368 merged. This commit migrates the remaining chip-level tests to the OTTF (partially addressing #8015).

Signed-off-by: Timothy Trippel <ttrippel@google.com>