### PR TITLE
[sw/silicon_creator] Remove empty DMEM space from RSA binary.

### DIFF
--- a/sw/device/silicon_creator/lib/crypto/ecdsa_p256/ecdsa_p256.c
+++ b/sw/device/silicon_creator/lib/crypto/ecdsa_p256/ecdsa_p256.c
@@ -59,18 +59,6 @@ static const uint32_t kOtbnEcdsaModeSign = 1;
 // static const uint32_t kOtbnEcdsaModeVerify = 2;
 
 /**
- * Makes a single dptr in the P256 library point to where its value is stored.
- */
-static otbn_error_t setup_data_pointer(otbn_t *otbn, const otbn_ptr_t dptr,
-                                       const otbn_ptr_t value) {
-  uint32_t value_dmem_addr;
-  OTBN_RETURN_IF_ERROR(
-      otbn_data_ptr_to_dmem_addr(otbn, value, &value_dmem_addr));
-  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(otbn, 1, &value_dmem_addr, dptr));
-  return kOtbnErrorOk;
-}
-
-/**
  * Sets up all data pointers used by the P256 library to point to DMEM.
  *
  * The ECDSA P256 OTBN library makes use of "named" data pointers as part of
@@ -83,21 +71,21 @@ static otbn_error_t setup_data_pointer(otbn_t *otbn, const otbn_ptr_t dptr,
  * This function makes the data pointers refer to the pre-allocated DMEM
  * regions to store the actual values.
  */
-static otbn_error_t setup_data_pointers(otbn_t *otbn) {
+static otbn_error_t set_data_pointers(otbn_t *otbn) {
   OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrMsg, kOtbnVarEcdsaMsg));
+      set_data_pointer(otbn, kOtbnVarEcdsaDptrMsg, kOtbnVarEcdsaMsg));
   OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrR, kOtbnVarEcdsaR));
+      set_data_pointer(otbn, kOtbnVarEcdsaDptrR, kOtbnVarEcdsaR));
   OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrS, kOtbnVarEcdsaS));
+      set_data_pointer(otbn, kOtbnVarEcdsaDptrS, kOtbnVarEcdsaS));
   OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX));
+      set_data_pointer(otbn, kOtbnVarEcdsaDptrX, kOtbnVarEcdsaX));
   OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY));
+      set_data_pointer(otbn, kOtbnVarEcdsaDptrY, kOtbnVarEcdsaY));
   OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrD, kOtbnVarEcdsaD));
+      set_data_pointer(otbn, kOtbnVarEcdsaDptrD, kOtbnVarEcdsaD));
   OTBN_RETURN_IF_ERROR(
-      setup_data_pointer(otbn, kOtbnVarEcdsaDptrXr, kOtbnVarEcdsaXr));
+      set_data_pointer(otbn, kOtbnVarEcdsaDptrXr, kOtbnVarEcdsaXr));
   return kOtbnErrorOk;
 }
 
@@ -111,7 +99,7 @@ otbn_error_t ecdsa_p256_sign(const ecdsa_p256_message_digest_t *digest,
 
   // Load the ECDSA/P-256 app and set up data pointers
   OTBN_RETURN_IF_ERROR(otbn_load_app(&otbn, kOtbnAppEcdsa));
-  OTBN_RETURN_IF_ERROR(setup_data_pointers(&otbn));
+  OTBN_RETURN_IF_ERROR(set_data_pointers(&otbn));
 
   // Set mode so start() will jump into p256_ecdsa_sign().
   OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.c
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.c
@@ -18,31 +18,31 @@ OTBN_DECLARE_APP_SYMBOLS(run_rsa_verify_3072);  // The OTBN RSA-3072 app.
 OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
                         mode);  // Mode (constants or modexp).
 OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        out_buf);  // Output buffer (message).
+                        exp);  // The RSA key exponent (e).
+OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072, dptr_mod);  // The RSA modulus (n).
+OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072, dptr_sig);  // The signature (s).
 OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        in_exp);  // The RSA key exponent (n).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072, in_mod);  // The RSA modulus (n).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072, in_buf);  // The signature (s).
+                        dptr_out_buf);  // Output buffer (message).
 OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        rr);  // The Montgomery constant R^2.
