### PR TITLE
[otbn] Initial DV work for CRC verification; fix minor RTL bug

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -103,6 +103,9 @@ struct ISSWrapper {
   // Mark all of IMEM as invalid so that any fetch causes an integrity error.
   void invalidate_imem();
 
+  // Step a CRC calculation with 48 bits of data
+  uint32_t step_crc(const std::array<uint8_t, 6> &item, uint32_t state) const;
+
   // Reset simulation
   //
   // This doesn't actually send anything to the ISS, but instead tells the

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -45,8 +45,6 @@ module otbn_core_model
   output bit [7:0]       status_o,   // STATUS register
   output bit [31:0]      insn_cnt_o, // INSN_CNT register
 
-  input logic            invalidate_imem_i, // Trash contents of IMEM (causing integrity errors)
-
   input keymgr_pkg::otbn_key_req_t keymgr_key_i,
 
   output bit             done_rr_o,
@@ -85,8 +83,6 @@ module otbn_core_model
   bit [31:0] raw_err_bits_d, raw_err_bits_q;
   bit [31:0] stop_pc_d, stop_pc_q;
   bit rnd_req_start_d, rnd_req_start_q;
-
-  bit failed_invalidate_imem;
 
   bit unused_raw_err_bits;
   logic unused_edn_rsp_fips;
@@ -157,13 +153,7 @@ module otbn_core_model
       rnd_req_start_q <= 0;
       raw_err_bits_q <= 0;
       stop_pc_q <= 0;
-      failed_invalidate_imem <= 0;
     end else begin
-      if (invalidate_imem_i) begin
-        if (otbn_model_invalidate_imem(model_handle) != 0) begin
-          failed_invalidate_imem <= 1'b1;
-        end
-      end
       if (edn_urnd_cdc_done_i) begin
         edn_model_urnd_cdc_done(model_handle);
       end
@@ -241,7 +231,7 @@ module otbn_core_model
       );
   end
 
-  assign err_o = failed_step | failed_cmp | failed_invalidate_imem;
+  assign err_o = failed_step | failed_cmp;
 
   // Derive a "done" signal. This should trigger for a single cycle when OTBN finishes its work.
   // It's analogous to the done_o signal on otbn_core, but this signal is delayed by a single cycle

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -74,6 +74,14 @@ class OtbnModel {
   // error. Returns 0 on success; -1 on failure.
   int invalidate_imem();
 
+  // Step CRC by consuming 48 bits of data.
+  //
+  // This doesn't actually update any internal state: we're just using the
+  // otbn_model framework as a convenient connection between SystemVerilog and
+  // Python. Returns 0 on success; -1 on failure.
+  int step_crc(const svBitVecVal *item /* bit [47:0] */,
+               svBitVecVal *state /* bit [31:0] */);
+
   // Flush any information in the model
   void reset();
 

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -85,6 +85,14 @@ unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned model_state,
 // integrity error. Returns 0 on success or -1 on failure.
 int otbn_model_invalidate_imem(OtbnModel *model);
 
+// Step the CRC calculation for item
+//
+// state is an inout parameter and should be updated in-place. This is
+// a "pure" function: there isn't actually any model state that gets
+// updated by calling it. Returns 0 on success or -1 on failure.
+int otbn_model_step_crc(OtbnModel *model, svBitVecVal *item /* bit [47:0] */,
+                        svBitVecVal *state /* inout bit [31:0] */);
+
 // Flush any information in the model
 void otbn_model_reset(OtbnModel *model);
 

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -42,7 +42,11 @@ package otbn_model_pkg;
                                  inout bit [31:0] err_bits,
                                  inout bit [31:0] stop_pc);
 
-  import "DPI-C" context function int otbn_model_invalidate_imem(chandle model);
+  import "DPI-C" function int otbn_model_invalidate_imem(chandle model);
+
+  import "DPI-C" function int otbn_model_step_crc(chandle          model,
+                                                  bit [47:0]       item,
+                                                  inout bit [31:0] state);
 
   import "DPI-C" function void otbn_model_reset(chandle model);
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -28,6 +28,8 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     key = cfg.get_imem_key();
     nonce = cfg.get_imem_nonce();
 
+    @(cfg.clk_rst_vif.cbn);
+
     // Mask to corrupt 1 to 2 bits of the imem memory
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
 
@@ -37,9 +39,7 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
       cfg.write_imem_word(i, bad_data, key, nonce);
     end
 
-    cfg.model_agent_cfg.vif.invalidate_imem <= 1'b1;
-    @(cfg.clk_rst_vif.cb);
-    cfg.model_agent_cfg.vif.invalidate_imem <= 1'b0;
+    cfg.model_agent_cfg.vif.invalidate_imem();
 
     // Wait until the ISS and RTL move to a locked state
     wait (cfg.model_agent_cfg.vif.status != otbn_pkg::StatusBusyExecute);

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.core
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_agent.core
@@ -10,6 +10,7 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:dv:dv_utils
       - lowrisc:dv:dv_lib
+      - lowrisc:dv:otbn_model
       - lowrisc:ip:otbn_pkg
       - lowrisc:ip:keymgr_pkg
     files:

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -23,9 +23,6 @@ interface otbn_model_if
   bit [31:0]                stop_pc;      // PC at end of operation
   otbn_pkg::err_bits_t      err_bits;     // Error bits; updated when STATUS switches to idle
 
