### PR TITLE
[dv/rstmgr] Fix cascading POR assertion

### DIFF
--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -28,10 +28,8 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
 
     // Clear reset_info register, and enable cpu and alert info capture.
     csr_wr(.ptr(ral.reset_info), .value('1));
-
     set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
 
-    // Send scan reset.
     send_scan_reset();
     // Scan reset triggers an AON reset (and all others).
     wait(cfg.rstmgr_vif.resets_o.rst_por_aon_n == '1);


### PR DESCRIPTION
Allow more flexibility for when the por_aon reset triggers.

Signed-off-by: Guillermo Maturana <maturana@google.com>