### PR TITLE
[csrng/rtl] fsm default value incorrect

### DIFF
--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -561,7 +561,7 @@ module csrng_ctr_drbg_upd #(
       OBError: begin
         ctr_drbg_updob_sm_err_o = 1'b1;
       end
-      default: outblk_state_d = AckIdle;
+      default: outblk_state_d = OBError;
     endcase
   end
 


### PR DESCRIPTION
While doing state machine error testing, the default value for the drbg_updob fsm was found to be incorrect.
It needs to be the error state.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>