### PR TITLE
[reggen] Tweak Register's _asdict to satisfy new mypy

### DIFF
--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -529,7 +529,7 @@ class Register(RegBase):
             'hwre': str(self.hwre),
             'tags': self.tags,
             'shadowed': str(self.shadowed),
-        }
+        }  # type: Dict[str, object]
         if self.regwen is not None:
             rd['regwen'] = self.regwen
         if self.update_err_alert is not None:


### PR DESCRIPTION
Mypy 0.920 was released last night and now infers a more precise type
for the "rd" object that we return. Instead of Dict[str, object], it
infers Dict[str, Sequence[object]] (presumably because we happen to
always use a string or a list as a value). Because Dict is not
covariant in the value type, mypy then complains that we're trying to
return rd from the function.

The fix is to explicitly tell mypy what type to infer for rd.

Marking as high priority because this is breaking the quick lint CI pass. This should be safe to merge as soon as quick lint passes (since that's the only thing that looks at the typing annotations).