### PR TITLE
[spi_device] TPM locality and read tests

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -172,7 +172,7 @@
             - When available, confirm that the TPM submodule sends START followed by the register value.
             - Compare this value with the expected value.'''
       milestone: V2
-      tests: []
+      tests: ["spi_device_tpm_read"]
     }
     {
       name: tpm_write

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_locality_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_locality_vseq.sv
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TPM Locality test, making transactions of various locality
+// Targeting HW sts register, randomizing it and checking data returned to host
+class spi_device_tpm_locality_vseq extends spi_device_tpm_base_vseq;
+  `uvm_object_utils(spi_device_tpm_locality_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    bit [31:0] device_word_rsp;
+    bit [7:0]  device_byte_rsp;
+    bit [7:0]  tpm_cmd = TPM_READ_CMD; //TPM Read command
+    bit [23:0] tpm_addr;
+    bit [31:0] address_command;
+    byte data_bytes[$];
+    bit [7:0] returned_bytes[*];
+    int pay_num;
+    bit [31:0]  wrfifo_data;
+    bit [7:0] access_q[$];
+    bit [31:0] sts;
+    bit [3:0] locality;
+    bit [11:0] hw_address;
+
+    spi_device_init();
+
+    // randomised tpm configuration.
+    tpm_init();
+    tpm_configure_locality();
+    repeat (num_trans) begin
+      pay_num = 0;
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(access_q, access_q.size() == 5;)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(sts)
+      ral.tpm_access_0.set({access_q[3], access_q[2], access_q[1], access_q[0]});
+      csr_update(.csr(ral.tpm_access_0));
+      ral.tpm_access_1.set(access_q[4]);
+      csr_update(.csr(ral.tpm_access_1));
+      ral.tpm_sts.sts.set(sts);
+      csr_update(.csr(ral.tpm_sts));
+      cfg.clk_rst_vif.wait_clks(100);
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(locality, locality <= 4;)
+      // Data size will be 5, first byte dummy for polling, remaining 4 for payload
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(data_bytes, data_bytes.size() == 5;)
+      tpm_addr = get_tpm_addr(locality);
+      tpm_addr = {<<1{tpm_addr}};
+      address_command = {tpm_addr, tpm_cmd};
+      `uvm_info(`gfn, $sformatf("Address Command = 0x%0h", address_command), UVM_LOW)
+      // send payload
+      cfg.m_spi_agent_cfg.csb_consecutive = 1;
+      spi_host_xfer_word(address_command, device_word_rsp);
+      // poll START and collect data
+      poll_start_collect_data(data_bytes, returned_bytes);
+
+      if (access_q[locality][5] == 1) begin
+        `DV_CHECK_CASE_EQ({returned_bytes[3], returned_bytes[2], returned_bytes[1],
+                          returned_bytes[0]}, sts)
+      end else begin
+        `DV_CHECK_CASE_EQ({returned_bytes[3], returned_bytes[2], returned_bytes[1],
+                          returned_bytes[0]}, 32'hFFFFFFFF)
+      end
+
+      cfg.clk_rst_vif.wait_clks(100);
+    end
+
+  endtask : body
+
+endclass : spi_device_tpm_locality_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_tpm_read_vseq.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TPM Read test, issuing READ command, writing to read fifo, checking host received data
+class spi_device_tpm_read_vseq extends spi_device_tpm_base_vseq;
+  `uvm_object_utils(spi_device_tpm_read_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    bit [31:0] device_word_rsp;
+    bit [7:0]  device_byte_rsp;
+    bit [7:0]  tpm_cmd = TPM_READ_CMD; //TPM Read command
+    bit [23:0] tpm_addr;
+    bit [31:0] address_command;
+    byte data_bytes[$];
+    bit [7:0] returned_bytes[*];
+    int pay_num;
+    bit [31:0]  wrfifo_data;
+    bit [7:0] read_fifo_data[$];
+    bit [3:0] locality;
+    bit [11:0] hw_address;
+
+    spi_device_init();
+
+    // randomised tpm configuration.
+    tpm_init();
+    tpm_configure();
+    repeat (num_trans) begin
+      pay_num = 0;
+
+      cfg.clk_rst_vif.wait_clks(100);
+      // send cmd_addr
+      `DV_CHECK_STD_RANDOMIZE_FATAL(tpm_addr)
+      // Data size will be 5, first byte dummy for polling, remaining 4 for payload
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(data_bytes, data_bytes.size() == 5;)
+      tpm_addr = {<<1{tpm_addr}};
+      address_command = {tpm_addr, tpm_cmd};
+      `uvm_info(`gfn, $sformatf("Address Command = 0x%0h", address_command), UVM_LOW)
+      cfg.m_spi_agent_cfg.csb_consecutive = 1;
+      spi_host_xfer_word(address_command, device_word_rsp);
+      fork
+        begin
+          // Upon receiving read command, set read fifo contents
+          `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(read_fifo_data, read_fifo_data.size() == 4;)
+          foreach (read_fifo_data[i]) csr_wr(.ptr(ral.tpm_read_fifo), .value(read_fifo_data[i]));
+        end // Write Read Fifo Thread
+        begin
+          // poll START and collect data
+          poll_start_collect_data(data_bytes, returned_bytes);
+        end // Poll read data thread
+      join
+
+      `DV_CHECK_CASE_EQ({returned_bytes[3], returned_bytes[2], returned_bytes[1],
+                          returned_bytes[0]}, {read_fifo_data[3], read_fifo_data[2],
+                          read_fifo_data[1], read_fifo_data[0]})
+
+      cfg.clk_rst_vif.wait_clks(100);
+    end
+
+  endtask : body
+
+endclass : spi_device_tpm_read_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -16,3 +16,5 @@
 `include "spi_device_byte_transfer_vseq.sv"
 `include "spi_device_tpm_base_vseq.sv"
 `include "spi_device_tpm_write_vseq.sv"
+`include "spi_device_tpm_locality_vseq.sv"
+`include "spi_device_tpm_read_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -32,6 +32,8 @@ filesets:
       - seq_lib/spi_device_rx_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_tpm_base_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_tpm_write_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_tpm_locality_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_tpm_read_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -50,15 +50,19 @@ package spi_device_env_pkg;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
 
   // SPI SRAM is 2kB
-  parameter uint SRAM_OFFSET              = 'h1000;
-  parameter uint SRAM_SIZE                = 4096; // 672 depth
-  parameter uint SRAM_MSB                 = $clog2(SRAM_SIZE) - 1;
-  parameter uint SRAM_PTR_PHASE_BIT       = SRAM_MSB + 1;
-  parameter uint SRAM_WORD_SIZE           = 4;
-  parameter uint ASYNC_FIFO_SIZE          = 8;
-  parameter bit[7:0] TPM_WRITE_CMD        = 8'hC0;
-  parameter byte TPM_START                = 8'h01;
-  parameter byte TPM_WAIT                 = 8'h00;
+  parameter uint SRAM_OFFSET                     = 'h1000;
+  parameter uint SRAM_SIZE                       = 4096; // 672 depth
+  parameter uint SRAM_MSB                        = $clog2(SRAM_SIZE) - 1;
+  parameter uint SRAM_PTR_PHASE_BIT              = SRAM_MSB + 1;
+  parameter uint SRAM_WORD_SIZE                  = 4;
+  parameter uint ASYNC_FIFO_SIZE                 = 8;
+  parameter bit[7:0] TPM_WRITE_CMD               = 8'hC0;
+  parameter bit[7:0] TPM_READ_CMD                = 8'hC1;
+  parameter byte TPM_START                       = 8'h01;
+  parameter byte TPM_WAIT                        = 8'h00;
+  parameter bit[11:0] TPM_HW_STS_OFFSET          = 12'h018;
+  parameter bit[11:0] TPM_HW_INT_CAP_OFFSET      = 12'h014;
+  parameter bit[23:0] TPM_BASE_ADDR              = 24'hD40000;
 
   string msg_id = "spi_device_env_pkg";
 
@@ -111,6 +115,11 @@ package spi_device_env_pkg;
       new_ptr[SRAM_PTR_PHASE_BIT] = ptr_phase_bit;
     end
     return new_ptr;
+  endfunction
+
+  // Get TPM address for locality TODO expand to other HW regs
+  function automatic bit[23:0] get_tpm_addr(bit[3:0] locality);
+    return TPM_BASE_ADDR | (locality << 12) | TPM_HW_STS_OFFSET;
   endfunction
 
   // macros

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -101,6 +101,16 @@
       name: spi_device_tpm_write
       uvm_test_seq: spi_device_tpm_write_vseq
     }
+    
+    {
+      name: spi_device_tpm_locality
+      uvm_test_seq: spi_device_tpm_locality_vseq
+    }
+    
+    {
+      name: spi_device_tpm_read
+      uvm_test_seq: spi_device_tpm_read_vseq
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
Added TPM read test, with checking read fifo data transfer over host interface after read command is performed. Added locality test where we issue proper command to provoke return by HW register read response.

Signed-off-by: Kosta Kojdic <kosta.kojdic@ensilica.com>