### PR TITLE
[entropy complex/doc] added logic integrity counter measure to list

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -90,10 +90,13 @@
       desc: "Sparse state machine implementation."
     }
     { name: "CNT.REDUN"
-      desc: "Counter hardening."
+      desc: "Counter hardening for generate command counter."
+    }
+    { name: "LOGIC.INTEGRITY"
+      desc: "Comparison on successive bus values for genbits returned on the software channel."
     }
     { name: "BUS.INTEGRITY"
-      desc: "End-to-end bus integrity scheme."
+      desc: "Tilelink end-to-end bus integrity scheme."
     }
   ],
 

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -55,10 +55,13 @@
       desc: "Sparse state machine implementation."
     }
     { name: "CNT.REDUN"
-      desc: "Counter hardening."
+      desc: "Counter hardening on the generate command maximum requests counter."
+    }
+    { name: "LOGIC.INTEGRITY"
+      desc: "Comparison on successive bus values for genbits returned from csrng that will destribute over the endpoint buses."
     }
     { name: "BUS.INTEGRITY"
-      desc: "End-to-end bus integrity scheme."
+      desc: "Tilelink end-to-end bus integrity scheme."
     }
   ],
 

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -86,10 +86,13 @@
       desc: "Sparse state machine implementation."
     }
     { name: "CNT.REDUN"
-      desc: "Counter hardening."
+      desc: "Counter hardening for all health test counters."
+    }
+    { name: "LOGIC.INTEGRITY"
+      desc: "Comparison on successive bus values for the post-conditioned entropy seed bus."
     }
     { name: "BUS.INTEGRITY"
-      desc: "End-to-end bus integrity scheme."
+      desc: "Tilelink end-to-end bus integrity scheme."
     }
   ],
 


### PR DESCRIPTION
All entropy complex blocks support a cycle to cycle comparison of bus bits, so this asset and type was added to the counter measures list.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>