### PR TITLE
[ entropy_src, rtl ] Correct bucket health test test_cnt_o

### DIFF
--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -25,6 +25,7 @@ filesets:
       - rtl/entropy_src_cntr_reg.sv
       - rtl/entropy_src_ack_sm.sv
       - rtl/entropy_src_main_sm.sv
+      - rtl/entropy_src_comparator_tree.sv
       - rtl/entropy_src_repcnt_ht.sv
       - rtl/entropy_src_repcnts_ht.sv
       - rtl/entropy_src_adaptp_ht.sv

--- a/hw/ip/entropy_src/rtl/entropy_src_bucket_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_bucket_ht.sv
@@ -29,11 +29,11 @@ module entropy_src_bucket_ht #(
   // signals
   logic [NUM_BINS-1:0] bin_incr;
   logic [NUM_BINS-1:0] bin_cnt_exceeds_thresh;
-  logic [RegWidth-1:0] bin_cntr[NUM_BINS];
+  logic [NUM_BINS - 1:0][RegWidth - 1:0] bin_cntr;
   logic [NUM_BINS-1:0] bin_cntr_err;
   logic [RegWidth-1:0] test_cnt;
   logic                test_cnt_err;
-
+  logic [RegWidth-1:0] bin_max;
 
   // Bucket Test
   //
@@ -68,6 +68,14 @@ module entropy_src_bucket_ht #(
     assign bin_cnt_exceeds_thresh[i] = (bin_cntr[i] > thresh_i);
   end : gen_symbol_match
 
+  entropy_src_comparator_tree #(
+    .Width(RegWidth),
+    .Depth(RngBusWidth)
+  ) u_comp (
+    .i(bin_cntr),
+    .o(bin_max)
+  );
+
   // Test event counter
   prim_count #(
       .Width(RegWidth),
@@ -87,7 +95,7 @@ module entropy_src_bucket_ht #(
 
   // the pulses will be only one clock in length
   assign test_fail_pulse_o = active_i && window_wrap_pulse_i && (test_cnt > '0);
-  assign test_cnt_o = test_cnt;
+  assign test_cnt_o = bin_max;
   assign count_err_o = test_cnt_err || (|bin_cntr_err);
 
 

--- a/hw/ip/entropy_src/rtl/entropy_src_comparator_tree.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_comparator_tree.sv
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//
+// Synthesizeable block for computing the maximum of an array
+//
+// For use by the entropy_src bucket test.
+//
+module entropy_src_comparator_tree
+  #(
+    parameter int Depth      = 1,
+    parameter int Width      = 16,
+    parameter int InputCnt   = (1 << Depth)
+  ) (
+    input logic  [InputCnt - 1:0][Width - 1:0] i,
+    output logic [Width - 1:0]                 o
+  );
+
+  if (Depth == 0) begin : gen_simple_comparator
+    assign o = i;
+  end else begin : gen_recursive_comparator
+    localparam int OutputCnt = InputCnt/2;
+    logic [1:0][Width - 1:0] o_prime;
+
+    for (genvar j = 0; j < 2; j++) begin : gen_nested_comparators
+      entropy_src_comparator_tree #(
+        .Depth(Depth - 1),
+        .Width(Width)
+      ) u_nested_comparator_tree (
+        .i(i[OutputCnt * j +: OutputCnt]),
+        .o(o_prime[j])
+      );
+    end : gen_nested_comparators
+
+    assign o = (o_prime[1] > o_prime[0]) ? o_prime[1] : o_prime[0];
+
+  end : gen_recursive_comparator
+
+endmodule


### PR DESCRIPTION
The previous version of entropy_src_bucket_ht output a count of failing tests on test_cnt_o
This is not what is specified in the documentation. Rather this is supposed to output the
value of the most heavily weighted bin.

This commit calculates the maximum of the (2 ** RngBusWidth) histogram bins, by creating
a tree of comparators (RngBusWidth deep).

Fixes #9757

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>