### PR TITLE
Spi segment update

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -37,7 +37,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
 
 
   // address width in bytes (default is 4 bytes)
-  int spi_addr_width = 4;
+  int spi_cmd_width   = 4;
 
   // how many bytes monitor samples per transaction
   int num_bytes_per_trans_in_mon = 4;

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_base_vseq.sv
@@ -128,6 +128,7 @@ class spi_host_base_vseq extends cip_base_vseq #(
     transaction.tx_only_weight = cfg.seq_cfg.tx_only_weight;
     transaction.spi_len_min    = cfg.seq_cfg.host_spi_min_len;
     transaction.spi_len_max    = cfg.seq_cfg.host_spi_max_len;
+    transaction.num_cmd_bytes  = cfg.num_cmd_bytes;
   endfunction
 
 

--- a/hw/ip/spi_host/dv/env/seq_lib/spi_host_tx_rx_vseq.sv
+++ b/hw/ip/spi_host/dv/env/seq_lib/spi_host_tx_rx_vseq.sv
@@ -39,14 +39,12 @@ class spi_host_tx_rx_vseq extends spi_host_base_vseq;
     bit [7:0] read_q[$];
 
     csr_rd(.ptr(ral.status.rxqd), .value(fifo_entries));
-    `uvm_info("READ_DBG", $sformatf("num entries %d", fifo_entries), UVM_LOW)
     do begin
       for(int i = 0; i <fifo_entries; i++) begin
         access_data_fifo(read_q, RxFifo);
       end
       csr_spinwait(.ptr(ral.status.active), .exp_data(1'b0));
       csr_rd(.ptr(ral.status.rxqd), .value(fifo_entries));
-             `uvm_info("READ_DBG", $sformatf("num entries_ %d", fifo_entries), UVM_LOW)
     end while (fifo_entries > 0 );
 
     // wait for all accesses to complete
@@ -61,7 +59,6 @@ class spi_host_tx_rx_vseq extends spi_host_base_vseq;
   // sending tx requests to the agent
   virtual task send_trans(spi_transaction_item trans);
     spi_segment_item segment = new();
