### PR TITLE
[kmac] 8982 LC input escalation

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -2252,6 +2252,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .run_i      (1'b0             ), // For software application
     .done_i     (sha3_done        ),
 
+    // LC escalation
+    .lc_escalate_en_i (lc_ctrl_pkg::Off),
+
     .absorbed_o (sha3_absorbed),
     .squeezing_o (sha3_squeezing),
 

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -148,6 +148,13 @@
       name:    "en_masking"
       act:     "req"
     }
+    { struct:  "lc_tx"
+      type:    "uni"
+      name:    "lc_escalate_en"
+      act:     "rcv"
+      default: "lc_ctrl_pkg::Off"
+      package: "lc_ctrl_pkg"
+    }
   ]
   countermeasures: [
     { name: "BUS.INTEGRITY",

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -63,6 +63,9 @@ module tb;
     .alert_rx_i         (alert_rx ),
     .alert_tx_o         (alert_tx ),
 
+    // life cycle escalation input
+    .lc_escalate_en_i   (lc_ctrl_pkg::Off ),
+
     // KeyMgr sideload key interface
     .keymgr_key_i       (kmac_sideload_key),
 

--- a/hw/ip/kmac/kmac.core
+++ b/hw/ip/kmac/kmac.core
@@ -20,6 +20,8 @@ filesets:
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:edn_req
       - lowrisc:ip:kmac_pkg
+      - lowrisc:ip:lc_ctrl_pkg
+      - lowrisc:prim:lc_sync
     files:
       - rtl/kmac_reg_pkg.sv
       - rtl/kmac_reg_top.sv

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -828,7 +828,7 @@ module kmac
     .done_i     (sha3_done        ),
 
     // LC escalation
-    //.lc_escalate_en_i (lc_escalate_en),
+    .lc_escalate_en_i (lc_escalate_en),
 
     .absorbed_o  (sha3_absorbed),
     .squeezing_o (unused_sha3_squeeze),

--- a/hw/ip/kmac/rtl/sha3_pkg.sv
+++ b/hw/ip/kmac/rtl/sha3_pkg.sv
@@ -101,7 +101,7 @@ package sha3_pkg;
   // and also in KMAC top module and the register interface for sw to track the
   // sha3 status.
   // Encoding generated with:
-  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 6 -n 6 \
+  // $ ./util/design/sparse-fsm-encode.py -d 3 -m 7 -n 6 \
   //      -s 4082450958 --language=sv
   //
   // Hamming distance histogram:
@@ -109,15 +109,15 @@ package sha3_pkg;
   //  0: --
   //  1: --
   //  2: --
-  //  3: |||||||||||||||||||| (53.33%)
-  //  4: ||||||||||||||| (40.00%)
-  //  5: || (6.67%)
+  //  3: |||||||||||||||||||| (57.14%)
+  //  4: ||||||||||||||| (42.86%)
+  //  5: --
   //  6: --
   //
   // Minimum Hamming distance: 3
-  // Maximum Hamming distance: 5
-  // Minimum Hamming weight: 2
-  // Maximum Hamming weight: 5
+  // Maximum Hamming distance: 4
+  // Minimum Hamming weight: 1
+  // Maximum Hamming weight: 4
   //
   localparam int StateWidth = 6;
   typedef enum logic [StateWidth-1:0] {
@@ -128,7 +128,7 @@ package sha3_pkg;
     // not sha3core. The core module and this state machine observe the status
     // of the process and mainly waits until all the sponge absorbing is
     // completed. The main indicator is `absorbed` signal.
-    StAbsorb_sparse = 6'b100111,
+    StAbsorb_sparse = 6'b100001,
 
     // TODO: Implement StAbort later after context-switching discussion.
     // Abort stage can be moved from StAbsorb stage. It basically holds the
@@ -136,23 +136,25 @@ package sha3_pkg;
     // software. This stage is for the software to pause current operation and
     // store the internal state elsewhere then initiates new KMAC/SHA3 process.
     // StAbort only can be moved to _StFlush_.
-    //StAbort_sparse = 6'b110000,
+    //StAbort_sparse = 6'b011101,
 
     // Squeeze stage allows the software to read the internal state.
     // If `EnMasking`, it opens the read permission of two share of the state.
     // The squeezing in SHA3 specification describes the software to read up to
     // the rate of SHA3 algorithm but this logic opens up the entire 1600 bits
     // of the state (3200bits if `EnMasking`).
-    StSqueeze_sparse = 6'b001010,
+    StSqueeze_sparse = 6'b001011,
 
     // ManualRun stage initiaties the keccak round and waits the completion.
     // This state is moved from Squeeze state by writing 1 to manual_run CSR.
     // When keccak round is completed, it goes back to Squeeze state.
-    StManualRun_sparse = 6'b111011,
+    StManualRun_sparse = 6'b010000,
 
     // Flush stage, the core clears out the internal variables and also
     // submodules' variables too. Then moves back to Idle state.
-    StFlush_sparse =  6'b010101
+    StFlush_sparse =  6'b000110,
+
+    StTerminalError_sparse = 6'b111010
   } sha3_st_sparse_e;
 
   localparam int StateWidthLogic = 3;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5148,6 +5148,18 @@
           index: -1
         }
         {
+          name: lc_escalate_en
+          struct: lc_tx
+          package: lc_ctrl_pkg
+          type: uni
+          act: rcv
+          width: 1
+          default: lc_ctrl_pkg::Off
+          inst_name: kmac
+          top_signame: lc_ctrl_lc_escalate_en
+          index: -1
+        }
+        {
           name: tl
           struct: tl
           package: tlul_pkg
@@ -7334,6 +7346,7 @@
       lc_ctrl.lc_escalate_en:
       [
         aes.lc_escalate_en
+        kmac.lc_escalate_en
         otbn.lc_escalate_en
         otp_ctrl.lc_escalate_en
         sram_ctrl_main.lc_escalate_en
@@ -16793,6 +16806,18 @@
         end_idx: -1
         top_type: broadcast
         top_signame: kmac_en_masking
+        index: -1
+      }
+      {
+        name: lc_escalate_en
+        struct: lc_tx
+        package: lc_ctrl_pkg
+        type: uni
+        act: rcv
+        width: 1
+        default: lc_ctrl_pkg::Off
+        inst_name: kmac
+        top_signame: lc_ctrl_lc_escalate_en
         index: -1
       }
       {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -881,6 +881,7 @@
       'lc_ctrl.lc_cpu_en'          : ['rv_core_ibex.lc_cpu_en'],
       'lc_ctrl.lc_keymgr_en'       : ['keymgr.lc_keymgr_en'],
       'lc_ctrl.lc_escalate_en'     : ['aes.lc_escalate_en',
+                                      'kmac.lc_escalate_en',
                                       'otbn.lc_escalate_en',
                                       'otp_ctrl.lc_escalate_en',
                                       'sram_ctrl_main.lc_escalate_en',

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2204,6 +2204,7 @@ module top_earlgrey #(
       .entropy_i(edn0_edn_rsp[3]),
       .idle_o(clkmgr_aon_idle[2]),
       .en_masking_o(kmac_en_masking),
+      .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .tl_i(kmac_tl_req),
       .tl_o(kmac_tl_rsp),
 


### PR DESCRIPTION
This PR adds lc_ctrl_escalate_en_i to kmac and sha3 as suggested in #8982
sha3 is also used in entropy_src. As there is no lc_ctrl_escalate_en_i at the toplevel, lc_ctrl_escalate_en_i is tied to lc_ctrl_pkg::Off for this sha3 instantiation.