### PR TITLE
[sw/silicon_creator] Add flash_ctrl_creator_info_pages_lockdown()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -208,7 +208,7 @@ static uint32_t info_page_addr(flash_ctrl_info_page_t info_page) {
   const uint32_t bank_index =
       bitfield_bit32_read(info_page, FLASH_CTRL_INFO_PAGE_BIT_BANK);
   const uint32_t page_index =
-      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_INDEX);
+      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_PAGE);
   return kMemBase + bank_index * FLASH_CTRL_PARAM_BYTES_PER_BANK +
          page_index * FLASH_CTRL_PARAM_BYTES_PER_PAGE;
 }
@@ -356,7 +356,7 @@ static info_cfg_regs_t info_cfg_regs(flash_ctrl_info_page_t info_page) {
   const uint32_t bank_index =
       bitfield_bit32_read(info_page, FLASH_CTRL_INFO_PAGE_BIT_BANK);
   const uint32_t page_index =
-      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_INDEX);
+      bitfield_field32_read(info_page, FLASH_CTRL_INFO_PAGE_FIELD_PAGE);
   const uint32_t pre_addr =
       kBase + bank_index * kBankOffset + page_index * kPageOffset;
   return (info_cfg_regs_t){

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -14,20 +14,6 @@ extern "C" {
 #endif
 
 /**
- * Flash memory banks.
- */
-enum {
-  /**
-   * Flash bank 0.
-   */
-  kFlashCtrlBank0 = 0,
-  /**
-   * Flash bank 1.
-   */
-  kFlashCtrlBank1 = 1,
-};
-
-/**
  * A flash partition.
  *
  * Each `flash_ctrl_partition_t` enumeration constant is a bitfield with the
@@ -70,7 +56,7 @@ typedef enum flash_crtl_partition {
 
 /**
  * Helper macro for defining the value of a `flash_ctrl_info_page_t` enumeration
- * constant.
+ * constant for information pages of type 0.
  *
  * Each `flash_ctrl_info_page_t` enumeration constant is a bitfield with the
  * following layout:
@@ -78,41 +64,43 @@ typedef enum flash_crtl_partition {
  * - Bits 4-6: Partition type (a `flash_ctrl_partition_type_t`).
  * - Bit 7: Bank index [0,1].
  *
+ * This macro assumes that all information pages are of type 0 since silicon
+ * creator code does not need to access information pages of other types.
+ *
  * @param bank_ Bank index.
- * @param partition_ Partition type, a `flash_ctrl_partition_type_t`.
- * @param index_ Page index.
+ * @param page_ Page index.
  */
-#define INFO_PAGE_(bank_, partition_, index_) \
-  ((bank_ << 7) | (partition_ << 4) | (index_))
+#define INFO_PAGE_(bank_, page_) \
+  ((bank_ << 7) | (kFlashCtrlPartitionInfo0 << 4) | (page_))
 
 // clang-format off
 #define FLASH_CTRL_INFO_PAGES_DEFINE(X) \
   /**
    * Bank 0 information partition type 0 pages.
    */ \
-  X(kFlashCtrlInfoPageFactoryId,          INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 0)), \
-  X(kFlashCtrlInfoPageCreatorSecret,      INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 1)), \
-  X(kFlashCtrlInfoPageOwnerSecret,        INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 2)), \
-  X(kFlashCtrlInfoPageWaferAuthSecret,    INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 3)), \
-  X(kFlashCtrlInfoPageBank0Type0Page4,    INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 4)), \
-  X(kFlashCtrlInfoPageBank0Type0Page5,    INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 5)), \
-  X(kFlashCtrlInfoPageOwnerReserved0,     INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 6)), \
-  X(kFlashCtrlInfoPageOwnerReserved1,     INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 7)), \
-  X(kFlashCtrlInfoPageOwnerReserved2,     INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 8)), \
-  X(kFlashCtrlInfoPageOwnerReserved3,     INFO_PAGE_(kFlashCtrlBank0, kFlashCtrlPartitionInfo0, 9)), \
+  X(kFlashCtrlInfoPageFactoryId,          0, 0), \
+  X(kFlashCtrlInfoPageCreatorSecret,      0, 1), \
+  X(kFlashCtrlInfoPageOwnerSecret,        0, 2), \
+  X(kFlashCtrlInfoPageWaferAuthSecret,    0, 3), \
+  X(kFlashCtrlInfoPageBank0Type0Page4,    0, 4), \
+  X(kFlashCtrlInfoPageBank0Type0Page5,    0, 5), \
+  X(kFlashCtrlInfoPageOwnerReserved0,     0, 6), \
+  X(kFlashCtrlInfoPageOwnerReserved1,     0, 7), \
+  X(kFlashCtrlInfoPageOwnerReserved2,     0, 8), \
+  X(kFlashCtrlInfoPageOwnerReserved3,     0, 9), \
   /**
    * Bank 1 information partition type 0 pages.
    */ \
