### PR TITLE
[ibex] Enable bit-manipulation extension

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6508,7 +6508,7 @@
         MHPMCounterWidth: "32"
         RV32E: "0"
         RV32M: ibex_pkg::RV32MSingleCycle
-        RV32B: ibex_pkg::RV32BNone
+        RV32B: ibex_pkg::RV32BOTEarlGrey
         RegFile: ibex_pkg::RegFileFF
         BranchTargetALU: "1"
         WritebackStage: "1"
@@ -6629,7 +6629,7 @@
         {
           name: RV32B
           type: ibex_pkg::rv32b_e
-          default: ibex_pkg::RV32BNone
+          default: ibex_pkg::RV32BOTEarlGrey
           expose: "true"
           name_top: RvCoreIbexRV32B
         }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -678,7 +678,7 @@
                    MHPMCounterWidth: "32",
                    RV32E: "0",
                    RV32M: "ibex_pkg::RV32MSingleCycle",
-                   RV32B: "ibex_pkg::RV32BNone",
+                   RV32B: "ibex_pkg::RV32BOTEarlGrey",
                    RegFile: "ibex_pkg::RegFileFF",
                    BranchTargetALU: "1",
                    WritebackStage: "1",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -83,7 +83,7 @@ module top_earlgrey #(
   parameter int unsigned RvCoreIbexMHPMCounterWidth = 32,
   parameter bit RvCoreIbexRV32E = 0,
   parameter ibex_pkg::rv32m_e RvCoreIbexRV32M = ibex_pkg::RV32MSingleCycle,
-  parameter ibex_pkg::rv32b_e RvCoreIbexRV32B = ibex_pkg::RV32BNone,
+  parameter ibex_pkg::rv32b_e RvCoreIbexRV32B = ibex_pkg::RV32BOTEarlGrey,
   parameter ibex_pkg::regfile_e RvCoreIbexRegFile = ibex_pkg::RegFileFF,
   parameter bit RvCoreIbexBranchTargetALU = 1,
   parameter bit RvCoreIbexWritebackStage = 1,

--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: a33a91b2326b560c76b780d12cae200a1302fb7d
+    rev: 410ffd349da1d4c13f77b208bb3b93adb154fac0
   }
 }

--- a/hw/vendor/lowrisc_ibex/README.md
+++ b/hw/vendor/lowrisc_ibex/README.md
@@ -29,8 +29,8 @@ These are configurations on which lowRISC is focusing for performance evaluation
 | ------ | ------- | --------| ----------| -------------------- |
 | Features | RV32EC | RV32IMC, 3 cycle mult | RV32IMC, 1 cycle mult, Branch target ALU, Writeback stage | RV32IMCB, 1 cycle mult, Branch target ALU, Writeback stage, 16 PMP regions |
 | Performance (CoreMark/MHz) | 0.904 | 2.47 | 3.13 | 3.13 |
-| Area - Yosys (kGE) | 17.44 | 26.06 | 35.64 | 58.74 |
-| Area - Commercial (estimated kGE) | ~16 | ~24 | ~33 | ~54 |
+| Area - Yosys (kGE) | 16.85 | 26.60 | 32.48 | 66.02 |
+| Area - Commercial (estimated kGE) | ~15 | ~24 | ~30 | ~61 |
 | Verification status | Red | Green | Amber | Amber |
 
 Notes:
@@ -46,8 +46,8 @@ Notes:
   Amber indicates that some verification has been performed, but the configuration is still experimental.
   Red indicates a configuration with minimal/no verification.
   Users must make their own assessment of verification readiness for any tapeout.
