### PR TITLE
[pwrmgr] Properly end a reset cycle in fast FSM

### DIFF
--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -312,6 +312,8 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
           ack_pwrup_d = 1'b0;
           clr_cfg_lock_o = 1'b1;
           wkup_o = pwrup_cause_i == Wake;
+          // This constitutes the end of a reset cycle
+          reset_ongoing_d = 1'b0;
           state_d = FastPwrStateRomCheck;
         end
       end


### PR DESCRIPTION
Once a reset cycle completes, we should also deassert the "reset_ongoing" variable inside the fast FSM of the power manager.

Fixes #9561

Signed-off-by: Michael Schaffner <msf@opentitan.org>