### PR TITLE
[jtag_riscv_agent] Fixed dout size in jtag_riscv_driver::send_csr_dr_req

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
@@ -100,7 +100,7 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
   // This task sends a CSR register read/write request via JTAG data register.
   protected virtual task send_csr_dr_req(
       input bit [DMI_OPW-1:0] op, input bit [DMI_DATAW-1:0] data,
-      input bit [DMI_ADDRW-1:0] addr, output bit [DMI_DATAW-1:0] dout);
+      input bit [DMI_ADDRW-1:0] addr, output bit [DMI_DRW-1:0] dout);
     jtag_dr_seq m_dr_seq;
     `uvm_create_obj(jtag_dr_seq, m_dr_seq);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(m_dr_seq,


### PR DESCRIPTION
- dout field of jtag_riscv_driver::send_csr_dr_req was incorrectly
sized and as a result the top three bits of read data was being lost.

Fixes: https://github.com/lowRISC/opentitan/issues/9795

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>