### PR TITLE
Added sysrst_ctrl_pin_accessibilty testcase

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_pin_access_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_pin_access_vseq.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence will read the raw input pins values.
+class sysrst_ctrl_pin_access_vseq extends sysrst_ctrl_base_vseq;
+  `uvm_object_utils(sysrst_ctrl_pin_access_vseq)
+
+  `uvm_object_new
+
+   uvm_reg_data_t rdata;
+
+   task body();
+      bit rdata_pwrb_in, rdata_key0_in, rdata_key1_in, rdata_key2_in,
+          rdata_ec_rst_l_in, rdata_ac_present, rdata_lid_open;
+
+      `uvm_info(`gfn, "Starting the body from pin_access_vseq", UVM_LOW)
+
+      repeat ($urandom_range(1,50)) begin
+        // Randomize the input pins
+        cfg.vif.randomize_input();
+
+        // Read the raw input pin values
+        cfg.clk_aon_rst_vif.wait_clks(1);
+        csr_rd(ral.pin_in_value, rdata);
+        rdata_pwrb_in = get_field_val(ral.pin_in_value.pwrb_in, rdata);
+        rdata_key0_in = get_field_val(ral.pin_in_value.key0_in, rdata);
+        rdata_key1_in = get_field_val(ral.pin_in_value.key1_in, rdata);
+        rdata_key2_in = get_field_val(ral.pin_in_value.key2_in, rdata);
+        rdata_ec_rst_l_in = get_field_val(ral.pin_in_value.ec_rst_l, rdata);
+        rdata_ac_present = get_field_val(ral.pin_in_value.ac_present, rdata);
+        rdata_lid_open = get_field_val(ral.pin_in_value.lid_open, rdata);
+
+        `DV_CHECK_EQ(cfg.vif.pwrb_in, rdata_pwrb_in)
+        `DV_CHECK_EQ(cfg.vif.key0_in, rdata_key0_in)
+        `DV_CHECK_EQ(cfg.vif.key1_in, rdata_key1_in)
+        `DV_CHECK_EQ(cfg.vif.key2_in, rdata_key2_in)
+        `DV_CHECK_EQ(cfg.vif.ec_rst_l_in, rdata_ec_rst_l_in)
+        `DV_CHECK_EQ(cfg.vif.ac_present, rdata_ac_present)
+        `DV_CHECK_EQ(cfg.vif.lid_open, rdata_lid_open)
+
+      end
+   endtask : body
+
+endclass : sysrst_ctrl_pin_access_vseq

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_vseq_list.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_vseq_list.sv
@@ -7,3 +7,5 @@
 `include "sysrst_ctrl_common_vseq.sv"
 `include "sysrst_ctrl_in_out_inverted_vseq.sv"
 `include "sysrst_ctrl_combo_detect_ec_rst_vseq.sv"
+`include "sysrst_ctrl_pin_access_vseq.sv"
+

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
@@ -23,6 +23,7 @@ filesets:
       - seq_lib/sysrst_ctrl_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/sysrst_ctrl_in_out_inverted_vseq.sv: {is_include_file: true}
       - seq_lib/sysrst_ctrl_combo_detect_ec_rst_vseq.sv: {is_include_file: true}
+      - seq_lib/sysrst_ctrl_pin_access_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -71,11 +71,7 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
       "intr_test": begin
         // FIXME
       end
-      "pin_out_ctl": begin
-      end
-      "pin_allowed_ctl": begin
-      end
-      "pin_out_value": begin
+      "pin_out_ctl","pin_allowed_ctl","pin_out_value": begin
       end
       "key_invert_ctl": begin
       end
@@ -91,6 +87,9 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;  //This check is done in sequence
       end
       "key_intr_status": begin
+      end
+      "pin_in_value": begin
+        do_read_check = 1'b0;  //This check is done in sequence
       end
       default: begin
         `uvm_error(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))

--- a/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
+++ b/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
@@ -28,7 +28,7 @@
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson", 
+                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
@@ -60,6 +60,10 @@
       name: sysrst_ctrl_combo_detect_ec_rst
       uvm_test_seq: sysrst_ctrl_combo_detect_ec_rst_vseq
       reseed: 1
+    }
+    {
+      name: sysrst_ctrl_pin_access_test
+      uvm_test_seq: sysrst_ctrl_pin_access_vseq
     }
 
   ]


### PR DESCRIPTION
This test will verify the sysrst_ctrl pin accessibility feature by reading the raw input pins.

Signed-off-by: Madhuri Patel <madhuri.patel@ensilica.com>