### PR TITLE
[entropy_src/rtl] lint fix for repcnt health tests

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -309,16 +309,8 @@ module entropy_src
      alert_tx_o[1])
   end : gen_rep_cntrs
 
-  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck6_A,
-    u_entropy_src_core.u_entropy_src_repcnt_ht.u_prim_count_test_cnt,
-    alert_tx_o[1])
-
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck7_A,
     u_entropy_src_core.u_entropy_src_repcnts_ht.u_prim_count_rep_cntr,
-    alert_tx_o[1])
-
-  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck8_A,
-    u_entropy_src_core.u_entropy_src_repcnts_ht.u_prim_count_test_cnt,
     alert_tx_o[1])
 
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlMainFsmCheck_A,

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnt_ht.sv
@@ -29,8 +29,6 @@ module entropy_src_repcnt_ht #(
   logic [RngBusWidth-1:0]               rep_cnt_fail;
   logic [RngBusWidth-1:0][RegWidth-1:0] rep_cntr;
   logic [RngBusWidth-1:0]               rep_cntr_err;
-  logic [RegWidth-1:0]                  test_cnt;
-  logic                                 test_cnt_err;
   logic [RegWidth-1:0]                  cntr_max;
 
   // flops
@@ -93,27 +91,10 @@ module entropy_src_repcnt_ht #(
     .o(cntr_max)
   );
 
-  // Test event counter
-    prim_count #(
-      .Width(RegWidth),
-      .OutSelDnCnt(1'b0), // count up
-      .CntStyle(prim_count_pkg::DupCnt)
-    ) u_prim_count_test_cnt (
-      .clk_i,
-      .rst_ni,
-      .clr_i(1'b0),
-      .set_i(!active_i || clear_i),
-      .set_cnt_i(RegWidth'(0)),
-      .en_i(entropy_bit_vld_i && (|rep_cnt_fail)),
-      .step_i(RegWidth'(1)),
-      .cnt_o(test_cnt),
-      .err_o(test_cnt_err)
-    );
-
   // the pulses will be only one clock in length
   assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
   assign test_cnt_o = cntr_max;
-  assign count_err_o = test_cnt_err || (|rep_cntr_err);
+  assign count_err_o = (|rep_cntr_err);
 
 
 endmodule

--- a/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_repcnts_ht.sv
@@ -29,8 +29,6 @@ module entropy_src_repcnts_ht #(
   logic  rep_cnt_fail;
   logic [RegWidth-1:0]    rep_cntr;
   logic                   rep_cntr_err;
-  logic [RegWidth-1:0]    test_cnt;
-  logic                   test_cnt_err;
 
   // flops
   logic [RngBusWidth-1:0] prev_sample_q, prev_sample_d;
@@ -81,28 +79,10 @@ module entropy_src_repcnts_ht #(
 
 
 
-  // Test event counter
-    prim_count #(
-      .Width(RegWidth),
-      .OutSelDnCnt(1'b0), // count up
-      .CntStyle(prim_count_pkg::DupCnt)
-    ) u_prim_count_test_cnt (
-      .clk_i,
-      .rst_ni,
-      .clr_i(1'b0),
-      .set_i(!active_i || clear_i),
-      .set_cnt_i(RegWidth'(0)),
-      .en_i(entropy_bit_vld_i && (|rep_cnt_fail)),
-      .step_i(RegWidth'(1)),
-      .cnt_o(test_cnt),
-      .err_o(test_cnt_err)
-    );
-
-
   // the pulses will be only one clock in length
   assign test_fail_pulse_o = active_i && entropy_bit_vld_i && (|rep_cnt_fail);
   assign test_cnt_o = rep_cntr;
-  assign count_err_o = test_cnt_err || (|rep_cntr_err);
+  assign count_err_o = (|rep_cntr_err);
 
 
 endmodule


### PR DESCRIPTION
The prim_count was removed because of a change to the watermark debug function.
This left some connections open, so removing this code.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>