### PR TITLE
[otbn,crypto] Create .bss section for OTBN and use for RSA

### DIFF
--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -52,7 +52,16 @@ SECTIONS
 
         *(.data*)
         . = ALIGN(32);
+
+        /* Align section end (see note in .text section) */
+        . = ALIGN(4);
+
+    } >dmem AT>dmem_load
+
+    .bss : ALIGN(32)
+    {
         *(.bss*)
+        . = ALIGN(32);
 
         /* Align section end (see note in .text section) */
         . = ALIGN(4);

--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -48,26 +48,28 @@ SECTIONS
 
     .data ORIGIN(dmem) : ALIGN(32)
     {
-        _dmem_start = .;
-
+        _dmem_data_start = .;
         *(.data*)
-        . = ALIGN(32);
 
         /* Align section end (see note in .text section) */
         . = ALIGN(4);
 
+        _dmem_data_end = .;
     } >dmem AT>dmem_load
 
     .bss : ALIGN(32)
     {
+        _dmem_bss_start = .;
         *(.bss*)
-        . = ALIGN(32);
 
         /* Align section end (see note in .text section) */
         . = ALIGN(4);
 
-        _dmem_end = .;
+        _dmem_bss_end = .;
     } >dmem AT>dmem_load
+
+    /* This matches the offset *in DMEM* of the .bss section. */
+    _dmem_bss_offset = ADDR(.bss) - ADDR(.data);
 
     .scratchpad ORIGIN(dmem_scratch) (NOLOAD) : ALIGN(32)
     {

--- a/sw/device/lib/runtime/otbn.h
+++ b/sw/device/lib/runtime/otbn.h
@@ -32,13 +32,30 @@ typedef struct otbn_app {
    */
   const uint8_t *imem_end;
   /**
-   * Start of OTBN data memory.
+   * Start of initialized OTBN data memory.
+   *
+   * Data in this section is copied into DMEM when the app is loaded.
    */
-  const uint8_t *dmem_start;
+  const uint8_t *dmem_data_start;
   /**
-   * End of OTBN data memory.
+   * End of initialized OTBN data memory.
    */
-  const uint8_t *dmem_end;
+  const uint8_t *dmem_data_end;
+  /**
+   * Start of uninitialized OTBN data memory.
+   *
+   * Data in this section is initialized to zeroes in DMEM when the app is
+   * loaded.
+   */
+  const uint8_t *dmem_bss_start;
+  /**
+   * End of uninitialized OTBN data memory.
+   */
+  const uint8_t *dmem_bss_end;
+  /**
+   * Offset of the BSS section within DMEM.
+   */
+  uint32_t dmem_bss_offset;
 } otbn_app_t;
 
 /**
@@ -113,11 +130,14 @@ typedef struct otbn {
  * @param app_name Name of the application to load, which is typically the
  *                 name of the main (assembly) source file.
  */
-#define OTBN_DECLARE_APP_SYMBOLS(app_name)                   \
-  extern const uint8_t _otbn_app_##app_name##__imem_start[]; \
-  extern const uint8_t _otbn_app_##app_name##__imem_end[];   \
-  extern const uint8_t _otbn_app_##app_name##__dmem_start[]; \
-  extern const uint8_t _otbn_app_##app_name##__dmem_end[]
+#define OTBN_DECLARE_APP_SYMBOLS(app_name)                        \
+  extern const uint8_t _otbn_app_##app_name##__imem_start[];      \
+  extern const uint8_t _otbn_app_##app_name##__imem_end[];        \
+  extern const uint8_t _otbn_app_##app_name##__dmem_data_start[]; \
+  extern const uint8_t _otbn_app_##app_name##__dmem_data_end[];   \
+  extern const uint8_t _otbn_app_##app_name##__dmem_bss_start[];  \
+  extern const uint8_t _otbn_app_##app_name##__dmem_bss_end[];    \
+  extern const uint8_t _otbn_app_##app_name##__dmem_bss_offset[];
 
 /**
  * Initializes the OTBN application information structure.
@@ -129,12 +149,15 @@ typedef struct otbn {
  * @param app_name Name of the application to load.
  * @see OTBN_DECLARE_APP_SYMBOLS()
  */
-#define OTBN_APP_T_INIT(app_name)                       \
-  ((otbn_app_t){                                        \
-      .imem_start = _otbn_app_##app_name##__imem_start, \
-      .imem_end = _otbn_app_##app_name##__imem_end,     \
-      .dmem_start = _otbn_app_##app_name##__dmem_start, \
-      .dmem_end = _otbn_app_##app_name##__dmem_end,     \
+#define OTBN_APP_T_INIT(app_name)                                           \
+  ((otbn_app_t){                                                            \
+      .imem_start = _otbn_app_##app_name##__imem_start,                     \
+      .imem_end = _otbn_app_##app_name##__imem_end,                         \
+      .dmem_data_start = _otbn_app_##app_name##__dmem_data_start,           \
+      .dmem_data_end = _otbn_app_##app_name##__dmem_data_end,               \
+      .dmem_bss_start = _otbn_app_##app_name##__dmem_bss_start,             \
+      .dmem_bss_end = _otbn_app_##app_name##__dmem_bss_end,                 \
+      .dmem_bss_offset = (uint32_t)_otbn_app_##app_name##__dmem_bss_offset, \
   })
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -87,7 +87,7 @@ otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
 otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
                              size_t num_words) {
   OTBN_RETURN_IF_ERROR(
-      check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
+      check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
     abs_mmio_write32(
@@ -101,7 +101,7 @@ otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
 otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
                             size_t num_words) {
   OTBN_RETURN_IF_ERROR(
-      check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
+      check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
     dest[i] = abs_mmio_read32(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes +

--- a/sw/otbn/crypto/rsa_verify_3072_m0inv.s
+++ b/sw/otbn/crypto/rsa_verify_3072_m0inv.s
@@ -173,13 +173,13 @@ compute_m0_inv:
   ret
 
 /* Input buffer for the modulus. */
-.section .data.in_mod
+.section .bss.in_mod
 .weak in_mod
 in_mod:
   .zero 384
 
 /* Output buffer for the Montgomery constant. */
-.section .data.m0inv
+.section .bss.m0inv
 .weak m0inv
 m0inv:
   .zero 32

--- a/sw/otbn/crypto/rsa_verify_3072_rr.s
+++ b/sw/otbn/crypto/rsa_verify_3072_rr.s
@@ -199,13 +199,13 @@ compute_rr:
   ret
 
 /* Input buffer for the modulus. */
-.section .data.in_mod
+.section .bss.in_mod
 .weak in_mod
 in_mod:
   .zero 384
 
 /* Output buffer for the Montgomery transformation constant R^2. */
-.section .data.rr
+.section .bss.rr
 .weak rr
 rr:
   .zero 384

--- a/sw/otbn/crypto/run_rsa_verify_3072.s
+++ b/sw/otbn/crypto/run_rsa_verify_3072.s
@@ -86,7 +86,7 @@ modexp_3:
   jal      x1, modexp_var_3072_3
   ecall
 
-.data
+.bss
 
 /* Mode (1=constants, 2=modexp) */
 .globl mode

--- a/sw/otbn/crypto/run_rsa_verify_3072_rr_modexp.s
+++ b/sw/otbn/crypto/run_rsa_verify_3072_rr_modexp.s
@@ -56,7 +56,7 @@ modexp_3:
 
   ecall
 
-.data
+.bss
 
 /* Exponent of the RSA-3072 key. Accepted values: 3 or F4=65537 */
 .globl in_exp

--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -200,9 +200,12 @@ def main() -> int:
         sym_pfx = '_otbn_app_{}_'.format(app_name)
         out_embedded_obj = out_dir / (app_name + '.rv32embed.o')
         args = (['-O', 'elf32-littleriscv',
-                 '--prefix-sections=.rodata.otbn',
-                 '--set-section-flags=*=alloc,readonly',
-                 '--set-section-flags=.data=load',
+                 '--set-section-flags=*=alloc,load,readonly',
+                 '--set-section-flags=.bss=alloc,readonly',
+                 '--rename-section=.text=.rodata.otbn.text',
+                 '--rename-section=.start=.rodata.otbn.start',
+                 '--rename-section=.data=.rodata.otbn.data',
+                 '--rename-section=.bss=.bss.otbn.bss',
                  '--remove-section=.scratchpad',
                  '--prefix-symbols', sym_pfx] +
                 [out_elf,

--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -201,7 +201,8 @@ def main() -> int:
         out_embedded_obj = out_dir / (app_name + '.rv32embed.o')
         args = (['-O', 'elf32-littleriscv',
                  '--prefix-sections=.rodata.otbn',
-                 '--set-section-flags=*=alloc,load,readonly',
+                 '--set-section-flags=*=alloc,readonly',
+                 '--set-section-flags=.data=load',
                  '--remove-section=.scratchpad',
                  '--prefix-symbols', sym_pfx] +
                 [out_elf,


### PR DESCRIPTION
This PR allows OTBN programs to specify data in a `.bss` section instead of a `.data` section in order to indicate that the data does not have to be initialized; only the size and symbol locations will be included in the resulting binary, not the code in between. 

This PR also uses the new `.bss` section on the RSA-3072 code used by mask ROM sigverify (mask ROM is sensitive to code and those buffers are a lot of space to spend on zeroes; that was the original motivation for this change!) The size of the `.elf` file for sigverify's OTBN application (`run_rsa_verify_3072_rr_modexp`) went from 11036 to 6488 bytes as a result of this change. That's honestly a bit of a surprisingly large reduction to me (I'd expect it to save ~1.5k bytes, not 4.5k), but the tests are passing. If anyone could educate me on that one, I'd be curious to know! :slightly_smiling_face: 

I also checked locally that the OTBN standalone tests still work; there's no issue with `.weak` symbols in `.bss` being overridden by symbols in `.data` that do need to be initialized.