### PR TITLE
[spi_device] Fix assertion condition TpmEnable

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1808,6 +1808,6 @@ module spi_device
   `ASSERT_KNOWN(AlertKnownO_A,         alert_tx_o)
 
   // Assume the tpm_en is set when TPM transaction is idle.
-  `ASSUME(TpmEnableWhenTpmCsbIdle_M, cfg_tpm_en |-> cio_tpm_csb_i)
+  `ASSUME(TpmEnableWhenTpmCsbIdle_M, $rose(cfg_tpm_en) |-> cio_tpm_csb_i)
 
 endmodule


### PR DESCRIPTION
The intention of `TpmEnableWhenTpmCsbIdle_M` assumption is to check the
SW sets tpm_en only when the traffic is in idle. The qualifier condition
should be `$rose(cfg_tpm_en)` to catch the write moment.

In previous design, it used `cfg_tpm_en` directly, so after the bit is
set, assumption fired at every cycle.

The issue is reported by @kosta-kojdic in #9629

