### PR TITLE
[otbn] Some reformatting changes suggested by verible formatter

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -47,21 +47,21 @@ module otbn
   input prim_ram_1p_pkg::ram_1p_cfg_t ram_cfg_i,
 
   // EDN clock and interface
-  input                                              clk_edn_i,
-  input                                              rst_edn_ni,
-  output edn_pkg::edn_req_t                          edn_rnd_o,
-  input  edn_pkg::edn_rsp_t                          edn_rnd_i,
+  input                     clk_edn_i,
+  input                     rst_edn_ni,
+  output edn_pkg::edn_req_t edn_rnd_o,
+  input  edn_pkg::edn_rsp_t edn_rnd_i,
 
-  output edn_pkg::edn_req_t                          edn_urnd_o,
-  input  edn_pkg::edn_rsp_t                          edn_urnd_i,
+  output edn_pkg::edn_req_t edn_urnd_o,
+  input  edn_pkg::edn_rsp_t edn_urnd_i,
 
   // Key request to OTP (running on clk_fixed)
-  input                                              clk_otp_i,
-  input                                              rst_otp_ni,
-  output otp_ctrl_pkg::otbn_otp_key_req_t            otbn_otp_key_o,
-  input  otp_ctrl_pkg::otbn_otp_key_rsp_t            otbn_otp_key_i,
+  input                                   clk_otp_i,
+  input                                   rst_otp_ni,
+  output otp_ctrl_pkg::otbn_otp_key_req_t otbn_otp_key_o,
+  input  otp_ctrl_pkg::otbn_otp_key_rsp_t otbn_otp_key_i,
 
-  input  keymgr_pkg::otbn_key_req_t                  keymgr_key_i
+  input keymgr_pkg::otbn_key_req_t keymgr_key_i
 );
 
   import prim_util_pkg::vbits;
@@ -86,8 +86,8 @@ module otbn
   localparam int ImemAddrWidth = vbits(ImemSizeByte);
   localparam int DmemAddrWidth = vbits(DmemSizeByte);
 
-  `ASSERT_INIT(ImemSizePowerOfTwo, 2**ImemAddrWidth == ImemSizeByte)
-  `ASSERT_INIT(DmemSizePowerOfTwo, 2**DmemAddrWidth == DmemSizeByte)
+  `ASSERT_INIT(ImemSizePowerOfTwo, 2 ** ImemAddrWidth == ImemSizeByte)
+  `ASSERT_INIT(DmemSizePowerOfTwo, 2 ** DmemAddrWidth == DmemSizeByte)
 
   logic start_d, start_q;
   logic busy_execute_d, busy_execute_q;
@@ -115,8 +115,8 @@ module otbn
     TlWinDmem = 1'b1
   } tl_win_e;
 
-  tlul_pkg::tl_h2d_t tl_win_h2d [2];
-  tlul_pkg::tl_d2h_t tl_win_d2h [2];
+  tlul_pkg::tl_h2d_t tl_win_h2d[2];
+  tlul_pkg::tl_d2h_t tl_win_d2h[2];
 
   // Inter-module signals ======================================================
 
@@ -149,15 +149,15 @@ module otbn
     .Width(1)
   ) u_intr_hw_done (
     .clk_i,
-    .rst_ni                 (rst_n),
-    .event_intr_i           (done),
-    .reg2hw_intr_enable_q_i (reg2hw.intr_enable.q),
-    .reg2hw_intr_test_q_i   (reg2hw.intr_test.q),
-    .reg2hw_intr_test_qe_i  (reg2hw.intr_test.qe),
-    .reg2hw_intr_state_q_i  (reg2hw.intr_state.q),
-    .hw2reg_intr_state_de_o (hw2reg.intr_state.de),
-    .hw2reg_intr_state_d_o  (hw2reg.intr_state.d),
-    .intr_o                 (intr_done_o)
+    .rst_ni                (rst_n),
+    .event_intr_i          (done),
+    .reg2hw_intr_enable_q_i(reg2hw.intr_enable.q),
+    .reg2hw_intr_test_q_i  (reg2hw.intr_test.q),
+    .reg2hw_intr_test_qe_i (reg2hw.intr_test.qe),
+    .reg2hw_intr_state_q_i (reg2hw.intr_state.q),
+    .hw2reg_intr_state_de_o(hw2reg.intr_state.de),
+    .hw2reg_intr_state_d_o (hw2reg.intr_state.d),
+    .intr_o                (intr_done_o)
   );
 
   // Instruction Memory (IMEM) =================================================
@@ -225,8 +225,8 @@ module otbn
   logic                    unused_otbn_dmem_scramble_key_seed_valid;
 
   otbn_scramble_ctrl #(
