### PR TITLE
[otbn, dv] Write to KEY_S*_* regs in ISS with key values generated in TB

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -153,8 +153,11 @@ class OTBNState:
         # signal from RTL
         self.urnd_256b_counter = 0
 
-    def set_keymgr_value(self, key0: int, key1: int, valid: bool) -> None:
-        return None
+    def set_keymgr_value(self, key0: int, key1: int, valid: int) -> None:
+        assert 0 <= key0 < (1 << 384)
+        assert 0 <= key1 < (1 << 384)
+        self.wsrs.KeyS0.write_unsigned(key0 if valid else None)
+        self.wsrs.KeyS1.write_unsigned(key1 if valid else None)
 
     def edn_rnd_step(self, rnd_data: int) -> None:
         # Take the new data

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -43,6 +43,9 @@ def main() -> int:
 
     sim = StandaloneSim()
     exp_end_addr = load_elf(sim, args.elf)
+    key0 = int((str("deadbeef") * 12), 16)
+    key1 = int((str("badf00d") * 12), 16)
+    sim.state.set_keymgr_value(key0, key1, 1)
 
     sim.state.ext_regs.commit()
 

--- a/hw/ip/otbn/dv/rig/rig/model.py
+++ b/hw/ip/otbn/dv/rig/rig/model.py
@@ -246,6 +246,10 @@ class Model:
         wsrs.touch_addr(0x1)        # RND
         wsrs.touch_addr(0x2)        # URND
         wsrs.touch_addr(0x3)        # ACC
+        wsrs.touch_addr(0x4)        # KEY_S0_L
+        wsrs.touch_addr(0x5)        # KEY_S0_H
+        wsrs.touch_addr(0x6)        # KEY_S1_L
+        wsrs.touch_addr(0x7)        # KEY_S1_H
 
         # The current PC (the address of the next instruction that needs
         # generating)


### PR DESCRIPTION
Following changes have been done in this commit:
1. Enhanced set_keymgr_value function to write to key registers in
   WSRFILE.
2. Made 0X4 to 0X7 as valid WSR addresses in model.py

This is a draft PR because it has to be merged after #9482 