### PR TITLE
[dv/prim_alert] Add randomization in ping request sequence

### DIFF
--- a/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
+++ b/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
@@ -35,15 +35,11 @@
     }
 
     {
-      name: prim_alert_init_trigger_test
-      desc: '''Verify init_trigger input from prim_alert_receiver.
+      name: prim_alert_ping_request_test
+      desc: '''Verify ping request from prim_alert_sender.
 
-            Based on the prim_alert_test, this test adds a parallel sequence to randomly drive
-            init_trigger_i in prim_alert_receiver.
-
-            Check if alert sender/receiver pairs can resume normal handshake after init_trigger_i
-            is set.
-            For fatal alert, check if fatal alerts keep firing until reset is issued.
+            - Send a ping request by driving `ping_req` pin to 1.
+            - Verify that `ping_ok` signal is set and ping handshake completes.
             '''
       milestone: V1
       tests: ["prim_async_alert",
@@ -53,13 +49,18 @@
     }
 
     {
-      name: prim_alert_ping_request_test
-      desc: '''Verify ping request from prim_alert_sender.
+      name: prim_alert_init_trigger_test
+      desc: '''Verify init_trigger input from prim_alert_receiver.
 
-             - Send a ping request by driving `ping_req` pin to 1.
-             - Verify that `ping_ok` signal is set and ping handshake completes.
-             Because ping reqeust is level trigger, in order to cover toggle coverage for
-             `alert_tx.ping_p/n` the above sequence will run twice.
+            This test is based on previous tests:
+            - Based on the prim_alert_request_test, this test adds a parallel sequence to randomly
+              drive `init_trigger_i` in prim_alert_receiver.
+              Check if alert sender/receiver pairs can resume normal handshake after init_trigger_i
+              is set.
+              For fatal alert, check if fatal alerts keep firing until reset is issued.
+            - Based on prim_alert_ping_request_test, this test adds a parallel sequence to randomly
+              drive `init_trigger_i` in prim_alert_receiver.
+              Check `ping_ok` returns 1.
             '''
       milestone: V1
       tests: ["prim_async_alert",

--- a/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
+++ b/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
@@ -195,30 +195,26 @@ module prim_alert_tb;
     $display("[prim_alert_seq] Alert test sequence finished!");
 
     // Sequence 3) Ping request sequence.
-    // Loop the ping request twice to cover the alert_rx.ping_p/n toggle coverage.
-    for (int i = 0; i < 2; i++) begin
-      int rand_wait_init_trig = $urandom_range(1, WaitAlertHandshakeDone + 10);
-      main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
-      ping_req = 1;
+    for (int num_trans = 0; num_trans < 10; num_trans++) begin
       fork
         begin
+          main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
+          ping_req = 1;
           `DV_SPINWAIT(wait (ping_ok == 1);, , , "Wait for ping_ok timeout");
           ping_req = 0;
           main_clk.wait_clks(WaitCycle + WaitAlertHandshakeDone);
         end
         begin
-          main_clk.wait_clks(rand_wait_init_trig);
-          init_trig = prim_mubi_pkg::MuBi4True;
+          if ($urandom_range(0, 1)) begin
+            main_clk.wait_clks($urandom_range(1, WaitAlertHandshakeDone + 10));
+            init_trig = prim_mubi_pkg::MuBi4True;
+            main_clk.wait_clks($urandom_range(0, 10));
+            init_trig = prim_mubi_pkg::MuBi4False;
+            main_clk.wait_clks(WaitAlertInitDone);
+          end
         end
-      join_any
-      disable fork;
-      if (init_trig == prim_mubi_pkg::MuBi4True) begin
-        ping_req = 0;
-        main_clk.wait_clks($urandom_range(0, 10));
-        init_trig = prim_mubi_pkg::MuBi4False;
-        main_clk.wait_clks(WaitAlertInitDone);
-      end
-      $display($sformatf("[prim_alert_seq] Ping request sequence[%0d] finished!", i));
+      join
+      $display($sformatf("[prim_alert_seq] Ping request sequence[%0d] finished!", num_trans));
     end
 
     // Sequence 4) `Ack_p/n` integrity check sequence.


### PR DESCRIPTION
This PR adds randomization about the timing to send ping_req, so
ping_req and alert_init_req threads can hit more corner cases

Signed-off-by: Cindy Chen <chencindy@opentitan.org>