-    .RndCnstOtbnKey   (RndCnstOtbnKey),
-    .RndCnstOtbnNonce (RndCnstOtbnNonce)
+    .RndCnstOtbnKey  (RndCnstOtbnKey),
+    .RndCnstOtbnNonce(RndCnstOtbnNonce)
   ) u_otbn_scramble_ctrl (
     .clk_i,
     .rst_ni,
@@ -237,33 +237,33 @@ module otbn
     .otbn_otp_key_o,
     .otbn_otp_key_i,
 
-    .otbn_dmem_scramble_key_o            (otbn_dmem_scramble_key           ),
-    .otbn_dmem_scramble_nonce_o          (otbn_dmem_scramble_nonce         ),
-    .otbn_dmem_scramble_valid_o          (otbn_dmem_scramble_valid         ),
-    .otbn_dmem_scramble_key_seed_valid_o (unused_otbn_dmem_scramble_key_seed_valid),
+    .otbn_dmem_scramble_key_o           (otbn_dmem_scramble_key),
+    .otbn_dmem_scramble_nonce_o         (otbn_dmem_scramble_nonce),
+    .otbn_dmem_scramble_valid_o         (otbn_dmem_scramble_valid),
+    .otbn_dmem_scramble_key_seed_valid_o(unused_otbn_dmem_scramble_key_seed_valid),
 
-    .otbn_imem_scramble_key_o            (otbn_imem_scramble_key           ),
-    .otbn_imem_scramble_nonce_o          (otbn_imem_scramble_nonce         ),
-    .otbn_imem_scramble_valid_o          (otbn_imem_scramble_valid         ),
-    .otbn_imem_scramble_key_seed_valid_o (unused_otbn_imem_scramble_key_seed_valid),
+    .otbn_imem_scramble_key_o           (otbn_imem_scramble_key),
+    .otbn_imem_scramble_nonce_o         (otbn_imem_scramble_nonce),
+    .otbn_imem_scramble_valid_o         (otbn_imem_scramble_valid),
+    .otbn_imem_scramble_key_seed_valid_o(unused_otbn_imem_scramble_key_seed_valid),
 
-    .otbn_dmem_scramble_new_req_i (1'b0),
-    .otbn_imem_scramble_new_req_i (1'b0)
+    .otbn_dmem_scramble_new_req_i(1'b0),
+    .otbn_imem_scramble_new_req_i(1'b0)
   );
 
   prim_ram_1p_scr #(
-    .Width           (39),
-    .Depth           (ImemSizeWords),
-    .DataBitsPerMask (39),
-    .EnableParity    (0),
-    .DiffWidth       (39)
+    .Width          (39),
+    .Depth          (ImemSizeWords),
+    .DataBitsPerMask(39),
+    .EnableParity   (0),
+    .DiffWidth      (39)
   ) u_imem (
     .clk_i,
-    .rst_ni      (rst_n),
+    .rst_ni(rst_n),
 
-    .key_valid_i (otbn_imem_scramble_valid),
-    .key_i       (otbn_imem_scramble_key),
-    .nonce_i     (otbn_imem_scramble_nonce),
+    .key_valid_i(otbn_imem_scramble_valid),
+    .key_i      (otbn_imem_scramble_key),
+    .nonce_i    (otbn_imem_scramble_nonce),
 
     .req_i       (imem_req),
     // TODO: OTBN should always get grant when active, wire up grant and add check it occurs,
@@ -275,11 +275,11 @@ module otbn
     .wmask_i     (imem_wmask),
     .intg_error_i(1'b0),
 
-    .rdata_o     (imem_rdata),
-    .rvalid_o    (imem_rvalid),
-    .raddr_o     (),
-    .rerror_o    (),
-    .cfg_i       (ram_cfg_i)
+    .rdata_o (imem_rdata),
+    .rvalid_o(imem_rvalid),
+    .raddr_o (),
+    .rerror_o(),
+    .cfg_i   (ram_cfg_i)
   );
 
   // IMEM access from main TL-UL bus
@@ -289,29 +289,29 @@ module otbn
 
   import prim_mubi_pkg::MuBi4False;
   tlul_adapter_sram #(
-    .SramAw      (ImemIndexWidth),
-    .SramDw      (32),
-    .Outstanding (1),
-    .ByteAccess  (0),
-    .ErrOnRead   (0),
-    .EnableDataIntgPt (1)
+    .SramAw          (ImemIndexWidth),
+    .SramDw          (32),
+    .Outstanding     (1),
+    .ByteAccess      (0),
+    .ErrOnRead       (0),
+    .EnableDataIntgPt(1)
   ) u_tlul_adapter_sram_imem (
     .clk_i,
-    .rst_ni      (rst_n                  ),
-    .tl_i        (tl_win_h2d[TlWinImem]  ),
-    .tl_o        (tl_win_d2h[TlWinImem]  ),
-    .en_ifetch_i (MuBi4False             ),
-    .req_o       (imem_req_bus           ),
-    .req_type_o  (                       ),
-    .gnt_i       (imem_gnt_bus           ),
-    .we_o        (imem_write_bus         ),
-    .addr_o      (imem_index_bus         ),
-    .wdata_o     (imem_wdata_bus         ),
-    .wmask_o     (imem_wmask_bus         ),
+    .rst_ni      (rst_n),
+    .tl_i        (tl_win_h2d[TlWinImem]),
+    .tl_o        (tl_win_d2h[TlWinImem]),
+    .en_ifetch_i (MuBi4False),
+    .req_o       (imem_req_bus),
+    .req_type_o  (),
+    .gnt_i       (imem_gnt_bus),
+    .we_o        (imem_write_bus),
+    .addr_o      (imem_index_bus),
+    .wdata_o     (imem_wdata_bus),
+    .wmask_o     (imem_wmask_bus),
     .intg_error_o(imem_bus_intg_violation),
-    .rdata_i     (imem_rdata_bus         ),
-    .rvalid_i    (imem_rvalid_bus        ),
-    .rerror_i    (imem_rerror_bus        )
+    .rdata_i     (imem_rdata_bus),
+    .rvalid_i    (imem_rvalid_bus),
+    .rerror_i    (imem_rerror_bus)
   );
 
 
@@ -343,17 +343,16 @@ module otbn
   // don't have the corresponding check for writes from the core because the
   // core cannot perform writes (and has no imem_wmask_o port).
   assign imem_wmask = imem_access_core ? '1 : imem_wmask_bus;
-  `ASSERT(ImemWmaskBusIsFullWord_A,
-      imem_req_bus && imem_write_bus |-> imem_wmask_bus == '1)
+  `ASSERT(ImemWmaskBusIsFullWord_A, imem_req_bus && imem_write_bus |-> imem_wmask_bus == '1)
 
   // Explicitly tie off bus interface during core operation to avoid leaking
   // the currently executed instruction from IMEM through the bus
   // unintentionally.
-  assign imem_rdata_bus  = !imem_access_core && !illegal_bus_access_q ? imem_rdata : 39'b0;
+  assign imem_rdata_bus = !imem_access_core && !illegal_bus_access_q ? imem_rdata : 39'b0;
   assign imem_rdata_core = imem_rdata;
 
   // When an illegal bus access is seen, always return a dummy response the follow cycle.
-  assign imem_rvalid_bus  = (~imem_access_core & imem_rvalid) | imem_dummy_response_q;
+  assign imem_rvalid_bus = (~imem_access_core & imem_rvalid) | imem_dummy_response_q;
   assign imem_rvalid_core = imem_access_core ? imem_rvalid : 1'b0;
 
   assign imem_byte_mask_bus = tl_win_h2d[TlWinImem].a_mask;
@@ -414,19 +413,19 @@ module otbn
   assign unused_dmem_addr_core_wordbits = ^dmem_addr_core[DmemAddrWidth-DmemIndexWidth-1:0];
 
   prim_ram_1p_scr #(
-    .Width              (ExtWLEN),
-    .Depth              (DmemSizeWords),
-    .DataBitsPerMask    (39),
-    .EnableParity       (0),
-    .DiffWidth          (39),
-    .ReplicateKeyStream (1)
+    .Width             (ExtWLEN),
+    .Depth             (DmemSizeWords),
+    .DataBitsPerMask   (39),
+    .EnableParity      (0),
+    .DiffWidth         (39),
+    .ReplicateKeyStream(1)
   ) u_dmem (
     .clk_i,
-    .rst_ni      (rst_n),
+    .rst_ni(rst_n),
 
-    .key_valid_i (otbn_dmem_scramble_valid),
-    .key_i       (otbn_dmem_scramble_key),
-    .nonce_i     (otbn_dmem_scramble_nonce),
+    .key_valid_i(otbn_dmem_scramble_valid),
+    .key_i      (otbn_dmem_scramble_key),
+    .nonce_i    (otbn_dmem_scramble_nonce),
 
     .req_i       (dmem_req),
     // TODO: OTBN should always get grant when active, wire up grant and add check it occurs,
@@ -438,11 +437,11 @@ module otbn
     .wmask_i     (dmem_wmask),
     .intg_error_i(1'b0),
 
-    .rdata_o     (dmem_rdata),
-    .rvalid_o    (dmem_rvalid),
-    .raddr_o     (),
-    .rerror_o    (),
-    .cfg_i       (ram_cfg_i)
+    .rdata_o (dmem_rdata),
+    .rvalid_o(dmem_rvalid),
+    .raddr_o (),
+    .rerror_o(),
+    .cfg_i   (ram_cfg_i)
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -462,10 +461,10 @@ module otbn
     // have functionality for only integrity checking, just fully integrated ECC. Integrity bits are
     // implemented on a 32-bit granule so separate checks are required for each.
     prim_secded_inv_39_32_dec u_dmem_intg_check (
-      .data_i     (dmem_rdata[i_word*39 +: 39]),
-      .data_o     (),
-      .syndrome_o (),
-      .err_o      (dmem_rerror_raw)
+      .data_i    (dmem_rdata[i_word*39+:39]),
+      .data_o    (),
+      .syndrome_o(),
+      .err_o     (dmem_rerror_raw)
     );
 
     // Only report an error where the word was actually accessed. Otherwise uninitialised memory
@@ -486,35 +485,35 @@ module otbn
   assign dmem_gnt_bus = dmem_req_bus;
 
   tlul_adapter_sram #(
-    .SramAw      (DmemIndexWidth - 1),
-    .SramDw      (WLEN),
-    .Outstanding (1),
-    .ByteAccess  (0),
-    .ErrOnRead   (0),
-    .EnableDataIntgPt (1)
+    .SramAw          (DmemIndexWidth - 1),
+    .SramDw          (WLEN),
+    .Outstanding     (1),
+    .ByteAccess      (0),
+    .ErrOnRead       (0),
+    .EnableDataIntgPt(1)
   ) u_tlul_adapter_sram_dmem (
     .clk_i,
-    .rst_ni      (rst_n                  ),
-    .tl_i        (tl_win_h2d[TlWinDmem]  ),
-    .tl_o        (tl_win_d2h[TlWinDmem]  ),
-    .en_ifetch_i (MuBi4False             ),
-    .req_o       (dmem_req_bus           ),
-    .req_type_o  (                       ),
-    .gnt_i       (dmem_gnt_bus           ),
-    .we_o        (dmem_write_bus         ),
-    .addr_o      (dmem_index_bus         ),
-    .wdata_o     (dmem_wdata_bus         ),
-    .wmask_o     (dmem_wmask_bus         ),
+    .rst_ni      (rst_n),
+    .tl_i        (tl_win_h2d[TlWinDmem]),
+    .tl_o        (tl_win_d2h[TlWinDmem]),
+    .en_ifetch_i (MuBi4False),
+    .req_o       (dmem_req_bus),
+    .req_type_o  (),
+    .gnt_i       (dmem_gnt_bus),
+    .we_o        (dmem_write_bus),
+    .addr_o      (dmem_index_bus),
+    .wdata_o     (dmem_wdata_bus),
+    .wmask_o     (dmem_wmask_bus),
     .intg_error_o(dmem_bus_intg_violation),
-    .rdata_i     (dmem_rdata_bus         ),
-    .rvalid_i    (dmem_rvalid_bus        ),
-    .rerror_i    (dmem_rerror_bus        )
+    .rdata_i     (dmem_rdata_bus),
+    .rvalid_i    (dmem_rvalid_bus),
+    .rerror_i    (dmem_rerror_bus)
   );
 
   // Mux core and bus access into dmem
   assign dmem_access_core = busy_execute_q;
 
-  assign dmem_req   = dmem_access_core ? dmem_req_core   : dmem_req_bus;
+  assign dmem_req = dmem_access_core ? dmem_req_core : dmem_req_bus;
   assign dmem_write = dmem_access_core ? dmem_write_core : dmem_write_bus;
   assign dmem_wmask = dmem_access_core ? dmem_wmask_core : dmem_wmask_bus;
   assign dmem_index = dmem_access_core ? dmem_index_core : {1'b0, dmem_index_bus};
@@ -573,19 +572,19 @@ module otbn
   prim_crc32 #(
     .BytesPerWord(6)
   ) u_mem_load_crc32 (
-    .clk_i       (clk_i                ),
-    .rst_ni      (rst_ni               ),
+    .clk_i (clk_i),
+    .rst_ni(rst_ni),
 
-    .set_crc_i   (set_crc              ),
-    .crc_in_i    (crc_in               ),
+    .set_crc_i(set_crc),
+    .crc_in_i (crc_in),
 
     .data_valid_i(mem_crc_data_in_valid),
-    .data_i      (mem_crc_data_in      ),
-    .crc_out_o   (crc_out              )
+    .data_i      (mem_crc_data_in),
+    .crc_out_o   (crc_out)
   );
 
   assign set_crc = reg2hw.load_checksum.qe;
-  assign crc_in  = reg2hw.load_checksum.q;
+  assign crc_in = reg2hw.load_checksum.q;
   assign hw2reg.load_checksum.d = crc_out;
 
   // Registers =================================================================
@@ -594,11 +593,11 @@ module otbn
 
   otbn_reg_top u_reg (
     .clk_i,
-    .rst_ni (rst_n),
+    .rst_ni  (rst_n),
     .tl_i,
     .tl_o,
-    .tl_win_o (tl_win_h2d),
-    .tl_win_i (tl_win_d2h),
+    .tl_win_o(tl_win_h2d),
+    .tl_win_i(tl_win_d2h),
 
     .reg2hw,
     .hw2reg,
@@ -709,21 +708,21 @@ module otbn
   // FATAL_ALERT_CAUSE register. The .de and .d values are equal for each bit, so that it can only
   // be set, not cleared.
   assign hw2reg.fatal_alert_cause.imem_intg_violation.de = insn_fetch_err;
-  assign hw2reg.fatal_alert_cause.imem_intg_violation.d  = insn_fetch_err;
+  assign hw2reg.fatal_alert_cause.imem_intg_violation.d = insn_fetch_err;
   assign hw2reg.fatal_alert_cause.dmem_intg_violation.de = dmem_rerror;
-  assign hw2reg.fatal_alert_cause.dmem_intg_violation.d  = dmem_rerror;
+  assign hw2reg.fatal_alert_cause.dmem_intg_violation.d = dmem_rerror;
   assign hw2reg.fatal_alert_cause.reg_intg_violation.de = reg_intg_violation;
-  assign hw2reg.fatal_alert_cause.reg_intg_violation.d  = reg_intg_violation;
+  assign hw2reg.fatal_alert_cause.reg_intg_violation.d = reg_intg_violation;
   assign hw2reg.fatal_alert_cause.bus_intg_violation.de = bus_intg_violation;
-  assign hw2reg.fatal_alert_cause.bus_intg_violation.d  = bus_intg_violation;
+  assign hw2reg.fatal_alert_cause.bus_intg_violation.d = bus_intg_violation;
   assign hw2reg.fatal_alert_cause.bad_internal_state.de = 0;
-  assign hw2reg.fatal_alert_cause.bad_internal_state.d  = 0;
+  assign hw2reg.fatal_alert_cause.bad_internal_state.d = 0;
   assign hw2reg.fatal_alert_cause.illegal_bus_access.de = illegal_bus_access_d;
-  assign hw2reg.fatal_alert_cause.illegal_bus_access.d  = illegal_bus_access_d;
+  assign hw2reg.fatal_alert_cause.illegal_bus_access.d = illegal_bus_access_d;
   assign hw2reg.fatal_alert_cause.lifecycle_escalation.de = lifecycle_escalation;
-  assign hw2reg.fatal_alert_cause.lifecycle_escalation.d  = lifecycle_escalation;
+  assign hw2reg.fatal_alert_cause.lifecycle_escalation.d = lifecycle_escalation;
   assign hw2reg.fatal_alert_cause.fatal_software.de = done;
-  assign hw2reg.fatal_alert_cause.fatal_software.d  = err_bits_d.fatal_software;
+  assign hw2reg.fatal_alert_cause.fatal_software.d = err_bits_d.fatal_software;
 
   // INSN_CNT register
   logic [31:0] insn_cnt;
@@ -737,10 +736,8 @@ module otbn
   // Alerts ====================================================================
 
   logic [NumAlerts-1:0] alert_test;
-  assign alert_test[AlertFatal] = reg2hw.alert_test.fatal.q &
-                                  reg2hw.alert_test.fatal.qe;
-  assign alert_test[AlertRecov] = reg2hw.alert_test.recov.q &
-                                  reg2hw.alert_test.recov.qe;
+  assign alert_test[AlertFatal] = reg2hw.alert_test.fatal.q & reg2hw.alert_test.fatal.qe;
+  assign alert_test[AlertRecov] = reg2hw.alert_test.recov.q & reg2hw.alert_test.recov.qe;
 
   logic [NumAlerts-1:0] alerts;
   assign alerts[AlertFatal] = insn_fetch_err       |
@@ -753,19 +750,19 @@ module otbn
 
   assign alerts[AlertRecov] = recoverable_err & done;
 
-  for (genvar i = 0; i < NumAlerts; i++) begin: gen_alert_tx
+  for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(
       .AsyncOn(AlertAsyncOn[i]),
       .IsFatal(i == AlertFatal)
     ) u_prim_alert_sender (
       .clk_i,
-      .rst_ni        ( rst_n         ),
-      .alert_test_i  ( alert_test[i] ),
-      .alert_req_i   ( alerts[i]     ),
-      .alert_ack_o   (               ),
-      .alert_state_o (               ),
-      .alert_rx_i    ( alert_rx_i[i] ),
-      .alert_tx_o    ( alert_tx_o[i] )
+      .rst_ni       (rst_n),
+      .alert_test_i (alert_test[i]),
+      .alert_req_i  (alerts[i]),
+      .alert_ack_o  (),
+      .alert_state_o(),
+      .alert_rx_i   (alert_rx_i[i]),
+      .alert_tx_o   (alert_tx_o[i])
     );
   end
 
@@ -1048,9 +1045,9 @@ module otbn
   // "status.q" (a signal that isn't directly accessible here).
   `ASSERT(LockedInsnCntReadsZero_A, (hw2reg.status.d == StatusLocked) |=> insn_cnt == 'd0)
   `ASSERT(NonIdleImemReadsZero_A,
-      (hw2reg.status.d != StatusIdle) & imem_rvalid_bus |-> imem_rdata_bus == 'd0)
+          (hw2reg.status.d != StatusIdle) & imem_rvalid_bus |-> imem_rdata_bus == 'd0)
   `ASSERT(NonIdleDmemReadsZero_A,
-      (hw2reg.status.d != StatusIdle) & dmem_rvalid_bus |-> dmem_rdata_bus == 'd0)
+          (hw2reg.status.d != StatusIdle) & dmem_rvalid_bus |-> dmem_rdata_bus == 'd0)
 
   // Constraint from package, check here as we cannot have `ASSERT_INIT in package
   `ASSERT_INIT(WsrESizeMatchesParameter_A, $bits(wsr_e) == WsrNumWidth)

--- a/hw/ip/otbn/rtl/otbn_alu_base.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_base.sv
@@ -13,14 +13,14 @@ module otbn_alu_base
   import otbn_pkg::*;
 (
   // Block is combinatorial; clk/rst are for assertions only.
-  input  logic                 clk_i,
-  input  logic                 rst_ni,
+  input logic clk_i,
+  input logic rst_ni,
 
-  input  alu_base_operation_t  operation_i,
-  input  alu_base_comparison_t comparison_i,
+  input alu_base_operation_t  operation_i,
+  input alu_base_comparison_t comparison_i,
 
-  output logic [31:0]          operation_result_o,
-  output logic                 comparison_result_o
+  output logic [31:0] operation_result_o,
+  output logic        comparison_result_o
 );
 
   logic [32:0] adder_op_a, adder_op_b;
@@ -32,7 +32,7 @@ module otbn_alu_base
   logic [31:0] xor_result;
   logic [31:0] not_result;
 
-  logic  is_equal;
+  logic        is_equal;
 
   ///////////
   // Adder //
@@ -64,12 +64,12 @@ module otbn_alu_base
   /////////////
 
   logic [32:0] shift_in;
-  logic [4:0]  shift_amt;
+  logic [ 4:0] shift_amt;
   logic [31:0] operand_a_reverse;
   logic [32:0] shift_out;
   logic [31:0] shift_out_reverse;
 
-  for (genvar i = 0;i < 32; i++) begin : g_shifter_reverses
+  for (genvar i = 0; i < 32; i++) begin : g_shifter_reverses
     assign operand_a_reverse[i] = operation_i.operand_a[31-i];
     assign shift_out_reverse[i] = shift_out[31-i];
   end
@@ -132,6 +132,6 @@ module otbn_alu_base
   logic unused_clk;
   logic unused_rst_n;
 
-  assign unused_clk = clk_i;
+  assign unused_clk   = clk_i;
   assign unused_rst_n = rst_ni;
 endmodule

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -121,9 +121,8 @@ module otbn_alu_bignum
 
   assign ispr_update_flags_en = ispr_base_wr_en_i[0] & (ispr_addr_i == IsprFlags);
 
-  `ASSERT(UpdateFlagsOnehot,
-          $onehot0({ispr_init_i, adder_update_flags_en, logic_update_flags_en, mac_update_flags_en,
-                    ispr_update_flags_en}))
+  `ASSERT(UpdateFlagsOnehot, $onehot0({ispr_init_i, adder_update_flags_en, logic_update_flags_en,
+                                       mac_update_flags_en, ispr_update_flags_en}))
 
   assign selected_flags = flags_q[operation_i.flag_group];
 
@@ -142,7 +141,7 @@ module otbn_alu_bignum
 
     assign is_operation_flag_group[i_fg] = operation_i.flag_group == i_fg;
 
-    assign flags_flattened[i_fg * FlagsWidth +: FlagsWidth] = flags_q[i_fg];
+    assign flags_flattened[i_fg*FlagsWidth+:FlagsWidth] = flags_q[i_fg];
 
     // Flag updates can come from the Y adder result, the logical operation result or from an ISPR
     // write.
@@ -154,7 +153,7 @@ module otbn_alu_bignum
         adder_update_flags_en: flags_d[i_fg] = adder_update_flags;
         logic_update_flags_en: flags_d[i_fg] = logic_update_flags;
         mac_update_flags_en:   flags_d[i_fg] = mac_update_flags;
-        ispr_update_flags_en:  flags_d[i_fg] = ispr_base_wdata_i[i_fg * FlagsWidth +: FlagsWidth];
+        ispr_update_flags_en:  flags_d[i_fg] = ispr_base_wdata_i[i_fg*FlagsWidth+:FlagsWidth];
         default: ;
       endcase
     end
@@ -182,13 +181,13 @@ module otbn_alu_bignum
 
     always_comb begin
 
-      unique case(1'b1)
+      unique case (1'b1)
         sec_wipe_mod_urnd_i: mod_d[i_word*32+:32] = urnd_data_i[i_word*32+:32];
         sec_wipe_zero_i:     mod_d[i_word*32+:32] = 32'd0;
         default:             mod_d[i_word*32+:32] = ispr_bignum_wdata_i[i_word*32+:32];
       endcase
 
-    `ASSERT(ModSecWipeSelOneHot, $onehot0({sec_wipe_mod_urnd_i, sec_wipe_zero_i}))
+      `ASSERT(ModSecWipeSelOneHot, $onehot0({sec_wipe_mod_urnd_i, sec_wipe_zero_i}))
 
       unique case (1'b1)
         ispr_init_i:               mod_d[i_word*32+:32] = '0;
@@ -240,16 +239,15 @@ module otbn_alu_bignum
   assign shifter_in_lower = operation_i.operand_b;
 
   for (genvar i = 0; i < WLEN; i++) begin : g_shifter_in_lower_reverse
-    assign shifter_in_lower_reverse[i] = shifter_in_lower[WLEN - i - 1];
+    assign shifter_in_lower_reverse[i] = shifter_in_lower[WLEN-i-1];
   end
 
-  assign shifter_in = {shifter_in_upper, shift_right ? shifter_in_lower :
-                                                       shifter_in_lower_reverse};
+  assign shifter_in = {shifter_in_upper, shift_right ? shifter_in_lower : shifter_in_lower_reverse};
 
   assign shifter_out = shifter_in >> operation_i.shift_amt;
 
   for (genvar i = 0; i < WLEN; i++) begin : g_shifter_out_lower_reverse
-    assign shifter_out_lower_reverse[i] = shifter_out[WLEN - i - 1];
+    assign shifter_out_lower_reverse[i] = shifter_out[WLEN-i-1];
   end
 
   assign shifter_res = shift_right ? shifter_out[WLEN-1:0] : shifter_out_lower_reverse;
@@ -422,7 +420,7 @@ module otbn_alu_bignum
       AluOpBignumOr:  logical_res = operation_i.operand_a | shifter_res;
       AluOpBignumAnd: logical_res = operation_i.operand_a & shifter_res;
       AluOpBignumNot: logical_res = ~shifter_res;
-      default:;
+      default: ;
     endcase
   end
 

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -20,13 +20,13 @@ module otbn_controller
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
 ) (
-  input  logic  clk_i,
-  input  logic  rst_ni,
+  input logic clk_i,
+  input logic rst_ni,
 
-  input  logic  start_i, // start the processing at address zero
-  output logic  locked_o, // OTBN in locked state and must be reset to perform any further actions
+  input  logic start_i,  // start the processing at address zero
+  output logic locked_o, // OTBN in locked state and must be reset to perform any further actions
 
-  output err_bits_t err_bits_o, // valid when done_o is asserted
+  output err_bits_t err_bits_o,           // valid when done_o is asserted
   output logic      recoverable_err_o,
   output logic      reg_intg_violation_o,
 
@@ -38,14 +38,14 @@ module otbn_controller
   input  logic                     insn_fetch_err_i,
 
   // Fetched/decoded instruction
-  input  logic                     insn_valid_i,
-  input  logic                     insn_illegal_i,
-  input  logic [ImemAddrWidth-1:0] insn_addr_i,
+  input logic                     insn_valid_i,
+  input logic                     insn_illegal_i,
+  input logic [ImemAddrWidth-1:0] insn_addr_i,
 
   // Decoded instruction data
-  input insn_dec_base_t       insn_dec_base_i,
-  input insn_dec_bignum_t     insn_dec_bignum_i,
-  input insn_dec_shared_t     insn_dec_shared_i,
+  input insn_dec_base_t   insn_dec_base_i,
+  input insn_dec_bignum_t insn_dec_bignum_i,
+  input insn_dec_shared_t insn_dec_shared_i,
 
   // Base register file
   output logic [4:0]               rf_base_wr_addr_o,
@@ -63,8 +63,8 @@ module otbn_controller
   input  logic [BaseIntgWidth-1:0] rf_base_rd_data_b_intg_i,
   output logic                     rf_base_rd_commit_o,
 
-  input  logic         rf_base_call_stack_err_i,
-  input  logic         rf_base_rd_data_err_i,
+  input logic rf_base_call_stack_err_i,
+  input logic rf_base_rd_data_err_i,
 
   // Bignum register file (WDRs)
   output logic [4:0]         rf_bignum_wr_addr_o,
@@ -81,7 +81,7 @@ module otbn_controller
   output logic               rf_bignum_rd_en_b_o,
   input  logic [ExtWLEN-1:0] rf_bignum_rd_data_b_intg_i,
 
-  input  logic               rf_bignum_rd_data_err_i,
+  input logic rf_bignum_rd_data_err_i,
 
   // Execution units
 
@@ -139,7 +139,7 @@ module otbn_controller
   input  logic        lifecycle_escalation_i,
   input  logic        software_errs_fatal_i,
 
-  input  logic [1:0]  sideload_key_shares_valid_i,
+  input logic [1:0] sideload_key_shares_valid_i,
 
   // Prefetch stage control
   output logic                     prefetch_en_o,
@@ -331,7 +331,7 @@ module otbn_controller
           if (stall) begin
             // When stalling don't request a new fetch and don't clear response either to keep
             // current instruction.
-            state_d               = OtbnStateStall;
+            state_d                  = OtbnStateStall;
             insn_fetch_req_valid_raw = 1'b0;
             insn_fetch_resp_clear_o  = 1'b0;
           end else begin
@@ -467,7 +467,7 @@ module otbn_controller
 
   assign reg_intg_violation_o = err_bits.reg_intg_violation;
 
-  if (SecWipeEn) begin: gen_sec_wipe
+  if (SecWipeEn) begin : gen_sec_wipe
     err_bits_t err_bits_d, err_bits_q;
     logic      recoverable_err_d, recoverable_err_q;
 
@@ -486,8 +486,7 @@ module otbn_controller
       end
     end
 
-  end
-  else begin: gen_bypass_sec_wipe
+  end else begin : gen_bypass_sec_wipe
     logic unused_err_bits_en;
 
     assign unused_err_bits_en = err_bits_en;
@@ -504,8 +503,8 @@ module otbn_controller
   `ASSERT(ErrSetOnFatalErr, fatal_err |-> err)
   `ASSERT(SoftwareErrIfNonInsnAddrSoftwareErr, non_insn_addr_software_err |-> software_err)
 
-  `ASSERT(ControllerStateValid, state_q inside {OtbnStateHalt, OtbnStateRun,
-                                                OtbnStateStall, OtbnStateLocked})
+  `ASSERT(ControllerStateValid,
+          state_q inside {OtbnStateHalt, OtbnStateRun, OtbnStateStall, OtbnStateLocked})
   // Branch only takes effect in OtbnStateRun so must not go into stall state for branch
   // instructions.
   `ASSERT(NoStallOnBranch,
@@ -549,23 +548,23 @@ module otbn_controller
     .clk_i,
     .rst_ni,
 
-    .state_reset_i       (loop_reset),
+    .state_reset_i(loop_reset),
 
     .insn_valid_i,
     .insn_addr_i,
-    .next_insn_addr_i    (next_insn_addr),
+    .next_insn_addr_i(next_insn_addr),
 
-    .loop_start_req_i    (loop_start_req),
-    .loop_start_commit_i (loop_start_commit),
-    .loop_bodysize_i     (loop_bodysize),
-    .loop_iterations_i   (loop_iterations),
+    .loop_start_req_i   (loop_start_req),
+    .loop_start_commit_i(loop_start_commit),
+    .loop_bodysize_i    (loop_bodysize),
+    .loop_iterations_i  (loop_iterations),
 
-    .loop_jump_o         (loop_jump),
-    .loop_jump_addr_o    (loop_jump_addr),
-    .loop_err_o          (loop_err),
+    .loop_jump_o     (loop_jump),
+    .loop_jump_addr_o(loop_jump_addr),
+    .loop_err_o      (loop_err),
 
-    .jump_or_branch_i    (jump_or_branch),
-    .otbn_stall_i        (stall),
+    .jump_or_branch_i(jump_or_branch),
+    .otbn_stall_i    (stall),
 
     .prefetch_loop_active_o,
     .prefetch_loop_iterations_o,
@@ -752,8 +751,8 @@ module otbn_controller
   end
 
   for (genvar i = 0; i < BaseWordsPerWLEN; ++i) begin : g_rf_bignum_rd_data
-    assign rf_bignum_rd_data_a_no_intg[i * 32 +: 32] = rf_bignum_rd_data_a_intg_i[i * 39 +: 32];
-    assign rf_bignum_rd_data_b_no_intg[i * 32 +: 32] = rf_bignum_rd_data_b_intg_i[i * 39 +: 32];
+    assign rf_bignum_rd_data_a_no_intg[i*32+:32] = rf_bignum_rd_data_a_intg_i[i*39+:32];
+    assign rf_bignum_rd_data_b_no_intg[i*32+:32] = rf_bignum_rd_data_b_intg_i[i*39+:32];
   end
 
   assign rf_bignum_rd_addr_a_o = insn_dec_bignum_i.rf_a_indirect ? rf_base_rd_data_a_no_intg[4:0] :
@@ -916,7 +915,7 @@ module otbn_controller
     csr_illegal_addr    = 1'b0;
 
     unique case (csr_addr)
-      CsrFlags, CsrFg0, CsrFg1 : begin
+      CsrFlags, CsrFg0, CsrFg1: begin
         ispr_addr_base      = IsprFlags;
         ispr_word_addr_base = '0;
       end

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -20,24 +20,24 @@ module otbn_core
   // Size of the data memory, in bytes
   parameter int DmemSizeByte = 4096,
   // Enable internal secure wipe
-  parameter bit SecWipeEn  = 1'b0,
+  parameter bit SecWipeEn = 1'b0,
 
   // Default seed for URND PRNG
-  parameter urnd_prng_seed_t       RndCnstUrndPrngSeed      = RndCnstUrndPrngSeedDefault,
+  parameter urnd_prng_seed_t RndCnstUrndPrngSeed = RndCnstUrndPrngSeedDefault,
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
-)(
-  input  logic  clk_i,
-  input  logic  rst_ni,
+) (
+  input logic clk_i,
+  input logic rst_ni,
 
-  input  logic  start_i, // start the operation
-  output logic  done_o,  // operation done
-  output logic  locked_o, // otbn locked, reset required to perform further commands
+  input  logic start_i,  // start the operation
+  output logic done_o,   // operation done
+  output logic locked_o, // otbn locked, reset required to perform further commands
 
-  output err_bits_t err_bits_o, // valid when done_o is asserted
-  output logic  recoverable_err_o,
-  output logic  reg_intg_violation_o,
+  output err_bits_t err_bits_o,  // valid when done_o is asserted
+  output logic recoverable_err_o,
+  output logic reg_intg_violation_o,
 
   // Instruction memory (IMEM)
   output logic                     imem_req_o,
@@ -45,7 +45,7 @@ module otbn_core
   input  logic [38:0]              imem_rdata_i,
   input  logic                     imem_rvalid_i,
 
-  output logic                     insn_fetch_err_o,
+  output logic insn_fetch_err_o,
 
   // Data memory (DMEM)
   output logic                        dmem_req_o,
@@ -68,24 +68,24 @@ module otbn_core
   input  logic                    edn_urnd_ack_i,
   input  logic [EdnDataWidth-1:0] edn_urnd_data_i,
 
-  output logic [31:0]             insn_cnt_o,
-  input  logic                    insn_cnt_clear_i,
+  output logic [31:0] insn_cnt_o,
+  input  logic        insn_cnt_clear_i,
 
   // An integrity check on an incoming bus transaction failed. Results in a fatal error.
-  input  logic                    bus_intg_violation_i,
+  input logic bus_intg_violation_i,
 
   // Asserted by system when bus tries to access OTBN memories whilst OTBN is active. Results in a
   // fatal error.
-  input  logic                    illegal_bus_access_i,
+  input logic illegal_bus_access_i,
 
   // Indicates an incoming escalation from the life cycle manager. Results in a fatal error.
-  input  logic                    lifecycle_escalation_i,
+  input logic lifecycle_escalation_i,
 
   // When set software errors become fatal errors.
-  input  logic                    software_errs_fatal_i,
+  input logic software_errs_fatal_i,
 
-  input  logic [1:0]                       sideload_key_shares_valid_i,
-  input  logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i
+  input logic [1:0]                       sideload_key_shares_valid_i,
+  input logic [1:0][SideloadKeyWidth-1:0] sideload_key_shares_i
 );
   // Fetch request (the next instruction)
   logic [ImemAddrWidth-1:0] insn_fetch_req_addr;
@@ -224,28 +224,28 @@ module otbn_core
 
     .start_i,
 
-    .controller_start_o (controller_start),
+    .controller_start_o(controller_start),
 
-    .urnd_reseed_req_o  (urnd_reseed_req),
-    .urnd_reseed_busy_i (urnd_reseed_busy),
-    .urnd_advance_o     (urnd_advance),
+    .urnd_reseed_req_o (urnd_reseed_req),
+    .urnd_reseed_busy_i(urnd_reseed_busy),
+    .urnd_advance_o    (urnd_advance),
 
-    .start_secure_wipe_i (start_secure_wipe),
-    .secure_wipe_running_o (secure_wipe_running),
+    .start_secure_wipe_i  (start_secure_wipe),
+    .secure_wipe_running_o(secure_wipe_running),
     .done_o,
 
-    .sec_wipe_wdr_o (sec_wipe_wdr),
+    .sec_wipe_wdr_o      (sec_wipe_wdr),
     .sec_wipe_wdr_urnd_o (sec_wipe_wdr_urnd),
-    .sec_wipe_base_o (sec_wipe_base),
-    .sec_wipe_base_urnd_o (sec_wipe_base_urnd),
-    .sec_wipe_addr_o (sec_wipe_addr),
+    .sec_wipe_base_o     (sec_wipe_base),
+    .sec_wipe_base_urnd_o(sec_wipe_base_urnd),
+    .sec_wipe_addr_o     (sec_wipe_addr),
 
-    .sec_wipe_acc_urnd_o (sec_wipe_acc_urnd),
-    .sec_wipe_mod_urnd_o (sec_wipe_mod_urnd),
-    .sec_wipe_zero_o (sec_wipe_zero),
+    .sec_wipe_acc_urnd_o(sec_wipe_acc_urnd),
+    .sec_wipe_mod_urnd_o(sec_wipe_mod_urnd),
+    .sec_wipe_zero_o    (sec_wipe_zero),
 
-    .ispr_init_o   (ispr_init),
-    .state_reset_o (state_reset)
+    .ispr_init_o  (ispr_init),
+    .state_reset_o(state_reset)
   );
 
   // Depending on its usage, the instruction address (program counter) is qualified by two valid
@@ -268,21 +268,21 @@ module otbn_core
     .imem_rvalid_i,
 
     // Instruction to fetch
-    .insn_fetch_req_addr_i  (insn_fetch_req_addr),
-    .insn_fetch_req_valid_i (insn_fetch_req_valid),
+    .insn_fetch_req_addr_i (insn_fetch_req_addr),
+    .insn_fetch_req_valid_i(insn_fetch_req_valid),
 
     // Fetched instruction
-    .insn_fetch_resp_addr_o  (insn_fetch_resp_addr),
-    .insn_fetch_resp_valid_o (insn_fetch_resp_valid),
-    .insn_fetch_resp_data_o  (insn_fetch_resp_data),
-    .insn_fetch_resp_clear_i (insn_fetch_resp_clear),
-    .insn_fetch_err_o        (insn_fetch_err),
+    .insn_fetch_resp_addr_o (insn_fetch_resp_addr),
+    .insn_fetch_resp_valid_o(insn_fetch_resp_valid),
+    .insn_fetch_resp_data_o (insn_fetch_resp_data),
+    .insn_fetch_resp_clear_i(insn_fetch_resp_clear),
+    .insn_fetch_err_o       (insn_fetch_err),
 
-    .prefetch_en_i              (prefetch_en),
-    .prefetch_loop_active_i     (prefetch_loop_active),
-    .prefetch_loop_iterations_i (prefetch_loop_iterations),
-    .prefetch_loop_end_addr_i   (prefetch_loop_end_addr),
-    .prefetch_loop_jump_addr_i  (prefetch_loop_jump_addr)
+    .prefetch_en_i             (prefetch_en),
+    .prefetch_loop_active_i    (prefetch_loop_active),
+    .prefetch_loop_iterations_i(prefetch_loop_iterations),
+    .prefetch_loop_end_addr_i  (prefetch_loop_end_addr),
+    .prefetch_loop_jump_addr_i (prefetch_loop_jump_addr)
   );
 
   assign insn_fetch_err_o = insn_fetch_err;
@@ -294,15 +294,15 @@ module otbn_core
     .rst_ni,
 
     // Instruction to decode
-    .insn_fetch_resp_data_i  (insn_fetch_resp_data),
-    .insn_fetch_resp_valid_i (insn_fetch_resp_valid),
+    .insn_fetch_resp_data_i (insn_fetch_resp_data),
+    .insn_fetch_resp_valid_i(insn_fetch_resp_valid),
 
     // Decoded instruction
-    .insn_valid_o      (insn_valid),
-    .insn_illegal_o    (insn_illegal),
-    .insn_dec_base_o   (insn_dec_base),
-    .insn_dec_bignum_o (insn_dec_bignum),
-    .insn_dec_shared_o (insn_dec_shared)
+    .insn_valid_o     (insn_valid),
+    .insn_illegal_o   (insn_illegal),
+    .insn_dec_base_o  (insn_dec_base),
+    .insn_dec_bignum_o(insn_dec_bignum),
+    .insn_dec_shared_o(insn_dec_shared)
   );
 
   // Controller: coordinate between functional units, prepare their inputs (e.g. by muxing between
@@ -315,7 +315,7 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
-    .start_i (controller_start),
+    .start_i(controller_start),
     .locked_o,
 
     .err_bits_o,
@@ -323,101 +323,101 @@ module otbn_core
     .reg_intg_violation_o,
 
     // Next instruction selection (to instruction fetch)
-    .insn_fetch_req_addr_o   (insn_fetch_req_addr),
-    .insn_fetch_req_valid_o  (insn_fetch_req_valid),
-    .insn_fetch_resp_clear_o (insn_fetch_resp_clear),
+    .insn_fetch_req_addr_o  (insn_fetch_req_addr),
+    .insn_fetch_req_valid_o (insn_fetch_req_valid),
+    .insn_fetch_resp_clear_o(insn_fetch_resp_clear),
     // Error from fetch requested last cycle
     .insn_fetch_err_i       (insn_fetch_err),
 
     // The current instruction
-    .insn_valid_i   (insn_valid),
-    .insn_illegal_i (insn_illegal),
-    .insn_addr_i    (insn_addr),
+    .insn_valid_i  (insn_valid),
+    .insn_illegal_i(insn_illegal),
+    .insn_addr_i   (insn_addr),
 
     // Decoded instruction from decoder
-    .insn_dec_base_i   (insn_dec_base),
-    .insn_dec_bignum_i (insn_dec_bignum),
-    .insn_dec_shared_i (insn_dec_shared),
+    .insn_dec_base_i  (insn_dec_base),
+    .insn_dec_bignum_i(insn_dec_bignum),
+    .insn_dec_shared_i(insn_dec_shared),
 
     // To/from base register file
-    .rf_base_wr_addr_o          (rf_base_wr_addr_ctrl),
-    .rf_base_wr_en_o            (rf_base_wr_en_ctrl),
-    .rf_base_wr_commit_o        (rf_base_wr_commit_ctrl),
-    .rf_base_wr_data_no_intg_o  (rf_base_wr_data_no_intg_ctrl),
-    .rf_base_wr_data_intg_o     (rf_base_wr_data_intg),
-    .rf_base_wr_data_intg_sel_o (rf_base_wr_data_intg_sel),
-    .rf_base_rd_addr_a_o        (rf_base_rd_addr_a),
-    .rf_base_rd_en_a_o          (rf_base_rd_en_a),
-    .rf_base_rd_data_a_intg_i   (rf_base_rd_data_a_intg),
-    .rf_base_rd_addr_b_o        (rf_base_rd_addr_b),
-    .rf_base_rd_en_b_o          (rf_base_rd_en_b),
-    .rf_base_rd_data_b_intg_i   (rf_base_rd_data_b_intg),
-    .rf_base_rd_commit_o        (rf_base_rd_commit),
-    .rf_base_call_stack_err_i   (rf_base_call_stack_err),
-    .rf_base_rd_data_err_i      (rf_base_rd_data_err),
+    .rf_base_wr_addr_o         (rf_base_wr_addr_ctrl),
+    .rf_base_wr_en_o           (rf_base_wr_en_ctrl),
+    .rf_base_wr_commit_o       (rf_base_wr_commit_ctrl),
+    .rf_base_wr_data_no_intg_o (rf_base_wr_data_no_intg_ctrl),
+    .rf_base_wr_data_intg_o    (rf_base_wr_data_intg),
+    .rf_base_wr_data_intg_sel_o(rf_base_wr_data_intg_sel),
+    .rf_base_rd_addr_a_o       (rf_base_rd_addr_a),
+    .rf_base_rd_en_a_o         (rf_base_rd_en_a),
+    .rf_base_rd_data_a_intg_i  (rf_base_rd_data_a_intg),
+    .rf_base_rd_addr_b_o       (rf_base_rd_addr_b),
+    .rf_base_rd_en_b_o         (rf_base_rd_en_b),
+    .rf_base_rd_data_b_intg_i  (rf_base_rd_data_b_intg),
+    .rf_base_rd_commit_o       (rf_base_rd_commit),
+    .rf_base_call_stack_err_i  (rf_base_call_stack_err),
+    .rf_base_rd_data_err_i     (rf_base_rd_data_err),
 
     // To/from bignunm register file
-    .rf_bignum_wr_addr_o          (rf_bignum_wr_addr_ctrl),
-    .rf_bignum_wr_en_o            (rf_bignum_wr_en_ctrl),
-    .rf_bignum_wr_data_no_intg_o  (rf_bignum_wr_data_no_intg_ctrl),
-    .rf_bignum_wr_data_intg_o     (rf_bignum_wr_data_intg),
-    .rf_bignum_wr_data_intg_sel_o (rf_bignum_wr_data_intg_sel),
-    .rf_bignum_rd_addr_a_o        (rf_bignum_rd_addr_a),
-    .rf_bignum_rd_en_a_o          (rf_bignum_rd_en_a),
-    .rf_bignum_rd_data_a_intg_i   (rf_bignum_rd_data_a_intg),
-    .rf_bignum_rd_addr_b_o        (rf_bignum_rd_addr_b),
-    .rf_bignum_rd_en_b_o          (rf_bignum_rd_en_b),
-    .rf_bignum_rd_data_b_intg_i   (rf_bignum_rd_data_b_intg),
-    .rf_bignum_rd_data_err_i      (rf_bignum_rd_data_err),
+    .rf_bignum_wr_addr_o         (rf_bignum_wr_addr_ctrl),
+    .rf_bignum_wr_en_o           (rf_bignum_wr_en_ctrl),
+    .rf_bignum_wr_data_no_intg_o (rf_bignum_wr_data_no_intg_ctrl),
+    .rf_bignum_wr_data_intg_o    (rf_bignum_wr_data_intg),
+    .rf_bignum_wr_data_intg_sel_o(rf_bignum_wr_data_intg_sel),
+    .rf_bignum_rd_addr_a_o       (rf_bignum_rd_addr_a),
+    .rf_bignum_rd_en_a_o         (rf_bignum_rd_en_a),
+    .rf_bignum_rd_data_a_intg_i  (rf_bignum_rd_data_a_intg),
+    .rf_bignum_rd_addr_b_o       (rf_bignum_rd_addr_b),
+    .rf_bignum_rd_en_b_o         (rf_bignum_rd_en_b),
+    .rf_bignum_rd_data_b_intg_i  (rf_bignum_rd_data_b_intg),
+    .rf_bignum_rd_data_err_i     (rf_bignum_rd_data_err),
 
     // To/from base ALU
-    .alu_base_operation_o         (alu_base_operation),
-    .alu_base_comparison_o        (alu_base_comparison),
-    .alu_base_operation_result_i  (alu_base_operation_result),
-    .alu_base_comparison_result_i (alu_base_comparison_result),
+    .alu_base_operation_o        (alu_base_operation),
+    .alu_base_comparison_o       (alu_base_comparison),
+    .alu_base_operation_result_i (alu_base_operation_result),
+    .alu_base_comparison_result_i(alu_base_comparison_result),
 
     // To/from bignum ALU
-    .alu_bignum_operation_o         (alu_bignum_operation),
-    .alu_bignum_operation_result_i  (alu_bignum_operation_result),
-    .alu_bignum_selection_flag_i    (alu_bignum_selection_flag),
+    .alu_bignum_operation_o       (alu_bignum_operation),
+    .alu_bignum_operation_result_i(alu_bignum_operation_result),
+    .alu_bignum_selection_flag_i  (alu_bignum_selection_flag),
 
     // To/from bignum MAC
-    .mac_bignum_operation_o        (mac_bignum_operation),
-    .mac_bignum_operation_result_i (mac_bignum_operation_result),
-    .mac_bignum_en_o               (mac_bignum_en),
+    .mac_bignum_operation_o       (mac_bignum_operation),
+    .mac_bignum_operation_result_i(mac_bignum_operation_result),
+    .mac_bignum_en_o              (mac_bignum_en),
 
     // To/from LSU (base and bignum)
-    .lsu_load_req_o     (lsu_load_req),
-    .lsu_store_req_o    (lsu_store_req),
-    .lsu_req_subset_o   (lsu_req_subset),
-    .lsu_addr_o         (lsu_addr),
+    .lsu_load_req_o  (lsu_load_req),
+    .lsu_store_req_o (lsu_store_req),
+    .lsu_req_subset_o(lsu_req_subset),
+    .lsu_addr_o      (lsu_addr),
 
-    .lsu_base_wdata_o   (lsu_base_wdata),
-    .lsu_bignum_wdata_o (lsu_bignum_wdata),
+    .lsu_base_wdata_o  (lsu_base_wdata),
+    .lsu_bignum_wdata_o(lsu_bignum_wdata),
 
-    .lsu_base_rdata_i   (lsu_base_rdata),
-    .lsu_bignum_rdata_i (lsu_bignum_rdata),
-    .lsu_rdata_err_i    (lsu_rdata_err),
+    .lsu_base_rdata_i  (lsu_base_rdata),
+    .lsu_bignum_rdata_i(lsu_bignum_rdata),
+    .lsu_rdata_err_i   (lsu_rdata_err),
 
     // Isprs read/write (base and bignum)
-    .ispr_addr_o         (ispr_addr),
-    .ispr_base_wdata_o   (ispr_base_wdata),
-    .ispr_base_wr_en_o   (ispr_base_wr_en),
-    .ispr_bignum_wdata_o (ispr_bignum_wdata),
-    .ispr_bignum_wr_en_o (ispr_bignum_wr_en),
-    .ispr_rdata_i        (ispr_rdata),
+    .ispr_addr_o        (ispr_addr),
+    .ispr_base_wdata_o  (ispr_base_wdata),
+    .ispr_base_wr_en_o  (ispr_base_wr_en),
+    .ispr_bignum_wdata_o(ispr_bignum_wdata),
+    .ispr_bignum_wr_en_o(ispr_bignum_wr_en),
+    .ispr_rdata_i       (ispr_rdata),
 
-    .rnd_req_o          (rnd_req),
-    .rnd_prefetch_req_o (rnd_prefetch_req),
-    .rnd_valid_i        (rnd_valid),
+    .rnd_req_o         (rnd_req),
+    .rnd_prefetch_req_o(rnd_prefetch_req),
+    .rnd_valid_i       (rnd_valid),
 
     // Secure wipe
-    .secure_wipe_running_i (secure_wipe_running),
-    .start_secure_wipe_o (start_secure_wipe),
-    .sec_wipe_zero_i (sec_wipe_zero),
+    .secure_wipe_running_i(secure_wipe_running),
+    .start_secure_wipe_o  (start_secure_wipe),
+    .sec_wipe_zero_i      (sec_wipe_zero),
 
-    .state_reset_i      (state_reset),
-    .insn_cnt_o         (insn_cnt),
+    .state_reset_i(state_reset),
+    .insn_cnt_o   (insn_cnt),
     .insn_cnt_clear_i,
     .bus_intg_violation_i,
     .illegal_bus_access_i,
@@ -426,11 +426,11 @@ module otbn_core
 
     .sideload_key_shares_valid_i,
 
-    .prefetch_en_o              (prefetch_en),
-    .prefetch_loop_active_o     (prefetch_loop_active),
-    .prefetch_loop_iterations_o (prefetch_loop_iterations),
-    .prefetch_loop_end_addr_o   (prefetch_loop_end_addr),
-    .prefetch_loop_jump_addr_o  (prefetch_loop_jump_addr)
+    .prefetch_en_o             (prefetch_en),
+    .prefetch_loop_active_o    (prefetch_loop_active),
+    .prefetch_loop_iterations_o(prefetch_loop_iterations),
+    .prefetch_loop_end_addr_o  (prefetch_loop_end_addr),
+    .prefetch_loop_jump_addr_o (prefetch_loop_jump_addr)
   );
 
   `ASSERT(InsnDataStableInStall, u_otbn_controller.state_q == OtbnStateStall |->
@@ -454,47 +454,47 @@ module otbn_core
     .dmem_rvalid_i,
     .dmem_rerror_i,
 
-    .lsu_load_req_i     (lsu_load_req),
-    .lsu_store_req_i    (lsu_store_req),
-    .lsu_req_subset_i   (lsu_req_subset),
-    .lsu_addr_i         (lsu_addr),
+    .lsu_load_req_i  (lsu_load_req),
+    .lsu_store_req_i (lsu_store_req),
+    .lsu_req_subset_i(lsu_req_subset),
+    .lsu_addr_i      (lsu_addr),
 
-    .lsu_base_wdata_i   (lsu_base_wdata),
-    .lsu_bignum_wdata_i (lsu_bignum_wdata),
+    .lsu_base_wdata_i  (lsu_base_wdata),
+    .lsu_bignum_wdata_i(lsu_bignum_wdata),
 
-    .lsu_base_rdata_o   (lsu_base_rdata),
-    .lsu_bignum_rdata_o (lsu_bignum_rdata),
-    .lsu_rdata_err_o    (lsu_rdata_err)
+    .lsu_base_rdata_o  (lsu_base_rdata),
+    .lsu_bignum_rdata_o(lsu_bignum_rdata),
+    .lsu_rdata_err_o   (lsu_rdata_err)
   );
 
   // Base Instruction Subset =======================================================================
 
   otbn_rf_base #(
-    .RegFile (RegFile)
+    .RegFile(RegFile)
   ) u_otbn_rf_base (
     .clk_i,
     .rst_ni,
 
-    .state_reset_i (state_reset),
-    .sec_wipe_stack_reset_i (sec_wipe_zero),
+    .state_reset_i         (state_reset),
+    .sec_wipe_stack_reset_i(sec_wipe_zero),
 
-    .wr_addr_i          (rf_base_wr_addr),
-    .wr_en_i            (rf_base_wr_en),
-    .wr_data_no_intg_i  (rf_base_wr_data_no_intg),
-    .wr_data_intg_i     (rf_base_wr_data_intg),
-    .wr_data_intg_sel_i (rf_base_wr_data_intg_sel),
-    .wr_commit_i        (rf_base_wr_commit),
+    .wr_addr_i         (rf_base_wr_addr),
+    .wr_en_i           (rf_base_wr_en),
+    .wr_data_no_intg_i (rf_base_wr_data_no_intg),
+    .wr_data_intg_i    (rf_base_wr_data_intg),
+    .wr_data_intg_sel_i(rf_base_wr_data_intg_sel),
+    .wr_commit_i       (rf_base_wr_commit),
 
-    .rd_addr_a_i      (rf_base_rd_addr_a),
-    .rd_en_a_i        (rf_base_rd_en_a),
-    .rd_data_a_intg_o (rf_base_rd_data_a_intg),
-    .rd_addr_b_i      (rf_base_rd_addr_b),
-    .rd_en_b_i        (rf_base_rd_en_b),
-    .rd_data_b_intg_o (rf_base_rd_data_b_intg),
-    .rd_commit_i      (rf_base_rd_commit),
+    .rd_addr_a_i     (rf_base_rd_addr_a),
+    .rd_en_a_i       (rf_base_rd_en_a),
+    .rd_data_a_intg_o(rf_base_rd_data_a_intg),
+    .rd_addr_b_i     (rf_base_rd_addr_b),
+    .rd_en_b_i       (rf_base_rd_en_b),
+    .rd_data_b_intg_o(rf_base_rd_data_b_intg),
+    .rd_commit_i     (rf_base_rd_commit),
 
-    .call_stack_err_o (rf_base_call_stack_err),
-    .rd_data_err_o    (rf_base_rd_data_err)
+    .call_stack_err_o(rf_base_call_stack_err),
+    .rd_data_err_o   (rf_base_rd_data_err)
   );
 
   assign rf_base_wr_addr         = sec_wipe_base ? sec_wipe_addr : rf_base_wr_addr_ctrl;
@@ -519,32 +519,32 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
-    .operation_i         (alu_base_operation),
-    .comparison_i        (alu_base_comparison),
-    .operation_result_o  (alu_base_operation_result),
-    .comparison_result_o (alu_base_comparison_result)
+    .operation_i        (alu_base_operation),
+    .comparison_i       (alu_base_comparison),
+    .operation_result_o (alu_base_operation_result),
+    .comparison_result_o(alu_base_comparison_result)
   );
 
   otbn_rf_bignum #(
-    .RegFile (RegFile)
+    .RegFile(RegFile)
   ) u_otbn_rf_bignum (
     .clk_i,
     .rst_ni,
 
-    .wr_addr_i          (rf_bignum_wr_addr),
-    .wr_en_i            (rf_bignum_wr_en),
-    .wr_data_no_intg_i  (rf_bignum_wr_data_no_intg),
-    .wr_data_intg_i     (rf_bignum_wr_data_intg),
-    .wr_data_intg_sel_i (rf_bignum_wr_data_intg_sel),
+    .wr_addr_i         (rf_bignum_wr_addr),
+    .wr_en_i           (rf_bignum_wr_en),
+    .wr_data_no_intg_i (rf_bignum_wr_data_no_intg),
+    .wr_data_intg_i    (rf_bignum_wr_data_intg),
+    .wr_data_intg_sel_i(rf_bignum_wr_data_intg_sel),
 
-    .rd_addr_a_i      (rf_bignum_rd_addr_a),
-    .rd_en_a_i        (rf_bignum_rd_en_a),
-    .rd_data_a_intg_o (rf_bignum_rd_data_a_intg),
-    .rd_addr_b_i      (rf_bignum_rd_addr_b),
-    .rd_en_b_i        (rf_bignum_rd_en_b),
-    .rd_data_b_intg_o (rf_bignum_rd_data_b_intg),
+    .rd_addr_a_i     (rf_bignum_rd_addr_a),
+    .rd_en_a_i       (rf_bignum_rd_en_a),
+    .rd_data_a_intg_o(rf_bignum_rd_data_a_intg),
+    .rd_addr_b_i     (rf_bignum_rd_addr_b),
+    .rd_en_b_i       (rf_bignum_rd_en_b),
+    .rd_data_b_intg_o(rf_bignum_rd_data_b_intg),
 
-    .rd_data_err_o (rf_bignum_rd_data_err)
+    .rd_data_err_o(rf_bignum_rd_data_err)
   );
 
   assign rf_bignum_wr_addr         = sec_wipe_wdr ? sec_wipe_addr : rf_bignum_wr_addr_ctrl;
@@ -568,30 +568,30 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
-    .operation_i              (alu_bignum_operation),
-    .operation_result_o       (alu_bignum_operation_result),
-    .selection_flag_o         (alu_bignum_selection_flag),
+    .operation_i       (alu_bignum_operation),
+    .operation_result_o(alu_bignum_operation_result),
+    .selection_flag_o  (alu_bignum_selection_flag),
 
-    .ispr_addr_i              (ispr_addr),
-    .ispr_base_wdata_i        (ispr_base_wdata),
-    .ispr_base_wr_en_i        (ispr_base_wr_en),
-    .ispr_bignum_wdata_i      (ispr_bignum_wdata),
-    .ispr_bignum_wr_en_i      (ispr_bignum_wr_en),
-    .ispr_init_i              (ispr_init),
-    .ispr_rdata_o             (ispr_rdata),
+    .ispr_addr_i        (ispr_addr),
+    .ispr_base_wdata_i  (ispr_base_wdata),
+    .ispr_base_wr_en_i  (ispr_base_wr_en),
+    .ispr_bignum_wdata_i(ispr_bignum_wdata),
+    .ispr_bignum_wr_en_i(ispr_bignum_wr_en),
+    .ispr_init_i        (ispr_init),
+    .ispr_rdata_o       (ispr_rdata),
 
-    .ispr_acc_i               (ispr_acc),
-    .ispr_acc_wr_data_o       (ispr_acc_wr_data),
-    .ispr_acc_wr_en_o         (ispr_acc_wr_en),
+    .ispr_acc_i        (ispr_acc),
+    .ispr_acc_wr_data_o(ispr_acc_wr_data),
+    .ispr_acc_wr_en_o  (ispr_acc_wr_en),
 
-    .sec_wipe_mod_urnd_i      (sec_wipe_mod_urnd),
-    .sec_wipe_zero_i          (sec_wipe_zero),
+    .sec_wipe_mod_urnd_i(sec_wipe_mod_urnd),
+    .sec_wipe_zero_i    (sec_wipe_zero),
 
-    .mac_operation_flags_i    (mac_bignum_operation_flags),
-    .mac_operation_flags_en_i (mac_bignum_operation_flags_en),
+    .mac_operation_flags_i   (mac_bignum_operation_flags),
+    .mac_operation_flags_en_i(mac_bignum_operation_flags_en),
 
-    .rnd_data_i               (rnd_data),
-    .urnd_data_i              (urnd_data),
+    .rnd_data_i (rnd_data),
+    .urnd_data_i(urnd_data),
 
     .sideload_key_shares_i
   );
@@ -600,37 +600,37 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
-    .operation_i          (mac_bignum_operation),
-    .operation_result_o   (mac_bignum_operation_result),
-    .operation_flags_o    (mac_bignum_operation_flags),
-    .operation_flags_en_o (mac_bignum_operation_flags_en),
+    .operation_i         (mac_bignum_operation),
+    .operation_result_o  (mac_bignum_operation_result),
+    .operation_flags_o   (mac_bignum_operation_flags),
+    .operation_flags_en_o(mac_bignum_operation_flags_en),
 
-    .urnd_data_i (urnd_data),
-    .sec_wipe_acc_urnd_i (sec_wipe_acc_urnd),
-    .sec_wipe_zero_i (sec_wipe_zero),
+    .urnd_data_i        (urnd_data),
+    .sec_wipe_acc_urnd_i(sec_wipe_acc_urnd),
+    .sec_wipe_zero_i    (sec_wipe_zero),
 
-    .mac_en_i           (mac_bignum_en),
+    .mac_en_i(mac_bignum_en),
 
-    .ispr_acc_o         (ispr_acc),
-    .ispr_acc_wr_data_i (ispr_acc_wr_data),
-    .ispr_acc_wr_en_i   (ispr_acc_wr_en)
+    .ispr_acc_o        (ispr_acc),
+    .ispr_acc_wr_data_i(ispr_acc_wr_data),
+    .ispr_acc_wr_en_i  (ispr_acc_wr_en)
   );
 
   otbn_rnd #(
-    .RndCnstUrndPrngSeed      (RndCnstUrndPrngSeed)
+    .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed)
   ) u_otbn_rnd (
     .clk_i,
     .rst_ni,
 
-    .rnd_req_i          (rnd_req),
-    .rnd_prefetch_req_i (rnd_prefetch_req),
-    .rnd_valid_o        (rnd_valid),
-    .rnd_data_o         (rnd_data),
+    .rnd_req_i         (rnd_req),
+    .rnd_prefetch_req_i(rnd_prefetch_req),
+    .rnd_valid_o       (rnd_valid),
+    .rnd_data_o        (rnd_data),
 
-    .urnd_reseed_req_i  (urnd_reseed_req),
-    .urnd_reseed_busy_o (urnd_reseed_busy),
-    .urnd_advance_i     (urnd_advance),
-    .urnd_data_o        (urnd_data),
+    .urnd_reseed_req_i (urnd_reseed_req),
+    .urnd_reseed_busy_o(urnd_reseed_busy),
+    .urnd_advance_i    (urnd_advance),
+    .urnd_data_o       (urnd_data),
 
     .edn_rnd_req_o,
     .edn_rnd_ack_i,
@@ -661,7 +661,7 @@ module otbn_core
   `ASSERT(EdnUrndReqStable_A, edn_urnd_req_o & ~edn_urnd_ack_i |=> edn_urnd_req_o)
 
   `ASSERT(OnlyWriteLoadDataBaseWhenDMemValid_A,
-    rf_bignum_wr_en_ctrl & insn_dec_bignum.rf_wdata_sel == RfWdSelLsu |-> dmem_rvalid_i)
+          rf_bignum_wr_en_ctrl & insn_dec_bignum.rf_wdata_sel == RfWdSelLsu |-> dmem_rvalid_i)
   `ASSERT(OnlyWriteLoadDataBignumWhenDMemValid_A,
-    rf_base_wr_en_ctrl & insn_dec_base.rf_wdata_sel == RfWdSelLsu |-> dmem_rvalid_i)
+          rf_base_wr_en_ctrl & insn_dec_base.rf_wdata_sel == RfWdSelLsu |-> dmem_rvalid_i)
 endmodule

--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -11,20 +11,20 @@ module otbn_decoder
   import otbn_pkg::*;
 (
   // For assertions only.
-  input  logic                 clk_i,
-  input  logic                 rst_ni,
+  input logic clk_i,
+  input logic rst_ni,
 
   // instruction data to be decoded
-  input  logic [31:0]          insn_fetch_resp_data_i,
-  input  logic                 insn_fetch_resp_valid_i,
+  input logic [31:0] insn_fetch_resp_data_i,
+  input logic        insn_fetch_resp_valid_i,
 
   // Decoded instruction
-  output logic                 insn_valid_o,
-  output logic                 insn_illegal_o,
+  output logic insn_valid_o,
+  output logic insn_illegal_o,
 
-  output insn_dec_base_t       insn_dec_base_o,
-  output insn_dec_bignum_t     insn_dec_bignum_o,
-  output insn_dec_shared_t     insn_dec_shared_o
+  output insn_dec_base_t   insn_dec_base_o,
+  output insn_dec_bignum_t insn_dec_bignum_o,
+  output insn_dec_shared_t insn_dec_shared_o
 );
 
   logic        illegal_insn;
@@ -95,15 +95,15 @@ module otbn_decoder
   logic rf_d_indirect_bignum;
 
   // immediate extraction and sign extension
-  assign imm_i_type_base = { {20{insn[31]}}, insn[31:20] };
-  assign imm_s_type_base = { {20{insn[31]}}, insn[31:25], insn[11:7] };
-  assign imm_b_type_base = { {19{insn[31]}}, insn[31], insn[7], insn[30:25], insn[11:8], 1'b0 };
-  assign imm_u_type_base = { insn[31:12], 12'b0 };
-  assign imm_j_type_base = { {12{insn[31]}}, insn[19:12], insn[20], insn[30:21], 1'b0 };
+  assign imm_i_type_base = {{20{insn[31]}}, insn[31:20]};
+  assign imm_s_type_base = {{20{insn[31]}}, insn[31:25], insn[11:7]};
+  assign imm_b_type_base = {{19{insn[31]}}, insn[31], insn[7], insn[30:25], insn[11:8], 1'b0};
+  assign imm_u_type_base = {insn[31:12], 12'b0};
+  assign imm_j_type_base = {{12{insn[31]}}, insn[19:12], insn[20], insn[30:21], 1'b0};
   // l type immediate is for the loop count in the LOOPI instruction and is not from the RISC-V ISA
-  assign imm_l_type_base = { 22'b0, insn[19:15], insn[11:7] };
+  assign imm_l_type_base = {22'b0, insn[19:15], insn[11:7]};
   // x type immediate is for BN.LID/BN.SID instructions and is not from the RISC-V ISA
-  assign imm_x_type_base = { {17{insn[11]}}, insn[11:9], insn[31:25], 5'b0 };
+  assign imm_x_type_base = {{17{insn[11]}}, insn[11:9], insn[31:25], 5'b0};
 
   logic [WLEN-1:0] imm_i_type_bignum;
 
@@ -177,14 +177,14 @@ module otbn_decoder
   logic [31:0] imm_b_base;
   always_comb begin : immediate_b_mux
     unique case (imm_b_mux_sel_base)
-      ImmBaseBI:   imm_b_base = imm_i_type_base;
-      ImmBaseBS:   imm_b_base = imm_s_type_base;
-      ImmBaseBU:   imm_b_base = imm_u_type_base;
-      ImmBaseBB:   imm_b_base = imm_b_type_base;
-      ImmBaseBJ:   imm_b_base = imm_j_type_base;
-      ImmBaseBL:   imm_b_base = imm_l_type_base;
-      ImmBaseBX:   imm_b_base = imm_x_type_base;
-      default:     imm_b_base = imm_i_type_base;
+      ImmBaseBI: imm_b_base = imm_i_type_base;
+      ImmBaseBS: imm_b_base = imm_s_type_base;
+      ImmBaseBU: imm_b_base = imm_u_type_base;
+      ImmBaseBB: imm_b_base = imm_b_type_base;
+      ImmBaseBJ: imm_b_base = imm_j_type_base;
+      ImmBaseBL: imm_b_base = imm_l_type_base;
+      ImmBaseBX: imm_b_base = imm_x_type_base;
+      default:   imm_b_base = imm_i_type_base;
     endcase
   end
 
@@ -314,14 +314,14 @@ module otbn_decoder
       //////////////
 
       InsnOpcodeBaseLui: begin  // Load Upper Immediate
-        insn_subset      = InsnSubsetBase;
-        rf_we_base       = 1'b1;
+        insn_subset = InsnSubsetBase;
+        rf_we_base  = 1'b1;
       end
 
-      InsnOpcodeBaseOpImm: begin // Register-Immediate ALU Operations
-        insn_subset      = InsnSubsetBase;
-        rf_ren_a_base    = 1'b1;
-        rf_we_base       = 1'b1;
+      InsnOpcodeBaseOpImm: begin  // Register-Immediate ALU Operations
+        insn_subset   = InsnSubsetBase;
+        rf_ren_a_base = 1'b1;
+        rf_we_base    = 1'b1;
 
         unique case (insn[14:12])
           3'b000,  // addi
@@ -332,7 +332,7 @@ module otbn_decoder
 
           3'b001: begin
             unique case (insn[31:25])
-              7'b0000000: illegal_insn = 1'b0;   // slli
+              7'b0000000: illegal_insn = 1'b0;  // slli
               default: illegal_insn = 1'b1;
             endcase
           end
@@ -351,10 +351,10 @@ module otbn_decoder
       end
 
       InsnOpcodeBaseOp: begin  // Register-Register ALU operation
-        insn_subset     = InsnSubsetBase;
-        rf_ren_a_base   = 1'b1;
-        rf_ren_b_base   = 1'b1;
-        rf_we_base      = 1'b1;
+        insn_subset   = InsnSubsetBase;
+        rf_ren_a_base = 1'b1;
+        rf_ren_b_base = 1'b1;
+        rf_we_base    = 1'b1;
         // Look at the funct7 and funct3 fields.
         unique case ({insn[31:25], insn[14:12]})
           {7'b000_0000, 3'b000},  // ADD
@@ -464,7 +464,7 @@ module otbn_decoder
             // No read if destination is x0
             ispr_rd_insn = insn_rd != 5'b0;
             ispr_wr_insn = 1'b1;
-          end else if(insn[14:12] == 3'b010) begin
+          end else if (insn[14:12] == 3'b010) begin
             // Read and set if source register isn't x0, otherwise read only
             if (insn_rs1 != 5'b0) begin
               ispr_rs_insn = 1'b1;
@@ -504,18 +504,18 @@ module otbn_decoder
 
       InsnOpcodeBignumBaseMisc: begin
         unique case (insn[14:12])
-          3'b000, 3'b001: begin // LOOP[I]
+          3'b000, 3'b001: begin  // LOOP[I]
             insn_subset   = InsnSubsetBase;
             rf_ren_a_base = ~insn[12];
             loop_insn     = 1'b1;
           end
-          3'b010, 3'b011, 3'b100, 3'b110, 3'b111: begin // BN.RHSI/BN.AND/BN.OR/BN.XOR
+          3'b010, 3'b011, 3'b100, 3'b110, 3'b111: begin  // BN.RHSI/BN.AND/BN.OR/BN.XOR
             insn_subset     = InsnSubsetBignum;
             rf_we_bignum    = 1'b1;
             rf_ren_a_bignum = 1'b1;
             rf_ren_b_bignum = 1'b1;
           end
-          3'b101: begin // BN.NOT
+          3'b101: begin  // BN.NOT
             insn_subset     = InsnSubsetBignum;
             rf_we_bignum    = 1'b1;
             rf_ren_a_bignum = 1'b1;
@@ -532,18 +532,18 @@ module otbn_decoder
         insn_subset = InsnSubsetBignum;
 
         unique case (insn[14:12])
-          3'b000: begin // BN.SEL
+          3'b000: begin  // BN.SEL
             rf_we_bignum        = 1'b1;
             rf_ren_a_bignum     = 1'b1;
             rf_ren_b_bignum     = 1'b1;
             rf_wdata_sel_bignum = RfWdSelMovSel;
             sel_insn_bignum     = 1'b1;
           end
-          3'b011, 3'b001: begin // BN.CMP[B]
+          3'b011, 3'b001: begin  // BN.CMP[B]
             rf_ren_a_bignum = 1'b1;
             rf_ren_b_bignum = 1'b1;
           end
-          3'b100: begin // BN.LID
+          3'b100: begin  // BN.LID
             ld_insn              = 1'b1;
             rf_we_bignum         = 1'b1;
             rf_ren_a_base        = 1'b1;
@@ -570,7 +570,7 @@ module otbn_decoder
               illegal_insn           = 1'b1;
             end
           end
-          3'b101: begin // BN.SID
+          3'b101: begin  // BN.SID
             st_insn              = 1'b1;
             rf_ren_a_base        = 1'b1;
             rf_ren_b_base        = 1'b1;
@@ -596,13 +596,13 @@ module otbn_decoder
               illegal_insn           = 1'b1;
             end
           end
-          3'b110: begin // BN.MOV/BN.MOVR
+          3'b110: begin  // BN.MOV/BN.MOVR
             insn_subset         = InsnSubsetBignum;
             rf_we_bignum        = 1'b1;
             rf_ren_a_bignum     = 1'b1;
             rf_wdata_sel_bignum = RfWdSelMovSel;
 
-            if (insn[31]) begin // BN.MOVR
+            if (insn[31]) begin  // BN.MOVR
               rf_a_indirect_bignum = 1'b1;
               rf_d_indirect_bignum = 1'b1;
               rf_ren_a_base        = 1'b1;
@@ -629,10 +629,10 @@ module otbn_decoder
             end
           end
           3'b111: begin
-            if (insn[31]) begin // BN.WSRW
+            if (insn[31]) begin  // BN.WSRW
               rf_ren_a_bignum = 1'b1;
               ispr_wr_insn    = 1'b1;
-            end else begin // BN.WSRR
+            end else begin  // BN.WSRR
               rf_we_bignum        = 1'b1;
               rf_wdata_sel_bignum = RfWdSelIspr;
               ispr_rd_insn        = 1'b1;
@@ -653,7 +653,7 @@ module otbn_decoder
         rf_wdata_sel_bignum = RfWdSelMac;
         mac_en_bignum       = 1'b1;
 
-        if (insn[30] == 1'b1 || insn[29] == 1'b1) begin // BN.MULQACC.WO/BN.MULQACC.SO
+        if (insn[30] == 1'b1 || insn[29] == 1'b1) begin  // BN.MULQACC.WO/BN.MULQACC.SO
           rf_we_bignum = 1'b1;
         end
       end
@@ -713,7 +713,7 @@ module otbn_decoder
         alu_operator_base     = AluOpBaseAdd;
       end
 
-      InsnOpcodeBaseOpImm: begin // Register-Immediate ALU Operations
+      InsnOpcodeBaseOpImm: begin  // Register-Immediate ALU Operations
         alu_op_a_mux_sel_base = OpASelRegister;
         alu_op_b_mux_sel_base = OpBSelImmediate;
         imm_b_mux_sel_base    = ImmBaseBI;
@@ -725,14 +725,14 @@ module otbn_decoder
           3'b111: alu_operator_base = AluOpBaseAnd;  // And with Immediate
 
           3'b001: begin
-            alu_operator_base = AluOpBaseSll; // Shift Left Logical by Immediate
+            alu_operator_base = AluOpBaseSll;  // Shift Left Logical by Immediate
           end
 
           3'b101: begin
             if (insn_alu[31:27] == 5'b0_0000) begin
-              alu_operator_base = AluOpBaseSrl; // Shift Right Logical by Immediate
+              alu_operator_base = AluOpBaseSrl;  // Shift Right Logical by Immediate
             end else if (insn_alu[31:27] == 5'b0_1000) begin
-              alu_operator_base = AluOpBaseSra; // Shift Right Arithmetically by Immediate
+              alu_operator_base = AluOpBaseSra;  // Shift Right Arithmetically by Immediate
             end
           end
 
@@ -821,7 +821,7 @@ module otbn_decoder
       InsnOpcodeBignumArith: begin
         alu_flag_en_bignum = 1'b1;
 
-        unique case(insn_alu[14:12])
+        unique case (insn_alu[14:12])
           3'b000: alu_operator_bignum = AluOpBignumAdd;
           3'b001: alu_operator_bignum = AluOpBignumSub;
           3'b010: alu_operator_bignum = AluOpBignumAddc;
@@ -861,7 +861,7 @@ module otbn_decoder
         imm_b_mux_sel_base      = ImmBaseBL;
         alu_op_b_mux_sel_bignum = OpBSelRegister;
 
-        unique case(insn_alu[14:12])
+        unique case (insn_alu[14:12])
           3'b010: begin
             shift_amt_mux_sel_bignum = ShamtSelBignumA;
             alu_operator_bignum      = AluOpBignumAnd;
@@ -897,20 +897,20 @@ module otbn_decoder
 
       InsnOpcodeBignumMisc: begin
         unique case (insn[14:12])
-          3'b001: begin // BN.CMP
+          3'b001: begin  // BN.CMP
             alu_operator_bignum      = AluOpBignumSub;
             alu_op_b_mux_sel_bignum  = OpBSelRegister;
             shift_amt_mux_sel_bignum = ShamtSelBignumA;
             alu_flag_en_bignum       = 1'b1;
           end
-          3'b011: begin // BN.CMPB
+          3'b011: begin  // BN.CMPB
             alu_operator_bignum      = AluOpBignumSubb;
             alu_op_b_mux_sel_bignum  = OpBSelRegister;
             shift_amt_mux_sel_bignum = ShamtSelBignumA;
             alu_flag_en_bignum       = 1'b1;
           end
           3'b100,
-          3'b101: begin // BN.LID/BN.SID
+          3'b101: begin  // BN.LID/BN.SID
             // Calculate memory address using base ALU
             alu_op_a_mux_sel_base = OpASelRegister;
             alu_op_b_mux_sel_base = OpBSelImmediate;
@@ -926,7 +926,7 @@ module otbn_decoder
       ////////////////////////////////////////////
 
       InsnOpcodeBignumMulqacc: begin
-        if (insn[30] == 1'b1 || insn[29] == 1'b1) begin // BN.MULQACC.WO/BN.MULQACC.SO
+        if (insn[30] == 1'b1 || insn[29] == 1'b1) begin  // BN.MULQACC.WO/BN.MULQACC.SO
           mac_flag_en_bignum = 1'b1;
         end
       end
@@ -940,7 +940,7 @@ module otbn_decoder
   logic unused_clk;
   logic unused_rst_n;
 
-  assign unused_clk = clk_i;
+  assign unused_clk   = clk_i;
   assign unused_rst_n = rst_ni;
 
   ////////////////
@@ -949,14 +949,13 @@ module otbn_decoder
 
 
   // Selectors must be known/valid.
-  `ASSERT(IbexRegImmAluOpBaseKnown, (opcode == InsnOpcodeBaseOpImm) |->
-      !$isunknown(insn[14:12]))
+  `ASSERT(IbexRegImmAluOpBaseKnown, (opcode == InsnOpcodeBaseOpImm) |-> !$isunknown(insn[14:12]))
 
   // Can only do a single inc. Selection mux in controller doesn't factor in instruction valid (to
   // ease timing), so these must always be one-hot to 0 to avoid violating unique constraint for mux
   // case statement.
   `ASSERT(BignumRegIncOnehot,
-    $onehot0({a_inc_bignum, a_wlen_word_inc_bignum, b_inc_bignum, d_inc_bignum}))
+          $onehot0({a_inc_bignum, a_wlen_word_inc_bignum, b_inc_bignum, d_inc_bignum}))
 
   // RfWdSelIncr requires active selection
   `ASSERT(BignumRegIncReq,

--- a/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
+++ b/hw/ip/otbn/rtl/otbn_instruction_fetch.sv
@@ -26,8 +26,8 @@ module otbn_instruction_fetch
   input  logic                     imem_rvalid_i,
 
   // Next instruction selection (to instruction fetch)
-  input  logic                     insn_fetch_req_valid_i,
-  input  logic [ImemAddrWidth-1:0] insn_fetch_req_addr_i,
+  input logic                     insn_fetch_req_valid_i,
+  input logic [ImemAddrWidth-1:0] insn_fetch_req_addr_i,
 
   // Decoded instruction
   output logic                     insn_fetch_resp_valid_o,
@@ -35,7 +35,7 @@ module otbn_instruction_fetch
   output logic [31:0]              insn_fetch_resp_data_o,
   input  logic                     insn_fetch_resp_clear_i,
 
-  output logic                     insn_fetch_err_o, // ECC error seen in instruction fetch
+  output logic insn_fetch_err_o,  // ECC error seen in instruction fetch
 
   input logic                     prefetch_en_i,
   input logic                     prefetch_loop_active_i,
@@ -124,10 +124,10 @@ module otbn_instruction_fetch
 
   // Check integrity on prefetched instruction
   prim_secded_inv_39_32_dec u_insn_intg_check (
-    .data_i     (insn_fetch_resp_data_intg_q),
-    .data_o     (),
-    .syndrome_o (),
-    .err_o      (insn_fetch_resp_intg_error_vec)
+    .data_i    (insn_fetch_resp_data_intg_q),
+    .data_o    (),
+    .syndrome_o(),
+    .err_o     (insn_fetch_resp_intg_error_vec)
   );
 
   assign imem_req_o = insn_prefetch;

--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -10,16 +10,16 @@ module otbn_loop_controller
   input clk_i,
   input rst_ni,
 
-  input                      state_reset_i,
+  input state_reset_i,
 
-  input                      insn_valid_i,
-  input [ImemAddrWidth-1:0]  insn_addr_i,
-  input [ImemAddrWidth-1:0]  next_insn_addr_i,
+  input                     insn_valid_i,
+  input [ImemAddrWidth-1:0] insn_addr_i,
+  input [ImemAddrWidth-1:0] next_insn_addr_i,
 
-  input                      loop_start_req_i,
-  input                      loop_start_commit_i,
-  input [11:0]               loop_bodysize_i,
-  input [31:0]               loop_iterations_i,
+  input        loop_start_req_i,
+  input        loop_start_commit_i,
+  input [11:0] loop_bodysize_i,
+  input [31:0] loop_iterations_i,
 
   output                     loop_jump_o,
   output [ImemAddrWidth-1:0] loop_jump_addr_o,
@@ -30,8 +30,8 @@ module otbn_loop_controller
   output [ImemAddrWidth-1:0] prefetch_loop_end_addr_o,
   output [ImemAddrWidth-1:0] prefetch_loop_jump_addr_o,
 
-  input                      jump_or_branch_i,
-  input                      otbn_stall_i
+  input jump_or_branch_i,
+  input otbn_stall_i
 );
   // The loop controller has a current loop and then a stack of outer loops, this sets the size of
   // the stack so maximum loop nesting depth is LoopStackDepth + 1.
@@ -196,16 +196,16 @@ module otbn_loop_controller
     .clk_i,
     .rst_ni,
 
-    .full_o      (loop_stack_full),
+    .full_o(loop_stack_full),
 
-    .clear_i     (state_reset_i),
+    .clear_i(state_reset_i),
 
-    .push_data_i (current_loop_q),
-    .push_i      (loop_stack_push),
+    .push_data_i(current_loop_q),
+    .push_i     (loop_stack_push),
 
-    .pop_i       (loop_stack_pop),
-    .top_data_o  (next_loop),
-    .top_valid_o (next_loop_valid)
+    .pop_i      (loop_stack_pop),
+    .top_data_o (next_loop),
+    .top_valid_o(next_loop_valid)
   );
 
   // Forward info about loop state for next cycle to prefetch stage

--- a/hw/ip/otbn/rtl/otbn_lsu.sv
+++ b/hw/ip/otbn/rtl/otbn_lsu.sv
@@ -48,7 +48,7 @@ module otbn_lsu
   output logic                     lsu_rdata_err_o
 );
   localparam int BaseWordsPerWLen = WLEN / 32;
-  localparam int BaseWordAddrW = prim_util_pkg::vbits(WLEN/8);
+  localparam int BaseWordAddrW = prim_util_pkg::vbits(WLEN / 8);
 
   // Produce a WLEN bit mask for 32-bit writes given the 32-bit word write address. This doesn't
   // propagate X so a separate assertion must be used to check the input isn't X when a valid output
@@ -138,6 +138,6 @@ module otbn_lsu
   logic unused_clk;
   logic unused_rst_n;
 
-  assign unused_clk = clk_i;
+  assign unused_clk   = clk_i;
   assign unused_rst_n = rst_ni;
 endmodule

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -77,10 +77,10 @@ module otbn_mac_bignum
     mul_res_shifted = '0;
 
     unique case (operation_i.pre_acc_shift_imm)
-      2'd0: mul_res_shifted = {{QWLEN*2{1'b0}}, mul_res};
+      2'd0: mul_res_shifted = {{QWLEN * 2{1'b0}}, mul_res};
       2'd1: mul_res_shifted = {{QWLEN{1'b0}}, mul_res, {QWLEN{1'b0}}};
-      2'd2: mul_res_shifted = {mul_res, {QWLEN*2{1'b0}}};
-      2'd3: mul_res_shifted = {mul_res[63:0], {QWLEN*3{1'b0}}};
+      2'd2: mul_res_shifted = {mul_res, {QWLEN * 2{1'b0}}};
+      2'd3: mul_res_shifted = {mul_res[63:0], {QWLEN * 3{1'b0}}};
       default: mul_res_shifted = '0;
     endcase
   end