-  X(kFlashCtrlInfoPageBootData0,          INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 0)), \
-  X(kFlashCtrlInfoPageBootData1,          INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 1)), \
-  X(kFlashCtrlInfoPageOwnerSlot0,         INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 2)), \
-  X(kFlashCtrlInfoPageOwnerSlot1,         INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 3)), \
-  X(kFlashCtrlInfoPageBank1Type0Page4,    INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 4)), \
-  X(kFlashCtrlInfoPageBank1Type0Page5,    INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 5)), \
-  X(kFlashCtrlInfoPageCreatorCertificate, INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 6)), \
-  X(kFlashCtrlInfoPageBootServices,       INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 7)), \
-  X(kFlashCtrlInfoPageOwnerCerificate0,   INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 8)), \
-  X(kFlashCtrlInfoPageOwnerCerificate1,   INFO_PAGE_(kFlashCtrlBank1, kFlashCtrlPartitionInfo0, 9)), \
+  X(kFlashCtrlInfoPageBootData0,          1, 0), \
+  X(kFlashCtrlInfoPageBootData1,          1, 1), \
+  X(kFlashCtrlInfoPageOwnerSlot0,         1, 2), \
+  X(kFlashCtrlInfoPageOwnerSlot1,         1, 3), \
+  X(kFlashCtrlInfoPageBank1Type0Page4,    1, 4), \
+  X(kFlashCtrlInfoPageBank1Type0Page5,    1, 5), \
+  X(kFlashCtrlInfoPageCreatorCertificate, 1, 6), \
+  X(kFlashCtrlInfoPageBootServices,       1, 7), \
+  X(kFlashCtrlInfoPageOwnerCerificate0,   1, 8), \
+  X(kFlashCtrlInfoPageOwnerCerificate1,   1, 9), \
 // clang-format on
 
 /**
@@ -120,7 +108,7 @@ typedef enum flash_crtl_partition {
  * @name_ Name of the enumeration constant.
  * @value_ Value of the enumeration constant.
  */
-#define INFO_PAGE_ENUM_INIT_(name_, value_) name_ = value_
+#define INFO_PAGE_ENUM_INIT_(name_, bank_, page_) name_ = INFO_PAGE_(bank_, page_)
 
 /**
  * Info pages.
@@ -133,7 +121,7 @@ typedef enum flash_ctrl_info_page {
  * Field and bit definitions to get page index, partition type, and bank index
  * from a `flash_ctrl_info_page_t`.
  */
