### PR TITLE
[spi_device] Continuous Code in JEDEC ID

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -522,6 +522,28 @@
       ]
     } // R: FLASH_STATUS
     {
+      name: "JEDEC_CC"
+      desc: '''JEDEC Continuation Code configuration register.
+
+        Read JEDEC ID must return the continuation code if the manufacturer ID
+        is not shown in the first page of JEDEC table. This register controls
+        the Continuation Code.
+        '''
+      swaccess: "rw"
+      hwaccess: "hro"
+      fields: [
+        { bits: "15:8"
+          name: "num_cc"
+          desc: "The number that Continuation Code repeats"
+        } // f: num_cc
+        { bits: "7:0"
+          name: "cc"
+          desc: "Continuation Code byte"
+          resval: "0x7F"
+        } // f: cc
+      ]
+    } // R: JEDEC_CC
+    {
       name: "JEDEC_ID"
       desc: '''JEDEC ID register.
         '''

--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -94,7 +94,7 @@ waive -rules TERMINAL_STATE -location {spi_readcmd.sv} \
       -regexp {Terminal state 'Main(Output|Error)' is detected} \
       -comment "Intentional dead-end. CSb will reset"
 waive -rules TERMINAL_STATE -location {spid_jedec.sv} \
-      -regexp {Terminal state 'StActive' is detected} \
+      -regexp {Terminal state 'StDevId' is detected} \
       -comment "Intentional dead-end. CSb will reset"
 
 # async resets

--- a/hw/ip/spi_device/pre_dv/tb/spid_common.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_common.sv
@@ -14,6 +14,8 @@ endinterface : spi_if
 
 // spid_common package contains common tasks, functions
 package spid_common;
+  import spi_device_pkg::*;
+
   typedef enum int unsigned {
     IoNone   = 0,
     IoSingle = 1,
@@ -48,10 +50,6 @@ package spid_common;
   } spi_fifo_t;
 
   // Command list parameters
-  import spi_device_pkg::cmd_info_t;
-  import spi_device_pkg::payload_dir_e;
-  import spi_device_pkg::PayloadIn;
-  import spi_device_pkg::PayloadOut;
 
   parameter spi_device_pkg::cmd_info_t [23:0] CmdInfo = {
     // 23:
@@ -65,6 +63,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -80,6 +79,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -95,6 +95,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -110,6 +111,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -125,6 +127,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -140,6 +143,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -155,6 +159,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -170,6 +175,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -185,6 +191,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -200,6 +207,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -215,6 +223,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0001, // MISO
       payload_dir:      PayloadIn,
+      payload_swap_en:  1'b 0,
       upload:           1'b 1,
       busy:             1'b 1
     },
@@ -230,6 +239,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0000, // MISO
       payload_dir:      PayloadIn,
+      payload_swap_en:  1'b 0,
       upload:           1'b 1,
       busy:             1'b 1
     },
@@ -245,6 +255,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0000, // MISO
       payload_dir:      PayloadIn,
+      payload_swap_en:  1'b 0,
       upload:           1'b 1,
       busy:             1'b 1
     },
@@ -260,6 +271,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -275,6 +287,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -290,6 +303,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -305,6 +319,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -320,6 +335,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -335,6 +351,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -350,6 +367,7 @@ package spid_common;
       dummy_size:       3'h 7,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -365,6 +383,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -380,6 +399,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -395,6 +415,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     },
@@ -410,6 +431,7 @@ package spid_common;
       dummy_size:          '0,
       payload_en:       4'b 0010, // MISO
       payload_dir:      PayloadOut,
+      payload_swap_en:  1'b 0,
       upload:           1'b 0,
       busy:             1'b 0
     }

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -276,7 +276,7 @@ module spi_device
   logic status_busy_broadcast; // from spid_status
 
   // Jedec ID
-  logic [23:0] jedec_id;
+  jedec_cfg_t jedec_cfg;
 
   // Interrupts in Flash mode
   logic intr_upload_cmdfifo_not_empty, intr_upload_payload_not_empty;
@@ -662,7 +662,11 @@ module spi_device
   end
 
   // Jedec ID
-  assign jedec_id = {reg2hw.jedec_id.mf.q, reg2hw.jedec_id.id.q};
+  assign jedec_cfg = '{ num_cc:    reg2hw.jedec_cc.num_cc.q,
+                        cc:        reg2hw.jedec_cc.cc.q,
+                        jedec_id:  reg2hw.jedec_id.mf.q,
+                        device_id: reg2hw.jedec_id.id.q
+                      };
 
   assign readbuf_threshold = reg2hw.read_threshold.q[BufferAw:0];
 
@@ -1311,7 +1315,7 @@ module spi_device
 
     .inclk_csb_asserted_pulse_i (csb_asserted_pulse_sckin),
 
-    .sys_jedec_i (jedec_id),
+    .sys_jedec_i (jedec_cfg),
 
     .io_mode_o (sub_iomode[IoModeJedec]),
 

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -241,6 +241,14 @@ package spi_device_pkg;
 
   parameter int unsigned CmdInfoIdxW = $clog2(NumCmdInfo);
 
+  // Jedec Configuration Structure
+  typedef struct packed {
+    logic [7:0]  num_cc;    // continuation code repeat
+    logic [7:0]  cc;        // the value of CC (default 7Fh)
+    logic [7:0]  jedec_id;  // JEDEC Manufacturer ID
+    logic [15:0] device_id; // Device ID
+  } jedec_cfg_t ;
+
   // SPI Operation mode
   typedef enum logic [1:0] {
     FwMode      = 'h0,

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -252,6 +252,15 @@ package spi_device_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic [7:0]  q;
+    } cc;
+    struct packed {
+      logic [7:0]  q;
+    } num_cc;
+  } spi_device_reg2hw_jedec_cc_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic [15:0] q;
     } id;
     struct packed {
@@ -599,19 +608,20 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1591:1581]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1580:1570]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1569:1548]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1547:1546]
-    spi_device_reg2hw_control_reg_t control; // [1545:1540]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1539:1526]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1525:1494]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1493:1478]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1477:1462]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1461:1430]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1429:1398]
-    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1397:1394]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [1393:1368]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1607:1597]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1596:1586]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1585:1564]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1563:1562]
+    spi_device_reg2hw_control_reg_t control; // [1561:1556]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1555:1542]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1541:1510]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1509:1494]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1493:1478]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1477:1446]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1445:1414]
+    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1413:1410]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1409:1384]
+    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1383:1368]
     spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1367:1344]
     spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1343:1334]
     spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1333:1302]
