### PR TITLE
[ entropy_src, rtl ] Improve watermarking for repcnt & repcnts

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1239,7 +1239,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .active_i            (repcnt_active),
-    .event_i             (health_test_done_pulse && !es_bypass_mode),
+    .event_i             (!es_bypass_mode),
     .value_i             (repcnt_event_cnt),
     .value_o             (repcnt_event_hwm_fips)
   );
@@ -1252,7 +1252,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .active_i            (repcnt_active),
-    .event_i             (health_test_done_pulse && es_bypass_mode),
+    .event_i             (es_bypass_mode),
     .value_i             (repcnt_event_cnt),
     .value_o             (repcnt_event_hwm_bypass)
   );
@@ -1300,7 +1300,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .active_i            (repcnts_active),
-    .event_i             (health_test_done_pulse && !es_bypass_mode),
+    .event_i             (!es_bypass_mode),
     .value_i             (repcnts_event_cnt),
     .value_o             (repcnts_event_hwm_fips)
   );
@@ -1313,7 +1313,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .active_i            (repcnts_active),
-    .event_i             (health_test_done_pulse && es_bypass_mode),
+    .event_i             (es_bypass_mode),
     .value_i             (repcnts_event_cnt),
     .value_o             (repcnts_event_hwm_bypass)
   );

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
@@ -24,13 +24,14 @@ module entropy_src_repcnt_ht #(
 );
 
   // signals
-  logic [RngBusWidth-1:0] samples_match_pulse;
-  logic [RngBusWidth-1:0] samples_no_match_pulse;
-  logic [RngBusWidth-1:0] rep_cnt_fail;
-  logic [RegWidth-1:0]    rep_cntr[RngBusWidth];
-  logic [RngBusWidth-1:0] rep_cntr_err;
-  logic [RegWidth-1:0]    test_cnt;
-  logic                   test_cnt_err;
+  logic [RngBusWidth-1:0]               samples_match_pulse;
+  logic [RngBusWidth-1:0]               samples_no_match_pulse;
+  logic [RngBusWidth-1:0]               rep_cnt_fail;
+  logic [RngBusWidth-1:0][RegWidth-1:0] rep_cntr;
+  logic [RngBusWidth-1:0]               rep_cntr_err;
+  logic [RegWidth-1:0]                  test_cnt;
+  logic                                 test_cnt_err;
+  logic [RegWidth-1:0]                  cntr_max;
 
   // flops
   logic [RngBusWidth-1:0] prev_sample_q, prev_sample_d;
@@ -84,6 +85,13 @@ module entropy_src_repcnt_ht #(
 
   end : gen_cntrs
 
+  entropy_src_comparator_tree #(
+    .Width(RegWidth),
+    .Depth(2)
+  ) u_comp (
+    .i(rep_cntr),
+    .o(cntr_max)
+  );
 
   // Test event counter
     prim_count #(
@@ -104,7 +112,7 @@ module entropy_src_repcnt_ht #(
 
   // the pulses will be only one clock in length
   assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
-  assign test_cnt_o = test_cnt;
+  assign test_cnt_o = cntr_max;
   assign count_err_o = test_cnt_err || (|rep_cntr_err);
 
 

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
@@ -101,7 +101,7 @@ module entropy_src_repcnts_ht #(
 
   // the pulses will be only one clock in length
   assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
-  assign test_cnt_o = test_cnt;
+  assign test_cnt_o = rep_cntr;
   assign count_err_o = test_cnt_err || (|rep_cntr_err);
 
 


### PR DESCRIPTION
- repcnt and repcnts ht outputs now indicate the largest repetition
count (regardless of threshold)
- watermarking can be updated even if not on the boundary of a
health check

Fixes #9819

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>