### PR TITLE
[dv/tools] Fix alert ping exclusion

### DIFF
--- a/hw/dv/tools/vcs/common_cov_excl.cfg
+++ b/hw/dv/tools/vcs/common_cov_excl.cfg
@@ -12,5 +12,6 @@
 -node tb.dut *tl_o.d_opcode[2]
 -node tb.dut *tl_o.d_sink
 
-// [LOW_RISK] Verified in prim_alert_receiver TB."
--node tb.dut *alert_rx_*.ping_*
+// [LOW_RISK] Verified in prim_alert_sender/receiver TB."
+-node tb.dut* *alert_rx_i*.ping_p
+-node tb.dut* *alert_rx_i*.ping_n


### PR DESCRIPTION
Fix alert ping exclusion only apply to DUT level but not
prim_alert_sender level.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>