### PR TITLE
[dv/flash_ctrl] Small change to flash_ctrl_rand_ops_base_vseq

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -310,8 +310,11 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
       for (int j = 1; j <= num_flash_ops_per_cfg; j++) begin
         data_q_t exp_data;
 
-        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(flash_op)
-        `DV_CHECK_MEMBER_RANDOMIZE_FATAL(flash_op_data)
+        // Those 2 has to be randomized simultaneously, otherwise the value of flash_op_data from
+        //  the previous iteration will affect the randomization of flash_op.
+        if (!randomize(flash_op, flash_op_data)) begin
+          `uvm_fatal(`gfn, "Randomization failed for flash_op & flash_op_data!")
+        end
 
         `uvm_info(`gfn, $sformatf("Starting flash_ctrl op: %0d/%0d: %p",
                                   j, num_flash_ops_per_cfg, flash_op), UVM_LOW)


### PR DESCRIPTION
Hi,
This is a small change to **flash_ctrl_rand_ops_base_vseq**.
The change is making the **flash_op** and **flash_op_data** fields to be randomized simultaneously instead of serially.
This serial randomization created wrong situation in which **flash_op_data**  previous value affected **flash_op** randomization.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>