### PR TITLE
[dv/prim_alert] Add async clock to prim_alert_sender

### DIFF
--- a/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
+++ b/hw/ip/prim/dv/prim_alert/data/prim_alert_testplan.hjson
@@ -102,7 +102,10 @@
               to return 1 after `alert_req` is sent.
             '''
       milestone: V3
-      tests: []
+      tests: ["prim_async_alert",
+              "prim_async_fatal_alert",
+              "prim_sync_alert",
+              "prim_sync_fatal_alert"]
     }
   ]
 }


### PR DESCRIPTION
This PR adds async clock to prim_alert_sender which drives a different
clock/rst. Then during alert_req, we will randomly disable async clock
and re-enable it. This test ensures alert_ack_o will be set.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>