### PR TITLE
[spi_device] Instantiate spid_addr_4b on SPI_DEVICE

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -246,6 +246,8 @@
         },
         { bits: "16"
           name: "addr_4b_en"
+          swaccess: "rw"
+          hwaccess: "hrw" // Updated by EN4B/EX4B
           desc: '''4B Address Mode enable.
 
             This field configures the internal module to receive 32 bits of the SPI commands. The affected commands are the SPI read commands except QPI, and program commands.

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -473,6 +473,13 @@ package spi_device_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic        d;
+      logic        de;
+    } addr_4b_en;
+  } spi_device_hw2reg_cfg_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic [7:0]  d;
     } rxlvl;
     struct packed {
@@ -649,7 +656,8 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [266:245]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [268:247]
+    spi_device_hw2reg_cfg_reg_t cfg; // [246:245]
     spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [244:229]
     spi_device_hw2reg_status_reg_t status; // [228:223]
     spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [222:206]

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -2509,8 +2509,8 @@ module spi_device_reg_top (
     .wd     (cfg_addr_4b_en_wd),
 
     // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
+    .de     (hw2reg.cfg.addr_4b_en.de),
+    .d      (hw2reg.cfg.addr_4b_en.d),
 
     // to internal hardware
     .qe     (),

--- a/hw/ip/spi_device/rtl/spid_addr_4b.sv
+++ b/hw/ip/spi_device/rtl/spid_addr_4b.sv
@@ -25,7 +25,6 @@ module spid_addr_4b (
   input sys_rst_ni,
 
   input spi_clk_i,
-  input spi_rst_ni,
 
   input spi_csb_asserted_pulse_i,
   input sys_csb_deasserted_pulse_i,


### PR DESCRIPTION
This commit revises CSR to change CFG.addr_4b_en to be sw/hw read/write.
Also the commit creates spid_addr_4b instance on SPI_DEVICE HWIP.
    
Now, `cfg_addr_4b_en` that is broadcasted to multiple submodules
(readcmd, passthrough) is generated from `spid_addr_4b` module. The HW
control path (set/clear of cfg_addr_4b_en) is not implemented yet.
Cmdparse submodule will receive the opcodes for the two commands and
generates event signals to change cfg_addr_4b_en value.

This PR contains #9649 