@@ -672,48 +682,49 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_INTERCEPT_EN_OFFSET = 13'h 34;
   parameter logic [BlockAw-1:0] SPI_DEVICE_LAST_READ_ADDR_OFFSET = 13'h 38;
   parameter logic [BlockAw-1:0] SPI_DEVICE_FLASH_STATUS_OFFSET = 13'h 3c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_ID_OFFSET = 13'h 40;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 44;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 48;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 4c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 50;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 54;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 58;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 5c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 60;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 64;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 68;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 6c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 70;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 74;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 78;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 7c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 80;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 84;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 98;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h 9c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h a0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h a4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h a8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h ac;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h b0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h b4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h b8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h bc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h c0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h c4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h c8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h cc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h d0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h d4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h d8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h dc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h e0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h e4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_CC_OFFSET = 13'h 40;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_JEDEC_ID_OFFSET = 13'h 44;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 48;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 4c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 50;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 54;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 58;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 5c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 60;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 64;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 68;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 6c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 70;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 74;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 78;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 7c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 80;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 84;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 88;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 9c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h a0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h a4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h a8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h ac;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h b0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h b4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h b8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h bc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h c0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h c4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h c8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h cc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h d0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h d8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h dc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h e0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h e4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h e8;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -781,6 +792,7 @@ package spi_device_reg_pkg;
     SPI_DEVICE_INTERCEPT_EN,
     SPI_DEVICE_LAST_READ_ADDR,
     SPI_DEVICE_FLASH_STATUS,
+    SPI_DEVICE_JEDEC_CC,
     SPI_DEVICE_JEDEC_ID,
     SPI_DEVICE_READ_THRESHOLD,
     SPI_DEVICE_MAILBOX_ADDR,
@@ -841,7 +853,7 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [73] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [74] = '{
     4'b 0011, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0011, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0011, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -858,63 +870,64 @@ package spi_device_reg_pkg;
     4'b 0001, // index[13] SPI_DEVICE_INTERCEPT_EN
     4'b 1111, // index[14] SPI_DEVICE_LAST_READ_ADDR
     4'b 0111, // index[15] SPI_DEVICE_FLASH_STATUS
-    4'b 0111, // index[16] SPI_DEVICE_JEDEC_ID
-    4'b 0011, // index[17] SPI_DEVICE_READ_THRESHOLD
-    4'b 1111, // index[18] SPI_DEVICE_MAILBOX_ADDR
-    4'b 1111, // index[19] SPI_DEVICE_UPLOAD_STATUS
-    4'b 0001, // index[20] SPI_DEVICE_UPLOAD_CMDFIFO
-    4'b 1111, // index[21] SPI_DEVICE_UPLOAD_ADDRFIFO
-    4'b 1111, // index[22] SPI_DEVICE_CMD_FILTER_0
-    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_1
-    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_2
-    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_3
-    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_4
-    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_5
-    4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_6
-    4'b 1111, // index[29] SPI_DEVICE_CMD_FILTER_7
-    4'b 1111, // index[30] SPI_DEVICE_ADDR_SWAP_MASK
-    4'b 1111, // index[31] SPI_DEVICE_ADDR_SWAP_DATA
-    4'b 1111, // index[32] SPI_DEVICE_PAYLOAD_SWAP_MASK
-    4'b 1111, // index[33] SPI_DEVICE_PAYLOAD_SWAP_DATA
-    4'b 1111, // index[34] SPI_DEVICE_CMD_INFO_0
-    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_1
-    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_2
-    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_3
-    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_4
-    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_5
-    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_6
-    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_7
-    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_8
-    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_9
-    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_10
-    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_11
-    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_12
-    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_13
-    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_14
-    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_15
-    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_16
-    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_17
-    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_18
-    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_19
-    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_20
-    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_21
-    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_22
-    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_23
-    4'b 0111, // index[58] SPI_DEVICE_TPM_CAP
-    4'b 0001, // index[59] SPI_DEVICE_TPM_CFG
-    4'b 0011, // index[60] SPI_DEVICE_TPM_STATUS
-    4'b 1111, // index[61] SPI_DEVICE_TPM_ACCESS_0
-    4'b 0001, // index[62] SPI_DEVICE_TPM_ACCESS_1
-    4'b 1111, // index[63] SPI_DEVICE_TPM_STS
-    4'b 1111, // index[64] SPI_DEVICE_TPM_INTF_CAPABILITY
-    4'b 1111, // index[65] SPI_DEVICE_TPM_INT_ENABLE
-    4'b 0001, // index[66] SPI_DEVICE_TPM_INT_VECTOR
-    4'b 1111, // index[67] SPI_DEVICE_TPM_INT_STATUS
-    4'b 1111, // index[68] SPI_DEVICE_TPM_DID_VID
-    4'b 0001, // index[69] SPI_DEVICE_TPM_RID
-    4'b 1111, // index[70] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 0001, // index[71] SPI_DEVICE_TPM_READ_FIFO
-    4'b 0001  // index[72] SPI_DEVICE_TPM_WRITE_FIFO
+    4'b 0011, // index[16] SPI_DEVICE_JEDEC_CC
+    4'b 0111, // index[17] SPI_DEVICE_JEDEC_ID
+    4'b 0011, // index[18] SPI_DEVICE_READ_THRESHOLD
+    4'b 1111, // index[19] SPI_DEVICE_MAILBOX_ADDR
+    4'b 1111, // index[20] SPI_DEVICE_UPLOAD_STATUS
+    4'b 0001, // index[21] SPI_DEVICE_UPLOAD_CMDFIFO
+    4'b 1111, // index[22] SPI_DEVICE_UPLOAD_ADDRFIFO
+    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_0
+    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_1
+    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_2
+    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_3
+    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_4
+    4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_5
+    4'b 1111, // index[29] SPI_DEVICE_CMD_FILTER_6
+    4'b 1111, // index[30] SPI_DEVICE_CMD_FILTER_7
+    4'b 1111, // index[31] SPI_DEVICE_ADDR_SWAP_MASK
+    4'b 1111, // index[32] SPI_DEVICE_ADDR_SWAP_DATA
+    4'b 1111, // index[33] SPI_DEVICE_PAYLOAD_SWAP_MASK
+    4'b 1111, // index[34] SPI_DEVICE_PAYLOAD_SWAP_DATA
+    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_0
+    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_1
+    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_2
+    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_3
+    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_4
+    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_5
+    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_6
+    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_7
+    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_8
+    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_9
+    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_10
+    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_11
+    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_12
+    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_13
+    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_14
+    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_16
+    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_17
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_18
+    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_19
+    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_20
+    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_21
+    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_22
+    4'b 1111, // index[58] SPI_DEVICE_CMD_INFO_23
+    4'b 0111, // index[59] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[60] SPI_DEVICE_TPM_CFG
+    4'b 0011, // index[61] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[62] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[63] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[64] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[65] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[66] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[67] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[68] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[69] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[70] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[71] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 0001, // index[72] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[73] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -298,6 +298,11 @@ module spi_device_reg_top (
   logic flash_status_busy_wd;
   logic [22:0] flash_status_status_qs;
   logic [22:0] flash_status_status_wd;
