### PR TITLE
[otbn,dv] Don't fetch next instruction in sim when stalled

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -196,7 +196,7 @@ class OTBNSim:
         if not sim_stalled:
             return (insn, self._on_retire(verbose, insn))
 
-        return (None, self._on_stall(verbose, fetch_next=True))
+        return (None, self._on_stall(verbose, fetch_next=False))
 
     def dump_data(self) -> bytes:
         return self.state.dmem.dump_le_words()


### PR DESCRIPTION
OTBN used to fetch the next instruction from memory on every cycle. If
memory changed under its feet in the middle of a multi-cycle
instruction, we'd see the integrity error on the next cycle. With the
prefetch stage, this works differently. Now we ignore responses from
IMEM unless we're unblocked (and can put something new into the
prefetch buffer).

This 1-line commit updates the ISS model to work the same way, fixing
failures in the `otbn_imem_err` sequence which was failing whenever we
happened to inject the error in the middle of a multi-cycle
instruction. Since reads from RND are sloooooow, this happened quite
frequently.
