### PR TITLE
[sw/silicon_creator] Lock CREATOR_SW_CFG OTP partition in rom_ext

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/mock_otp.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_otp.h
@@ -19,6 +19,7 @@ class MockOtp : public GlobalMock<MockOtp> {
   MOCK_METHOD(uint32_t, read32, (uint32_t address));
   MOCK_METHOD(uint32_t, read64, (uint32_t address));
   MOCK_METHOD(void, read, (uint32_t address, uint32_t *data, size_t num_words));
+  MOCK_METHOD(void, CreatorSwCfgLockdown, ());
 };
 
 }  // namespace internal
@@ -45,6 +46,10 @@ uint64_t otp_read64(uint32_t address) {
 
 void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
   return MockOtp::Instance().read(address, data, num_words);
+}
+
+void otp_creator_sw_cfg_lockdown(void) {
+  MockOtp::Instance().CreatorSwCfgLockdown();
 }
 
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -34,3 +34,8 @@ void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
     data[i] = sec_mmio_read32(kBase + reg_offset + i * sizeof(uint32_t));
   }
 }
+
+void otp_creator_sw_cfg_lockdown(void) {
+  sec_mmio_write32(kBase + OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET, 0);
+  sec_mmio_write_increment(1);
+}

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -46,6 +46,14 @@ uint64_t otp_read64(uint32_t address);
  */
 void otp_read(uint32_t address, uint32_t *data, size_t num_words);
 
+/**
+ * Disables read access to CREATOR_SW_CFG partition until next reset.
+ *
+ * This function must be called in ROM_EXT before handing over execution to the
+ * first owner boot stage.
+ */
+void otp_creator_sw_cfg_lockdown(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -26,6 +26,13 @@ class OtpTest : public mask_rom_test::MaskRomTest {
   mask_rom_test::MockSecMmio mmio_;
 };
 
+TEST_F(OtpTest, CreatorSwCfgLockdown) {
+  EXPECT_SEC_WRITE32(base_ + OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET, 0);
+  EXPECT_SEC_WRITE_INCREMENT(1);
+
+  otp_creator_sw_cfg_lockdown();
+}
+
 class OtpReadTest : public OtpTest {
  protected:
   const ptrdiff_t offset_ = OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET;

--- a/sw/device/silicon_creator/rom_ext/meson.build
+++ b/sw/device/silicon_creator/rom_ext/meson.build
@@ -92,6 +92,7 @@ foreach slot, slot_link_args : rom_ext_link_info
         sw_silicon_creator_lib_base_sec_mmio,
         sw_silicon_creator_lib_driver_flash_ctrl,
         sw_silicon_creator_lib_driver_hmac,
+        sw_silicon_creator_lib_driver_otp,
         sw_silicon_creator_lib_driver_pinmux,
         sw_silicon_creator_lib_driver_uart,
         sw_silicon_creator_lib_fake_deps,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -13,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/log.h"
@@ -92,8 +93,10 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest) {
 }
 
 static rom_error_t rom_ext_boot(const manifest_t *manifest) {
-  // Lock down silicon creator info pages until next reset.
+  // Disable access to silicon creator info pages and OTP partitions until next
+  // reset.
   flash_ctrl_creator_info_pages_lockdown();
+  otp_creator_sw_cfg_lockdown();
   // Unlock execution of owner stage executable code (text) sections.
   rom_ext_epmp_unlock_owner_stage_rx(&epmp, manifest_code_region_get(manifest));
 


### PR DESCRIPTION
This PR adds `otp_creator_sw_cfg_lockdown()` and calls it in ROM_EXT to disable read access to `CREATOR_SW_CFG` OTP partition before handing over execution to the first owner boot stage.

Please note that ROM_EXT is still in early development, this PR only aims to add the minimum functionality required. We can iterate on this if needed.

Signed-off-by: Alphan Ulusoy <alphan@google.com>