### PR TITLE
[sw,tests] Testing KMAC clock gating using clkmgr clock hints

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1724,17 +1724,16 @@
       name: chip_sw_kmac_idle
       desc: '''Verify the KMAC idle signaling to clkmgr.
 
-            - Write the KMAC clk hint to 1 within clkmgr to indicate KMAC clk is ready to be gated.
-              Verify that the KMAC clk hint status within clkmgr reads 0 (KMAC is idle).
-            - Initiate an KMAC operation with a known key, plain text and digest.
-              Verify that the KMAC clk hint status within clkmgr now reads 1 (KMAC is not idle),
-              before the KMAC operation is complete.
+            - Program the KMAC clk hint within clkmgr to indicate KMAC clk is ready to be gated.
+              Verify that the KMAC clk enabled status within clkmgr reads disabled (KMAC is idle).
+            - Initiate a KMAC operation with a known key, plain text and digest.
+              Verify that when enabling the KMAC clk hint after the operation has started but is not
+              yet complete, the clk enabled status in clkmgr stays enabled (KMAC is not idle).
             - After the KMAC operation is complete, verify the digest for correctness.
-              Verify that the KMAC clk hint status within clkmgr now reads 0 again (KMAC is idle),
-              after the KMAC operation is complete.
+              Verify that the KMAC clk enabled status reads as disabled (KMAC is idle).
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_kmac_idle_test"]
     }
 
     // ENTROPY_SRC (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -313,12 +313,17 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
+      name: chip_sw_kmac_idle_test
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/kmac_idle_test:1"]
+      en_run_modes: ["sw_test_mode"]
+    }
+    {
       name: chip_sw_rom_ctrl_integrity_check_test
       uvm_test_seq: chip_sw_rom_ctrl_integrity_check_vseq
       sw_images: ["sw/device/tests/rom_ctrl_integrity_check_test:1"]
       en_run_modes: ["sw_test_mode"]
     }
-
     {
       name: chip_sw_coremark
       uvm_test_seq: chip_sw_base_vseq

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -759,13 +759,5 @@ dif_result_t dif_kmac_end(const dif_kmac_t *kmac,
   operation_state->r = 0;
   operation_state->d = 0;
 
-  // Poll status register until in idle state.
-  while (true) {
-    if (is_state_idle(kmac)) {
-      break;
-    }
-    // TODO(#6248): check for error.
-  }
-
   return kDifOk;
 }

--- a/sw/device/tests/kmac_idle_test.c
+++ b/sw/device/tests/kmac_idle_test.c
@@ -1,0 +1,135 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_clkmgr_t clkmgr;
+static dif_kmac_t kmac;
+
+const test_config_t kTestConfig;
+
+const dif_clkmgr_hintable_clock_t kmac_clock =
+    kTopEarlgreyHintableClocksMainKmac;
+
+// Digest lengths in 32-bit words.
+#define DIGEST_LEN_SHA3_256 (256 / 32)
+#define DIGEST_LEN_SHA3_512 (512 / 32)
+#define DIGEST_LEN_SHA3_MAX DIGEST_LEN_SHA3_512
+
+// SHA-3 test description.
+typedef struct sha3_test {
+  dif_kmac_mode_sha3_t mode;
+
+  const char *message;
+  size_t message_len;
+
+  const uint32_t digest[DIGEST_LEN_SHA3_MAX];
+  size_t digest_len;
+} sha3_test_t;
+
+// SHA-3 test.
+const sha3_test_t sha3_256_test = {
+    // Example taken from NIST FIPS-202 Algorithm Test Vectors:
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Algorithm-Validation-Program/documents/sha3/sha-3bytetestvectors.zip
+    .mode = kDifKmacModeSha3Len256,
+    .message = "\xe7\x37\x21\x05",
+    .message_len = 4,
+    .digest = {0x8ab6423a, 0x8cf279b0, 0x52c7a34c, 0x90276f29, 0x78fec406,
+               0xd979ebb1, 0x057f7789, 0xae46401e},
+    .digest_len = DIGEST_LEN_SHA3_256};
+
+static void check_clock_state(dif_toggle_t expected_clock_state) {
+  dif_toggle_t clock_state;
+  CHECK_DIF_OK(
+      dif_clkmgr_hintable_clock_get_enabled(&clkmgr, kmac_clock, &clock_state));
+  CHECK(clock_state == expected_clock_state,
+        "Clock enabled state is not as expected (%0d).", expected_clock_state);
+}
+
+static void do_sha3_test(void) {
+  dif_kmac_operation_state_t kmac_operation_state;
+  // Run SHA3 test case using single blocking absorb/squeeze operations.
+  CHECK_DIF_OK(dif_kmac_mode_sha3_start(&kmac, &kmac_operation_state,
+                                        sha3_256_test.mode));
+
+  // Set hint and check clk state remains enabled as KMAC is now not idle.
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(&clkmgr, kmac_clock,
+                                                  kDifToggleDisabled));
+  check_clock_state(kDifToggleEnabled);
+
+  CHECK_DIF_OK(dif_kmac_absorb(&kmac, &kmac_operation_state,
+                               sha3_256_test.message, sha3_256_test.message_len,
+                               NULL));
+
+  uint32_t out[DIGEST_LEN_SHA3_MAX];
+  CHECK_DIF_OK(dif_kmac_squeeze(&kmac, &kmac_operation_state, out,
+                                sha3_256_test.digest_len, NULL));
+
+  // Check clock state again which should still be enabled.
+  check_clock_state(kDifToggleEnabled);
+
+  CHECK_DIF_OK(dif_kmac_end(&kmac, &kmac_operation_state));
+
+  // Check the clock is now stopped.
+  check_clock_state(kDifToggleDisabled);
+
+  // Check the result to be sure the SHA3 operation completed correctly.
+  CHECK_BUFFER(out, sha3_256_test.digest, sha3_256_test.digest_len,
+               "Digest mismatch for test SHA3 256.");
+
+  // Set hint to enabled again to check that clock can be re-enabled.
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(&clkmgr, kmac_clock,
+                                                  kDifToggleEnabled));
+  check_clock_state(kDifToggleEnabled);
+}
+
+bool test_main(void) {
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
+  // Get initial hint and enable for KMAC clock and check both are enabled.
+  dif_toggle_t clock_hint_state;
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_get_hint(&clkmgr, kmac_clock,
+                                                  &clock_hint_state));
+  CHECK(clock_hint_state == kDifToggleEnabled);
+  check_clock_state(kDifToggleEnabled);
+
+  // While KMAC is not in use, set disabled hint for KMAC clock
+  // then check clock state, set back to enabled and check again.
+  // Note: disabled means the clock can be disabled.
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(&clkmgr, kmac_clock,
+                                                  kDifToggleDisabled));
+  check_clock_state(kDifToggleDisabled);
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(&clkmgr, kmac_clock,
+                                                  kDifToggleEnabled));
+  check_clock_state(kDifToggleEnabled);
+
+  // Initialize KMAC hardware.
+  CHECK_DIF_OK(
+      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+
+  // Configure KMAC hardware using software entropy.
+  dif_kmac_config_t config = (dif_kmac_config_t){
+      .entropy_mode = kDifKmacEntropyModeSoftware,
+      .entropy_seed = 0xffff,
+      .entropy_fast_process = kDifToggleEnabled,
+  };
+  CHECK_DIF_OK(dif_kmac_configure(&kmac, config));
+
+  // call sha3 test twice to check that when clock
+  // is enabled again after the first call
+  // that all still works for the second call.
+
+  do_sha3_test();
+  do_sha3_test();
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -515,6 +515,24 @@ sw_tests += {
   }
 }
 
+kmac_idle_test_lib = declare_dependency(
+  link_with: static_library(
+    'kmac_idle_test_lib',
+    sources: ['kmac_idle_test.c'],
+    dependencies: [
+      sw_lib_dif_kmac,
+      sw_lib_dif_clkmgr,
+      sw_lib_runtime_log,
+      sw_lib_mmio,
+    ],
+  ),
+)
+sw_tests += {
+  'kmac_idle_test': {
+    'library': kmac_idle_test_lib,
+  }
+}
+
 # Lifecycle Controller Tests
 lc_ctrl_otp_hw_cfg_test_lib = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
Checks that the KMAC clock can be stopped by writing the hint in the clkmgr when the KMAC is idle, then
checks that the hint will not stop the clock while KMAC is processing an operation.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>