+                        dptr_rr);  // The Montgomery constant R^2.
 OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        m0inv);  // The Montgomery constant m0_inv.
+                        dptr_m0inv);  // The Montgomery constant m0_inv.
 
 static const otbn_app_t kOtbnAppRsa = OTBN_APP_T_INIT(run_rsa_verify_3072);
 static const otbn_ptr_t kOtbnVarRsaMode =
     OTBN_PTR_T_INIT(run_rsa_verify_3072, mode);
-static const otbn_ptr_t kOtbnVarRsaOutBuf =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, out_buf);
-static const otbn_ptr_t kOtbnVarRsaInExp =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, in_exp);
-static const otbn_ptr_t kOtbnVarRsaInMod =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, in_mod);
-static const otbn_ptr_t kOtbnVarRsaInBuf =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, in_buf);
-static const otbn_ptr_t kOtbnVarRsaRR =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, rr);
-static const otbn_ptr_t kOtbnVarRsaM0Inv =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, m0inv);
+static const otbn_ptr_t kOtbnVarRsaExp =
+    OTBN_PTR_T_INIT(run_rsa_verify_3072, exp);
+static const otbn_ptr_t kOtbnVarRsaDptrMod =
+    OTBN_PTR_T_INIT(run_rsa_verify_3072, dptr_mod);
+static const otbn_ptr_t kOtbnVarRsaDptrSig =
+    OTBN_PTR_T_INIT(run_rsa_verify_3072, dptr_sig);
+static const otbn_ptr_t kOtbnVarRsaDptrOutBuf =
+    OTBN_PTR_T_INIT(run_rsa_verify_3072, dptr_out_buf);
+static const otbn_ptr_t kOtbnVarRsaDptrRR =
+    OTBN_PTR_T_INIT(run_rsa_verify_3072, dptr_rr);
+static const otbn_ptr_t kOtbnVarRsaDptrM0Inv =
+    OTBN_PTR_T_INIT(run_rsa_verify_3072, dptr_m0inv);
 
 /* Mode is represented by a single word: 1=constant computation, 2=modexp */
 static const uint32_t kOtbnRsaModeNumWords = 1;
@@ -97,32 +97,6 @@ rom_error_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
   return kErrorOk;
 }
 
-/**
- * Copies a 3072-bit number from the CPU memory to OTBN data memory.
- *
- * @param otbn The OTBN context object.
- * @param src Source of the data to copy.
- * @param dst Pointer to the destination in OTBN's data memory.
- * @return The result of the operation.
- */
-otbn_error_t write_rsa_3072_int_to_otbn(otbn_t *otbn, const rsa_3072_int_t *src,
-                                        otbn_ptr_t dst) {
-  return otbn_copy_data_to_otbn(otbn, kRsa3072NumWords, src->data, dst);
-}
-
-/**
- * Copies a 3072-bit number from OTBN data memory to CPU memory.
- *
- * @param otbn The OTBN context object.
- * @param src The pointer in OTBN data memory to copy from.
- * @param dst The destination of the copied data in main memory (preallocated).
- * @return The result of the operation.
- */
-otbn_error_t read_rsa_3072_int_from_otbn(otbn_t *otbn, const otbn_ptr_t src,
-                                         rsa_3072_int_t *dst) {
-  return otbn_copy_data_from_otbn(otbn, kRsa3072NumWords, src, dst->data);
-}
-
 // TODO: This implementation waits while OTBN is processing; it should be
 // modified to be non-blocking.
 otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
@@ -138,8 +112,14 @@ otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
       &otbn, kOtbnRsaModeNumWords, &kOtbnRsaModeConstants, kOtbnVarRsaMode));
 
   // Set the modulus (n).
