### PR TITLE
[entropy_src, dv] Restructuring of "rng" vseq

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -20,6 +20,16 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   virtual pins_if#(8)   otp_en_es_fw_read_vif;
   virtual pins_if#(8)   otp_en_es_fw_over_vif;
 
+  //
+  // Variables for controlling test duration.  Depending on the test there are two options:
+  // fixed duration in time or total number of seeds.
+  //
+  // When selecting fixed duration, the total simulated duration of the test is approximately
+  // equal to cfg.sim_duration
+  //
+  realtime sim_duration;
+  int      seed_cnt;
+
   // Knobs & Weights
   uint          enable_pct, route_software_pct, regwen_pct,
                 otp_en_es_fw_read_pct, otp_en_es_fw_over_pct,
@@ -35,7 +45,6 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
 
   // TODO: randomize
   uint fips_window_size, bypass_window_size, boot_mode_retry_limit;
-  int  seed_cnt;
 
   rand prim_mubi_pkg::mubi8_t   otp_en_es_fw_read, otp_en_es_fw_over;
 
@@ -112,7 +121,7 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
                  enable.name()),
         $sformatf("\n\t |***** route_software              : %12s *****| \t",
                   route_software.name()),
-         $sformatf("\n\t |***** type_bypass                 : %12s *****| \t",
+        $sformatf("\n\t |***** type_bypass                 : %12s *****| \t",
                    type_bypass.name()),
         $sformatf("\n\t |***** entropy_data_reg_enable     : %12s *****| \t",
                   entropy_data_reg_enable.name()),
@@ -129,7 +138,9 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
         $sformatf("\n\t |***** boot_mode_retry_limit       : %12d *****| \t",
                   boot_mode_retry_limit),
         $sformatf("\n\t |***** seed_cnt                    : %12d *****| \t",
-                  seed_cnt)
+                  seed_cnt),
+        $sformatf("\n\t |***** sim_duration                : %9.2f ms *****| \t",
+                  sim_duration/1ms)
     };
 
     str = {str, "\n\t |----------------- knobs ------------------------------| \t"};

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -12,9 +12,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
 
   rand bit [3:0]   rng_val;
 
-  push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
-  push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)     m_csrng_pull_seq;
-
   // various knobs to enable certain routines
   bit  do_entropy_src_init = 1'b1;
 
@@ -101,7 +98,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
   // b. The intr_state register indicates no more data in entropy_data
   //
   // If max_tries < 0, simply reads all available seeds.
-  task do_entropy_data_read(int max_seeds, output int seeds_found);
+  task do_entropy_data_read(int max_seeds = -1, output int seeds_found);
     bit intr_status;
     bit done;
     seeds_found = 0;

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -4,30 +4,79 @@
 
 // rng test vseq
 class entropy_src_rng_vseq extends entropy_src_base_vseq;
+
   `uvm_object_utils(entropy_src_rng_vseq)
 
   `uvm_object_new
 
-  // TODO: This variable currently overlaps with cfg.seed_cnt
-  rand int num_seeds_requested;
+  push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)   m_csrng_pull_seq;
+  push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
+
+  task software_read_seed();
+    int seeds_found;
+    `uvm_info(`gfn, "CSR Thread: Reading seed via SW", UVM_FULL)
+    ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4True);
+    csr_update(.csr(ral.entropy_control));
+    // Wait for data to arrive for TL consumption via the ENTROPY_DATA register
+    csr_spinwait(.ptr(ral.intr_state.es_entropy_valid), .exp_data(1'b1));
+    ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4False);
+    csr_update(.csr(ral.entropy_control));
+
+    // read all available seeds
+    do begin
+      do_entropy_data_read(.seeds_found(seeds_found));
+    end while (seeds_found > 0);
+    `uvm_info(`gfn, "CSR Thread: Seed read Successfully", UVM_HIGH)
+  endtask
+
+  task enable_dut();
+    `uvm_info(`gfn, "CSR Thread: Enabling DUT", UVM_MEDIUM)
+    ral.conf.enable.set(prim_mubi_pkg::MuBi4True);
+    csr_update(.csr(ral.conf));
+  endtask
+
+  //
+  // The csr_access seq task executes all csr accesses for enabling/disabling the DUT as needed,
+  // clearing assertions
+  //
+  // TODO: the current CSR sequence is a placeholder with a single enable and a single software read
+  // about halfway through the test.
+  task csr_access_seq();
+    // Explicitly enable the DUT
+    enable_dut();
+    #(cfg.sim_duration/2);
+    software_read_seed();
+    #(cfg.sim_duration/2);
+  endtask
 
   task body();
     // Create rng host sequence
