### PR TITLE
[dv/alert_handler] Add covpoints and change some randomization

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cov.sv
@@ -65,7 +65,7 @@ class alert_esc_agent_cov extends dv_base_agent_cov #(alert_esc_agent_cfg);
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     if (cfg.en_ping_cov) m_alert_esc_trans_cg = new();
-    if (cfg.en_lpg_cov) begin
+    if (cfg.en_lpg_cov && cfg.is_alert) begin
       m_alert_ping_lpg_cg = new();
       m_alert_lpg_cg = new();
     end

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -9,7 +9,7 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
   // alert_handler_env_cfg: cfg
 
   // covergroups
-  covergroup accum_cnt_cg with function sample (int class_i, int cnt);
+  covergroup accum_cnt_cg with function sample(int class_i, int cnt);
     class_index_cp: coverpoint class_i {
       bins class_index[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
     }
@@ -20,7 +20,7 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     class_cnt_cross: cross class_index_cp, accum_cnt_cp;
   endgroup : accum_cnt_cg
 
-  covergroup esc_sig_length_cg with function sample (int sig_index, int sig_len);
+  covergroup esc_sig_length_cg with function sample(int sig_index, int sig_len);
     esc_sig_index: coverpoint sig_index {
       bins index[NUM_ESC_SIGNALS] = {[0:NUM_ESC_SIGNALS-1]};
     }
@@ -31,11 +31,65 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     len_per_esc_sig: cross esc_sig_index, esc_sig_len;
   endgroup : esc_sig_length_cg
 
+  covergroup alert_cause_cg with function sample(int alert_index, int class_index);
+    alert_cause_cp: coverpoint alert_index {
+      bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
+      illegal_bins il = default;
+    }
+    class_i_cp: coverpoint class_index {
+      bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
+      illegal_bins il = default;
+    }
+    alert_cause_cross_class_index: cross alert_cause_cp, class_i_cp;
+  endgroup
+
+  covergroup alert_loc_alert_cause_cg with function sample(local_alert_type_e local_alert,
+                                                           int alert_index,
+                                                           int class_index);
+    loc_alert_cause_cp: coverpoint local_alert {
+      bins alert_ping_fail = {LocalAlertPingFail};
+      bins alert_integrity_fail = {LocalAlertIntFail};
+      illegal_bins il = default;
+    }
+    alert_i_cp: coverpoint alert_index {
+      bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
+      illegal_bins il = default;
+    }
+    class_i_cp: coverpoint class_index {
+      bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
+      illegal_bins il = default;
+    }
+    loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, alert_i_cp;
+    loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_i_cp;
+  endgroup
+
+  covergroup esc_loc_alert_cause_cg with function sample(local_alert_type_e local_alert,
+                                                         int esc_index,
+                                                         int class_index);
+    loc_alert_cause_cp: coverpoint local_alert {
+      bins esc_ping_fail = {LocalEscPingFail};
+      bins esc_integrity_fail = {LocalEscIntFail};
+      illegal_bins il = default;
+    }
+    esc_i_cp: coverpoint esc_index {
+      bins alert[NUM_ESCS] = {[0:NUM_ESCS-1]};
+      illegal_bins il = default;
+    }
+    class_i_cp: coverpoint class_index {
+      bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
+      illegal_bins il = default;
+    }
+    loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, esc_i_cp;
+    loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_i_cp;
+  endgroup
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // instantiate all covergroups here
     accum_cnt_cg = new();
     esc_sig_length_cg = new();
+    alert_cause_cg = new();
+    alert_loc_alert_cause_cg = new();
+    esc_loc_alert_cause_cg = new();
   endfunction : new
 
 endclass

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -157,9 +157,18 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           if (!is_int_err) begin
             class_i = `gmv(ral.alert_class_shadowed[alert_i]);
             void'(ral.alert_cause[alert_i].predict(1));
+            if (cfg.en_cov) cov.alert_cause_cg.sample(alert_i, class_i);
           end else begin
             class_i = `gmv(ral.loc_alert_class_shadowed[int'(local_alert_type)]);
-            void'(ral.loc_alert_cause[int'(local_alert_type)].predict(1));
+            void'(ral.loc_alert_cause[int'(local_alert_type)].predict(
+                .value(1), .kind(UVM_PREDICT_READ)));
+            if (cfg.en_cov) begin
+              if (local_alert_type inside {LocalAlertPingFail, LocalAlertIntFail}) begin
+                cov.alert_loc_alert_cause_cg.sample(local_alert_type, alert_i, class_i);
+              end else begin
+                cov.esc_loc_alert_cause_cg.sample(local_alert_type, alert_i, class_i);
+              end
+            end
           end
 
           intr_state_field = intr_state_fields[class_i];

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
@@ -9,11 +9,6 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_smoke_vseq;
 
   `uvm_object_new
 
-  constraint sig_int_c {
-    esc_int_err == 0;
-    esc_standalone_int_err == 0;
-  }
-
   constraint esc_accum_thresh_c {
     foreach (accum_thresh[i]) {accum_thresh[i] dist {[0:1] :/ 5, [2:10] :/ 5};}
   }
@@ -21,6 +16,7 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_smoke_vseq;
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);
+    this.sig_int_c.constraint_mode(0);
   endfunction
 
 endclass : alert_handler_sig_int_fail_vseq

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_env_cov.sv
@@ -9,7 +9,7 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
   // alert_handler_env_cfg: cfg
 
   // covergroups
-  covergroup accum_cnt_cg with function sample (int class_i, int cnt);
+  covergroup accum_cnt_cg with function sample(int class_i, int cnt);
     class_index_cp: coverpoint class_i {
       bins class_index[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
     }
@@ -20,7 +20,7 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     class_cnt_cross: cross class_index_cp, accum_cnt_cp;
   endgroup : accum_cnt_cg
 
-  covergroup esc_sig_length_cg with function sample (int sig_index, int sig_len);
+  covergroup esc_sig_length_cg with function sample(int sig_index, int sig_len);
     esc_sig_index: coverpoint sig_index {
       bins index[NUM_ESC_SIGNALS] = {[0:NUM_ESC_SIGNALS-1]};
     }
@@ -31,11 +31,65 @@ class alert_handler_env_cov extends cip_base_env_cov #(.CFG_T(alert_handler_env_
     len_per_esc_sig: cross esc_sig_index, esc_sig_len;
   endgroup : esc_sig_length_cg
 
+  covergroup alert_cause_cg with function sample(int alert_index, int class_index);
+    alert_cause_cp: coverpoint alert_index {
+      bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
+      illegal_bins il = default;
+    }
+    class_i_cp: coverpoint class_index {
+      bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
+      illegal_bins il = default;
+    }
+    alert_cause_cross_class_index: cross alert_cause_cp, class_i_cp;
+  endgroup
+
+  covergroup alert_loc_alert_cause_cg with function sample(local_alert_type_e local_alert,
+                                                           int alert_index,
+                                                           int class_index);
+    loc_alert_cause_cp: coverpoint local_alert {
+      bins alert_ping_fail = {LocalAlertPingFail};
+      bins alert_integrity_fail = {LocalAlertIntFail};
+      illegal_bins il = default;
+    }
+    alert_i_cp: coverpoint alert_index {
+      bins alert[NUM_ALERTS] = {[0:NUM_ALERTS-1]};
+      illegal_bins il = default;
+    }
+    class_i_cp: coverpoint class_index {
+      bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
+      illegal_bins il = default;
+    }
+    loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, alert_i_cp;
+    loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_i_cp;
+  endgroup
+
+  covergroup esc_loc_alert_cause_cg with function sample(local_alert_type_e local_alert,
+                                                         int esc_index,
+                                                         int class_index);
+    loc_alert_cause_cp: coverpoint local_alert {
+      bins esc_ping_fail = {LocalEscPingFail};
+      bins esc_integrity_fail = {LocalEscIntFail};
+      illegal_bins il = default;
+    }
+    esc_i_cp: coverpoint esc_index {
+      bins alert[NUM_ESCS] = {[0:NUM_ESCS-1]};
+      illegal_bins il = default;
+    }
+    class_i_cp: coverpoint class_index {
+      bins class_i[NUM_ALERT_CLASSES] = {[0:NUM_ALERT_CLASSES-1]};
+      illegal_bins il = default;
+    }
+    loc_alert_cause_cross_alert_index: cross loc_alert_cause_cp, esc_i_cp;
+    loc_alert_cause_cross_class_index: cross loc_alert_cause_cp, class_i_cp;
+  endgroup
+
   function new(string name, uvm_component parent);
     super.new(name, parent);
-    // instantiate all covergroups here
     accum_cnt_cg = new();
     esc_sig_length_cg = new();
+    alert_cause_cg = new();
+    alert_loc_alert_cause_cg = new();
+    esc_loc_alert_cause_cg = new();
   endfunction : new
 
 endclass

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_scoreboard.sv
@@ -157,9 +157,18 @@ class alert_handler_scoreboard extends cip_base_scoreboard #(
           if (!is_int_err) begin
             class_i = `gmv(ral.alert_class_shadowed[alert_i]);
             void'(ral.alert_cause[alert_i].predict(1));