+  OTBN_RETURN_IF_ERROR(otbn_dmem_write_indirect(
+      &otbn, kRsa3072NumWords, public_key->n.data, kOtbnVarRsaDptrMod));
+
+  // Allocate free DMEM space for output buffers and set up pointers
   OTBN_RETURN_IF_ERROR(
-      write_rsa_3072_int_to_otbn(&otbn, &public_key->n, kOtbnVarRsaInMod));
+      otbn_dmem_alloc(&otbn, kRsa3072NumWords, kOtbnVarRsaDptrRR));
+  OTBN_RETURN_IF_ERROR(
+      otbn_dmem_alloc(&otbn, kRsa3072NumWords, kOtbnVarRsaDptrM0Inv));
 
   // Start the OTBN routine.
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
@@ -148,12 +128,12 @@ otbn_error_t rsa_3072_compute_constants(const rsa_3072_public_key_t *public_key,
   OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
 
   // Read constant rr out of DMEM.
-  OTBN_RETURN_IF_ERROR(
-      read_rsa_3072_int_from_otbn(&otbn, kOtbnVarRsaRR, &result->rr));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_read_indirect(
+      &otbn, kRsa3072NumWords, kOtbnVarRsaDptrRR, result->rr.data));
 
   // Read constant m0_inv out of DMEM.
-  OTBN_RETURN_IF_ERROR(otbn_copy_data_from_otbn(
-      &otbn, kOtbnWideWordNumWords, kOtbnVarRsaM0Inv, result->m0_inv));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_read_indirect(
+      &otbn, kOtbnWideWordNumWords, kOtbnVarRsaDptrM0Inv, result->m0_inv));
 
   return kOtbnErrorOk;
 }
@@ -166,7 +146,6 @@ otbn_error_t rsa_3072_verify(const rsa_3072_int_t *signature,
                              const rsa_3072_constants_t *constants,
                              hardened_bool_t *result) {
   otbn_t otbn;
-  rsa_3072_int_t recoveredMessage;
 
   // For now, only the F4 modulus is supported.
   if (public_key->e != 65537) {
@@ -185,23 +164,27 @@ otbn_error_t rsa_3072_verify(const rsa_3072_int_t *signature,
 
   // Set the exponent (e).
   OTBN_RETURN_IF_ERROR(
-      otbn_copy_data_to_otbn(&otbn, 1, &public_key->e, kOtbnVarRsaInExp));
+      otbn_copy_data_to_otbn(&otbn, 1, &public_key->e, kOtbnVarRsaExp));
 
   // Set the modulus (n).
-  OTBN_RETURN_IF_ERROR(
-      write_rsa_3072_int_to_otbn(&otbn, &public_key->n, kOtbnVarRsaInMod));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_write_indirect(
+      &otbn, kRsa3072NumWords, public_key->n.data, kOtbnVarRsaDptrMod));
 
   // Set the signature.
-  OTBN_RETURN_IF_ERROR(
-      write_rsa_3072_int_to_otbn(&otbn, signature, kOtbnVarRsaInBuf));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_write_indirect(
+      &otbn, kRsa3072NumWords, signature->data, kOtbnVarRsaDptrSig));
 
   // Set the precomputed constant R^2.
-  OTBN_RETURN_IF_ERROR(
-      write_rsa_3072_int_to_otbn(&otbn, &constants->rr, kOtbnVarRsaRR));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_write_indirect(
+      &otbn, kRsa3072NumWords, constants->rr.data, kOtbnVarRsaDptrRR));
 
   // Set the precomputed constant m0_inv.
-  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(
-      &otbn, kOtbnWideWordNumWords, constants->m0_inv, kOtbnVarRsaM0Inv));
+  OTBN_RETURN_IF_ERROR(otbn_dmem_write_indirect(
+      &otbn, kOtbnWideWordNumWords, constants->m0_inv, kOtbnVarRsaDptrM0Inv));
+
+  // Allocate space for output buffer
+  OTBN_RETURN_IF_ERROR(
+      otbn_dmem_alloc(&otbn, kRsa3072NumWords, kOtbnVarRsaDptrOutBuf));
 
   // Start the OTBN routine.
   OTBN_RETURN_IF_ERROR(otbn_execute_app(&otbn));
