### PR TITLE
[doc] Automatically generate countermeasure tables in IP docs

### DIFF
--- a/util/reggen/gen_cfg_html.py
+++ b/util/reggen/gen_cfg_html.py
@@ -112,3 +112,17 @@ def gen_cfg_html(cfgs: IpBlock, outfile: TextIO) -> None:
                    .format(x.name,
                            render_td(x.desc, rnames, None)))
         genout(outfile, "</table>\n")
+
+    if not cfgs.countermeasures:
+        genout(outfile, "<p><i>Security Countermeasures: none</i></p>\n")
+    else:
+        genout(outfile, "<p><i>Security Countermeasures:</i></p>\n")
+        genout(
+            outfile, "<table class=\"cfgtable\"><tr><th>Countermeasure ID</th>" +
+            "<th>Description</th></tr>\n")
+        for cm in cfgs.countermeasures:
+            genout(outfile,
+                   '<tr><td>{}</td>{}</tr>'
+                   .format(cfgs.name.upper() + '.' + str(cm),
+                           render_td(cm.desc, rnames, None)))
+        genout(outfile, "</table>\n")


### PR DESCRIPTION
This automatically generates documentation tables from the countermeasures entry in the IP Hjsons in a similar way as we currently do so for alerts etc.

For AES, this would look for example as follows (once the bus integrity CM has been added):

----------------------

<p style="box-sizing: border-box; margin: 1em 0px 0px; font-size: 16px; line-height: 1.778; transition: color 0.5s ease 0s; color: rgb(29, 0, 55); font-family: Ubuntu, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><i style="box-sizing: border-box;">Security Countermeasures:</i></p><div class="overflow-table" style="box-sizing: border-box; margin-top: 1em; width: 804.094px; overflow-x: auto; color: rgb(29, 0, 55); font-family: Ubuntu, sans-serif; font-size: 16px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">

Countermeasure ID | Description
-- | --
AES.BUS.INTEGRITY | End-to-end bus integrity scheme.

</div>

----------------------


Signed-off-by: Michael Schaffner <msf@opentitan.org>