### PR TITLE
[lc_ctrl/dv] Added state_post_trans test.

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -42,7 +42,7 @@
             and check state count.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_state_post_trans"]
     }
     {
       name: regwen_during_op

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
@@ -178,7 +178,9 @@ package lc_ctrl_dv_utils_pkg;
       DecLcStProdEnd: return LcStProdEnd;
       DecLcStRma: return LcStRma;
       DecLcStScrap: return LcStScrap;
-      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_state 0x%0h", curr_state))
+      default: begin
+        `uvm_fatal("lc_env_pkg", $sformatf("encode_lc_state: unknown lc_state 0x%0h", curr_state))
+      end
     endcase
   endfunction
 
@@ -209,7 +211,7 @@ package lc_ctrl_dv_utils_pkg;
       LcCnt22: return 22;
       LcCnt23: return 23;
       LcCnt24: return 24;
-      default: `uvm_fatal("lc_env_pkg", $sformatf("unknown lc_cnt 0x%0h", curr_cnt))
+      default: `uvm_fatal("lc_env_pkg", $sformatf("dec_lc_cnt: unknown lc_cnt 0x%0h", curr_cnt))
     endcase
   endfunction
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -26,6 +26,7 @@ filesets:
       - seq_lib/lc_ctrl_prog_failure_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_state_failure_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_errors_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_state_post_trans_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -33,6 +33,8 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   event fatal_bus_integ_error_ev;
   // Test phase - used to synchronise scoreboard
   lc_ctrl_test_phase_e test_phase;
+  // Test phase has been set event
+  event set_test_phase_ev;
   // Max delay for alerts in clocks
   uint alert_max_delay;
 
@@ -94,6 +96,7 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
 
   virtual function void set_test_phase(lc_ctrl_test_phase_e test_phase);
     this.test_phase = test_phase;
+    ->set_test_phase_ev;
   endfunction
 
   virtual function lc_ctrl_test_phase_e get_test_phase();

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
@@ -29,6 +29,12 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
     count_err_cp: coverpoint cfg.err_inj.count_err;
     count_backdoor_err_cp: coverpoint cfg.err_inj.count_backdoor_err;
     transition_err_cp: coverpoint cfg.err_inj.transition_err;
+    post_trans_err_cp: coverpoint cfg.err_inj.post_trans_err;
+
+    // Cross for attempted second transition with and without failure
+    state_post_trans_xp: cross post_trans_err_cp, state_err_cp, state_backdoor_err_cp,
+        count_err_cp, count_backdoor_err_cp;
+
   endgroup
 
   function new(string name, uvm_component parent);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -66,6 +66,8 @@ package lc_ctrl_env_pkg;
     bit state_backdoor_err;
     // Invalid count      - via force in lc_ctrl_if
     bit count_backdoor_err;
+    // Send a transition request in post_trans state
+    bit post_trans_err;
     bit transition_err;
   } lc_ctrl_err_inj_t;
 
@@ -74,11 +76,14 @@ package lc_ctrl_env_pkg;
     LcCtrlTestInit,
     LcCtrlIterStart,
     LcCtrlDutReady,
+    LcCtrlBadNextState,
     LcCtrlWaitTransition,
     LcCtrlTransitionComplete,
     LcCtrlReadState1,
     LcCtrlEscalate,
     LcCtrlReadState2,
+    LcCtrlPostTransition,
+    LcCtrlPostTransTransitionComplete,
     LcCtrlPostStart
   } lc_ctrl_test_phase_e;
 
@@ -149,28 +154,35 @@ package lc_ctrl_env_pkg;
   typedef virtual pins_if #(LcPwrIfWidth) pwr_lc_vif;
   typedef virtual lc_ctrl_if lc_ctrl_vif;
 
+  // LC states which are valid for transitions
+  const
+  lc_state_e
+  LcValidStateForTrans[] = '{
+      LcStRaw,
+      LcStTestUnlocked0,
+      LcStTestLocked0,
+      LcStTestUnlocked1,
+      LcStTestLocked1,
+      LcStTestUnlocked2,
+      LcStTestLocked2,
+      LcStTestUnlocked3,
+      LcStTestLocked3,
+      LcStTestUnlocked4,
+      LcStTestLocked4,
+      LcStTestUnlocked5,
+      LcStTestLocked5,
+      LcStTestUnlocked6,
+      LcStTestLocked6,
+      LcStTestUnlocked7,
+      LcStDev,
+      LcStProd,
+      LcStProdEnd,
+      LcStRma
+  };
+
   // functions
   function automatic bit valid_state_for_trans(lc_state_e curr_state);
-    return (curr_state inside {LcStRaw,
-                               LcStTestUnlocked0,
-                               LcStTestLocked0,
-                               LcStTestUnlocked1,
-                               LcStTestLocked1,
-                               LcStTestUnlocked2,
-                               LcStTestLocked2,
-                               LcStTestUnlocked3,
-                               LcStTestLocked3,
-                               LcStTestUnlocked4,
-                               LcStTestLocked4,
-                               LcStTestUnlocked5,
-                               LcStTestLocked5,
-                               LcStTestUnlocked6,
-                               LcStTestLocked6,
-                               LcStTestUnlocked7,
-                               LcStDev,
-                               LcStProd,
-                               LcStProdEnd,
-                               LcStRma});
+    return (curr_state inside {LcValidStateForTrans});
   endfunction
 
   // verilog_format: off - avoid bad reformatting

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_post_trans_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_post_trans_vseq.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Attempt second transition before reset
+class lc_ctrl_state_post_trans_vseq extends lc_ctrl_errors_vseq;
+
+  `uvm_object_utils(lc_ctrl_state_post_trans_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[10 : 15]};}
+  constraint post_trans_c {
+    err_inj.post_trans_err == 1;
+    // Allow for post_trans_err plus one other error
+    // 50% just post_trans_err
+    // 50% post_trans_err plus another error for first tranistion attempt
+    $countones(
+        err_inj
+    ) dist {
+      1 := 1,
+      2 := 1
+    };
+  }
+
+  constraint lc_state_failure_c {}
+
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -8,3 +8,5 @@
 `include "lc_ctrl_errors_vseq.sv"
 `include "lc_ctrl_prog_failure_vseq.sv"
 `include "lc_ctrl_state_failure_vseq.sv"
+`include "lc_ctrl_state_post_trans_vseq.sv"
+

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -57,6 +57,11 @@
     }
 
     {
+      name: lc_ctrl_state_post_trans
+      uvm_test_seq: lc_ctrl_state_post_trans_vseq
+    }
+
+    {
       name: lc_ctrl_prog_failure
       uvm_test_seq: lc_ctrl_prog_failure_vseq
     }


### PR DESCRIPTION
- Added lc_ctrl_state_post_trans_vseq.
- Modified lc_ctrl_errors_vseq to attempt a transistion after a
previous attempt (successful or not)
- Modified scoreboard to check no OTP program transaction after
test state LcCtrlTransitionComplete
- Tweaked lc_ctrl_errors_vseq to fix remaining state error test failures

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>