### PR TITLE
[dv/flash_ctrl] Adding he_en to mp cfg and randomization

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -102,6 +102,7 @@ package flash_ctrl_env_pkg;
     bit  read_en;     // enable reads
     bit  program_en;  // enable write
     bit  erase_en;    // enable erase
+    bit  he_en;       // enable high endurance
     uint num_pages;   // 0:NumPages % start_page
     uint start_page;  // 0:NumPages-1
   } flash_mp_region_cfg_t;
@@ -111,6 +112,7 @@ package flash_ctrl_env_pkg;
     bit read_en;     // enable reads
     bit program_en;  // enable write
     bit erase_en;    // enable erase
+    bit he_en;       // enable high endurance
   } flash_bank_mp_info_page_cfg_t;
 
   typedef struct packed {

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -31,6 +31,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint mp_region_read_en_pc;
   uint mp_region_program_en_pc;
   uint mp_region_erase_en_pc;
+  uint mp_region_he_en_pc;
   uint mp_region_max_pages;
 
   // Knob to control bank level erasability.
@@ -47,6 +48,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint mp_info_page_read_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
   uint mp_info_page_program_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
   uint mp_info_page_erase_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_he_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
 
   // Control the number of flash ops.
   uint max_flash_ops_per_cfg;
@@ -123,6 +125,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
     mp_region_read_en_pc = 50;
     mp_region_program_en_pc = 50;
     mp_region_erase_en_pc = 50;
+    mp_region_he_en_pc = 0;
     mp_region_max_pages = 32;
 
     bank_erase_en_pc = 50;
@@ -136,6 +139,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
       mp_info_page_read_en_pc[i][j] = 50;
       mp_info_page_program_en_pc[i][j] = 50;
       mp_info_page_erase_en_pc[i][j] = 50;
+      mp_info_page_he_en_pc[i][j] = 0;
     end
 
     flash_only_op = FlashOpInvalid;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -84,6 +84,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
                                        region_cfg.program_en) |
         get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].erase_en, data,
                                        region_cfg.erase_en) |
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].he_en, data,
+                                       region_cfg.he_en) |
         get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].base, data,
                                        region_cfg.start_page) |
         get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].size, data,
@@ -120,7 +122,10 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
         get_csr_val_with_updated_field(csr.get_field_by_name("rd_en"), data, page_cfg.read_en) |
         get_csr_val_with_updated_field(csr.get_field_by_name("prog_en"), data,
                                        page_cfg.program_en) |
-        get_csr_val_with_updated_field(csr.get_field_by_name("erase_en"), data, page_cfg.erase_en);
+        get_csr_val_with_updated_field(csr.get_field_by_name("erase_en"), data,
+                                       page_cfg.erase_en) |
+        get_csr_val_with_updated_field(csr.get_field_by_name("he_en"), data,
+                                       page_cfg.he_en);
     csr_wr(.ptr(csr), .value(data));
   endtask
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -126,6 +126,11 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
         1 :/ cfg.seq_cfg.mp_region_erase_en_pc
       };
 
+      mp_regions[i].he_en dist {
+        0 :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+        1 :/ cfg.seq_cfg.mp_region_he_en_pc
+      };
+
       mp_regions[i].start_page inside {[0:FlashNumPages - 1]};
       mp_regions[i].num_pages inside {[1:FlashNumPages - mp_regions[i].start_page]};
       mp_regions[i].num_pages <= cfg.seq_cfg.mp_region_max_pages;
@@ -202,6 +207,11 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
         mp_info_pages[i][j][k].erase_en dist {
           0 :/ (100 - cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]),
           1 :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
+        };
+
+        mp_info_pages[i][j][k].he_en dist {
+          0 :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
+          1 :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]
         };
 
       }


### PR DESCRIPTION
Hi,
This PR is adding the randomization and handling of high endurance enable in the memory protection configurations of the flash_ctrl DV.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>