### PR TITLE
[aes] Fix IV register status tracking

### DIFF
--- a/hw/ip/aes/rtl/aes_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm.sv
@@ -392,7 +392,7 @@ module aes_control_fsm
         // Signal that we have used the current key, IV, data input to register status tracking.
         key_init_load =  cipher_dec_key_gen_i; // This key is no longer "new", but still clean.
         key_init_arm  = ~cipher_dec_key_gen_i; // The key is still "new", prevent partial updates.
-        iv_load       =  cipher_dec_key_gen_i & (doing_cbc_enc |
+        iv_load       = ~cipher_dec_key_gen_i & (doing_cbc_enc |
                                                  doing_cbc_dec |
                                                  doing_cfb_enc |
                                                  doing_cfb_dec |


### PR DESCRIPTION
In commit 168d81499a898211b2d6e8e58818510c1dd1463c, the status tracking of the IV register got accidentally messed up. In particular, the load signal got never set. As a result, the IV register wasn't marked anymore as consumed after being loaded into the cipher core.