### PR TITLE
[sram/dv] clean up scb to remove old backdoor checking

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.sv
@@ -54,12 +54,6 @@ class sram_ctrl_env #(parameter int AddrWidth = 10) extends cip_base_env #(
     super.connect_phase(phase);
 
     if (cfg.en_scb) begin
-      // connect SRAM TLUL ports
-      m_tl_agents[cfg.sram_ral_name].monitor.a_chan_port.connect(
-          scoreboard.sram_tl_a_chan_fifo.analysis_export);
-      m_tl_agents[cfg.sram_ral_name].monitor.d_chan_port.connect(
-          scoreboard.sram_tl_d_chan_fifo.analysis_export);
-
       // connect KDI port
       m_kdi_agent.monitor.analysis_port.connect(scoreboard.kdi_fifo.analysis_export);
     end


### PR DESCRIPTION
The new backdoor checking was added in #9573, which is pretty stable.
Now removed the old backdoor checks. 
The diff looks very big, but there is no other function change in this
update.

Signed-off-by: Weicai Yang <weicai@google.com>