### PR TITLE
[otbn] Fix a couple of lint errors

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -660,7 +660,7 @@ module otbn
   assign hw2reg.err_bits.bad_internal_state.d = err_bits_q.bad_internal_state;
   assign hw2reg.err_bits.illegal_bus_access.d = err_bits_q.illegal_bus_access;
   assign hw2reg.err_bits.lifecycle_escalation.d = err_bits_q.lifecycle_escalation;
-  assign hw2reg.err_bits.fatal_software.d = err_bits.fatal_software;
+  assign hw2reg.err_bits.fatal_software.d = err_bits_q.fatal_software;
 
   assign err_bits_clear = reg2hw.err_bits.bad_data_addr.qe & ~busy_execute_q;
   assign err_bits_d = err_bits_clear ? '0 : err_bits;

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -552,8 +552,8 @@ module otbn
   assign mem_crc_data_in.wr_data = imem_req_bus ? imem_wdata_bus[31:0] :
                                                   dmem_wdata_narrow_bus[31:0];
   // TODO: Expand DMem index so it's per 32-bit not per 256-bit
-  assign mem_crc_data_in.index   = imem_req_bus ? {{(15 - ImemIndexWidth){1'b0}}, imem_index_bus} :
-                                                   {{(15 - DmemIndexWidth + 3){1'b0}},
+  assign mem_crc_data_in.index   = imem_req_bus ? {{15 - ImemIndexWidth{1'b0}}, imem_index_bus} :
+                                                   {{15 - (DmemIndexWidth - 2){1'b0}},
                                                     dmem_addr_bus[DmemIndexWidth-1:2]};
   assign mem_crc_data_in.imem    = imem_req_bus;
 


### PR DESCRIPTION
@vrozic: The second commit fixes what appears to be a typo in the external CSR clearing code. Can you confirm that I've understood right?

@GregAC: There's one remaining lint error with Verilator to do with the fact that we're not looking at the whole of the DMEM address for the CRC calculation. It looks like we still need to do a bit of fiddling around, though because we're not getting the sub-word index, so I thought I'd leave it for now. As a note, if it's easier to grab something like the DMEM index plus the write mask (8 bits, if you only look at bits 0, 8, 16, ...), I don't see any reason not to change the spec to do that.