### PR TITLE
[spi_device] Cmdparse to process EN4B/EX4B

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -741,44 +741,6 @@
         } // f: data
       ]
     } // R: PAYLOAD_SWAP_DATA
-    { name: "CMD_INFO_EN4B"
-      swaccess: "rw"
-      hwaccess: "hro"
-      desc: '''Opcode for EN4B.
-
-        If the register is active and the IP receives the matched opcode, the
-        HW sets `CFG.addr_4b_en` at the end of the SPI transaction.
-        '''
-      fields:  [
-        { bits: "31"
-          name: "valid"
-          desc: "If 1, Opcode affects"
-        } // f: valid
-        { bits: "7:0"
-          name: "opcode"
-          desc: "EN4B opcode"
-        } // f: opcode
-      ]
-    } // R: CMD_INFO_EN4B
-    { name: "CMD_INFO_EX4B"
-      swaccess: "rw"
-      hwaccess: "hro"
-      desc: '''Opcode for EX4B
-
-        If the register is active and the IP receives the matched opcode, the
-        HW clears `CFG.addr_4b_en` at the end of the SPI transaction.
-        '''
-      fields:  [
-        { bits: "31"
-          name: "valid"
-          desc: "If 1, Opcode affects"
-        } // f: valid
-        { bits: "7:0"
-          name: "opcode"
-          desc: "EX4B opcode"
-        } // f: opcode
-      ]
-    } // R: CMD_INFO_EX4B
     { multireg: {
         cname: "SPI_DEVICE"
         name:  "CMD_INFO"
@@ -915,6 +877,41 @@
         ]
       }
     }
+    { name: "CMD_INFO_EN4B"
+      swaccess: "rw"
+      hwaccess: "hro"
+      desc: '''Opcode for EN4B.
+
+        If the register is active, it affects in flash / passthrough modes.
+        '''
+      fields:  [
+        { bits: "31"
+          name: "valid"
+          desc: "If 1, Opcode affects"
+        } // f: valid
+        { bits: "7:0"
+          name: "opcode"
+          desc: "EN4B opcode"
+        } // f: opcode
+      ]
+    } // R: CMD_INFO_EN4B
+    { name: "CMD_INFO_EX4B"
+      swaccess: "rw"
+      hwaccess: "hro"
+      desc: '''Opcode for EX4B
+        '''
+      fields:  [
+        { bits: "31"
+          name: "valid"
+          desc: "If 1, Opcode affects"
+        } // f: valid
+        { bits: "7:0"
+          name: "opcode"
+          desc: "EX4B opcode"
+        } // f: opcode
+      ]
+    } // R: CMD_INFO_EX4B
+
     //===============================================================
     // TPM registers
     { skipto: "0x800"}

--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -89,7 +89,7 @@ waive -rules CONST_FF -location {spi_device.sv} -msg {Flip-flop 'fwm_rxerr_q' is
       -comment "This is an unimplemented error signal which is currently tied to 0."
 
 # intentional terminal states
-waive -rules TERMINAL_STATE -location {spi_cmdparse.sv} -regexp {Terminal state 'St(Status|Jedec|Sfdp|ReadCmd|Upload)' is detected}
+waive -rules TERMINAL_STATE -location {spi_cmdparse.sv} -regexp {Terminal state 'St(Status|Jedec|Sfdp|ReadCmd|Upload|Addr4B)' is detected}
 waive -rules TERMINAL_STATE -location {spi_readcmd.sv} \
       -regexp {Terminal state 'Main(Output|Error)' is detected} \
       -comment "Intentional dead-end. CSb will reset"

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -231,15 +231,21 @@ package spi_device_pkg;
     // "Manufacture/Device ID", etc.  They are not always Input mode. Some has
     // a dummy cycle followed by the output field.
     CmdInfoReserveStart = 11,
-    CmdInfoReserveEnd   = spi_device_reg_pkg::NumCmdInfo -1
+    CmdInfoReserveEnd   = spi_device_reg_pkg::NumCmdInfo - 1,
+    CmdInfoEn4B         = CmdInfoReserveEnd + 1,
+    CmdInfoEx4B         = CmdInfoEn4B + 1,
+    NumTotalCmdInfo
   } cmd_info_index_e;
 
   parameter int unsigned NumReadCmdInfo = CmdInfoReadCmdEnd - CmdInfoReadCmdStart + 1;
 
