### PR TITLE
[edn/rtl] replace parameters with registers

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -163,6 +163,38 @@
         }
       ]
     },
+    { name: "BOOT_INS_CMD",
+      desc: "EDN boot instantiate command register",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [// Internal HW can modify status register
+                "excl:CsrAllTests:CsrExclWrite"]
+      fields: [
+        { bits: "31:0",
+          name: "BOOT_INS_CMD",
+          desc: '''
+                This field is used as the value for Instantiate command at boot time.
+                '''
+         resval: 0x0000_0001
+        }
+      ]
+    },
+    { name: "BOOT_GEN_CMD",
+      desc: "EDN boot generate command register",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [// Internal HW can modify status register
+                "excl:CsrAllTests:CsrExclWrite"]
+      fields: [
+        { bits: "31:0",
+          name: "BOOT_GEN_CMD",
+          desc: '''
+                This field is used as the value for generate command at boot time.
+                '''
+         resval: 0x00ff_f003
+       }
+      ]
+    },
     { name: "SW_CMD_REQ",
       desc: "EDN csrng app command request register",
       swaccess: "wo",

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -11,9 +11,7 @@ module edn
   import edn_reg_pkg::*;
 #(
   parameter int NumEndPoints = 7,
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
-  parameter int BootInsCmd = 32'h0000_0001,
-  parameter int BootGenCmd = 32'h00ff_f003
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -61,9 +59,7 @@ module edn
   );
 
   edn_core #(
-    .NumEndPoints(NumEndPoints),
-    .BootInsCmd(BootInsCmd),
-    .BootGenCmd(BootGenCmd)
+    .NumEndPoints(NumEndPoints)
   ) u_edn_core (
     .clk_i,
     .rst_ni,

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -10,9 +10,7 @@
 
 module edn_core import edn_pkg::*;
 #(
-  parameter int NumEndPoints = 4,
-  parameter int BootInsCmd = 32'h0000_0001,
-  parameter int BootGenCmd = 32'h0000_1003
+  parameter int NumEndPoints = 4
 ) (
   input logic clk_i,
   input logic rst_ni,
@@ -145,6 +143,8 @@ module edn_core import edn_pkg::*;
   logic                               edn_cntr_err;
   logic [RegWidth-1:0]                max_reqs_cnt;
   logic                               max_reqs_cnt_err;
+  logic [31:0]                        boot_ins_cmd;
+  logic [31:0]                        boot_gen_cmd;
 
   // unused
   logic                               unused_err_code_test_bit;
@@ -286,6 +286,9 @@ module edn_core import edn_pkg::*;
   assign hw2reg.err_code.edn_cntr_err.d = 1'b1;
   assign hw2reg.err_code.edn_cntr_err.de = edn_cntr_err_sum;
 
+  assign boot_ins_cmd = reg2hw.boot_ins_cmd.q;
+  assign boot_gen_cmd = reg2hw.boot_gen_cmd.q;
+
 
  // set the err code type bits
   assign hw2reg.err_code.fifo_write_err.d = 1'b1;
@@ -375,7 +378,7 @@ module edn_core import edn_pkg::*;
 
   assign cs_cmd_req_d =
          (!edn_enable) ? '0 :
-         boot_wr_cmd_reg ? BootInsCmd :
+         boot_wr_cmd_reg ? boot_ins_cmd :
          sw_cmd_req_load ? sw_cmd_req_bus :
          cs_cmd_req_q;
 
@@ -480,7 +483,7 @@ module edn_core import edn_pkg::*;
 
   assign sfifo_gencmd_wdata =
          (!edn_enable) ? '0 :
-         boot_wr_cmd_genfifo ? BootGenCmd :
+         boot_wr_cmd_genfifo ? boot_gen_cmd :
          seq_auto_req_mode ? cs_cmd_req_out_q :
          generate_cmd_bus;
 

--- a/hw/ip/edn/rtl/edn_reg_pkg.sv
+++ b/hw/ip/edn/rtl/edn_reg_pkg.sv
@@ -10,7 +10,7 @@ package edn_reg_pkg;
   parameter int NumAlerts = 2;
 
   // Address widths within the block
-  parameter int BlockAw = 6;
+  parameter int BlockAw = 7;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -70,6 +70,14 @@ package edn_reg_pkg;
       logic [3:0]  q;
     } cmd_fifo_rst;
   } edn_reg2hw_ctrl_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } edn_reg2hw_boot_ins_cmd_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } edn_reg2hw_boot_gen_cmd_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -189,11 +197,13 @@ package edn_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    edn_reg2hw_intr_state_reg_t intr_state; // [165:164]
-    edn_reg2hw_intr_enable_reg_t intr_enable; // [163:162]
-    edn_reg2hw_intr_test_reg_t intr_test; // [161:158]
-    edn_reg2hw_alert_test_reg_t alert_test; // [157:154]
-    edn_reg2hw_ctrl_reg_t ctrl; // [153:138]
+    edn_reg2hw_intr_state_reg_t intr_state; // [229:228]
+    edn_reg2hw_intr_enable_reg_t intr_enable; // [227:226]
+    edn_reg2hw_intr_test_reg_t intr_test; // [225:222]
+    edn_reg2hw_alert_test_reg_t alert_test; // [221:218]
+    edn_reg2hw_ctrl_reg_t ctrl; // [217:202]
+    edn_reg2hw_boot_ins_cmd_reg_t boot_ins_cmd; // [201:170]
+    edn_reg2hw_boot_gen_cmd_reg_t boot_gen_cmd; // [169:138]
     edn_reg2hw_sw_cmd_req_reg_t sw_cmd_req; // [137:105]
     edn_reg2hw_reseed_cmd_reg_t reseed_cmd; // [104:72]
     edn_reg2hw_generate_cmd_reg_t generate_cmd; // [71:39]
