### PR TITLE
[rstmgr] fix unit test

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -348,11 +348,19 @@ cc_library(
 
 cc_test(
     name = "rstmgr_unittest",
-    srcs = ["rstmgr_unittest.cc"],
+    srcs = [
+        "rstmgr.c",
+        "rstmgr.h",
+        "rstmgr_unittest.cc",
+    ],
+    defines = [
+        "OT_OFF_TARGET_TEST",
+    ],
     deps = [
-        ":rstmgr",
         "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.c
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.c
@@ -9,7 +9,11 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/multibits.h"
+
+#ifdef OT_PLATFORM_RV32
 #include "sw/device/lib/runtime/hart.h"
+#endif
+
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"


### PR DESCRIPTION
rstmgr.c needs to run on OT and x86 and shouldn't include
//sw/device/lib/runtime:hart when building for x86 or bazel will not test it.

Signed-off-by: Drew Macrae <drewmacrae@google.com>