### PR TITLE
[lc_ctrl/dv] Implemented jtag_access jtag_priority and regwen_during_op

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -55,7 +55,7 @@
             - Check that accessing its locked CSRs is gated during the transition operation.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_regwen_during_op"]
     }
     {
       name: lc_prog_failure
@@ -126,7 +126,21 @@
             All above CSR sequences should be accessible via both interfaces.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_jtag_access",
+              "lc_ctrl_jtag_smoke",
+              "lc_ctrl_jtag_state_post_trans",
+              "lc_ctrl_jtag_errors",
+              "lc_ctrl_jtag_prog_failure",
+              "lc_ctrl_jtag_errors",
+              "lc_ctrl_jtag_regwen_during_op",
+              "lc_ctrl_jtag_csr_hw_reset",
+              "lc_ctrl_jtag_csr_rw",
+              "lc_ctrl_jtag_csr_bit_bash",
+              "lc_ctrl_jtag_csr_aliasing",
+              "lc_ctrl_jtag_same_csr_outstanding",
+              "lc_ctrl_jtag_csr_mem_rw_with_rand_reset",
+              "lc_ctrl_jtag_alert_test"
+              ]
     }
     {
       name: jtag_priority
@@ -143,7 +157,7 @@
               interfaces.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_jtag_priority"]
     }
     {
       name: stress_all

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -28,6 +28,9 @@ filesets:
       - seq_lib/lc_ctrl_errors_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_state_post_trans_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_lc_errors_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_jtag_access_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_jtag_priority_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_regwen_during_op_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -37,6 +37,8 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   event set_test_phase_ev;
   // Max delay for alerts in clocks
   uint alert_max_delay;
+  // Enable scoreboard ral update on write
+  bit en_scb_ral_update_write = 1;
 
   `uvm_object_utils_begin(lc_ctrl_env_cfg)
   `uvm_object_utils_end
@@ -86,7 +88,7 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
     // Set base address for JTAG map
     ral.set_base_addr(ral.default_map.get_base_addr(), jtag_riscv_map);
 
-    alert_max_delay = 1000;
+    alert_max_delay = 1500;
   endfunction
 
   protected virtual function void post_build_ral_settings(dv_base_reg_block ral);

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -189,6 +189,12 @@ package lc_ctrl_env_pkg;
       LcStRma
   };
 
+  // CSR interfaces
+  typedef enum {
+    LcCtrlTLUL = 0,
+    LcCtrlJTAG = 1
+  } lc_ctrl_csr_intf_e;
+
   // functions
   function automatic bit valid_state_for_trans(lc_state_e curr_state);
     return (curr_state inside {LcValidStateForTrans});

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -57,6 +57,14 @@ interface lc_ctrl_if (
   event                                 fsm_backdoor_count_write_ev;
   event                                 fsm_backdoor_count_read_ev;
 
+  //
+  // Whitebox signals - these come from within the RTL
+  //
+
+  // Decoded mutex claim signal for JTAG and TL
+  logic                                 mutex_claim_jtag;
+  logic                                 mutex_claim_tl;
+
   // Debug signals
   lc_ctrl_env_pkg::lc_ctrl_err_inj_t    err_inj;
   lc_ctrl_env_pkg::lc_ctrl_test_phase_e test_phase;

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_errors_vseq.sv
@@ -146,8 +146,15 @@ class lc_ctrl_errors_vseq extends lc_ctrl_smoke_vseq;
                 err_inj
                 ), UVM_MEDIUM)
 
+      // Randomly check for ready - but not when a non transition state
+      // or an illegal state will be driven via the OTP
       if ($urandom_range(0, 1)) begin
