### PR TITLE
[padring] set pad_pok_o to 1

### DIFF
--- a/hw/top_earlgrey/rtl/physical_pads.sv
+++ b/hw/top_earlgrey/rtl/physical_pads.sv
@@ -15,6 +15,6 @@ module physical_pads
   output pad_pok_t [NIoBanks-1:0] pad_pok_o
 );
 
-  assign pad_pok_o = '0;
+  assign pad_pok_o = '1;
 
 endmodule : physical_pads


### PR DESCRIPTION
Signed-off-by: Sharon Topaz <sharon.topaz@nuvoton.com>
Setting pad_pok_o to 1 is required for the closed source, not connected to anything in the open source.