### PR TITLE
[dv/clkmgr] Fix frequency measurement coverage

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -87,38 +87,58 @@ interface clkmgr_if (
 `endif
 
   freq_measurement_t io_freq_measurement;
-  always @(posedge `PATH_TO_DUT.u_io_meas.valid_o) begin
-    io_freq_measurement = '{valid: `PATH_TO_DUT.u_io_meas.valid_o,
-                            slow: `PATH_TO_DUT.u_io_meas.slow_o,
-                            fast: `PATH_TO_DUT.u_io_meas.fast_o};
+  always @(posedge `PATH_TO_DUT.u_io_meas.clk_i) begin
+    if (`PATH_TO_DUT.u_io_meas.valid_o) begin
+      io_freq_measurement = '{valid: `PATH_TO_DUT.u_io_meas.valid_o,
+                              slow: `PATH_TO_DUT.u_io_meas.slow_o,
+                              fast: `PATH_TO_DUT.u_io_meas.fast_o};
+      `uvm_info("clkmgr_if", $sformatf("Sampled coverage for ClkMesrIo as %p", io_freq_measurement),
+                UVM_MEDIUM)
+    end
   end
 
   freq_measurement_t io_div2_freq_measurement;
-  always @(posedge `PATH_TO_DUT.u_io_div2_meas.valid_o) begin
-    io_div2_freq_measurement = '{valid: `PATH_TO_DUT.u_io_div2_meas.valid_o,
-                                 slow: `PATH_TO_DUT.u_io_div2_meas.slow_o,
-                                 fast: `PATH_TO_DUT.u_io_div2_meas.fast_o};
+  always @(posedge `PATH_TO_DUT.u_io_div2_meas.clk_i) begin
+    if (`PATH_TO_DUT.u_io_div2_meas.valid_o) begin
+      io_div2_freq_measurement = '{valid: `PATH_TO_DUT.u_io_div2_meas.valid_o,
+                                   slow: `PATH_TO_DUT.u_io_div2_meas.slow_o,
+                                   fast: `PATH_TO_DUT.u_io_div2_meas.fast_o};
+      `uvm_info("clkmgr_if", $sformatf(
+                "Sampled coverage for ClkMesrIoDiv2 as %p", io_div2_freq_measurement), UVM_MEDIUM)
+    end
   end
 
   freq_measurement_t io_div4_freq_measurement;
-  always @(posedge `PATH_TO_DUT.u_io_div4_meas.valid_o) begin
-    io_div4_freq_measurement = '{valid: `PATH_TO_DUT.u_io_div4_meas.valid_o,
-                                 slow: `PATH_TO_DUT.u_io_div4_meas.slow_o,
-                                 fast: `PATH_TO_DUT.u_io_div4_meas.fast_o};
+  always @(posedge `PATH_TO_DUT.u_io_div4_meas.clk_i) begin
+    if (`PATH_TO_DUT.u_io_div4_meas.valid_o) begin
+      io_div4_freq_measurement = '{valid: `PATH_TO_DUT.u_io_div4_meas.valid_o,
+                                   slow: `PATH_TO_DUT.u_io_div4_meas.slow_o,
+                                   fast: `PATH_TO_DUT.u_io_div4_meas.fast_o};
+      `uvm_info("clkmgr_if", $sformatf(
+                "Sampled coverage for ClkMesrIoDiv4 as %p", io_div4_freq_measurement), UVM_MEDIUM)
+    end
   end
 
   freq_measurement_t main_freq_measurement;
-  always @(posedge `PATH_TO_DUT.u_main_meas.valid_o) begin
-    main_freq_measurement = '{valid: `PATH_TO_DUT.u_main_meas.valid_o,
-                              slow: `PATH_TO_DUT.u_main_meas.slow_o,
-                              fast: `PATH_TO_DUT.u_main_meas.fast_o};
+  always @(posedge `PATH_TO_DUT.u_main_meas.clk_i) begin
+    if (`PATH_TO_DUT.u_main_meas.valid_o) begin
+      main_freq_measurement = '{valid: `PATH_TO_DUT.u_main_meas.valid_o,
+                                slow: `PATH_TO_DUT.u_main_meas.slow_o,
+                                fast: `PATH_TO_DUT.u_main_meas.fast_o};
+      `uvm_info("clkmgr_if", $sformatf(
+                "Sampled coverage for ClkMesrMain as %p", main_freq_measurement), UVM_MEDIUM)
+    end
   end
 
   freq_measurement_t usb_freq_measurement;
-  always @(posedge `PATH_TO_DUT.u_usb_meas.valid_o) begin
-    usb_freq_measurement = '{valid: `PATH_TO_DUT.u_usb_meas.valid_o,
-                             slow: `PATH_TO_DUT.u_usb_meas.slow_o,
-                             fast: `PATH_TO_DUT.u_usb_meas.fast_o};
+  always @(posedge `PATH_TO_DUT.u_usb_meas.clk_i) begin
+    if (`PATH_TO_DUT.u_usb_meas.valid_o) begin
+      usb_freq_measurement = '{valid: `PATH_TO_DUT.u_usb_meas.valid_o,
+                               slow: `PATH_TO_DUT.u_usb_meas.slow_o,
+                               fast: `PATH_TO_DUT.u_usb_meas.fast_o};
+      `uvm_info("clkmgr_if", $sformatf("Sampled coverage for ClkMesrUsb as %p", usb_freq_measurement
+                ), UVM_MEDIUM)
+    end
   end
 
   function automatic void update_extclk_ctrl(logic [2*LcTxTWidth-1:0] value);

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -197,6 +197,12 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
                 !cfg.clkmgr_vif.io_freq_measurement.slow &&
                 !cfg.clkmgr_vif.io_freq_measurement.fast,
                 cfg.clkmgr_vif.io_freq_measurement.slow, cfg.clkmgr_vif.io_freq_measurement.fast);
+            `uvm_info(`gfn, $sformatf(
+                      "Cov for ClkMesrIo: %0s",
+                      cfg.clkmgr_vif.io_freq_measurement.slow ? "slow" :
+                      cfg.clkmgr_vif.io_freq_measurement.fast ? "fast" : "okay"
+                      ), UVM_MEDIUM)
+            cfg.clkmgr_vif.io_freq_measurement = '{default: 0};
           end
         end
       forever
@@ -207,6 +213,12 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
                 !cfg.clkmgr_vif.io_div2_freq_measurement.fast,
                 cfg.clkmgr_vif.io_div2_freq_measurement.slow,
                 cfg.clkmgr_vif.io_div2_freq_measurement.fast);
+            `uvm_info(`gfn, $sformatf(
+                      "Cov for ClkMesrIoDiv2: %0s",
+                      cfg.clkmgr_vif.io_div2_freq_measurement.slow ? "slow" :
+                      cfg.clkmgr_vif.io_div2_freq_measurement.fast ? "fast" : "okay"
+                      ), UVM_MEDIUM)
+            cfg.clkmgr_vif.io_div2_freq_measurement = '{default: 0};
           end
         end
       forever
@@ -217,6 +229,12 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
                 !cfg.clkmgr_vif.io_div4_freq_measurement.fast,
                 cfg.clkmgr_vif.io_div4_freq_measurement.slow,
                 cfg.clkmgr_vif.io_div4_freq_measurement.fast);
+            `uvm_info(`gfn, $sformatf(
+                      "Cov for ClkMesrIoDiv4: %0s",
+                      cfg.clkmgr_vif.io_div4_freq_measurement.slow ? "slow" :
+                      cfg.clkmgr_vif.io_div4_freq_measurement.fast ? "fast" : "okay"
+                      ), UVM_MEDIUM)
+            cfg.clkmgr_vif.io_div4_freq_measurement = '{default: 0};
           end
         end
       forever
@@ -227,6 +245,12 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
                 !cfg.clkmgr_vif.main_freq_measurement.fast,
                 cfg.clkmgr_vif.main_freq_measurement.slow,
                 cfg.clkmgr_vif.main_freq_measurement.fast);
+            `uvm_info(`gfn, $sformatf(
+                      "Cov for ClkMesrMain: %0s",
+                      cfg.clkmgr_vif.main_freq_measurement.slow ? "slow" :
+                      cfg.clkmgr_vif.main_freq_measurement.fast ? "fast" : "okay"
+                      ), UVM_MEDIUM)
+            cfg.clkmgr_vif.main_freq_measurement = '{default: 0};
           end
         end
       forever
@@ -236,6 +260,12 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
                 !cfg.clkmgr_vif.usb_freq_measurement.slow &&
                 !cfg.clkmgr_vif.usb_freq_measurement.fast,
                 cfg.clkmgr_vif.usb_freq_measurement.slow, cfg.clkmgr_vif.usb_freq_measurement.fast);
+            `uvm_info(`gfn, $sformatf(
+                      "Cov for ClkMesrUsb: %0s",
+                      cfg.clkmgr_vif.usb_freq_measurement.slow ? "slow" :
+                      cfg.clkmgr_vif.usb_freq_measurement.fast ? "fast" : "okay"
+                      ), UVM_MEDIUM)
+            cfg.clkmgr_vif.usb_freq_measurement = '{default: 0};
           end
         end
     join_none

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_vseq.sv
@@ -166,6 +166,10 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
           min_threshold = expected + min_offset;
           max_threshold = expected + max_offset;
           if (min_threshold > expected || max_threshold < expected - 1) begin
+            `uvm_info(`gfn, $sformatf(
+                      "Expect %0s to get a %0s error",
+                      clk_mesr.name,
+                      (min_threshold > expected ? "slow" : "fast" )), UVM_MEDIUM)
             cfg.scoreboard.set_exp_alert(.alert_name("recov_fault"), .max_delay(4000));
             expected_recov_err[clk] = 1;
           end
@@ -177,6 +181,7 @@ class clkmgr_frequency_vseq extends clkmgr_base_vseq;
       end
       wait_before_read_recov_err_code();
       csr_rd(.ptr(ral.recov_err_code), .value(actual_recov_err));
+      `uvm_info(`gfn, $sformatf("Expected recov err register=0x%x", expected_recov_err), UVM_MEDIUM)
       if (actual_recov_err != expected_recov_err) begin
         logic [ClkMesrUsb:0] mismatch_recov_err = actual_recov_err ^ expected_recov_err;
         foreach (mismatch_recov_err[clk]) begin


### PR DESCRIPTION
Collect info for measurement at clock edges.
Clear the info after it is used for coverage, so it becomes pulses.

Signed-off-by: Guillermo Maturana <maturana@google.com>