### PR TITLE
[dv] Add integrity test for passthru mem

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__sram.sv
@@ -337,7 +337,8 @@ endfunction
 virtual function void sram_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
                                                  logic [31:0]                       data,
                                                  logic [SRAM_KEY_WIDTH-1:0]         key,
-                                                 logic [SRAM_BLOCK_WIDTH-1:0]       nonce);
+                                                 logic [SRAM_BLOCK_WIDTH-1:0]       nonce,
+                                                 bit   [38:0]                       flip_bits = 0);
   logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
   logic [38:0]                       integ_data;
   logic [38:0]                       scrambled_data;
@@ -360,6 +361,9 @@ virtual function void sram_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1
 
   // Calculate the integrity constant
   integ_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
+
+  // flip some bits to inject integrity fault
+  integ_data ^= flip_bits;
 
   // Calculate the scrambled data
   wdata_arr = {<<{integ_data}};

--- a/hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  testpoints: [
+    {
+      name: passthru_mem_tl_intg_err
+      desc: '''Verify data integrity is stored in the passthru memory rather than generated after
+               a read.
+
+               - Randomly read a memory location and check the data integrity is correct.
+               - Backdoor inject fault into this location.
+               - Check the data integrity is incorrect but there is no d_error as the memory block
+                 should just pass the stored data and integrity to the processor where the
+                 integrity is compared.
+               - Above sequences will be run with `csr_rw_vseq` to ensure it won't affect CSR
+                 accesses.
+            '''
+      milestone: V2
+      tests: ["{name}_passthru_mem_tl_intg_err"]
+    }
+  ]
+}
+

--- a/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson
+++ b/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  build_modes: [
+    {
+      name: cover_reg_top
+    }
+  ]
+
+  tests: [
+    {
+      name: "{name}_passthru_mem_tl_intg_err"
+      build_mode: "cover_reg_top"
+      uvm_test_seq: "{name}_common_vseq"
+      run_opts: ["+run_passthru_mem_tl_intg_err"]
+      reseed: 20
+    }
+  ]
+}

--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -7,6 +7,7 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
   testpoints: [

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_common_vseq.sv
@@ -17,7 +17,9 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
     void'($value$plusargs("run_%0s", common_seq_type));
 
     // To avoid reading out unknown data from mem, do init for mem test after 1st reset
-    if (!uvm_re_match("*mem*", common_seq_type) && !first_reset) begin
+    // Also do init for integrity test to make sure mem has correct integrit
+    if ((!uvm_re_match("*mem*", common_seq_type) || !uvm_re_match("*intg*", common_seq_type)) &&
+        !first_reset) begin
       do_sram_ctrl_init = 1;
       first_reset       = 1;
     end else begin
@@ -30,10 +32,30 @@ class sram_ctrl_common_vseq extends sram_ctrl_base_vseq;
     if (!cfg.en_scb && do_sram_ctrl_init) begin
       void'(ral.status.init_done.predict(.value(1), .kind(UVM_PREDICT_READ)));
     end
+
+    // disable running csr_vseq, as we do sram_ctrl_init which affects several CSRs' values
+    en_csr_vseq_w_passthru_mem_intg = 0;
   endtask
 
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body
+
+  virtual function void inject_intg_fault_in_passthru_mem(dv_base_mem mem,
+                                                          bit [bus_params_pkg::BUS_AW-1:0] addr);
+    bit[bus_params_pkg::BUS_DW-1:0] rdata;
+    bit[tlul_pkg::DataIntgWidth+bus_params_pkg::BUS_DW-1:0] flip_bits;
+
+    rdata = cfg.mem_bkdr_util_h.sram_encrypt_read32_integ(addr, cfg.scb.key, cfg.scb.nonce);
+
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bits,
+        $countones(flip_bits) inside {[1:cip_base_pkg::MAX_TL_ECC_ERRORS]};)
+
+    `uvm_info(`gfn, $sformatf("Backdoor change mem (addr 0x%0h) value 0x%0h by flipping bits %0h",
+                              addr, rdata, flip_bits), UVM_LOW)
+
+    cfg.mem_bkdr_util_h.sram_encrypt_write32_integ(addr, rdata, cfg.scb.key, cfg.scb.nonce,
+                                                   flip_bits);
+  endfunction
 
 endclass

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -545,6 +545,7 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
       // add individual case item for each csr
       "alert_test": begin
         // do nothing
+        if (addr_phase_write) set_exp_alert("fatal_error", .is_fatal(0));
       end
       "exec_regwen": begin
         // do nothing

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -33,6 +33,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
+                "{proj_root}/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson"
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
                 ]
 


### PR DESCRIPTION
2 commits in this PR:
[dv] Add integrity test for passthru mem
Addressed #9546
For detail sequences, please refer to the added testplan

[sram/dv] Enable the integrity test for passthru
1. override `inject_intg_fault_in_passthru_mem` to inject integrity
fault in sram
2. slightly update scb so that this test can work with sram scb

Signed-off-by: Weicai Yang <weicai@google.com>
