### PR TITLE
[sram/dv] Fix 2 regression failures

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_smoke_vseq.sv
@@ -84,9 +84,15 @@ class sram_ctrl_smoke_vseq extends sram_ctrl_base_vseq;
             // cycles to finish
             cfg.clk_rst_vif.wait_clks(2);
             `uvm_info(`gfn, "accessing during key req", UVM_HIGH)
+
+            // SRAM init is basically to write all the mem with random value.
+            // When a read happens right after init, it's read-after-write hazard. SCB expects the
+            // read value is from memory directly, but it's actually from the last write of init.
+            // To avoid this case, don't access the last address in this parallel `do_rand_ops`
             do_rand_ops(.num_ops($urandom_range(100, 500)),
                         .abort(1),
-                        .en_ifetch(en_ifetch));
+                        .en_ifetch(en_ifetch),
+                        .not_use_last_addr(1));
             csr_utils_pkg::wait_no_outstanding_access();
           end
         join

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_pipeline_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_stress_pipeline_vseq.sv
@@ -18,6 +18,11 @@ class sram_ctrl_stress_pipeline_vseq extends sram_ctrl_multiple_keys_vseq;
     };
   }
 
+  // Reduce iteration as stress_pipeline runs many operations in one iteration
+  constraint num_trans_c {
+    num_trans inside {[5:10]};
+  }
+
   virtual task pre_start();
 
     stress_pipeline = 1'b1;


### PR DESCRIPTION
1. there is a corner case - A read occurs right after init. Init is
doing a bunch of write with random value in design, so it causes
read-after-write hazard. Scb doesn't know what random value is used, so
update seq to avoid this case
2. reduce iteration to avoid timeout for stress_pipeline, which runs so
many operations in an iteration

Signed-off-by: Weicai Yang <weicai@google.com>