### PR TITLE
[aes] DOM S-Box optimizations

### DIFF
--- a/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
@@ -75,7 +75,7 @@ module aes_sbox_tb #(
   // PRD Generation
   parameter int unsigned WidthPRDSBoxCanrightMasked        = 8;
   parameter int unsigned WidthPRDSBoxCanrightMaskedNoreuse = 18;
-  parameter int unsigned WidthPRDSBoxDOM                   = 8;
+  parameter int unsigned WidthPRDSBoxDOM                   = 28;
 
   logic                                   [31:0] prd;
   logic [31-WidthPRDSBoxCanrightMaskedNoreuse:0] unused_prd;
@@ -87,7 +87,7 @@ module aes_sbox_tb #(
       prd <= {$random};
     end
   end
-  assign unused_prd = prd[31:WidthPRDSBoxCanrightMaskedNoreuse];
+  assign unused_prd = prd[31:WidthPRDSBoxDOM];
 
   // Instantiate Masked SBox Implementations
   aes_sbox_canright_masked_noreuse aes_sbox_canright_masked_noreuse (
@@ -109,7 +109,8 @@ module aes_sbox_tb #(
   );
 
   // Instantiate DOM SBox Implementation
-  logic dom_done;
+  logic        dom_done;
+  logic [19:0] unused_out_prd, out_prd;
   aes_sbox_dom aes_sbox_dom (
     .clk_i     ( clk_i                    ),
     .rst_ni    ( rst_ni                   ),
@@ -121,8 +122,10 @@ module aes_sbox_tb #(
     .mask_i    ( in_mask                  ),
     .prd_i     ( prd[WidthPRDSBoxDOM-1:0] ),
     .data_o    ( masked_response[2]       ),
-    .mask_o    ( out_mask[2]              )
+    .mask_o    ( out_mask[2]              ),
+    .prd_o     ( out_prd                  )
   );
+  assign unused_out_prd = out_prd;
 
   // Unmask responses
   always_comb begin : unmask_resp


### PR DESCRIPTION
This PR contains two optimizations to the AES DOM S-Box that allow for a substantial area reduction of the entire AES by ~10%. The two changes are:

- Re-using some pipeline registers between Stages 2 and 3. The registers are already available as we use fully pipelined DOM multipliers. But synthesis can no longer do the optimization automatically due to the prim_buf/flop_en primitives -> saves 8 flops per S-Box instance
- Using partial, intermediate results of Stage X in S-Box Y as randomness for independent computations in Stage X+1 in S-Box Z. This reduces the amount of logic spent on buffering and distributing randomness -> saves 20 flops per S-Box, 40 2-input 1-bit mux cells per S-Box instance

The changes have been verified formally at the individual S-Box level and the level of a reduced round (SubBytes, ShiftRows, MixColumns with a total of 16 S-Boxes incl. distribution and re-use of intermediate results as randomness). The implementation successfully passes stable and transient analysis, i.e., there should no leakage be introduced through this optimization.

I am currently running some more FPGA experiments.