### PR TITLE
[dv,xcelium] Fix Xcelium compile error.

### DIFF
--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -35,6 +35,10 @@
                "-nowarn DSEMEL",
                // Ignore hierarchial ref warnings in interfaces
                "-nowarn CUVIHR",
+               // Needed for including "secded_enc.h".
+               "-I{build_dir}/src/lowrisc_dv_secded_enc_0",
+               // Needed to support "$assertcontrol" used in hw/top_earlgrey/dv/env/ast_supply_if.sv.
+               "-abv_lrmcompliant_asrtctrl",
                ]
 
   run_opts:   ["-input {run_script}",


### PR DESCRIPTION
This adds an include path and build option to Xcelium dvsim configuration so that both compilation /elaboration succeed.

This fixes #4230.

Signed-off-by: Timothy Trippel <ttrippel@google.com>