### PR TITLE
[sw/silicon_creator] Avoid double-writes when invalidating boot_data entries

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -15,11 +15,18 @@ extern "C" {
 
 #define HMAC_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 
+enum {
+  /**
+   * Size of a SHA-256 digest in words.
+   */
+  kHmacDigestNumWords = 8,
+};
+
 /**
  * A typed representation of the HMAC digest.
  */
 typedef struct hmac_digest {
-  uint32_t digest[8];
+  uint32_t digest[kHmacDigestNumWords];
 } hmac_digest_t;
 
 /**


### PR DESCRIPTION
Currently, we invalidate previous `boot_data` entries by writing 0 to their `identifier` fields. This scheme, however, is not compatible with ECC and scrambling because writing a different value to a previously written flash word results in flash_ctrl errors in subsequent reads (please see #9729).

This commit adds a new `is_valid` field (`uint64_t`, flash word sized, flash word aligned) to `boot_data_t` to be able to invalidate previous `boot_data` entries without modifying previously written flash words. This field is skipped when a `boot_data` entry is written and is only written when invalidating previous entries.

Signed-off-by: Alphan Ulusoy <alphan@google.com>