-  // Backdoor inputs to DUT
-  bit                       invalidate_imem;   // Trash the contents of IMEM, causing integrity errors
-
   // Mirrored registers
   bit [7:0]                 status;       // STATUS register
 
@@ -49,6 +46,16 @@ interface otbn_model_if
     @(posedge clk_i or negedge rst_ni);
     start = 1'b0;
   endtask
+
+  // Mark the entirety of IMEM as invalid
+  //
+  // Call this on a negedge of clk_i to ensure sequencing with the otbn_model_step on the following
+  // posedge.
+  function automatic void invalidate_imem();
+    `uvm_info("otbn_model_if", "Invalidating IMEM", UVM_HIGH)
+    `DV_CHECK_FATAL(otbn_model_pkg::otbn_model_invalidate_imem(handle) == 0,
+                    "Failed to invalidate IMEM", "otbn_model_if")
+  endfunction
 
   // The err signal is asserted by the model if it fails to find the DUT or if it finds a mismatch
   // in results. It should never go high.

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -57,6 +57,18 @@ interface otbn_model_if
                     "Failed to invalidate IMEM", "otbn_model_if")
   endfunction
 
+  // Ask the Python model to compute a CRC step for a memory write
+  //
+  // This doesn't actually update any model state (we pass in the old state and delta, and the
+  // function returns the new state). But we still call out to Python because that avoids us having
+  // to write our own CRC function and ensures that the RTL matches the standardised CRC-32-IEEE
+  // checksum.
+  function automatic bit [31:0] step_crc(bit [47:0] item, bit [31:0] crc_state);
+    `DV_CHECK_FATAL(otbn_model_pkg::otbn_model_step_crc(handle, item, crc_state) == 0,
+                    "Failed to update CRC", "otbn_model_if")
+    return crc_state;
+  endfunction
+
   // The err signal is asserted by the model if it fails to find the DUT or if it finds a mismatch
   // in results. It should never go high.
   `ASSERT(NoModelErrs, !err)

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -219,8 +219,6 @@ module tb;
     .status_o     (model_if.status),
     .insn_cnt_o   (model_insn_cnt),
 
-    .invalidate_imem_i (model_if.invalidate_imem),
-
     .done_rr_o    (),
 
     .err_o        (model_if.err),

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -321,8 +321,6 @@ module otbn_top_sim (
     .status_o              ( ),
     .insn_cnt_o            ( otbn_model_insn_cnt ),
 
-    .invalidate_imem_i     ( 1'b0 ),
-
     .keymgr_key_i          ( keymgr_key),
 
     .done_rr_o             ( otbn_model_done_rr ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -398,7 +398,7 @@ module otbn
   logic [ExtWLEN-1:0] dmem_wdata_bus;
   logic [ExtWLEN-1:0] dmem_wmask_bus;
   logic [ExtWLEN-1:0] dmem_rdata_bus;
-  logic [top_pkg::TL_AW-1:0] dmem_addr_bus;
+  logic [DmemAddrWidth-1:0] dmem_addr_bus;
   logic unused_dmem_addr_bus;
   logic [31:0] dmem_wdata_narrow_bus;
   logic [top_pkg::TL_DBW-1:0] dmem_byte_mask_bus;
@@ -546,7 +546,7 @@ module otbn
   assign dmem_rerror_bus  = 2'b00;
   assign dmem_rerror_core = dmem_rerror;
 
-  assign dmem_addr_bus = tl_win_h2d[TlWinDmem].a_address;
+  assign dmem_addr_bus = tl_win_h2d[TlWinDmem].a_address[DmemAddrWidth-1:0];
   assign dmem_wdata_narrow_bus = tl_win_h2d[TlWinDmem].a_data[31:0];
   assign dmem_byte_mask_bus = tl_win_h2d[TlWinDmem].a_mask;
 
@@ -561,14 +561,13 @@ module otbn
 
   assign mem_crc_data_in.wr_data = imem_req_bus ? imem_wdata_bus[31:0] :
                                                   dmem_wdata_narrow_bus[31:0];
-  // TODO: Expand DMem index so it's per 32-bit not per 256-bit
   assign mem_crc_data_in.index   = imem_req_bus ? {{15 - ImemIndexWidth{1'b0}}, imem_index_bus} :
                                                    {{15 - (DmemIndexWidth - 2){1'b0}},
                                                     dmem_addr_bus[DmemIndexWidth-1:2]};
   assign mem_crc_data_in.imem    = imem_req_bus;
 
   // Only the bits that factor into the dmem index and dmem word enables are required
-  assign unused_dmem_addr_bus = ^{dmem_addr_bus[top_pkg::TL_AW-1:DmemIndexWidth],
+  assign unused_dmem_addr_bus = ^{dmem_addr_bus[DmemAddrWidth-1:DmemIndexWidth],
                                   dmem_addr_bus[1:0]};
 
   prim_crc32 #(

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -895,8 +895,6 @@ module otbn
       .status_o              (),
       .insn_cnt_o            (insn_cnt_model),
 
-      .invalidate_imem_i     (1'b0),
-
       .done_rr_o (done_rr_model),
 
       .err_o ()


### PR DESCRIPTION
The RTL bugfix is the first commit. The second is a small tidy-up which moves away from everything appearing in `otbn_core_model.sv`. The third commit is the DV feature itself.