### PR TITLE
[spi_device] Passthrough command filtering

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -19,6 +19,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   bit partial_byte;       // Transfering less than byte
   bit [2:0] bits_to_transfer; // Bits to transfer if using less than byte
   bit csb_consecutive;            // Don't deassert CSB
+  bit passthrough_on;     // Using passthrough mode
 
   //-------------------------
   // spi_host regs
@@ -64,6 +65,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (csb_sel,        UVM_DEFAULT)
     `uvm_field_int (partial_byte,   UVM_DEFAULT)
     `uvm_field_int (csb_consecutive,    UVM_DEFAULT)
+    `uvm_field_int (passthrough_on,     UVM_DEFAULT)
     `uvm_field_int (bits_to_transfer,             UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_sck,         UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_sck,     UVM_DEFAULT)

--- a/hw/dv/sv/spi_agent/spi_host_driver.sv
+++ b/hw/dv/sv/spi_agent/spi_host_driver.sv
@@ -101,7 +101,11 @@ class spi_host_driver extends spi_driver;
         cfg.wait_sck_edge(SamplingEdge);
         if (cfg.partial_byte == 1 && j >= cfg.bits_to_transfer) break;
         which_bit = cfg.device_bit_dir ? j : 7 - j;
-        device_byte[which_bit] = cfg.vif.sio[1];
+        if (cfg.passthrough_on == 0) begin
+          device_byte[which_bit] = cfg.vif.sio[1];
+        end else begin
+          device_byte[which_bit] = cfg.vif.sio[2];
+        end
         // wait for driving edge to complete 1 cycle
         if (i != req.data.size() - 1 || j != 7) cfg.wait_sck_edge(DrivingEdge);
       end

--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -206,6 +206,19 @@
       milestone: V2
       tests: []
     }
