### PR TITLE
[csrng/rtl] replace InstanceReq with ReseedReq

### DIFF
--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -175,7 +175,7 @@ module csrng_main_sm import csrng_pkg::*; (
         end else begin
           if (flag0_i) begin
             // assumes all adata is present now
-            state_d = InstantReq;
+            state_d = ReseedReq;
           end else begin
             // delay one clock to fix timing issue
             cmd_entropy_req_o = 1'b1;


### PR DESCRIPTION
It appears that there is a duplication error, since the InstanceReq was being done a ReseedReq in the ReseedReq state of the main csrng state machine.
Fixes #9642.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>