### PR TITLE
[sw/silicon_creator] Support RSA keys with exponent 3 in sigverify.

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
@@ -108,8 +108,7 @@ otbn_error_t run_otbn_rsa_3072_modexp(
 rom_error_t sigverify_mod_exp_otbn(const sigverify_rsa_key_t *key,
                                    const sigverify_rsa_buffer_t *sig,
                                    sigverify_rsa_buffer_t *result) {
-  // TODO: The OTBN routines should be consistent with ibex exponent support.
-  if (key->exponent != 65537) {
+  if (key->exponent != 65537 && key->exponent != 3) {
     return kErrorSigverifyBadExponent;
   }
 


### PR DESCRIPTION
This was already supported by the OTBN code as of #9623 , but I hadn't removed the check in `sigverify_mod_exp_otbn.c`.