+  logic jedec_cc_we;
+  logic [7:0] jedec_cc_cc_qs;
+  logic [7:0] jedec_cc_cc_wd;
+  logic [7:0] jedec_cc_num_cc_qs;
+  logic [7:0] jedec_cc_num_cc_wd;
   logic jedec_id_we;
   logic [15:0] jedec_id_id_qs;
   logic [15:0] jedec_id_id_wd;
@@ -3061,6 +3066,58 @@ module spi_device_reg_top (
     .qe     (reg2hw.flash_status.status.qe),
     .q      (reg2hw.flash_status.status.q),
     .qs     (flash_status_status_qs)
+  );
+
+
+  // R[jedec_cc]: V(False)
+  //   F[cc]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h7f)
+  ) u_jedec_cc_cc (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (jedec_cc_we),
+    .wd     (jedec_cc_cc_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.jedec_cc.cc.q),
+
+    // to register interface (read)
+    .qs     (jedec_cc_cc_qs)
+  );
+
+  //   F[num_cc]: 15:8
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_jedec_cc_num_cc (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (jedec_cc_we),
+    .wd     (jedec_cc_num_cc_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.jedec_cc.num_cc.q),
+
+    // to register interface (read)
+    .qs     (jedec_cc_num_cc_qs)
   );
 
 
