### PR TITLE
[dv/prim_alert_tb] Modify the seq to ensure alert always sends

### DIFF
--- a/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
+++ b/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
@@ -55,8 +55,8 @@
             This test is based on previous tests:
             - Based on the prim_alert_request_test, this test adds a parallel sequence to randomly
               drive `init_trigger_i` in prim_alert_receiver.
-              Check if alert sender/receiver pairs can resume normal handshake after init_trigger_i
-              is set.
+              Check if `alert_ack_o` returns 1 and check if alert sender/receiver pairs can resume
+              normal handshake after alert init finishes.
               For fatal alert, check if fatal alerts keep firing until reset is issued.
             - Based on prim_alert_ping_request_test, this test adds a parallel sequence to randomly
               drive `init_trigger_i` in prim_alert_receiver.

--- a/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
+++ b/hw/ip/prim/dv/prim_alert/tb/prim_alert_tb.sv
@@ -144,28 +144,25 @@ module prim_alert_tb;
 
     // Sequence 1). Alert request sequence.
     for (int num_trans = 1; num_trans <= 10; num_trans++) begin
-      automatic int rand_wait_init_trig = $urandom_range(2, WaitAlertHandshakeDone + 10);
-      alert_req = 1;
       fork
         begin
+          main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
+          alert_req = 1;
           `DV_SPINWAIT(wait (alert_ack == 1);, , , "Wait for alert_ack timeout");
           alert_req = 0;
           main_clk.wait_clks(WaitAlertHandshakeDone);
         end
         begin
-          main_clk.wait_clks(rand_wait_init_trig);
-          init_trig = prim_mubi_pkg::MuBi4True;
+          if ($urandom_range(0, 1)) begin
+            main_clk.wait_clks($urandom_range(MinHandshakeWait, 10));
+            init_trig = prim_mubi_pkg::MuBi4True;
+            main_clk.wait_clks($urandom_range(1, 10));
+            init_trig = prim_mubi_pkg::MuBi4False;
+            main_clk.wait_clks(WaitAlertInitDone);
+          end
         end
-      join_any
-      disable fork;
+      join
 
-      // Clean up sequence in case alert init or dut init was triggered.
-      main_clk.wait_clks($urandom_range(1, 10));
-      if (init_trig == prim_mubi_pkg::MuBi4True) begin
-        alert_req = 0;
-        init_trig = prim_mubi_pkg::MuBi4False;
-        main_clk.wait_clks(WaitAlertInitDone);
-      end
       if (IsFatal) begin
         // For fatal alert, ensure alert keeps firing until reset.
         // If only alert_init is triggered, alert_sender side still expect fatal alert to fire.


### PR DESCRIPTION
According to alert_handler V2 review meeting, designer confirms that
alert_sender will always finishes the alert handshake even when
alert_init happens in between the handshake.
This PR modifies to seq to cover this case.

FYI: @msfschaffner 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>