### PR TITLE
[fpv/script] Clean up script

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -45,10 +45,10 @@ if {$env(DUT_TOP) == "prim_count_tb"} {
 
 if {$env(DUT_TOP) == "rv_dm"} {
   clock clk_i -both_edges
-  clock jtag_req_i.tck
-  clock -rate {testmode_i, unavailable_i, tl_d_i, tl_h_i} clk_i
-  clock -rate {jtag_req_i.tms, jtag_req_i.tdi} jtag_req_i.tck
-  reset -expr {!rst_ni !jtag_req_i.trst_n}
+  clock jtag_i.tck
+  clock -rate {testmode, unavailable_i, reg_tl_d_i, sba_tl_h_i} clk_i
+  clock -rate {jtag_i.tms, jtag_i.tdi} jtag_i.tck
+  reset -expr {!rst_ni !jtag_i.trst_n}
 
 } elseif {$env(DUT_TOP) == "spi_device"} {
   clock clk_i -both_edges
@@ -89,13 +89,19 @@ if {$env(DUT_TOP) == "rv_dm"} {
   clock -rate -default clk_i
 }
 
-# use counter abstractions to reduce the run time:
-# alert_handler ping_timer: timer to count until reaches ping threshold
-# hmac sha2: does not check any calculation results, so 64 rounds of calculation can be abstracted
+# Use counter abstractions to reduce the run time.
 if {$env(DUT_TOP) == "alert_handler"} {
-  abstract -counter -env i_ping_timer.cnt_q
+  abstract -counter -env \
+      {u_ping_timer.u_prim_double_lfsr.gen_double_lfsr[0].u_prim_lfsr.gen_max_len_sva.cnt_q}
+  abstract -counter -env \
+      {u_ping_timer.u_prim_double_lfsr.gen_double_lfsr[1].u_prim_lfsr.gen_max_len_sva.cnt_q}
+  abstract -counter -env {gen_classes[0].u_accu.u_prim_count.gen_cross_cnt_hardening.down_cnt}
+  abstract -counter -env {gen_classes[1].u_accu.u_prim_count.gen_cross_cnt_hardening.down_cnt}
+  abstract -counter -env {gen_classes[2].u_accu.u_prim_count.gen_cross_cnt_hardening.down_cnt}
+  abstract -counter -env {gen_classes[3].u_accu.u_prim_count.gen_cross_cnt_hardening.down_cnt}
 
 } elseif {$env(DUT_TOP) == "hmac"} {
+  # SHA2: does not check any calculation results, so 64 rounds of calculation can be abstracted.
   abstract -counter -env u_sha2.round
   # disable these assertions because they are unreachable when the fifo is WO
   assert -disable {*hmac.u_tlul_adapter.u_*fifo.*.depthShallNotExceedParamDepth}

--- a/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
+++ b/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
@@ -16,6 +16,11 @@ set_message -error VERI-1402
 # type.
 set_message -warning VERI-1348
 
+# Downgrade the following error to warning:
+# Assert with local variable assignment in non supported position: Non negative environment.
+# Used for pwrmgr's pwrmgr_clock_enables_sva_if.sv assertion.
+set_message -warning EOBS012
+
 # Disabling warnings:
 # We use parameter instead of localparam in packages to allow redefinition
 # at elaboration time.

--- a/hw/formal/tools/jaspergold/parse-formal-report.py
+++ b/hw/formal/tools/jaspergold/parse-formal-report.py
@@ -119,7 +119,8 @@ def get_cov_results(logpath, dut_name):
                     cov_results[key] = item[0] + " %"
                 else:
                     cov_results[key] = "N/A"
-                    log.error("Parse %s coverage error. Expect one matching value, get %s",
+                    # Report ERROR but continue the parsing script.
+                    log.info("ERROR: parse %s coverage error. Expect one matching value, get %s",
                               key, item)
             return cov_results
 

--- a/hw/ip/rv_dm/dv/sva/rv_dm_bind.sv
+++ b/hw/ip/rv_dm/dv/sva/rv_dm_bind.sv
@@ -9,8 +9,8 @@ module rv_dm_bind;
   ) tlul_assert_device (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_d_i),
-    .d2h  (tl_d_o)
+    .h2d  (regs_tl_d_i),
+    .d2h  (regs_tl_d_o)
   );
 
   bind rv_dm tlul_assert #(
@@ -18,8 +18,8 @@ module rv_dm_bind;
   ) tlul_assert_host (
     .clk_i,
     .rst_ni,
-    .h2d  (tl_h_o),
-    .d2h  (tl_h_i)
+    .h2d  (sba_tl_h_o),
+    .d2h  (sba_tl_h_i)
   );
 
 endmodule


### PR DESCRIPTION
1. Clean up alert_handler's counter abstraction path because
alert_handler updated the counters to double_lsfr and prim_count.
2. Clean up result parsing script to continue the parsing script even
though there was coverage error. This can ensure we still have the
assertion pass/fail results.
3. Clean up port updates from rv_dm.
4. Downgrade a pwrmgr's error to warning, as both xcelium and VCS did
not report it as an error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>