### PR TITLE
[dv/prim_count] Add an assertion to check max count stable

### DIFF
--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -196,6 +196,9 @@ module prim_count import prim_count_pkg::*; #(
   `ASSERT(OutSet_A, ##1 set_i |=>
           (CntStyle == DupCnt || OutSelDnCnt) ? cnt_o == $past(set_cnt_i) : cnt_o == 0)
 
+  // If the up counter reaches its max value, the value won't increment or change.
+  `ASSERT(MaxUpCntStable_A, up_cnt_q[0] == max_val && !clr_i && !set_i |=> $stable(up_cnt_q[0]))
+
   // This logic that will be assign to one, when user adds macro
   // ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT to check the error with alert, in case that prim_count
   // is used in design without adding this assertion check.

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_accu.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_accu.sv
@@ -59,5 +59,5 @@ module alert_handler_accu import alert_pkg::*; (
 
   `ASSERT(DisabledNoTrigFwd_A, !class_en_i |-> !accu_trig_o)
   `ASSERT(DisabledNoTrigBkwd_A, accu_trig_o |-> class_en_i)
-
+  `ASSERT(CountSaturateStable_A, accu_cnt_o == {AccuCntDw{1'b1}} |=> $stable(accu_cnt_o))
 endmodule : alert_handler_accu

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_accu.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_accu.sv
@@ -59,5 +59,5 @@ module alert_handler_accu import alert_pkg::*; (
 
   `ASSERT(DisabledNoTrigFwd_A, !class_en_i |-> !accu_trig_o)
   `ASSERT(DisabledNoTrigBkwd_A, accu_trig_o |-> class_en_i)
-
+  `ASSERT(CountSaturateStable_A, accu_cnt_o == {AccuCntDw{1'b1}} |=> $stable(accu_cnt_o))
 endmodule : alert_handler_accu


### PR DESCRIPTION
This assertion was brought up during alert_handler review. We wanted to
ensure the accumulate_cnt for alert cause once reaches its max value, it
won't overflow, but stays at the current max value.
Because alert_handler used the prim_count, I decided to add the assertion
check in prim_count.sv and alert_handler_accum.sv


Signed-off-by: Cindy Chen <chencindy@opentitan.org>