### PR TITLE
[otbn] Fix calculation of CRC index for DMEM writes

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -562,8 +562,8 @@ module otbn
   assign mem_crc_data_in.wr_data = imem_req_bus ? imem_wdata_bus[31:0] :
                                                   dmem_wdata_narrow_bus[31:0];
   assign mem_crc_data_in.index   = imem_req_bus ? {{15 - ImemIndexWidth{1'b0}}, imem_index_bus} :
-                                                   {{15 - (DmemIndexWidth - 2){1'b0}},
-                                                    dmem_addr_bus[DmemIndexWidth-1:2]};
+                                                   {{15 - (DmemAddrWidth - 2){1'b0}},
+                                                    dmem_addr_bus[DmemAddrWidth-1:2]};
   assign mem_crc_data_in.imem    = imem_req_bus;
 
   // Only the bits that factor into the dmem index and dmem word enables are required


### PR DESCRIPTION
`dmem_addr_bus` is of width `DmemAddrWidth` (12), rather than
`DmemIndexWidth` (7). The previous code dropped the upper bits of the
word address and computed the wrong CRC.

This caused all sorts of exciting failures in the nightlies last night :-) I think the wrong parameter was left over from the initial implementation which used the output of the TL SRAM adapter and I didn't notice it when writing 45a72a2 (which fixed a different but related issue).