+            if (cfg.en_cov) cov.alert_cause_cg.sample(alert_i, class_i);
           end else begin
             class_i = `gmv(ral.loc_alert_class_shadowed[int'(local_alert_type)]);
-            void'(ral.loc_alert_cause[int'(local_alert_type)].predict(1));
+            void'(ral.loc_alert_cause[int'(local_alert_type)].predict(
+                .value(1), .kind(UVM_PREDICT_READ)));
+            if (cfg.en_cov) begin
+              if (local_alert_type inside {LocalAlertPingFail, LocalAlertIntFail}) begin
+                cov.alert_loc_alert_cause_cg.sample(local_alert_type, alert_i, class_i);
+              end else begin
+                cov.esc_loc_alert_cause_cg.sample(local_alert_type, alert_i, class_i);
+              end
+            end
           end
 
           intr_state_field = intr_state_fields[class_i];

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_sig_int_fail_vseq.sv
@@ -9,11 +9,6 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_smoke_vseq;
 
   `uvm_object_new
 
-  constraint sig_int_c {
-    esc_int_err == 0;
-    esc_standalone_int_err == 0;
-  }
-
   constraint esc_accum_thresh_c {
     foreach (accum_thresh[i]) {accum_thresh[i] dist {[0:1] :/ 5, [2:10] :/ 5};}
   }
@@ -21,6 +16,7 @@ class alert_handler_sig_int_fail_vseq extends alert_handler_smoke_vseq;
   function void pre_randomize();
     this.enable_one_alert_c.constraint_mode(0);
     this.enable_classa_only_c.constraint_mode(0);
+    this.sig_int_c.constraint_mode(0);
   endfunction
 
 endclass : alert_handler_sig_int_fail_vseq


### PR DESCRIPTION
1). Add coverpoints to collect alert_cause and loc_alert_cause and cross
with alert/esc_index and class_index.
2). Relax a randomization about sig_integrity_err.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>