### PR TITLE
[sw, tests] Adding test to verify ROM interface to KMAC

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1687,7 +1687,7 @@
             X-ref'ed with ROM_CTRL test/env.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_kmac_app_rom_test"]
     }
     {
       name: chip_sw_kmac_entropy

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -306,6 +306,12 @@
       sw_images: ["sw/device/tests/kmac_mode_kmac_test:1"]
       en_run_modes: ["sw_test_mode"]
     }
+    {
+      name: chip_sw_kmac_app_rom_test
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/kmac_app_rom_test:1"]
+      en_run_modes: ["sw_test_mode"]
+    }
 
     {
       name: chip_sw_coremark

--- a/sw/device/tests/kmac_app_rom_test.c
+++ b/sw/device/tests/kmac_app_rom_test.c
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_rom_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_rom_ctrl_t rom_ctrl;
+
+const test_config_t kTestConfig;
+
+bool test_main(void) {
+  dif_rom_ctrl_digest_t computed_digest;
+  dif_rom_ctrl_digest_t expected_digest;
+
+  // initialize rom_ctrl
+  mmio_region_t rom_ctrl_reg =
+      mmio_region_from_addr(TOP_EARLGREY_ROM_CTRL_REGS_BASE_ADDR);
+  CHECK_DIF_OK(dif_rom_ctrl_init(rom_ctrl_reg, &rom_ctrl));
+
+  // get computed and expected digests and check that they match
+  CHECK_DIF_OK(dif_rom_ctrl_get_digest(&rom_ctrl, &computed_digest));
+  CHECK_DIF_OK(dif_rom_ctrl_get_expected_digest(&rom_ctrl, &expected_digest));
+  CHECK_BUFFER(computed_digest.digest, expected_digest.digest,
+               ROM_CTRL_DIGEST_MULTIREG_COUNT,
+               "Mismatch between computed and expected digest.");
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -509,6 +509,25 @@ sw_tests += {
   }
 }
 
+kmac_app_rom_test_lib = declare_dependency(
+  link_with: static_library(
+    'kmac_app_rom_test_lib',
+    sources: [
+      hw_ip_rom_ctrl_reg_h,
+      'kmac_app_rom_test.c',
+    ],
+    dependencies: [
+      sw_lib_dif_rom_ctrl,
+      sw_lib_runtime_log,
+      sw_lib_mmio,
+    ],
+  ),
+)
+sw_tests += {
+  'kmac_app_rom_test': {
+    'library': kmac_app_rom_test_lib,
+  }
+}
 
 # Lifecycle Controller Tests
 lc_ctrl_otp_hw_cfg_test_lib = declare_dependency(


### PR DESCRIPTION
When the system has booted checks that the KMAC block has received the request to hash the contents of the ROM and returned the digests. These are compared against the expected digests stored in the ROM. They are accessed by reading the ROM_CTRL expected and computed digest registers.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>