### PR TITLE
[fpv/pinmux] Add tapstrap assertions and adding one more config to tb

### DIFF
--- a/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
+++ b/hw/ip/pinmux/fpv/tb/pinmux_tb.sv
@@ -10,7 +10,19 @@ module pinmux_tb
   import pinmux_reg_pkg::*;
   import prim_pad_wrapper_pkg::*;
 #(
-  parameter target_cfg_t TargetCfg = DefaultTargetCfg,
+  parameter int Tap0PadIdx = 0,
+  parameter int Tap1PadIdx = 1,
+  parameter int Dft0PadIdx = 2,
+  parameter int Dft1PadIdx = 3,
+  parameter int TckPadIdx = 4,
+  parameter int TmsPadIdx = 5,
+  parameter int TrstNPadIdx = 6,
+  parameter int TdiPadIdx = 7,
+  parameter int TdoPadIdx = 8,
+  parameter int DioUsbdevDp = 9,
+  parameter int DioUsbdevDn = 10,
+  parameter int DioUsbdevDpPullup = 11,
+  parameter int DioUsbdevDnPullup = 12,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
   input  clk_i,
@@ -57,9 +69,28 @@ module pinmux_tb
   input [NDioPads-1:0] dio_in_i
 );
 
+  localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{
+    tck_idx:           TckPadIdx,
+    tms_idx:           TmsPadIdx,
+    trst_idx:          TrstNPadIdx,
+    tdi_idx:           TdiPadIdx,
+    tdo_idx:           TdoPadIdx,
+    tap_strap0_idx:    Tap0PadIdx,
+    tap_strap1_idx:    Tap1PadIdx,
+    dft_strap0_idx:    Dft0PadIdx,
+    dft_strap1_idx:    Dft1PadIdx,
+    // TODO: check whether there is a better way to pass these USB-specific params
+    usb_dp_idx:        DioUsbdevDp,
+    usb_dn_idx:        DioUsbdevDn,
+    usb_dp_pullup_idx: DioUsbdevDpPullup,
+    usb_dn_pullup_idx: DioUsbdevDnPullup,
+    // Pad types for attribute WARL behavior
+    dio_pad_type:      {NDioPads{BidirStd}},
+    mio_pad_type:      {NMioPads{BidirStd}}
+  };
 
   pinmux #(
-    .TargetCfg(TargetCfg),
+    .TargetCfg(PinmuxTargetCfg),
     .AlertAsyncOn(AlertAsyncOn)
   ) dut (
     .clk_i,
@@ -106,5 +137,51 @@ module pinmux_tb
     .dio_in_i
   );
 
+  pinmux #(
+    .AlertAsyncOn(AlertAsyncOn)
+  ) default_target_dut (
+    .clk_i,
+    .rst_ni,
+    .scanmode_i,
+    .clk_aon_i,
+    .rst_aon_ni,
+    .pin_wkup_req_o,
+    .usb_wkup_req_o,
+    .sleep_en_i,
+    .strap_en_i,
+    .lc_dft_en_i,
+    .lc_hw_debug_en_i,
+    .dft_strap_test_o,
+    .dft_hold_tap_sel_i,
+    .lc_jtag_o,
+    .lc_jtag_i,
+    .rv_jtag_o,
+    .rv_jtag_i,
+    .dft_jtag_o,
+    .dft_jtag_i,
+    .usb_out_of_rst_i,
+    .usb_aon_wake_en_i,
+    .usb_aon_wake_ack_i,
+    .usb_suspend_i,
+    .usb_state_debug_o,
+    .tl_i,
+    .tl_o,
+    .alert_rx_i,
+    .alert_tx_o,
+    .periph_to_mio_i,
+    .periph_to_mio_oe_i,
+    .mio_to_periph_o,
+    .periph_to_dio_i,
+    .periph_to_dio_oe_i,
+    .dio_to_periph_o,
+    .mio_attr_o,
+    .mio_out_o,
+    .mio_oe_o,
+    .mio_in_i,
+    .dio_attr_o,
+    .dio_out_o,
+    .dio_oe_o,
+    .dio_in_i
+  );
 
 endmodule : pinmux_tb


### PR DESCRIPTION
This PR has two commits:
1). Add tapstrap assertions.
2). Add a different pinmux TargetCfg that is different from default value (which is all 0s).