### PR TITLE
[opentitantool] Support configuration of GPIO pin modes

### DIFF
--- a/sw/host/opentitanlib/src/app/conf.rs
+++ b/sw/host/opentitanlib/src/app/conf.rs
@@ -4,23 +4,9 @@
 
 //! Schema for configuration files, exact encoding json/xml to be worked out.
 
+use crate::io::gpio::{PinMode, PullMode};
+
 use serde::Deserialize;
-
-/// Overall operating mode of a single GPIO pin.
-#[derive(Deserialize, Clone, Debug)]
-pub enum PinMode {
-    Input,
-    PushPull,
-    OpenDrain,
-}
-
-/// Configuration of passive pullup/down for a single GPIO pin.
-#[derive(Deserialize, Clone, Debug)]
-pub enum PullMode {
-    None,
-    PullUp,
-    PullDown,
-}
 
 /// Configuration of a particular GPIO pin.
 #[derive(Deserialize, Clone, Debug)]
@@ -36,6 +22,16 @@ pub struct PinConfiguration {
     /// Name of a pin defined by the transport (or a lower level
     /// PinConfiguration).
     pub alias_of: Option<String>,
+}
+
+/// Configuration of a particular GPIO pin.
+#[derive(Deserialize, Clone, Debug)]
+pub struct StrappingConfiguration {
+    /// The user-visible name of the strapping combination.
+    pub name: String,
+    /// List of GPIO pin configurations (the alias_of) field should not be used in these.
+    #[serde(default)]
+    pub pins: Vec<PinConfiguration>,
 }
 
 /// Parity configuration for UART communication.
@@ -143,6 +139,9 @@ pub struct ConfigurationFile {
     /// List of GPIO pin configurations.
     #[serde(default)]
     pub pins: Vec<PinConfiguration>,
+    /// List of named sets of additional GPIO pin configurations (pullup/pulldown).
+    #[serde(default)]
+    pub strappings: Vec<StrappingConfiguration>,
     /// List of UART configurations.
     #[serde(default)]
     pub uarts: Vec<UartConfiguration>,

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -6,7 +6,7 @@
 pub mod command;
 pub mod conf;
 
-use crate::io::gpio::GpioPin;
+use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
@@ -17,15 +17,33 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Invalid pin strapping name \"{0}\"")]
+    InvalidStrappingName(String),
+}
+
+#[derive(Default)]
+pub struct PinConfiguration {
+    /// The input/output mode of the GPIO pin.
+    pub mode: Option<PinMode>,
+    /// The default/initial level of the pin (true means high).
+    pub level: Option<bool>,
+    /// Whether the pin has pullup/down resistor enabled.
+    pub pull_mode: Option<PullMode>,
+}
+
 // This is the structure to be passed to each Command implementation,
 // replacing the "bare" Transport argument.  The fields other than
 // transport will have been computed from a number ConfigurationFiles.
 pub struct TransportWrapper {
     transport: RefCell<Box<dyn crate::transport::Transport>>,
-    pub pin_map: HashMap<String, String>,
-    pub uart_map: HashMap<String, String>,
-    pub spi_map: HashMap<String, String>,
-    pub flash_map: HashMap<String, conf::FlashConfiguration>,
+    pin_map: HashMap<String, String>,
+    uart_map: HashMap<String, String>,
+    spi_map: HashMap<String, String>,
+    flash_map: HashMap<String, conf::FlashConfiguration>,
+    pin_conf_map: HashMap<String, PinConfiguration>,
+    strapping_conf_map: HashMap<String, HashMap<String, PinConfiguration>>,
 }
 
 impl TransportWrapper {
@@ -36,6 +54,8 @@ impl TransportWrapper {
             uart_map: HashMap::new(),
             spi_map: HashMap::new(),
             flash_map: HashMap::new(),
+            pin_conf_map: HashMap::new(),
+            strapping_conf_map: HashMap::new(),
         }
     }
 
@@ -82,20 +102,114 @@ impl TransportWrapper {
         map.get(&name).cloned().unwrap_or(name)
     }
 