@@ -105,16 +105,14 @@ module otbn_mac_bignum
 
   assign operation_flags_o.L    = adder_result[0];
   // L is always updated for .WO, and for .SO when writing to the lower half-word
-  assign operation_flags_en_o.L = operation_i.shift_acc ? ~operation_i.wr_hw_sel_upper :
-                                                          1'b1;
+  assign operation_flags_en_o.L = operation_i.shift_acc ? ~operation_i.wr_hw_sel_upper : 1'b1;
 
   // For .SO M is taken from the top-bit of shifted out half-word, otherwise it is taken from the
   // top-bit of the full result.
   assign operation_flags_o.M    = operation_i.shift_acc ? adder_result[WLEN/2-1] :
                                                           adder_result[WLEN-1];
   // M is always updated for .WO, and for .SO when writing to the upper half-word.
-  assign operation_flags_en_o.M = operation_i.shift_acc ? operation_i.wr_hw_sel_upper :
-                                                          1'b1;
+  assign operation_flags_en_o.M = operation_i.shift_acc ? operation_i.wr_hw_sel_upper : 1'b1;
 
   // For .SO Z is calculated from the shifted out half-word, otherwise it is calculated on the full
   // result.
@@ -133,7 +131,7 @@ module otbn_mac_bignum
   assign operation_flags_en_o.C = 1'b0;
 
   always_comb begin