-  import spi_device_reg_pkg::NumCmdInfo;
-  export spi_device_reg_pkg::NumCmdInfo;
+  // NumCmdInfo adds two more entries (EN4B/ EX4B)
+  // or, add NumTotalCmdInfo inside cmd_info_index_e and use?
+  //parameter int unsigned NumFixedCmdInfo = 2;
+  //parameter int unsigned NumTotalCmdInfo = NumFixedCmdInfo
+  //                                       + spi_device_reg_pkg::NumCmdInfo;
 
-  parameter int unsigned CmdInfoIdxW = $clog2(NumCmdInfo);
+  parameter int unsigned CmdInfoIdxW = $clog2(NumTotalCmdInfo);
 
   // Jedec Configuration Structure
   typedef struct packed {
@@ -305,21 +311,24 @@ package spi_device_pkg;
 
   localparam int MEM_AW = 12; // Memory Address width (Byte based)
 
-  typedef enum logic [5:0] {
-    DpNone       = 'b 000000,
-    DpReadCmd    = 'b 000001,
-    DpReadStatus = 'b 000010,
-    DpReadSFDP   = 'b 000100,
-    DpReadJEDEC  = 'b 001000,
+  typedef enum logic [7:0] {
+    DpNone       = 'b 00000000,
+    DpReadCmd    = 'b 00000001,
+    DpReadStatus = 'b 00000010,
+    DpReadSFDP   = 'b 00000100,
+    DpReadJEDEC  = 'b 00001000,
 
     // Command + Address only: e.g Block Erase
     // Command + Address + Paylod: Program
     // Command followed by direct payload
     // Write Status could be an example
     // Command only: Write Protect Enable / Chip Erase
-    DpUpload     = 'b 010000,
+    DpUpload     = 'b 00010000,
+
+    DpEn4B       = 'b 00100000,
+    DpEx4B       = 'b 01000000,
     // Unrecognizable commands: Just handle this as DpPayload
-    DpUnknown    = 'b 100000
+    DpUnknown    = 'b 10000000
   } sel_datapath_e;
 
   typedef enum spi_byte_t {
@@ -381,6 +390,8 @@ package spi_device_pkg;
   // Sram Depth is set to 1024 to satisfy DPSRAM parameter even though
   // SramTotalDepth above is 928.
   //parameter int unsigned SramDepth = 1024;
+  import spi_device_reg_pkg::SramDepth;
+  export spi_device_reg_pkg::SramDepth;
 
   parameter int unsigned SramAw = $clog2(spi_device_reg_pkg::SramDepth);
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -311,24 +311,6 @@ package spi_device_reg_pkg;
       logic [7:0]  q;
     } opcode;
     struct packed {
-      logic        q;
-    } valid;
-  } spi_device_reg2hw_cmd_info_en4b_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic [7:0]  q;
-    } opcode;
-    struct packed {
-      logic        q;
-    } valid;
-  } spi_device_reg2hw_cmd_info_ex4b_reg_t;
-
-  typedef struct packed {
-    struct packed {
-      logic [7:0]  q;
-    } opcode;
-    struct packed {
       logic [1:0]  q;
     } addr_mode;
     struct packed {
@@ -362,6 +344,24 @@ package spi_device_reg_pkg;
       logic        q;
     } valid;
   } spi_device_reg2hw_cmd_info_mreg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } opcode;
+    struct packed {
+      logic        q;
+    } valid;
+  } spi_device_reg2hw_cmd_info_en4b_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } opcode;
+    struct packed {
+      logic        q;
+    } valid;
+  } spi_device_reg2hw_cmd_info_ex4b_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -657,9 +657,9 @@ package spi_device_reg_pkg;
     spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [989:958]
     spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [957:926]
     spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [925:894]
-    spi_device_reg2hw_cmd_info_en4b_reg_t cmd_info_en4b; // [893:885]
-    spi_device_reg2hw_cmd_info_ex4b_reg_t cmd_info_ex4b; // [884:876]
-    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [875:276]
+    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [893:294]
+    spi_device_reg2hw_cmd_info_en4b_reg_t cmd_info_en4b; // [293:285]
+    spi_device_reg2hw_cmd_info_ex4b_reg_t cmd_info_ex4b; // [284:276]
     spi_device_reg2hw_tpm_cfg_reg_t tpm_cfg; // [275:271]
     spi_device_reg2hw_tpm_access_mreg_t [4:0] tpm_access; // [270:231]
     spi_device_reg2hw_tpm_sts_reg_t tpm_sts; // [230:199]
