### PR TITLE
[sram/dv] Better support partial write in scb

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/sram_scrambler_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_util/sram_scrambler_pkg.sv
@@ -212,6 +212,29 @@ package sram_scrambler_pkg;
 
   endfunction : encrypt_sram_addr
 
+  // Deccrypts the target SRAM address using the custom S&P network.
+  function automatic state_t decrypt_sram_addr(logic addr[], int addr_width,
+                                               logic full_nonce[]);
+
+    logic nonce[] = new[addr_width];
+    logic encrypted_addr[] = new[addr_width];
+
+    // The address encryption nonce is the same width as the address,
+    // and is constructed from the top addr_width bits of the full nonce.
+    //
+    // `with` syntax is currently unsupported by Verible,
+    // uncomment once support has been added
+    //
+    // nonce = {>> {full_nonce with [SRAM_BLOCK_WIDTH - addr_width +: addr_width]}};
+    for (int i = 0; i < addr_width; i++) begin
+      nonce[i] = full_nonce[SRAM_BLOCK_WIDTH - addr_width + i];
+    end
+
+    encrypted_addr = sp_decrypt(addr, addr_width, nonce);
+    return encrypted_addr;
+
+  endfunction : decrypt_sram_addr
+
   // SRAM data encryption is more involved, we need to run 2 rounds of PRINCE on the nonce and key
   // and then XOR the result with the data.
   //

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -31,7 +31,6 @@
                 "{proj_root}/hw/dv/verilator/memutil_dpi_scrambled_opts.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
                 // Enable stress tests later
@@ -110,6 +109,18 @@
     {
       name: "{variant}_executable"
       uvm_test_seq: sram_ctrl_executable_vseq
+    }
+    // Below 2 tests are same as the tests in dvsim/tests/mem_tests.hjson
+    // Replicate them here in order to enable scb
+    {
+      name: "{variant}_mem_walk"
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+csr_mem_walk"]
+    }
+    {
+      name: "{variant}_mem_partial_access"
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+run_mem_partial_access"]
     }
   ]
 


### PR DESCRIPTION
1. after design removes the temporary workaround, the write timing can
be more compact. We may see write_start -> write_start -> write_finish
-> write_finish. Use a queue to process write_finsh one by one

2. add address decrypt function and once comparing the write data with
backdoor value, also decode the internal address and check it matches to
the item address.

3. Enable scb for mem_walk and mem_partial_access

Signed-off-by: Weicai Yang <weicai@google.com>