### PR TITLE
[mem_bkdr_util] Use inverted integrity in rom_encrypt_write32_integ

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
@@ -95,7 +95,7 @@ virtual function void rom_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:
 
   if(scramble_data) begin
     // Calculate the integrity constant
-    integ_data = prim_secded_pkg::prim_secded_39_32_enc(data);
+    integ_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
   
     // Calculate the scrambled data
     wdata_arr = {<<{integ_data}};


### PR DESCRIPTION
We forgot to update this in 8089c12, and then merged c3c689d57 (racing
against it, so we didn't see the problem in CI) which started
requiring the integrity to match.

Marking this as high priority because it's breaking CI. Since this only touches the class-heavy `mem_bkdr_util` code, it should be safe to merge as soon as private CI passes.