### PR TITLE
[dv/mem_bkdr_util] added backdoor write of LC counter into LC partition in OTP

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
@@ -5,11 +5,24 @@
 // Wrapper functions to write different partitions in OTP.
 // This file is included in `mem_bkdr_util.sv` as a continuation of `mem_bkdr_util` class.
 
-virtual function void otp_write_lc_partition(lc_ctrl_state_pkg::lc_state_e lc_state);
+virtual function void otp_write_lc_partition_state(lc_ctrl_state_pkg::lc_state_e lc_state);
   for (int i = 0; i < LcStateSize; i+=4) begin
     write32(i + LcStateOffset, lc_state[i*8+:32]);
   end
 endfunction
+
+virtual function otp_write_lc_partition_cnt(lc_ctrl_state_pkg::lc_cnt_e lc_cnt);
+  for (int i = 0; i < LcTransitionCntSize; i+=4) begin
+    write32(i + LcTransitionCntOffset, lc_cnt[i*8+:32]);
+  end
+endfunction : otp_write_lc_partition_cnt
+
+function void otp_write_lc_partition(lc_ctrl_state_pkg::lc_cnt_e lc_cnt,
+                                     lc_ctrl_state_pkg::lc_state_e lc_state);
+
+  otp_write_lc_partition_cnt(lc_cnt);
+  otp_write_lc_partition_state(lc_state);
+endfunction: otp_write_lc_partition
 
 // The following steps are needed to backdoor write a secret partition:
 // 1). Scramble the RAW input data.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -27,7 +27,7 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
 
   virtual function void backdoor_override_otp();
     // Override the LC partition to TestLocked1 state.
-    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition(LcStTestLocked1);
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStTestLocked1);
 
     // Override the test exit token to match SW test's input token.
     cfg.mem_bkdr_util_h[Otp].otp_write_secret0_partition(


### PR DESCRIPTION
…on in OTP

Signed-off-by: Dror Kabely <dror.kabely@opentitan.org>

CS requires change of entire LC partition (including LC counter) via backdoor, so I added the following funcionality.