### PR TITLE
[otbn, dv] Write to KEY_S*_* regs in ISS with key values generated in TB

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -355,6 +355,24 @@ void ISSWrapper::edn_urnd_step(uint32_t edn_urnd_data) {
   run_command(oss.str(), nullptr);
 }
 
+void ISSWrapper::set_keymgr_value(std::array<uint32_t, 12> key0_arr,
+                                  std::array<uint32_t, 12> key1_arr,
+                                  unsigned char valid) {
+  std::ostringstream oss;
+
+  oss << "set_keymgr_value 0x" << std::hex << std::setfill('0');
+  for (int i = 0; i < 12; ++i) {
+    oss << std::setw(8) << key0_arr[11 - i];
+  }
+  oss << " 0x";
+  for (int i = 0; i < 12; ++i) {
+    oss << std::setw(8) << key1_arr[11 - i];
+  }
+  oss << " " << (int)valid << "\n";
+
+  run_command(oss.str(), nullptr);
+}
+
 int ISSWrapper::step(bool gen_trace) {
   std::vector<std::string> lines;
   bool error = false;

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -75,6 +75,10 @@ struct ISSWrapper {
   // also RTL signals CDC is done.
   void edn_urnd_step(uint32_t edn_urnd_data);
 
+  // Provide keymgr values to model
+  void set_keymgr_value(std::array<uint32_t, 12> key0_arr,
+                        std::array<uint32_t, 12> key1_arr, unsigned char valid);
+
   // Signals 256b EDN random number for RND is valid in the RTL.
   void edn_rnd_cdc_done();
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -306,6 +306,22 @@ void OtbnModel::edn_urnd_step(svLogicVecVal *edn_urnd_data /* logic [31:0] */) {
   iss->edn_urnd_step(edn_urnd_data->aval);
 }
 
+void OtbnModel::set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
+                                 svLogicVecVal *key1 /* logic [383:0] */,
+                                 unsigned char valid) {
+  ISSWrapper *iss = ensure_wrapper();
+
+  std::array<uint32_t, 12> key0_arr;
+  std::array<uint32_t, 12> key1_arr;
+
+  for (int i = 0; i < 12; i++) {
+    key0_arr[i] = key0[i].aval;
+    key1_arr[i] = key1[i].aval;
+  }
+
+  iss->set_keymgr_value(key0_arr, key1_arr, valid);
+}
+
 void OtbnModel::edn_urnd_cdc_done() {
   ISSWrapper *iss = ensure_wrapper();
   iss->edn_urnd_cdc_done();
@@ -760,4 +776,10 @@ void otbn_model_reset(OtbnModel *model) {
 void otbn_take_loop_warps(OtbnModel *model, OtbnMemUtil *memutil) {
   assert(model && memutil);
   model->take_loop_warps(*memutil);
+}
+
+void otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
+                                 svLogicVecVal *key1, unsigned char valid) {
+  assert(model && key0 && key1);
+  model->set_keymgr_value(key0, key1, valid);
 }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -39,6 +39,10 @@ class OtbnModel {
   // EDN Step sends ISS the RND data when ACK signal is high.
   void edn_rnd_step(svLogicVecVal *edn_rnd_data /* logic [31:0] */);
 
+  void set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
+                        svLogicVecVal *key1 /* logic [383:0] */,
+                        unsigned char valid);
+
   // EDN Step sends ISS the URND related EDN data when ACK signal is high.
   void edn_urnd_step(svLogicVecVal *edn_urnd_data /* logic [31:0] */);
 

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -39,6 +39,10 @@ void edn_model_rnd_cdc_done(OtbnModel *model);
 // Signal RTL is finished processing EDN data for URND to Model
 void edn_model_urnd_cdc_done(OtbnModel *model);
 
+// Pass keymgr data to model
+void otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
+                                 svLogicVecVal *key1, unsigned char valid);
+
 // The main entry point to the OTBN model, exported from here and used in
 // otbn_core_model.sv.
 //

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -28,6 +28,10 @@ package otbn_model_pkg;
     void edn_model_urnd_cdc_done(chandle model);
 
   import "DPI-C" function
+    void otbn_model_set_keymgr_value(chandle model, logic [383:0] key0,
+                                     logic [383:0] key1, bit valid);
+
+  import "DPI-C" function
     void edn_model_rnd_cdc_done(chandle model);
 
   import "DPI-C" context function

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -153,6 +153,9 @@ class OTBNState:
         # signal from RTL
         self.urnd_256b_counter = 0
 
+    def set_keymgr_value(self, key0: int, key1: int, valid: int) -> None:
+        return None
+
     def edn_rnd_step(self, rnd_data: int) -> None:
         # Take the new data
         assert 0 <= rnd_data < (1 << 32)

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -154,6 +154,14 @@ class OTBNState:
         self.urnd_256b_counter = 0
 
     def set_keymgr_value(self, key0: int, key1: int, valid: int) -> None:
+        assert 0 <= key0 < (1 << 384)
+        assert 0 <= key1 < (1 << 384)
+        if valid:
+            self.wsrs.KeyS0.write_unsigned(key0)
+            self.wsrs.KeyS1.write_unsigned(key1)
+        else:
+            self.wsrs.KeyS0.write_unsigned(None)
+            self.wsrs.KeyS1.write_unsigned(None)
         return None
 
     def edn_rnd_step(self, rnd_data: int) -> None:

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -8,7 +8,6 @@ from .trace import Trace
 
 from .ext_regs import TraceExtRegChange, ExtRegChange
 
-
 class TraceWSR(Trace):
     def __init__(self, wsr_name: str, new_value: int):
         self.wsr_name = wsr_name

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -55,6 +55,8 @@ prefixed with "0x" if they are hexadecimal.
 
     invalidate_imem      Mark all of IMEM as having invalid ECC checksums
 
+    set_keymgr_value     Send keymgr data to the model.
+
 '''
 
 import sys
@@ -260,6 +262,18 @@ def on_edn_urnd_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
+def on_set_keymgr_value(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    if len(args) != 3:
+        raise ValueError('set_keymgr_value expects exactly 1 argument. Got {}.'
+                         .format(args))
+    key0 = int(args[0], 0)
+    key1 = int(args[1], 0)
+    valid = read_word('set_keymgr_value', args[2], 1)
+    sim.state.set_keymgr_value(key0, key1, valid)
+
+    return None
+
+
 def on_edn_flush(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     if len(args) != 0:
         raise ValueError('edn_flush expects zero arguments. Got {}.'
@@ -321,7 +335,8 @@ _HANDLERS = {
     'edn_rnd_cdc_done': on_edn_rnd_cdc_done,
     'edn_urnd_cdc_done': on_edn_urnd_cdc_done,
     'edn_flush': on_edn_flush,
-    'invalidate_imem': on_invalidate_imem
+    'invalidate_imem': on_invalidate_imem,
+    'set_keymgr_value': on_set_keymgr_value
 }
 
 

--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -246,6 +246,10 @@ class Model:
         wsrs.touch_addr(0x1)        # RND
         wsrs.touch_addr(0x2)        # URND
         wsrs.touch_addr(0x3)        # ACC
+        wsrs.touch_addr(0x4)        # KEY_S0_L
+        wsrs.touch_addr(0x5)        # KEY_S0_H
+        wsrs.touch_addr(0x6)        # KEY_S1_L
+        wsrs.touch_addr(0x7)        # KEY_S1_H
 
         # The current PC (the address of the next instruction that needs
         # generating)

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.core
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
       - lowrisc:ip:otbn_pkg
+      - lowrisc:ip:keymgr_pkg
     files:
       - otbn_model_if.sv
       - otbn_model_agent_pkg.sv

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -2,14 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-interface otbn_model_if #(
+interface otbn_model_if
+  import keymgr_pkg::otbn_key_req_t;
+#(
   // Size of the instruction memory, in bytes
   parameter int ImemSizeByte = 4096,
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte)
 ) (
   input logic clk_i,
-  input logic rst_ni
+  input logic rst_ni,
+  input otbn_key_req_t keymgr_key_i
 );
 
   // Inputs to DUT

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -23,6 +23,7 @@ module tb;
   wire clk, rst_n;
   wire idle, intr_done;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  otbn_key_req_t keymgr_key;
 
   // interfaces
   clk_rst_if                    clk_rst_if (.clk(clk), .rst_n(rst_n));
@@ -35,11 +36,16 @@ module tb;
   // needed for sequences that trigger alerts (locking OTBN) without telling the model.
   `DV_ASSERT_CTRL("otbn_status_assert_en", tb.MatchingStatus_A)
 
+  assign keymgr_key.key[0] = {12{32'hDEADBEEF}};
+  assign keymgr_key.key[1] = {12{32'hBAADF00D}};
+  assign keymgr_key.valid  = 1'b1;
+
   otbn_model_if #(
     .ImemSizeByte (otbn_reg_pkg::OTBN_IMEM_SIZE)
   ) model_if (
-    .clk_i  (clk),
-    .rst_ni (rst_n)
+    .clk_i         (clk),
+    .rst_ni        (rst_n),
+    .keymgr_key_i  (keymgr_key)
   );
 
   // edn_clk, edn_rst_n and edn_if is defined and driven in below macro
@@ -89,12 +95,6 @@ module tb;
   assign otp_key_rsp.key = TestScrambleKey;
   assign otp_key_rsp.nonce = TestScrambleNonce;
   assign otp_key_rsp.seed_valid = 1'b0;
-
-  otbn_key_req_t keymgr_key;
-
-  assign keymgr_key.key[0] = {12{32'hDEADBEEF}};
-  assign keymgr_key.key[1] = {12{32'hBAADF00D}};
-  assign keymgr_key.valid  = 1'b1;
 
   // dut
   otbn # (
@@ -225,7 +225,9 @@ module tb;
 
     .done_rr_o    (),
 
-    .err_o        (model_if.err)
+    .err_o        (model_if.err),
+
+    .keymgr_key_i (model_if.keymgr_key_i)
   );
 
   // Pull the final PC and the OtbnModel handle out of the SV model wrapper.

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.core
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:otbn
       - lowrisc:dv:otbn_model
       - lowrisc:ip:otbn_tracer
+      - lowrisc:ip:keymgr_pkg
   files_verilator:
     depend:
       - lowrisc:dv:otbn_memutil

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -8,6 +8,7 @@ module otbn_top_sim (
 );
   import otbn_pkg::*;
   import edn_pkg::*;
+  import keymgr_pkg::otbn_key_req_t;
 
   // Size of the instruction memory, in bytes
   parameter int ImemSizeByte = otbn_reg_pkg::OTBN_IMEM_SIZE;
@@ -56,9 +57,15 @@ module otbn_top_sim (
   logic [31:0]              insn_cnt;
 
   logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares;
-
+  
   assign sideload_key_shares[0] = {12{32'hDEADBEEF}};
   assign sideload_key_shares[1] = {12{32'hBAADF00D}};
+
+  otbn_key_req_t keymgr_key;
+  
+  assign keymgr_key.key[0] = sideload_key_shares[0]; 
+  assign keymgr_key.key[1] = sideload_key_shares[1]; 
+  assign keymgr_key.valid  = 1'b1;
 
   otbn_core #(
     .ImemSizeByte ( ImemSizeByte ),
@@ -324,7 +331,9 @@ module otbn_top_sim (
 
     .done_rr_o             ( otbn_model_done_rr ),
 
-    .err_o                 ( otbn_model_err )
+    .err_o                 ( otbn_model_err ),
+
+    .keymgr_key_i          (keymgr_key)
   );
 
   bit done_mismatch_latched, err_bits_mismatch_latched, cnt_mismatch_latched;


### PR DESCRIPTION
Following changes have been done in this commit:
1. Enhanced set_keymgr_value function to write to key registers in
   WSRFILE.
2. Made 0X4 to 0X7 as valid WSR addresses in model.py