### PR TITLE
[aes/rtl] Fix AscentLint lint errors and an Xcelium compile error

### DIFF
--- a/hw/ip/aes/rtl/aes_ctr_fsm.sv
+++ b/hw/ip/aes/rtl/aes_ctr_fsm.sv
@@ -66,7 +66,7 @@ module aes_ctr_fsm import aes_pkg::*;
   /////////////
 
   // FSM
-  always_comb begin : aes_ctr_fsm
+  always_comb begin : aes_ctr_fsm_comb
 
     // Outputs
     ready_o         = 1'b0;

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -325,6 +325,9 @@ typedef enum logic [Sp2VWidth-1:0] {
   SP2V_LOW  = MUX2_SEL_1
 } sp2v_e;
 
+typedef logic [Sp2VWidth-1:0] sp2v_logic_t;
+parameter sp2v_logic_t SP2V_LOGIC_HIGH = {SP2V_HIGH};
+
 // Control register type
 typedef struct packed {
   logic      force_zero_masks;


### PR DESCRIPTION
This PR fixes a large series of lint errors in AscentLint and a compile error in Xcelium introduced with the recent switch to the
multi-rail FSM implementation.

This fixes lowRISC/OpenTitan#9608.
