### PR TITLE
[dv/alert_handler] Fix alert class error

### DIFF
--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -47,11 +47,13 @@ class alert_handler_base_vseq extends cip_base_vseq #(
 
   // setup basic alert_handler features
   // alert_class default 0 -> all alert will trigger interrupt classA
-  virtual task alert_handler_init(bit [NUM_ALERT_CLASSES-1:0]            intr_en = '1,
-                                  bit [NUM_ALERTS-1:0]                   alert_en = '1,
-                                  bit [NUM_ALERT_CLASSES-1:0][TL_DW-1:0] alert_class = 'h0,
-                                  bit [NUM_LOCAL_ALERTS-1:0]             loc_alert_en = '1,
-                                  bit [NUM_ALERT_CLASSES-1:0][TL_DW-1:0] loc_alert_class = 'h0);
+  virtual task alert_handler_init(
+      bit [NUM_ALERT_CLASSES-1:0]                       intr_en = '1,
+      bit [NUM_ALERTS-1:0]                              alert_en = '1,
+      bit [NUM_ALERTS-1:0][NUM_ALERT_CLASSES-1:0]       alert_class = 'h0,
+      bit [NUM_LOCAL_ALERTS-1:0]                        loc_alert_en = '1,
+      bit [NUM_LOCAL_ALERTS-1:0][NUM_ALERT_CLASSES-1:0] loc_alert_class = 'h0);
+
     csr_wr(.ptr(ral.intr_enable), .value(intr_en));
     foreach (alert_en[i])        csr_wr(.ptr(ral.alert_en_shadowed[i]),
                                         .value(alert_en[i]));

--- a/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/ip_templates/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -18,10 +18,10 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
   rand bit [NUM_ALERTS-1:0]                              alert_int_err;
   rand bit [NUM_ALERTS-1:0]                              alert_en;
   rand bit [NUM_ALERTS-1:0]                              alert_ping_timeout;
-  rand bit [NUM_ALERT_CLASSES-1:0][NUM_ALERTS-1:0]       alert_class_map;
+  rand bit [NUM_ALERTS-1:0][NUM_ALERT_CLASSES-1:0]       alert_class_map;
   rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_regwen;
   rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_en;
-  rand bit [NUM_ALERT_CLASSES-1:0][NUM_LOCAL_ALERTS-1:0] local_alert_class_map;
+  rand bit [NUM_LOCAL_ALERTS-1:0][NUM_ALERT_CLASSES-1:0] local_alert_class_map;
   rand bit [NUM_ESCS-1:0]                                esc_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_standalone_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_ping_timeout;
@@ -127,8 +127,8 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
     for (int i = 1; i <= num_trans; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
 
-      `uvm_info(`gfn,
-          $sformatf("start seq %0d/%0d: intr_en=%0b, alert=%0b, alert_en=%0b, loc_alert_en=%0b",
+      `uvm_info(`gfn, $sformatf(
+          "start seq %0d/%0d: intr_en=0x%0h, alert=0x%0h, alert_en=0x%0h, loc_alert_en=0x%0h",
           i, num_trans, intr_en, alert_trigger, alert_en, local_alert_en), verbosity)
 
       // write initial settings (enable and mapping csrs)

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_base_vseq.sv
@@ -47,11 +47,13 @@ class alert_handler_base_vseq extends cip_base_vseq #(
 
   // setup basic alert_handler features
   // alert_class default 0 -> all alert will trigger interrupt classA
-  virtual task alert_handler_init(bit [NUM_ALERT_CLASSES-1:0]            intr_en = '1,
-                                  bit [NUM_ALERTS-1:0]                   alert_en = '1,
-                                  bit [NUM_ALERT_CLASSES-1:0][TL_DW-1:0] alert_class = 'h0,
-                                  bit [NUM_LOCAL_ALERTS-1:0]             loc_alert_en = '1,
-                                  bit [NUM_ALERT_CLASSES-1:0][TL_DW-1:0] loc_alert_class = 'h0);
+  virtual task alert_handler_init(
+      bit [NUM_ALERT_CLASSES-1:0]                       intr_en = '1,
+      bit [NUM_ALERTS-1:0]                              alert_en = '1,
+      bit [NUM_ALERTS-1:0][NUM_ALERT_CLASSES-1:0]       alert_class = 'h0,
+      bit [NUM_LOCAL_ALERTS-1:0]                        loc_alert_en = '1,
+      bit [NUM_LOCAL_ALERTS-1:0][NUM_ALERT_CLASSES-1:0] loc_alert_class = 'h0);
+
     csr_wr(.ptr(ral.intr_enable), .value(intr_en));
     foreach (alert_en[i])        csr_wr(.ptr(ral.alert_en_shadowed[i]),
                                         .value(alert_en[i]));

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/seq_lib/alert_handler_smoke_vseq.sv
@@ -18,10 +18,10 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
   rand bit [NUM_ALERTS-1:0]                              alert_int_err;
   rand bit [NUM_ALERTS-1:0]                              alert_en;
   rand bit [NUM_ALERTS-1:0]                              alert_ping_timeout;
-  rand bit [NUM_ALERT_CLASSES-1:0][NUM_ALERTS-1:0]       alert_class_map;
+  rand bit [NUM_ALERTS-1:0][NUM_ALERT_CLASSES-1:0]       alert_class_map;
   rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_regwen;
   rand bit [NUM_LOCAL_ALERTS-1:0]                        local_alert_en;
-  rand bit [NUM_ALERT_CLASSES-1:0][NUM_LOCAL_ALERTS-1:0] local_alert_class_map;
+  rand bit [NUM_LOCAL_ALERTS-1:0][NUM_ALERT_CLASSES-1:0] local_alert_class_map;
   rand bit [NUM_ESCS-1:0]                                esc_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_standalone_int_err;
   rand bit [NUM_ESCS-1:0]                                esc_ping_timeout;
@@ -127,8 +127,8 @@ class alert_handler_smoke_vseq extends alert_handler_base_vseq;
     for (int i = 1; i <= num_trans; i++) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
 
-      `uvm_info(`gfn,
-          $sformatf("start seq %0d/%0d: intr_en=%0b, alert=%0b, alert_en=%0b, loc_alert_en=%0b",
+      `uvm_info(`gfn, $sformatf(
+          "start seq %0d/%0d: intr_en=0x%0h, alert=0x%0h, alert_en=0x%0h, loc_alert_en=0x%0h",
           i, num_trans, intr_en, alert_trigger, alert_en, local_alert_en), verbosity)
 
       // write initial settings (enable and mapping csrs)


### PR DESCRIPTION
From the coverage, we found alert_class b/c/d has a smaller chance of
being chosen. This was because of a declaration error.
This PR redeclared the 2D array and should fix this coverage hole.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>