### PR TITLE
[csrng/rtl] wrong parameter on packer_fifo

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -991,7 +991,7 @@ module csrng_core import csrng_pkg::*; #(
   prim_packer_fifo #(
     .InW(32),
     .OutW(SeedLen),
-    .ClearOnRead(1'b0)
+    .ClearOnRead(1'b1)
   ) u_prim_packer_fifo_adata (
     .clk_i      (clk_i),
     .rst_ni     (rst_ni),


### PR DESCRIPTION
When the clear on read feature was added to the packer fifo, the setting for the acmd usage was not set properly.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>