### PR TITLE
[sw/dif] Add `toggle_to_bool()` and `bool_to_toggle()` to DIF base.

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -6,6 +6,9 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "base",
+    srcs = [
+        "dif_base.c",
+    ],
     hdrs = [
         "dif_base.h",
     ],

--- a/sw/device/lib/dif/autogen/meson.build
+++ b/sw/device/lib/dif/autogen/meson.build
@@ -11,6 +11,7 @@ sw_lib_dif_autogen_adc_ctrl = declare_dependency(
       'dif_adc_ctrl_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -25,6 +26,7 @@ sw_lib_dif_autogen_aes = declare_dependency(
       'dif_aes_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -39,6 +41,7 @@ sw_lib_dif_autogen_alert_handler = declare_dependency(
       'dif_alert_handler_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -53,6 +56,7 @@ sw_lib_dif_autogen_aon_timer = declare_dependency(
       'dif_aon_timer_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -67,6 +71,7 @@ sw_lib_dif_autogen_clkmgr = declare_dependency(
       'dif_clkmgr_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -81,6 +86,7 @@ sw_lib_dif_autogen_csrng = declare_dependency(
       'dif_csrng_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -95,6 +101,7 @@ sw_lib_dif_autogen_edn = declare_dependency(
       'dif_edn_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -109,6 +116,7 @@ sw_lib_dif_autogen_entropy_src = declare_dependency(
       'dif_entropy_src_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -123,6 +131,7 @@ sw_lib_dif_autogen_flash_ctrl = declare_dependency(
       'dif_flash_ctrl_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -137,6 +146,7 @@ sw_lib_dif_autogen_gpio = declare_dependency(
       'dif_gpio_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -151,6 +161,7 @@ sw_lib_dif_autogen_hmac = declare_dependency(
       'dif_hmac_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -165,6 +176,7 @@ sw_lib_dif_autogen_i2c = declare_dependency(
       'dif_i2c_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -179,6 +191,7 @@ sw_lib_dif_autogen_keymgr = declare_dependency(
       'dif_keymgr_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -193,6 +206,7 @@ sw_lib_dif_autogen_kmac = declare_dependency(
       'dif_kmac_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -207,6 +221,7 @@ sw_lib_dif_autogen_lc_ctrl = declare_dependency(
       'dif_lc_ctrl_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -221,6 +236,7 @@ sw_lib_dif_autogen_otbn = declare_dependency(
       'dif_otbn_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -235,6 +251,7 @@ sw_lib_dif_autogen_otp_ctrl = declare_dependency(
       'dif_otp_ctrl_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -249,6 +266,7 @@ sw_lib_dif_autogen_pattgen = declare_dependency(
       'dif_pattgen_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -263,6 +281,7 @@ sw_lib_dif_autogen_pinmux = declare_dependency(
       'dif_pinmux_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -277,6 +296,7 @@ sw_lib_dif_autogen_pwrmgr = declare_dependency(
       'dif_pwrmgr_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -291,6 +311,7 @@ sw_lib_dif_autogen_rstmgr = declare_dependency(
       'dif_rstmgr_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -305,6 +326,7 @@ sw_lib_dif_autogen_rom_ctrl = declare_dependency(
       'dif_rom_ctrl_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -319,6 +341,7 @@ sw_lib_dif_autogen_rv_plic = declare_dependency(
       'dif_rv_plic_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -333,6 +356,7 @@ sw_lib_dif_autogen_rv_timer = declare_dependency(
       'dif_rv_timer_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -347,6 +371,7 @@ sw_lib_dif_autogen_spi_device = declare_dependency(
       'dif_spi_device_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -361,6 +386,7 @@ sw_lib_dif_autogen_spi_host = declare_dependency(
       'dif_spi_host_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -375,6 +401,7 @@ sw_lib_dif_autogen_sram_ctrl = declare_dependency(
       'dif_sram_ctrl_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -389,6 +416,7 @@ sw_lib_dif_autogen_sysrst_ctrl = declare_dependency(
       'dif_sysrst_ctrl_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -403,6 +431,7 @@ sw_lib_dif_autogen_usbdev = declare_dependency(
       'dif_usbdev_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )
@@ -417,6 +446,7 @@ sw_lib_dif_autogen_uart = declare_dependency(
       'dif_uart_autogen.c',
     ],
     dependencies: [
+      sw_lib_dif_base,
       sw_lib_mmio,
     ],
   )

