### PR TITLE
[sw/dif] Add `dif_multi_bit_bool_to_toggle()` base DIFs.

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -12,6 +12,9 @@ cc_library(
     hdrs = [
         "dif_base.h",
     ],
+    deps = [
+        "//sw/device/lib/base",
+    ],
 )
 
 cc_library(

--- a/sw/device/lib/dif/dif_base.c
+++ b/sw/device/lib/dif/dif_base.c
@@ -6,8 +6,11 @@
 
 #include <stdbool.h>
 
+#include "sw/device/lib/base/multibits.h"
+
 // `extern` declarations to give the inline functions in the corresponding
 // header a link location.
 extern bool dif_is_valid_toggle(dif_toggle_t val);
 extern bool dif_toggle_to_bool(dif_toggle_t val);
 extern dif_toggle_t dif_bool_to_toggle(bool val);
+extern dif_toggle_t dif_multi_bit_bool_to_toggle(multi_bit_bool_t val);

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -12,6 +12,9 @@
 
 #include <stdbool.h>
 
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/multibits.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -119,13 +122,31 @@ inline bool dif_toggle_to_bool(dif_toggle_t val) {
 }
 
 /**
- * Converts a `dif_toggle_t` to a `bool`.
+ * Converts a bool to a `dif_toggle_t`.
  *
  * @param val A bool value.
  * @return Corresponding dif_toggle_t value.
  */
 inline dif_toggle_t dif_bool_to_toggle(bool val) {
   return val ? kDifToggleEnabled : kDifToggleDisabled;
+}
+
+/**
+ * Converts a multi-bit bool to a `dif_toggle_t`.
+ *
+ * @param val A multi-bit bool value.
+ * @return Corresponding dif_toggle_t value.
+ */
+inline dif_toggle_t dif_multi_bit_bool_to_toggle(multi_bit_bool_t val) {
+  switch (val) {
+    case kMultiBitBool4True:
+    case kMultiBitBool8True:
+    case kMultiBitBool12True:
+    case kMultiBitBool16True:
+      return kDifToggleEnabled;
+    default:
+      return kDifToggleDisabled;
+  }
 }
 
 #ifdef __cplusplus

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -27,13 +27,6 @@ static_assert(
     CLKMGR_PARAM_NUM_HINTABLE_CLOCKS <= CLKMGR_PARAM_REG_WIDTH,
     "Expected the number of hintable clocks to be <= the width of a CSR.");
 
-/**
- * Converts a `multi_bit_bool_t` to `dif_toggle_t`.
- */
-static dif_toggle_t mubi4_to_toggle(multi_bit_bool_t val) {
-  return (val == kMultiBitBool4True) ? kDifToggleEnabled : kDifToggleDisabled;
-}
-
 static bool clkmgr_valid_gateable_clock(dif_clkmgr_gateable_clock_t clock) {
   return clock < CLKMGR_PARAM_NUM_SW_GATEABLE_CLOCKS;
 }
@@ -50,7 +43,7 @@ dif_result_t dif_clkmgr_jitter_get_enabled(const dif_clkmgr_t *clkmgr,
 
   multi_bit_bool_t clk_jitter_val =
       mmio_region_read32(clkmgr->base_addr, CLKMGR_JITTER_ENABLE_REG_OFFSET);
-  *state = mubi4_to_toggle(clk_jitter_val);
+  *state = dif_multi_bit_bool_to_toggle(clk_jitter_val);
 
   return kDifOk;
 }


### PR DESCRIPTION
Some clkmgr DIFs require converting a multi-bit boolean value to a DIF toggle value. This commit adds a base DIF to do the conversion that can be shared across all IP DIF libs.

This fixes #9036.

Signed-off-by: Timothy Trippel <ttrippel@google.com>