### PR TITLE
[test] Connectivity simulation test for rom_cfg signal

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2035,7 +2035,7 @@
             - In open source, this is verified by a simple connectivity assertion check.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_rom_ctrl_ast_rom_cfg"]
     }
     {
       name: chip_sw_rom_ctrl_integrity_check

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -295,6 +295,11 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
+      name: chip_rom_ctrl_ast_rom_cfg
+      uvm_test_seq: chip_rom_ctrl_ast_rom_cfg_vseq
+      en_run_modes: ["stub_cpu_mode"]
+    }
+    {
       name: chip_sw_kmac_mode_cshake_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_cshake_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_rom_ctrl_ast_rom_cfg_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - ast_supply_if.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_rom_ctrl_ast_rom_cfg_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_rom_ctrl_ast_rom_cfg_vseq.sv
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_rom_ctrl_ast_rom_cfg_vseq extends chip_base_vseq;
+  `uvm_object_utils(chip_rom_ctrl_ast_rom_cfg_vseq)
+
+  `uvm_object_new
+
+  localparam string ROM_CFG_SOURCE_PATH = "tb.dut.u_ast.u_ast_dft.sprom_rm_o";
+  localparam string ROM_CFG_DEST_PATH = {
+    "tb.dut.top_earlgrey.u_rom_ctrl.",
+    "gen_rom_scramble_enabled.u_rom.u_rom.u_prim_rom.",
+    "gen_generic.u_impl_generic.cfg_i"
+  };
+
+  virtual task rom_cfg_conn_check();
+    prim_rom_pkg::rom_cfg_t rom_cfg_dest;
+    int retval;
+    // check hdl paths are valid
+    retval = uvm_hdl_check_path(ROM_CFG_SOURCE_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", ROM_CFG_SOURCE_PATH))
+    retval = uvm_hdl_check_path(ROM_CFG_DEST_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", ROM_CFG_DEST_PATH))
+
+    // force in turn every possible value onto the source path,
+    // read from the destination path then do a check
+    // that the forced data has arrived.
+    for (int i = 0; i < 2 ** $bits(rom_cfg_dest); i++) begin
+      retval = uvm_hdl_force(ROM_CFG_SOURCE_PATH, i);
+      `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_force failed for %0s", ROM_CFG_SOURCE_PATH))
+
+      retval = uvm_hdl_read(ROM_CFG_DEST_PATH, rom_cfg_dest);
+      `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", ROM_CFG_DEST_PATH))
+
+      `DV_CHECK_EQ(
+          i, rom_cfg_dest, $sformatf(
+          "rom_cfg connectivity check failed, source = 0x%0x, dest = 0x%0x", i, rom_cfg_dest))
+    end
+  endtask
+
+  virtual task body();
+    rom_cfg_conn_check();
+  endtask
+
+endclass : chip_rom_ctrl_ast_rom_cfg_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -14,4 +14,5 @@
 `include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
+`include "chip_rom_ctrl_ast_rom_cfg_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"


### PR DESCRIPTION
Tests that the rom_cfg signal from the AST is connected to the ROM_CTRL block using simulation.
All possible values of rom_cfg are tested by forcing values at the source and confirming receipt at the destination.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>