@@ -17830,7 +17887,7 @@ module spi_device_reg_top (
 
 
 
-  logic [72:0] addr_hit;
+  logic [73:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -17849,63 +17906,64 @@ module spi_device_reg_top (
     addr_hit[13] = (reg_addr == SPI_DEVICE_INTERCEPT_EN_OFFSET);
     addr_hit[14] = (reg_addr == SPI_DEVICE_LAST_READ_ADDR_OFFSET);
     addr_hit[15] = (reg_addr == SPI_DEVICE_FLASH_STATUS_OFFSET);
-    addr_hit[16] = (reg_addr == SPI_DEVICE_JEDEC_ID_OFFSET);
-    addr_hit[17] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
-    addr_hit[18] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
-    addr_hit[19] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
-    addr_hit[20] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
-    addr_hit[21] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
-    addr_hit[22] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
-    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
-    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
-    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
-    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
-    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
-    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
-    addr_hit[29] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
-    addr_hit[30] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
-    addr_hit[31] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
-    addr_hit[32] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
-    addr_hit[33] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
-    addr_hit[34] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
-    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
-    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
-    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
-    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
-    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
-    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
-    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
-    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
-    addr_hit[58] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
-    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
-    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
-    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
-    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
-    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
-    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
-    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
-    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
-    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
-    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
-    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
-    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
-    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
-    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
+    addr_hit[16] = (reg_addr == SPI_DEVICE_JEDEC_CC_OFFSET);
+    addr_hit[17] = (reg_addr == SPI_DEVICE_JEDEC_ID_OFFSET);
+    addr_hit[18] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
+    addr_hit[19] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
+    addr_hit[20] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
+    addr_hit[21] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
+    addr_hit[22] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
+    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
+    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
+    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
+    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
+    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
+    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
+    addr_hit[29] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
+    addr_hit[30] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
+    addr_hit[31] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
+    addr_hit[32] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
+    addr_hit[33] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
+    addr_hit[34] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
+    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
+    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[73] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -17985,7 +18043,8 @@ module spi_device_reg_top (
                (addr_hit[69] & (|(SPI_DEVICE_PERMIT[69] & ~reg_be))) |
                (addr_hit[70] & (|(SPI_DEVICE_PERMIT[70] & ~reg_be))) |
                (addr_hit[71] & (|(SPI_DEVICE_PERMIT[71] & ~reg_be))) |
-               (addr_hit[72] & (|(SPI_DEVICE_PERMIT[72] & ~reg_be)))));
+               (addr_hit[72] & (|(SPI_DEVICE_PERMIT[72] & ~reg_be))) |
+               (addr_hit[73] & (|(SPI_DEVICE_PERMIT[73] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -18124,20 +18183,25 @@ module spi_device_reg_top (
   assign flash_status_busy_wd = reg_wdata[0];
 
   assign flash_status_status_wd = reg_wdata[23:1];
-  assign jedec_id_we = addr_hit[16] & reg_we & !reg_error;
+  assign jedec_cc_we = addr_hit[16] & reg_we & !reg_error;
+
+  assign jedec_cc_cc_wd = reg_wdata[7:0];
+
+  assign jedec_cc_num_cc_wd = reg_wdata[15:8];
+  assign jedec_id_we = addr_hit[17] & reg_we & !reg_error;
 
   assign jedec_id_id_wd = reg_wdata[15:0];
 
   assign jedec_id_mf_wd = reg_wdata[23:16];
-  assign read_threshold_we = addr_hit[17] & reg_we & !reg_error;
+  assign read_threshold_we = addr_hit[18] & reg_we & !reg_error;
 
   assign read_threshold_wd = reg_wdata[9:0];
-  assign mailbox_addr_we = addr_hit[18] & reg_we & !reg_error;
+  assign mailbox_addr_we = addr_hit[19] & reg_we & !reg_error;
 
   assign mailbox_addr_wd = reg_wdata[31:0];
-  assign upload_cmdfifo_re = addr_hit[20] & reg_re & !reg_error;
-  assign upload_addrfifo_re = addr_hit[21] & reg_re & !reg_error;
-  assign cmd_filter_0_we = addr_hit[22] & reg_we & !reg_error;
+  assign upload_cmdfifo_re = addr_hit[21] & reg_re & !reg_error;
+  assign upload_addrfifo_re = addr_hit[22] & reg_re & !reg_error;
+  assign cmd_filter_0_we = addr_hit[23] & reg_we & !reg_error;
 
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
 
@@ -18202,7 +18266,7 @@ module spi_device_reg_top (
   assign cmd_filter_0_filter_30_wd = reg_wdata[30];
 
   assign cmd_filter_0_filter_31_wd = reg_wdata[31];
-  assign cmd_filter_1_we = addr_hit[23] & reg_we & !reg_error;
+  assign cmd_filter_1_we = addr_hit[24] & reg_we & !reg_error;
 
   assign cmd_filter_1_filter_32_wd = reg_wdata[0];
 
@@ -18267,7 +18331,7 @@ module spi_device_reg_top (
   assign cmd_filter_1_filter_62_wd = reg_wdata[30];
 
   assign cmd_filter_1_filter_63_wd = reg_wdata[31];
-  assign cmd_filter_2_we = addr_hit[24] & reg_we & !reg_error;
+  assign cmd_filter_2_we = addr_hit[25] & reg_we & !reg_error;
 
   assign cmd_filter_2_filter_64_wd = reg_wdata[0];
 
@@ -18332,7 +18396,7 @@ module spi_device_reg_top (
   assign cmd_filter_2_filter_94_wd = reg_wdata[30];
 
   assign cmd_filter_2_filter_95_wd = reg_wdata[31];
-  assign cmd_filter_3_we = addr_hit[25] & reg_we & !reg_error;
+  assign cmd_filter_3_we = addr_hit[26] & reg_we & !reg_error;
 
   assign cmd_filter_3_filter_96_wd = reg_wdata[0];
 
@@ -18397,7 +18461,7 @@ module spi_device_reg_top (
   assign cmd_filter_3_filter_126_wd = reg_wdata[30];
 
   assign cmd_filter_3_filter_127_wd = reg_wdata[31];
-  assign cmd_filter_4_we = addr_hit[26] & reg_we & !reg_error;
+  assign cmd_filter_4_we = addr_hit[27] & reg_we & !reg_error;
 
   assign cmd_filter_4_filter_128_wd = reg_wdata[0];
 
@@ -18462,7 +18526,7 @@ module spi_device_reg_top (
   assign cmd_filter_4_filter_158_wd = reg_wdata[30];
 
   assign cmd_filter_4_filter_159_wd = reg_wdata[31];
-  assign cmd_filter_5_we = addr_hit[27] & reg_we & !reg_error;
+  assign cmd_filter_5_we = addr_hit[28] & reg_we & !reg_error;
 
   assign cmd_filter_5_filter_160_wd = reg_wdata[0];
 
@@ -18527,7 +18591,7 @@ module spi_device_reg_top (
   assign cmd_filter_5_filter_190_wd = reg_wdata[30];
 
   assign cmd_filter_5_filter_191_wd = reg_wdata[31];
-  assign cmd_filter_6_we = addr_hit[28] & reg_we & !reg_error;
+  assign cmd_filter_6_we = addr_hit[29] & reg_we & !reg_error;
 
   assign cmd_filter_6_filter_192_wd = reg_wdata[0];
 
@@ -18592,7 +18656,7 @@ module spi_device_reg_top (
   assign cmd_filter_6_filter_222_wd = reg_wdata[30];
 
   assign cmd_filter_6_filter_223_wd = reg_wdata[31];
-  assign cmd_filter_7_we = addr_hit[29] & reg_we & !reg_error;
+  assign cmd_filter_7_we = addr_hit[30] & reg_we & !reg_error;
 
   assign cmd_filter_7_filter_224_wd = reg_wdata[0];
 
@@ -18657,19 +18721,19 @@ module spi_device_reg_top (
   assign cmd_filter_7_filter_254_wd = reg_wdata[30];
 
   assign cmd_filter_7_filter_255_wd = reg_wdata[31];
-  assign addr_swap_mask_we = addr_hit[30] & reg_we & !reg_error;
+  assign addr_swap_mask_we = addr_hit[31] & reg_we & !reg_error;
 
   assign addr_swap_mask_wd = reg_wdata[31:0];
-  assign addr_swap_data_we = addr_hit[31] & reg_we & !reg_error;
+  assign addr_swap_data_we = addr_hit[32] & reg_we & !reg_error;
 
   assign addr_swap_data_wd = reg_wdata[31:0];
-  assign payload_swap_mask_we = addr_hit[32] & reg_we & !reg_error;
+  assign payload_swap_mask_we = addr_hit[33] & reg_we & !reg_error;
 
   assign payload_swap_mask_wd = reg_wdata[31:0];
-  assign payload_swap_data_we = addr_hit[33] & reg_we & !reg_error;
+  assign payload_swap_data_we = addr_hit[34] & reg_we & !reg_error;
 
   assign payload_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_0_we = addr_hit[34] & reg_we & !reg_error;
+  assign cmd_info_0_we = addr_hit[35] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -18694,7 +18758,7 @@ module spi_device_reg_top (
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
 
   assign cmd_info_0_valid_0_wd = reg_wdata[31];
-  assign cmd_info_1_we = addr_hit[35] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -18719,7 +18783,7 @@ module spi_device_reg_top (
   assign cmd_info_1_busy_1_wd = reg_wdata[25];
 
   assign cmd_info_1_valid_1_wd = reg_wdata[31];
-  assign cmd_info_2_we = addr_hit[36] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -18744,7 +18808,7 @@ module spi_device_reg_top (
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
 
   assign cmd_info_2_valid_2_wd = reg_wdata[31];
-  assign cmd_info_3_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -18769,7 +18833,7 @@ module spi_device_reg_top (
   assign cmd_info_3_busy_3_wd = reg_wdata[25];
 
   assign cmd_info_3_valid_3_wd = reg_wdata[31];
-  assign cmd_info_4_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -18794,7 +18858,7 @@ module spi_device_reg_top (
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
 
   assign cmd_info_4_valid_4_wd = reg_wdata[31];
-  assign cmd_info_5_we = addr_hit[39] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[40] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -18819,7 +18883,7 @@ module spi_device_reg_top (
   assign cmd_info_5_busy_5_wd = reg_wdata[25];
 
   assign cmd_info_5_valid_5_wd = reg_wdata[31];
-  assign cmd_info_6_we = addr_hit[40] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[41] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -18844,7 +18908,7 @@ module spi_device_reg_top (
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
 
   assign cmd_info_6_valid_6_wd = reg_wdata[31];
-  assign cmd_info_7_we = addr_hit[41] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[42] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -18869,7 +18933,7 @@ module spi_device_reg_top (
   assign cmd_info_7_busy_7_wd = reg_wdata[25];
 
   assign cmd_info_7_valid_7_wd = reg_wdata[31];
-  assign cmd_info_8_we = addr_hit[42] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[43] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -18894,7 +18958,7 @@ module spi_device_reg_top (
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
 
   assign cmd_info_8_valid_8_wd = reg_wdata[31];
-  assign cmd_info_9_we = addr_hit[43] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[44] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -18919,7 +18983,7 @@ module spi_device_reg_top (
   assign cmd_info_9_busy_9_wd = reg_wdata[25];
 
   assign cmd_info_9_valid_9_wd = reg_wdata[31];
-  assign cmd_info_10_we = addr_hit[44] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[45] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -18944,7 +19008,7 @@ module spi_device_reg_top (
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
 
   assign cmd_info_10_valid_10_wd = reg_wdata[31];
-  assign cmd_info_11_we = addr_hit[45] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[46] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -18969,7 +19033,7 @@ module spi_device_reg_top (
   assign cmd_info_11_busy_11_wd = reg_wdata[25];
 
   assign cmd_info_11_valid_11_wd = reg_wdata[31];
-  assign cmd_info_12_we = addr_hit[46] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[47] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -18994,7 +19058,7 @@ module spi_device_reg_top (
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
 
   assign cmd_info_12_valid_12_wd = reg_wdata[31];
-  assign cmd_info_13_we = addr_hit[47] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[48] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -19019,7 +19083,7 @@ module spi_device_reg_top (
   assign cmd_info_13_busy_13_wd = reg_wdata[25];
 
   assign cmd_info_13_valid_13_wd = reg_wdata[31];
-  assign cmd_info_14_we = addr_hit[48] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[49] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -19044,7 +19108,7 @@ module spi_device_reg_top (
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
 
   assign cmd_info_14_valid_14_wd = reg_wdata[31];
-  assign cmd_info_15_we = addr_hit[49] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[50] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -19069,7 +19133,7 @@ module spi_device_reg_top (
   assign cmd_info_15_busy_15_wd = reg_wdata[25];
 
   assign cmd_info_15_valid_15_wd = reg_wdata[31];
-  assign cmd_info_16_we = addr_hit[50] & reg_we & !reg_error;
+  assign cmd_info_16_we = addr_hit[51] & reg_we & !reg_error;
 
   assign cmd_info_16_opcode_16_wd = reg_wdata[7:0];
 
@@ -19094,7 +19158,7 @@ module spi_device_reg_top (
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
 
   assign cmd_info_16_valid_16_wd = reg_wdata[31];
-  assign cmd_info_17_we = addr_hit[51] & reg_we & !reg_error;
+  assign cmd_info_17_we = addr_hit[52] & reg_we & !reg_error;
 
   assign cmd_info_17_opcode_17_wd = reg_wdata[7:0];
 
@@ -19119,7 +19183,7 @@ module spi_device_reg_top (
   assign cmd_info_17_busy_17_wd = reg_wdata[25];
 
   assign cmd_info_17_valid_17_wd = reg_wdata[31];
-  assign cmd_info_18_we = addr_hit[52] & reg_we & !reg_error;
+  assign cmd_info_18_we = addr_hit[53] & reg_we & !reg_error;
 
   assign cmd_info_18_opcode_18_wd = reg_wdata[7:0];
 
@@ -19144,7 +19208,7 @@ module spi_device_reg_top (
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
 
   assign cmd_info_18_valid_18_wd = reg_wdata[31];
-  assign cmd_info_19_we = addr_hit[53] & reg_we & !reg_error;
+  assign cmd_info_19_we = addr_hit[54] & reg_we & !reg_error;
 
   assign cmd_info_19_opcode_19_wd = reg_wdata[7:0];
 
@@ -19169,7 +19233,7 @@ module spi_device_reg_top (
   assign cmd_info_19_busy_19_wd = reg_wdata[25];
 
   assign cmd_info_19_valid_19_wd = reg_wdata[31];
-  assign cmd_info_20_we = addr_hit[54] & reg_we & !reg_error;
+  assign cmd_info_20_we = addr_hit[55] & reg_we & !reg_error;
 
   assign cmd_info_20_opcode_20_wd = reg_wdata[7:0];
 
@@ -19194,7 +19258,7 @@ module spi_device_reg_top (
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
 
   assign cmd_info_20_valid_20_wd = reg_wdata[31];
-  assign cmd_info_21_we = addr_hit[55] & reg_we & !reg_error;
+  assign cmd_info_21_we = addr_hit[56] & reg_we & !reg_error;
 
   assign cmd_info_21_opcode_21_wd = reg_wdata[7:0];
 
@@ -19219,7 +19283,7 @@ module spi_device_reg_top (
   assign cmd_info_21_busy_21_wd = reg_wdata[25];
 
   assign cmd_info_21_valid_21_wd = reg_wdata[31];
-  assign cmd_info_22_we = addr_hit[56] & reg_we & !reg_error;
+  assign cmd_info_22_we = addr_hit[57] & reg_we & !reg_error;
 
   assign cmd_info_22_opcode_22_wd = reg_wdata[7:0];
 
@@ -19244,7 +19308,7 @@ module spi_device_reg_top (
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
 
   assign cmd_info_22_valid_22_wd = reg_wdata[31];
-  assign cmd_info_23_we = addr_hit[57] & reg_we & !reg_error;
+  assign cmd_info_23_we = addr_hit[58] & reg_we & !reg_error;
 
   assign cmd_info_23_opcode_23_wd = reg_wdata[7:0];
 
@@ -19269,7 +19333,7 @@ module spi_device_reg_top (
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
 
   assign cmd_info_23_valid_23_wd = reg_wdata[31];
-  assign tpm_cfg_we = addr_hit[59] & reg_we & !reg_error;
+  assign tpm_cfg_we = addr_hit[60] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
 
@@ -19280,7 +19344,7 @@ module spi_device_reg_top (
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_access_0_we = addr_hit[61] & reg_we & !reg_error;
+  assign tpm_access_0_we = addr_hit[62] & reg_we & !reg_error;
 
   assign tpm_access_0_access_0_wd = reg_wdata[7:0];
 
@@ -19289,37 +19353,37 @@ module spi_device_reg_top (
   assign tpm_access_0_access_2_wd = reg_wdata[23:16];
 
   assign tpm_access_0_access_3_wd = reg_wdata[31:24];
-  assign tpm_access_1_we = addr_hit[62] & reg_we & !reg_error;
+  assign tpm_access_1_we = addr_hit[63] & reg_we & !reg_error;
 
   assign tpm_access_1_wd = reg_wdata[7:0];
-  assign tpm_sts_we = addr_hit[63] & reg_we & !reg_error;
+  assign tpm_sts_we = addr_hit[64] & reg_we & !reg_error;
 
   assign tpm_sts_wd = reg_wdata[31:0];
-  assign tpm_intf_capability_we = addr_hit[64] & reg_we & !reg_error;
+  assign tpm_intf_capability_we = addr_hit[65] & reg_we & !reg_error;
 
   assign tpm_intf_capability_wd = reg_wdata[31:0];
-  assign tpm_int_enable_we = addr_hit[65] & reg_we & !reg_error;
+  assign tpm_int_enable_we = addr_hit[66] & reg_we & !reg_error;
 
   assign tpm_int_enable_wd = reg_wdata[31:0];
-  assign tpm_int_vector_we = addr_hit[66] & reg_we & !reg_error;
+  assign tpm_int_vector_we = addr_hit[67] & reg_we & !reg_error;
 
   assign tpm_int_vector_wd = reg_wdata[7:0];
-  assign tpm_int_status_we = addr_hit[67] & reg_we & !reg_error;
+  assign tpm_int_status_we = addr_hit[68] & reg_we & !reg_error;
 
   assign tpm_int_status_wd = reg_wdata[31:0];
-  assign tpm_did_vid_we = addr_hit[68] & reg_we & !reg_error;
+  assign tpm_did_vid_we = addr_hit[69] & reg_we & !reg_error;
 
   assign tpm_did_vid_vid_wd = reg_wdata[15:0];
 
   assign tpm_did_vid_did_wd = reg_wdata[31:16];
-  assign tpm_rid_we = addr_hit[69] & reg_we & !reg_error;
+  assign tpm_rid_we = addr_hit[70] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = addr_hit[70] & reg_re & !reg_error;
-  assign tpm_read_fifo_we = addr_hit[71] & reg_we & !reg_error;
+  assign tpm_cmd_addr_re = addr_hit[71] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[72] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[7:0];
-  assign tpm_write_fifo_re = addr_hit[72] & reg_re & !reg_error;
+  assign tpm_write_fifo_re = addr_hit[73] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -19445,19 +19509,24 @@ module spi_device_reg_top (
       end
 
       addr_hit[16]: begin
+        reg_rdata_next[7:0] = jedec_cc_cc_qs;
+        reg_rdata_next[15:8] = jedec_cc_num_cc_qs;
+      end
+
+      addr_hit[17]: begin
         reg_rdata_next[15:0] = jedec_id_id_qs;
         reg_rdata_next[23:16] = jedec_id_mf_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[18]: begin
         reg_rdata_next[9:0] = read_threshold_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[19]: begin
         reg_rdata_next[31:0] = mailbox_addr_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[20]: begin
         reg_rdata_next[4:0] = upload_status_cmdfifo_depth_qs;
         reg_rdata_next[7] = upload_status_cmdfifo_notempty_qs;
         reg_rdata_next[12:8] = upload_status_addrfifo_depth_qs;
@@ -19465,15 +19534,15 @@ module spi_device_reg_top (
         reg_rdata_next[24:16] = upload_status_payload_depth_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[21]: begin
         reg_rdata_next[7:0] = upload_cmdfifo_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[22]: begin
         reg_rdata_next[31:0] = upload_addrfifo_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[23]: begin
         reg_rdata_next[0] = cmd_filter_0_filter_0_qs;
         reg_rdata_next[1] = cmd_filter_0_filter_1_qs;
         reg_rdata_next[2] = cmd_filter_0_filter_2_qs;
@@ -19508,7 +19577,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_0_filter_31_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[24]: begin
         reg_rdata_next[0] = cmd_filter_1_filter_32_qs;
         reg_rdata_next[1] = cmd_filter_1_filter_33_qs;
         reg_rdata_next[2] = cmd_filter_1_filter_34_qs;
@@ -19543,7 +19612,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_1_filter_63_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = cmd_filter_2_filter_64_qs;
         reg_rdata_next[1] = cmd_filter_2_filter_65_qs;
         reg_rdata_next[2] = cmd_filter_2_filter_66_qs;
@@ -19578,7 +19647,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_2_filter_95_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = cmd_filter_3_filter_96_qs;
         reg_rdata_next[1] = cmd_filter_3_filter_97_qs;
         reg_rdata_next[2] = cmd_filter_3_filter_98_qs;
@@ -19613,7 +19682,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_3_filter_127_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = cmd_filter_4_filter_128_qs;
         reg_rdata_next[1] = cmd_filter_4_filter_129_qs;
         reg_rdata_next[2] = cmd_filter_4_filter_130_qs;
@@ -19648,7 +19717,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_4_filter_159_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = cmd_filter_5_filter_160_qs;
         reg_rdata_next[1] = cmd_filter_5_filter_161_qs;
         reg_rdata_next[2] = cmd_filter_5_filter_162_qs;
@@ -19683,7 +19752,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_5_filter_191_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[0] = cmd_filter_6_filter_192_qs;
         reg_rdata_next[1] = cmd_filter_6_filter_193_qs;
         reg_rdata_next[2] = cmd_filter_6_filter_194_qs;
@@ -19718,7 +19787,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_6_filter_223_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[0] = cmd_filter_7_filter_224_qs;
         reg_rdata_next[1] = cmd_filter_7_filter_225_qs;
         reg_rdata_next[2] = cmd_filter_7_filter_226_qs;
@@ -19753,23 +19822,23 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_7_filter_255_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = addr_swap_mask_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = addr_swap_data_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[31:0] = payload_swap_mask_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[31:0] = payload_swap_data_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[9:8] = cmd_info_0_addr_mode_0_qs;
         reg_rdata_next[10] = cmd_info_0_addr_swap_en_0_qs;
@@ -19784,7 +19853,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_0_valid_0_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[9:8] = cmd_info_1_addr_mode_1_qs;
         reg_rdata_next[10] = cmd_info_1_addr_swap_en_1_qs;
@@ -19799,7 +19868,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_1_valid_1_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[9:8] = cmd_info_2_addr_mode_2_qs;
         reg_rdata_next[10] = cmd_info_2_addr_swap_en_2_qs;
@@ -19814,7 +19883,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_2_valid_2_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[9:8] = cmd_info_3_addr_mode_3_qs;
         reg_rdata_next[10] = cmd_info_3_addr_swap_en_3_qs;
@@ -19829,7 +19898,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_3_valid_3_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[9:8] = cmd_info_4_addr_mode_4_qs;
         reg_rdata_next[10] = cmd_info_4_addr_swap_en_4_qs;
@@ -19844,7 +19913,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_4_valid_4_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[9:8] = cmd_info_5_addr_mode_5_qs;
         reg_rdata_next[10] = cmd_info_5_addr_swap_en_5_qs;
@@ -19859,7 +19928,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_5_valid_5_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[9:8] = cmd_info_6_addr_mode_6_qs;
         reg_rdata_next[10] = cmd_info_6_addr_swap_en_6_qs;
@@ -19874,7 +19943,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_6_valid_6_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[9:8] = cmd_info_7_addr_mode_7_qs;
         reg_rdata_next[10] = cmd_info_7_addr_swap_en_7_qs;
@@ -19889,7 +19958,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_7_valid_7_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[9:8] = cmd_info_8_addr_mode_8_qs;
         reg_rdata_next[10] = cmd_info_8_addr_swap_en_8_qs;
@@ -19904,7 +19973,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_8_valid_8_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[9:8] = cmd_info_9_addr_mode_9_qs;
         reg_rdata_next[10] = cmd_info_9_addr_swap_en_9_qs;
@@ -19919,7 +19988,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_9_valid_9_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[45]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[9:8] = cmd_info_10_addr_mode_10_qs;
         reg_rdata_next[10] = cmd_info_10_addr_swap_en_10_qs;
@@ -19934,7 +20003,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_10_valid_10_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[46]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[9:8] = cmd_info_11_addr_mode_11_qs;
         reg_rdata_next[10] = cmd_info_11_addr_swap_en_11_qs;
@@ -19949,7 +20018,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_11_valid_11_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[47]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[9:8] = cmd_info_12_addr_mode_12_qs;
         reg_rdata_next[10] = cmd_info_12_addr_swap_en_12_qs;
@@ -19964,7 +20033,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_12_valid_12_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[48]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[9:8] = cmd_info_13_addr_mode_13_qs;
         reg_rdata_next[10] = cmd_info_13_addr_swap_en_13_qs;
@@ -19979,7 +20048,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_13_valid_13_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[49]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[9:8] = cmd_info_14_addr_mode_14_qs;
         reg_rdata_next[10] = cmd_info_14_addr_swap_en_14_qs;
@@ -19994,7 +20063,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_14_valid_14_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[50]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[9:8] = cmd_info_15_addr_mode_15_qs;
         reg_rdata_next[10] = cmd_info_15_addr_swap_en_15_qs;
@@ -20009,7 +20078,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_15_valid_15_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[51]: begin
         reg_rdata_next[7:0] = cmd_info_16_opcode_16_qs;
         reg_rdata_next[9:8] = cmd_info_16_addr_mode_16_qs;
         reg_rdata_next[10] = cmd_info_16_addr_swap_en_16_qs;
@@ -20024,7 +20093,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_16_valid_16_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[7:0] = cmd_info_17_opcode_17_qs;
         reg_rdata_next[9:8] = cmd_info_17_addr_mode_17_qs;
         reg_rdata_next[10] = cmd_info_17_addr_swap_en_17_qs;
@@ -20039,7 +20108,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_17_valid_17_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[7:0] = cmd_info_18_opcode_18_qs;
         reg_rdata_next[9:8] = cmd_info_18_addr_mode_18_qs;
         reg_rdata_next[10] = cmd_info_18_addr_swap_en_18_qs;
@@ -20054,7 +20123,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_18_valid_18_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[7:0] = cmd_info_19_opcode_19_qs;
         reg_rdata_next[9:8] = cmd_info_19_addr_mode_19_qs;
         reg_rdata_next[10] = cmd_info_19_addr_swap_en_19_qs;
@@ -20069,7 +20138,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_19_valid_19_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[7:0] = cmd_info_20_opcode_20_qs;
         reg_rdata_next[9:8] = cmd_info_20_addr_mode_20_qs;
         reg_rdata_next[10] = cmd_info_20_addr_swap_en_20_qs;
@@ -20084,7 +20153,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_20_valid_20_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[56]: begin
         reg_rdata_next[7:0] = cmd_info_21_opcode_21_qs;
         reg_rdata_next[9:8] = cmd_info_21_addr_mode_21_qs;
         reg_rdata_next[10] = cmd_info_21_addr_swap_en_21_qs;
@@ -20099,7 +20168,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_21_valid_21_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[57]: begin
         reg_rdata_next[7:0] = cmd_info_22_opcode_22_qs;
         reg_rdata_next[9:8] = cmd_info_22_addr_mode_22_qs;
         reg_rdata_next[10] = cmd_info_22_addr_swap_en_22_qs;
@@ -20114,7 +20183,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_22_valid_22_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[58]: begin
         reg_rdata_next[7:0] = cmd_info_23_opcode_23_qs;
         reg_rdata_next[9:8] = cmd_info_23_addr_mode_23_qs;
         reg_rdata_next[10] = cmd_info_23_addr_swap_en_23_qs;
@@ -20129,13 +20198,13 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_23_valid_23_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[59]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
         reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[60]: begin
         reg_rdata_next[0] = tpm_cfg_en_qs;
         reg_rdata_next[1] = tpm_cfg_tpm_mode_qs;
         reg_rdata_next[2] = tpm_cfg_hw_reg_dis_qs;
@@ -20143,63 +20212,63 @@ module spi_device_reg_top (
         reg_rdata_next[4] = tpm_cfg_invalid_locality_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[61]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
         reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[62]: begin
         reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
         reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
         reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
         reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[63]: begin
         reg_rdata_next[7:0] = tpm_access_1_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[64]: begin
         reg_rdata_next[31:0] = tpm_sts_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[65]: begin
         reg_rdata_next[31:0] = tpm_intf_capability_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[66]: begin
         reg_rdata_next[31:0] = tpm_int_enable_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[67]: begin
         reg_rdata_next[7:0] = tpm_int_vector_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[68]: begin
         reg_rdata_next[31:0] = tpm_int_status_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[69]: begin
         reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
         reg_rdata_next[31:16] = tpm_did_vid_did_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[70]: begin
         reg_rdata_next[7:0] = tpm_rid_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[71]: begin
         reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
         reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[72]: begin
         reg_rdata_next[7:0] = '0;
       end
 
-      addr_hit[72]: begin
+      addr_hit[73]: begin
         reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 

--- a/hw/ip/spi_device/rtl/spid_jedec.sv
+++ b/hw/ip/spi_device/rtl/spid_jedec.sv
@@ -16,7 +16,7 @@ module spid_jedec
 
   input inclk_csb_asserted_pulse_i,
 
-  input logic [23:0] sys_jedec_i, // from CSR
+  input jedec_cfg_t sys_jedec_i, // from CSR
 
   output io_mode_e io_mode_o,
 
@@ -29,9 +29,19 @@ module spid_jedec
   input  logic      outclk_p2s_sent_i
 );
 
-  typedef enum logic {
+  typedef enum logic [1:0] {
     StIdle,
-    StActive
+
+    // If num_cc is non-zero, State machine moves to CC state and sends CC up
+    // to num_cc times.
+    StCC,
+
+    // In JedecId state, the logic sends manufacturer ID (jedec.jedec_id)
+    StJedecId,
+
+    // After sending a byte at StJedecId, the logic returns 2 DevId bytes to
+    // the host system.
+    StDevId
   } st_e;
   st_e st_q, st_d;
 
@@ -41,7 +51,7 @@ module spid_jedec
 
   assign io_mode_o = SingleIO;
 
-  logic [23:0] jedec;
+  jedec_cfg_t jedec;
 
   logic      p2s_valid;
   spi_byte_t p2s_byte;
@@ -59,8 +69,20 @@ module spid_jedec
 
   // Jedec latch
   always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni)                         jedec <= 24'h 0;
+    if (!rst_ni)                         jedec <= '{default: '0};
     else if (inclk_csb_asserted_pulse_i) jedec <= sys_jedec_i;
+  end
+
+  // If num_cc is non-zero, the logic shall return CC first
+  logic cc_needed;
+  assign cc_needed = |jedec.num_cc;
+
+  logic [7:0] cc_count;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) cc_count <= '0;
+    else if (st_q == StCC && outclk_p2s_sent_i) begin
+      cc_count <= cc_count + 1'b 1;
+    end
   end
 
   // Output to Parallel-to-Serial
@@ -79,23 +101,27 @@ module spid_jedec
 
     if (st_q == StIdle) begin
       // Manufacturer ID always
-      p2s_byte = jedec[23:16];
-    end else if (byte_sel_q == 2'h 3) begin
+      p2s_byte = (cc_needed) ? jedec.cc : jedec.jedec_id;
+    end else if (st_q == StCC) begin
+      p2s_byte = jedec.cc;
+    end else if (st_q == StJedecId) begin
+      p2s_byte = jedec.jedec_id;
+    end else if (byte_sel_q == 2'h 2) begin
       // End of the transfer but host keep toggles SCK. Sending out 0 always
       p2s_byte = 8'h 0;
     end else begin
       // based on byte_sel_q
-      p2s_byte = jedec[8*byte_sel_q+:8];
+      p2s_byte = jedec.device_id[8*byte_sel_q+:8];
     end
   end : p2s_byte_logic
 
   // Byte selection
   always_ff @(posedge clk_i or negedge rst_ni) begin : byte_sel_latch
-    if (!rst_ni)        byte_sel_q <= 8'h 2; // select manufacturer id
+    if (!rst_ni)        byte_sel_q <= 8'h 0; // select manufacturer id
     else if (next_byte) byte_sel_q <= byte_sel_d;
   end : byte_sel_latch
 
-  assign byte_sel_d = (byte_sel_q == 2'b 11) ? 2'b 11 : byte_sel_q - 1'b 1;
+  assign byte_sel_d = (byte_sel_q == 2'b 10) ? 2'b 10 : byte_sel_q + 1'b 1;
 
   ///////////
   // State //
@@ -115,14 +141,36 @@ module spid_jedec
     unique case (st_q)
       StIdle: begin
         if (sel_dp_i == DpReadJEDEC) begin
-          st_d = StActive;
+          st_d = (cc_needed) ? StCC : StJedecId ;
 
           // Send out the dat
           p2s_valid = 1'b 1;
         end
       end
 
-      StActive: begin
+      StCC: begin
+
+        // cc_count is increased by 1 when outclk_p2s_sent_i is asserted
+        // outclk_p2s_sent_i asserts at the 7th beat, not 8th beat.  When
+        // cc_count reaches to num_cc, it is the end of a byte transaction in
+        // SCK input clock domain. So, that time state machine moves to
+        // JedecId
+        if (cc_count == jedec.num_cc) begin
+          st_d = StJedecId;
+        end
+
+        p2s_valid = 1'b 1;
+      end
+
+      StJedecId: begin
+        if (outclk_p2s_sent_i) begin
+          st_d = StDevId;
+        end
+
+        p2s_valid = 1'b 1;
+      end
+
+      StDevId: begin
         // TERMINAL_STATE
 
         // Sends data


### PR DESCRIPTION
This commit revises Read JEDEC ID command to support Continuous Code.

If the manufacturer ID is not in the first page in JEDEC ID table, the
return of JEDEC ID should follow N number of Continuous Code (7Fh
default).

I added JEDEC_CC CSR for SW to configure the repeat counter and the
ContinuousCode value. The logic supports up to 255 repeat of CC, which
exceeds the current maximum CC counter. Also SW may change the CC value.
Default value is 7Fh.