+    {
+      name: pass_cmd_filtering
+      desc: '''
+            - Randomize command opcode.
+            - Configure unused CMD_INFO reg with new opcode and set it to valid.
+            - Check opcode and address are passing through
+            - Configure filter bit corresponding to opcode to 1
+            - Check only opcode is passing through
+            - Set filter bit back to 0
+            - Check opcode and address are passing through again.'''
+      milestone: V2
+      tests: ["spi_device_pass_cmd_filtering"]
+    }
   ]
   covergroups: [
     {

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -133,6 +133,20 @@ class spi_device_base_vseq extends cip_base_vseq #(
     cfg.m_spi_agent_cfg.partial_byte = 0;
     cfg.m_spi_agent_cfg.csb_consecutive = 0;
     cfg.m_spi_agent_cfg.passthrough_on = 0;
+    if (spi_freq_faster) begin
+      cfg.spi_device_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps / core_spi_freq_ratio;
+    end else begin
+      cfg.spi_device_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
+    end
+    // update host agent
+    cfg.spi_device_cfg.sck_polarity[0] = sck_polarity;
+    cfg.spi_device_cfg.sck_phase[0] = sck_phase;
+    cfg.spi_device_cfg.host_bit_dir = host_bit_dir;
+    cfg.spi_device_cfg.device_bit_dir = device_bit_dir;
+    cfg.spi_device_cfg.csb_sel = 0;
+    cfg.spi_device_cfg.partial_byte = 0;
+    cfg.spi_device_cfg.csb_consecutive = 0;
+    cfg.spi_device_cfg.passthrough_on = 0;
     // update device rtl
     ral.control.mode.set(spi_mode);
     csr_update(.csr(ral.control));

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -132,6 +132,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     cfg.m_spi_agent_cfg.csb_sel = 0;
     cfg.m_spi_agent_cfg.partial_byte = 0;
     cfg.m_spi_agent_cfg.csb_consecutive = 0;
+    cfg.m_spi_agent_cfg.passthrough_on = 0;
     // update device rtl
     ral.control.mode.set(spi_mode);
     csr_update(.csr(ral.control));

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Passthrough mode filtering of commands scenario, filter on and off
+class spi_device_pass_cmd_filtering_vseq extends spi_device_base_vseq;
+  `uvm_object_utils(spi_device_pass_cmd_filtering_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    bit [31:0] device_word_rsp;
+    bit [7:0]  pass_cmd;
+    bit [23:0] pass_addr;
+    bit [31:0] address_command;
+    bit [7:0] cmd_position;
+    bit [7:0] cmd_offset;
+
+    spi_device_init();
+    // Fixed config for this scenario
+    cfg.m_spi_agent_cfg.sck_polarity[0] = 0;
+    cfg.m_spi_agent_cfg.sck_phase[0] = 0;
+    cfg.m_spi_agent_cfg.host_bit_dir = 1;
+    cfg.m_spi_agent_cfg.device_bit_dir = 1;
+    ral.cfg.tx_order.set(1);
+    ral.cfg.rx_order.set(1);
+    ral.cfg.cpol.set(1'b0);
+    ral.cfg.cpha.set(1'b0);
+    csr_update(.csr(ral.cfg)); // TODO check if randomization possible
+
+    ral.control.mode.set(PassthroughMode);
+    csr_update(.csr(ral.control));
+    // Config for response data from passthrough_o
+    cfg.m_spi_agent_cfg.passthrough_on = 1;
+
+    repeat (num_trans) begin
+      // Randomize opcode and address
+      `DV_CHECK_STD_RANDOMIZE_FATAL(pass_addr)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(pass_cmd)
+      // Needed for filter bit position
+      cmd_position = pass_cmd / 32;
+      cmd_offset = pass_cmd % 32;
+      // Configure unused CMD_INFO and enable this opcode
+      ral.cmd_info[11].valid.set(1'b1); // Enable this OPCODE
+      ral.cmd_info[11].opcode.set(pass_cmd);
+      ral.cmd_info[11].addr_mode.set(2'h2); //  3B address for this scenario
+      csr_update(.csr(ral.cmd_info[11]));
+      // Make sure filter is not blocking command opcode
+      ral.cmd_filter[cmd_position].filter[cmd_offset].set(1'b0);
+      csr_update(.csr(ral.cmd_filter[cmd_position]));
+      // Prepare data for transfer
+      pass_cmd = {<<1{pass_cmd}};
+      pass_addr = {<<1{pass_addr}};
+      address_command = {pass_addr, pass_cmd};
+      spi_host_xfer_word(address_command, device_word_rsp);
+      // Check if we have full command and address passing
+      `DV_CHECK_CASE_EQ(address_command, device_word_rsp)
+      cfg.clk_rst_vif.wait_clks(100);
+      // Set filtering of this command
+      ral.cmd_filter[cmd_position].filter[cmd_offset].set(1'b1);
+      csr_update(.csr(ral.cmd_filter[cmd_position]));
+      spi_host_xfer_word(address_command, device_word_rsp);
+      // Check if device passess only command, address should be blocked
+      `DV_CHECK_CASE_EQ(address_command[7:0], device_word_rsp)
+      cfg.clk_rst_vif.wait_clks(100);
+      // Unset filtering and check if pass works again
+      ral.cmd_filter[cmd_position].filter[cmd_offset].set(1'b0);
+      csr_update(.csr(ral.cmd_filter[cmd_position]));
+      spi_host_xfer_word(address_command, device_word_rsp);
+      `DV_CHECK_CASE_EQ(address_command, device_word_rsp)
+      cfg.clk_rst_vif.wait_clks(100);
+    end
+
+  endtask : body
+
+endclass : spi_device_pass_cmd_filtering_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -18,3 +18,4 @@
 `include "spi_device_tpm_write_vseq.sv"
 `include "spi_device_tpm_locality_vseq.sv"
 `include "spi_device_tpm_read_vseq.sv"
+`include "spi_device_pass_cmd_filtering_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/spi_device_tpm_write_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_tpm_locality_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_tpm_read_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_pass_cmd_filtering_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/spi_device/dv/env/spi_device_env.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env.sv
@@ -8,22 +8,25 @@ class spi_device_env extends cip_base_env #(
         .VIRTUAL_SEQUENCER_T (spi_device_virtual_sequencer),
         .SCOREBOARD_T        (spi_device_scoreboard)
     );
-  `uvm_component_utils(spi_device_env)
-
+ `uvm_component_utils(spi_device_env)
+  spi_agent spi_device;
   spi_agent m_spi_agent;
-  spi_agent p_spi_agent;
-
   `uvm_component_new
+  
+  
+  
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // build child components
+   // p_spi_agent = new();
+    spi_device = spi_agent::type_id::create("spi_device", this);
+    uvm_config_db#(spi_agent_cfg)::set(this, "spi_device", "cfg", cfg.spi_device_cfg);
+    cfg.spi_device_cfg.en_cov = cfg.en_cov;
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
-    uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent*", "cfg", cfg.m_spi_agent_cfg);
+    uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent", "cfg", cfg.m_spi_agent_cfg);
     cfg.m_spi_agent_cfg.en_cov = cfg.en_cov;
-    p_spi_agent = spi_agent::type_id::create("p_spi_agent", this);
-    uvm_config_db#(spi_agent_cfg)::set(this, "p_spi_agent*", "cfg", cfg.p_spi_agent_cfg);
-    cfg.p_spi_agent_cfg.en_cov = cfg.en_cov;
+    
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -33,17 +36,17 @@ class spi_device_env extends cip_base_env #(
           scoreboard.host_spi_data_fifo.analysis_export);
       m_spi_agent.monitor.device_analysis_port.connect(
           scoreboard.device_spi_data_fifo.analysis_export);
-      p_spi_agent.monitor.host_analysis_port.connect(
-          scoreboard.host_spi_data_fifo.analysis_export);
-      p_spi_agent.monitor.device_analysis_port.connect(
-          scoreboard.device_spi_data_fifo.analysis_export);
+   //   p_spi_agent.monitor.host_analysis_port.connect(
+   //       scoreboard.host_spi_data_fifo.analysis_export);
+   //   p_spi_agent.monitor.device_analysis_port.connect(
+   //       scoreboard.device_spi_data_fifo.analysis_export);
     end
     if (cfg.m_spi_agent_cfg.is_active) begin
       virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
     end
-    if (cfg.p_spi_agent_cfg.is_active) begin
-      virtual_sequencer.spi_sequencer_h = p_spi_agent.sequencer;
-    end
+  //  if (cfg.p_spi_agent_cfg.is_active) begin
+ //     virtual_sequencer.spi_sequencer_h = p_spi_agent.sequencer;
+ //   end
   endfunction
 
 endclass

--- a/hw/ip/spi_device/dv/env/spi_device_env.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env.sv
@@ -11,6 +11,7 @@ class spi_device_env extends cip_base_env #(
   `uvm_component_utils(spi_device_env)
 
   spi_agent m_spi_agent;
+  spi_agent p_spi_agent;
 
   `uvm_component_new
 
@@ -20,6 +21,9 @@ class spi_device_env extends cip_base_env #(
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
     uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent*", "cfg", cfg.m_spi_agent_cfg);
     cfg.m_spi_agent_cfg.en_cov = cfg.en_cov;
+    p_spi_agent = spi_agent::type_id::create("p_spi_agent", this);
+    uvm_config_db#(spi_agent_cfg)::set(this, "p_spi_agent*", "cfg", cfg.p_spi_agent_cfg);
+    cfg.p_spi_agent_cfg.en_cov = cfg.en_cov;
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -29,9 +33,16 @@ class spi_device_env extends cip_base_env #(
           scoreboard.host_spi_data_fifo.analysis_export);
       m_spi_agent.monitor.device_analysis_port.connect(
           scoreboard.device_spi_data_fifo.analysis_export);
+      p_spi_agent.monitor.host_analysis_port.connect(
+          scoreboard.host_spi_data_fifo.analysis_export);
+      p_spi_agent.monitor.device_analysis_port.connect(
+          scoreboard.device_spi_data_fifo.analysis_export);
     end
     if (cfg.m_spi_agent_cfg.is_active) begin
       virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
+    end
+    if (cfg.p_spi_agent_cfg.is_active) begin
+      virtual_sequencer.spi_sequencer_h = p_spi_agent.sequencer;
     end
   endfunction
 

--- a/hw/ip/spi_device/dv/env/spi_device_env.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env.sv
@@ -12,9 +12,6 @@ class spi_device_env extends cip_base_env #(
   spi_agent spi_device;
   spi_agent m_spi_agent;
   `uvm_component_new
-  
-  
-  
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
@@ -26,7 +23,7 @@ class spi_device_env extends cip_base_env #(
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
     uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent", "cfg", cfg.m_spi_agent_cfg);
     cfg.m_spi_agent_cfg.en_cov = cfg.en_cov;
-    
+
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -44,9 +41,9 @@ class spi_device_env extends cip_base_env #(
     if (cfg.m_spi_agent_cfg.is_active) begin
       virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
     end
-  //  if (cfg.p_spi_agent_cfg.is_active) begin
- //     virtual_sequencer.spi_sequencer_h = p_spi_agent.sequencer;
- //   end
+   // if (cfg.spi_device_cfg.is_active) begin
+      virtual_sequencer.spi_sequencer_d = spi_device.sequencer;
+   // end
   endfunction
 
 endclass

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -4,13 +4,13 @@
 
 class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block));
   rand spi_agent_cfg  m_spi_agent_cfg;
-  rand spi_agent_cfg  p_spi_agent_cfg;
+ rand spi_agent_cfg  spi_device_cfg;
   bit [TL_AW-1:0]     sram_start_addr;
   bit [TL_AW-1:0]     sram_end_addr;
 
   `uvm_object_utils_begin(spi_device_env_cfg)
+    `uvm_field_object(spi_device_cfg, UVM_DEFAULT)
     `uvm_field_object(m_spi_agent_cfg, UVM_DEFAULT)
-    `uvm_field_object(p_spi_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -20,7 +20,7 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
     super.initialize(csr_base_addr);
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
-    p_spi_agent_cfg = spi_agent_cfg::type_id::create("p_spi_agent_cfg");
+    spi_device_cfg = spi_agent_cfg::type_id::create("spi_device_cfg");
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -4,11 +4,13 @@
 
 class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block));
   rand spi_agent_cfg  m_spi_agent_cfg;
+  rand spi_agent_cfg  p_spi_agent_cfg;
   bit [TL_AW-1:0]     sram_start_addr;
   bit [TL_AW-1:0]     sram_end_addr;
 
   `uvm_object_utils_begin(spi_device_env_cfg)
     `uvm_field_object(m_spi_agent_cfg, UVM_DEFAULT)
+    `uvm_field_object(p_spi_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -18,6 +20,7 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
     super.initialize(csr_base_addr);
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
+    p_spi_agent_cfg = spi_agent_cfg::type_id::create("p_spi_agent_cfg");
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -45,6 +45,12 @@ package spi_device_env_pkg;
     TpmCrbMode
   } tpm_cfg_mode_e;
 
+  typedef enum {
+    GenericMode,
+    FlashMode,
+    PassthroughMode
+  } device_mode_e;
+
   // alerts
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};

--- a/hw/ip/spi_device/dv/env/spi_device_virtual_sequencer.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_virtual_sequencer.sv
@@ -9,6 +9,7 @@ class spi_device_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(spi_device_virtual_sequencer)
 
   spi_sequencer  spi_sequencer_h;
+  spi_sequencer  spi_sequencer_d;
 
   `uvm_component_new
 

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -111,6 +111,11 @@
       name: spi_device_tpm_read
       uvm_test_seq: spi_device_tpm_read_vseq
     }
+    
+    {
+      name: spi_device_pass_cmd_filtering
+      uvm_test_seq: spi_device_pass_cmd_filtering_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -25,6 +25,7 @@ module tb;
   wire [3:0] sd_out_en;
   wire [3:0] sd_in;
   spi_device_pkg::passthrough_req_t pass_out;
+  spi_device_pkg::passthrough_req_t pass_in;
 
   wire intr_rxf;
   wire intr_rxlvl;
@@ -67,7 +68,7 @@ module tb;
 
     .cio_tpm_csb_i  (tpm_csb   ),
 
-    .passthrough_i  (sd_in     ),
+    .passthrough_i  (pass_in.s   ),
     .passthrough_o  (pass_out  ),
 
     .intr_generic_rx_full_o             (intr_rxf  ),
@@ -83,17 +84,17 @@ module tb;
     .intr_tpm_header_not_empty_o(intr_tpm_header_not_empty),
     .mbist_en_i     (1'b0),
     .scanmode_i     (prim_mubi_pkg::MuBi4False)
-    
   );
 
   assign sck           = spi_if.sck;
   assign csb           = spi_if.csb[0];
   assign tpm_csb       = spi_if.csb[1];
-  
-//  assign spi_p_if.sck = pass_out.sck;
-//  assign spi_p_if.csb = pass_out.csb;
-//  assign spi_p_if.sio = pass_out.s;
-  
+
+  assign spi_p_if.sck = pass_out.sck;
+  assign spi_p_if.csb = pass_out.csb;
+  assign spi_p_if.sio = pass_out.s;
+  assign pass_in.s = spi_p_if.sio;
+
   // TODO: quad SPI mode is currently not yet implemented
   assign sd_in         = {3'b000, spi_if.sio[0]};
   assign spi_if.sio[1] = sd_out_en[1] ? sd_out[1] : 1'bz;

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -44,6 +44,7 @@ module tb;
   pins_if #(NUM_MAX_INTERRUPTS) intr_if(.pins(interrupts));
   pins_if #(1) devmode_if(devmode);
   spi_if  spi_if(.rst_n(rst_n));
+  spi_if  spi_p_if(.rst_n(rst_n));
 
   `DV_ALERT_IF_CONNECT
 
@@ -82,11 +83,17 @@ module tb;
     .intr_tpm_header_not_empty_o(intr_tpm_header_not_empty),
     .mbist_en_i     (1'b0),
     .scanmode_i     (prim_mubi_pkg::MuBi4False)
+    
   );
 
   assign sck           = spi_if.sck;
   assign csb           = spi_if.csb[0];
   assign tpm_csb       = spi_if.csb[1];
+  
+  assign spi_p_if.sck = pass_out.sck;
+  assign spi_p_if.csb = pass_out.csb;
+  assign spi_p_if.sio = pass_out.s;
+  
   // TODO: quad SPI mode is currently not yet implemented
   assign sd_in         = {3'b000, spi_if.sio[0]};
   assign spi_if.sio[1] = sd_out_en[1] ? sd_out[1] : 1'bz;
@@ -112,6 +119,7 @@ module tb;
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
+    uvm_config_db#(virtual spi_if)::set(null, "*.env.p_spi_agent*", "vif", spi_p_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -24,6 +24,7 @@ module tb;
   wire [3:0] sd_out;
   wire [3:0] sd_out_en;
   wire [3:0] sd_in;
+  spi_device_pkg::passthrough_req_t pass_out;
 
   wire intr_rxf;
   wire intr_rxlvl;
@@ -65,6 +66,9 @@ module tb;
 
     .cio_tpm_csb_i  (tpm_csb   ),
 
+    .passthrough_i  (sd_in     ),
+    .passthrough_o  (pass_out  ),
+
     .intr_generic_rx_full_o             (intr_rxf  ),
     .intr_generic_rx_watermark_o        (intr_rxlvl),
     .intr_generic_tx_watermark_o        (intr_txlvl),
@@ -86,6 +90,7 @@ module tb;
   // TODO: quad SPI mode is currently not yet implemented
   assign sd_in         = {3'b000, spi_if.sio[0]};
   assign spi_if.sio[1] = sd_out_en[1] ? sd_out[1] : 1'bz;
+  assign spi_if.sio[2] = pass_out.csb ? 1'bz : pass_out.s;
 
   assign interrupts[RxFifoFull]      = intr_rxf;
   assign interrupts[RxFifoGeLevel]   = intr_rxlvl;

--- a/hw/ip/spi_device/dv/tb/tb.sv
+++ b/hw/ip/spi_device/dv/tb/tb.sv
@@ -90,14 +90,14 @@ module tb;
   assign csb           = spi_if.csb[0];
   assign tpm_csb       = spi_if.csb[1];
   
-  assign spi_p_if.sck = pass_out.sck;
-  assign spi_p_if.csb = pass_out.csb;
-  assign spi_p_if.sio = pass_out.s;
+//  assign spi_p_if.sck = pass_out.sck;
+//  assign spi_p_if.csb = pass_out.csb;
+//  assign spi_p_if.sio = pass_out.s;
   
   // TODO: quad SPI mode is currently not yet implemented
   assign sd_in         = {3'b000, spi_if.sio[0]};
   assign spi_if.sio[1] = sd_out_en[1] ? sd_out[1] : 1'bz;
-  assign spi_if.sio[2] = pass_out.csb ? 1'bz : pass_out.s;
+  //assign spi_if.sio[2] = pass_out.csb ? 1'bz : pass_out.s;
 
   assign interrupts[RxFifoFull]      = intr_rxf;
   assign interrupts[RxFifoGeLevel]   = intr_rxlvl;
@@ -119,7 +119,7 @@ module tb;
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual spi_if)::set(null, "*.env.m_spi_agent*", "vif", spi_if);
-    uvm_config_db#(virtual spi_if)::set(null, "*.env.p_spi_agent*", "vif", spi_p_if);
+    uvm_config_db#(virtual spi_if)::set(null, "*.env.spi_device*", "vif", spi_p_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
+++ b/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
@@ -14,7 +14,7 @@ class spi_device_base_test extends cip_base_test #(.ENV_T(spi_device_env),
     // configure the spi agent to be in Host mode
     cfg.m_spi_agent_cfg.if_mode = Host;
     // configure passthrough agent to be in Device mode
-    cfg.p_spi_agent_cfg.if_mode = Device;
+    cfg.spi_device_cfg.if_mode = Device;
   endfunction
 
 endclass : spi_device_base_test

--- a/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
+++ b/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
@@ -13,6 +13,8 @@ class spi_device_base_test extends cip_base_test #(.ENV_T(spi_device_env),
     super.build_phase(phase);
     // configure the spi agent to be in Host mode
     cfg.m_spi_agent_cfg.if_mode = Host;
+    // configure passthrough agent to be in Device mode
+    cfg.p_spi_agent_cfg.if_mode = Device;
   endfunction
 
 endclass : spi_device_base_test


### PR DESCRIPTION
Added scenario for filtering out randomized opcode commands. Checking for filtered out data. Added capability to tb and spi_agent for getting data from passthrough_o. Driving passthrough_i.

Signed-off-by: Kosta Kojdic <kosta.kojdic@ensilica.com>