-#define FLASH_CTRL_INFO_PAGE_FIELD_INDEX \
+#define FLASH_CTRL_INFO_PAGE_FIELD_PAGE \
   ((bitfield_field32_t){.mask = 0xf, .index = 0})
 #define FLASH_CTRL_INFO_PAGE_FIELD_PARTITION \
   ((bitfield_field32_t){.mask = 0x7, .index = 4})

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -319,6 +319,14 @@ typedef enum flash_ctrl_exec {
  */
 void flash_ctrl_exec_set(flash_ctrl_exec_t enable);
 
+/**
+ * Disables all access to silicon creator info pages until next reset.
+ *
+ * This function must be called in ROM_EXT before handing over execution to the
+ * first owner boot stage.
+ */
+void flash_ctrl_creator_info_pages_lockdown(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -16,6 +16,41 @@
 
 namespace flash_ctrl_unittest {
 namespace {
+using ::testing::Each;
+using ::testing::SizeIs;
+
+/**
+ * A struct that holds bank, page, and config register information for an
+ * information page.
+ */
+struct InfoPage {
+  uint32_t bank;
+  uint32_t page;
+  uint32_t cfg_offset;
+  uint32_t cfg_wen_offset;
+};
+
+/**
+ * Returns a map from `flash_ctrl_info_page_t` to `InfoPage` to be used in
+ * tests.
+ */
+const std::map<flash_ctrl_info_page_t, InfoPage> &InfoPages() {
+#define INFO_PAGE_MAP_INIT(name_, bank_, page_)                                    \
+  {                                                                                \
+    name_,                                                                         \
+        {                                                                          \
+            bank_,                                                                 \
+            page_,                                                                 \
+            FLASH_CTRL_BANK##bank_##_INFO0_PAGE_CFG_SHADOWED_##page_##_REG_OFFSET, \
+            FLASH_CTRL_BANK##bank_##_INFO0_REGWEN_##page_##_REG_OFFSET,            \
+        },                                                                         \
+  }
+
+  static const std::map<flash_ctrl_info_page_t, InfoPage> *const kInfoPages =
+      new std::map<flash_ctrl_info_page_t, InfoPage>{
+          FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_MAP_INIT)};
+  return *kInfoPages;
+}
 
 class FlashCtrlTest : public mask_rom_test::MaskRomTest {
  protected:
@@ -23,6 +58,41 @@ class FlashCtrlTest : public mask_rom_test::MaskRomTest {
   mask_rom_test::MockAbsMmio mmio_;
   mask_rom_test::MockSecMmio sec_mmio_;
 };
+
+class InfoPagesTest : public FlashCtrlTest {};
+TEST_F(InfoPagesTest, NumberOfPages) { EXPECT_THAT(InfoPages(), SizeIs(20)); }
+
+TEST_F(InfoPagesTest, PagesPerBank) {
+  std::array<uint32_t, 2> pages_per_bank = {0, 0};
+  for (const auto &it : InfoPages()) {
+    const uint32_t bank = it.second.bank;
+    EXPECT_EQ(bank, static_cast<uint32_t>(bitfield_bit32_read(
+                        it.first, FLASH_CTRL_INFO_PAGE_BIT_BANK)));
+    EXPECT_LE(bank, 1);
+    ++pages_per_bank[bank];
+  }
+
+  EXPECT_THAT(pages_per_bank, Each(10));
+}
+
+TEST_F(InfoPagesTest, AllType0) {
+  for (const auto &it : InfoPages()) {
+    const flash_ctrl_partition_t partition =
+        static_cast<flash_ctrl_partition_t>(bitfield_field32_read(
+            it.first, FLASH_CTRL_INFO_PAGE_FIELD_PARTITION));
+    EXPECT_EQ(partition, kFlashCtrlPartitionInfo0);
+  }
+}
+
+TEST_F(InfoPagesTest, PageIndices) {
+  for (const auto &it : InfoPages()) {
+    const uint32_t page = it.second.page;
+
+    EXPECT_EQ(page,
+              bitfield_field32_read(it.first, FLASH_CTRL_INFO_PAGE_FIELD_PAGE));
+    EXPECT_LE(page, 9);
+  }
+}
 
 class InitTest : public FlashCtrlTest {};
 

--- a/sw/device/silicon_creator/rom_ext/meson.build
+++ b/sw/device/silicon_creator/rom_ext/meson.build
@@ -90,6 +90,7 @@ foreach slot, slot_link_args : rom_ext_link_info
       dependencies: [
         freestanding_headers,
         sw_silicon_creator_lib_base_sec_mmio,
+        sw_silicon_creator_lib_driver_flash_ctrl,
         sw_silicon_creator_lib_driver_hmac,
         sw_silicon_creator_lib_driver_pinmux,
         sw_silicon_creator_lib_driver_uart,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -10,6 +10,7 @@
 #include "sw/device/lib/base/stdasm.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
@@ -91,6 +92,8 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest) {
 }
 
 static rom_error_t rom_ext_boot(const manifest_t *manifest) {
+  // Lock down silicon creator info pages until next reset.
+  flash_ctrl_creator_info_pages_lockdown();
   // Unlock execution of owner stage executable code (text) sections.
   rom_ext_epmp_unlock_owner_stage_rx(&epmp, manifest_code_region_get(manifest));
 


### PR DESCRIPTION
This PR adds `flash_ctrl_creator_info_pages_lockdown()` to disable access to silicon creator info pages until next reset. The pages that are locked down are those that should not be accessible after ROM_EXT (taken from the flash info map spreadsheet). Please note that `kFlashCtrlInfoPageCreatorSecret` is locked down in `flash_ctrl_init()`.

Unit test changes rely on the preprocessor and auto-generated register offset defines to generate a map for tests. I think we can do something similar in `flash_ctrl.c` to generate a switch to be able to use hardened info page enums (instead of relying on low hamming weight bit fields and arithmetic operations). Please let me know what you think.
