### PR TITLE
[entropy_src, dv] Entropy_src testplan update

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -84,7 +84,7 @@
             Verify es_fifo_err interrupt asserts as predicted.
             '''
       milestone: V2
-      tests: []
+      tests: ["entropy_src_intr"]
     }
     {
       name: alerts
@@ -92,7 +92,7 @@
             Verify es_alert_count_met asserts as expected.
             '''
       milestone: V2
-      tests: []
+      tests: ["entropy_src_alert"]
     }
     {
       name: stress_all
@@ -109,7 +109,31 @@
             Verify they never occur with asserts
             '''
       milestone: V2
-      tests: []
+      tests: ["entropy_src_err"]
+    }
+  ]
+  covergroups: [
+    {
+      name: err_test_cg
+      desc: '''
+            Covers that all health test fails, fatal errors, all counters errors and
+            all error codes of entropy_src have been tested.
+            Individual config settings that will be covered include:
+            - which_ht_fail (0 to 3), 4 health tests, repcnt, adaptp, bucket and markov test
+            - which_ht (0 to 1), some health tests have low and high fails
+            - which_markov_cntr (0 to 3), markov test has 4 counters
+            - which_fatal_err (0 to 5), 6 fatal errors, esrng, observe, esfinal fifo errors,
+              main state machine, ack state machine errors, and counter error
+            - which_fifo_err_2 (0 to 1), esrng and observe fifo has only read and state errors
+            - which_fifo_err_3 (0 to 2), esfinal fifo has write, read and state errors
+            - which_cntr (0 to 5), 6 possible counter errors, window counter, repcnt ht counter,
+              repcnts ht counter, adaptive proportion ht counter, bucket ht counter and
+              markov ht counter
+            - which_err_code (0 to 17), ERR_CODE has 9 fields, plus 9 ERR_CODE_TEST bits test
+            - which_fifo_read_err (0 to 2), esrng, observe and esfinal fifos
+            - which_fifo_state_err (0 to 2), esrng, observe and esfinal fifos
+            - which_invalid_mubi (0 to 8), 9 possible invalid mubi value fields
+            '''
     }
   ]
 }


### PR DESCRIPTION
  - Update the entropy_src testplan to include a covergroup for interrupt, alert and err tests

Signed-off-by: Muqing Liu <muqing.liu@wdc.com>