@@ -210,8 +193,9 @@ otbn_error_t rsa_3072_verify(const rsa_3072_int_t *signature,
   OTBN_RETURN_IF_ERROR(otbn_busy_wait_for_done(&otbn));
 
   // Read recovered message out of OTBN dmem.
-  OTBN_RETURN_IF_ERROR(
-      read_rsa_3072_int_from_otbn(&otbn, kOtbnVarRsaOutBuf, &recoveredMessage));
+  rsa_3072_int_t recoveredMessage;
+  OTBN_RETURN_IF_ERROR(otbn_dmem_read_indirect(
+      &otbn, kRsa3072NumWords, kOtbnVarRsaDptrOutBuf, recoveredMessage.data));
 
   // TODO: harden this memory comparison
   // Check if recovered message matches expectation

--- a/sw/device/silicon_creator/lib/otbn_util.c
+++ b/sw/device/silicon_creator/lib/otbn_util.c
@@ -22,13 +22,12 @@ void otbn_init(otbn_t *ctx) {
   };
 }
 
-otbn_error_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
-                                        uint32_t *dmem_addr_otbn) {
-  if (ptr < ctx->app.dmem_start || ptr > ctx->app.dmem_end) {
-    return kOtbnErrorInvalidArgument;
-  }
-  *dmem_addr_otbn = (uintptr_t)ptr - (uintptr_t)ctx->app.dmem_start;
-  return kOtbnErrorOk;
+uint32_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr) {
+  return (uintptr_t)ptr - (uintptr_t)ctx->app.dmem_start;
+}
+
+otbn_ptr_t otbn_dmem_addr_to_data_ptr(const otbn_t *ctx, uint32_t dmem_addr) {
+  return (otbn_ptr_t)((uintptr_t)ctx->app.dmem_start + (uintptr_t)dmem_addr);
 }
 
 otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
@@ -63,6 +62,7 @@ otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
 
   ctx->app = app;
   ctx->app_is_loaded = true;
+  ctx->free_dmem = (otbn_ptr_t)app.dmem_end;
   return kOtbnErrorOk;
 }
 
@@ -77,18 +77,112 @@ otbn_error_t otbn_execute_app(otbn_t *ctx) {
 
 otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
                                     const uint32_t *src, otbn_ptr_t dest) {
-  uint32_t dest_dmem_addr;
-  OTBN_RETURN_IF_ERROR(otbn_data_ptr_to_dmem_addr(ctx, dest, &dest_dmem_addr));
+  uint32_t dest_dmem_addr = otbn_data_ptr_to_dmem_addr(ctx, dest);
   OTBN_RETURN_IF_ERROR(otbn_dmem_write(dest_dmem_addr, src, len));
 
   return kOtbnErrorOk;
 }
 
-otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
-                                      otbn_ptr_t src, uint32_t *dest) {
-  uint32_t src_dmem_addr;
-  OTBN_RETURN_IF_ERROR(otbn_data_ptr_to_dmem_addr(ctx, src, &src_dmem_addr));
-  OTBN_RETURN_IF_ERROR(otbn_dmem_read(src_dmem_addr, dest, len_bytes));
+otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len, otbn_ptr_t src,
+                                      uint32_t *dest) {
+  uint32_t src_dmem_addr = otbn_data_ptr_to_dmem_addr(ctx, src);
+  OTBN_RETURN_IF_ERROR(otbn_dmem_read(src_dmem_addr, dest, len));
 
+  return kOtbnErrorOk;
+}
+
+/**
+ * Rounds a pointer up to the next 256-bit-aligned DMEM address.
+ *
+ * The alignment is with respect to DMEM's address space, not the CPU's.
+ *
+ * @param otbn The OTBN context object.
+ * @param ptr The OTBN pointer to align.
+ * @return The new, aligned pointer
+ */
+static otbn_ptr_t otbn_pointer_balign_wide(otbn_t *otbn, otbn_ptr_t ptr) {
+  // Extract the DMEM relative address.
+  uint32_t addr = otbn_data_ptr_to_dmem_addr(otbn, ptr);
+  uint32_t misalign = addr & 31;
+  if (misalign == 0) {
+    // Already 32-byte aligned; done
+    return ptr;
+  }
+  // Get the next 32-byte aligned address
+  addr += (32 - misalign);
+  return otbn_dmem_addr_to_data_ptr(otbn, addr);
+}
+
+/**
+ * Increments an OTBN pointer by `len`.
+ *
+ * Afterwards, the pointer points to a DMEM region `len` bytes after the
+ * original pointer pointed to. For instance, if you wrote 5 bytes to the
+ * location at the original pointer, incrementing the pointer by 5 would make
+ * the pointer point to the end of the region you just wrote.
+ *
+ * @param otbn The OTBN context
+ * @param ptr The OTBN pointer to align.
+ * @param len Number of DMEM bytes to advance the pointer.
+ * @return The new, incremented pointer
+ */
+static otbn_ptr_t otbn_pointer_inc(otbn_t *otbn, otbn_ptr_t ptr, uint32_t len) {
+  // Extract the DMEM relative address.
+  uint32_t addr = otbn_data_ptr_to_dmem_addr(otbn, ptr);
+  addr += len;
+  return otbn_dmem_addr_to_data_ptr(otbn, addr);
+}
+
+otbn_error_t set_data_pointer(otbn_t *otbn, const otbn_ptr_t dptr,
+                              const otbn_ptr_t value) {
+  uint32_t value_dmem_addr = otbn_data_ptr_to_dmem_addr(otbn, value);
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(otbn, 1, &value_dmem_addr, dptr));
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_dmem_alloc(otbn_t *otbn, size_t len, otbn_ptr_t dptr) {
+  if (!otbn->app_is_loaded) {
+    return kOtbnErrorInvalidArgument;
+  }
+  // Set dest to the next aligned, free address.
+  otbn_ptr_t dest = otbn_pointer_balign_wide(otbn, otbn->free_dmem);
+  // Set up the dptr to point to dest.
+  OTBN_RETURN_IF_ERROR(set_data_pointer(otbn, dptr, dest));
+  // Increment the pointer by the number of bytes allocated.
+  otbn->free_dmem = otbn_pointer_inc(otbn, dest, len * sizeof(uint32_t));
+  // Check that there was enough space in DMEM for this allocation (including
+  // checking whether the pointer increment overflowed).
+  uint32_t free_dmem_addr = otbn_data_ptr_to_dmem_addr(otbn, otbn->free_dmem);
+  if (free_dmem_addr >= kOtbnDMemSizeBytes ||
+      free_dmem_addr < len * sizeof(uint32_t)) {
+    return kOtbnErrorBadOffsetLen;
+  }
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_dmem_write_indirect(otbn_t *otbn, size_t len,
+                                      const uint32_t *src, otbn_ptr_t dptr) {
+  if (!otbn->app_is_loaded) {
+    return kOtbnErrorInvalidArgument;
+  }
+  // Set dest to the next aligned, free address and write data.
+  otbn_ptr_t dest = otbn_pointer_balign_wide(otbn, otbn->free_dmem);
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(otbn, len, src, dest));
+  // Set up the dptr to point to dest.
+  OTBN_RETURN_IF_ERROR(set_data_pointer(otbn, dptr, dest));
+  // Increment the pointer by the number of bytes written.
+  otbn->free_dmem = otbn_pointer_inc(otbn, dest, len * sizeof(uint32_t));
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_dmem_read_indirect(otbn_t *otbn, size_t len, otbn_ptr_t dptr,
+                                     uint32_t *dest) {
+  // Read one word from DMEM[dptr]
+  uint32_t src_addr;
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_from_otbn(otbn, 1, dptr, &src_addr));
+  // Convert the DMEM address to an OTBN pointer
+  otbn_ptr_t src = otbn_dmem_addr_to_data_ptr(otbn, src_addr);
+  // Copy data from DMEM
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_from_otbn(otbn, len, src, dest));
   return kOtbnErrorOk;
 }

--- a/sw/device/silicon_creator/lib/sigverify_rsa_key.h
+++ b/sw/device/silicon_creator/lib/sigverify_rsa_key.h
@@ -17,9 +17,13 @@ enum {
    */
   kSigVerifyRsaNumBits = 3072,
   /**
+   * Length of an RSA-3072 modulus or signature in bytes.
+   */
+  kSigVerifyRsaNumBytes = kSigVerifyRsaNumBits / 8,
+  /**
    * Length of an RSA-3072 modulus or signature in words.
    */
-  kSigVerifyRsaNumWords = kSigVerifyRsaNumBits / (sizeof(uint32_t) * 8),
+  kSigVerifyRsaNumWords = kSigVerifyRsaNumBytes / sizeof(uint32_t),
 };
 
 /**

--- a/sw/otbn/crypto/rsa_verify_3072_consts_test.s
+++ b/sw/otbn/crypto/rsa_verify_3072_consts_test.s
@@ -11,6 +11,18 @@
  * w0). See comment at the end of the file for expected values.
  */
 run_rsa_verify_3072_consts_test:
