### PR TITLE
[dv/alert_handler] Remove alert_cause exclusion

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -390,9 +390,6 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
       fields: [
         { bits: "0", name: "A", desc: "Cause bit ", resval: 0}
       ],
-      tags: [// The value of this register is determined by triggering different kinds of alerts
-             // Cannot be auto-predicted so excluded from read check
-             "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
 ##############################################################################
@@ -603,8 +600,8 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
           resval: 1,
         }
       ],
-      tags: [// The value of this register is set to false only by hardware,
-             // under the condition that escalation is triggered and the corresponding lock bit is true
+      tags: [// The value of this register is set to false only by hardware, under the condition
+             // that escalation is triggered and the corresponding lock bit is true
              // Cannot not be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -501,9 +501,6 @@
       fields: [
         { bits: "0", name: "A", desc: "Cause bit ", resval: 0}
       ],
-      tags: [// The value of this register is determined by triggering different kinds of alerts
-             // Cannot be auto-predicted so excluded from read check
-             "excl:CsrNonInitTests:CsrExclWriteCheck"]
       }
     },
 # local alerts
@@ -712,8 +709,8 @@
           resval: 1,
         }
       ],
-      tags: [// The value of this register is set to false only by hardware,
-             // under the condition that escalation is triggered and the corresponding lock bit is true
+      tags: [// The value of this register is set to false only by hardware, under the condition
+             // that escalation is triggered and the corresponding lock bit is true
              // Cannot not be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
@@ -1015,8 +1012,8 @@
           resval: 1,
         }
       ],
-      tags: [// The value of this register is set to false only by hardware,
-             // under the condition that escalation is triggered and the corresponding lock bit is true
+      tags: [// The value of this register is set to false only by hardware, under the condition
+             // that escalation is triggered and the corresponding lock bit is true
              // Cannot not be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
@@ -1318,8 +1315,8 @@
           resval: 1,
         }
       ],
-      tags: [// The value of this register is set to false only by hardware,
-             // under the condition that escalation is triggered and the corresponding lock bit is true
+      tags: [// The value of this register is set to false only by hardware, under the condition
+             // that escalation is triggered and the corresponding lock bit is true
              // Cannot not be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },
@@ -1621,8 +1618,8 @@
           resval: 1,
         }
       ],
-      tags: [// The value of this register is set to false only by hardware,
-             // under the condition that escalation is triggered and the corresponding lock bit is true
+      tags: [// The value of this register is set to false only by hardware, under the condition
+             // that escalation is triggered and the corresponding lock bit is true
              // Cannot not be auto-predicted so it is excluded from read check
              "excl:CsrNonInitTests:CsrExclWriteCheck"]
     },


### PR DESCRIPTION
This PR removes alert_cause register read exclusion because alert_en
registers are excluded from write.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>