@@ -211,21 +221,23 @@ package edn_reg_pkg;
   } edn_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] EDN_INTR_STATE_OFFSET = 6'h 0;
-  parameter logic [BlockAw-1:0] EDN_INTR_ENABLE_OFFSET = 6'h 4;
-  parameter logic [BlockAw-1:0] EDN_INTR_TEST_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] EDN_ALERT_TEST_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] EDN_REGWEN_OFFSET = 6'h 10;
-  parameter logic [BlockAw-1:0] EDN_CTRL_OFFSET = 6'h 14;
-  parameter logic [BlockAw-1:0] EDN_SUM_STS_OFFSET = 6'h 18;
-  parameter logic [BlockAw-1:0] EDN_SW_CMD_REQ_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] EDN_SW_CMD_STS_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] EDN_RESEED_CMD_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] EDN_GENERATE_CMD_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_OFFSET = 6'h 2c;
-  parameter logic [BlockAw-1:0] EDN_RECOV_ALERT_STS_OFFSET = 6'h 30;
-  parameter logic [BlockAw-1:0] EDN_ERR_CODE_OFFSET = 6'h 34;
-  parameter logic [BlockAw-1:0] EDN_ERR_CODE_TEST_OFFSET = 6'h 38;
+  parameter logic [BlockAw-1:0] EDN_INTR_STATE_OFFSET = 7'h 0;
+  parameter logic [BlockAw-1:0] EDN_INTR_ENABLE_OFFSET = 7'h 4;
+  parameter logic [BlockAw-1:0] EDN_INTR_TEST_OFFSET = 7'h 8;
+  parameter logic [BlockAw-1:0] EDN_ALERT_TEST_OFFSET = 7'h c;
+  parameter logic [BlockAw-1:0] EDN_REGWEN_OFFSET = 7'h 10;
+  parameter logic [BlockAw-1:0] EDN_CTRL_OFFSET = 7'h 14;
+  parameter logic [BlockAw-1:0] EDN_SUM_STS_OFFSET = 7'h 18;
+  parameter logic [BlockAw-1:0] EDN_BOOT_INS_CMD_OFFSET = 7'h 1c;
+  parameter logic [BlockAw-1:0] EDN_BOOT_GEN_CMD_OFFSET = 7'h 20;
+  parameter logic [BlockAw-1:0] EDN_SW_CMD_REQ_OFFSET = 7'h 24;
+  parameter logic [BlockAw-1:0] EDN_SW_CMD_STS_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] EDN_RESEED_CMD_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] EDN_GENERATE_CMD_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] EDN_RECOV_ALERT_STS_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] EDN_ERR_CODE_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] EDN_ERR_CODE_TEST_OFFSET = 7'h 40;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] EDN_INTR_TEST_RESVAL = 2'h 0;
@@ -247,6 +259,8 @@ package edn_reg_pkg;
     EDN_REGWEN,
     EDN_CTRL,
     EDN_SUM_STS,
+    EDN_BOOT_INS_CMD,
+    EDN_BOOT_GEN_CMD,
     EDN_SW_CMD_REQ,
     EDN_SW_CMD_STS,
     EDN_RESEED_CMD,
@@ -258,7 +272,7 @@ package edn_reg_pkg;
   } edn_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] EDN_PERMIT [15] = '{
+  parameter logic [3:0] EDN_PERMIT [17] = '{
     4'b 0001, // index[ 0] EDN_INTR_STATE
     4'b 0001, // index[ 1] EDN_INTR_ENABLE
     4'b 0001, // index[ 2] EDN_INTR_TEST
@@ -266,14 +280,16 @@ package edn_reg_pkg;
     4'b 0001, // index[ 4] EDN_REGWEN
     4'b 0011, // index[ 5] EDN_CTRL
     4'b 0001, // index[ 6] EDN_SUM_STS
-    4'b 1111, // index[ 7] EDN_SW_CMD_REQ
-    4'b 0001, // index[ 8] EDN_SW_CMD_STS
-    4'b 1111, // index[ 9] EDN_RESEED_CMD
-    4'b 1111, // index[10] EDN_GENERATE_CMD
-    4'b 1111, // index[11] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS
-    4'b 0011, // index[12] EDN_RECOV_ALERT_STS
-    4'b 1111, // index[13] EDN_ERR_CODE
-    4'b 0001  // index[14] EDN_ERR_CODE_TEST
+    4'b 1111, // index[ 7] EDN_BOOT_INS_CMD
+    4'b 1111, // index[ 8] EDN_BOOT_GEN_CMD
+    4'b 1111, // index[ 9] EDN_SW_CMD_REQ
+    4'b 0001, // index[10] EDN_SW_CMD_STS
+    4'b 1111, // index[11] EDN_RESEED_CMD
+    4'b 1111, // index[12] EDN_GENERATE_CMD
+    4'b 1111, // index[13] EDN_MAX_NUM_REQS_BETWEEN_RESEEDS
+    4'b 0011, // index[14] EDN_RECOV_ALERT_STS
+    4'b 1111, // index[15] EDN_ERR_CODE
+    4'b 0001  // index[16] EDN_ERR_CODE_TEST
   };
 
 endpackage


### PR DESCRIPTION
This change preserves the original boot behavior, but allows easier verification when trying other values.
Fixes #9635.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>