### PR TITLE
[sw] Starting point for an HMAC driver.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "hmac",
+    srcs = ["hmac.c"],
+    hdrs = ["hmac.h"],
+    deps = [
+        "//hw/ip/hmac/data:hmac_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+    ],
+)
+

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -2,90 +2,84 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/lib/crypto/drivers/hmac.h"
 
 #include "sw/device/lib/base/bitfield.h"
-#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/memory.h"
-#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
-#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/lib/base/mmio.h"
 
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 void hmac_sha256_init(void) {
+  mmio_region_t hmac_base = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
+
   // Clear the config, stopping the SHA engine.
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, 0u);
+  mmio_region_write32(hmac_base, HMAC_CFG_REG_OFFSET, 0);
 
   // Disable and clear interrupts. INTR_STATE register is rw1c.
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_ENABLE_REG_OFFSET,
-                   0u);
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
-                   UINT32_MAX);
+  mmio_region_write32(hmac_base, HMAC_INTR_ENABLE_REG_OFFSET, 0);
+  mmio_region_write32(hmac_base, HMAC_INTR_STATE_REG_OFFSET, 0);
 
   uint32_t reg = 0;
+  // Digest is little-endian by default.
   reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, false);
   // Enable endian swap since our inputs are little-endian.
   reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, true);
   reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
   reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, reg);
+  mmio_region_write32(hmac_base, HMAC_CFG_REG_OFFSET, reg);
 
   reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_START_BIT, true);
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
+  mmio_region_write32(hmac_base, HMAC_CMD_REG_OFFSET, reg);
 }
 
-rom_error_t hmac_sha256_update(const void *data, size_t len) {
+hmac_error_t hmac_sha256_update(const void *data, size_t len) {
   if (data == NULL) {
-    return kErrorHmacInvalidArgument;
+    return kHmacErrorBadArg;
   }
+  mmio_region_t hmac_base = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
   const uint8_t *data_sent = (const uint8_t *)data;
 
   // Individual byte writes are needed if the buffer isn't word aligned.
   for (; len != 0 && (uintptr_t)data_sent & 3; --len) {
-    abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
-                    *data_sent++);
+    mmio_region_write8(hmac_base, HMAC_MSG_FIFO_REG_OFFSET, *data_sent++);
   }
 
   for (; len >= sizeof(uint32_t); len -= sizeof(uint32_t)) {
-    // FIXME: read_32 does not work for unittests.
-    uint32_t data_aligned = *(const uint32_t *)data_sent;
-    abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
-                     data_aligned);
+    uint32_t data_aligned = read_32(data_sent);
+    mmio_region_write32(hmac_base, HMAC_MSG_FIFO_REG_OFFSET, data_aligned);
     data_sent += sizeof(uint32_t);
   }
 
   // Handle non-32bit aligned bytes at the end of the buffer.
   for (; len != 0; --len) {
-    abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
-                    *data_sent++);
+    mmio_region_write8(hmac_base, HMAC_MSG_FIFO_REG_OFFSET, *data_sent++);
   }
-  return kErrorOk;
+  return kHmacOk;
 }
 
-rom_error_t hmac_sha256_final(hmac_digest_t *digest) {
+hmac_error_t hmac_sha256_final(hmac_digest_t *digest) {
   if (digest == NULL) {
-    return kErrorHmacInvalidArgument;
+    return kHmacErrorBadArg;
   }
+  mmio_region_t hmac_base = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
 
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_PROCESS_BIT, true);
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
+  mmio_region_write32(hmac_base, HMAC_CMD_REG_OFFSET, reg);
 
   do {
-    reg = abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR +
-                          HMAC_INTR_STATE_REG_OFFSET);
+    reg = mmio_region_read32(hmac_base, HMAC_INTR_STATE_REG_OFFSET);
   } while (!bitfield_bit32_read(reg, HMAC_INTR_STATE_HMAC_DONE_BIT));
-  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
-                   reg);
+  mmio_region_write32(hmac_base, HMAC_INTR_STATE_REG_OFFSET, reg);
 
   // Read the digest in reverse to preserve the numerical value.
   // The least significant word is at HMAC_DIGEST_7_REG_OFFSET.
   for (size_t i = 0; i < ARRAYSIZE(digest->digest); ++i) {
-    digest->digest[i] =
-        abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_7_REG_OFFSET -
-                        (i * sizeof(uint32_t)));
+    digest->digest[i] = mmio_region_read32(
+        hmac_base, HMAC_DIGEST_7_REG_OFFSET - (i * sizeof(uint32_t)));
   }