@@ -729,32 +729,32 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 80;
   parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 84;
   parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EN4B_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EX4B_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 98;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 9c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h a0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h a4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h a8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h ac;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h b0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h b4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h b8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h bc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h c0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h c4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h c8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h cc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h d0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h d4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h d8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h dc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h e0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h e4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h e8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h ec;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h f0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 9c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h a0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h a4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h a8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h ac;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h b0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h b4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h b8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h bc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h c0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h c4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h c8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h cc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h d0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h d8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h dc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h e0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h e4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h e8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EN4B_OFFSET = 13'h ec;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EX4B_OFFSET = 13'h f0;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -841,8 +841,6 @@ package spi_device_reg_pkg;
     SPI_DEVICE_ADDR_SWAP_DATA,
     SPI_DEVICE_PAYLOAD_SWAP_MASK,
     SPI_DEVICE_PAYLOAD_SWAP_DATA,
-    SPI_DEVICE_CMD_INFO_EN4B,
-    SPI_DEVICE_CMD_INFO_EX4B,
     SPI_DEVICE_CMD_INFO_0,
     SPI_DEVICE_CMD_INFO_1,
     SPI_DEVICE_CMD_INFO_2,
@@ -867,6 +865,8 @@ package spi_device_reg_pkg;
     SPI_DEVICE_CMD_INFO_21,
     SPI_DEVICE_CMD_INFO_22,
     SPI_DEVICE_CMD_INFO_23,
+    SPI_DEVICE_CMD_INFO_EN4B,
+    SPI_DEVICE_CMD_INFO_EX4B,
     SPI_DEVICE_TPM_CAP,
     SPI_DEVICE_TPM_CFG,
     SPI_DEVICE_TPM_STATUS,
@@ -921,32 +921,32 @@ package spi_device_reg_pkg;
     4'b 1111, // index[32] SPI_DEVICE_ADDR_SWAP_DATA
     4'b 1111, // index[33] SPI_DEVICE_PAYLOAD_SWAP_MASK
     4'b 1111, // index[34] SPI_DEVICE_PAYLOAD_SWAP_DATA
