### PR TITLE
[cdc] Add link to nightly CDC build to HW dashboard

### DIFF
--- a/hw/_index.md
+++ b/hw/_index.md
@@ -48,6 +48,7 @@ Finally, we provide the same set of information for all available [top level des
 * [Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/lint/veriblelint/latest/results.html)
 * [DV Style lint results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/dv/lint/veriblelint/latest/results.html)
 * [Synthesis results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/syn/latest/results.html)
+* [CDC results (nightly)](https://reports.opentitan.org/hw/top_earlgrey/cdc/latest/results.html)
 
 ### Earl Grey-specific comportable IPs
 


### PR DESCRIPTION
This adds a link to the nightly CDC regression results to the HW dashboard.

I still need to add a bunch of common waivers, and I believe that will cut down the number of warnings quite a bit.

But otherwise we can start to dig in - happy fixing ;).

Btwy, in order to understand the errors better, have a look at the CDC report from the tool - it provides additional descriptions of these messages.

Signed-off-by: Michael Schaffner <msf@opentitan.org>