### PR TITLE
[bazel] Fix rust libudev-sys to build under bazel

### DIFF
--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -38,3 +38,7 @@ opentitantool_derive = {path = "opentitantool_derive"}
 
 [package.metadata.raze.crates.libudev-sys.'0.1.4']
 gen_buildrs = true
+patches = [
+    "@//third_party/cargo/patches:libudev-sys-0.1.4.patch"
+]
+patch_args = ["-p1"]

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -538,6 +538,12 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         sha256 = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324",
         strip_prefix = "libudev-sys-0.1.4",
+        patches = [
+            "@//third_party/cargo/patches:libudev-sys-0.1.4.patch",
+        ],
+        patch_args = [
+            "-p1",
+        ],
         build_file = Label("//third_party/cargo/remote:BUILD.libudev-sys-0.1.4.bazel"),
     )
 

--- a/third_party/cargo/patches/BUILD
+++ b/third_party/cargo/patches/BUILD
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/cargo/patches/libudev-sys-0.1.4.patch
+++ b/third_party/cargo/patches/libudev-sys-0.1.4.patch
@@ -1,0 +1,14 @@
+diff --git a/build.rs b/build.rs
+index 20cf4a0..3b6adc5 100644
+--- a/build.rs
++++ b/build.rs
+@@ -25,7 +25,8 @@ fn check_func(function_name: &str) -> bool {
+         writeln!(&mut test_file, "}}").unwrap();
+     }
+ 
+-    let output = Command::new("rustc").
++    let rustc = env::var("RUSTC").unwrap();
++    let output = Command::new(rustc).
+         arg(&test_file_name).
+         arg("--out-dir").arg(&out_dir).
+         arg("-l").arg("udev").


### PR DESCRIPTION
The libudev-sys crate invokes the compiler directly rather than via the
cargo (and bazel) supplied `RUSTC` environment variable.  This causes the
library to fail when building under bazel.  This patch fixes the
libudev-sys crate to invoke the compiler via the `RUSTC` variable.

This is the same patch as the [PR](https://github.com/dcuddeback/libudev-sys/pull/11)
sent to libudev-sys.

Signed-off-by: Chris Frantz <cfrantz@google.com>