-    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_EN4B
-    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_EX4B
-    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_0
-    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_1
-    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_2
-    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_3
-    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_4
-    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_5
-    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_6
-    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_7
-    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_8
-    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_9
-    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_10
-    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_11
-    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_12
-    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_13
-    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_14
-    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_15
-    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_16
-    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_17
-    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_18
-    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_19
-    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_20
-    4'b 1111, // index[58] SPI_DEVICE_CMD_INFO_21
-    4'b 1111, // index[59] SPI_DEVICE_CMD_INFO_22
-    4'b 1111, // index[60] SPI_DEVICE_CMD_INFO_23
+    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_0
+    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_1
+    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_2
+    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_3
+    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_4
+    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_5
+    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_6
+    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_7
+    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_8
+    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_9
+    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_10
+    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_11
+    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_12
+    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_13
+    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_14
+    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_16
+    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_17
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_18
+    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_19
+    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_20
+    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_21
+    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_22
+    4'b 1111, // index[58] SPI_DEVICE_CMD_INFO_23
+    4'b 1111, // index[59] SPI_DEVICE_CMD_INFO_EN4B
+    4'b 1111, // index[60] SPI_DEVICE_CMD_INFO_EX4B
     4'b 0111, // index[61] SPI_DEVICE_TPM_CAP
     4'b 0001, // index[62] SPI_DEVICE_TPM_CFG
     4'b 0011, // index[63] SPI_DEVICE_TPM_STATUS

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -855,16 +855,6 @@ module spi_device_reg_top (
   logic payload_swap_data_we;
   logic [31:0] payload_swap_data_qs;
   logic [31:0] payload_swap_data_wd;
-  logic cmd_info_en4b_we;
-  logic [7:0] cmd_info_en4b_opcode_qs;
-  logic [7:0] cmd_info_en4b_opcode_wd;
-  logic cmd_info_en4b_valid_qs;
-  logic cmd_info_en4b_valid_wd;
-  logic cmd_info_ex4b_we;
-  logic [7:0] cmd_info_ex4b_opcode_qs;
-  logic [7:0] cmd_info_ex4b_opcode_wd;
-  logic cmd_info_ex4b_valid_qs;
-  logic cmd_info_ex4b_valid_wd;
   logic cmd_info_0_we;
   logic [7:0] cmd_info_0_opcode_0_qs;
   logic [7:0] cmd_info_0_opcode_0_wd;
@@ -1465,6 +1455,16 @@ module spi_device_reg_top (
   logic cmd_info_23_busy_23_wd;
   logic cmd_info_23_valid_23_qs;
   logic cmd_info_23_valid_23_wd;
+  logic cmd_info_en4b_we;
+  logic [7:0] cmd_info_en4b_opcode_qs;
+  logic [7:0] cmd_info_en4b_opcode_wd;
+  logic cmd_info_en4b_valid_qs;
+  logic cmd_info_en4b_valid_wd;
+  logic cmd_info_ex4b_we;
+  logic [7:0] cmd_info_ex4b_opcode_qs;
+  logic [7:0] cmd_info_ex4b_opcode_wd;
+  logic cmd_info_ex4b_valid_qs;
+  logic cmd_info_ex4b_valid_wd;
   logic [7:0] tpm_cap_rev_qs;
   logic tpm_cap_locality_qs;
   logic [2:0] tpm_cap_max_xfer_size_qs;
@@ -9920,110 +9920,6 @@ module spi_device_reg_top (
   );
 
 
-  // R[cmd_info_en4b]: V(False)
-  //   F[opcode]: 7:0
-  prim_subreg #(
-    .DW      (8),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
-  ) u_cmd_info_en4b_opcode (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (cmd_info_en4b_we),
-    .wd     (cmd_info_en4b_opcode_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.cmd_info_en4b.opcode.q),
-
-    // to register interface (read)
-    .qs     (cmd_info_en4b_opcode_qs)
-  );
-
-  //   F[valid]: 31:31
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_cmd_info_en4b_valid (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (cmd_info_en4b_we),
-    .wd     (cmd_info_en4b_valid_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.cmd_info_en4b.valid.q),
-
-    // to register interface (read)
-    .qs     (cmd_info_en4b_valid_qs)
-  );
-
-
-  // R[cmd_info_ex4b]: V(False)
-  //   F[opcode]: 7:0
-  prim_subreg #(
-    .DW      (8),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (8'h0)
-  ) u_cmd_info_ex4b_opcode (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (cmd_info_ex4b_we),
-    .wd     (cmd_info_ex4b_opcode_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.cmd_info_ex4b.opcode.q),
-
-    // to register interface (read)
-    .qs     (cmd_info_ex4b_opcode_qs)
-  );
-
-  //   F[valid]: 31:31
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h0)
-  ) u_cmd_info_ex4b_valid (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (cmd_info_ex4b_we),
-    .wd     (cmd_info_ex4b_valid_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.cmd_info_ex4b.valid.q),
-
-    // to register interface (read)
-    .qs     (cmd_info_ex4b_valid_qs)
-  );
-
-
   // Subregister 0 of Multireg cmd_info
   // R[cmd_info_0]: V(False)
   //   F[opcode_0]: 7:0
@@ -17296,6 +17192,110 @@ module spi_device_reg_top (
   );
 
 
+  // R[cmd_info_en4b]: V(False)
+  //   F[opcode]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_cmd_info_en4b_opcode (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_en4b_we),
+    .wd     (cmd_info_en4b_opcode_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_en4b.opcode.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_en4b_opcode_qs)
+  );
+
+  //   F[valid]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_en4b_valid (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_en4b_we),
+    .wd     (cmd_info_en4b_valid_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_en4b.valid.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_en4b_valid_qs)
+  );
+
+
+  // R[cmd_info_ex4b]: V(False)
+  //   F[opcode]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_cmd_info_ex4b_opcode (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_ex4b_we),
+    .wd     (cmd_info_ex4b_opcode_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_ex4b.opcode.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_ex4b_opcode_qs)
+  );
+
+  //   F[valid]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_ex4b_valid (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_ex4b_we),
+    .wd     (cmd_info_ex4b_valid_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_ex4b.valid.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_ex4b_valid_qs)
+  );
+
+
   // R[tpm_cap]: V(False)
   //   F[rev]: 7:0
   prim_subreg #(
@@ -18039,32 +18039,32 @@ module spi_device_reg_top (
     addr_hit[32] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
     addr_hit[33] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
     addr_hit[34] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_EN4B_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_EX4B_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
-    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
-    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
-    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
-    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
-    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
-    addr_hit[58] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
-    addr_hit[59] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
-    addr_hit[60] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
+    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
+    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_CMD_INFO_EN4B_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_CMD_INFO_EX4B_OFFSET);
     addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
     addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
     addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
