### PR TITLE
[dv] Disable functional coverage in tl_agent/dv

### DIFF
--- a/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
+++ b/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson
@@ -33,6 +33,7 @@
     {
       name: tl_agent_smoke
       uvm_test_seq: tl_agent_base_vseq
+      run_opts: ["-covg_disable_cg"]
     }
   ]
 


### PR DESCRIPTION
We just need some basic check for tl_agent. Don't need to review
coverage.
With this update, coverage report will be shown as follows
|  SCORE  |  LINE  |  COND  |  TOGGLE  |  FSM  |  BRANCH  |  ASSERT  |
|:-------:|:------:|:------:|:--------:|:-----:|:--------:|:--------:|
|  -- %   |  -- %  |  -- %  |   -- %   | -- %  |   -- %   |   -- %   |

Signed-off-by: Weicai Yang <weicai@google.com>