### PR TITLE
[lc_ctrl/dv] Added lc_errors test

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/lc_ctrl_state_failure_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_errors_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_state_post_trans_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_lc_errors_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -86,7 +86,7 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
     // Set base address for JTAG map
     ral.set_base_addr(ral.default_map.get_base_addr(), jtag_riscv_map);
 
-    alert_max_delay = 500;
+    alert_max_delay = 1000;
   endfunction
 
   protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
@@ -95,7 +95,10 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   endfunction
 
   virtual function void set_test_phase(lc_ctrl_test_phase_e test_phase);
+    // Set in config object
     this.test_phase = test_phase;
+    // And interface
+    lc_ctrl_vif.test_phase <= test_phase;
     ->set_test_phase_ev;
   endfunction
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -54,9 +54,15 @@ package lc_ctrl_env_pkg;
 
   // error injection
   typedef struct packed {
+    // Bad protocol on clk_byp_ack_i
     bit clk_byp_error_rsp;
+    // Bad protocol on flash_rma_ack_i
     bit flash_rma_error_rsp;
+    // OTP responds with error
     bit otp_prog_err;
+    // OTP data to lc_ctrl has error bit set
+    bit otp_partition_err;
+    // Incorrect token for state change
     bit token_mismatch_err;
     // Invalid state driven via OTP interface
     bit state_err;
@@ -68,7 +74,10 @@ package lc_ctrl_env_pkg;
     bit count_backdoor_err;
     // Send a transition request in post_trans state
     bit post_trans_err;
+    // Invalid transition for current state
     bit transition_err;
+    // Invalid transition because count already at maximum
+    bit transition_count_err;
   } lc_ctrl_err_inj_t;
 
   // Test phase - used to synchronise the scoreboard

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -25,42 +25,47 @@ interface lc_ctrl_if (
   import otp_ctrl_pkg::*;
   import otp_ctrl_part_pkg::*;
 
-  logic               tdo_oe;  // TODO: add assertions
-  otp_lc_data_t       otp_i;
-  otp_device_id_t     otp_device_id_i;
-  otp_device_id_t     otp_manuf_state_i;
-  lc_token_t          hashed_token;
+  logic                                 tdo_oe;  // TODO: add assertions
+  otp_lc_data_t                         otp_i;
+  otp_device_id_t                       otp_device_id_i;
+  otp_device_id_t                       otp_manuf_state_i;
+  lc_token_t                            hashed_token;
 
-  lc_tx_t             lc_dft_en_o;
-  lc_tx_t             lc_nvm_debug_en_o;
-  lc_tx_t             lc_hw_debug_en_o;
-  lc_tx_t             lc_cpu_en_o;
-  lc_tx_t             lc_creator_seed_sw_rw_en_o;
-  lc_tx_t             lc_owner_seed_sw_rw_en_o;
-  lc_tx_t             lc_iso_part_sw_rd_en_o;
-  lc_tx_t             lc_iso_part_sw_wr_en_o;
-  lc_tx_t             lc_seed_hw_rd_en_o;
-  lc_tx_t             lc_keymgr_en_o;
-  lc_tx_t             lc_escalate_en_o;
-  lc_tx_t             lc_check_byp_en_o;
+  lc_tx_t                               lc_dft_en_o;
+  lc_tx_t                               lc_nvm_debug_en_o;
+  lc_tx_t                               lc_hw_debug_en_o;
+  lc_tx_t                               lc_cpu_en_o;
+  lc_tx_t                               lc_creator_seed_sw_rw_en_o;
+  lc_tx_t                               lc_owner_seed_sw_rw_en_o;
+  lc_tx_t                               lc_iso_part_sw_rd_en_o;
+  lc_tx_t                               lc_iso_part_sw_wr_en_o;
+  lc_tx_t                               lc_seed_hw_rd_en_o;
+  lc_tx_t                               lc_keymgr_en_o;
+  lc_tx_t                               lc_escalate_en_o;
+  lc_tx_t                               lc_check_byp_en_o;
 
-  lc_tx_t             clk_byp_req_o;
-  lc_tx_t             clk_byp_ack_i;
-  lc_tx_t             flash_rma_req_o;
-  lc_tx_t             flash_rma_ack_i;
+  lc_tx_t                               clk_byp_req_o;
+  lc_tx_t                               clk_byp_ack_i;
+  lc_tx_t                               flash_rma_req_o;
+  lc_tx_t                               flash_rma_ack_i;
 
-  lc_keymgr_div_t     keymgr_div_o;
-  lc_flash_rma_seed_t flash_rma_seed_o;
+  lc_keymgr_div_t                       keymgr_div_o;
+  lc_flash_rma_seed_t                   flash_rma_seed_o;
 
-  event               fsm_backdoor_state_write_ev;
-  event               fsm_backdoor_state_read_ev;
-  event               fsm_backdoor_count_write_ev;
-  event               fsm_backdoor_count_read_ev;
+  event                                 fsm_backdoor_state_write_ev;
+  event                                 fsm_backdoor_state_read_ev;
+  event                                 fsm_backdoor_count_write_ev;
+  event                                 fsm_backdoor_count_read_ev;
+
+  // Debug signals
+  lc_ctrl_env_pkg::lc_ctrl_err_inj_t    err_inj;
+  lc_ctrl_env_pkg::lc_ctrl_test_phase_e test_phase;
 
   task automatic init(lc_state_e lc_state = LcStRaw, lc_cnt_e lc_cnt = LcCnt0,
-                      lc_tx_t clk_byp_ack = Off, lc_tx_t flash_rma_ack = Off);
+                      lc_tx_t clk_byp_ack = Off, lc_tx_t flash_rma_ack = Off,
+                      logic otp_partition_err = 0);
     otp_i.valid             = 1;