+
+  /* Set up pointers */
+  la       x2, mod
+  la       x3, dptr_mod
+  sw       x2, 0(x3)
+  la       x2, rr
+  la       x3, dptr_rr
+  sw       x2, 0(x3)
+  la       x2, m0inv
+  la       x3, dptr_m0inv
+  sw       x2, 0(x3)
+
   /* Compute R^2 = (2^3072)^2 mod M */
   jal      x1, compute_rr
 
@@ -34,8 +46,8 @@ run_rsa_verify_3072_consts_test:
 .data
 
 /* Modulus of test key */
-.globl in_mod
-in_mod:
+.globl mod
+mod:
   .word 0x6a6a75e1
   .word 0xa018ddc5
   .word 0x687bb168

--- a/sw/otbn/crypto/rsa_verify_3072_m0inv.s
+++ b/sw/otbn/crypto/rsa_verify_3072_m0inv.s
@@ -124,7 +124,8 @@ compute_m0_inv:
 
   /* w5 <= M[0] = M mod (2^256) */
   li        x3, 5
-  la        x16, in_mod
+  la        x16, dptr_mod
+  lw        x16, 0(x16)
   bn.lid    x3, 0(x16)
 
   /* w6 <= 1 */
@@ -167,19 +168,24 @@ compute_m0_inv:
 
   /* Store result in dmem[m0inv]. */
   li        x9, 2
-  la        x26, m0inv
+  la        x26, dptr_m0inv
+  lw        x26, 0(x26)
   bn.sid    x9, 0(x26)
 
   ret
 
-/* Input buffer for the modulus. */
-.section .data.in_mod
-.weak in_mod
-in_mod:
-  .zero 384
+.section .data
 
-/* Output buffer for the Montgomery constant. */
-.section .data.m0inv
-.weak m0inv
-m0inv:
-  .zero 32
+/* Pointer to modulus. */
+.globl dptr_mod
+.weak dptr_mod
+.balign 4
+dptr_mod:
+.zero 4
+
+/* Pointer to the output buffer for the Montgomery constant. */
+.globl dptr_m0inv
+.weak dptr_m0inv
+.balign 4
+dptr_m0inv:
+.zero 4

--- a/sw/otbn/crypto/rsa_verify_3072_test.s
+++ b/sw/otbn/crypto/rsa_verify_3072_test.s
@@ -14,6 +14,24 @@
  * w0). See comment at the end of the file for expected values.
  */
 run_rsa_verify_3072:
+
+  /* Set up pointers */
+  la       x2, mod
+  la       x3, dptr_mod
+  sw       x2, 0(x3)
+  la       x2, sig
+  la       x3, dptr_sig
+  sw       x2, 0(x3)
+  la       x2, rr
+  la       x3, dptr_rr
+  sw       x2, 0(x3)
+  la       x2, m0inv
+  la       x3, dptr_m0inv
+  sw       x2, 0(x3)
+  la       x2, out_buf
+  la       x3, dptr_out_buf
+  sw       x2, 0(x3)
+
   /* run modular exponentiation */
   jal      x1, modexp_var_3072_f4
 
@@ -30,8 +48,8 @@ run_rsa_verify_3072:
 .data
 
 /* Modulus of test key */
-.globl in_mod
-in_mod:
+.globl mod
+mod:
   .word 0x6a6a75e1
   .word 0xa018ddc5
   .word 0x687bb168
@@ -250,8 +268,8 @@ rr:
 .word 0x9e2dcea8
 
 /* signature */
-.globl in_buf
-in_buf:
+.globl sig
+sig:
 .word 0xceb7e983
 .word 0xe693b200
 .word 0xf9153989
@@ -349,6 +367,10 @@ in_buf:
 .word 0x8fc62fbe
 .word 0x114e6da5
 
