### PR TITLE
[rom_ctrl] Checker/counter hardening

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
@@ -72,14 +72,21 @@ module rom_ctrl_counter
   logic          done_q, done_d;
   logic          last_nontop_q, last_nontop_d;
 
+  assign done_d = addr_q == TopAddr;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      done_q <= 1'b0;
+    end else begin
+      done_q <= done_d;
+    end
+  end
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       addr_q        <= '0;
-      done_q        <= 1'b0;
       last_nontop_q <= 1'b0;
     end else if (go) begin
       addr_q        <= addr_d;
-      done_q        <= done_d;
       last_nontop_q <= last_nontop_d;
     end
   end
@@ -99,10 +106,9 @@ module rom_ctrl_counter
     end
   end
 
-  assign go = data_rdy_i & data_vld_o & ~done_q;
+  assign go = data_rdy_i & data_vld_o & ~done_d;
 
   assign addr_d        = addr_q + {{AW-1{1'b0}}, 1'b1};
-  assign done_d        = addr_q == TopAddr;
   assign last_nontop_d = addr_q == TNTAddr;
 
   assign done_o             = done_q;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -269,6 +269,15 @@ module rom_ctrl_fsm
     end
   end
 
+  // The counter is supposed to run from zero up to the top of memory and then tell us that it's
+  // done with the counter_done signal. We would like to be sure that no-one can fiddle with the
+  // counter address once the hash has been computed (if they could subvert the mux as well, this
+  // would allow them to generate a useful wrong address for a fetch). Fortunately, doing so would
+  // cause the counter_done signal to drop again and we *know* that it should stay high when our FSM
+  // is in the Done state.
+  logic unexpected_counter_change;
+  assign unexpected_counter_change = mubi4_test_true_loose(in_state_done) & !counter_done;
+
   // We keep control of the ROM mux from reset until we're done.
   assign rom_select_bus_o = in_state_done;
 
@@ -277,6 +286,6 @@ module rom_ctrl_fsm
 
   // TODO: There are lots more checks that we could do here (things like spotting vld signals that
   //       occur when we're in an FSM state that doesn't expect them)
-  assign alert_o = fsm_alert | checker_alert;
+  assign alert_o = fsm_alert | checker_alert | unexpected_counter_change;
 
 endmodule

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -501,7 +501,7 @@ class Scrambler:
                 w39 = w32 | (chk_bits << 32)
                 clr39 = self.unscramble_word(39, log_addr, w39)
                 clr32 = clr39 & mask32
-                exp39 = ecc_encode_some('hsiao', 32, [clr32])[0][0]
+                exp39 = ecc_encode_some('inv_hsiao', 32, [clr32])[0][0]
                 if clr39 != exp39:
                     # The checksum doesn't match. Excellent!
                     found_mismatch = True


### PR DESCRIPTION
This is motivated by a possible attack where someone manages to glitch (bits of) the mux and pass the address from the checker FSM when responding to a TL access. This would be bad, because it might allow skipping instructions. These commits ensure that the address that comes from the checker points at the top word in ROM and also that this word has invalid integrity bits. That way, even if an attacker did manage to grab the "wrong" address, they'd just get junk back which would kill the boot-up sequence.