-    `uvm_info("RX FIFO", $sformatf("New TRansaction"), UVM_LOW)
     while (trans.segments.size() > 0) begin
       // wait on DUT ready
       segment = trans.segments.pop_back();

--- a/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_cfg.sv
@@ -19,14 +19,15 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
   int         min_dummy_cycles = 0;
 
   // bumber of address bytes
-  rand int    num_addr_bytes;
+  rand int    num_cmd_bytes;
 
   constraint dummy_c {
     num_dummy inside { [min_dummy_cycles:max_dummy_cycles]};
   }
 
-  constraint addr_bytes_c {
-    num_addr_bytes inside { [3:4] };
+  constraint cmd_bytes_c {
+    num_cmd_bytes inside { [seq_cfg.host_spi_min_len:seq_cfg.host_spi_max_len] };
+    num_cmd_bytes%4 == 0;
   }
 
 
@@ -55,7 +56,9 @@ class spi_host_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_host_reg_block));
     m_spi_agent_cfg.byte_order = SPI_HOST_BYTEORDER;
     // make spi behave as realistic spi. (set to 1 byte per transaction)
     m_spi_agent_cfg.num_bytes_per_trans_in_mon = 1;
-
+    // set the number of bytes in first segment
+    // needed for the agent to know when to take control of the bus
+    m_spi_agent_cfg.spi_cmd_width = num_cmd_bytes;
     // create the seq_cfg
     seq_cfg = spi_host_seq_cfg::type_id::create("seq_cfg");
 

--- a/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_env_pkg.sv
@@ -49,7 +49,6 @@ package spi_host_env_pkg;
 
   typedef enum {
     Command,
-    Address,
     Dummy,
     Data
   } spi_segment_type_e;

--- a/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
+++ b/hw/ip/spi_host/dv/env/spi_host_scoreboard.sv
@@ -129,8 +129,8 @@ class spi_host_scoreboard extends cip_base_scoreboard #(
             txt = {txt, $sformatf("\n \t [%d] \t\t\t      %0h  \t\t\t %0h",
                         i, dut_item.data[0], exp_segment.spi_data[i])};
             `uvm_fatal(`gfn,
-                       $sformatf("\n\t WRITE: actual data did not match exp data %s \n len %d %s",
-                           txt, exp_segment.command_reg.len+1, txt))
+                       $sformatf("\n\t WRITE: actual data did not match exp data \n len %d %s",
+                           exp_segment.command_reg.len+1, txt))
           end else begin
             txt = {txt, $sformatf("\n \t [%d] \t\t\t %0h \t\t\t %0h",
                                   i, dut_item.data[0], exp_segment.spi_data[i])};

--- a/hw/ip/spi_host/dv/env/spi_segment_item.sv
+++ b/hw/ip/spi_host/dv/env/spi_segment_item.sv
@@ -25,7 +25,7 @@ class spi_segment_item extends uvm_sequence_item;
   // num dummy cycles
   int num_dummy                       = 0;
   //num_addr_bytes
-  int num_addr_bytes                  = 4;
+  int num_cmd_bytes                  = 4;
 
   // transaction len
   int  spi_len_min = 2;
@@ -52,24 +52,25 @@ class spi_segment_item extends uvm_sequence_item;
     if (seg_type == Command) {
       command_reg.mode == Standard;
     } else {
-      if (cmd inside {ReadStd, WriteStd})        { command_reg.mode == Standard; }
+      if      (cmd inside {ReadStd, WriteStd})   { command_reg.mode == Standard; }
       else if (cmd inside {ReadDual, WriteDual}) { command_reg.mode == Dual; }
       else                                       { command_reg.mode == Quad; }
     }
 
-    if (seg_type == Dummy)         { command_reg.len == num_dummy-1; }
-    else if (seg_type == Address)  { command_reg.len == num_addr_bytes-1; }
-    else if (seg_type == Command)  { command_reg.len == 0; }
-    else { command_reg.len inside  { [spi_len_min-1:spi_len_max-1]}; }
+    if      (seg_type == Command) { command_reg.len == num_cmd_bytes-1; }
+    else if (seg_type == Dummy  ) { command_reg.len == num_dummy-1; }
+    else {   command_reg.len inside  { [spi_len_min-1:spi_len_max-1]}; }
 
+    // ensure we only half or full word writes
+    (command_reg.len+1)%2 == 0;
+    // default set keep transaction going
     command_reg.csaat == 1;
   }
 
   constraint data_c {
-    if (seg_type == Data)          { spi_data.size() == command_reg.len+1; }
+    if      (seg_type == Command)  { spi_data.size() == num_cmd_bytes; }
     else if (seg_type == Dummy)    { spi_data.size() == num_dummy; }
-    else if (seg_type == Address)  { spi_data.size() == num_addr_bytes; }
-    else                           { spi_data.size() == 1; }
+    else                           { spi_data.size() == command_reg.len+1; }
 
     solve command_reg before spi_data;
   }
@@ -83,7 +84,7 @@ class spi_segment_item extends uvm_sequence_item;
     rx_only_weight         =    rhs_.rx_only_weight;
     tx_only_weight         =    rhs_.tx_only_weight;
     num_dummy              =    rhs_.num_dummy;
-    num_addr_bytes         =    rhs_.num_addr_bytes;
+    num_cmd_bytes          =    rhs_.num_cmd_bytes;
     seg_type               =    rhs_.seg_type;
     command_reg.csaat      =    rhs_.command_reg.csaat;
     command_reg.direction  =    rhs_.command_reg.direction;


### PR DESCRIPTION
this is a follow up to #8856 
to address the comments made by @martin-lueker about transactions being too restricted.
this contains a minor update to remove the address phase of a transaction in the agent

and another update of the spi_host env to allow for any number of segments and sizes.
and a small fix to only allow half or full word writes to the tx fifo as per the spi_host specification


@martin-lueker Please be aware as long as the previous commit is unmerged those files are listed as changed so only look at the last two commits
