### PR TITLE
[entropy complex/hjson] add exclusions to fix csr tests

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -179,6 +179,8 @@
       desc: "Application interface command status register",
       swaccess: "ro",
       hwaccess: "hwo",
+      tags: [// Internal HW can modify status register
+                 "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "0",
           name: "CMD_RDY",
@@ -592,6 +594,8 @@
       hwaccess: "hro",
       hwqe: "true",
       regwen: "REGWEN",
+      tags: [// Setting this register will force an unwanted fatal alert.
+                 "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         {
             bits: "4:0",

--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -221,6 +221,8 @@
       desc: "EDN command status register",
       swaccess: "ro",
       hwaccess: "hwo",
+      tags: [// Internal HW can modify status register
+                 "excl:CsrNonInitTests:CsrExclCheck"]
       fields: [
         { bits: "0",
           name: "CMD_RDY",
@@ -433,6 +435,8 @@
       swaccess: "rw",
       hwaccess: "hro",
       hwqe: "true",
+      tags: [// Setting this register will force an unwanted fatal alert.
+                 "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         {
             bits: "4:0",

--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1303,6 +1303,8 @@
       hwaccess: "hro",
       hwqe: "true",
       regwen: "REGWEN",
+      tags: [// Setting this register will force an unwanted fatal alert.
+                 "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         {
             bits: "4:0",


### PR DESCRIPTION
Regression fails require some CSR test exclusions to pass.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>