### PR TITLE
[entropy_src, dv] New RNG failure seqeunces

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -71,13 +71,22 @@
 
   component_a: "uvm_test_top.env.scoreboard"
   id_a : _ALL_
-  verbosity_a: UVM_MEDIUM
+  verbosity_a: UVM_FULL
   phase_a: run
+
+  component_b: "uvm_test_top.env.m_rng_agent.sequencer"
+  id_b : _ALL_
+  verbosity_b: UVM_HIGH
+  phase_b: run
 
   run_modes: [
     {
       name: set_verbosity_comp_a_uvm_debug
       run_opts: ["+uvm_set_verbosity={component_a},{id_a},{verbosity_a},{phase_a}"]
+    }
+    {
+      name: set_verbosity_comp_b_uvm_debug
+      run_opts: ["+uvm_set_verbosity={component_b},{id_b},{verbosity_b},{phase_b}"]
     }
   ]
 }

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -23,6 +23,7 @@ filesets:
       - seq_lib/entropy_src_common_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_rng_vseq.sv: {is_include_file: true}
+      - seq_lib/entropy_src_base_rng_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -30,6 +30,15 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   realtime sim_duration;
   int      seed_cnt;
 
+  // Mean time before hard RNG failure
+  realtime hard_mtbf;
+  // Mean time before "soft" RNG failure (still functions but less entropy per bit)
+  realtime soft_mtbf;
+
+  // When expecting an alert, the cip scoreboarding routines expect a to see the
+  // alert within alert_max_delay clock cycles.
+  int      alert_max_delay;
+
   // Knobs & Weights
   uint          enable_pct, route_software_pct, regwen_pct,
                 otp_en_es_fw_read_pct, otp_en_es_fw_over_pct,

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_rng_seq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_rng_seq.sv
@@ -1,0 +1,254 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Base class for generating non-ideal RNG sequences for entropy_src
+//
+// Three major features distinguigh this class from its push_pull_indefinite_host_seq baseclass:
+// 1. Methods to return the expected mean and standard deviation of the various health checks
+// 2. Introduces support for both complete and soft failures of the RNG, with expected (short)
+//    lifetimes of hard_mtbf or soft_mtbf.  This base class implements hard failures by
+//    freezing the outputs at a random value at some randomly distributed time, as determined by a
+//    exponential distibution with a mean time of hard_mtbf.
+//    This base class does not generate soft failures, e.g. intolerable statistical deviations
+//    from the ideal uniform distribution.  Unless in a hard failure state, the RNG outputs
+//    are always ideal.  However, the frame work for the timing soft failures is implemented here.
+// 3. The "reset_rng()" method should be used to initialize the sequence, and to bring the sequence
+//    back into the typical/good state.  After reset the failure control variables are randomized,
+//    to simulate a different future failure.
+//
+// Extending this class:
+//
+// This class generates three new methods: random_data_typical, random_data_soft_fail and
+// threshold_rec. In order to generate weak failures (or rng streams where the typical performance
+// is less than ideal), these methods should be overloaded.
+//
+// The threshold_rec method should be written assuming that the RNG is operating in the "typical"
+// performance mode.
+
+class entropy_src_base_rng_seq extends push_pull_indefinite_host_seq#(
+    .HostDataWidth (entropy_src_pkg::RNG_BUS_WIDTH)
+  );
+
+  realtime hard_mtbf;
+  realtime soft_mtbf;
+
+  `uvm_object_utils_begin(entropy_src_base_rng_seq)
+    `uvm_field_real(hard_mtbf, UVM_DEFAULT)
+    `uvm_field_real(soft_mtbf, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+   bit is_initialized;
+
+  // Failure bit control: Controls which lines will fail in the next hard failure event
+  rand bit [RNG_BUS_WIDTH - 1:0] hard_fail_bit_ctrl;
+
+  // In hard failure, at least one bit must be stuck
+  constraint hard_fail_bit_ctrl_c { hard_fail_bit_ctrl != {RNG_BUS_WIDTH{1'b0}};}
+
+  // Failure bit control: Controls the state of any failed RNG lines
+  rand bit [RNG_BUS_WIDTH - 1:0] hard_fail_state;
+
+  realtime hard_fail_time, soft_fail_time;
+  bit      is_hard_failed, is_soft_failed;
+
+  typedef enum bit [1:0] {
+    AdaptP,
+    Bucket,
+    Markov
+  } health_test_e;
+
+  // Determine a random failure time according to an exponential distribution with
+  // mean failure time mtbf.
+  //
+  // The exponential distribution is appropriate for any process where the instantaneous likelihood
+  // of failure is the same regardless of how long the device has been active.  For example,
+  // if the MTBF is 1s, then the probability of failing in any particular 1 ns period is 1e-9.
+  //
+  // For more information about the exponential distribution see (for example):
+  // https://en.wikipedia.org/wiki/Exponential_distribution
+
+  function realtime randomize_failure_time(realtime mtbf);
+    // Random non-zero integer
+    int      rand_i;
+    // Uniformly distributed random float in range (0, 1].
+    // 0 is not included in this range, but 1 is.
+    real     rand_r;
+    realtime now, random_fail_time;
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rand_i, rand_i > 0;)
+
+    rand_r = real'(rand_i)/{$bits(rand_i){1'b1}};
+
+    now = $realtime();
+
+    random_fail_time = now - $ln(rand_r) * mtbf;
+
+    return random_fail_time;
+  endfunction
+
+  task reset_rng();
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(hard_fail_bit_ctrl);
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(hard_fail_state)
+
+    `uvm_info(`gfn, "Initializing RNG sequence", UVM_MEDIUM)
+
+    if (check_soft_failure()) begin
+      `uvm_info(`gfn, "Resetting soft failure", UVM_MEDIUM)
+      is_soft_failed = 0;
+    end
+    soft_fail_time = randomize_failure_time(soft_mtbf);
+
+    if (check_hard_failure()) begin
+      `uvm_info(`gfn, "Resetting hard failure", UVM_MEDIUM)
+      is_hard_failed = 0;
+    end
+    hard_fail_time = randomize_failure_time(hard_mtbf);
+
+    is_initialized = 1;
+
+  endtask
+
+  function bit check_soft_failure();
+    bit result;
+    result = is_initialized && ($realtime() > soft_fail_time);
+    if (!is_soft_failed && result) begin
+      `uvm_info(`gfn, "Soft Failure Detected", UVM_MEDIUM)
+    end
+    is_soft_failed = result;
+    return is_soft_failed;
+  endfunction
+
+  function bit check_hard_failure();
+    bit result;
+    result = is_initialized && ($realtime() > hard_fail_time);
+    if (!is_hard_failed && result) begin
+      `uvm_info(`gfn, "Hard Failure Detected", UVM_MEDIUM)
+    end
+    is_hard_failed = result;
+    return is_hard_failed;
+  endfunction
+
+  virtual task pre_body();
+    super.pre_body();
+    reset_rng();
+  endtask
+
+  virtual function rng_val_t random_data_typical();
+    rng_val_t next_rng_val;
+    `DV_CHECK_STD_RANDOMIZE_FATAL(next_rng_val)
+    return next_rng_val;
+  endfunction
+
+  virtual function bit [RNG_BUS_WIDTH - 1:0] random_data_soft_fail();
+    // For this base class, soft failure is identical
+    return random_data_typical();
+  endfunction
+
+  virtual function void randomize_item(push_pull_item#(RNG_BUS_WIDTH) item);
+    super.randomize_item(item);
+    if(check_soft_failure()) begin
+      item.h_data = random_data_soft_fail();
+    end else begin
+      item.h_data = random_data_typical();
+    end
+    if(check_hard_failure()) begin
+      item.h_data = (item.h_data     & ~hard_fail_bit_ctrl) |
+                    (hard_fail_state &  hard_fail_bit_ctrl);
+    end
+  endfunction
+
+  // Function threshold_rec
+  //
+  // Purpose:
+  // Estimates the typical normal statistical range for each test, to within a desired number of
+  // standard deviations (desired_sigma).
+  //
+  // Inputs:
+  // int    window_size: the number of bits to consider for the test (combining all RNG bus lines)
+  // test_e        test: the test to consider (AdaptP, Bucket, or Markov)
+  // bit       per_line: set to 1 if the test is being evaluated on a per_line basis
+  //                     (if 0, the range applies if the results are summed over all RNG lines)
+  // real desired_sigma: the number of standard deviations to provide within the range.  Assuming
+  //                     the window size is large enough to treat the test as normally distributed,
+  //                     the probability of the test within the range increases with the number of
+  //                     sigma
+  //
+  // Outputs:
+  // lower_threshold, upper_threshold: A min/max threshold pair with the desired certainty of
+  // test passing.
+  //
+  // The function computes the mean and standard deviation of the test result, assuming a binomial
+  // distribution (or multinomial distribution in the case of the Bucket test).  Then the min/max
+  // range is generated assuming that the window size is large enough to apply a gaussian
+  // approximation.
+  //
+  // This base sequence generates a uniform rng sequence (when not failing), the thresholds
+  // are generated assuming all bits are equally likely, and there are no correlations of any kind.
+  // (e.g. a maximum entropy RNG stream). Derived classes which overload the randomize() method
+  // to introduce statistical defects should also overload this function to match the new
+  // distribution.
+  //
+  // This function can be used to generate high and low test thresholds with a desired likelihood
+  // of failure
+  //
+  //      No. of sigma   Approximate probability of test failure ( P(x) = 1 - erf( x / sqrt(2) ))
+  //     ------------------------------------------------
+  //                 1   31.7%
+  //               1.5   13.4%
+  //                 2    4.6%
+  //               2.5    1.2%
+  //                 3   0.27%
+  //               3.3    0.1%
+  //               3.9    1e-4
+  //              4.42    1e-5
+  //               4.9    1e-6
+  //
+  // The table above can be used to estimate the likelihood of failure for the AdaptP and Markov
+  // tests, which have both high and low thresholds.  Since the Bucket test has only a single
+  // threshold, the likelihood of chance bucket-test failure is 1/2 the above value for the same
+  // sigma value.
+  //
+  // The table above does not account for rounding error. Furthermore, since the approximation to a
+  // normal distribution ignores any skew or other higher moments, this leads additional devations
+  // from the tabled values particularly for smaller window sizes and at higher sigma values.
+
+  virtual function void threshold_rec(int window_size, health_test_e test, bit per_line,
+                                      real desired_sigma, output int lower_threshold,
+                                      output int upper_threshold);
+    int n, minv, maxv;
+    real p, mean, stddev;
+    case(test)
+      AdaptP: begin
+        // number of trials is equal to number of bits, either in the whole window or per line
+        n = per_line ? (window_size / RNG_BUS_WIDTH) : window_size;
+        p = 0.5;
+      end
+      Bucket: begin
+        n = (window_size / RNG_BUS_WIDTH);
+        p = 1.0/real'(1 << RNG_BUS_WIDTH);
+      end
+      Markov: begin
+        n = per_line ? (window_size / RNG_BUS_WIDTH / 2) : window_size / 2;
+        p = 0.5;
+      end
+      default: begin
+        `dv_fatal("Invalid test!", `gfn)
+      end
+    endcase
+    mean   = p * n;
+    stddev = $sqrt(p * (1 - p) * n);
+
+    lower_threshold = (test == Bucket) ? 0 : $floor(mean - desired_sigma * stddev);
+    upper_threshold = $ceil(mean + desired_sigma * stddev);
+    // For large values of sigma, the gaussian approximation can recommend thresholds larger than
+    // the total number of trials.   In such cases we cap the threshold at the total number of
+    // trials for the given test.
+    upper_threshold = (upper_threshold > n) ? n : upper_threshold;
+    lower_threshold = (lower_threshold < 0) ? 0 : lower_threshold;
+
+  endfunction
+
+endclass

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+`include "entropy_src_base_rng_seq.sv"
+
 // rng test vseq
 class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
@@ -9,8 +11,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   `uvm_object_new
 
-  push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)   m_csrng_pull_seq;
-  push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
+  push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH) m_csrng_pull_seq;
+  entropy_src_base_rng_seq                                              m_rng_push_seq;
 
   task software_read_seed();
     int seeds_found;
@@ -39,8 +41,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   // The csr_access seq task executes all csr accesses for enabling/disabling the DUT as needed,
   // clearing assertions
   //
-  // TODO: the current CSR sequence is a placeholder with a single enable and a single software read
-  // about halfway through the test.
   task csr_access_seq();
     // Explicitly enable the DUT
     enable_dut();
@@ -51,12 +51,14 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   task body();
     // Create rng host sequence
-    m_rng_push_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::
-        type_id::create("m_rng_push_seq");
+    m_rng_push_seq = entropy_src_base_rng_seq::type_id::create("m_rng_push_seq");
 
     // Create csrng host sequence
     m_csrng_pull_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::FIPS_CSRNG_BUS_WIDTH)::
         type_id::create("m_csrng_pull_seq");
+
+    m_rng_push_seq.hard_mtbf = cfg.hard_mtbf;
+    m_rng_push_seq.soft_mtbf = cfg.soft_mtbf;
 
     // m_csrng_pull_seq.num_trans = cfg.seed_cnt;
     // TODO: Enhance seq to work for hardware or software entropy consumer

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -17,7 +17,10 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.bypass_window_size          = 384;
     cfg.boot_mode_retry_limit       = 10;
     cfg.entropy_data_reg_enable_pct = 100;
-    cfg.sim_duration                = 7500us;
+    cfg.sim_duration                = 10ms;
+    cfg.hard_mtbf                   = 500us;
+    cfg.soft_mtbf                   = 7500us;
+    cfg.alert_max_delay             = 5;
 
     // Allow for software reads, but let the vseq body do the enabling
     cfg.route_software_pct          = 0;


### PR DESCRIPTION
In order to improve the testing of health checks this commit introduces
a new entropy_src_base_rng_seq.  This sequence is an extension of the
push_pull_indefinite_host_seq, but it provides new methods to control
(and predict) the randomization of the RNG data.

There are now three modes of operation for the RNG sequence:
- Typical: Of the three modes this is the highest entropy. In this
  base class, this typical entropy is ideal however a derived class
  could be made to generate weaker entropy
- Soft failure: the entropy of the RNG sequence is degraded either
  through bias or correlations in the output stream.  In the base
  class however, the soft failure mode is the same as typical.
- Hard failure: In this mode one or more bits becomes "stuck",
  which is a complete failure of the RNG stream.

Entry into the soft or hard failure modes is random.
There are two variables hard_mtbf, and soft_mtbf (mean time before
failure) which control average time before failing into one of
these states.  If the parent vseq identifies that the RNG
sequence has encountered a failure (perhaps through an alert)
it can call the reset_rng sequence.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>