-    otp_i.error             = 0;
+    otp_i.error             = otp_partition_err;
     otp_i.state             = lc_state;
     otp_i.count             = lc_cnt;
     otp_i.test_unlock_token = lc_ctrl_env_pkg::get_random_token();

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_lc_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_lc_errors_vseq.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Error injection and checks for:
+// Invalid transition
+// Transition count = 24
+// Clock bypass invalid response
+// Flash RMA invalid response
+// Incorrect token for transition
+// OTP partition error
+
+class lc_ctrl_lc_errors_vseq extends lc_ctrl_errors_vseq;
+
+  `uvm_object_utils(lc_ctrl_lc_errors_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[50 : 100]};}
+
+  constraint lc_errors_c {
+    $onehot(
+        {
+          err_inj.transition_err,
+          err_inj.transition_count_err,
+          err_inj.clk_byp_error_rsp,
+          err_inj.flash_rma_error_rsp,
+          err_inj.token_mismatch_err,
+          err_inj.otp_partition_err
+        }
+    );
+  }
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_prog_failure_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_prog_failure_vseq.sv
@@ -4,18 +4,11 @@
 
 // This sequence triggers prog_failure alert by setting the error bit in otp_program_rsp
 // Then check in scb if the alert is triggered correctly
-class lc_ctrl_prog_failure_vseq extends lc_ctrl_smoke_vseq;
+class lc_ctrl_prog_failure_vseq extends lc_ctrl_errors_vseq;
   `uvm_object_utils(lc_ctrl_prog_failure_vseq)
 
   `uvm_object_new
 
-  constraint otp_prog_err_c {
-    otp_prog_err == 1;
-  }
-
-  virtual task post_start();
-    expect_fatal_alerts = 1;
-    super.post_start();
-  endtask
+  constraint otp_prog_err_c {err_inj.otp_prog_err == 1;}
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -9,4 +9,5 @@
 `include "lc_ctrl_prog_failure_vseq.sv"
 `include "lc_ctrl_state_failure_vseq.sv"
 `include "lc_ctrl_state_post_trans_vseq.sv"
