### PR TITLE
[doc] List common bus integrity CM in all block Hjsons

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -54,6 +54,11 @@
       local:   "true",
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "adc_en_ctl",

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -194,6 +194,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
 ##############################################################################

--- a/hw/ip/aon_timer/data/aon_timer.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.hjson
@@ -75,6 +75,11 @@
       width:   "1"
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   no_auto_intr_regs: "true",
   regwidth: "32",
   registers: [

--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -156,6 +156,11 @@
     },
   ],
 
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   registers: [
     { name: "EXTCLK_CTRL_REGWEN",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -173,6 +173,11 @@
     }
 
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   scan: "true",       // Enable `scanmode_i` port
   scan_en: "true",    // Enable `scan_en_i` port

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -180,6 +180,11 @@
     }
 
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   scan: "true",       // Enable `scanmode_i` port
   scan_en: "true",    // Enable `scan_en_i` port

--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -26,6 +26,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   regwidth: "32",
   registers: [

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -41,6 +41,11 @@
       local:   "true"
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "CFG",

--- a/hw/ip/i2c/data/i2c.hjson
+++ b/hw/ip/i2c/data/i2c.hjson
@@ -77,6 +77,11 @@
       default: "64",
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   // REGISTER definition
   regwidth: "32"

--- a/hw/ip/keymgr/data/keymgr.hjson
+++ b/hw/ip/keymgr/data/keymgr.hjson
@@ -219,6 +219,11 @@
       local: "true"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   regwidth: "32",
   registers: [

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -142,6 +142,11 @@
       act:     "req"
     }
   ]
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32"
   registers: [
     { name: "CFG_REGWEN"

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -327,6 +327,16 @@
     },
   ] // inter_signal_list
 
+  /////////////////////
+  // Countermeasures //
+  /////////////////////
+
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
   registers: [
 
     ////////////////

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -129,6 +129,11 @@
       package: "keymgr_pkg"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   regwidth: "32"
   registers: [

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -839,6 +839,20 @@
     }
   ] // inter_signal_list
 
+  /////////////////////
+  // Countermeasures //
+  /////////////////////
+
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
+  ///////////////
+  // Registers //
+  ///////////////
+
   regwidth: "32",
   registers: {
     core: [

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -328,6 +328,20 @@
     }
   ] // inter_signal_list
 
+  /////////////////////
+  // Countermeasures //
+  /////////////////////
+
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
+  ///////////////
+  // Registers //
+  ///////////////
+
   regwidth: "32",
   registers: {
     core: [

--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -39,6 +39,12 @@
       local:   "true"
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
   // REGISTER definition
   registers: [
     // CTRL register

--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -214,6 +214,12 @@
       expose:  "true"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
   registers: [
 //////////////////////////
 // MIO Inputs           //

--- a/hw/ip/pwm/data/pwm.hjson
+++ b/hw/ip/pwm/data/pwm.hjson
@@ -30,6 +30,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   registers: [
     { name: "REGWEN",
       desc: "Register write enable for all control registers",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -177,6 +177,11 @@
       local: "true"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   regwidth: "32",
   registers: [

--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -83,6 +83,11 @@
       type:    "req_rsp"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32"
   registers: {
     regs: [

--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -29,6 +29,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   scan: "true",
   scan_reset: "true",

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -305,6 +305,11 @@
       local: "true"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   regwidth: "32",
   registers: {

--- a/hw/ip/rv_dm/data/rv_dm.hjson
+++ b/hw/ip/rv_dm/data/rv_dm.hjson
@@ -73,6 +73,11 @@
       act:     "req"
     },
   ]
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: {
     regs:[

--- a/hw/ip/rv_timer/data/rv_timer.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.hjson
@@ -36,6 +36,11 @@
     }
   ],
   no_auto_intr_regs: "true",
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { multireg: {

--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -124,6 +124,11 @@
       act:     "req"
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "CONTROL",

--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -82,6 +82,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   registers: [
     { name: "CONTROL",
       desc: "Control register",

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -112,6 +112,16 @@
     },
   ]
 
+  /////////////////////
+  // Countermeasures //
+  /////////////////////
+
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
   regwidth: "32",
   registers: {
     regs: [

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -87,6 +87,11 @@
       width:   "1"
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "REGWEN",

--- a/hw/ip/uart/data/uart.hjson
+++ b/hw/ip/uart/data/uart.hjson
@@ -41,6 +41,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "CTRL",

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -187,6 +187,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "usbctrl",

--- a/hw/ip/usbuart/data/usbuart.hjson
+++ b/hw/ip/usbuart/data/usbuart.hjson
@@ -58,6 +58,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   registers: [
     { name: "CTRL",

--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -222,6 +222,12 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       package: "prim_esc_pkg"
     },
   ]
+
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 ##############################################################################
 # interrupt registers for the classes
   interrupt_list: [

--- a/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
+++ b/hw/ip_templates/rv_plic/data/rv_plic.hjson.tpl
@@ -73,6 +73,12 @@
     },
   ]
 
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
   regwidth: "32",
   registers: [
 % for i in range(src):

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -154,6 +154,11 @@
     },
   ],
 
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   registers: [
     { name: "EXTCLK_CTRL_REGWEN",

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -179,6 +179,11 @@
     }
 
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   scan: "true",       // Enable `scanmode_i` port
   scan_en: "true",    // Enable `scan_en_i` port

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -210,6 +210,12 @@
       expose:  "true"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
   registers: [
 //////////////////////////
 // MIO Inputs           //

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -216,6 +216,11 @@
       local: "true"
     },
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 
   regwidth: "32",
   registers: [

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -33,6 +33,11 @@
       '''
     }
   ],
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
   regwidth: "32",
   scan: "true",
   scan_reset: "true",

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -322,6 +322,12 @@
       package: "prim_esc_pkg"
     },
   ]
+
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
 # interrupt registers for the classes
   interrupt_list: [
     { name: "classa",

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.hjson
@@ -72,6 +72,12 @@
     },
   ]
 
+  countermeasures: [
+    { name: "BUS.INTEGRITY",
+      desc: "End-to-end bus integrity scheme."
+    }
+  ]
+
   regwidth: "32",
   registers: [
     { name: "PRIO0",


### PR DESCRIPTION
This adds the end-to-end bus integrity scheme to all comportable IPs in the system, since they all have it by default.

Also, this serves as a starting point / example that can be used to prepare for the D2S review of security IP.

Signed-off-by: Michael Schaffner <msf@opentitan.org>