-  return kErrorOk;
+  return kHmacOk;
 }

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -1,0 +1,91 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hmac_regs.h"  // Generated.
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+void hmac_sha256_init(void) {
+  // Clear the config, stopping the SHA engine.
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, 0u);
+
+  // Disable and clear interrupts. INTR_STATE register is rw1c.
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_ENABLE_REG_OFFSET,
+                   0u);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
+                   UINT32_MAX);
+
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(reg, HMAC_CFG_DIGEST_SWAP_BIT, false);
+  // Enable endian swap since our inputs are little-endian.
+  reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, true);
+  reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
+  reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, reg);
+
+  reg = 0;
+  reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_START_BIT, true);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
+}
+
+rom_error_t hmac_sha256_update(const void *data, size_t len) {
+  if (data == NULL) {
+    return kErrorHmacInvalidArgument;
+  }
+  const uint8_t *data_sent = (const uint8_t *)data;
+
+  // Individual byte writes are needed if the buffer isn't word aligned.
+  for (; len != 0 && (uintptr_t)data_sent & 3; --len) {
+    abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
+                    *data_sent++);
+  }
+
+  for (; len >= sizeof(uint32_t); len -= sizeof(uint32_t)) {
+    // FIXME: read_32 does not work for unittests.
+    uint32_t data_aligned = *(const uint32_t *)data_sent;
+    abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
+                     data_aligned);
+    data_sent += sizeof(uint32_t);
+  }
+
+  // Handle non-32bit aligned bytes at the end of the buffer.
+  for (; len != 0; --len) {
+    abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
+                    *data_sent++);
+  }
+  return kErrorOk;
+}
+
+rom_error_t hmac_sha256_final(hmac_digest_t *digest) {
+  if (digest == NULL) {
+    return kErrorHmacInvalidArgument;
+  }
+
+  uint32_t reg = 0;
+  reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_PROCESS_BIT, true);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
+
+  do {
+    reg = abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR +
+                          HMAC_INTR_STATE_REG_OFFSET);
+  } while (!bitfield_bit32_read(reg, HMAC_INTR_STATE_HMAC_DONE_BIT));
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
+                   reg);
+
+  // Read the digest in reverse to preserve the numerical value.
+  // The least significant word is at HMAC_DIGEST_7_REG_OFFSET.
+  for (size_t i = 0; i < ARRAYSIZE(digest->digest); ++i) {
+    digest->digest[i] =
+        abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_7_REG_OFFSET -
+                        (i * sizeof(uint32_t)));
+  }
+  return kErrorOk;
+}

--- a/sw/device/lib/crypto/drivers/hmac.h
+++ b/sw/device/lib/crypto/drivers/hmac.h
@@ -1,25 +1,45 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_HMAC_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_HMAC_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_HMAC_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_HMAC_H_
 
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/lib/base/macros.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define HMAC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+enum {
+  /* Number of bits in an HMAC or SHA-256 digest. */
+  kHmacDigestNumBits = 256,
+  /* Number of bytes in an HMAC or SHA-256 digest. */
+  kHmacDigestNumBytes = kHmacDigestNumBits / 8,
+  /* Number of words in an HMAC or SHA-256 digest. */
+  kHmacDigestNumWords = kHmacDigestNumBytes / sizeof(uint32_t),
+};
+
+/**
+ * Error types for the HMAC driver.
+ */
+typedef enum hmac_error {
+  kHmacOk = 0,
+  /* Invalid argument.*/
+  kHmacErrorBadArg = 1,
+  /* HMAC device is still processing. */
+  kHmacErrorBusy = 2,
+  /* Attempt to push when FIFO is full. */
+  kHmacErrorFifoFull = 3,
+} hmac_error_t;
 
 /**
  * A typed representation of the HMAC digest.
  */
 typedef struct hmac_digest {
-  uint32_t digest[8];
+  uint32_t digest[kHmacDigestNumWords];
 } hmac_digest_t;
 
 /**
@@ -39,23 +59,25 @@ void hmac_sha256_init(void);
  * polling for FIFO status is equivalent to stalling on FIFO write.
  *
  * @param data Buffer to copy data from.
- * @param len size of the `data` buffer.
+ * @param len size of the `data` buffer in bytes.
  * @return The result of the operation.
  */
