### PR TITLE
[syn] Enable full compilation in GTECH synthesis flow 

### DIFF
--- a/hw/ip/prim_generic/rtl/prim_generic_buf.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_buf.sv
@@ -11,6 +11,8 @@ module prim_generic_buf #(
   output logic [Width-1:0] out_o
 );
 
-  assign out_o = in_i;
+  logic [Width-1:0] inv;
+  assign inv = ~in_i;
+  assign out_o = ~inv;
 
 endmodule

--- a/hw/ip/prim_generic/rtl/prim_generic_clock_buf.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_clock_buf.sv
@@ -11,6 +11,8 @@ module prim_generic_clock_buf #(
   output logic clk_o
 );
 
-  assign clk_o = clk_i;
+  logic inv;
+  assign inv = ~clk_i;
+  assign clk_o = ~inv;
 
 endmodule // prim_generic_clock_buf

--- a/hw/ip/prim_generic/rtl/prim_generic_clock_mux2.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_clock_mux2.sv
@@ -13,7 +13,8 @@ module prim_generic_clock_mux2 #(
   output logic clk_o
 );
 
-  assign clk_o = (sel_i) ? clk1_i : clk0_i;
+  // We model the mux with logic operations for GTECH runs.
+  assign clk_o = (sel_i & clk1_i) | (~sel_i & clk0_i);
 
   // make sure sel is never X (including during reset)
   // need to use ##1 as this could break with inverted clocks that

--- a/hw/syn/tools/dc/gtech-constraints.sdc
+++ b/hw/syn/tools/dc/gtech-constraints.sdc
@@ -1,0 +1,18 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generic constraints file for GTECH testsynthesis flow
+
+#####################
+# Size Only Cells   #
+#####################
+
+# This is analogous to the size_only constraint when using real ASIC cells.
+set_dont_touch [get_designs -h prim_generic_xor*]
+set_dont_touch [get_designs -h prim_generic_buf*]
+set_dont_touch [get_designs -h prim_generic_clock_buf*]
+set_dont_touch [get_designs -h prim_generic_inv*]
+set_dont_touch [get_designs -h prim_generic_clock_inv*]
+set_dont_touch [get_designs -h prim_generic_clock_mux*]
+set_dont_touch [get_designs -h prim_generic_flop*]

--- a/hw/syn/tools/dc/gtech-setup.tcl
+++ b/hw/syn/tools/dc/gtech-setup.tcl
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# GTECH library setup for DC.
+
+set_app_var target_library "gtech.db"
+set_app_var synthetic_library "dw_foundation.sldb"
+set_app_var synlib_wait_for_design_license "DesignWare-Foundation"
+set_app_var link_library "* ${target_library} ${synthetic_library}"
+set_app_var symbol_library "generic.sdb"
+set NAND2_GATE_EQUIVALENT 1.0

--- a/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson
@@ -16,7 +16,8 @@
     }
   ]
 
-  // No timing constraints needed for GTECH flow
-  sdc_file: ""
+  // Load common dont_touch wildcard constraints for the primitives. No other
+  // timing constraints are needed for this flow.
+  sdc_file: "{syn_root}/tools/dc/gtech-constraints.sdc"
   foundry_sdc_file: ""
 }


### PR DESCRIPTION
Previously, we only created elaborated netlists in the GTECH synthesis flow. 
This update enables full mapping against the GTECH library, including boundary optimization and auto-ungrouping.

The size_only constraints on primitive cells is emulated with don't touch constraints (since the GTECH lib does not contain any timing info, no up or downsizing is required, hence these constraints are roughly equivalent).

Note that some primitives need to be updated for this to work:
1. the generic buffer primitives just contained an assign statement, this is changed so that they always contain two inverter cells to more accurately model the reality.
2. the clock mux is modeled using logic gates. this is needed since otherwise the dont touch constraint on the mux will cause GTECH synthesis to not fully map the ternary expression to GTECH gates.