### PR TITLE
[test] Set up the PLL for test bitstreams

### DIFF
--- a/test/systemtest/earlgrey/test_fpga_cw310.py
+++ b/test/systemtest/earlgrey/test_fpga_cw310.py
@@ -35,6 +35,7 @@ def board_earlgrey(tmp_path_factory, topsrcdir, bin_dir, localconf_board):
         topsrcdir / 'util/fpga/cw310_loader.py',
         '--bitstream',
         bitstream,
+        '--set-pll-defaults',
     ]
 
     log.debug("Flashing ChipWhisperer CW310 board with bitstream {}".format(


### PR DESCRIPTION
The CI script needs to ensure the FPGA is provided a clock before
running tests. Set up the PLL for every new bitstream to be certain.

Signed-off-by: Alexander Williams <awill@google.com>