--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -199,26 +199,6 @@ static bool classify_local_alerts(
 }
 
 /**
- * Converts a toggle_t to bool.
- *
- * Returns false if `toggle` is out of range.
- */
-OT_WARN_UNUSED_RESULT
-static bool toggle_to_bool(dif_toggle_t toggle, bool *flag) {
-  switch (toggle) {
-    case kDifToggleEnabled:
-      *flag = true;
-      break;
-    case kDifToggleDisabled:
-      *flag = false;
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-
-/**
  * Configures the control registers of a particular alert handler class.
  */
 OT_WARN_UNUSED_RESULT
@@ -251,22 +231,14 @@ static bool configure_class(const dif_alert_handler_t *alert_handler,
   uint32_t ctrl_reg = 0;
 
   // Configure the escalation protocol enable flag.
-  bool use_escalation_protocol;
-  if (!toggle_to_bool(class->use_escalation_protocol,
-                      &use_escalation_protocol)) {
-    return false;
-  }
   ctrl_reg =
       bitfield_bit32_write(ctrl_reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_EN_BIT,
-                           use_escalation_protocol);
+                           dif_toggle_to_bool(class->use_escalation_protocol));
 
   // Configure the escalation protocol auto-lock flag.
-  bool automatic_locking;
-  if (!toggle_to_bool(class->automatic_locking, &automatic_locking)) {
-    return false;
-  }
-  ctrl_reg = bitfield_bit32_write(
-      ctrl_reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_LOCK_BIT, automatic_locking);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg,
+                                  ALERT_HANDLER_CLASSA_CTRL_SHADOWED_LOCK_BIT,
+                                  dif_toggle_to_bool(class->automatic_locking));
 
   if (class->phase_signals == NULL && class->phase_signals_len != 0) {
     return false;

--- a/sw/device/lib/dif/dif_base.c
+++ b/sw/device/lib/dif/dif_base.c
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_base.h"
+
+#include <stdbool.h>
+
+// `extern` declarations to give the inline functions in the corresponding
+// header a link location.
+extern bool dif_is_valid_toggle(dif_toggle_t val);
+extern bool dif_toggle_to_bool(dif_toggle_t val);
+extern dif_toggle_t dif_bool_to_toggle(bool val);

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -10,6 +10,8 @@
  * @brief Shared macros and headers for DIFs.
  */
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -81,6 +83,50 @@ typedef enum dif_toggle {
    */
   kDifToggleEnabled = 1,
 } dif_toggle_t;
+
+/**
+ * Checks if a DIF toggle type is valid.
+ *
+ * @param val A potential dif_toggle_t value.
+ * @return Bool indicating validity of toggle value.
+ */
+inline bool dif_is_valid_toggle(dif_toggle_t val) {
+  switch (val) {
+    case kDifToggleEnabled:
+      return true;
+    case kDifToggleDisabled:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Converts a `dif_toggle_t` to a `bool`.
+ *
+ * @param val A dif_toggle_t value.
+ * @return Corresponding bool value.
+ */
+inline bool dif_toggle_to_bool(dif_toggle_t val) {
+  switch (val) {
+    case kDifToggleEnabled:
+      return true;
+    case kDifToggleDisabled:
+      return false;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Converts a `dif_toggle_t` to a `bool`.
+ *
+ * @param val A bool value.
+ * @return Corresponding dif_toggle_t value.
+ */
+inline dif_toggle_t dif_bool_to_toggle(bool val) {
+  return val ? kDifToggleEnabled : kDifToggleDisabled;
+}
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -28,13 +28,6 @@ static_assert(
     "Expected the number of hintable clocks to be <= the width of a CSR.");
 
 /**
- * Converts a `bool` to `dif_toggle_t`.
- */
-static dif_toggle_t bool_to_toggle(bool val) {
-  return val ? kDifToggleEnabled : kDifToggleDisabled;
-}
-
-/**
  * Converts a `multi_bit_bool_t` to `dif_toggle_t`.
  */
 static dif_toggle_t mubi4_to_toggle(multi_bit_bool_t val) {
@@ -93,7 +86,7 @@ dif_result_t dif_clkmgr_gateable_clock_get_enabled(
 
   uint32_t clk_enables_val =
       mmio_region_read32(clkmgr->base_addr, CLKMGR_CLK_ENABLES_REG_OFFSET);
-  *state = bool_to_toggle(bitfield_bit32_read(clk_enables_val, clock));
+  *state = dif_bool_to_toggle(bitfield_bit32_read(clk_enables_val, clock));
 
   return kDifOk;
 }
@@ -101,22 +94,12 @@ dif_result_t dif_clkmgr_gateable_clock_get_enabled(
 dif_result_t dif_clkmgr_gateable_clock_set_enabled(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_gateable_clock_t clock,
     dif_toggle_t new_state) {
-  if (clkmgr == NULL || !clkmgr_valid_gateable_clock(clock)) {
+  if (clkmgr == NULL || !clkmgr_valid_gateable_clock(clock) ||
+      !dif_is_valid_toggle(new_state)) {
     return kDifBadArg;
   }
 
-  bool new_clk_enables_bit;
-  switch (new_state) {
-    case kDifToggleEnabled:
-      new_clk_enables_bit = true;
-      break;
-    case kDifToggleDisabled:
-      new_clk_enables_bit = false;
-      break;
-    default:
-      return kDifBadArg;
-  }
-
+  bool new_clk_enables_bit = dif_toggle_to_bool(new_state);
   uint32_t clk_enables_val =
       mmio_region_read32(clkmgr->base_addr, CLKMGR_CLK_ENABLES_REG_OFFSET);
   clk_enables_val =
@@ -136,7 +119,7 @@ dif_result_t dif_clkmgr_hintable_clock_get_enabled(
 
   uint32_t clk_hints_val =
       mmio_region_read32(clkmgr->base_addr, CLKMGR_CLK_HINTS_STATUS_REG_OFFSET);
-  *state = bool_to_toggle(bitfield_bit32_read(clk_hints_val, clock));
+  *state = dif_bool_to_toggle(bitfield_bit32_read(clk_hints_val, clock));
 
   return kDifOk;
 }
@@ -144,22 +127,12 @@ dif_result_t dif_clkmgr_hintable_clock_get_enabled(
 dif_result_t dif_clkmgr_hintable_clock_set_hint(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_hintable_clock_t clock,
     dif_toggle_t new_state) {
-  if (clkmgr == NULL || !clkmgr_valid_hintable_clock(clock)) {
+  if (clkmgr == NULL || !clkmgr_valid_hintable_clock(clock) ||
+      !dif_is_valid_toggle(new_state)) {
     return kDifBadArg;
   }
 
-  bool new_clk_hints_bit;
-  switch (new_state) {
-    case kDifToggleEnabled:
-      new_clk_hints_bit = true;
-      break;
-    case kDifToggleDisabled:
-      new_clk_hints_bit = false;
-      break;
-    default:
-      return kDifBadArg;
-  }
-
+  bool new_clk_hints_bit = dif_toggle_to_bool(new_state);
   uint32_t clk_hints_val =
       mmio_region_read32(clkmgr->base_addr, CLKMGR_CLK_HINTS_REG_OFFSET);
   clk_hints_val = bitfield_bit32_write(clk_hints_val, clock, new_clk_hints_bit);
@@ -178,7 +151,7 @@ dif_result_t dif_clkmgr_hintable_clock_get_hint(
 
   uint32_t clk_hints_val =
       mmio_region_read32(clkmgr->base_addr, CLKMGR_CLK_HINTS_REG_OFFSET);
-  *state = bool_to_toggle(bitfield_bit32_read(clk_hints_val, clock));
+  *state = dif_bool_to_toggle(bitfield_bit32_read(clk_hints_val, clock));
 
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -231,31 +231,6 @@ static void start_operation(const dif_keymgr_t *keymgr,
                       reg_control);
 }
 
-/**
- * Checks if a value is a valid `dif_toggle_t` and converts it to `bool`.
- */
-OT_WARN_UNUSED_RESULT
-static bool toggle_to_bool(dif_toggle_t val, bool *val_bool) {
-  switch (val) {
-    case kDifToggleEnabled:
-      *val_bool = true;
-      break;
-    case kDifToggleDisabled:
-      *val_bool = false;
-      break;
-    default:
-      return false;
-  }
-  return true;
-}
-
-/**
- * Converts a `bool` to `dif_toggle_t`.
- */
-static dif_toggle_t bool_to_toggle(bool val) {
-  return val ? kDifToggleEnabled : kDifToggleDisabled;
-}
-
 dif_result_t dif_keymgr_configure(const dif_keymgr_t *keymgr,
                                   dif_keymgr_config_t config) {
   if (keymgr == NULL) {
@@ -518,8 +493,7 @@ dif_result_t dif_keymgr_generate_versioned_key(
 
 dif_result_t dif_keymgr_sideload_clear_set_enabled(const dif_keymgr_t *keymgr,
                                                    dif_toggle_t state) {
-  bool enable = false;
-  if (keymgr == NULL || !toggle_to_bool(state, &enable)) {
+  if (keymgr == NULL || !dif_is_valid_toggle(state)) {
     return kDifBadArg;
   }
 
@@ -540,7 +514,7 @@ dif_result_t dif_keymgr_sideload_clear_get_enabled(const dif_keymgr_t *keymgr,
 
   uint32_t reg_val =
       mmio_region_read32(keymgr->base_addr, KEYMGR_SIDELOAD_CLEAR_REG_OFFSET);
-  *state = bool_to_toggle(reg_val == kDifKeyMgrSideLoadClearAll);
+  *state = dif_bool_to_toggle(reg_val == kDifKeyMgrSideLoadClearAll);
 
   return kDifOk;
 }

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -2,6 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+# Base DIF library
+sw_lib_dif_base = declare_dependency(
+  link_with: static_library(
+    'sw_lib_dif_base',
+    sources: [
+      'dif_base.c',
+    ],
+  )
+)
+
 subdir('autogen')
 
 # ADC Control Interface DIF Library (dif_adc_ctrl)
@@ -56,6 +66,7 @@ test('dif_clkmgr_unittest', executable(
     sources: [
       'dif_clkmgr_unittest.cc',
       'autogen/dif_clkmgr_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_base.c',
       meson.source_root() / 'sw/device/lib/dif/dif_clkmgr.c',
       meson.source_root() / 'sw/device/lib/dif/autogen/dif_clkmgr_autogen.c',
       hw_ip_clkmgr_reg_h,
@@ -585,6 +596,7 @@ test('dif_alert_handler_unittest', executable(
     sources: [
       'dif_alert_handler_unittest.cc',
       'autogen/dif_alert_handler_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_base.c',
       meson.source_root() / 'sw/device/lib/dif/dif_alert_handler.c',
       meson.source_root() / 'sw/device/lib/dif/autogen/dif_alert_handler_autogen.c',
       hw_ip_alert_handler_reg_h,
@@ -621,6 +633,7 @@ test('dif_pwrmgr_unittest', executable(
     sources: [
       'dif_pwrmgr_unittest.cc',
       'autogen/dif_pwrmgr_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_base.c',
       meson.source_root() / 'sw/device/lib/dif/dif_pwrmgr.c',
       meson.source_root() / 'sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c',
       hw_ip_pwrmgr_reg_h,
@@ -657,6 +670,7 @@ test('dif_keymgr_unittest', executable(
     sources: [
       'dif_keymgr_unittest.cc',
       'autogen/dif_keymgr_autogen_unittest.cc',
+      meson.source_root() / 'sw/device/lib/dif/dif_base.c',
       meson.source_root() / 'sw/device/lib/dif/dif_keymgr.c',
       meson.source_root() / 'sw/device/lib/dif/autogen/dif_keymgr_autogen.c',
       hw_ip_keymgr_reg_h,


### PR DESCRIPTION
Several DIF libraries had redefined the same logic to translate `dif_toggle_t` types to/from bool types. This commit adds one shared implementation of said functions, and removes the duplicates across individual DIF libraries.

This partially addresses a task item in #9036.

Signed-off-by: Timothy Trippel <ttrippel@google.com>