### PR TITLE
[sram/dv] Add generic mem_bkdr_scb and enable it in sram scb

### DIFF
--- a/hw/dv/sv/mem_bkdr_scb/README.md
+++ b/hw/dv/sv/mem_bkdr_scb/README.md
@@ -1,0 +1,36 @@
+## Memory Backdoor Scoreboard
+The mem_model_pkg checks write value matches with previous write value, but
+there are some limitations.
+  - Can’t check memory ECC if encoding and decoding match each other.
+  - Can’t check the read value if the address hasn't been written after init
+     or after a key request.
+  - Can’t check the write value if the address isn’t read after the write.
+  - Not aware of any B2B hazard (such as RAW).
+This scoreboard can cover all above limitations, as it checks read/write value
+matches with backdoor value. B2B hazard will be handled when predicting expected
+value. All kinds of hazard corner cases will be sampled in functional coverage.
+
+### `get_bkdr_val(mem_addr_t addr);`
+User must override this pure virtual function to return backdoor value from the
+memory based on the given address.
+
+### `read_start(mem_addr_t addr, mem_mask_t mask)`
+This function should be called when a read request is latched by design.
+Predicted read value is calculated in this function:
+ - If there is a pending write with same address (RAW hazard), the expected value is
+ from this write (also depends on which bytes is enabled)
+ - If no RAW hazard, the expected value is from latching backdoor value at the
+ time of calling this function.
+
+### `read_finish(mem_data_t act_data, mem_addr_t addr, mem_mask_t mask, bit en_check_consistency)`
+This function should be called when a read transaction is done. It compares the read
+value with expected value calculated at `read_start`.
+
+### `write_start(mem_addr_t addr, mem_mask_t mask)`
+This function should be called when a write request is latched by design.
+Write items will be stored in the queue for checking RAW hazard and future comparison.
+
+### `write_finish(mem_addr_t addr, mem_mask_t mask, bit en_check_consistency)`
+This function should be called once the write data is written into the memory.
+This function will read back the data from backdoor and compare with write value stored
+in write_item_q.

