### PR TITLE
[dv] Replace fileset_partner flag with fileset_ast flag

### DIFF
--- a/hw/ip/adc_ctrl/adc_ctrl.core
+++ b/hw/ip/adc_ctrl/adc_ctrl.core
@@ -10,8 +10,8 @@ filesets:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
       - lowrisc:ip:tlul
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - "fileset_ast  ? (partner:systems:ast_pkg)"
+      - "!fileset_ast ? (lowrisc:systems:ast_pkg)"
       
       
     files:

--- a/hw/ip/flash_ctrl/flash_ctrl_pkg.core
+++ b/hw/ip/flash_ctrl/flash_ctrl_pkg.core
@@ -14,8 +14,8 @@ filesets:
       - lowrisc:ip:pwrmgr_pkg
       - lowrisc:ip:jtag_pkg
       - lowrisc:ip:edn_pkg
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - "fileset_ast  ? (partner:systems:ast_pkg)"
+      - "!fileset_ast ? (lowrisc:systems:ast_pkg)"
       - "fileset_top    ? (lowrisc:systems:flash_ctrl_pkg)"
       - "fileset_topgen ? (lowrisc:systems:topgen)"
     files:

--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -23,8 +23,8 @@ filesets:
       - lowrisc:ip:pwrmgr_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - "fileset_ast  ? (partner:systems:ast_pkg)"
+      - "!fileset_ast ? (lowrisc:systems:ast_pkg)"
     files:
       - rtl/otp_ctrl_core_reg_top.sv
       - rtl/otp_ctrl_ecc_reg.sv

--- a/hw/ip/prim_generic/prim_generic_flash.core
+++ b/hw/ip/prim_generic/prim_generic_flash.core
@@ -10,8 +10,8 @@ filesets:
     depend:
       - lowrisc:ip:tlul
       - lowrisc:prim:ram_1p
-      - "fileset_partner  ? (partner:systems:ast_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - "fileset_ast  ? (partner:systems:ast_pkg)"
+      - "!fileset_ast ? (lowrisc:systems:ast_pkg)"
       - lowrisc:ip:flash_ctrl_pkg
     files:
       - rtl/prim_generic_flash_bank.sv

--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -10,10 +10,10 @@ filesets:
       - lowrisc:systems:top_earlgrey:0.1
       - lowrisc:systems:top_earlgrey_pkg
       - lowrisc:systems:padring
-      - "fileset_partner ? (partner:systems:ast)"
-      - "fileset_partner ? (partner:systems:scan_role_pkg)"
-      - "!fileset_partner ? (lowrisc:systems:ast)"
-      - "!fileset_partner ? (lowrisc:systems:scan_role_pkg)"
+      - "fileset_ast ? (partner:systems:ast)"
+      - "fileset_ast ? (partner:systems:scan_role_pkg)"
+      - "!fileset_ast ? (lowrisc:systems:ast)"
+      - "!fileset_ast ? (lowrisc:systems:scan_role_pkg)"
     files:
       - rtl/autogen/chip_earlgrey_asic.sv
     file_type: systemVerilogSource

--- a/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
+++ b/hw/top_earlgrey/ip/sensor_ctrl/sensor_ctrl_pkg.core
@@ -9,8 +9,8 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:constants:top_pkg
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
-      - "fileset_partner ? (partner:systems:ast_pkg)"
+      - "!fileset_ast ? (lowrisc:systems:ast_pkg)"
+      - "fileset_ast ? (partner:systems:ast_pkg)"
       - lowrisc:systems:sensor_ctrl_reg
     files:
       - rtl/sensor_ctrl_pkg.sv

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -47,8 +47,8 @@ filesets:
       - lowrisc:ip:rom_ctrl
       - lowrisc:systems:clkmgr
       - lowrisc:systems:sensor_ctrl
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
-      - "fileset_partner ? (partner:systems:ast_pkg)"
+      - "!fileset_ast ? (lowrisc:systems:ast_pkg)"
+      - "fileset_ast ? (partner:systems:ast_pkg)"
       - lowrisc:tlul:headers
       - lowrisc:prim:all
       - lowrisc:prim:usb_diff_rx


### PR DESCRIPTION
Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>
This PR replaces the fileset_partner with fileset_ast for ast core.
It is required to enable to work in top level with the foundry database (that requires fileset_partner for the padring) and the open source AST.
