### PR TITLE
[dv] Support data_intg_passthru for sram, rom and flash

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -44,6 +44,11 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
   bit  en_devmode = 1;
   bit  has_shadowed_regs = 0;
 
+  // If the data intg is passthru for the memory and the data intg value in mem is incorrect, it
+  // won't trigger d_error in this mem block and the check is done in the processor
+  // User can set this flag to disable the check for d_user.data_intg
+  bit disable_d_user_data_intg_check_for_passthru_mem;
+
   uint num_interrupts;
   uint num_edn;
   // if module has alerts, this list_of_alerts needs to override in cfg before super.initialize()

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -341,6 +341,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     bit csr_size_err, tl_item_err;
     bit has_intg_err;
     bit mem_byte_access_err, mem_wo_err, mem_ro_err;
+    bit is_passthru_mem = is_data_intg_passthru_mem(item, ral_name);
 
     if (!is_tl_access_mapped_addr(item, ral_name)) begin
       is_tl_unmapped_addr = 1;
@@ -368,8 +369,12 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       tl_intg_err_e tl_intg_err_type;
       uint num_cmd_err_bits, num_data_err_bits;
 
-      // integrity at d_user is from DUT, which should be always correct
-      if (en_d_user_intg_chk) void'(item.is_d_chan_intg_ok(.throw_error(1)));
+      // integrity at d_user is from DUT, which should be always correct, except data integrity for
+      // passthru memory
+      void'(item.is_d_chan_intg_ok(
+            .en_data_intg_chk(!is_passthru_mem ||
+                              !cfg.disable_d_user_data_intg_check_for_passthru_mem),
+            .throw_error(1)));
 
       // sample covergroup
       `downcast(cip_item, item)
@@ -445,6 +450,19 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
       if (mem_byte_access_err || mem_wo_err || mem_ro_err) return 0;
     end
     return 1;
+  endfunction
+
+  virtual function bit is_data_intg_passthru_mem(tl_seq_item item, string ral_name);
+    uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
+    uvm_mem mem = ral.default_map.get_mem_by_offset(addr);
+
+    if (mem == null) begin
+      return 0;
+    end else begin
+      dv_base_mem dv_mem;
+      `downcast(dv_mem, mem)
+      return dv_mem.get_data_intg_passthru();
+    end
   endfunction
 
   // check if csr write size greater or equal to csr width

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -307,7 +307,7 @@ virtual task issue_tl_access_w_intg_err(string ral_name);
                             cfg.ral_models[ral_name].mem_ranges[mem_idx].end_addr);
     end
   endcase
