### PR TITLE
[otp_ctrl] Enable inverted ECC in OTP buffer registers

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -4,7 +4,7 @@
 
 // This interface collect the broadcast output data from OTP,
 // and drive input requests coming into OTP.
-`define ECC_REG_PATH u_otp_ctrl_ecc_reg.gen_ecc_dec[0].u_prim_secded_72_64_dec
+`define ECC_REG_PATH u_otp_ctrl_ecc_reg.gen_ecc_dec[0].u_prim_secded_inv_72_64_dec
 
 // This only supports buffered partitions.
 `define BUF_PART_OTP_CMD_PATH(i) \

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -879,8 +879,8 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
 
   virtual function bit [1:0] read_a_word_with_ecc(bit [TL_DW-1:0] dai_addr,
                                                   ref bit [TL_DW-1:0] readout_word);
-    prim_secded_pkg::secded_28_22_t ecc_rd_data0 = cfg.mem_bkdr_util_h.ecc_read16(dai_addr);
-    prim_secded_pkg::secded_28_22_t ecc_rd_data1 = cfg.mem_bkdr_util_h.ecc_read16(dai_addr + 2);
+    prim_secded_pkg::secded_22_16_t ecc_rd_data0 = cfg.mem_bkdr_util_h.ecc_read16(dai_addr);
+    prim_secded_pkg::secded_22_16_t ecc_rd_data1 = cfg.mem_bkdr_util_h.ecc_read16(dai_addr + 2);
     readout_word[15:0]  = ecc_rd_data0.data;
     readout_word[31:16] = ecc_rd_data1.data;
     return max2(ecc_rd_data0.err, ecc_rd_data1.err);

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_ecc_reg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_ecc_reg.sv
@@ -37,7 +37,7 @@ module otp_ctrl_ecc_reg #(
   logic [Width+EccWidth-1:0] ecc_enc;
 
   // Only one encoder is needed.
-  prim_secded_72_64_enc u_prim_secded_72_64_enc (
+  prim_secded_inv_72_64_enc u_prim_secded_inv_72_64_enc (
     .data_i(wdata_i),
     .data_o(ecc_enc)
   );
@@ -67,7 +67,7 @@ module otp_ctrl_ecc_reg #(
   // Concurrent ECC checks.
   logic [Depth-1:0][1:0] err;
   for (genvar k = 0; k < Depth; k++) begin : gen_ecc_dec
-    prim_secded_72_64_dec u_prim_secded_72_64_dec (
+    prim_secded_inv_72_64_dec u_prim_secded_inv_72_64_dec (
       .data_i({ecc_q[k], data_q[k]}),
       // We only rely on the error detection mechanism,
       // and not on error correction.
@@ -81,7 +81,7 @@ module otp_ctrl_ecc_reg #(
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
-      ecc_q  <= '0;
+      ecc_q  <= {Depth{prim_secded_pkg::SecdedInv7264ZeroEcc}};
       data_q <= '0;
     end else begin
       ecc_q  <= ecc_d;


### PR DESCRIPTION
This has been split out from #9472 since it is not directly related to the end-to-end bus integrity scheme, and can be merged separately.