### PR TITLE
[sram/dv] Fix regression failures

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -454,7 +454,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
   virtual function bit is_data_intg_passthru_mem(tl_seq_item item, string ral_name);
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);
-    uvm_mem mem = ral.default_map.get_mem_by_offset(addr);
+    uvm_mem mem = cfg.ral_models[ral_name].default_map.get_mem_by_offset(addr);
 
     if (mem == null) begin
       return 0;

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -143,6 +143,12 @@
                   This condition is terminal.
                   ''',
             resval: 0,
+            tags: [// avoid checking this field. When sram_mem has received an item with integrity
+                   // error, in the meanwhile, the reg TLUL interface reads this status, tl_errors
+                   // sequence will update the status predict value but read TLUL interface may
+                   // latch the old value. So only read this status when sram TLUL has finished the
+                   // error integrity transaction.
+                   "excl:CsrNonInitTests:CsrExclCheck"]
           }
           { bits: "1"
             name: "INIT_ERROR"

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
@@ -34,6 +34,7 @@ class sram_ctrl_lc_escalation_vseq extends sram_ctrl_multiple_keys_vseq;
   virtual task body();
     repeat (num_trans) begin
       req_mem_init();
+      cfg.disable_d_user_data_intg_check_for_passthru_mem = 0;
       fork
         begin
           // when esc occurs during a OP, the OP can't be finished until esc drops.
@@ -45,6 +46,8 @@ class sram_ctrl_lc_escalation_vseq extends sram_ctrl_multiple_keys_vseq;
           #lc_esc_delay;
 
           cfg.lc_vif.drive_lc_esc_en(lc_ctrl_pkg::On);
+          // after escalation, key will become invalid and design will returns invalid integrity
+          cfg.disable_d_user_data_intg_check_for_passthru_mem = 1;
         end
       join
 


### PR DESCRIPTION
Fix 3 issues:
1. for multi-ral in cip_base_scoreboard, ral -> cfg.ral_models[ral_name]
2. disable integrity check after escalation as sram key becomes invalid
3. exclude checking status.bus_integ_error due to 2 TLUL Interfaces. One
trys to read it and check, in the same time the other may trigger
integrity error and want to update it. Need to avoid these 2 things
happen at the same time

Signed-off-by: Weicai Yang <weicai@google.com>