### PR TITLE
[doc] Fix line break in verilator doc.

### DIFF
--- a/doc/ug/getting_started_verilator.md
+++ b/doc/ug/getting_started_verilator.md
@@ -198,7 +198,7 @@ $ cd $REPO_TOP
 $ build/lowrisc_dv_chip_verilator_sim_0.1/sim-verilator/Vchip_sim_tb \
   --meminit=rom,build-bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
   --meminit=flash,build-bin/sw/device/examples/hello_world/hello_world_sim_verilator.64.scr.vmem \
-  --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem
+  --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
   --trace
 $ gtkwave sim.fst
 ```


### PR DESCRIPTION
Add missing line break separator in verilator getting-started
documentation.

Signed-off-by: Pascal Nasahl <nasahl@google.com>