+/* Buffer for result */
+.globl out_buf
+out_buf:
+.zero 384
 
 /* Full key for reference:
    modulus                       n = 0xe1df9be8a6c7bf58a792e13e81f787930fce770a5e4ed04d24bd4fbf663209f21344ceaf90e82c7346c9addeb52f170d24c5052559cf874df24f038b21f57f30e18e1206131000ea4d6713ff782e02047a8dfb7f9a29e77d59e0765580a85056565afdbc33976249987caa5b45185f0f04afc71aeb6c3d05b02d90b75f78cb0daf4c58b43970dcb933370e5d78916a8cb70d6b88c8c7100ff0250bf5a137ac60c3d9945f996b62414021b0bd5402c462edf34bc0c4aba4e589c240e0c253ac43c9e0e12fe3bc0f60c13c437e069eccc9eb27475435bf0dfb49d8b510aab78f7bfad39f161ab269e9d2947d3d4d783a7c24e415466e66b8c82819a938fa7b49ee9ebd1ff224e2efdb4f40def28c28f251235574d2b62ed01530e74d0d8018385091b74a8443cccdf7d41db7aa8ae28eb94b1431e3ef762d5bc56ad0f27b9d63661c8be7b3824fb1421c4fb8d78e1dd008b27e206a57f51964a825f9880ce3f8a3e1312531f84d21cfc8722ac57dbfffa78e8205a5687bb168a018ddc56a6a75e1

--- a/sw/otbn/crypto/run_rsa_verify_3072.s
+++ b/sw/otbn/crypto/run_rsa_verify_3072.s
@@ -8,8 +8,28 @@
  * Standalone embeddable wrapper for 3072 bit RSA signature verification.
  * Performs either computation of Montgomery constants or modular
  * exponentiation, depending on mode.
+ *
+ * This file allocates space only for the pointers to large buffers, in order
+ * to avoid including empty DMEM space in the binary. The caller must, before
+ * executing this application, ensure that all input, output, and intermediate
+ * buffers are allocated and non-overlapping, and that the pointers needed by
+ * the given mode point to the correct locations.
+ *
+ * For computing constants (mode=1), the caller must allocate:
+ *   - a 384-byte buffer holding the modulus at dmem[dptr_mod]
+ *   - a 384-byte buffer for the output R^2 at dmem[dptr_rr]
+ *   - a 32-byte buffer for the output m0_inv at dmem[dptr_m0_inv]
+ *
+ * For modular exponentiation (mode=2), the caller must allocate:
+ *   - a 384-byte buffer holding the modulus at dmem[dptr_mod]
+ *   - a 384-byte buffer holding the signature at dmem[dptr_sig]
+ *   - a 384-byte buffer holding R^2 at dmem[dptr_rr]
+ *   - a 32-byte buffer holding m0_inv at dmem[dptr_m0_inv]
+ *   - a 384-byte buffer for the output at dmem[dptr_out_buf]
+ *
  */
 run_rsa_verify_3072:
+
   /* Get the mode input value: x3 <= mode */
   la       x2, mode
   lw       x3, 0(x2)
@@ -28,9 +48,9 @@ run_rsa_verify_3072:
 /**
  * Compute the two Montgomery constants for the given modulus.
  *
- * @param[in] dmem[in_mod]: Modulus of the RSA public key
- * @param[out] dmem[rr]: Montgomery constant R^2 = (2^3072)^2 mod M
- * @param[out] dmem[m0inv]: Montgomery constant m0_inv = (-(M^-1)) mod 2^256
+ * @param[in] dmem[dptr_mod]: Modulus of the RSA public key
+ * @param[out] dmem[dptr_rr]: Montgomery constant R^2 = (2^3072)^2 mod M
+ * @param[out] dmem[dptr_m0inv]: Montgomery constant m0_inv = (-(M^-1)) mod 2^256
 */
 compute_constants:
   jal       x1, compute_rr
@@ -47,16 +67,16 @@ compute_constants:
  *
  * The result, msg, is the recovered message digest.
  *
