### PR TITLE
[lc_ctrl/alert_handler] Add full list of countermeasures in preparation for D2S sign-off

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -89,7 +89,7 @@
     { name: "FSM.SPARSE"
       desc: "Sparse state machine implementation."
     }
-    { name: "CNT.REDUN"
+    { name: "CTR.REDUN"
       desc: "Counter hardening for generate command counter."
     }
     { name: "LOGIC.INTEGRITY"

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -54,7 +54,7 @@
     { name: "FSM.SPARSE"
       desc: "Sparse state machine implementation."
     }
-    { name: "CNT.REDUN"
+    { name: "CTR.REDUN"
       desc: "Counter hardening on the generate command maximum requests counter."
     }
     { name: "LOGIC.INTEGRITY"

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -85,7 +85,7 @@
     { name: "FSM.SPARSE"
       desc: "Sparse state machine implementation."
     }
-    { name: "CNT.REDUN"
+    { name: "CTR.REDUN"
       desc: "Counter hardening for all health test counters."
     }
     { name: "LOGIC.INTEGRITY"

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -335,6 +335,33 @@
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
+    { name: "STATE.SPARSE",
+      desc: "Sparse manufacturing state encoding."
+    }
+    { name: "MAIN.FSM.SPARSE",
+      desc: "The main state FSM is sparsely encoded."
+    }
+    { name: "KMAC.FSM.SPARSE",
+      desc: "The KMAC interface FSM is sparsely encoded."
+    }
+    { name: "KMAC.FSM.LOCAL_ESC",
+      desc: "The KMAC interface FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "MAIN.FSM.LOCAL_ESC",
+      desc: "The main state FSM moves to a virtual scrap state upon local escalation."
+    }
+    { name: "MAIN.FSM.GLOBAL_ESC",
+      desc: "The main state FSM moves to a virtual scrap state upon global escalation."
+    }
+    { name: "KMAC.CTR.REDUN",
+      desc: "The counter inside the KMAC interface is replicated."
+    }
+    { name: "INTERSIG.MUBI",
+      desc: "Life cycle control signals are multibit encoded."
+    }
+    { name: "TOKEN.DIGEST",
+      desc: "Life cycle transition tokens are hashed with cSHAKE128."
+    }
   ]
 
   registers: [

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -883,6 +883,102 @@
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
+    { name: "SECRET.MEM.SCRAMBLE",
+      desc: "Secret partitions are scrambled with a full-round PRESENT cipher."
+    }
+    { name: "PART.MEM.DIGEST",
+      desc: "Integrity of buffered partitions is ensured via a 64bit digest."
+    }
+    { name: "DAI.FSM.SPARSE",
+      desc: "The direct access interface FSM is sparsely encoded."
+    }
+    { name: "KDI.FSM.SPARSE",
+      desc: "The key derivation interface FSM is sparsely encoded."
+    }
+    { name: "LCI.FSM.SPARSE",
+      desc: "The life cycle interface FSM is sparsely encoded."
+    }
+    { name: "PART.FSM.SPARSE",
+      desc: "The partition FSMs are sparsely encoded."
+    }
+    { name: "SCRMBL.FSM.SPARSE",
+      desc: "The scramble datapath FSM is sparsely encoded."
+    }
+    { name: "TIMER.FSM.SPARSE",
+      desc: "The background check timer FSM is sparsely encoded."
+    }
+    { name: "DAI.CTR.REDUN",
+      desc: "The direct access interface address counter is duplicated."
+    }
+    { name: "KDI_SEED.CTR.REDUN",
+      desc: "The key derivation interface counter is duplicated."
+    }
+    { name: "KDI_ENTROPY.CTR.REDUN",
+      desc: "The key derivation entropy counter is duplicated."
+    }
+    { name: "LCI.CTR.REDUN",
+      desc: "The life cycle interface address counter is duplicated."
+    }
+    { name: "PART.CTR.REDUN",
+      desc: "The address counter of buffered partitions is duplicated."
+    }
+    { name: "SCRMBL.CTR.REDUN",
+      desc: "The srambling datapath counter is duplicated."
+    }
+    { name: "TIMER_INTEG.CTR.REDUN",
+      desc: "The background integrity check timer is duplicated."
+    }
+    { name: "TIMER_CNSTY.CTR.REDUN",
+      desc: "The background consistency check timer is duplicated."
+    }
+    { name: "TIMER.LFSR.REDUN",
+      desc: "The background check LFSR is duplicated."
+    }
+    { name: "DAI.FSM.LOCAL_ESC",
+      desc: "The direct access interface FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "LCI.FSM.LOCAL_ESC",
+      desc: "The life cycle interface FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "KDI.FSM.LOCAL_ESC",
+      desc: "The key derivation interface FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "PART.FSM.LOCAL_ESC",
+      desc: "The partition FSMs are moved into an invalid state upon local escalation."
+    }
+    { name: "SCRMBL.FSM.LOCAL_ESC",
+      desc: "The scramble datapath FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "TIMER.FSM.LOCAL_ESC",
+      desc: "The background check timer FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "DAI.FSM.GLOBAL_ESC",
+      desc: "The direct access interface FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "LCI.FSM.GLOBAL_ESC",
+      desc: "The life cycle interface FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "KDI.FSM.GLOBAL_ESC",
+      desc: "The key derivation interface FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "PART.FSM.GLOBAL_ESC",
+      desc: "The partition FSMs are moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "SCRMBL.FSM.GLOBAL_ESC",
+      desc: "The scramble datapath FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "TIMER.FSM.GLOBAL_ESC",
+      desc: "The background check timer FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "PART.DATA_REG.INTEGRITY",
+      desc: "All partition buffer registers are protected with ECC on 64bit blocks."
+    }
+    { name: "MACRO.MEM.INTEGRITY",
+      desc: "All OTP macro words are protected with ECC on 16bit words."
+    }
+    { name: "PART.DATA_REG.BKGN_CHK",
+      desc: "The digest of buffered partitions is recomputed and checked at pseudorandom intervals in the background."
+    }
   ]
 
   ///////////////

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -336,6 +336,102 @@
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
+    { name: "SECRET.MEM.SCRAMBLE",
+      desc: "Secret partitions are scrambled with a full-round PRESENT cipher."
+    }
+    { name: "PART.MEM.DIGEST",
+      desc: "Integrity of buffered partitions is ensured via a 64bit digest."
+    }
+    { name: "DAI.FSM.SPARSE",
+      desc: "The direct access interface FSM is sparsely encoded."
+    }
+    { name: "KDI.FSM.SPARSE",
+      desc: "The key derivation interface FSM is sparsely encoded."
+    }
+    { name: "LCI.FSM.SPARSE",
+      desc: "The life cycle interface FSM is sparsely encoded."
+    }
+    { name: "PART.FSM.SPARSE",
+      desc: "The partition FSMs are sparsely encoded."
+    }
+    { name: "SCRMBL.FSM.SPARSE",
+      desc: "The scramble datapath FSM is sparsely encoded."
+    }
+    { name: "TIMER.FSM.SPARSE",
+      desc: "The background check timer FSM is sparsely encoded."
+    }
+    { name: "DAI.CTR.REDUN",
+      desc: "The direct access interface address counter is duplicated."
+    }
+    { name: "KDI_SEED.CTR.REDUN",
+      desc: "The key derivation interface counter is duplicated."
+    }
+    { name: "KDI_ENTROPY.CTR.REDUN",
+      desc: "The key derivation entropy counter is duplicated."
+    }
+    { name: "LCI.CTR.REDUN",
+      desc: "The life cycle interface address counter is duplicated."
+    }
+    { name: "PART.CTR.REDUN",
+      desc: "The address counter of buffered partitions is duplicated."
+    }
+    { name: "SCRMBL.CTR.REDUN",
+      desc: "The srambling datapath counter is duplicated."
+    }
+    { name: "TIMER_INTEG.CTR.REDUN",
+      desc: "The background integrity check timer is duplicated."
+    }
+    { name: "TIMER_CNSTY.CTR.REDUN",
+      desc: "The background consistency check timer is duplicated."
+    }
+    { name: "TIMER.LFSR.REDUN",
+      desc: "The background check LFSR is duplicated."
+    }
+    { name: "DAI.FSM.LOCAL_ESC",
+      desc: "The direct access interface FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "LCI.FSM.LOCAL_ESC",
+      desc: "The life cycle interface FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "KDI.FSM.LOCAL_ESC",
+      desc: "The key derivation interface FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "PART.FSM.LOCAL_ESC",
+      desc: "The partition FSMs are moved into an invalid state upon local escalation."
+    }
+    { name: "SCRMBL.FSM.LOCAL_ESC",
+      desc: "The scramble datapath FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "TIMER.FSM.LOCAL_ESC",
+      desc: "The background check timer FSM is moved into an invalid state upon local escalation."
+    }
+    { name: "DAI.FSM.GLOBAL_ESC",
+      desc: "The direct access interface FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "LCI.FSM.GLOBAL_ESC",
+      desc: "The life cycle interface FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "KDI.FSM.GLOBAL_ESC",
+      desc: "The key derivation interface FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "PART.FSM.GLOBAL_ESC",
+      desc: "The partition FSMs are moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "SCRMBL.FSM.GLOBAL_ESC",
+      desc: "The scramble datapath FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "TIMER.FSM.GLOBAL_ESC",
+      desc: "The background check timer FSM is moved into an invalid state upon global escalation via life cycle."
+    }
+    { name: "PART.DATA_REG.INTEGRITY",
+      desc: "All partition buffer registers are protected with ECC on 64bit blocks."
+    }
+    { name: "MACRO.MEM.INTEGRITY",
+      desc: "All OTP macro words are protected with ECC on 16bit words."
+    }
+    { name: "PART.DATA_REG.BKGN_CHK",
+      desc: "The digest of buffered partitions is recomputed and checked at pseudorandom intervals in the background."
+    }
   ]
 
   ///////////////

--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -120,6 +120,27 @@
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
+    { name: "MEM.INTEGRITY",
+      desc: "End-to-end data/memory integrity scheme."
+    }
+    { name: "MEM.SCRAMBLE",
+      desc: "Data is scrambled with a keyed reduced-round PRINCE cipher in CTR mode."
+    }
+    { name: "ADDR.SCRAMBLE",
+      desc: "Address is scrambled with a keyed lightweight permutation/diffusion function."
+    }
+    { name: "INSTR.BUS.LC_GATED",
+      desc: "Prevent code execution from SRAM in non-test lifecycle states."
+    }
+    { name: "KEY.GLOBAL_ESC",
+      desc: "Scrambling key and nonce are reset to a fixed value upon escalation."
+    }
+    { name: "KEY.LOCAL_ESC",
+      desc: "Scrambling key and nonce are reset to a fixed value upon local escalation due to bus integrity or counter errors."
+    }
+    { name: "CTR.REDUN",
+      desc: "The initialization counter is duplicated."
+    }
   ]
 
   regwidth: "32",

--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -227,7 +227,53 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
+    { name: "CONFIG.SHADOW",
+      desc: "Important CSRs are shadowed."
+    }
+    { name: "ALERT.INTERSIG.DIFF",
+      desc: "Differentially encoded alert channels."
+    }
+    { name: "LPG.INTERSIG.MUBI",
+      desc: "LPG signals are encoded with MUBI types."
+    }
+    { name: "ESC.INTERSIG.DIFF",
+      desc: "Differentially encoded escalation channels."
+    }
+    { name: "ALERT_RX.INTERSIG.BKGN_CHK",
+      desc: "Periodic background checks on alert channels (ping mechanism)."
+    }
+    { name: "ESC_TX.INTERSIG.BKGN_CHK",
+      desc: "Periodic background checks on escalation channels (ping mechanism)."
+    }
+    { name: "ESC_RX.INTERSIG.BKGN_CHK",
+      desc: "Escalation receivers can detect absence of periodic ping requests."
+    }
+    { name: "ESC_TIMER.FSM.SPARSE",
+      desc: "Escalation timer FSMs are sparsely encoded."
+    }
+    { name: "PING_TIMER.FSM.SPARSE",
+      desc: "Ping timer FSM is sparsely encoded."
+    }
+    { name: "ESC_TIMER.FSM.LOCAL_ESC",
+      desc: "Escalation timer FSMs move into an invalid state upon local escalation."
+    }
+    { name: "PING_TIMER.FSM.LOCAL_ESC",
+      desc: "Ping timer FSM moves into an invalid state upon local escalation."
+    }
+    { name: "ACCU.CTR.REDUN",
+      desc: "Accumulator counters are redundant."
+    }
+    { name: "ESC_TIMER.CTR.REDUN",
+      desc: "Escalation timer counters are redundant."
+    }
+    { name: "PING_TIMER.CTR.REDUN",
+      desc: "Ping timer counters are redundant."
+    }
+    { name: "PING_TIMER.LFSR.REDUN",
+      desc: "Ping timer LFSR is redundant."
+    }
   ]
+
 ##############################################################################
 # interrupt registers for the classes
   interrupt_list: [

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -327,7 +327,53 @@
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
+    { name: "CONFIG.SHADOW",
+      desc: "Important CSRs are shadowed."
+    }
+    { name: "ALERT.INTERSIG.DIFF",
+      desc: "Differentially encoded alert channels."
+    }
+    { name: "LPG.INTERSIG.MUBI",
+      desc: "LPG signals are encoded with MUBI types."
+    }
+    { name: "ESC.INTERSIG.DIFF",
+      desc: "Differentially encoded escalation channels."
+    }
+    { name: "ALERT_RX.INTERSIG.BKGN_CHK",
+      desc: "Periodic background checks on alert channels (ping mechanism)."
+    }
+    { name: "ESC_TX.INTERSIG.BKGN_CHK",
+      desc: "Periodic background checks on escalation channels (ping mechanism)."
+    }
+    { name: "ESC_RX.INTERSIG.BKGN_CHK",
+      desc: "Escalation receivers can detect absence of periodic ping requests."
+    }
+    { name: "ESC_TIMER.FSM.SPARSE",
+      desc: "Escalation timer FSMs are sparsely encoded."
+    }
+    { name: "PING_TIMER.FSM.SPARSE",
+      desc: "Ping timer FSM is sparsely encoded."
+    }
+    { name: "ESC_TIMER.FSM.LOCAL_ESC",
+      desc: "Escalation timer FSMs move into an invalid state upon local escalation."
+    }
+    { name: "PING_TIMER.FSM.LOCAL_ESC",
+      desc: "Ping timer FSM moves into an invalid state upon local escalation."
+    }
+    { name: "ACCU.CTR.REDUN",
+      desc: "Accumulator counters are redundant."
+    }
+    { name: "ESC_TIMER.CTR.REDUN",
+      desc: "Escalation timer counters are redundant."
+    }
+    { name: "PING_TIMER.CTR.REDUN",
+      desc: "Ping timer counters are redundant."
+    }
+    { name: "PING_TIMER.LFSR.REDUN",
+      desc: "Ping timer LFSR is redundant."
+    }
   ]
+
 # interrupt registers for the classes
   interrupt_list: [
     { name: "classa",

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -9,19 +9,23 @@ from .lib import check_keys, check_str, check_list
 
 CM_ASSETS = [
     'KEY',
+    'ADDR',
     'DATA_REG',
+    'CTRL_FLOW',
+    'CTRL',
     'CONFIG',
     'LFSR',
-    'CNT',
+    'CTR',
     'FSM',
     'MEM',
     'CLK',
     'RST',
     'BUS',
-    'CTRL_FLOW',
+    'INTERSIG',
     'MUX',
-    'CTRL',
     'CONSTANTS',
+    'STATE',
+    'TOKEN',
     'LOGIC'
 ]
 
@@ -36,12 +40,13 @@ CM_TYPES = [
     'CONSISTENCY',
     'DIGEST',
     'LC_GATED',
-    'LOCAL_ESC',
     'BKGN_CHK',
     'GLITCH_DETECT',
     'SW_UNREADABLE',
     'SCA',
-    'MASKING'
+    'MASKING',
+    'LOCAL_ESC',
+    'GLOBAL_ESC'
 ]
 
 

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -166,11 +166,19 @@ class IpBlock:
         alerts = Alert.from_raw_list('alert_list for block {}'
                                      .format(name),
                                      rd.get('alert_list', []))
+        known_cms = {}
+        raw_cms = rd.get('countermeasures', [])
 
         countermeasures = CounterMeasure.from_raw_list(
             'countermeasure list for block {}'
-            .format(name),
-            rd.get('countermeasures', []))
+            .format(name), raw_cms)
+
+        # Ensure that the countermeasures are unique
+        for x in countermeasures:
+            if str(x) in known_cms:
+                raise RuntimeError(f"Duplicate countermeasure {str(x)}")
+            else:
+                known_cms.update({str(x): 1})
 
         no_auto_intr = check_bool(rd.get('no_auto_intr_regs', not interrupts),
                                   'no_auto_intr_regs field of ' + what)


### PR DESCRIPTION
This PR extends the list of available CM_ASSET labels and adds a check to reggen that ensures uniqueness of the canonical countermeasure names.

Also, the new asset labels are used to formulate the lists for lc_ctrl and alert_handler.

Let me know what you think - I am happy to rename some of the assets if needed.