--- a/hw/dv/sv/mem_bkdr_scb/mem_bkdr_scb.core
+++ b/hw/dv/sv/mem_bkdr_scb/mem_bkdr_scb.core
@@ -1,0 +1,21 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:mem_bkdr_scb"
+description: "DV Memory Model"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:opentitan:bus_params_pkg
+      - lowrisc:dv:dv_macros
+    files:
+      - mem_bkdr_scb_pkg.sv
+      - mem_bkdr_scb.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/mem_bkdr_scb/mem_bkdr_scb.sv
+++ b/hw/dv/sv/mem_bkdr_scb/mem_bkdr_scb.sv
@@ -1,0 +1,147 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+virtual class mem_bkdr_scb #(int AddrWidth = bus_params_pkg::BUS_AW,
+                             int DataWidth = bus_params_pkg::BUS_DW) extends uvm_object;
+
+  localparam int MaskWidth  = DataWidth / 8;
+
+  typedef bit [AddrWidth-1:0] mem_addr_t;
+  typedef bit [DataWidth-1:0] mem_data_t;
+  typedef bit [MaskWidth-1:0] mem_mask_t;
+
+  typedef struct {
+    mem_addr_t addr;
+    mem_data_t data;
+    mem_mask_t mask;
+  } mem_item_t;
+
+  // Queue to save pending items
+  mem_item_t read_item_q[$];
+  mem_item_t write_item_q[$];
+
+  `uvm_object_new
+
+  // User must override this function to return backdoor value from the memory based on given addr
+  pure virtual function mem_data_t get_bkdr_val(mem_addr_t addr);
+
+  function void reset();
+    read_item_q.delete();
+    write_item_q.delete();
+  endfunction
+
+  // utility function to expand a TLUL mask to a full bit-mask
+  function mem_data_t expand_bit_mask(mem_mask_t mask);
+    mem_data_t bitmask = '0;
+    for (int i = 0; i < MaskWidth; i++) begin
+      bitmask[i*8 +: 8] = {8{mask[i]}};
+    end
+    return bitmask;
+  endfunction
+
+  // Check if read-after-write hazard occurs. If so, return 1 and output data & mask of the last
+  // match item
+  function bit check_raw_hazard(input mem_addr_t addr,
+                                output mem_data_t data, output mem_mask_t mask);
+    int found_idx_q[$];
+
+    found_idx_q = write_item_q.find_last_index() with (item.addr == addr);
+    if (found_idx_q.size) begin
+      data = write_item_q[found_idx_q[0]].data;
+      mask = write_item_q[found_idx_q[0]].mask;
+      return 1;
+    end else begin
+      return 0;
+    end
+  endfunction
+
+  // check the item is consistent between read|write_start and read|write_finish
+  function void check_item_consistency(mem_item_t start_item,
+                                       mem_addr_t finish_item_addr,
+                                       mem_mask_t finish_item_mask);
+    `DV_CHECK_EQ(start_item.addr, finish_item_addr)
+    `DV_CHECK_EQ(start_item.mask, finish_item_mask)
+  endfunction
+
+  // Call this function when a read request is latched by design
+  // Predicted read value is calculated in this function:
+  //  - If there is a pending write with same addr (RAW hazard), the expected value is from this
+  //  write (also depends on which bytes is enabled)
+  //  - If no RAW hazard, the expected value is from latching backdoor value at the time of calling
+  //  this function
+  function void read_start(mem_addr_t addr, mem_mask_t mask);
+    bit is_raw;
+    mem_data_t raw_data, bkdr_data, exp_data;
+    mem_mask_t raw_mask;
+    mem_data_t raw_bit_mask, exp_bit_mask;
+
+    // TODO, sample is_raw in coverage
+    is_raw = check_raw_hazard(addr, raw_data, raw_mask);
+    if (is_raw) begin
+      raw_bit_mask = expand_bit_mask(raw_mask);
+      `uvm_info(`gfn, $sformatf("Found RAW hazard : Addr[0x%0h], Data[0x%0h], Mask[0x%0h]",
+                                addr, raw_data, raw_mask), UVM_MEDIUM)
+    end
+
+    bkdr_data = get_bkdr_val(addr);
+    exp_data = (raw_data & raw_bit_mask) | (bkdr_data & ~raw_bit_mask);
+
+    exp_bit_mask = expand_bit_mask(mask);
+    exp_data &= exp_bit_mask;
+
+    read_item_q.push_back(mem_item_t'{addr, exp_data, mask});
+
+    `uvm_info(`gfn, $sformatf("read_start : Addr[0x%0h], Exp_data[0x%0h], Mask[0x%0h]",
+                              addr, exp_data, mask), UVM_MEDIUM)
+  endfunction
+
+  // Call this function when a read transaction is done and compare the read value with expected
+  // value calculated at read_start
+  function void read_finish(mem_data_t act_data,
+                            mem_addr_t addr = 0,
+                            mem_mask_t mask = '1,
+                            bit en_check_consistency = 1);
+    mem_item_t exp_item;
+    `DV_CHECK_NE(read_item_q.size, 0)
+    exp_item = read_item_q.pop_front();
+    act_data &= expand_bit_mask(mask);
+
+    if (en_check_consistency) check_item_consistency(exp_item, addr, mask);
+    `DV_CHECK_EQ(act_data, exp_item.data, $sformatf("addr 0x%0h read out mismatch", exp_item.addr))
+
+    `uvm_info(`gfn, $sformatf("read_finish: Addr[0x%0h], data[0x%0h], Mask[0x%0h]",
+                              exp_item.addr, act_data, exp_item.mask), UVM_MEDIUM)
+  endfunction
+
+  // Call this function when a write request is latched by design
+  // Write item will be stored in the queue for checking RAW hazard and future comparison
+  function void write_start(mem_addr_t addr, mem_data_t exp_data, mem_mask_t mask);
+    write_item_q.push_back(mem_item_t'{addr, exp_data, mask});
+    `uvm_info(`gfn, $sformatf("write_start : Addr[0x%0h], Exp_data[0x%0h], Mask[0x%0h]",
+                              addr, exp_data, mask), UVM_MEDIUM)
+  endfunction
+
+  // Call this function once the write data is written into the memory
+  // this function will read back the data from backdoor and compare with write value stored in
+  // write_item_q
+  function void write_finish(mem_addr_t addr = 0,
+                             mem_mask_t mask = '1,
+                             bit en_check_consistency = 1);
+    mem_data_t act_data, exp_data;
+    mem_data_t bit_mask;
+    mem_item_t exp_item;
+    `DV_CHECK_NE(write_item_q.size, 0)
+    exp_item = write_item_q.pop_front();
+    bit_mask = expand_bit_mask(exp_item.mask);
+
+    if (en_check_consistency) check_item_consistency(exp_item, addr, mask);
+
+    act_data = get_bkdr_val(exp_item.addr) & bit_mask;
+    exp_data = exp_item.data & bit_mask;
+    `DV_CHECK_EQ(act_data, exp_data, $sformatf("addr 0x%0h write mismatch", exp_item.addr))
+
+    `uvm_info(`gfn, $sformatf("write_finish: Addr[0x%0h], data[0x%0h], Mask[0x%0h]",
+                              exp_item.addr, act_data, exp_item.mask), UVM_MEDIUM)
+  endfunction
+endclass

--- a/hw/dv/sv/mem_bkdr_scb/mem_bkdr_scb_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_scb/mem_bkdr_scb_pkg.sv
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package mem_bkdr_scb_pkg;
+
+  import uvm_pkg::*;
+
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+  `include "mem_bkdr_scb.sv"
+
+endpackage

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:mem_bkdr_util
+      - lowrisc:dv:mem_bkdr_scb
     files:
       - sram_ctrl_prim_ral_pkg.sv
       - sram_ctrl_env_pkg.sv
@@ -18,6 +19,7 @@ filesets:
       - sram_ctrl_env_cfg.sv: {is_include_file: true}
       - sram_ctrl_env_cov.sv: {is_include_file: true}
       - sram_ctrl_virtual_sequencer.sv: {is_include_file: true}
+      - sram_ctrl_mem_bkdr_scb.sv: {is_include_file: true}
       - sram_ctrl_scoreboard.sv: {is_include_file: true}
       - sram_ctrl_env.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_vseq_list.sv: {is_include_file: true}

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
@@ -20,6 +20,7 @@ package sram_ctrl_env_pkg;
   import lc_ctrl_pkg::*;
   import crypto_dpi_prince_pkg::*;
   import mem_bkdr_util_pkg::*;
+  import mem_bkdr_scb_pkg::*;
   import prim_mubi_pkg::*;
 
   // macro includes
@@ -65,6 +66,7 @@ package sram_ctrl_env_pkg;
   `include "sram_ctrl_env_cfg.sv"
   `include "sram_ctrl_env_cov.sv"
   `include "sram_ctrl_virtual_sequencer.sv"
+  `include "sram_ctrl_mem_bkdr_scb.sv"
   `include "sram_ctrl_scoreboard.sv"
   `include "sram_ctrl_env.sv"
   `include "sram_ctrl_vseq_list.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_mem_bkdr_scb.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_mem_bkdr_scb.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class sram_ctrl_mem_bkdr_scb extends mem_bkdr_scb;
+
+  `uvm_object_utils(sram_ctrl_mem_bkdr_scb)
+  `uvm_object_new
+
+  mem_bkdr_util mem_bkdr_util_h;
+
+  protected otp_ctrl_pkg::sram_key_t   key;
+  protected otp_ctrl_pkg::sram_nonce_t nonce;
+
+  virtual function mem_data_t get_bkdr_val(mem_addr_t addr);
+    return mem_bkdr_util_h.sram_encrypt_read32_integ(addr, key, nonce);
+  endfunction
+
+  virtual function void update_key(otp_ctrl_pkg::sram_key_t   key,
+                                   otp_ctrl_pkg::sram_nonce_t nonce);
+    this.key   = key;
+    this.nonce = nonce;
+  endfunction
+
+endclass

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -46,6 +46,10 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
   bit in_executable_mode;
 
+  string write_en_path;
+
+  sram_ctrl_mem_bkdr_scb mem_bkdr_scb;
+
   typedef struct {
     // 1 for writes, 0 for reads
     bit we;
@@ -110,6 +114,10 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
   // (SRAM is indexed at word granularity)
   function bit [TL_AW-1:0] word_align_addr(bit [TL_AW-1:0] addr);
     return {addr[TL_AW-1:2], 2'b00};
+  endfunction
+
+  function bit [TL_AW-1:0] normalize_addr(bit [TL_AW-1:0] addr);
+    return cfg.ral_models[cfg.sram_ral_name].get_normalized_addr(addr);
   endfunction
 
   // utility function to check whether two addresses map to the same SRAM memory line
@@ -214,6 +222,14 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
   endfunction
 
   task run_phase(uvm_phase phase);
+    string mem_path = dv_utils_pkg::get_parent_hier(cfg.mem_bkdr_util_h.get_path());
+    write_en_path = $sformatf("%s.write_i", mem_path);
+    `DV_CHECK(uvm_hdl_check_path(write_en_path),
+              $sformatf("Hierarchical path %0s appears to be invalid.", write_en_path))
+
+    mem_bkdr_scb = sram_ctrl_mem_bkdr_scb::type_id::create("mem_bkdr_scb");
+    mem_bkdr_scb.mem_bkdr_util_h = cfg.mem_bkdr_util_h;
+
     super.run_phase(phase);
     fork
       sample_key_req_access_cg();
@@ -225,6 +241,22 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
       process_kdi_fifo();
       process_completed_trans();
     join_none
+  endtask
+
+  // write usually completes in a few cycles after TL addrss phase, but it may take longer time
+  // when it's partial write or when RAW hazard occurs. It's not easy to know when it actually
+  // finishes, so probe internal write_i instead
+  task wait_write_done_and_check_nonblocking();
+    bit write_en;
+    fork begin
+      while (!write_en) begin
+        cfg.clk_rst_vif.wait_n_clks(1);
+        `DV_CHECK(uvm_hdl_read(write_en_path, write_en))
+      end
+      cfg.clk_rst_vif.wait_n_clks(1);
+      // There is no addr and mask info collected for this write, skipping the consistency check
+      mem_bkdr_scb.write_finish(.en_check_consistency(0));
+    end join_none
   endtask
 
   // This task spins forever and samples the appropriate covergroup whenever
@@ -412,6 +444,14 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
           continue;
         end
 
+        if (item.is_write()) begin
+          mem_bkdr_scb.write_start(normalize_addr(item.a_addr), item.a_data, item.a_mask);
+
+          wait_write_done_and_check_nonblocking();
+        end else begin
+          mem_bkdr_scb.read_start(normalize_addr(item.a_addr), item.a_mask);
+        end
+
         addr_trans.we    = item.is_write();
         addr_trans.addr  = word_align_addr(item.a_addr);
         addr_trans.mask  = item.a_mask;
@@ -509,6 +549,10 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
           `DV_CHECK_EQ(addr_trans_available, 1,
               "SRAM returned TLUL response in LC escalation state")
         end
+      end
+
+      if (!item.is_write()) begin
+        mem_bkdr_scb.read_finish(item.d_data, normalize_addr(item.a_addr), item.a_mask);
       end
 
       // the addr_phase_mbox will be populated during A_phase of each memory transaction.
@@ -655,6 +699,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
       // When KDI item is seen, update key, nonce
       {key, nonce, seed_valid} = item.d_data;
+      mem_bkdr_scb.update_key(key, nonce);
 
       // sample coverage on seed_valid
       if (cfg.en_cov) begin
@@ -725,7 +770,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
     // backdoor read the mem
     exp_data = cfg.mem_bkdr_util_h.sram_encrypt_read32_integ(word_addr, t.key, t.nonce);
-    `uvm_info(`gfn, $sformatf("exp_data: 0x%0x", exp_data), UVM_HIGH)
+    `uvm_info(`gfn, $sformatf("exp_data: 0x%0x", exp_data), UVM_MEDIUM)
 
     exp_masked_data = exp_data & bit_mask;
     act_masked_data = t.data & bit_mask;
@@ -733,7 +778,12 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     `uvm_info(`gfn, $sformatf("exp_masked_data: 0x%0x", exp_masked_data), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("act_masked_data: 0x%0x", act_masked_data), UVM_HIGH)
 
-    `DV_CHECK_EQ(exp_masked_data, act_masked_data)
+    // TODO, downgrade this check and it can't handle a few b2b cases
+    // This part of checking will be removed once mem_bkdr_scb works well.
+    if (exp_masked_data != act_masked_data) begin
+      `uvm_info(`gfn, $sformatf("act_masked_data: 0x%0x != exp_masked_data: 0x%0x",
+                                act_masked_data, exp_masked_data), UVM_LOW)
+    end
   endfunction
 
 

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -33,8 +33,10 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
+                // Enable stress tests later
+                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                ]
 
   en_build_modes: ["{tool}_memutil_dpi_scrambled_build_opts"]
 


### PR DESCRIPTION
The current sram mem scb can't handle a few corner cases like b2b write
after write, write after read and read after partial write. Instead of
hacking it to support them, I created a generic mem_bkdr_scb to compare
read/write value with expected value from backdoor. 
For details, refer to README or [slides](https://docs.google.com/presentation/d/1jvE5RmzlL7eZLwgmQJQUlbnr3beb1KXypzxk9LblIyg/edit#slide=id.p) 

2 more PRs will come soon to address
1. remove design hack for partial write
2. clean up the old sram mem backdoor check. Keep it for now as it may
help to debug the new checks

Signed-off-by: Weicai Yang <weicai@google.com>