+`include "lc_ctrl_lc_errors_vseq.sv"
 

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -68,7 +68,7 @@
 
     {
       name: lc_ctrl_errors
-      uvm_test_seq: lc_ctrl_errors_vseq
+      uvm_test_seq: lc_ctrl_lc_errors_vseq
     }
 
   ]

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -25,18 +25,42 @@ module tb;
   assign otp_vendor_test_status = '0;
 
   // interfaces
-  clk_rst_if   clk_rst_if(.clk(clk), .rst_n(rst_n));
-  pins_if      #(1) devmode_if(devmode);
-  pins_if      #(LcPwrIfWidth) pwr_lc_if(pwr_lc);
-  tl_if        tl_if(.clk(clk), .rst_n(rst_n));
-  lc_ctrl_if   lc_ctrl_if(.clk(clk), .rst_n(rst_n));
-  alert_esc_if esc_scrap_state1_if(.clk(clk), .rst_n(rst_n));
-  alert_esc_if esc_scrap_state0_if(.clk(clk), .rst_n(rst_n));
-  jtag_if      jtag_if();
-  push_pull_if #(.HostDataWidth(OTP_PROG_HDATA_WIDTH), .DeviceDataWidth(OTP_PROG_DDATA_WIDTH))
-               otp_prog_if(.clk(clk), .rst_n(rst_n));
-  push_pull_if #(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth))
-               otp_token_if(.clk(clk), .rst_n(rst_n));
+  clk_rst_if clk_rst_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
+  pins_if #(1) devmode_if (devmode);
+  pins_if #(LcPwrIfWidth) pwr_lc_if (pwr_lc);
+  tl_if tl_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
+  lc_ctrl_if lc_ctrl_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
+  alert_esc_if esc_scrap_state1_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
+  alert_esc_if esc_scrap_state0_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
+  jtag_if jtag_if ();
+  push_pull_if #(
+    .HostDataWidth  (OTP_PROG_HDATA_WIDTH),
+    .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)
+  ) otp_prog_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
+  push_pull_if #(
+    .HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)
+  ) otp_token_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
 
   // TODO: need to properly hook up KMAC agent.
   logic req_q;
@@ -54,16 +78,16 @@ module tb;
 
   always_ff @(posedge clk or negedge rst_n) begin : p_kmac_regs
     if (!rst_n) begin
-      req_q <= 1'b0;
+      req_q   <= 1'b0;
       token_q <= '0;
     end else begin
       req_q <= req_q & ~otp_token_if.ack;
       if (kmac_data_out.valid) begin
         if (kmac_data_out.last) begin
           req_q <= 1'b1;
-          token_q[64 +: 64] <= kmac_data_out.data;
+          token_q[64+:64] <= kmac_data_out.data;
         end else begin
-          token_q[0 +: 64] <= kmac_data_out.data;
+          token_q[0+:64] <= kmac_data_out.data;
         end
       end
     end
@@ -74,66 +98,66 @@ module tb;
 
   // dut
   lc_ctrl dut (
-    .clk_i                      (clk      ),
-    .rst_ni                     (rst_n    ),
+    .clk_i (clk),
+    .rst_ni(rst_n),
 
     // TODO: connect this to a different clock
-    .clk_kmac_i                 (clk      ),
-    .rst_kmac_ni                (rst_n    ),
+    .clk_kmac_i (clk),
+    .rst_kmac_ni(rst_n),
 
-    .tl_i                       (tl_if.h2d),
-    .tl_o                       (tl_if.d2h),
-    .alert_rx_i                 (alert_rx ),
-    .alert_tx_o                 (alert_tx ),
+    .tl_i      (tl_if.h2d),
+    .tl_o      (tl_if.d2h),
+    .alert_rx_i(alert_rx),
+    .alert_tx_o(alert_tx),
 
-    .jtag_i                     ({jtag_if.tck, jtag_if.tms, jtag_if.trst_n, jtag_if.tdi}),
-    .jtag_o                     ({jtag_if.tdo, lc_ctrl_if.tdo_oe}),
-    .scanmode_i                 (1'b0     ),
+    .jtag_i    ({jtag_if.tck, jtag_if.tms, jtag_if.trst_n, jtag_if.tdi}),
+    .jtag_o    ({jtag_if.tdo, lc_ctrl_if.tdo_oe}),
+    .scanmode_i(1'b0),
 
-    .esc_scrap_state0_tx_i      (esc_scrap_state0_if.esc_tx),
-    .esc_scrap_state0_rx_o      (esc_scrap_state0_if.esc_rx),
-    .esc_scrap_state1_tx_i      (esc_scrap_state1_if.esc_tx),
-    .esc_scrap_state1_rx_o      (esc_scrap_state1_if.esc_rx),
+    .esc_scrap_state0_tx_i(esc_scrap_state0_if.esc_tx),
+    .esc_scrap_state0_rx_o(esc_scrap_state0_if.esc_rx),
+    .esc_scrap_state1_tx_i(esc_scrap_state1_if.esc_tx),
+    .esc_scrap_state1_rx_o(esc_scrap_state1_if.esc_rx),
 
-    .pwr_lc_i                   (pwr_lc[LcPwrInitReq]),
-    .pwr_lc_o                   (pwr_lc[LcPwrDoneRsp:LcPwrIdleRsp]),
+    .pwr_lc_i(pwr_lc[LcPwrInitReq]),
+    .pwr_lc_o(pwr_lc[LcPwrDoneRsp:LcPwrIdleRsp]),
 
-    .lc_otp_vendor_test_o       (otp_vendor_test_ctrl),
-    .lc_otp_vendor_test_i       (otp_vendor_test_status),
+    .lc_otp_vendor_test_o(otp_vendor_test_ctrl),
+    .lc_otp_vendor_test_i(otp_vendor_test_status),
 
-    .lc_otp_program_o           ({otp_prog_if.req, otp_prog_if.h_data}),
-    .lc_otp_program_i           ({otp_prog_if.d_data, otp_prog_if.ack}),
+    .lc_otp_program_o({otp_prog_if.req, otp_prog_if.h_data}),
+    .lc_otp_program_i({otp_prog_if.d_data, otp_prog_if.ack}),
 
-    .kmac_data_i                (kmac_data_in),
-    .kmac_data_o                (kmac_data_out),
+    .kmac_data_i(kmac_data_in),
+    .kmac_data_o(kmac_data_out),
 
-    .otp_lc_data_i              (lc_ctrl_if.otp_i),
+    .otp_lc_data_i(lc_ctrl_if.otp_i),
 
-    .lc_dft_en_o                (lc_ctrl_if.lc_dft_en_o),
-    .lc_nvm_debug_en_o          (lc_ctrl_if.lc_nvm_debug_en_o),
-    .lc_hw_debug_en_o           (lc_ctrl_if.lc_hw_debug_en_o),
-    .lc_cpu_en_o                (lc_ctrl_if.lc_cpu_en_o),
-    .lc_creator_seed_sw_rw_en_o (lc_ctrl_if.lc_creator_seed_sw_rw_en_o),
-    .lc_owner_seed_sw_rw_en_o   (lc_ctrl_if.lc_owner_seed_sw_rw_en_o),
-    .lc_iso_part_sw_rd_en_o     (lc_ctrl_if.lc_iso_part_sw_rd_en_o),
-    .lc_iso_part_sw_wr_en_o     (lc_ctrl_if.lc_iso_part_sw_wr_en_o),
-    .lc_seed_hw_rd_en_o         (lc_ctrl_if.lc_seed_hw_rd_en_o),
-    .lc_keymgr_en_o             (lc_ctrl_if.lc_keymgr_en_o),
-    .lc_escalate_en_o           (lc_ctrl_if.lc_escalate_en_o),
-    .lc_check_byp_en_o          (lc_ctrl_if.lc_check_byp_en_o),
+    .lc_dft_en_o               (lc_ctrl_if.lc_dft_en_o),
+    .lc_nvm_debug_en_o         (lc_ctrl_if.lc_nvm_debug_en_o),
+    .lc_hw_debug_en_o          (lc_ctrl_if.lc_hw_debug_en_o),
+    .lc_cpu_en_o               (lc_ctrl_if.lc_cpu_en_o),
+    .lc_creator_seed_sw_rw_en_o(lc_ctrl_if.lc_creator_seed_sw_rw_en_o),
+    .lc_owner_seed_sw_rw_en_o  (lc_ctrl_if.lc_owner_seed_sw_rw_en_o),
+    .lc_iso_part_sw_rd_en_o    (lc_ctrl_if.lc_iso_part_sw_rd_en_o),
+    .lc_iso_part_sw_wr_en_o    (lc_ctrl_if.lc_iso_part_sw_wr_en_o),
+    .lc_seed_hw_rd_en_o        (lc_ctrl_if.lc_seed_hw_rd_en_o),
+    .lc_keymgr_en_o            (lc_ctrl_if.lc_keymgr_en_o),
+    .lc_escalate_en_o          (lc_ctrl_if.lc_escalate_en_o),
+    .lc_check_byp_en_o         (lc_ctrl_if.lc_check_byp_en_o),
 
-    .lc_clk_byp_req_o           (lc_ctrl_if.clk_byp_req_o),
-    .lc_clk_byp_ack_i           (lc_ctrl_if.clk_byp_ack_i),
+    .lc_clk_byp_req_o(lc_ctrl_if.clk_byp_req_o),
+    .lc_clk_byp_ack_i(lc_ctrl_if.clk_byp_ack_i),
 
-    .lc_flash_rma_seed_o        (lc_ctrl_if.flash_rma_seed_o),
-    .lc_flash_rma_req_o         (lc_ctrl_if.flash_rma_req_o),
-    .lc_flash_rma_ack_i         (lc_ctrl_if.flash_rma_ack_i),
+    .lc_flash_rma_seed_o(lc_ctrl_if.flash_rma_seed_o),
+    .lc_flash_rma_req_o (lc_ctrl_if.flash_rma_req_o),
+    .lc_flash_rma_ack_i (lc_ctrl_if.flash_rma_ack_i),
 
-    .lc_keymgr_div_o            (lc_ctrl_if.keymgr_div_o),
+    .lc_keymgr_div_o(lc_ctrl_if.keymgr_div_o),
 
-    .otp_device_id_i            (lc_ctrl_if.otp_device_id_i),
+    .otp_device_id_i(lc_ctrl_if.otp_device_id_i),
 
-    .otp_manuf_state_i          (lc_ctrl_if.otp_manuf_state_i)
+    .otp_manuf_state_i(lc_ctrl_if.otp_manuf_state_i)
   );
 
   initial begin
@@ -145,22 +169,35 @@ module tb;
     uvm_config_db#(pwr_lc_vif)::set(null, "*.env", "pwr_lc_vif", pwr_lc_if);
     uvm_config_db#(virtual lc_ctrl_if)::set(null, "*.env", "lc_ctrl_vif", lc_ctrl_if);
 
+    // verilog_format: off - avoid bad formatting
     // The jtag_agent is a low_level agent that configured inside jtag_riscv_agent.
     uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_riscv_agent.m_jtag_agent*", "vif",
                                          jtag_if);
-
     uvm_config_db#(virtual alert_esc_if)::set(null, "*env.m_esc_scrap_state1_agent*", "vif",
                                               esc_scrap_state1_if);
     uvm_config_db#(virtual alert_esc_if)::set(null, "*env.m_esc_scrap_state0_agent*", "vif",
                                               esc_scrap_state0_if);
-
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(OTP_PROG_HDATA_WIDTH),
                                          .DeviceDataWidth(OTP_PROG_DDATA_WIDTH)))::
                    set(null, "*env.m_otp_prog_pull_agent*", "vif", otp_prog_if);
     uvm_config_db#(virtual push_pull_if#(.HostDataWidth(lc_ctrl_state_pkg::LcTokenWidth)))::
                    set(null, "*env.m_otp_token_pull_agent*", "vif", otp_token_if);
+    // verilog_format: on
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
+
+  // Assertion controls
+  `DV_ASSERT_CTRL("OtpProgH_DataStableWhenBidirectionalAndReq_A",
+                  otp_prog_if.H_DataStableWhenBidirectionalAndReq_A)
+  `DV_ASSERT_CTRL("OtpProgReqHighUntilAck_A", otp_prog_if.ReqHighUntilAck_A)
+  `DV_ASSERT_CTRL("OtpProgAckAssertedOnlyWhenReqAsserted_A",
+                  otp_prog_if.AckAssertedOnlyWhenReqAsserted_A)
+  `DV_ASSERT_CTRL(
+      "KmacIfSyncReqAckAckNeedsReq",
+      dut.u_lc_ctrl_kmac_if.u_prim_sync_reqack_data_in.u_prim_sync_reqack.SyncReqAckAckNeedsReq)
+  `DV_ASSERT_CTRL(
+      "KmacIfSyncReqAckAckNeedsReq",
+      tb.dut.u_lc_ctrl_kmac_if.u_prim_sync_reqack_data_out.u_prim_sync_reqack.SyncReqAckAckNeedsReq)
 
 endmodule

--- a/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
+++ b/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
@@ -33,6 +33,14 @@ class lc_ctrl_base_test extends cip_base_test #(
     // Demote address maps warnings
     msg = "\s*map .* does not seem to be initialized correctly.*";
     catcher.add_change_sev("RegModel", msg, UVM_INFO);
+
+    // Demote field busy warning
+    msg = {
+      "\s*Setting the value of field \".*\" while containing",
+      "\s+register \"lc_ctrl_reg_block.alert_test\" is being accessed"
+    };
+    catcher.add_change_sev("UVM/FLD/SET/BSY", msg, UVM_INFO);
+
   endfunction
 
 endclass : lc_ctrl_base_test


### PR DESCRIPTION
- Added error injection and checks for:
  - Invalid transition
  - Transition count = 24
  - Clock bypass invalid response
  - Flash RMA invalid response
  - Incorrect token for transition
  - OTP partition error
- Added sequence lc_ctrl_lc_errors_vseq
- Fixed up OTP program error injection
- lc_ctrl_prog_failure test works as intended and passes
- Added demote in base test for [UVM/FLD/SET/BSY]
Setting the value of field... UVM_WARNING

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>