### PR TITLE
[entropy complex/doc] update description for ERR_CODE reg

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -352,7 +352,7 @@
                 This bit will be set to one when an error has been detected for the
                 command stage command FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "1",
@@ -361,7 +361,7 @@
                 This bit will be set to one when an error has been detected for the
                 command stage genbits FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "2",
@@ -370,7 +370,7 @@
                 This bit will be set to one when an error has been detected for the
                 cmdreq FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "3",
@@ -379,7 +379,7 @@
                 This bit will be set to one when an error has been detected for the
                 rcstage FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "4",
@@ -388,7 +388,7 @@
                 This bit will be set to one when an error has been detected for the
                 keyvrc FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "5",
@@ -397,7 +397,7 @@
                 This bit will be set to one when an error has been detected for the
                 updreq FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "6",
@@ -406,7 +406,7 @@
                 This bit will be set to one when an error has been detected for the
                 bencreq FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "7",
@@ -415,7 +415,7 @@
                 This bit will be set to one when an error has been detected for the
                 bencack FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "8",
@@ -424,7 +424,7 @@
                 This bit will be set to one when an error has been detected for the
                 pdata FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "9",
@@ -433,7 +433,7 @@
                 This bit will be set to one when an error has been detected for the
                 final FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "10",
@@ -442,7 +442,7 @@
                 This bit will be set to one when an error has been detected for the
                 gbencack FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "11",
@@ -451,7 +451,7 @@
                 This bit will be set to one when an error has been detected for the
                 grcstage FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "12",
@@ -460,7 +460,7 @@
                 This bit will be set to one when an error has been detected for the
                 ggenreq FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "13",
@@ -469,7 +469,7 @@
                 This bit will be set to one when an error has been detected for the
                 gadstage FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "14",
@@ -478,7 +478,7 @@
                 This bit will be set to one when an error has been detected for the
                 ggenbits FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "15",
@@ -487,7 +487,7 @@
                 This bit will be set to one when an error has been detected for the
                 blkenc FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "20",
@@ -496,7 +496,7 @@
                 This bit will be set to one when an illegal state has been detected for the
                 command stage state machine. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "21",
@@ -505,7 +505,7 @@
                 This bit will be set to one when an illegal state has been detected for the
                 main state machine. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "22",
@@ -514,7 +514,7 @@
                 This bit will be set to one when an illegal state has been detected for the
                 ctr_dbrg gen state machine. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "23",
@@ -523,7 +523,7 @@
                 This bit will be set to one when an illegal state has been detected for the
                 ctr_dbrg update block encode state machine. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "24",
@@ -532,7 +532,7 @@
                 This bit will be set to one when an illegal state has been detected for the
                 ctr_dbrg update out block state machine. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "25",
@@ -541,7 +541,7 @@
                 This bit will be set to one when an AES fatal error has been detected.
                 This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "26",
@@ -551,7 +551,7 @@
                 has been detected.
                 This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "28",
@@ -560,7 +560,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 15 of this
                 this register) are asserted as a result of an error pulse generated from
                 any full FIFO that has been recieved a write pulse.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "29",
@@ -569,7 +569,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 15 of this
                 this register) are asserted as a result of an error pulse generated from
                 any empty FIFO that has recieved a read pulse.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "30",
@@ -578,7 +578,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 15 of this
                 this register) are asserted as a result of an error pulse generated from
                 any FIFO where both the empty and full status bits are set.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
       ]

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -328,7 +328,7 @@
                 This bit will be set to one when an error has been detected for the
                 reseed command FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "1",
@@ -337,7 +337,7 @@
                 This bit will be set to one when an error has been detected for the
                 generate command FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "20",
@@ -345,7 +345,7 @@
           desc: '''
                 This bit will be set to one when an illegal state has been detected for the
                 EDN ack stage state machine. This error will signal a fatal alert.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "21",
@@ -353,7 +353,7 @@
           desc: '''
                 This bit will be set to one when an illegal state has been detected for the
                 EDN main stage state machine. This error will signal a fatal alert.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "22",
@@ -361,7 +361,7 @@
           desc: '''
                 This bit will be set to one when a hardened counter has detected an error
                 condition. This error will signal a fatal alert.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "28",
@@ -370,7 +370,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 1 of this
                 this register) are asserted as a result of an error pulse generated from
                 any full FIFO that has been recieved a write pulse.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "29",
@@ -379,7 +379,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 1 of this
                 this register) are asserted as a result of an error pulse generated from
                 any empty FIFO that has recieved a read pulse.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "30",
@@ -388,7 +388,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 1 of this
                 this register) are asserted as a result of an error pulse generated from
                 any FIFO where both the empty and full status bits are set.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
       ]

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1217,7 +1217,7 @@
                 This bit will be set to one when an error has been detected for the
                 esrng FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "1",
@@ -1226,7 +1226,7 @@
                 This bit will be set to one when an error has been detected for the
                 observe FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "2",
@@ -1235,7 +1235,7 @@
                 This bit will be set to one when an error has been detected for the
                 esfinal FIFO. The type of error is reflected in the type status
                 bits (bits 28 through 30 of this register).
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "20",
@@ -1244,7 +1244,7 @@
                 This bit will be set to one when an illegal state has been detected for the
                 ES ack stage state machine. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "21",
@@ -1253,7 +1253,7 @@
                 This bit will be set to one when an illegal state has been detected for the
                 ES main stage state machine. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "22",
@@ -1262,7 +1262,7 @@
                 This bit will be set to one when a hardened counter has detected an error
                 condition. This error will signal a fatal alert, and also
                 an interrupt if enabled.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "28",
@@ -1271,7 +1271,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 1 of this
                 this register) are asserted as a result of an error pulse generated from
                 any full FIFO that has been recieved a write pulse.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "29",
@@ -1280,7 +1280,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 1 of this
                 this register) are asserted as a result of an error pulse generated from
                 any empty FIFO that has recieved a read pulse.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
         { bits: "30",
@@ -1289,7 +1289,7 @@
                 This bit will be set to one when any of the source bits (bits 0 through 1 of this
                 this register) are asserted as a result of an error pulse generated from
                 any FIFO where both the empty and full status bits are set.
-                This bit will stay set until firmware clears it.
+                This bit will stay set until the next reset.
                 '''
         }
       ]


### PR DESCRIPTION
This test says that the ERR_CODE register can be cleared by firmware, but that function is not possible.
Fixes #9704.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>