### PR TITLE
[ entropy_src, dv ] Support for indefinitely long sequences

### DIFF
--- a/hw/dv/sv/push_pull_agent/push_pull_agent.core
+++ b/hw/dv/sv/push_pull_agent/push_pull_agent.core
@@ -21,6 +21,7 @@ filesets:
       - push_pull_agent.sv: {is_include_file: true}
       - seq_lib/push_pull_base_seq.sv: {is_include_file: true}
       - seq_lib/push_pull_host_seq.sv: {is_include_file: true}
+      - seq_lib/push_pull_indefinite_host_seq.sv: {is_include_file: true}
       - seq_lib/push_pull_device_seq.sv: {is_include_file: true}
       - seq_lib/push_pull_seq_list.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Request sequence for Push and Pull protocols.
+//
+// Similiar push_pull_host_seq, this sequence will send an unlimited number of requests to
+// the DUT. It is the responsibility of the parent sequence to halt this sequence by setting
+// the stop field.
+//
+
+class push_pull_indefinite_host_seq #(parameter int HostDataWidth = 32,
+                                      parameter int DeviceDataWidth = HostDataWidth)
+  extends push_pull_base_seq #(HostDataWidth, DeviceDataWidth);
+
+  `uvm_object_param_utils(push_pull_indefinite_host_seq#(HostDataWidth, DeviceDataWidth))
+
+  `uvm_object_new
+
+  bit do_stop;
+
+  virtual task body();
+    while (!do_stop) begin : send_req
+      `uvm_create(req)
+      start_item(req);
+      randomize_item(req);
+      finish_item(req);
+      get_response(rsp);
+    end : send_req
+  endtask
+
+  virtual task stop();
+    do_stop = 1;
+  endtask
+
+  virtual task pre_start();
+    super.pre_start();
+    do_stop = 0;
+  endtask
+endclass

--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_seq_list.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_seq_list.sv
@@ -4,4 +4,5 @@
 
 `include "push_pull_base_seq.sv"
 `include "push_pull_host_seq.sv"
+`include "push_pull_indefinite_host_seq.sv"
 `include "push_pull_device_seq.sv"

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -10,7 +10,15 @@ class entropy_src_rng_test extends entropy_src_base_test;
   function void configure_env();
     super.configure_env();
 
-    cfg.rng_bit_enable_pct = 10;
+    cfg.rng_bit_enable_pct          = 0;
+
+    cfg.en_scb                      = 1;
+    cfg.fips_window_size            = 2048;
+    cfg.bypass_window_size          = 384;
+    cfg.boot_mode_retry_limit       = 10;
+    cfg.route_software_pct          = 100;
+    cfg.entropy_data_reg_enable_pct = 100;
+    cfg.seed_cnt                    = 4;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)

--- a/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
@@ -13,6 +13,7 @@ class entropy_src_smoke_test extends entropy_src_base_test;
     cfg.en_scb                      = 1;
     cfg.fips_window_size            = 2048;
     cfg.bypass_window_size          = 384;
+    cfg.seed_cnt                    = 100;
     cfg.boot_mode_retry_limit       = 10;
     cfg.route_software_pct          = 100;
     cfg.entropy_data_reg_enable_pct = 100;


### PR DESCRIPTION
- New "indefinite" push-pull sequence for generating arbitrary long sequences
   - Will send host sequences indefinitely until stop() method invoked
   - Has a virtual callback method for generating custom sequences, which must be overriden
      by a derived class.
   - Not implemented in the default indefinite sequence, which therefore only generates
      uniform random variables
- Base, smoke and RNG sequences rewritten to use indefinite sequences
- Scoreboard modified to support dropped seeds.
   - If a given RNG-derived sequence item does not match what is read from TLUL, it is assumed
     that the corresponding seed has been dropped.
   - The scoreboard goes through the TLM FIFO examining all available seeds.  If none match,
     then the TL transaction is found to be in error.
   - NOTE: This mechanism has yet to be implemented for the CSRNG interface.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>