-    unique case(1'b1)
+    unique case (1'b1)
     sec_wipe_acc_urnd_i: acc_d = urnd_data_i;
     sec_wipe_zero_i:     acc_d = '0;
     // If performing an ACC ISPR write the next accumulator value is taken from the ISPR write data,

--- a/util/verible-format.py
+++ b/util/verible-format.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import shutil
 import sys
 import os
 import argparse
@@ -25,12 +26,7 @@ def get_repo_top():
 
 
 def get_verible_executable_path():
-    try:
-        return subprocess.run(['which', 'verible-verilog-format'],
-                              check=True, universal_newlines=True,
-                              stdout=subprocess.PIPE).stdout.strip()
-    except subprocess.CalledProcessError:
-        return None
+    return shutil.which('verible-verilog-format')
 
 
 def get_verible_version(verible_exec_path):


### PR DESCRIPTION
*The first commit here is just a minor cleanup in our script to run Verible. The interesting commit is the second, whose commit message appears below:*

These seem to match our style guide and to improve the general layout.
There are some other changes that verible suggests at the moment that
look a bit more suspect and we might want to tweak it for. Those
changes are not included in this commit.

These come from running

    find hw/ip/otbn/rtl -name '*.sv' | \
      xargs util/verible-format.py --inplace -f

with the most recent version of Verible (v0.0-1784-g9f0278ee).

I've only included 10 files in the commit because reviewing this sort
of thing is a bit painful, so I thought it might be better to do it in
batches!

All of the changes are shuffling around whitespace. To see this, run
something like `git diff -w HEAD^..HEAD`. That should give us
confidence that the commit won't introduce any RTL bugs.

Other than little typos, most of the changes here are to do with
formatting port lists, both in the declarations of modules, and in
their instantiations. For better or for worse, we've agreed on a
format in our style guide; these changes tweak our code to match that.
