### PR TITLE
[dv/pwrmgr] Add escalation reset

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
@@ -10,6 +10,8 @@ class pwrmgr_env extends cip_base_env #(
 );
   `uvm_component_utils(pwrmgr_env)
 
+  alert_esc_agent m_esc_agent;
+
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -37,6 +39,10 @@ class pwrmgr_env extends cip_base_env #(
         )) begin
       `uvm_fatal(`gfn, "failed to get pwrmgr_rstmgr_sva_vif from uvm_config_db")
     end
+
+    m_esc_agent = alert_esc_agent::type_id::create("m_esc_agent", this);
+    uvm_config_db#(alert_esc_agent_cfg)::set(this, "m_esc_agent", "cfg", cfg.m_esc_agent_cfg);
+    cfg.m_esc_agent_cfg.en_cov = cfg.en_cov;
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -7,6 +7,7 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
 );
 
   // ext component cfgs
+  alert_esc_agent_cfg m_esc_agent_cfg;
 
   `uvm_object_utils_begin(pwrmgr_env_cfg)
   `uvm_object_utils_end
@@ -31,6 +32,9 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
     `uvm_info(`gfn, $sformatf("num_interrupts = %0d", num_interrupts), UVM_MEDIUM)
     tl_intg_alert_fields[ral.fault_status.reg_intg_err] = 1;
     m_tl_agent_cfg.max_outstanding_req = 1;
+    m_esc_agent_cfg = alert_esc_agent_cfg::type_id::create("m_esc_agent_cfg");
+    `DV_CHECK_RANDOMIZE_FATAL(m_esc_agent_cfg)
+    m_esc_agent_cfg.is_alert = 0;
   endfunction
 
 endclass

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -108,6 +108,7 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
     reset_cross: cross reset_cp, enable_cp, sleep_cp;
   endgroup
 
+  // This reset cannot be generated in low power state since it is triggered by software.
   covergroup rstmgr_sw_reset_cg with function sample (logic sw_reset);
     sw_reset_cp: coverpoint sw_reset;
   endgroup

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
@@ -13,6 +13,7 @@ package pwrmgr_env_pkg;
   import dv_base_reg_pkg::*;
   import csr_utils_pkg::*;
   import pwrmgr_ral_pkg::*;
+  import alert_esc_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -48,9 +48,6 @@ interface pwrmgr_if (
 
   prim_mubi_pkg::mubi4_t                                       sw_rst_req_i;
 
-  prim_esc_pkg::esc_tx_t                                       esc_rst_tx;
-  prim_esc_pkg::esc_rx_t                                       esc_rst_rx;
-
   logic                                                        intr_wakeup;
 
   // Relevant CSR values.
@@ -187,7 +184,6 @@ interface pwrmgr_if (
     rstreqs_i = pwrmgr_pkg::RSTREQS_DEFAULT;
     sw_rst_req_i = prim_mubi_pkg::MuBi4False;
     rom_ctrl = rom_ctrl_pkg::PWRMGR_DATA_DEFAULT;
-    esc_rst_tx = prim_esc_pkg::ESC_TX_DEFAULT;
   end
 
   clocking slow_cb @(posedge clk_slow);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
@@ -53,6 +53,10 @@ class pwrmgr_reset_vseq extends pwrmgr_base_vseq;
       `uvm_info(`gfn, $sformatf("Sending resets=0x%x", resets), UVM_MEDIUM)
       cfg.pwrmgr_vif.update_resets(resets);
       `uvm_info(`gfn, $sformatf("Sending sw reset from rstmgr=%b", sw_rst_from_rstmgr), UVM_MEDIUM)
+      if (escalation_reset)
+        fork
+          send_escalation_reset(20);
+        join_none
       cfg.pwrmgr_vif.update_sw_rst_req(sw_rst_from_rstmgr);
 
       cfg.slow_clk_rst_vif.wait_clks(4);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
@@ -74,7 +74,15 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
             `uvm_info(`gfn, "Sending power glitch", UVM_MEDIUM)
             cfg.pwrmgr_vif.glitch_power_reset();
           end
-          `uvm_info(`gfn, $sformatf("Sending reset=%b, power_glitch=%b", resets, power_glitch_reset
+          if (escalation_reset)
+            fork
+              send_escalation_reset(20);
+            join_none
+          `uvm_info(`gfn, $sformatf(
+                    "Sending reset=%b, power_glitch=%b, escalation=%b",
+                    resets,
+                    power_glitch_reset,
+                    escalation_reset
                     ), UVM_MEDIUM)
         end
         begin

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_clock_enables_sva_if.sv
@@ -6,21 +6,21 @@
 // to the control CSR when transitioning into or out of the active state. In
 // addition, the usb clock can change anytime when in the active state.
 interface pwrmgr_clock_enables_sva_if (
-  input logic clk_i,
-  input logic rst_ni,
+  input logic                        clk_i,
+  input logic                        rst_ni,
   input pwrmgr_pkg::fast_pwr_state_e fast_state,
   input pwrmgr_pkg::slow_pwr_state_e slow_state,
- // The synchronized control CSR bits.
-  input logic main_pd_ni,
-  input logic io_clk_en_i,
-  input logic core_clk_en_i,
-  input logic usb_clk_en_lp_i,
-  input logic usb_clk_en_active_i,
+  // The synchronized control CSR bits.
+  input logic                        main_pd_ni,
+  input logic                        io_clk_en_i,
+  input logic                        core_clk_en_i,
+  input logic                        usb_clk_en_lp_i,
+  input logic                        usb_clk_en_active_i,
   // The output enables.
-  input logic main_pd_n,
-  input logic io_clk_en,
-  input logic core_clk_en,
-  input logic usb_clk_en
+  input logic                        main_pd_n,
+  input logic                        io_clk_en,
+  input logic                        core_clk_en,
+  input logic                        usb_clk_en
 );
 
   bit disable_sva;
@@ -48,10 +48,7 @@ interface pwrmgr_clock_enables_sva_if (
           reset_or_disable)
 
   // This deals with transitions while the fast fsm is active.
-  `ASSERT(UsbClkActive_A,
-          fast_is_active && $changed(
-              usb_clk_en_active_i
-          ) |-> usbActiveTransition_S,
+  `ASSERT(UsbClkActive_A, fast_is_active && $changed(usb_clk_en_active_i) |-> usbActiveTransition_S,
           clk_i, reset_or_disable)
 
   `ASSERT(CoreClkPwrDown_A, transitionDown_S |=> core_clk_en == core_clk_en_i, clk_i,

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -28,6 +28,10 @@ module tb;
     .rst_n(rst_slow_n)
   );
   pins_if #(NUM_MAX_INTERRUPTS) intr_if (interrupts);
+  alert_esc_if esc_if (
+    .clk  (clk),
+    .rst_n(rst_n)
+  );
   pins_if #(1) devmode_if (devmode);
   tl_if tl_if (
     .clk  (clk),
@@ -93,8 +97,8 @@ module tb;
 
     .sw_rst_req_i(pwrmgr_if.sw_rst_req_i),
 
-    .esc_rst_tx_i(pwrmgr_if.esc_rst_tx),
-    .esc_rst_rx_o(pwrmgr_if.esc_rst_rx),
+    .esc_rst_tx_i(esc_if.esc_tx),
+    .esc_rst_rx_o(esc_if.esc_rx),
 
     .intr_wakeup_o(pwrmgr_if.intr_wakeup)
   );
@@ -108,6 +112,7 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "slow_clk_rst_vif", slow_clk_rst_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+    uvm_config_db#(virtual alert_esc_if)::set(null, "*.env.m_esc_agent*", "vif", esc_if);
     uvm_config_db#(virtual pwrmgr_if)::set(null, "*.env", "pwrmgr_vif", pwrmgr_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     // Bound assertions interfaces.


### PR DESCRIPTION
Connect alert_esc_agent and cfg to environment.
Use escalation interface in testbench.
Add timeout if a WFI doesn't occur when transitioning to low power
for the sake of simplicity.

Signed-off-by: Guillermo Maturana <maturana@google.com>