### PR TITLE
[rom_ctrl] Split ROM index to catch FI on address lines

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -21,7 +21,8 @@ module rom_ctrl_mux
   input mubi4_t         sel_bus_i,
 
   // Interface for bus
-  input logic [AW-1:0]  bus_addr_i,
+  input logic [AW-1:0]  bus_rom_addr_i,
+  input logic [AW-1:0]  bus_prince_addr_i,
   input logic           bus_req_i,
   output logic          bus_gnt_o,
   output logic [DW-1:0] bus_rdata_o,
@@ -33,7 +34,8 @@ module rom_ctrl_mux
   output logic [DW-1:0] chk_rdata_o,
 
   // Interface for ROM
-  output logic [AW-1:0] rom_addr_o,
+  output logic [AW-1:0] rom_rom_addr_o,
+  output logic [AW-1:0] rom_prince_addr_o,
   output logic          rom_req_o,
   input logic [DW-1:0]  rom_scr_rdata_i,
   input logic [DW-1:0]  rom_clr_rdata_i,
@@ -96,7 +98,8 @@ module rom_ctrl_mux
 
   assign chk_rdata_o = rom_scr_rdata_i;
 
-  assign rom_addr_o = mubi4_test_true_strict(sel_bus_i) ? bus_addr_i : chk_addr_i;
-  assign rom_req_o  = mubi4_test_true_strict(sel_bus_i) ? bus_req_i  : chk_req_i;
+  assign rom_req_o         = mubi4_test_true_strict(sel_bus_i) ? bus_req_i         : chk_req_i;
+  assign rom_rom_addr_o    = mubi4_test_true_strict(sel_bus_i) ? bus_rom_addr_i    : chk_addr_i;
+  assign rom_prince_addr_o = mubi4_test_true_strict(sel_bus_i) ? bus_prince_addr_i : chk_addr_i;
 
 endmodule


### PR DESCRIPTION
Before this change, there were some unprotected address line signals
between the TL -> SRAM adapter and the ROM. If an attacker managed to
inject a fault into one of these lines, they could redirect a fetch
and potentially redirect the ROM code. This would probably be bad!

This commit splits the ROM addresses that we pass around into two so
that the scrambled ROM now takes two addresses. It uses one to index
into the physical ROM and the other to derive the (address-tweakable)
keystream. The idea is that if you inject a fault on only one of these
addresses then you'll get garbage because it will descramble to the
wrong value.

Note that we don't bother splitting the addresses that come out of the
checker FSM: there are probably easier ways to redirect that anyway
and they won't help an attacker because the result will fail the ROM
integrity check.

For bus accesses, we split out one of the addresses "upstream" of the
TL -> SRAM adapter. Because that adapter contains an ECC check, we'd
expect to detect any FI attack that affected both sides of the fork.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>