### PR TITLE
[gpio/pinmux] Instantiate 2-stage sync in prim_filter

### DIFF
--- a/hw/ip/gpio/data/gpio.hjson
+++ b/hw/ip/gpio/data/gpio.hjson
@@ -26,6 +26,17 @@
       '''
     }
   ],
+  param_list: [
+    { name:    "GpioAsyncOn",
+      type:    "bit",
+      default: "1'b1",
+      desc:    '''
+      Instantiates 2-flop synchronizers on all GPIO inputs if set to 1.
+      '''
+      local:   "false",
+      expose:  "true"
+    },
+  ]
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."

--- a/hw/ip/gpio/dv/tb/tb.sv
+++ b/hw/ip/gpio/dv/tb/tb.sv
@@ -41,7 +41,12 @@ module tb;
   pins_if #(NUM_GPIOS) gpio_if (.pins(gpio_pins));
 
   // dut
-  gpio dut (
+  gpio #(
+    // TODO: The scoreboard does not handle the 2 cycle delay yet, hence we disable the 2-flop
+    // synchronizers in the block level TB (they are enabled at the top). This should be aligned,
+    // so that synchronizers are always enabled.
+    .GpioAsyncOn(0)
+  ) dut (
     .clk_i (clk),
     .rst_ni(rst_n),
 

--- a/hw/ip/gpio/rtl/gpio.sv
+++ b/hw/ip/gpio/rtl/gpio.sv
@@ -43,15 +43,17 @@ module gpio
 
   // possibly filter the input based upon register configuration
   logic [31:0] data_in_d;
+  localparam int unsigned CntWidth = 4;
   for (genvar i = 0 ; i < 32 ; i++) begin : gen_filter
     prim_filter_ctr #(
       .AsyncOn(GpioAsyncOn),
-      .Cycles(16)
+      .CntWidth(CntWidth)
     ) filter (
       .clk_i,
       .rst_ni,
       .enable_i(reg2hw.ctrl_en_input_filter.q[i]),
       .filter_i(cio_gpio_i[i]),
+      .thresh_i({CntWidth{1'b1}}),
       .filter_o(data_in_d[i])
     );
   end

--- a/hw/ip/gpio/rtl/gpio.sv
+++ b/hw/ip/gpio/rtl/gpio.sv
@@ -9,7 +9,9 @@
 module gpio
   import gpio_reg_pkg::*;
 #(
-  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
+  parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}},
+  // This parameter instantiates 2-stage synchronizers on all GPIO inputs.
+  parameter bit GpioAsyncOn = 1
 ) (
   input clk_i,
   input rst_ni,
@@ -40,11 +42,12 @@ module gpio
   logic [31:0] cio_gpio_en_q;
 
   // possibly filter the input based upon register configuration
-
   logic [31:0] data_in_d;
-
   for (genvar i = 0 ; i < 32 ; i++) begin : gen_filter
-    prim_filter_ctr #(.Cycles(16)) filter (
+    prim_filter_ctr #(
+      .AsyncOn(GpioAsyncOn),
+      .Cycles(16)
+    ) filter (
       .clk_i,
       .rst_ni,
       .enable_i(reg2hw.ctrl_en_input_filter.q[i]),

--- a/hw/ip/pinmux/rtl/pinmux_wkup.sv
+++ b/hw/ip/pinmux/rtl/pinmux_wkup.sv
@@ -23,29 +23,18 @@ module pinmux_wkup
   // Optional Signal Filter //
   ////////////////////////////
 
-  // This uses a lower value for filtering than GPIO since
-  // the always-on clock is slower. This can be disabled,
-  // in which case the signal is just combinationally bypassed.
-  logic filter_out, filter_out_d, filter_out_q;
+  // This uses a lower value for filtering than GPIO since the always-on clock is slower. If the
+  // filter is disabled, this reduces to a plain 2-stage flop synchronizer.
+  logic filter_out_d, filter_out_q;
   prim_filter #(
+    .AsyncOn(1), // Instantiate 2-stage synchronizer
     .Cycles(Cycles)
   ) u_prim_filter (
     .clk_i,
     .rst_ni,
     .enable_i(filter_en_i),
     .filter_i(pin_value_i),
-    .filter_o(filter_out)
-  );
-
-  // Run this through a 2 stage synchronizer to
-  // prevent metastability.
-  prim_flop_2sync #(
-    .Width(1)
-  ) u_prim_flop_2sync_filter (
-    .clk_i,
-    .rst_ni,
-    .d_i(filter_out),
-    .q_o(filter_out_d)
+    .filter_o(filter_out_d)
   );
 
   //////////////////////

--- a/hw/ip/prim/rtl/prim_filter.sv
+++ b/hw/ip/prim/rtl/prim_filter.sv
@@ -10,32 +10,54 @@
 //   new input must be opposite value from stored value for
 //   #Cycles before switching to new value.
 
-module prim_filter #(parameter int Cycles = 4) (
-  input  clk_i,
-  input  rst_ni,
-  input  enable_i,
-  input  filter_i,
-  output filter_o
+module prim_filter #(
+  // If this parameter is set, an additional 2-stage synchronizer will be
+  // added at the input.
+  parameter bit AsyncOn = 0,
+  parameter int unsigned Cycles = 4
+) (
+  input        clk_i,
+  input        rst_ni,
+  input        enable_i,
+  input        filter_i,
+  output logic filter_o
 );
 
   logic [Cycles-1:0] stored_vector_q, stored_vector_d;
   logic stored_value_q, update_stored_value;
   logic unused_stored_vector_q_msb;
 
+  logic filter_synced;
+
+  if (AsyncOn) begin : gen_async
+    // Run this through a 2 stage synchronizer to
+    // prevent metastability.
+    prim_flop_2sync #(
+      .Width(1)
+    ) prim_flop_2sync (
+      .clk_i,
+      .rst_ni,
+      .d_i(filter_i),
+      .q_o(filter_synced)
+    );
+  end else begin : gen_sync
+    assign filter_synced = filter_i;
+  end
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       stored_value_q <= 1'b0;
     end else if (update_stored_value) begin
-      stored_value_q <= filter_i;
+      stored_value_q <= filter_synced;
     end
   end
 
-  assign stored_vector_d = {stored_vector_q[Cycles-2:0],filter_i};
+  assign stored_vector_d = {stored_vector_q[Cycles-2:0],filter_synced};
   assign unused_stored_vector_q_msb = stored_vector_q[Cycles-1];
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      stored_vector_q <= {Cycles{1'b0}};
+      stored_vector_q <= '0;
     end else begin
       stored_vector_q <= stored_vector_d;
     end
@@ -45,7 +67,7 @@ module prim_filter #(parameter int Cycles = 4) (
              (stored_vector_d == {Cycles{1'b0}}) |
              (stored_vector_d == {Cycles{1'b1}});
 
-  assign filter_o = enable_i ? stored_value_q : filter_i;
+  assign filter_o = enable_i ? stored_value_q : filter_synced;
 
 endmodule
 

--- a/hw/ip/prim/rtl/prim_filter_ctr.sv
+++ b/hw/ip/prim/rtl/prim_filter_ctr.sv
@@ -12,7 +12,12 @@
 //   new input must be opposite value from stored value for
 //   #Cycles before switching to new value.
 
-module prim_filter_ctr #(parameter int unsigned Cycles = 4) (
+module prim_filter_ctr #(
+  // If this parameter is set, an additional 2-stage synchronizer will be
+  // added at the input.
+  parameter bit AsyncOn = 0,
+  parameter int unsigned Cycles = 4
+) (
   input  clk_i,
   input  rst_ni,
   input  enable_i,
@@ -26,11 +31,28 @@ module prim_filter_ctr #(parameter int unsigned Cycles = 4) (
   logic [CTR_WIDTH-1:0] diff_ctr_q, diff_ctr_d;
   logic filter_q, stored_value_q, update_stored_value;
 
+  logic filter_synced;
+
+  if (AsyncOn) begin : gen_async
+    // Run this through a 2 stage synchronizer to
+    // prevent metastability.
+    prim_flop_2sync #(
+      .Width(1)
+    ) prim_flop_2sync (
+      .clk_i,
+      .rst_ni,
+      .d_i(filter_i),
+      .q_o(filter_synced)
+    );
+  end else begin : gen_sync
+    assign filter_synced = filter_i;
+  end
+
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       filter_q <= 1'b0;
     end else begin
-      filter_q <= filter_i;
+      filter_q <= filter_synced;
     end
   end
 
@@ -38,26 +60,25 @@ module prim_filter_ctr #(parameter int unsigned Cycles = 4) (
     if (!rst_ni) begin
       stored_value_q <= 1'b0;
     end else if (update_stored_value) begin
-      stored_value_q <= filter_i;
+      stored_value_q <= filter_synced;
     end
   end
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      diff_ctr_q <= {CTR_WIDTH{1'b0}};
+      diff_ctr_q <= '0;
     end else begin
       diff_ctr_q <= diff_ctr_d;
     end
   end
 
   // always look for differences, even if not filter enabled
-  assign diff_ctr_d =
-             (filter_i != filter_q)           ? '0       : // restart
-                     (diff_ctr_q == CYCLESM1) ? CYCLESM1 : // saturate
-                         (diff_ctr_q + 1'b1);              // count up
   assign update_stored_value = (diff_ctr_d == CYCLESM1);
+  assign diff_ctr_d = (filter_synced != filter_q) ? '0                   : // restart
+                      (diff_ctr_q == CYCLESM1)    ? CYCLESM1             : // saturate
+                                                    (diff_ctr_q + 1'b1);   // count up
 
-  assign filter_o = enable_i ? stored_value_q : filter_i;
+  assign filter_o = enable_i ? stored_value_q : filter_synced;
 
 endmodule
 

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -91,7 +91,10 @@ module usbdev_linkstate (
   // four ticks is a bit time
   // Could completely filter out 2-cycle EOP SE0 here but
   // does not seem needed
-  prim_filter #(.Cycles(6)) filter_se0 (
+  prim_filter #(
+    .AsyncOn(0), // No synchronizer required
+    .Cycles(6)
+  ) filter_se0 (
     .clk_i    (clk_48mhz_i),
     .rst_ni   (rst_ni),
     .enable_i (1'b1),
@@ -99,7 +102,10 @@ module usbdev_linkstate (
     .filter_o (see_se0)
   );
 
-  prim_filter #(.Cycles(6)) filter_pwr_sense (
+  prim_filter #(
+    .AsyncOn(0), // No synchronizer required
+    .Cycles(6)
+  ) filter_pwr_sense (
     .clk_i    (clk_48mhz_i),
     .rst_ni   (rst_ni),
     .enable_i (1'b1),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -697,6 +697,10 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        GpioAsyncOn: "1"
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -705,8 +709,18 @@
       [
         "0"
       ]
-      param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: GpioAsyncOn
+          desc: Instantiates 2-flop synchronizers on all GPIO inputs if set to 1.
+          type: bit
+          default: "1"
+          expose: "true"
+          name_top: GpioGpioAsyncOn
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -241,6 +241,9 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "sys_io_div4"},
       base_addr: "0x40040000",
+      param_decl: {
+        GpioAsyncOn: "1"
+      }
     }
     { name: "spi_device",
       type: "spi_device",

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -18,6 +18,7 @@ module top_earlgrey #(
   // parameters for uart2
   // parameters for uart3
   // parameters for gpio
+  parameter bit GpioGpioAsyncOn = 1,
   // parameters for spi_device
   // parameters for i2c0
   // parameters for i2c1
@@ -1108,7 +1109,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   gpio #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[4:4])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[4:4]),
+    .GpioAsyncOn(GpioGpioAsyncOn)
   ) u_gpio (
 
       // Input

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -199,6 +199,9 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "sys_io_div4"},
       base_addr: "0x40040000",
+      param_decl: {
+        GpioAsyncOn: "1"
+      }
     }
     { name: "spi_device",
       type: "spi_device",


### PR DESCRIPTION
The GPIO instantiates `prim_filter_cnt`. However, the `prim_filter*` modules do not properly synchronize the input signal using a 2 stage synchronizer (there is path from input through the filter logic to the first flop enable).

I think it would be good to stay on the safe side and always instantiate a 2 stage synchronizer in front of `prim_filter*` when we are sampling pin inputs - WDYT?

----------------------------------------------

The PR adds a parameter to `prim_filter*` so that a 2 stage synchronizer can be optionally instantiated.
If it is instantiated, the synchronizer is enabled no matter whether the debounce filter is selected or not. 

This change allows us to remove explicit synchronizer instances  from the usb and pinmux wakeup detectors.

Signed-off-by: Michael Schaffner <msf@opentitan.org>