### PR TITLE
[mask_rom] Set the alert configuration for RMA OTP.

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -43,6 +43,163 @@
                 {
                     name:  "OWNER_SW_CFG_DIGEST",
                     value: "0x0",
+                },
+                {
+                    name: "ROM_ALERT_CLASS_EN"
+                    // Set the enables to kAlertEnableNone.
+                    // See `alert_enable_t`
+                    // in sw/device/silicon_creator/lib/drivers/alert.h
+                    value: "0xa9a9a9a9",
+                },
+                {
+                    name: "ROM_ALERT_ESCALATION"
+                    // Set the esclation policies to kAlertEscalateNone.
+                    // See `alert_escalate_t`
+                    // in sw/device/silicon_creator/lib/drivers/alert.h
+                    value: "0xd1d1d1d1",
+                },
+                {
+                    name: "ROM_ALERT_CLASSIFICATION"
+                    // Set the classifiactions to kAlertClassX.
+                    // See `alert_class_t`
+                    // in sw/device/silicon_creator/lib/drivers/alert.h
+                    value: [
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                    ],
+                },
+                {
+                    name: "ROM_LOCAL_ALERT_CLASSIFICATION"
+                    // Set the classifiactions to kAlertClassX.
+                    // See `alert_class_t`
+                    // in sw/device/silicon_creator/lib/drivers/alert.h
+                    value: [
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                        "0x94949494",
+                    ],
+                },
+                {
+                    name: "ROM_ALERT_ACCUM_THRESH"
+                    // Set the alert accumulation thresholds to 0 per class.
+                    value: [
+                        "0x00000000",
+                        "0x00000000",
+                        "0x00000000",
+                        "0x00000000",
+                    ],
+                },
+                {
+                    name: "ROM_ALERT_TIMEOUT_CYCLES"
+                    // Set the alert timeout cycles to 0 per class.
+                    value: [
+                        "0x00000000",
+                        "0x00000000",
+                        "0x00000000",
+                        "0x00000000",
+                    ],
+                },
+                {
+                    name: "ROM_ALERT_PHASE_CYCLES"
+                    // Set the alert phase cycles to 0,10,10,0xFFFFFFFF for 
+                    // classes A and B, and to all zeros for classes C and D.
+                    value: [
+                        "0x0", "0xa", "0xa", "0xFFFFFFFF",
+                        "0x0", "0xa", "0xa", "0xFFFFFFFF",
+                        "0x0", "0x0", "0x0", "0x0",
+                        "0x0", "0x0", "0x0", "0x0",
+                    ],
                 }
             ],
         }

--- a/sw/device/tests/otp_ctrl_smoketest.c
+++ b/sw/device/tests/otp_ctrl_smoketest.c
@@ -45,13 +45,13 @@ bool test_main(void) {
 
     otp_ctrl_testutils_wait_for_dai(&otp);
     CHECK_DIF_OK(dif_otp_ctrl_dai_program32(
-                     &otp, kDifOtpCtrlPartitionOwnerSwCfg, 0x100 + i, word),
+                     &otp, kDifOtpCtrlPartitionVendorTest, 0x10 + i, word),
                  "Failed to program word kTestData[%d] = 0x%8x.", i, word);
   }
 
   uint32_t readout[ARRAYSIZE(kTestData) / sizeof(uint32_t)] = {0};
-  CHECK_DIF_OK(dif_otp_ctrl_read_blocking(&otp, kDifOtpCtrlPartitionOwnerSwCfg,
-                                          0x100, readout, ARRAYSIZE(kTestData)),
+  CHECK_DIF_OK(dif_otp_ctrl_read_blocking(&otp, kDifOtpCtrlPartitionVendorTest,
+                                          0x10, readout, ARRAYSIZE(kTestData)),
                "Failed to perform OTP blocking readout.");
 
   CHECK(memcmp(kTestData, readout, ARRAYSIZE(kTestData)) == 0);

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -212,6 +212,26 @@ def permute_bits(bits, permutation):
     return permword
 
 
+def _parse_hex(value):
+    '''Parse a hex value into an integer.
+
+    Args:
+      value: list[str] or str:
+        If a `list[str]`, parse each element as a 32-bit integer.
+        If a `str`, parse as a single hex string.
+    Returns:
+        int
+    '''
+    if isinstance(value, list):
+        result = 0
+        for (i, v) in enumerate(value):
+            result |= int(v, 16) << (i * 32)
+        return result
+    else:
+        value = value.translate(str.maketrans('', '', ' \r\n\t'))
+        return int(value, 16)
+
+
 def random_or_hexvalue(dict_obj, key, num_bits):
     '''Convert hex value at "key" to an integer or draw a random number.'''
 
@@ -225,7 +245,7 @@ def random_or_hexvalue(dict_obj, key, num_bits):
     # Check that the range is correct.
     else:
         try:
-            dict_obj[key] = int(dict_obj[key], 16)
+            dict_obj[key] = _parse_hex(dict_obj[key])
             if dict_obj[key] >= 2**num_bits:
                 raise RuntimeError(
                     'Value "{}" is out of range.'


### PR DESCRIPTION
The Mask ROM fails to boot in verilator because an empty (all zeros)
alert configuration does not correspond to any valid configuration
value, thus resulting in an error such as `kErrorAlertBadEnable`.

This configuration represends no alert configuration: all escalations
disabled and all alerts unclassified.

Signed-off-by: Chris Frantz <cfrantz@google.com>