@@ -18851,17 +18851,7 @@ module spi_device_reg_top (
   assign payload_swap_data_we = addr_hit[34] & reg_we & !reg_error;
 
   assign payload_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_en4b_we = addr_hit[35] & reg_we & !reg_error;
-
-  assign cmd_info_en4b_opcode_wd = reg_wdata[7:0];
-
-  assign cmd_info_en4b_valid_wd = reg_wdata[31];
-  assign cmd_info_ex4b_we = addr_hit[36] & reg_we & !reg_error;
-
-  assign cmd_info_ex4b_opcode_wd = reg_wdata[7:0];
-
-  assign cmd_info_ex4b_valid_wd = reg_wdata[31];
-  assign cmd_info_0_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_0_we = addr_hit[35] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -18886,7 +18876,7 @@ module spi_device_reg_top (
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
 
   assign cmd_info_0_valid_0_wd = reg_wdata[31];
-  assign cmd_info_1_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -18911,7 +18901,7 @@ module spi_device_reg_top (
   assign cmd_info_1_busy_1_wd = reg_wdata[25];
 
   assign cmd_info_1_valid_1_wd = reg_wdata[31];
-  assign cmd_info_2_we = addr_hit[39] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -18936,7 +18926,7 @@ module spi_device_reg_top (
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
 
   assign cmd_info_2_valid_2_wd = reg_wdata[31];
-  assign cmd_info_3_we = addr_hit[40] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -18961,7 +18951,7 @@ module spi_device_reg_top (
   assign cmd_info_3_busy_3_wd = reg_wdata[25];
 
   assign cmd_info_3_valid_3_wd = reg_wdata[31];
-  assign cmd_info_4_we = addr_hit[41] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -18986,7 +18976,7 @@ module spi_device_reg_top (
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
 
   assign cmd_info_4_valid_4_wd = reg_wdata[31];
-  assign cmd_info_5_we = addr_hit[42] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[40] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -19011,7 +19001,7 @@ module spi_device_reg_top (
   assign cmd_info_5_busy_5_wd = reg_wdata[25];
 
   assign cmd_info_5_valid_5_wd = reg_wdata[31];
-  assign cmd_info_6_we = addr_hit[43] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[41] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -19036,7 +19026,7 @@ module spi_device_reg_top (
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
 
   assign cmd_info_6_valid_6_wd = reg_wdata[31];
-  assign cmd_info_7_we = addr_hit[44] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[42] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -19061,7 +19051,7 @@ module spi_device_reg_top (
   assign cmd_info_7_busy_7_wd = reg_wdata[25];
 
   assign cmd_info_7_valid_7_wd = reg_wdata[31];
-  assign cmd_info_8_we = addr_hit[45] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[43] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -19086,7 +19076,7 @@ module spi_device_reg_top (
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
 
   assign cmd_info_8_valid_8_wd = reg_wdata[31];
-  assign cmd_info_9_we = addr_hit[46] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[44] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -19111,7 +19101,7 @@ module spi_device_reg_top (
   assign cmd_info_9_busy_9_wd = reg_wdata[25];
 
   assign cmd_info_9_valid_9_wd = reg_wdata[31];
-  assign cmd_info_10_we = addr_hit[47] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[45] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -19136,7 +19126,7 @@ module spi_device_reg_top (
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
 
   assign cmd_info_10_valid_10_wd = reg_wdata[31];
-  assign cmd_info_11_we = addr_hit[48] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[46] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -19161,7 +19151,7 @@ module spi_device_reg_top (
   assign cmd_info_11_busy_11_wd = reg_wdata[25];
 
   assign cmd_info_11_valid_11_wd = reg_wdata[31];
-  assign cmd_info_12_we = addr_hit[49] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[47] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -19186,7 +19176,7 @@ module spi_device_reg_top (
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
 
   assign cmd_info_12_valid_12_wd = reg_wdata[31];
-  assign cmd_info_13_we = addr_hit[50] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[48] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -19211,7 +19201,7 @@ module spi_device_reg_top (
   assign cmd_info_13_busy_13_wd = reg_wdata[25];
 
   assign cmd_info_13_valid_13_wd = reg_wdata[31];
-  assign cmd_info_14_we = addr_hit[51] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[49] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -19236,7 +19226,7 @@ module spi_device_reg_top (
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
 
   assign cmd_info_14_valid_14_wd = reg_wdata[31];
-  assign cmd_info_15_we = addr_hit[52] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[50] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -19261,7 +19251,7 @@ module spi_device_reg_top (
   assign cmd_info_15_busy_15_wd = reg_wdata[25];
 
   assign cmd_info_15_valid_15_wd = reg_wdata[31];
-  assign cmd_info_16_we = addr_hit[53] & reg_we & !reg_error;
+  assign cmd_info_16_we = addr_hit[51] & reg_we & !reg_error;
 
   assign cmd_info_16_opcode_16_wd = reg_wdata[7:0];
 
@@ -19286,7 +19276,7 @@ module spi_device_reg_top (
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
 
   assign cmd_info_16_valid_16_wd = reg_wdata[31];
-  assign cmd_info_17_we = addr_hit[54] & reg_we & !reg_error;
+  assign cmd_info_17_we = addr_hit[52] & reg_we & !reg_error;
 
   assign cmd_info_17_opcode_17_wd = reg_wdata[7:0];
 
@@ -19311,7 +19301,7 @@ module spi_device_reg_top (
   assign cmd_info_17_busy_17_wd = reg_wdata[25];
 
   assign cmd_info_17_valid_17_wd = reg_wdata[31];
-  assign cmd_info_18_we = addr_hit[55] & reg_we & !reg_error;
+  assign cmd_info_18_we = addr_hit[53] & reg_we & !reg_error;
 
   assign cmd_info_18_opcode_18_wd = reg_wdata[7:0];
 
@@ -19336,7 +19326,7 @@ module spi_device_reg_top (
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
 
   assign cmd_info_18_valid_18_wd = reg_wdata[31];
-  assign cmd_info_19_we = addr_hit[56] & reg_we & !reg_error;
+  assign cmd_info_19_we = addr_hit[54] & reg_we & !reg_error;
 
   assign cmd_info_19_opcode_19_wd = reg_wdata[7:0];
 
@@ -19361,7 +19351,7 @@ module spi_device_reg_top (
   assign cmd_info_19_busy_19_wd = reg_wdata[25];
 
   assign cmd_info_19_valid_19_wd = reg_wdata[31];
-  assign cmd_info_20_we = addr_hit[57] & reg_we & !reg_error;
+  assign cmd_info_20_we = addr_hit[55] & reg_we & !reg_error;
 
   assign cmd_info_20_opcode_20_wd = reg_wdata[7:0];
 
@@ -19386,7 +19376,7 @@ module spi_device_reg_top (
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
 
   assign cmd_info_20_valid_20_wd = reg_wdata[31];
-  assign cmd_info_21_we = addr_hit[58] & reg_we & !reg_error;
+  assign cmd_info_21_we = addr_hit[56] & reg_we & !reg_error;
 
   assign cmd_info_21_opcode_21_wd = reg_wdata[7:0];
 
@@ -19411,7 +19401,7 @@ module spi_device_reg_top (
   assign cmd_info_21_busy_21_wd = reg_wdata[25];
 
   assign cmd_info_21_valid_21_wd = reg_wdata[31];
-  assign cmd_info_22_we = addr_hit[59] & reg_we & !reg_error;
+  assign cmd_info_22_we = addr_hit[57] & reg_we & !reg_error;
 
   assign cmd_info_22_opcode_22_wd = reg_wdata[7:0];
 
@@ -19436,7 +19426,7 @@ module spi_device_reg_top (
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
 
   assign cmd_info_22_valid_22_wd = reg_wdata[31];
-  assign cmd_info_23_we = addr_hit[60] & reg_we & !reg_error;
+  assign cmd_info_23_we = addr_hit[58] & reg_we & !reg_error;
 
   assign cmd_info_23_opcode_23_wd = reg_wdata[7:0];
 
@@ -19461,6 +19451,16 @@ module spi_device_reg_top (
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
 
   assign cmd_info_23_valid_23_wd = reg_wdata[31];
+  assign cmd_info_en4b_we = addr_hit[59] & reg_we & !reg_error;
+
+  assign cmd_info_en4b_opcode_wd = reg_wdata[7:0];
+
+  assign cmd_info_en4b_valid_wd = reg_wdata[31];
+  assign cmd_info_ex4b_we = addr_hit[60] & reg_we & !reg_error;
+
+  assign cmd_info_ex4b_opcode_wd = reg_wdata[7:0];
+
+  assign cmd_info_ex4b_valid_wd = reg_wdata[31];
   assign tpm_cfg_we = addr_hit[62] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
@@ -19967,16 +19967,6 @@ module spi_device_reg_top (
       end
 
       addr_hit[35]: begin
-        reg_rdata_next[7:0] = cmd_info_en4b_opcode_qs;
-        reg_rdata_next[31] = cmd_info_en4b_valid_qs;
-      end
-
-      addr_hit[36]: begin
-        reg_rdata_next[7:0] = cmd_info_ex4b_opcode_qs;
-        reg_rdata_next[31] = cmd_info_ex4b_valid_qs;
-      end
-
-      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[9:8] = cmd_info_0_addr_mode_0_qs;
         reg_rdata_next[10] = cmd_info_0_addr_swap_en_0_qs;
@@ -19991,7 +19981,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_0_valid_0_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[9:8] = cmd_info_1_addr_mode_1_qs;
         reg_rdata_next[10] = cmd_info_1_addr_swap_en_1_qs;
@@ -20006,7 +19996,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_1_valid_1_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[9:8] = cmd_info_2_addr_mode_2_qs;
         reg_rdata_next[10] = cmd_info_2_addr_swap_en_2_qs;
@@ -20021,7 +20011,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_2_valid_2_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[9:8] = cmd_info_3_addr_mode_3_qs;
         reg_rdata_next[10] = cmd_info_3_addr_swap_en_3_qs;
@@ -20036,7 +20026,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_3_valid_3_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[9:8] = cmd_info_4_addr_mode_4_qs;
         reg_rdata_next[10] = cmd_info_4_addr_swap_en_4_qs;
@@ -20051,7 +20041,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_4_valid_4_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[40]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[9:8] = cmd_info_5_addr_mode_5_qs;
         reg_rdata_next[10] = cmd_info_5_addr_swap_en_5_qs;
@@ -20066,7 +20056,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_5_valid_5_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[9:8] = cmd_info_6_addr_mode_6_qs;
         reg_rdata_next[10] = cmd_info_6_addr_swap_en_6_qs;
@@ -20081,7 +20071,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_6_valid_6_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[42]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[9:8] = cmd_info_7_addr_mode_7_qs;
         reg_rdata_next[10] = cmd_info_7_addr_swap_en_7_qs;
@@ -20096,7 +20086,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_7_valid_7_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[43]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[9:8] = cmd_info_8_addr_mode_8_qs;
         reg_rdata_next[10] = cmd_info_8_addr_swap_en_8_qs;
@@ -20111,7 +20101,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_8_valid_8_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[44]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[9:8] = cmd_info_9_addr_mode_9_qs;
         reg_rdata_next[10] = cmd_info_9_addr_swap_en_9_qs;
@@ -20126,7 +20116,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_9_valid_9_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[45]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[9:8] = cmd_info_10_addr_mode_10_qs;
         reg_rdata_next[10] = cmd_info_10_addr_swap_en_10_qs;
@@ -20141,7 +20131,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_10_valid_10_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[46]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[9:8] = cmd_info_11_addr_mode_11_qs;
         reg_rdata_next[10] = cmd_info_11_addr_swap_en_11_qs;
@@ -20156,7 +20146,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_11_valid_11_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[47]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[9:8] = cmd_info_12_addr_mode_12_qs;
         reg_rdata_next[10] = cmd_info_12_addr_swap_en_12_qs;
@@ -20171,7 +20161,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_12_valid_12_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[48]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[9:8] = cmd_info_13_addr_mode_13_qs;
         reg_rdata_next[10] = cmd_info_13_addr_swap_en_13_qs;
@@ -20186,7 +20176,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_13_valid_13_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[49]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[9:8] = cmd_info_14_addr_mode_14_qs;
         reg_rdata_next[10] = cmd_info_14_addr_swap_en_14_qs;
@@ -20201,7 +20191,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_14_valid_14_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[50]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[9:8] = cmd_info_15_addr_mode_15_qs;
         reg_rdata_next[10] = cmd_info_15_addr_swap_en_15_qs;
@@ -20216,7 +20206,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_15_valid_15_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[51]: begin
         reg_rdata_next[7:0] = cmd_info_16_opcode_16_qs;
         reg_rdata_next[9:8] = cmd_info_16_addr_mode_16_qs;
         reg_rdata_next[10] = cmd_info_16_addr_swap_en_16_qs;
@@ -20231,7 +20221,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_16_valid_16_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[52]: begin
         reg_rdata_next[7:0] = cmd_info_17_opcode_17_qs;
         reg_rdata_next[9:8] = cmd_info_17_addr_mode_17_qs;
         reg_rdata_next[10] = cmd_info_17_addr_swap_en_17_qs;
@@ -20246,7 +20236,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_17_valid_17_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[53]: begin
         reg_rdata_next[7:0] = cmd_info_18_opcode_18_qs;
         reg_rdata_next[9:8] = cmd_info_18_addr_mode_18_qs;
         reg_rdata_next[10] = cmd_info_18_addr_swap_en_18_qs;
@@ -20261,7 +20251,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_18_valid_18_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[54]: begin
         reg_rdata_next[7:0] = cmd_info_19_opcode_19_qs;
         reg_rdata_next[9:8] = cmd_info_19_addr_mode_19_qs;
         reg_rdata_next[10] = cmd_info_19_addr_swap_en_19_qs;
@@ -20276,7 +20266,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_19_valid_19_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[55]: begin
         reg_rdata_next[7:0] = cmd_info_20_opcode_20_qs;
         reg_rdata_next[9:8] = cmd_info_20_addr_mode_20_qs;
         reg_rdata_next[10] = cmd_info_20_addr_swap_en_20_qs;
@@ -20291,7 +20281,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_20_valid_20_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[56]: begin
         reg_rdata_next[7:0] = cmd_info_21_opcode_21_qs;
         reg_rdata_next[9:8] = cmd_info_21_addr_mode_21_qs;
         reg_rdata_next[10] = cmd_info_21_addr_swap_en_21_qs;
@@ -20306,7 +20296,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_21_valid_21_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[57]: begin
         reg_rdata_next[7:0] = cmd_info_22_opcode_22_qs;
         reg_rdata_next[9:8] = cmd_info_22_addr_mode_22_qs;
         reg_rdata_next[10] = cmd_info_22_addr_swap_en_22_qs;
@@ -20321,7 +20311,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_22_valid_22_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[58]: begin
         reg_rdata_next[7:0] = cmd_info_23_opcode_23_qs;
         reg_rdata_next[9:8] = cmd_info_23_addr_mode_23_qs;
         reg_rdata_next[10] = cmd_info_23_addr_swap_en_23_qs;
@@ -20334,6 +20324,16 @@ module spi_device_reg_top (
         reg_rdata_next[24] = cmd_info_23_upload_23_qs;
         reg_rdata_next[25] = cmd_info_23_busy_23_qs;
         reg_rdata_next[31] = cmd_info_23_valid_23_qs;
+      end
+
+      addr_hit[59]: begin
+        reg_rdata_next[7:0] = cmd_info_en4b_opcode_qs;
+        reg_rdata_next[31] = cmd_info_en4b_valid_qs;
+      end
+
+      addr_hit[60]: begin
+        reg_rdata_next[7:0] = cmd_info_ex4b_opcode_qs;
+        reg_rdata_next[31] = cmd_info_ex4b_valid_qs;
       end
 
       addr_hit[61]: begin

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -101,7 +101,7 @@ module spi_passthrough
   input spi_mode_e spi_mode_i,
 
   // Command Info structure
-  input cmd_info_t [NumCmdInfo-1:0] cmd_info_i,
+  input cmd_info_t [NumTotalCmdInfo-1:0] cmd_info_i,
 
   // SPI in
   //
@@ -412,7 +412,7 @@ module spi_passthrough
   always_comb begin
     cmd_info_7th_d = {CmdInfoInput, CmdInfoInput};
     if (cmd_7th) begin
-      for(int unsigned i = 0 ; i < NumCmdInfo ; i++) begin
+      for(int unsigned i = 0 ; i < NumTotalCmdInfo ; i++) begin
         if (cmd_info_i[i].valid) begin
           if (cmd_info_i[i].opcode == {opcode_d[6:0], 1'b1}) begin
             cmd_info_7th_d[1] = cmd_info_i[i];


### PR DESCRIPTION
This commit adds EN4B/ EX4B datapath to the cmdparse module. at the top
level the cmd_info list is expanded to have manual (fixed) command info
entries. As of now, two fixed cmd_info entries (EN4B/EX4B) are added.
    
The manual expansion is to reduce the register size. Other than valid,
opcode, no other fields are necessary for EN4B/ EX4B.

Also, the PR relocates the EN4B/EX4B CSRs to the end of the command list to make it same order with the RTL.