### PR TITLE
[sw/silicon_creator] Use software reset in asm exception handler

### DIFF
--- a/sw/device/silicon_creator/lib/irq_asm.S
+++ b/sw/device/silicon_creator/lib/irq_asm.S
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/base/multibits_asm.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "flash_ctrl_regs.h"
 #include "rstmgr_regs.h"
 
   // This code is in the .crt section since it is designed to be safe
@@ -26,6 +27,13 @@ _asm_exception_handler:
   li t0, TOP_EARLGREY_RSTMGR_AON_BASE_ADDR
   li t1, MULTIBIT_ASM_BOOL4_TRUE
   sw t1, RSTMGR_RESET_REQ_REG_OFFSET(t0)
+
+  // Disable access to flash.
+  //
+  // This is done after requesting a reset so that this function will
+  // work even if it is in flash.
+  li t0, TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR
+  sw zero, FLASH_CTRL_DIS_REG_OFFSET(t0)
 
   // Enter a wait for interrupt loop, the device should reset shortly.
 .L_wfi_loop:

--- a/sw/device/silicon_creator/lib/irq_asm.S
+++ b/sw/device/silicon_creator/lib/irq_asm.S
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/multibits_asm.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
-#include "aon_timer_regs.h"
-#include "pwrmgr_regs.h"
+#include "rstmgr_regs.h"
 
   // This code is in the .crt section since it is designed to be safe
   // to run before the C runtime has been initialized.
@@ -22,24 +22,10 @@
   .globl _asm_exception_handler
   .type _asm_exception_handler, @function
 _asm_exception_handler:
-  // Configure the power manager to enable resets.
-  // Note: this enables all types of reset request for simplicity.
-  li t0, TOP_EARLGREY_PWRMGR_AON_BASE_ADDR
-  li t1, -1
-  sw t1, PWRMGR_RESET_EN_REG_OFFSET(t0)
-
-  // Trigger a configuration synchronization.
-  li t1, (1 << PWRMGR_CFG_CDC_SYNC_SYNC_BIT)
-  sw t1, PWRMGR_CFG_CDC_SYNC_REG_OFFSET(t0)
-
-  // Set the watchdog bite threshold to 0 so that a reset will be
-  // triggered immediately when the watchdog timer is enabled.
-  li t0, TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR
-  sw zero, AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET(t0)
-
-  // Enable the watchdog timer (if it is not already enabled).
-  li t1, (1 << AON_TIMER_WDOG_CTRL_ENABLE_BIT)
-  sw t1, AON_TIMER_WDOG_CTRL_REG_OFFSET(t0)
+  // Request a system reset.
+  li t0, TOP_EARLGREY_RSTMGR_AON_BASE_ADDR
+  li t1, MULTIBIT_ASM_BOOL4_TRUE
+  sw t1, RSTMGR_RESET_REQ_REG_OFFSET(t0)
 
   // Enter a wait for interrupt loop, the device should reset shortly.
 .L_wfi_loop:

--- a/sw/device/silicon_creator/lib/irq_asm_functest.c
+++ b/sw/device/silicon_creator/lib/irq_asm_functest.c
@@ -15,7 +15,6 @@
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
-#include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
 
@@ -62,8 +61,8 @@ bool test_main(void) {
     _asm_exception_handler();
 
     CHECK(false);  // Unreachable.
-  } else if (bitfield_bit32_read(reason, kRstmgrReasonWatchdog)) {
-    // Watchdog bite: check that the test phase is correct.
+  } else if (bitfield_bit32_read(reason, kRstmgrReasonSoftwareRequest)) {
+    // Software reset: check that the test phase is correct.
     LOG_INFO("Detected reset after exception test");
     if (*phase != kTestPhaseReset) {
       LOG_ERROR("Test failure: expected phase %d but got phase %d",

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -143,8 +143,7 @@ sw_silicon_creator_lib_irq_asm = declare_dependency(
   link_with: static_library(
     'sw_silicon_creator_lib_irq_asm',
     sources: [
-      hw_ip_aon_timer_reg_h,
-      hw_ip_pwrmgr_reg_h,
+      hw_ip_rstmgr_reg_h,
       'irq_asm.S',
     ],
   ),
@@ -322,7 +321,6 @@ sw_silicon_creator_lib_irq_asm_functest = declare_dependency(
       sw_silicon_creator_lib_irq_asm,
       sw_silicon_creator_lib_driver_retention_sram,
       sw_silicon_creator_lib_driver_rstmgr,
-      sw_silicon_creator_lib_driver_watchdog,
     ],
   ),
 )

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -144,6 +144,7 @@ sw_silicon_creator_lib_irq_asm = declare_dependency(
     'sw_silicon_creator_lib_irq_asm',
     sources: [
       hw_ip_rstmgr_reg_h,
+      hw_ip_flash_ctrl_reg_h,
       'irq_asm.S',
     ],
   ),


### PR DESCRIPTION
This PR updates the asm exception handler to use rstmgr reset request instead of pwrmgr and watchdog.

~Marked as draft until #9557 (for multibits_asm.h) and #8308 (to avoid conflict) are merged.~

Signed-off-by: Alphan Ulusoy <alphan@google.com>