-* v0.92 of the RISC-V Bit Manipulation Extension is supported.
-  This is *not ratified* and there may be changes for the v1.0 ratified version.
+* v.1.0.0 of the RISC-V Bit-Manipulation Extension is supported as well as the remaining sub-extensions of draft v.0.93 of the bitmanip spec.
+  The latter are *not ratified* and there may be changes before ratification.
   See [Standards Compliance](https://ibex-core.readthedocs.io/en/latest/01_overview/compliance.html) in the Ibex documentation for more information.
 
 ## Documentation

--- a/hw/vendor/lowrisc_ibex/doc/01_overview/compliance.rst
+++ b/hw/vendor/lowrisc_ibex/doc/01_overview/compliance.rst
@@ -8,7 +8,7 @@ It follows these specifications:
 * `RISC-V Instruction Set Manual, Volume II: Privileged Architecture, document version 20190608-Base-Ratified (June 8, 2019) <https://github.com/riscv/riscv-isa-manual/releases/download/Ratified-IMFDQC-and-Priv-v1.11/riscv-privileged-20190608.pdf>`_.
   Ibex implements the Machine ISA version 1.11.
 * `RISC-V External Debug Support, version 0.13.2 <https://content.riscv.org/wp-content/uploads/2019/03/riscv-debug-release.pdf>`_
-* `RISC-V Bit Manipulation Extension, version 0.92 (draft from November 8, 2019) <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.92.pdf>`_
+* `RISC-V Bit-Manipulation Extension, version 1.0.0 <https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf>`_ and `version 0.93 (draft from January 10, 2021) <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.93.pdf>`_
 * `PMP Enhancements for memory access and execution prevention on Machine mode (Smepmp) version 0.9.3 <https://github.com/riscv/riscv-tee/blob/61455747230a26002d741f64879dd78cc9689323/Smepmp/Smepmp.pdf>`_
 
 Many features in the RISC-V specification are optional, and Ibex can be parametrized to enable or disable some of them.
@@ -35,8 +35,8 @@ In addition, the following instruction set extensions are available.
      - 2.0
      - optional
 
-   * - **B**: Draft Extension for Bit Manipulation Instructions
-     - 0.92 [#B_draft]_
+   * - **B**: Standard Extension for Bit-Manipulation Instructions
+     - 1.0.0 + 0.93 [#B_draft]_
      - optional
 
    * - **Zicsr**: Control and Status Register Instructions
@@ -59,7 +59,9 @@ See :ref:`PMP Enhancements<pmp-enhancements>` for more information on Ibex's exp
 
 .. rubric:: Footnotes
 
-.. [#B_draft] Note that while Ibex fully implements draft version 0.92 of the RISC-V Bit Manipulation Extension, this extension may change before being ratified as a standard by the RISC-V Foundation.
+.. [#B_draft] Ibex fully implements the ratified version 1.0.0 of the RISC-V Bit-Manipulation Extension including the Zba, Zbb, Zbc and Zbs sub-extensions.
+   In addition, Ibex also supports the remaining Zbe, Zbf, Zbp, Zbr and Zbt sub-extensions as defined in draft version 0.93 of the RISC-V Bit-Manipulation Extension.
+   Note that the latter sub-extensions may change before being ratified as a standard by the RISC-V Foundation.
    Ibex will be updated to match future versions of the specification.
    Prior to ratification this may involve backwards incompatible changes.
    Additionally, neither GCC or Clang have committed to maintaining support upstream for unratified versions of the specification.

--- a/hw/vendor/lowrisc_ibex/doc/01_overview/targets.rst
+++ b/hw/vendor/lowrisc_ibex/doc/01_overview/targets.rst
@@ -7,7 +7,7 @@ ASIC Synthesis
 ASIC synthesis is supported for Ibex.
 The whole design is completely synchronous and uses positive-edge triggered flip-flops, except for the register file, which can be implemented either with latches or with flip-flops.
 See :ref:`register-file` for more details.
-The core occupies an area of roughly 24 kGE when using the latch-based register file and implementing the RV32IMC ISA, or 16 kGE when implementing the RV32EC ISA.
+The core occupies an area of roughly 24 kGE when using the latch-based register file and implementing the RV32IMC ISA, or 15 kGE when implementing the RV32EC ISA.
 
 
 FPGA Synthesis

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/instruction_decode_execute.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/instruction_decode_execute.rst
@@ -64,44 +64,45 @@ Other blocks use the ALU for the following tasks:
 * It computes memory addresses for loads and stores with a Reg + Imm calculation
 * The LSU uses it to increment addresses when performing two accesses to handle an unaligned access
 
-Bit Manipulation Extension
-  Support for the `RISC-V Bit Manipulation Extension (draft version 0.92 from November 8, 2019) <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.92.pdf>`_ is optional. [#B_draft]_
+Bit-Manipulation Extension
+  Support for the `RISC-V Bit-Manipulation Extension version 1.0.0 <https://github.com/riscv/riscv-bitmanip/releases/download/1.0.0/bitmanip-1.0.0-38-g865e7a7.pdf>`_ and `draft version 0.93 from January 10, 2021 <https://github.com/riscv/riscv-bitmanip/blob/master/bitmanip-0.93.pdf>`_ is optional. [#B_draft]_
   It can be enabled via the enumerated parameter ``RV32B`` defined in :file:`rtl/ibex_pkg.sv`.
-  By default, this parameter is set to "ibex_pkg::RV32BNone" to disable the bit manipulation extension.
+  By default, this parameter is set to "ibex_pkg::RV32BNone" to disable the bit-manipulation extension.
 
-  There are two versions of the bit manipulation extension available:
-  The balanced implementation comprises a set of sub-extensions aiming for good benefits at a reasonable area overhead.
+  There are three versions of the bit-manipulation extension available:
+  The balanced version comprises a set of sub-extensions aiming for good benefits at a reasonable area overhead.
   It can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BBalanced".
-  The full implementation comprises all 32 bit instructions defined in the extension.
-  This version can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BFull".
-  The following table lists the implemented instructions in each version.
+  The OTEarlGrey version comprises all sub-extensions except for the Zbe.
+  This version can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BOTEarlGrey".
+  The full version comprises all sub-extensions and can be selected by setting the ``RV32B`` parameter to "ibex_pkg::RV32BFull".
+  The following table gives an overview of which sub-extensions are implemented in each version and of which instructions are implemented as multi-cycle instructions.
   Multi-cycle instructions are completed in 2 cycles.
   All remaining instructions complete in a single cycle.
 
-  +---------------------------------+---------------+--------------------------+
-  | Z-Extension                     | Version       | Multi-Cycle Instructions |
-  +=================================+===============+==========================+
-  | Zbb (Base)                      | Balanced/Full | rol, ror[i]              |
-  +---------------------------------+---------------+--------------------------+
-  | Zbs (Single-bit)                | Balanced/Full | None                     |
-  +---------------------------------+---------------+--------------------------+
-  | Zbp (Permutation)               | Full          | None                     |
-  +---------------------------------+---------------+--------------------------+
-  | Zbe (Bit compress/decompress)   | Full          | All                      |
-  +---------------------------------+---------------+--------------------------+
-  | Zbf (Bit-field place)           | Balanced/Full | All                      |
-  +---------------------------------+---------------+--------------------------+
-  | Zbc (Carry-less multiply)       | Full          | None                     |
-  +---------------------------------+---------------+--------------------------+
-  | Zbr (CRC)                       | Full          | All                      |
-  +---------------------------------+---------------+--------------------------+
-  | Zbt (Ternary)                   | Balanced/Full | All                      |
-  +---------------------------------+---------------+--------------------------+
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Bit-Manipulation Sub-Extension | Spec.   | Balanced | OTEarlGrey | Full | Multi-Cycle Instr. |
+  +================================+=========+==========+============+======+====================+
+  | Zba (Address generation)       | v.1.0.0 |    X     |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbb (Base)                     | v.1.0.0 |    X     |     X      |  X   | rol, ror[i]        |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbc (Carry-less multiply)      | v.1.0.0 |          |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbs (Single-bit)               | v.1.0.0 |    X     |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbe (Bit compress/decompress)  | v.0.93  |          |            |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbf (Bit-field place)          | v.0.93  |    X     |     X      |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbp (Permutation)              | v.0.93  |          |     X      |  X   | None               |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbr (CRC)                      | v.0.93  |          |     X      |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
+  | Zbt (Ternary)                  | v.0.93  |    X     |     X      |  X   | All                |
+  +--------------------------------+---------+----------+------------+------+--------------------+
 
-  The implementation of the B-extension comes with an area overhead of 1.8 to 3.0 kGE for the balanced version and 6.0 to 8.7 kGE for the full version.
-  That corresponds to an approximate percentage increase in area of 9 to 14 % and 25 to 30 % for the balanced and full versions respectively.
-  The ranges correspond to synthesis results generated using relaxed and maximum frequency targets respectively.
-  The designs have been synthesized using Synopsys Design Compiler targeting TSMC 65 nm technology.
+  The implementation of the Bit-Manipulation Extension comes with an area overhead of 2.7 kGE for the balanced version, 6.1 kGE for the OTEarlGrey version, and 7.5 kGE for the full version.
+  These numbers were obtained by synthesizing the design with Yosys and relaxed timing constraints.
 
 
 .. _mult-div:
@@ -171,8 +172,9 @@ See :ref:`load-store-unit` for more details.
 
 .. rubric:: Footnotes
 
-.. [#B_draft] Ibex fully implements draft version 0.92 of the RISC-V Bit Manipulation Extension.
-   This extension may change before being ratified as a standard by the RISC-V Foundation.
+.. [#B_draft] Ibex fully implements the ratified version 1.0.0 of the RISC-V Bit-Manipulation Extension including the Zba, Zbb, Zbc and Zbs sub-extensions.
+   In addition, Ibex also supports the remaining Zbe, Zbf, Zbp, Zbr and Zbt sub-extensions as defined in draft version 0.93 of the RISC-V Bit-Manipulation Extension.
+   Note that the latter sub-extensions may change before being ratified as a standard by the RISC-V Foundation.
    Ibex will be updated to match future versions of the specification.
    Prior to ratification this may involve backwards incompatible changes.
    Additionally, neither GCC or Clang have committed to maintaining support upstream for unratified versions of the specification.

--- a/hw/vendor/lowrisc_ibex/ibex_configs.yaml
+++ b/hw/vendor/lowrisc_ibex/ibex_configs.yaml
@@ -26,7 +26,7 @@ small:
 opentitan:
   RV32E                    : 0
   RV32M                    : "ibex_pkg::RV32MSingleCycle"
-  RV32B                    : "ibex_pkg::RV32BNone"
+  RV32B                    : "ibex_pkg::RV32BOTEarlGrey"
   RegFile                  : "ibex_pkg::RegFileFF"
   BranchTargetALU          : 1
   WritebackStage           : 1

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_pkg.sv
@@ -45,9 +45,10 @@ package ibex_pkg;
   } rv32m_e;
 
   typedef enum integer {
-    RV32BNone     = 0,
-    RV32BBalanced = 1,
-    RV32BFull     = 2
+    RV32BNone       = 0,
+    RV32BBalanced   = 1,
+    RV32BOTEarlGrey = 2,
+    RV32BFull       = 3
   } rv32b_e;
 
   /////////////

--- a/hw/vendor/lowrisc_ibex/syn/syn_yosys.sh
+++ b/hw/vendor/lowrisc_ibex/syn/syn_yosys.sh
@@ -48,6 +48,7 @@ for file in ../rtl/*.sv; do
     --define=SYNTHESIS \
     ../rtl/*_pkg.sv \
     ../vendor/lowrisc_ip/ip/prim/rtl/prim_ram_1p_pkg.sv \
+    ../vendor/lowrisc_ip/ip/prim/rtl/prim_secded_pkg.sv \
     -I../vendor/lowrisc_ip/ip/prim/rtl \
     -I../vendor/lowrisc_ip/dv/sv/dv_utils \
     $file \

--- a/test/systemtest/earlgrey/test_sim_verilator.py
+++ b/test/systemtest/earlgrey/test_sim_verilator.py
@@ -238,7 +238,7 @@ def test_openocd_basic_connectivity(tmp_path, bin_dir, topsrcdir, openocd):
         ('Info : JTAG tap: riscv.tap tap/device found: 0x04f5484d '
          '(mfg: 0x426 (Google Inc), part: 0x4f54, ver: 0x0)'),
         'Info : Examined RISC-V core; found 1 harts',
-        'Info :  hart 0: XLEN=32, misa=0x40101104',
+        'Info :  hart 0: XLEN=32, misa=0x40101106',
     ]
 
     for msg_exp in msgs_exp:


### PR DESCRIPTION
This vendors in the latest version of Ibex supporting the OTEarlGrey bitmanip configuration and enables this config in Earl Grey. This adds support for the Zba, Zbb, Zbc and Zbs bit-manipulation sub-extensions ratified in v.1.0.0 of the RISC-V Bit- Manipulation ISA Extension, as well as support for the non-ratified sub-extensions Zbf, Zbp, Zbr, Zbt part of the draft v.0.93 spec.

The expected area increase is around 6 kGE or 12 kGE w/o or w/ lockstep, respectively.

Toolchain support is currently being worked on. Nevertheless, this should be sufficient to unblock some software work. AFAIK, the current toolchain already has support for draft v.0.92 of the bitmanip and the amount of changes are very low. For example, the are no changes around the carry-less multiplier (Zbc) instructions. For details, refer to this [document](https://docs.google.com/document/d/1CFIdnXT66RbaYx3qTkAaM-tDchNtZEYYC2_UYuYr0Vc/edit#bookmark=id.rc47xlh8hocm).

This resolves lowRISC/OpenTitan#2708.