+    /// Apply given configuration to a single pins.
+    fn apply_pin_configuration(&self, name: &str, conf: &PinConfiguration) -> Result<()> {
+        let pin = self.gpio_pin(name)?;
+        if let Some(pin_mode) = conf.mode {
+            pin.set_mode(pin_mode)?;
+        }
+        if let Some(pull_mode) = conf.pull_mode {
+            pin.set_pull_mode(pull_mode)?;
+        }
+        if let Some(level) = conf.level {
+            pin.write(level)?;
+        }
+        Ok(())
+    }
+
+    /// Apply given configuration to a all the given pins.
+    fn apply_pin_configurations(&self, conf_map: &HashMap<String, PinConfiguration>) -> Result<()> {
+        for (name, conf) in conf_map {
+            self.apply_pin_configuration(name, conf)?
+        }
+        Ok(())
+    }
+
+    /// Configure all pins as input/output, pullup, etc. as declared in cofiguration files.
+    pub fn apply_default_pin_configurations(&self) -> Result<()> {
+        self.apply_pin_configurations(&self.pin_conf_map)
+    }
+
+    /// Configure a specific set of pins as strong/weak pullup/pulldown as declared in
+    /// cofiguration files under a given strapping name.
+    pub fn apply_pin_strapping(&self, strapping_name: &str) -> Result<()> {
+        if let Some(strapping_conf_map) = self.strapping_conf_map.get(strapping_name) {
+            self.apply_pin_configurations(&strapping_conf_map)
+        } else {
+            Err(Error::InvalidStrappingName(strapping_name.to_string()).into())
+        }
+    }
+
+    /// Return the set of pins affected by the given strapping to their "default" (un-strapped)
+    /// configuration, that is, to the level declared in the "pins" section of configuration
+    /// files, outside of any "strappings" section.
+    pub fn remove_pin_strapping(&self, strapping_name: &str) -> Result<()> {
+        if let Some(strapping_conf_map) = self.strapping_conf_map.get(strapping_name) {
+            for (pin_name, _conf) in strapping_conf_map {
+                if let Some(default_pin_conf) = self.pin_conf_map.get(pin_name) {
+                    self.apply_pin_configuration(&pin_name, &default_pin_conf)?;
+                }
+            }
+            Ok(())
+        } else {
+            Err(Error::InvalidStrappingName(strapping_name.to_string()).into())
+        }
+    }
+
+    /// Records the default configuration of a pin, possibly partially overriding previous
+    /// configuration.  (E.g. base level configuration files declares a pin as push/pull with a
+    /// low level.  A higher level configuration file (which referred to the former in an
+    /// include directive) then declares a high level without mentioning input/output/open-drain
+    /// mode.  The latter will be processed last, and override just the "level" field, while
+    /// leaving the "pin_mode" field unchanged.
+    fn record_pin_conf(
+        pin_map: &HashMap<String, String>,
+        pin_conf_map: &mut HashMap<String, PinConfiguration>,
+        pin_conf: &conf::PinConfiguration,
+    ) {
+        if let Some(pin_mode) = pin_conf.mode {
+            pin_conf_map
+                .entry(Self::map_name(pin_map, &pin_conf.name))
+                .or_insert(Default::default())
+                .mode = Some(pin_mode);
+        }
+        if let Some(pull_mode) = pin_conf.pull_mode {
+            pin_conf_map
+                .entry(Self::map_name(pin_map, &pin_conf.name))
+                .or_insert(Default::default())
+                .pull_mode = Some(pull_mode);
+        }
+        if let Some(level) = pin_conf.level {
+            pin_conf_map
+                .entry(Self::map_name(pin_map, &pin_conf.name))
+                .or_insert(Default::default())
+                .level = Some(level);
+        }
+    }
+
     pub fn add_configuration_file(&mut self, file: conf::ConfigurationFile) -> Result<()> {
         // Merge content of configuration file into pin_map and other
         // members.
         for pin_conf in file.pins {
-            if let Some(alias_of) = pin_conf.alias_of {
-                self.pin_map.insert(pin_conf.name.to_uppercase(), alias_of);
+            if let Some(alias_of) = &pin_conf.alias_of {
+                self.pin_map
+                    .insert(pin_conf.name.to_uppercase(), alias_of.clone());
             }
-            // TODO(#8769): Apply input / open drain / push pull
-            // configuration to the pin.
+            // Record default input / open drain / push pull configuration to the pin.
+            Self::record_pin_conf(&self.pin_map, &mut self.pin_conf_map, &pin_conf);
+        }
+        for strapping_conf in file.strappings {
+            let mut strapping_pin_map = HashMap::new();
+            for pin_conf in strapping_conf.pins {
+                Self::record_pin_conf(&self.pin_map, &mut strapping_pin_map, &pin_conf);
+            }
+            self.strapping_conf_map
+                .insert(strapping_conf.name.to_uppercase(), strapping_pin_map);
         }
         for uart_conf in file.uarts {
-            if let Some(alias_of) = uart_conf.alias_of {
+            if let Some(alias_of) = &uart_conf.alias_of {
                 self.uart_map
-                    .insert(uart_conf.name.to_uppercase(), alias_of);
+                    .insert(uart_conf.name.to_uppercase(), alias_of.clone());
             }
             // TODO(#8769): Record baud / parity configration for later
             // use when opening uart.

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use serde::Deserialize;
 use std::time::Duration;
 use structopt::clap::arg_enum;
 use thiserror::Error;
@@ -27,7 +28,7 @@ arg_enum! {
     /// The 'Emulator' value indicates that this tool has a direct way
     /// of communicating with the OpenTitan emulator, to replace the
     /// contents of the emulated flash storage.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
     pub enum BootstrapProtocol {
         Primitive,
         Legacy,

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use serde::Deserialize;
 use structopt::clap::arg_enum;
 use thiserror::Error;
 
@@ -12,16 +13,32 @@ pub enum GpioError {
     InvalidPinName(String),
     #[error("Invalid GPIO pin number {0}")]
     InvalidPinNumber(u8),
-    #[error("Invalid GPIO pin direction: {0}")]
-    InvalidPinDirection(u8),
+    /// The current mode of the pin (input) does not support the requested operation (set
+    /// level).
+    #[error("Invalid GPIO mode for pin {0}")]
+    InvalidPinMode(u8),
+    /// The hardware does not support the requested mode (open drain, pull down input, etc.)
+    #[error("Unsupported GPIO mode requested")]
+    UnsupportedPinMode(),
 }
 
 arg_enum! {
-    /// Direction for I/O pins.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub enum PinDirection {
+    /// Mode of I/O pins.
+    #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+    pub enum PinMode {
         Input,
-        Output,
+        PushPull,
+        OpenDrain,
+    }
+}
+
+arg_enum! {
+    /// Mode of weak pull (relevant in Input and OpenDrain modes).
+    #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+    pub enum PullMode {
+        None,
+        PullUp,
+        PullDown,
     }
 }
 
@@ -33,6 +50,9 @@ pub trait GpioPin {
     /// Sets the value of the GPIO pin to `value`.
     fn write(&self, value: bool) -> Result<()>;
 
-    /// Sets the `direction` of the GPIO pin as input or output.
-    fn set_direction(&self, direction: PinDirection) -> Result<()>;
+    /// Sets the mode of the GPIO pin as input, output, or open drain I/O.
+    fn set_mode(&self, mode: PinMode) -> Result<()>;
+
+    /// Sets the weak pull resistors of the GPIO pin.
+    fn set_pull_mode(&self, mode: PullMode) -> Result<()>;
 }

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -5,7 +5,7 @@
 use anyhow::Result;
 use std::rc::Rc;
 
-use crate::io::gpio::{GpioPin, PinDirection};
+use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::transport::hyperdebug::{Error, Hyperdebug, Inner};
 
 pub struct HyperdebugGpioPin {
@@ -43,8 +43,33 @@ impl GpioPin for HyperdebugGpioPin {
         )
     }
 
-    /// Sets the `direction` of GPIO `id` as input or output.
-    fn set_direction(&self, _direction: PinDirection) -> Result<()> {
-        unimplemented!()
+    fn set_mode(&self, mode: PinMode) -> Result<()> {
+        self.inner.execute_command(
+            &format!(
+                "gpiomode {} {}",
+                &self.pinname,
+                match mode {
+                    PinMode::Input => "input",
+                    PinMode::OpenDrain => "opendrain",
+                    PinMode::PushPull => "pushpull",
+                }
+            ),
+            |_| {},
+        )
+    }
+
+    fn set_pull_mode(&self, mode: PullMode) -> Result<()> {
+        self.inner.execute_command(
+            &format!(
+                "gpiopullmode {} {}",
+                &self.pinname,
+                match mode {
+                    PullMode::None => "none",
+                    PullMode::PullUp => "up",
+                    PullMode::PullDown => "down",
+                }
+            ),
+            |_| {},
+        )
     }
 }

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use crate::collection;
-use crate::io::gpio::{GpioError, GpioPin, PinDirection};
+use crate::io::gpio::{GpioError, GpioPin, PinMode, PullMode};
 use crate::transport::ultradebug::mpsse;
 use crate::transport::ultradebug::Ultradebug;
 use crate::util::parse_int::ParseInt;
@@ -83,10 +83,19 @@ impl GpioPin for UltradebugGpioPin {
     }
 
     /// Sets the `direction` of GPIO `id` as input or output.
-    fn set_direction(&self, direction: PinDirection) -> Result<()> {
+    fn set_mode(&self, mode: PinMode) -> Result<()> {
+        let direction = match mode {
+            PinMode::Input => false,
+            PinMode::PushPull => true,
+            PinMode::OpenDrain => return Err(GpioError::UnsupportedPinMode().into()),
+        };
         self.device
             .borrow_mut()
-            .gpio_set_direction(self.pin_id, direction == PinDirection::Output)
+            .gpio_set_direction(self.pin_id, direction)
+    }
+
+    fn set_pull_mode(&self, _mode: PullMode) -> Result<()> {
+        Err(GpioError::UnsupportedPinMode().into())
     }
 }
 

--- a/sw/host/opentitanlib/src/transport/ultradebug/mpsse.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/mpsse.rs
@@ -327,7 +327,7 @@ impl Context {
     pub fn gpio_set(&mut self, pin: u8, high: bool) -> Result<()> {
         let dir = GpioDirection::from_bits(1 << pin).ok_or(GpioError::InvalidPinNumber(pin))?;
         if (dir & self.gpio_direction).bits() == 0 {
-            return Err(GpioError::InvalidPinDirection(pin).into());
+            return Err(GpioError::InvalidPinMode(pin).into());
         }
         if high {
             self.gpio_value |= 1 << pin;

--- a/sw/host/opentitantool/config/opentitan.json
+++ b/sw/host/opentitantool/config/opentitan.json
@@ -1,14 +1,19 @@
 {
-  "strappings": [
+  "pins": [
     {
-      "name": "None",
-      "pins": [
-        {
-          "name": "BOOTSTRAP",
-          "level": false
-        }
-      ]
+      "name": "RESET",
+      "mode": "OpenDrain",
+      "level": true,
+      "pull_mode": "PullUp"
     },
+    {
+      "name": "BOOTSTRAP",
+      "mode": "PushPull",
+      "level": false,
+      "pull_mode": "None"
+    }
+  ],
+  "strappings": [
     {
       "name": "RomBootstrap",
       "pins": [

--- a/sw/host/opentitantool/config/opentitan_ultradebug.json
+++ b/sw/host/opentitantool/config/opentitan_ultradebug.json
@@ -4,16 +4,10 @@
   "pins": [
     {
       "name": "RESET",
-      "mode": "OpenDrain",
-      "level": true,
-      "pullup": true,
       "alias_of": "RESET_B"
     },
     {
-      "name": "BOOTSTRAP",
-      "mode": "PushPull",
-      "level": false,
-      "pullup": false
+      "name": "BOOTSTRAP"
     }
   ],
   "uarts": [


### PR DESCRIPTION
Replace GPIO direction enum (in/out) with a mode enum
(input/push pull/open drain).

Also, introduce functionality in TransportWrapper to iterate over pin
declarations and apply mode and default output level on a set of pins.
This is intended to be used both on a broad set of pins, as well as
multiple named combinations on a smaller set of pins strappings.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>