### PR TITLE
[spi_device] TPM locality test reference

### DIFF
--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -196,7 +196,7 @@
             - Ensure that the data returned is correct for the given locality.
             - Randomise TPM_CFG.invalid_locality and confirm response.'''
       milestone: V2
-      tests: []
+      tests: ["spi_device_tpm_locality"]
     }
     {
       name: partial_tpm_txrx


### PR DESCRIPTION
Added reference to proper TPM locality test in the testplan.

Signed-off-by: Kosta Kojdic <kosta.kojdic@ensilica.com>