### PR TITLE
[sw,tests] ROM Integrity check in PROD and non-PROD LC States

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2026,7 +2026,7 @@
             - Verify that the CPU can fetch instructions from the ROM.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_rom_ctrl_integrity_check_test"]
     }
     {
       name: chip_rom_ctrl_ast_rom_cfg
@@ -2047,7 +2047,7 @@
               digest does not match the top 8 words of the ROM.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_rom_ctrl_integrity_check_test"]
     }
     {
       name: chip_sw_rom_ctrl_reset_glitch

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -312,6 +312,12 @@
       sw_images: ["sw/device/tests/kmac_app_rom_test:1"]
       en_run_modes: ["sw_test_mode"]
     }
+    {
+      name: chip_sw_rom_ctrl_integrity_check_test
+      uvm_test_seq: chip_sw_rom_ctrl_integrity_check_vseq
+      sw_images: ["sw/device/tests/rom_ctrl_integrity_check_test:1"]
+      en_run_modes: ["sw_test_mode"]
+    }
 
     {
       name: chip_sw_coremark

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - ast_supply_if.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv
@@ -1,0 +1,71 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_rom_ctrl_integrity_check_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_rom_ctrl_integrity_check_vseq)
+
+  `uvm_object_new
+
+  localparam uint TimeoutNs = 1_000_000;  // 1ms
+
+  // Overwrite the last expected digest word in the ROM which is
+  // sufficient to cause an integrity failure.
+  virtual task rom_digest_overwrite();
+    int retval;
+    string rom_nonce_hdl_path = "tb.dut.top_earlgrey.u_rom_ctrl.RndCnstScrNonce";
+    bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0] rom_nonce;
+    uint32_t addr = (cfg.mem_bkdr_util_h[Rom].get_depth() * 4) - 4;  // digest at last ROM location.
+
+    // Get ROM nonce directly from rom_ctrl instance rather
+    // than using a hard coded value.
+    retval = uvm_hdl_check_path(rom_nonce_hdl_path);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", rom_nonce_hdl_path))
+    retval = uvm_hdl_read(rom_nonce_hdl_path, rom_nonce);
+    `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", rom_nonce_hdl_path))
+
+    // Write to ROM at last digest location with random data (which can be unscrambled).
+    cfg.mem_bkdr_util_h[Rom].rom_encrypt_write32_integ(
+        addr, $urandom(), sram_scrambler_pkg::SRAM_KEY_WIDTH'('b0), rom_nonce, 1'b0);
+  endtask
+
+  virtual task test_state_monitor();
+    // wait for the test to boot and issue the WFI status
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+
+    // update the lc state to a production state and do a reset
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition(lc_ctrl_state_pkg::LcStProd);
+    apply_reset();
+
+    // At this point, a successful boot would be an error. We will start a
+    // parallel timeout thread which will be expected to complete as the boot
+    // process should be locked up.
+    fork
+      begin
+        wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+        `uvm_error(`gfn, "Unexpected successful boot in PROD LC_STATE.")
+      end
+      begin
+        #(TimeoutNs * 1ns);
+        cfg.sw_test_status_vif.sw_test_status = SwTestStatusPassed;
+        cfg.sw_test_status_vif.sw_test_done   = 1'b1;
+      end
+    join_any
+    disable fork;
+  endtask
+
+  // The test will do the standard setup and then overwrite the
+  // expected ROM digest via the backdoor which is a condition
+  // that when in non production LC state (the default) should still boot.
+  // We then launch a task to monitor the test state and make changes
+  // following the successful boot to change the lc state to a production
+  // state then do a reset after which it should be expected not to boot.
+  virtual task body();
+    super.body();
+    rom_digest_overwrite();
+    test_state_monitor();
+  endtask
+
+endclass : chip_sw_rom_ctrl_integrity_check_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -15,3 +15,5 @@
 `include "chip_sw_gpio_vseq.sv"
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"
+`include "chip_sw_rom_ctrl_integrity_check_vseq.sv"
+

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -136,3 +136,24 @@ sw_tests += {
     'library': spi_tx_rx_test_lib,
   }
 }
+
+rom_ctrl_integrity_check_test_lib = declare_dependency(
+  link_with: static_library(
+    'rom_ctrl_integrity_check_test_lib',
+    sources: [
+      hw_ip_rom_ctrl_reg_h,
+      'rom_ctrl_integrity_check_test.c',
+    ],
+    dependencies: [
+      sw_lib_dif_lc_ctrl,
+      sw_lib_dif_rom_ctrl,
+      sw_lib_runtime_log,
+      sw_lib_mmio,
+    ],
+  ),
+)
+sw_tests += {
+  'rom_ctrl_integrity_check_test': {
+    'library': rom_ctrl_integrity_check_test_lib,
+  }
+}

--- a/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
+++ b/sw/device/tests/sim_dv/rom_ctrl_integrity_check_test.c
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_rom_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+#include "sw/device/lib/testing/test_framework/test_status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_lc_ctrl_t lc;
+static dif_rom_ctrl_t rom_ctrl;
+
+const test_config_t kTestConfig;
+
+// The testbench will start in a non-production LC state.
+// It will use backdoor access to overwrite one of the expected
+// digests present in the ROM image which will cause the integrity check
+// to fail. Because we are in the non-production LC state we expect
+// to still boot and run this code. Upon reaching the wait for interrupt
+// the testbench will reset the system into production LC state. We should then
+// not expect a successful boot with the failed integrity check.
+
+bool test_main(void) {
+  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+  mmio_region_t rom_ctrl_reg =
+      mmio_region_from_addr(TOP_EARLGREY_ROM_CTRL_REGS_BASE_ADDR);
+  CHECK_DIF_OK(dif_rom_ctrl_init(rom_ctrl_reg, &rom_ctrl));
+
+  // Check that the LC_STATE is not PROD as the boot is not
+  // expected to be successful in that state.
+  dif_lc_ctrl_state_t lc_state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc, &lc_state));
+  CHECK(lc_state != kDifLcCtrlStateProd, "PROD LC_STATE not expected.");
+
+  // Check that the upper expected digest in the ROM has been
+  // modified and no longer matches the calculated digest. If it matches
+  // then the testbench has not successfully overwritten the digest.
+  dif_rom_ctrl_digest_t computed_digest;
+  dif_rom_ctrl_digest_t expected_digest;
+  CHECK_DIF_OK(dif_rom_ctrl_get_digest(&rom_ctrl, &computed_digest));
+  CHECK_DIF_OK(dif_rom_ctrl_get_expected_digest(&rom_ctrl, &expected_digest));
+  CHECK(expected_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1] !=
+            computed_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1],
+        "Expected and computed digests match. Digests = %0x",
+        expected_digest.digest[ROM_CTRL_DIGEST_MULTIREG_COUNT - 1]);
+
+  // set test_status to wfi and call wait_for_interrupt to make
+  // the cpu idle, the testbench sequence will wait for this test
+  // status and issue a reset once it gets this far.
+  LOG_INFO("Waiting for interrupt.");
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+
+  return true;
+}


### PR DESCRIPTION
Checks that the ROM will successfully boot when there is a mismatch of the computed and expected digests in non-production LC state. Checks that it will NOT boot when the same mismatch occurs when in production LC state.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>