### PR TITLE
[rom_ctrl,doc] Add an hjson countermeasures list

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -84,9 +84,48 @@
     },
   ],
   countermeasures: [
-    { name: "BUS.INTEGRITY",
-      desc: "End-to-end bus integrity scheme."
-    }
+    {
+      name: "FSM.SPARSE",
+      desc: "FSMs are sparsely encoded."
+    },
+    {
+      name: "MEM.SCRAMBLE",
+      desc: "The ROM is scrambled."
+    },
+    {
+      name: "MEM.DIGEST",
+      desc: "A cSHAKE digest is computed of the ROM contents."
+    },
+    {
+      name: "BUS.MUBI",
+      desc: "Checker FSM 'done' signal is multi-bit encoded when passed to pwrmgr."
+    },
+    {
+      name: "BUS.INTEGRITY",
+      desc: '''
+        TL bus control and data signals are integrity protected (using the system-wide end-to-end
+        integrity scheme).
+      '''
+    },
+    {
+      name: "MUX.MUBI",
+      desc: "Checker/Bus mux is multi-bit encoded."
+    },
+    {
+      name: "CTRL.REDUN",
+      desc: '''
+        Addresses from TL accesses are passed redundantly to the scrambled ROM module, to ensure the
+        address lines are not independently faultable downstream of the bus integrity ECC check.
+      '''
+    },
+    {
+      name: "CTRL.CONSISTENCY",
+      desc: '''
+        There are simple checks to detect unexpected changes in the state of the checker, especially
+        after it should have finished working (and the host processor is now accessing ROM to
+        execute code).
+      '''
+    },
   ]
   regwidth: "32"
   registers: {


### PR DESCRIPTION
@msfschaffner: I struggled to come up with sensible encodings for some of these items. In particular, it seems like the fact that we pass mubi-encoded signals to pwrmgr makes sense to track. But should it be `ROM_CTRL.BUS.MUBI`? The point-to-point connection isn't really a bus, but I'm not sure what a better name would be.