-HMAC_WARN_UNUSED_RESULT
-rom_error_t hmac_sha256_update(const void *data, size_t len);
+OT_WARN_UNUSED_RESULT
+hmac_error_t hmac_sha256_update(const void *data, size_t len);
 
 /**
  * Finalizes SHA256 operation and writes `digest` buffer.
  *
+ * Blocks while the device is processing.
+ *
  * @param[out] digest Buffer to copy digest to.
  * @return The result of the operation.
  */
-HMAC_WARN_UNUSED_RESULT
-rom_error_t hmac_sha256_final(hmac_digest_t *digest);
+OT_WARN_UNUSED_RESULT
+hmac_error_t hmac_sha256_final(hmac_digest_t *digest);
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_HMAC_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_HMAC_H_

--- a/sw/device/lib/crypto/drivers/hmac.h
+++ b/sw/device/lib/crypto/drivers/hmac.h
@@ -1,0 +1,61 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_HMAC_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_HMAC_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define HMAC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+
+/**
+ * A typed representation of the HMAC digest.
+ */
+typedef struct hmac_digest {
+  uint32_t digest[8];
+} hmac_digest_t;
+
+/**
+ * Initializes the HMAC in SHA256 mode.
+ *
+ * This function resets the HMAC module to clear the digest register.
+ * It then configures the HMAC block in SHA256 mode with little endian
+ * data input and digest output.
+ */
+void hmac_sha256_init(void);
+
+/**
+ * Sends `len` bytes from `data` to the SHA2-256 function.
+ *
+ * This function does not check for the size of the available HMAC
+ * FIFO. Since the this function is meant to run in blocking mode,
+ * polling for FIFO status is equivalent to stalling on FIFO write.
+ *
+ * @param data Buffer to copy data from.
+ * @param len size of the `data` buffer.
+ * @return The result of the operation.
+ */
+HMAC_WARN_UNUSED_RESULT
+rom_error_t hmac_sha256_update(const void *data, size_t len);
+
+/**
+ * Finalizes SHA256 operation and writes `digest` buffer.
+ *
+ * @param[out] digest Buffer to copy digest to.
+ * @return The result of the operation.
+ */
+HMAC_WARN_UNUSED_RESULT
+rom_error_t hmac_sha256_final(hmac_digest_t *digest);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_HMAC_H_

--- a/sw/device/lib/crypto/drivers/meson.build
+++ b/sw/device/lib/crypto/drivers/meson.build
@@ -1,0 +1,19 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# HMAC driver
+sw_lib_crypto_hmac = declare_dependency(
+  link_with: static_library(
+    'sw_lib_crypto_hmac',
+    sources: [
+      hw_ip_hmac_reg_h,
+      'hmac.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_bitfield,
+      top_earlgrey,
+    ]
+  )
+)

--- a/sw/device/lib/crypto/meson.build
+++ b/sw/device/lib/crypto/meson.build
@@ -1,0 +1,5 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+subdir('drivers')

--- a/sw/device/lib/meson.build
+++ b/sw/device/lib/meson.build
@@ -7,6 +7,7 @@ subdir('arch')
 subdir('crt')
 subdir('dif')
 subdir('runtime')
+subdir('crypto')
 
 # Flash controller library (sw_lib_flash_ctrl)
 sw_lib_flash_ctrl = declare_dependency(


### PR DESCRIPTION
Needed for #9622 

This PR essentially just copies the HMAC driver from `silicon_creator/lib/drivers` into `device/lib/runtime` and makes the minimal necessary changes (e.g. `abs_mmio` -> `mmio_region`) to remove the `silicon_creator` dependencies.

This isn't meant to be a complete or final-form driver; there are changes that will need to be made here. For instance, this driver currently only supports SHA-256-only mode, and has a blocking interface that waits for the FIFO to free up when passing the message, and also for the digest processing when the message is complete. Later, we'll want a non-blocking interface. If this is merged, I will make an issue to track those improvements.