-        csr_rd_check(.ptr(ral.status.ready), .compare_value(1));
+        if (valid_state_for_trans(lc_state) && !err_inj.state_err && !err_inj.count_err) begin
+          csr_rd_check(.ptr(ral.status.ready), .compare_value(1));
+        end else begin
+          // We expect ready to be zero when a bad state is driven
+          csr_rd_check(.ptr(ral.status.ready), .compare_value(0));
+        end
       end
 
       cfg.set_test_phase(LcCtrlDutReady);

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_access_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_access_vseq.sv
@@ -1,0 +1,218 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// JTAG and TL CSR test
+class lc_ctrl_jtag_access_vseq extends lc_ctrl_base_vseq;
+
+  // Who should claim the mutex
+  rand lc_ctrl_csr_intf_e mutex_owner_write, mutex_owner_read;
+
+  // Writable registers gated by transition_regwen
+  // verilog_format: off - avoid bad formatting
+  const string LcCtrlRWRegs[] = '{
+      "transition_ctrl",
+      "transition_token_0",
+      "transition_token_1",
+      "transition_token_2",
+      "transition_token_3",
+      "transition_target",
+      "otp_vendor_test_ctrl"
+  };
+  // verilog_format: on
+
+  // Read/write access
+  typedef struct {
+    dv_base_reg r;
+    bit map_sel;
+    bit blocking;
+  } reg_access_t;
+  // Read / write registers controlled by the mutex
+  dv_base_reg m_mutex_regs[$];
+  // Mutex register
+  dv_base_reg m_claim_transition_if;
+  // regwen register
+  dv_base_reg m_transition_regwen;
+  // Acccess maps [LcCtrlTLUL] -> Tile Link, [LcCtrlJTAG] -> JTAG
+  uvm_reg_map m_map[lc_ctrl_csr_intf_e];
+  // Queue of register access specs
+  reg_access_t m_reg_accesses[$];
+
+  `uvm_object_utils(lc_ctrl_jtag_access_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[1 : 20]};}
+
+  virtual task pre_start();
+    uvm_reg rs[$];
+    uvm_reg_map maps[$];
+    super.pre_start();
+
+    cfg.ral.get_registers(rs);
+    while (rs.size()) begin
+      dv_base_reg r;
+      `downcast(r, rs.pop_front())
+      if (r.get_name() inside {LcCtrlRWRegs}) m_mutex_regs.push_back(r);
+      if (r.get_name() == "claim_transition_if") m_claim_transition_if = r;
+      if (r.get_name() == "transition_regwen") m_transition_regwen = r;
+    end
+
+    cfg.ral.get_maps(maps);
+    while (maps.size()) begin
+      uvm_reg_map m;
+      m = maps.pop_front();
+      if (m.get_name() == "default_map") m_map[0] = m;
+      if (m.get_name() == "jtag_riscv_map") m_map[1] = m;
+    end
+
+  endtask
+
+  // Overload this to ensure we don't get scrap state
+  // Drive OTP input `lc_state` and `lc_cnt`.
+  virtual task drive_otp_i(bit rand_otp_i = 1);
+    if (rand_otp_i) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(lc_state, !(lc_state inside {LcStScrap});)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(lc_cnt, (lc_state != LcStRaw) -> (lc_cnt != LcCnt0);)
+    end else begin
+      lc_state = LcStRaw;
+      lc_cnt   = LcCnt0;
+    end
+    cfg.lc_ctrl_vif.init(lc_state, lc_cnt);
+  endtask
+
+  virtual task body();
+    int i = 0;
+
+    repeat (num_trans) begin
+      i++;
+      `uvm_info(`gfn, $sformatf(
+                "body: start of iteration %0d mutex_owner_write=%s mutex_owner_read=%s",
+                i,
+                mutex_owner_write.name(),
+                mutex_owner_read.name()
+                ), UVM_MEDIUM)
+
+      create_reg_accesses();
+      m_reg_accesses.shuffle();
+
+      // Claim the mutex for the write phase
+      csr_write_mutex_claim();
+
+      //
+      // Write registers by both interfaces
+      // Only expect that the unlocked interface will update the register
+      //
+
+      foreach (m_reg_accesses[i]) begin
+        const bit Blocking = m_reg_accesses[i].blocking;
+        const bit IsUnlocked = (m_reg_accesses[i].map_sel == mutex_owner_write);
+        const uvm_reg_map Map = m_map[m_reg_accesses[i].map_sel];
+        csr_wr(.ptr(m_reg_accesses[i].r), .value($urandom()), .check(UVM_NO_CHECK), .map(Map),
+               .predict(IsUnlocked), .blocking(Blocking));
+      end
+      csr_utils_pkg::wait_no_outstanding_access();
+
+      create_reg_accesses();
+      m_reg_accesses.shuffle();
+
+      // Claim the mutex for the read phase
+      csr_read_mutex_claim();
+
+      //
+      // Read after writing
+      // If we are reading via the unlocked interface we check against the mirrored value
+      // Otherwise we expect to read 0
+      //
+      foreach (m_reg_accesses[i]) begin
+        const bit Blocking = m_reg_accesses[i].blocking;
+        const bit IsUnlocked = (m_reg_accesses[i].map_sel == mutex_owner_read);
+        const uvm_reg_map Map = m_map[m_reg_accesses[i].map_sel];
+
+        csr_rd_check(.ptr(m_reg_accesses[i].r), .compare_vs_ral(IsUnlocked), .map(Map),
+                     .blocking(Blocking), .compare_value(0));
+      end
+      csr_utils_pkg::wait_no_outstanding_access();
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+    end
+
+  endtask
+
+  // Claim the mutex for the register writes
+  virtual task csr_write_mutex_claim;
+    `uvm_info(`gfn, $sformatf(
+              "csr_write_mutex_claim: claiming mutex for interface %s", mutex_owner_write.name()),
+              UVM_MEDIUM)
+    // verilog_format: off
+    `DV_SPINWAIT(
+        fork
+          claim_mutex(mutex_owner_write);
+          release_mutex(!mutex_owner_write);
+        join
+        )
+     // verilog_format: on
+    `uvm_info(`gfn, $sformatf(
+              "csr_write_mutex_claim: mutex claimed for interface %s", mutex_owner_write.name()),
+              UVM_MEDIUM)
+  endtask
+
+  // Claim the mutex for the register reads
+  virtual task csr_read_mutex_claim;
+    `uvm_info(`gfn, $sformatf(
+              "csr_read_mutex_claim: claiming mutex for interface %s", mutex_owner_read.name()),
+              UVM_MEDIUM)
+    // verilog_format: off
+    `DV_SPINWAIT(
+        fork
+          claim_mutex(mutex_owner_read);
+          release_mutex(!mutex_owner_read);
+        join
+        )
+    // verilog_format: on
+    `uvm_info(`gfn, $sformatf(
+              "csr_read_mutex_claim: mutex claimed for interface %s", mutex_owner_read.name()),
+              UVM_MEDIUM)
+  endtask
+
+  // Claim the Mutex for a particular interface
+  virtual task claim_mutex(lc_ctrl_csr_intf_e sel);
+    uvm_reg_data_t read_val = 0;
+
+    while (read_val != CLAIM_TRANS_VAL) begin
+      csr_wr(.ptr(m_claim_transition_if), .value(CLAIM_TRANS_VAL), .map(m_map[sel]));
+      csr_rd(.ptr(m_claim_transition_if), .value(read_val), .map(m_map[sel]));
+      `uvm_info(`gfn, $sformatf("claim_mutex: sel=%0d claim_transition_if = %8h", sel, read_val),
+                UVM_MEDIUM)
+    end
+    // Read transition_regwen to make sure it is 1
+    csr_rd(.ptr(m_transition_regwen), .value(read_val), .map(m_map[sel]));
+    `DV_CHECK_EQ(read_val, 1)
+  endtask
+
+  // Release the Mutex for a particular interface
+  virtual task release_mutex(lc_ctrl_csr_intf_e sel);
+    uvm_reg_data_t read_val = CLAIM_TRANS_VAL;
+
+    while (read_val == CLAIM_TRANS_VAL) begin
+      csr_wr(.ptr(m_claim_transition_if), .value(0), .map(m_map[sel]));
+      csr_rd(.ptr(m_claim_transition_if), .value(read_val), .map(m_map[sel]));
+      `uvm_info(`gfn, $sformatf("release_mutex: sel=%0d claim_transition_if = %8h", sel, read_val),
+                UVM_MEDIUM)
+    end
+    // Read transition_regwen to make sure it is 0
+    csr_rd(.ptr(m_transition_regwen), .value(read_val), .map(m_map[sel]));
+    `DV_CHECK_EQ(read_val, 0)
+
+  endtask
+
+  // Create a queue of register accesses
+  virtual function void create_reg_accesses();
+    m_reg_accesses.delete();
+    foreach (m_mutex_regs[i]) begin
+      m_reg_accesses.push_front('{r: m_mutex_regs[i], map_sel: 0, blocking: $urandom_range(1, 0)
+                                });
+      m_reg_accesses.push_front('{r: m_mutex_regs[i], map_sel: 1, blocking: $urandom_range(1, 0)
+                                });
+    end
+  endfunction
+
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_priority_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_priority_vseq.sv
@@ -1,0 +1,149 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Verify the JTAG has priority over TL for the Mutex
+class lc_ctrl_jtag_priority_vseq extends lc_ctrl_jtag_access_vseq;
+
+  `uvm_object_utils(lc_ctrl_jtag_priority_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[1 : 1]};}
+
+  // We expect JTAG to be the mutex owner at the end of the claim phase
+  constraint mutex_owner_c {
+    mutex_owner_write == LcCtrlJTAG;
+    mutex_owner_read == LcCtrlJTAG;
+  }
+
+  // Write to a JTAG register directly using the CSR sequence
+  task write_jtag_reg_direct(uvm_reg r, uvm_reg_data_t data);
+    jtag_riscv_csr_seq csr_seq;
+    uvm_reg_addr_t addr = r.get_address();
+    `uvm_create_on(csr_seq, p_sequencer.jtag_riscv_sequencer_h)
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(csr_seq,
+                                   addr == local::addr[jtag_riscv_agent_pkg::DMI_ADDRW + 1 : 0];
+        data == local::data[DMI_DATAW - 1 : 0];
+        do_write == 1;)
+    csr_seq.start(p_sequencer.jtag_riscv_sequencer_h);
+  endtask
+
+  // Simultaneous claim via TL and JTAG
+  task claim_mutex_simultaneous;
+    int tl_delay, tl_delay_incr, jtag_clks, tl_clks;
+    `uvm_info(`gfn, $sformatf("claim_mutex_simultaneous: started"), UVM_MEDIUM)
+
+    tl_delay = 0;
+
+    do begin
+      // Clear clock counters
+      jtag_clks = 0;
+      tl_clks   = 0;
+
+      // Release Mutex for both I/F
+      // verilog_format: off
+      `DV_SPINWAIT(
+          fork
+            release_mutex(LcCtrlTLUL);
+            release_mutex(LcCtrlJTAG);
+          join
+          )
+      // verilog_format: on
+
+      // Ensure eventual convergence by making start point randomized
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 2));
+
+      fork
+        // Try to claim from both interfaces
+        begin
+          write_jtag_reg_direct(.r(m_claim_transition_if), .data(CLAIM_TRANS_VAL));
+        end
+
+        begin
+          cfg.clk_rst_vif.wait_clks(tl_delay);
+          csr_wr(.ptr(m_claim_transition_if), .value(CLAIM_TRANS_VAL), .map(m_map[0]),
+                 .blocking(1));
+        end
+
+        // Count clocks to active claim signals
+        begin : count_jtag_clks
+          while (cfg.lc_ctrl_vif.mutex_claim_jtag != 1) begin
+            cfg.clk_rst_vif.wait_clks(1);
+            jtag_clks++;
+          end
+        end : count_jtag_clks
+
+        begin : count_tl_clks
+          while (cfg.lc_ctrl_vif.mutex_claim_tl != 1) begin
+            cfg.clk_rst_vif.wait_clks(1);
+            tl_clks++;
+          end
+        end : count_tl_clks
+      join
+
+      // Adjust TL delay so that claims happen simultaneously
+      if (jtag_clks > tl_clks) begin
+        tl_delay_incr = (jtag_clks - tl_clks) / 2;
+        tl_delay_incr = (tl_delay_incr > 0) ? tl_delay_incr : 1;
+      end else if (jtag_clks < tl_clks) begin
+        tl_delay_incr = (jtag_clks - tl_clks) / 2;
+        tl_delay_incr = (tl_delay_incr < 0) ? tl_delay_incr : -1;
+      end else tl_delay_incr = 0;
+
+      tl_delay += tl_delay_incr;
+      `uvm_info(`gfn, $sformatf(
+                {
+                  "claim_mutex_simultaneous: tl_delay=%0d tl_delay_incr=%d ",
+                  "tl_jtag_clks=%0d tl_clks=%0d"
+                },
+                tl_delay,
+                tl_delay_incr,
+                jtag_clks,
+                tl_clks
+                ), UVM_MEDIUM)
+    end while (!(jtag_clks == tl_clks));
+  endtask
+
+  // Claim the mutex for the register writes
+  virtual task csr_write_mutex_claim;
+    uvm_reg_data_t mutex_val = 0;
+    `uvm_info(`gfn, $sformatf(
+              "csr_write_mutex_claim: claiming mutex for interface %s", mutex_owner_write.name()),
+              UVM_MEDIUM)
+
+    `DV_SPINWAIT(claim_mutex_simultaneous();)
+
+    // Check that JTAG has control of the mutex
+    csr_rd_check(.ptr(m_claim_transition_if), .compare_value(CLAIM_TRANS_VAL),
+                 .map(m_map[LcCtrlJTAG]));
+
+    // Check TL hasn't got control of the mutex
+    csr_rd(.ptr(m_claim_transition_if), .value(mutex_val), .map(m_map[LcCtrlTLUL]));
+    `DV_CHECK_NE(mutex_val, CLAIM_TRANS_VAL)
+
+    `uvm_info(`gfn, $sformatf(
+              "csr_write_mutex_claim: mutex claimed for interface %s", mutex_owner_write.name()),
+              UVM_MEDIUM)
+  endtask
+
+  // Claim the mutex for the register reads
+  virtual task csr_read_mutex_claim;
+    uvm_reg_data_t mutex_val = 0;
+    `uvm_info(`gfn, $sformatf(
+              "csr_read_mutex_claim: claiming mutex for interface %s", mutex_owner_read.name()),
+              UVM_MEDIUM)
+
+    `DV_SPINWAIT(claim_mutex_simultaneous();)
+
+    // Check that JTAG has control of the mutex
+    csr_rd_check(.ptr(m_claim_transition_if), .compare_value(CLAIM_TRANS_VAL),
+                 .map(m_map[LcCtrlJTAG]));
+
+    // Check TL hasn't got control of the mutex
+    csr_rd(.ptr(m_claim_transition_if), .value(mutex_val), .map(m_map[LcCtrlTLUL]));
+    `DV_CHECK_NE(mutex_val, CLAIM_TRANS_VAL)
+
+    `uvm_info(`gfn, $sformatf(
+              "csr_read_mutex_claim: mutex claimed for interface %s", mutex_owner_read.name()),
+              UVM_MEDIUM)
+  endtask
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_regwen_during_op_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_regwen_during_op_vseq.sv
@@ -1,0 +1,83 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class lc_ctrl_regwen_during_op_vseq extends lc_ctrl_smoke_vseq;
+  `uvm_object_utils(lc_ctrl_regwen_during_op_vseq)
+
+  constraint num_trans_c {num_trans inside {[5 : 10]};}
+  `uvm_object_new
+
+
+  virtual task pre_start();
+    super.pre_start();
+    // Increase delay for otp token agents
+    // This is to give us time to try some reads and writes to
+    // transition_regwen locked registers while the transition is in progress
+    if (!cfg.jtag_csr) begin  // TL access
+      cfg.m_otp_token_pull_agent_cfg.device_delay_min = 3000;
+      cfg.m_otp_token_pull_agent_cfg.device_delay_max = 4000;
+    end else begin  // JTAG Access - give us some more time for JTAG
+      cfg.m_otp_token_pull_agent_cfg.device_delay_min = 10000;
+      cfg.m_otp_token_pull_agent_cfg.device_delay_max = 12000;
+    end
+    cfg.m_otp_token_pull_agent_cfg.zero_delays = 0;
+  endtask
+
+  virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*4-1:0] token_val);
+    uint max_wait = !cfg.jtag_csr ? 500 : 3000;
+    string wait_msg = $sformatf(
+        "No OTP program request received - delayed %0d clock cycles instead", max_wait
+    );
+
+    `uvm_info(`gfn, "sw_transition_req: started", UVM_MEDIUM)
+    fork
+      // Run base sw_transition_req
+      super.sw_transition_req(next_lc_state, token_val);
+
+      begin : test_regs_process
+        uvm_reg_data_t read_val = 0;
+        uvm_reg_data_t write_val = 0;
+        bit old_en_scb_ral_update_write = cfg.en_scb_ral_update_write;
+
+        // Wait until we are sure the transition has started
+        // indicated be an OTP program request or a number of clock cycles
+        `DV_SPINWAIT_EXIT(
+            while(cfg.m_otp_prog_pull_agent_cfg.vif.req != 1) cfg.clk_rst_vif.wait_clks(1);,
+            cfg.clk_rst_vif.wait_clks(max_wait);, wait_msg)
+
+        // Read TRANSITION_REGWEN register - should be 0 by now
+        csr_rd_check(.ptr(ral.transition_regwen), .compare_value(0));
+
+        // Try some writes / reads
+        write_val = $urandom();
+        // Disable write predict in scoreboard to prevent RAL being updated
+        // by the writes below - we expect these writes to fail in the RTL
+        cfg.en_scb_ral_update_write = 0;
+        csr_wr(.ptr(ral.transition_ctrl), .value(write_val));
+        csr_wr(.ptr(ral.transition_target), .value(write_val));
+        csr_wr(.ptr(ral.otp_vendor_test_ctrl), .value(write_val));
+        csr_wr(.ptr(ral.transition_token[0]), .value(write_val));
+        csr_wr(.ptr(ral.transition_token[1]), .value(write_val));
+        csr_wr(.ptr(ral.transition_token[2]), .value(write_val));
+        csr_wr(.ptr(ral.transition_token[3]), .value(write_val));
+        // restore en_scb_write_predict
+        cfg.en_scb_ral_update_write = old_en_scb_ral_update_write;
+
+        // All should read back with the previous values not the values
+        // written above
+        csr_rd_check(.ptr(ral.transition_ctrl), .compare_value(`gmv(ral.transition_ctrl)));
+        csr_rd_check(.ptr(ral.transition_target), .compare_value(`gmv(ral.transition_target)));
+        csr_rd_check(.ptr(ral.otp_vendor_test_ctrl),
+                     .compare_value(`gmv(ral.otp_vendor_test_ctrl)));
+        csr_rd_check(.ptr(ral.transition_token[0]), .compare_value(`gmv(ral.transition_token[0])));
+        csr_rd_check(.ptr(ral.transition_token[1]), .compare_value(`gmv(ral.transition_token[1])));
+        csr_rd_check(.ptr(ral.transition_token[2]), .compare_value(`gmv(ral.transition_token[2])));
+        csr_rd_check(.ptr(ral.transition_token[3]), .compare_value(`gmv(ral.transition_token[3])));
+
+      end : test_regs_process
+    join
+    `uvm_info(`gfn, "sw_transition_req: finished", UVM_MEDIUM)
+  endtask
+
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -40,8 +40,14 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
       `uvm_info(`gfn, $sformatf("starting seq %0d/%0d, init LC_state is %0s, LC_cnt is %0s",
                                 i, num_trans, lc_state.name, lc_cnt.name), UVM_MEDIUM)
 
-      if ($urandom_range(0, 1)) begin
-        csr_rd_check(.ptr(ral.status.ready), .compare_value(1));
+      if ($urandom_range(0, 1) && valid_state_for_trans(lc_state)) begin
+        if(valid_state_for_trans(lc_state)) begin
+          // We expect ready to be 1 when a non transition state is driven
+          csr_rd_check(.ptr(ral.status.ready), .compare_value(1));
+        end else begin
+          // We expect ready to be 0 when a non transition state is driven
+          csr_rd_check(.ptr(ral.status.ready), .compare_value(0));
+        end
         rd_lc_state_and_cnt_csrs();
       end
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -10,4 +10,8 @@
 `include "lc_ctrl_state_failure_vseq.sv"
 `include "lc_ctrl_state_post_trans_vseq.sv"
 `include "lc_ctrl_lc_errors_vseq.sv"
+`include "lc_ctrl_jtag_access_vseq.sv"
+`include "lc_ctrl_jtag_priority_vseq.sv"
+`include "lc_ctrl_regwen_during_op_vseq.sv"
+
 

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -71,6 +71,130 @@
       uvm_test_seq: lc_ctrl_lc_errors_vseq
     }
 
+    {
+      name: lc_ctrl_regwen_during_op
+      uvm_test_seq: lc_ctrl_regwen_during_op_vseq
+      reseed: 10
+    }
+
+    {
+      name: lc_ctrl_jtag_smoke
+      uvm_test_seq: lc_ctrl_smoke_vseq
+      run_opts: ["+jtag_csr=1"]
+      reseed: 20
+    }
+
+    {
+      name: lc_ctrl_jtag_state_failure
+      uvm_test_seq: lc_ctrl_state_failure_vseq
+      run_opts: ["+jtag_csr=1"]
+      reseed: 20
+    }
+
+    {
+      name: lc_ctrl_jtag_state_post_trans
+      uvm_test_seq: lc_ctrl_state_post_trans_vseq
+      run_opts: ["+jtag_csr=1"]
+      reseed: 20
+    }
+
+    {
+      name: lc_ctrl_jtag_prog_failure
+      uvm_test_seq: lc_ctrl_prog_failure_vseq
+      run_opts: ["+jtag_csr=1"]
+      reseed: 20
+    }
+
+    {
+      name: lc_ctrl_jtag_errors
+      uvm_test_seq: lc_ctrl_lc_errors_vseq
+      run_opts: ["+jtag_csr=1"]
+      reseed: 20
+    }
+
+    {
+      name: lc_ctrl_jtag_access
+      uvm_test_seq: lc_ctrl_jtag_access_vseq
+      run_opts: ["+en_scb=0"]
+      reseed: 50
+    }
+
+    {
+      name: lc_ctrl_jtag_priority
+      uvm_test_seq: lc_ctrl_jtag_priority_vseq
+      run_opts: ["+en_scb=0"]
+      reseed: 10
+    }
+
+    {
+      name: lc_ctrl_jtag_regwen_during_op
+      uvm_test_seq: lc_ctrl_regwen_during_op_vseq
+      run_opts: ["+jtag_csr=1"]
+      reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_hw_reset"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_hw_reset", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_rw"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_rw", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_bit_bash"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_bit_bash", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_aliasing"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+csr_aliasing", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_jtag_same_csr_outstanding"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+run_same_csr_outstanding", "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_jtag_csr_mem_rw_with_rand_reset"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+run_csr_mem_rw_with_rand_reset", "+test_timeout_ns=10000000000",  "+jtag_csr=1"]
+      en_run_modes: ["csr_tests_mode"]
+      reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_jtag_alert_test"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "lc_ctrl_common_vseq"
+      run_opts: ["+run_alert_test", "+en_scb=0", "+jtag_csr=1"]
+      reseed: 10
+    }
+
   ]
 
   // List of regressions.
@@ -78,6 +202,24 @@
     {
       name: smoke
       tests: ["lc_ctrl_smoke"]
+    }
+    {
+      name: jtag
+      tests : [ "lc_ctrl_jtag_access",
+              "lc_ctrl_jtag_priority",
+              "lc_ctrl_jtag_smoke",
+              "lc_ctrl_jtag_state_post_trans",
+              "lc_ctrl_jtag_errors",
+              "lc_ctrl_jtag_prog_failure",
+              "lc_ctrl_jtag_regwen_during_op",
+              "lc_ctrl_jtag_csr_hw_reset",
+              "lc_ctrl_jtag_csr_rw",
+              "lc_ctrl_jtag_csr_bit_bash",
+              "lc_ctrl_jtag_csr_aliasing",
+              "lc_ctrl_jtag_same_csr_outstanding",
+              "lc_ctrl_jtag_csr_mem_rw_with_rand_reset",
+              "lc_ctrl_jtag_alert_test"
+      ]
     }
   ]
 }

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -160,6 +160,23 @@ module tb;
     .otp_manuf_state_i(lc_ctrl_if.otp_manuf_state_i)
   );
 
+  //
+  // Whitebox signals - these come from within the RTL
+  //
+
+  // JTAG/TL Mutex claim
+  // Need a small delay to filter out glitches
+  assign #1ps lc_ctrl_if.mutex_claim_jtag = (dut.tap_reg2hw.claim_transition_if.qe == 1) &&
+      prim_mubi_pkg::mubi8_test_false_loose(
+      dut.tap_claim_transition_if_q
+  );
+
+  assign #1ps lc_ctrl_if.mutex_claim_tl = (dut.reg2hw.claim_transition_if.qe == 1) &&
+      prim_mubi_pkg::mubi8_test_false_loose(
+      dut.sw_claim_transition_if_q
+  );
+
+
   initial begin
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();

--- a/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
+++ b/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
@@ -16,6 +16,9 @@ class lc_ctrl_base_test extends cip_base_test #(
     // Enable JTAG TAP CSR access via command line option
     void'($value$plusargs("jtag_csr=%0b", cfg.jtag_csr));
 
+    // Increase alert wait time if using JTAG
+    if (cfg.jtag_csr) cfg.alert_max_delay = 4000;
+
   endfunction : build_phase
 
   // Add message demotes here


### PR DESCRIPTION
[lc_ctrl/dv] Implemented jtag_access jtag_priority and regwen_during_op testpoints

- Added test sequences:
  - lc_ctrl_jtag_access_vseq to test the the mutex controlled registers via
  both the locked and unlocked interface to verify the interfaces and mutex
  control.
  - lc_ctrl_jtag_priority_vseq to test that when claiming the mutex that
  JTAG has priority over Tile Link
  - lc_ctrl_regwen_during_op_vseq to test mutex controlled registers are
  locked during state transition
- Added tests:
  - lc_ctrl_jtag_access
  - lc_ctrl_jtag_smoke
  - lc_ctrl_jtag_state_post_trans
  - lc_ctrl_jtag_errors
  - lc_ctrl_jtag_prog_failure
  - lc_ctrl_jtag_csr_hw_reset
  - lc_ctrl_jtag_csr_rw
  - lc_ctrl_jtag_csr_bit_bash
  - lc_ctrl_jtag_csr_aliasing
  - lc_ctrl_jtag_same_csr_outstanding
  - lc_ctrl_jtag_csr_mem_rw_with_rand_reset
  - lc_ctrl_jtag_alert_test
  - lc_ctrl_regwen_during_op
  - lc_ctrl_jtag_regwen_during_op
- Added regression jtag
- Fixed up sequences for corrected status ready bit semantics
from PR lowRISC#9860
Signed-off-by: Nigel Scales <nigel.scales@gmail.com>