- * @param[in] dmem[in_exp]: Exponent of the RSA public key (must be 3 or F4=65537)
- * @param[in] dmem[in_mod]: Modulus of the RSA public key
- * @param[in] dmem[in_buf]: Signature to check against
- * @param[in] dmem[rr]: Montgomery constant R^2
- * @param[in] dmem[m0inv]: Montgomery constant m0_inv
- * @param[out] dmem[out_buf]: Recovered message digest (msg)
+ * @param[in] dmem[exp]: Exponent of the RSA public key (must be 3 or F4=65537)
+ * @param[in] dmem[dptr_mod]: Modulus of the RSA public key
+ * @param[in] dmem[dptr_sig]: Signature to check against
+ * @param[in] dmem[dptr_rr]: Montgomery constant R^2
+ * @param[in] dmem[dptr_m0inv]: Montgomery constant m0_inv
+ * @param[out] dmem[dptr_out_buf]: Recovered message digest (msg)
 */
 modexp:
-  /* Get the exponent: x3 <= dmem[in_exp] */
-  la       x2, in_exp
+  /* Get the exponent: x3 <= dmem[exp] */
+  la       x2, exp
   lw       x3, 0(x2)
 
   /* Call a modexp implementation matching the exponent.
@@ -88,31 +108,37 @@ mode:
 .zero 4
 
 /* Exponent of the RSA-3072 key. Accepted values: 3 or F4=65537 */
-.globl in_exp
+.globl exp
 .balign 4
-in_exp:
+exp:
 .zero 4
 
-/* Modulus of RSA-3072 key */
-.globl in_mod
-.balign 32
-in_mod:
-.zero 384
+/* Pointer to output buffer. */
+.globl dptr_out_buf
+.balign 4
+dptr_out_buf:
+.zero 4
 
-/* Montgomery constant m0' */
-.globl m0inv
-.balign 32
-m0inv:
-.zero 32
+/* Pointer to modulus. */
+.globl dptr_mod
+.balign 4
+dptr_mod:
+.zero 4
 
-/* Squared Mongomery Radix RR = (2^3072)^2 mod N */
-.globl rr
-.balign 32
-rr:
-.zero 384
+/* Pointer to signature. */
+.globl dptr_sig
+.balign 4
+dptr_sig:
+.zero 4
 
-/* signature */
-.globl in_buf
-.balign 32
-in_buf:
-.zero 384
+/* Pointer to the Montgomery transformation constant R^2. */
+.globl dptr_rr
+.balign 4
+dptr_rr:
+.zero 4
+
+/* Pointer to the Montgomery constant -(M^-1) mod 2^256. */
+.globl dptr_m0inv
+.balign 4
+dptr_m0inv:
+.zero 4


### PR DESCRIPTION
I'll break this into a couple different pieces to merge it, but I wanted to get some early, high-level feedback on the overall design.

The problem this is solving is that the RSA-3072 OTBN application used by sigverify (`run_rsa_verify_3072_rr_modexp`) currently allocates empty space in DMEM for all its input/output/intermediate buffers and prefills them with zeroes. Altogether that's 384+384+384+384+32 = 1568 bytes (14% of the total size of the binary) spent on empty space. This isn't ideal given code size restrictions for mask ROM/ROM_EXT. With this setup the same application includes only 20 bytes of DMEM in the binary (one 4-byte pointer for each buffer). Just to be safe, I double-checked that the size decreased as expected with a quick `stat` on the generated `.elf` and `.rv32embed.o` files.

Of course, it's slightly more complex on the Ibex side to allocate space from DMEM than it is to simply overwrite a pre-allocated buffer of zeroes. I've added some utilities to `otbn_util` to make this process easier. In particular:
- The `otbn_t` struct now includes a pointer to the next free DMEM address. This pointer starts at the end of the application's used DMEM region.
- The function `otbn_dmem_alloc` allocates a certain amount of free DMEM and sets a particular DMEM pointer to point to it.
- The function `otbn_dmem_write_indirect` writes an input buffer that is indirectly referenced (it does essentially the same thing as `otbn_dmem_alloc`, except that it copies a value to the allocated buffer as well).
- The function `otbn_dmem_write_indirect` reads an output buffer that is indirectly referenced (i.e. the reverse of `write_indirect`)

While I was doing an overhaul, I also did some renaming of the input/output buffers to make things a little clearer.