### PR TITLE
[otbn,dv] Fix loop warping for 1st iteration of single insn loop

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
@@ -26,7 +26,8 @@ interface otbn_loop_if (
   input logic [31:0] current_loop_end,
   input logic [31:0] next_loop_end,
 
-  input logic [31:0] current_loop_d_iterations
+  input logic [31:0] current_loop_d_iterations,
+  input logic [31:0] current_loop_q_iterations
 );
 
   function automatic otbn_env_pkg::stack_fullness_e get_fullness();

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -169,8 +169,9 @@ module tb;
       .current_loop_end   (32'(current_loop_q.loop_end)),
       .next_loop_end      (32'(next_loop.loop_end)),
 
-      // This count is used by the loop warping code.
-      .current_loop_d_iterations (current_loop_d.loop_iterations)
+      // These counts are used by the loop warping code.
+      .current_loop_d_iterations (current_loop_d.loop_iterations),
+      .current_loop_q_iterations (current_loop_q.loop_iterations)
     );
 
   bind dut.u_otbn_core.u_otbn_alu_bignum otbn_alu_bignum_if i_otbn_alu_bignum_if (.*);


### PR DESCRIPTION
The previous code looked at `current_loop_d.iterations` but the problem
is that if the loop has only one instruction then the count has
already been decremented the first time we check.

Fix things by looking at `current_loop_q.iterations` and then fixing
things up appropriately for updating the "_d version" afterwards.

This fixes a nightly test failure (version bf6f6d15b; `util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson -i otbn_single --fixed-seed 2823513755`)