-  tl_access(.addr($urandom), .write(write), .data(data), .tl_intg_err_type(tl_intg_err_type), 
+  tl_access(.addr($urandom), .write(write), .data(data), .tl_intg_err_type(tl_intg_err_type),
             .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
 endtask
 

--- a/hw/dv/sv/dv_base_reg/dv_base_mem.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_mem.sv
@@ -11,6 +11,10 @@ class dv_base_mem extends uvm_mem;
   // if mem doesn't support partial write, doing that will result d_error = 1
   local bit mem_partial_write_support;
 
+  // if data integrity is passthru, mem stores integrity along with data but it won't check the
+  // data integrity
+  local bit data_intg_passthru;
+
   function new(string           name,
                longint unsigned size,
                int unsigned     n_bits,
@@ -27,6 +31,14 @@ class dv_base_mem extends uvm_mem;
   function bit get_mem_partial_write_support();
     return mem_partial_write_support;
   endfunction : get_mem_partial_write_support
+
+  function void set_data_intg_passthru(bit enable);
+    data_intg_passthru = enable;
+  endfunction : set_data_intg_passthru
+
+  function bit get_data_intg_passthru();
+    return data_intg_passthru;
+  endfunction : get_data_intg_passthru
 
   // rewrite this function to support "WO" access type for mem
   function void configure(uvm_reg_block  parent,

--- a/hw/dv/sv/tl_agent/tl_seq_item.sv
+++ b/hw/dv/sv/tl_agent/tl_seq_item.sv
@@ -318,12 +318,16 @@ class tl_seq_item extends uvm_sequence_item;
   //
   // Returns 1 if the integrity of a_channel is maintained, 0 otherwise. This base
   // class implementation vacuously returns 1.
-  virtual function bit is_a_chan_intg_ok(bit throw_error = 1'b1);
+  virtual function bit is_a_chan_intg_ok(bit en_cmd_intg_chk = 1,
+                                         bit en_data_intg_chk = 1,
+                                         bit throw_error = 1'b1);
     return 1;
   endfunction
 
   // d_channel version of the function above
-  virtual function bit is_d_chan_intg_ok(bit throw_error = 1'b1);
+  virtual function bit is_d_chan_intg_ok(bit en_rsp_intg_chk = 1,
+                                         bit en_data_intg_chk = 1,
+                                         bit throw_error = 1'b1);
     return 1;
   endfunction
 endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -68,12 +68,14 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
             // during key or init req, sram access shouldn't be taken
             randcase
               1: begin
-                // If we only do scrambling without re-init the mem, data intg will be wrong
-                cfg.scb.en_d_user_intg_chk = 0;
+                // If we only do scrambling without re-initializing the mem, data intg will be wrong
+                // since it's data intg passthru mem, it doesn't matter, just don't check it.
+                cfg.disable_d_user_data_intg_check_for_passthru_mem = 1;
                 req_scr_key();
               end
               1: begin
                 req_mem_init();
+                cfg.disable_d_user_data_intg_check_for_passthru_mem = 0;
               end
             endcase
           end

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -43,6 +43,7 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
     clk_freqs_mhz[sram_ral_name] = clk_freq_mhz;
 
     super.initialize(csr_base_addr);
+    tl_intg_alert_fields[ral.status.bus_integ_error] = 1;
 
     // Build KDI cfg object and configure
     m_kdi_cfg = push_pull_agent_cfg#(.DeviceDataWidth(KDI_DATA_SIZE))::type_id::create("m_kdi_cfg");

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_prim_ral_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_prim_ral_pkg.sv
@@ -23,6 +23,7 @@ package sram_ctrl_prim_ral_pkg;
                  int              has_coverage = UVM_NO_COVERAGE);
       super.new(name, size, n_bits, access, has_coverage);
       set_mem_partial_write_support(1);
+      set_data_intg_passthru(1);
     endfunction : new
 
   endclass : sram_ctrl_prim_mem_sram_mem

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -3866,6 +3866,7 @@
         {
           label: ram_ret_aon
           swaccess: rw
+          data_intg_passthru: "true"
           exec: True
           byte_write: True
           size: 0x1000
@@ -4057,6 +4058,7 @@
         {
           label: eflash
           swaccess: ro
+          data_intg_passthru: "true"
           exec: True
           byte_write: False
           config:
@@ -6162,6 +6164,7 @@
         {
           label: ram_main
           swaccess: rw
+          data_intg_passthru: "true"
           exec: True
           byte_write: True
           size: 0x20000
@@ -6351,10 +6354,10 @@
         {
           label: rom
           swaccess: ro
+          data_intg_passthru: True
           exec: True
           byte_write: False
           size: 0x8000
-          data_intg_passthru: True
         }
       }
       param_decl:

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -513,6 +513,7 @@
         ram: {
           label:    "ram_ret_aon",
           swaccess:   "rw",
+          data_intg_passthru: "true",
           exec:       "True",
           byte_write: "True",
           size:     "0x1000"
@@ -529,6 +530,7 @@
         mem: {
           label:      "eflash",
           swaccess:   "ro",
+          data_intg_passthru: "true",
           exec:       "True",
           byte_write: "False",
           config: {
@@ -643,6 +645,7 @@
         ram: {
           label:      "ram_main",
           swaccess:   "rw",
+          data_intg_passthru: "true",
           exec:       "True",
           byte_write: "True",
           size:       "0x20000"
@@ -659,6 +662,7 @@
         rom: {
           label:              "rom",
           swaccess:           "ro",
+          data_intg_passthru: "true",
           exec:               "True",
           byte_write:         "False",
           size:               "0x8000"

--- a/util/reggen/uvm_reg_base.sv.tpl
+++ b/util/reggen/uvm_reg_base.sv.tpl
@@ -440,6 +440,9 @@ reg_field_name, field)">\
 %     if window.byte_write:
       set_mem_partial_write_support(1);
 %     endif
+%     if window.data_intg_passthru:
+      set_data_intg_passthru(1);
+%     endif
     endfunction : new
 
   endclass : ${class_name}


### PR DESCRIPTION
There are 3 commits in this PR.

Commit 1: [dv] Pass data_intg_passthru to dv_base_mem
Need to know if mem has passthr data_intg, in order to know if we can
skip testing d_user.data_intg error

Commit 2:[dv] Update CIP to handle passthru mem
1. provide a flag to disable checking d_user.data_intg for passthru
memory
2. Remove old similar flag in sram_ctrl and add tl_intg_alert_fields to
fix sram_ctrl_tl_intg_err

Commit 3:Enable data_intg_passthru for rom, sram, flash mem
These mem are meant to have data intg passthru. With that enabled,
data_intg will be generated in ibex and these mem won't re-generate it
again.

Set `disable_d_user_data_intg_check_for_passthru_mem` in
rom_ctrl_env_cfg as the rom isn't initilized with correct ECC