-    m_rng_push_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
-         create("m_rng_push_seq");
+    m_rng_push_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::
+        type_id::create("m_rng_push_seq");
 
     // Create csrng host sequence
-    m_csrng_pull_seq = push_pull_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::type_id::
-         create("m_csrng_pull_seq");
-    m_csrng_pull_seq.num_trans = num_seeds_requested;
+    m_csrng_pull_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
+        type_id::create("m_csrng_pull_seq");
+
+    // m_csrng_pull_seq.num_trans = cfg.seed_cnt;
     // TODO: Enhance seq to work for hardware or software entropy consumer
 
     // Start sequences
     fork
       m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
+      m_csrng_pull_seq.start(p_sequencer.csrng_sequencer_h);
       begin
-        m_csrng_pull_seq.start(p_sequencer.csrng_sequencer_h);
-        m_rng_push_seq.stop();
+        csr_access_seq();
+        // Once the CSR access is done, we can shut down everything else
+        // Note: the CSRNG agent needs to be completely shut down before
+        // shutting down the the AST/RNG.  Otherwise the CSRNG pull agent
+        // will stall waiting for entropy.
+        `uvm_info(`gfn, "Stopping CSRNG seq", UVM_LOW)
+         m_csrng_pull_seq.stop();
+         m_csrng_pull_seq.wait_for_sequence_state(UVM_FINISHED);
+         `uvm_info(`gfn, "Stopping RNG seq", UVM_LOW)
+         m_rng_push_seq.stop();
+         m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
       end
     join
   endtask : body

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
@@ -10,6 +10,8 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
   int rng_count = 0;
   int offset = 0;
 
+  push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
+
   task body();
 
     int seed_cnt = cfg.seed_cnt;
@@ -27,7 +29,7 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
           // Wait for data to arrive for TL consumption via the ENTROPY_DATA register
           csr_spinwait(.ptr(ral.intr_state.es_entropy_valid), .exp_data(1'b1));
           // Read all currently available data (but no more than seed_cnt)
-          do_entropy_data_read(seed_cnt, available_seeds);
+          do_entropy_data_read(.max_seeds(seed_cnt), .seeds_found(available_seeds));
           // Update the count of remaining seeds to read
           seed_cnt -= available_seeds;
         end while (seed_cnt > 0);

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -16,9 +16,12 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.fips_window_size            = 2048;
     cfg.bypass_window_size          = 384;
     cfg.boot_mode_retry_limit       = 10;
-    cfg.route_software_pct          = 100;
     cfg.entropy_data_reg_enable_pct = 100;
-    cfg.seed_cnt                    = 4;
+    cfg.sim_duration                = 7500us;
+
+    // Allow for software reads, but let the vseq body do the enabling
+    cfg.route_software_pct          = 0;
+    cfg.enable_pct                  = 0;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)


### PR DESCRIPTION
- Implemented scoreboarding for CSRNG bus seeds
- Added two new processings to RNG test
   - A csrng pull thread
   - A thread for sending CSR commands (which currently holds just some
     placeholder commands, but will hold alert handling in a future PR)
- Added a new cfg variable "Duration" to control how long the test runs
   - Currently the test runs for 7.5ms

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>