### PR TITLE
[edn, dv] EDN interrupt, alert and error verification

### DIFF
--- a/hw/ip/edn/dv/edn_sim_cfg.hjson
+++ b/hw/ip/edn/dv/edn_sim_cfg.hjson
@@ -64,6 +64,24 @@
       uvm_test_seq: edn_stress_all_vseq
     }
 
+    {
+      name: edn_intr
+      uvm_test: edn_intr_test
+      uvm_test_seq: edn_intr_vseq
+    }
+
+    {
+      name: edn_alert
+      uvm_test: edn_alert_test
+      uvm_test_seq: edn_alert_vseq
+    }
+
+    {
+      name: edn_err
+      uvm_test: edn_intr_test
+      uvm_test_seq: edn_err_vseq
+    }
+
     // TODO: add more tests here
   ]
 

--- a/hw/ip/edn/dv/env/edn_env.core
+++ b/hw/ip/edn/dv/env/edn_env.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:dv:csrng_agent
     files:
       - edn_env_pkg.sv
+      - edn_path_if.sv
       - edn_env_cfg.sv: {is_include_file: true}
       - edn_env_cov.sv: {is_include_file: true}
       - edn_virtual_sequencer.sv: {is_include_file: true}
@@ -24,6 +25,9 @@ filesets:
       - seq_lib/edn_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/edn_genbits_vseq.sv: {is_include_file: true}
       - seq_lib/edn_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/edn_intr_vseq.sv: {is_include_file: true}
+      - seq_lib/edn_alert_vseq.sv: {is_include_file: true}
+      - seq_lib/edn_err_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/edn/dv/env/edn_env.sv
+++ b/hw/ip/edn/dv/env/edn_env.sv
@@ -37,6 +37,11 @@ class edn_env extends cip_base_env #(
       // TODO: Move these
       cfg.m_endpoint_agent_cfg[i].zero_delays = 1'b1;
     end
+
+    // config edn path virtual interface
+    if (!uvm_config_db#(virtual edn_path_if)::get(this, "", "edn_path_vif", cfg.edn_path_vif)) begin
+      `uvm_fatal(`gfn, "failed to get edn_path_vif from uvm_config_db")
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -38,6 +38,51 @@ package edn_env_pkg;
     BootReqMode = 2
   } hw_req_mode_e;
 
+  typedef enum int {
+    invalid_edn_enable    = 0,
+    invalid_boot_req_mode = 1,
+    invalid_auto_req_mode = 2,
+    invalid_cmd_fifo_rst  = 3
+  } invalid_mubi_e;
+
+  typedef enum int {
+    sfifo_rescmd_error    = 0,
+    sfifo_gencmd_error    = 1,
+    edn_ack_sm_error      = 2,
+    edn_main_sm_error     = 3,
+    edn_cntr_error        = 4
+  } fatal_err_e;
+
+  typedef enum int {
+    sfifo_rescmd_err      = 0,
+    sfifo_gencmd_err      = 1,
+    edn_ack_sm_err        = 2,
+    edn_main_sm_err       = 3,
+    edn_cntr_err          = 4,
+    fifo_write_err        = 5,
+    fifo_read_err         = 6,
+    fifo_state_err        = 7,
+    sfifo_rescmd_err_test = 8,
+    sfifo_gencmd_err_test = 9,
+    edn_ack_sm_err_test   = 10,
+    edn_main_sm_err_test  = 11,
+    edn_cntr_err_test     = 12,
+    fifo_write_err_test   = 13,
+    fifo_read_err_test    = 14,
+    fifo_state_err_test   = 15
+  } err_code_e;
+
+  typedef enum int {
+    sfifo_rescmd = 0,
+    sfifo_gencmd = 1
+  } which_fifo_e;
+
+  typedef enum int {
+    fifo_write_error = 0,
+    fifo_read_error  = 1,
+    fifo_state_error = 2
+  } which_fifo_err_e;
+
   // package sources
   `include "edn_env_cfg.sv"
   `include "edn_env_cov.sv"

--- a/hw/ip/edn/dv/env/edn_path_if.sv
+++ b/hw/ip/edn/dv/env/edn_path_if.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This interface deals with the force paths in EDN interrupt and error tests
+
+interface edn_path_if
+(
+  input edn_i
+);
+
+  import uvm_pkg::*;
+
+  string core_path = "tb.dut.u_edn_core";
+
+  function automatic string fifo_err_path(string fifo_name, string which_path);
+    return {core_path, ".", fifo_name, "_", which_path};
+  endfunction // fifo_err_path
+
+  function automatic string sm_err_path(string which_sm);
+    case (which_sm)
+      "edn_ack_sm": return {core_path, ".gen_ep_blk[0].u_edn_ack_sm_ep.state_q"};
+      "edn_main_sm": return {core_path, ".u_edn_main_sm.state_q"};
+      default: `uvm_fatal("edn_path_if", "Invalid sm name!")
+    endcase // case (which_sm)
+  endfunction // sm_err_path
+
+  function automatic string cntr_err_path();
+    return {core_path, ".u_prim_count_max_reqs_cntr.gen_cross_cnt_hardening.msb"};
+  endfunction // cntr_err_path
+endinterface // edn_path_if

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -119,6 +119,8 @@ class edn_scoreboard extends cip_base_scoreboard #(
       end
       "max_num_reqs_between_reseeds": begin
       end
+      "recov_alert_sts": begin
+      end
       default: begin
         `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end

--- a/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_alert_vseq.sv
@@ -1,0 +1,131 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test recoverable alerts with invalid mubi data type inputs and edn_bus_cmp_alert
+class edn_alert_vseq extends edn_base_vseq;
+  `uvm_object_utils(edn_alert_vseq)
+
+  `uvm_object_new
+
+  push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)   m_endpoint_pull_seq;
+  bit [csrng_pkg::GENBITS_BUS_WIDTH - 1:0]                genbits;
+  bit [entropy_src_pkg::FIPS_BUS_WIDTH - 1:0]             fips;
+  bit [31:0]                                              exp_recov_alert_sts;
+  uint                                                    endpoint_port;
+
+  task test_edn_bus_cmp_alert();
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(endpoint_port,
+                                       endpoint_port inside { [0:cfg.num_endpoints - 1] };)
+
+    m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
+        create("m_endpoint_pull_seq");
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(fips)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(genbits)
+
+    // Load randomly generated but constant fips and genbits data through this test
+    // to induce edn bus cmp alert
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+
+    // Send INS cmd
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(1), .glen(0));
+
+    // Send GEN cmd w/ GLEN 1 (request single genbits)
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(1), .glen(1));
+    // Load constant genbits data
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+    // Request data
+    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+
+    // Load constant genbits data
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+    // Request data
+    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+
+    // Load constant genbits data
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+    // Request data
+    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+
+    // Load constant genbits data
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+    // Request data
+    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+
+    // Send GEN cmd w/ GLEN 1 (request single genbits)
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(1), .glen(1));
+
+    // Load constant genbits data
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+    // Request data
+    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+
+    // Check recov_alert_sts register
+    cfg.clk_rst_vif.wait_clks(100);
+    exp_recov_alert_sts = 32'b0;
+    exp_recov_alert_sts[ral.recov_alert_sts.edn_bus_cmp_alert.get_lsb_pos()] = 1;
+    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
+  endtask // edn_bus_cmp_alert
+
+  task body();
+    int           first_index;
+    string        reg_name;
+    string        fld_name;
+    uvm_reg       csr;
+    uvm_reg_field fld;
+
+    // Depending on the value of cfg.which_invalid_mubi, one of the following ctrl register fields
+    // will be set to an invalid MuBI value.
+    // Apply the bad settings, and confirm the corresponding alert is fired.
+    ral.ctrl.edn_enable.set(cfg.enable);
+    ral.ctrl.boot_req_mode.set(cfg.boot_req_mode);
+    ral.ctrl.auto_req_mode.set(cfg.auto_req_mode);
+    ral.ctrl.cmd_fifo_rst.set(cfg.cmd_fifo_rst);
+    csr_update(.csr(ral.ctrl));
+
+    cfg.clk_rst_vif.wait_clks(100);
+
+    // Check the recov_alert_sts register
+    reg_name = "recov_alert_sts";
+    fld_name = cfg.which_invalid_mubi.name();
+
+    first_index = find_index("_", fld_name, "first");
+
+    csr = ral.get_reg_by_name(reg_name);
+    fld = csr.get_field_by_name({fld_name.substr(first_index+1, fld_name.len()-1), "_field_alert"});
+
+    exp_recov_alert_sts = 32'b0;
+    exp_recov_alert_sts[fld.get_lsb_pos()] = 1;
+    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(exp_recov_alert_sts));
+
+    // Write valid values
+    ral.ctrl.edn_enable.set(prim_mubi_pkg::MuBi4True);
+    ral.ctrl.boot_req_mode.set(prim_mubi_pkg::MuBi4False);
+    ral.ctrl.auto_req_mode.set(prim_mubi_pkg::MuBi4False);
+    ral.ctrl.cmd_fifo_rst.set(prim_mubi_pkg::MuBi4True);
+    csr_update(.csr(ral.ctrl));
+
+    // Clear recov_alert_sts register
+    csr_wr(.ptr(ral.recov_alert_sts), .value(32'b0));
+
+    // Check recov_alert_sts register
+    cfg.clk_rst_vif.wait_clks(100);
+    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
+
+    // edn_bus_cmp_alert test, verify EDN.CS_RDATA.BUS.CONSISTENCY
+    test_edn_bus_cmp_alert();
+
+    cfg.clk_rst_vif.wait_clks(100);
+
+    // Clear the recov_alert_sts register
+    csr_wr(.ptr(ral.recov_alert_sts), .value(32'h0));
+    // Check the recov_alert_sts register
+    csr_rd_check(.ptr(ral.recov_alert_sts), .compare_value(0));
+
+    // Turn assertions back on
+    cfg.edn_assert_vif.assert_on_alert();
+
+  endtask
+
+endclass : edn_alert_vseq

--- a/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_err_vseq.sv
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test ERR_CODE fields asserted as expected, as well as the ERR_CODE_TEST register
+
+class edn_err_vseq extends edn_base_vseq;
+  `uvm_object_utils(edn_err_vseq)
+
+  `uvm_object_new
+
+  push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)   m_endpoint_pull_seq;
+
+  bit [csrng_pkg::GENBITS_BUS_WIDTH - 1:0]      genbits;
+  bit [entropy_src_pkg::FIPS_BUS_WIDTH - 1:0]   fips;
+  bit [edn_pkg::ENDPOINT_BUS_WIDTH - 1:0]       edn_bus[MAX_NUM_ENDPOINTS];
+  uint                                          endpoint_port;
+
+  task body();
+    bit [5:0]     err_code_test_bit;
+    string        path, path1, path2;
+    bit           value1, value2;
+    string        fifo_name;
+    int           first_index, last_index;
+    string        fifo_base_path;
+    string        path_exts [4] = {"push", "full", "pop", "not_empty"};
+    string        fifo_forced_paths [4];
+    bit           fifo_forced_values [4] = {1'b1, 1'b1, 1'b1, 1'b0};
+    string        fifo_err_path [2][string];
+    bit           fifo_err_value [2][string];
+    string        path_key;
+    string        reg_name, fld_name;
+    uvm_reg       csr;
+    uvm_reg_field fld;
+
+    fifo_err_path[0] = '{"write": "push", "read": "pop", "state": "full"};
+    fifo_err_path[1] = '{"write": "full", "read": "not_empty", "state": "not_empty"};
+    fifo_err_value[0] = '{"write": 1'b1, "read": 1'b1, "state": 1'b1};
+    fifo_err_value[1] = '{"write": 1'b1, "read": 1'b0, "state": 1'b0};
+
+    // Turn off fatal alert check
+    expect_fatal_alerts = 1'b1;
+
+    // Turn off assertions
+    $assertoff(0, "tb.dut.u_edn_core.u_prim_fifo_sync_rescmd.DataKnown_A");
+    $assertoff(0, "tb.dut.u_edn_core.u_prim_fifo_sync_gencmd.DataKnown_A");
+    cfg.edn_assert_vif.assert_off();
+
+    // Send INS cmd
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(0), .glen(0));
+
+    // Send GEN cmd w/ GLEN 1 (request single genbits)
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(0), .glen(1));
+
+    // Load genbits data
+    m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
+        create("m_endpoint_pull_seq");
+    `DV_CHECK_STD_RANDOMIZE_FATAL(fips)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(genbits)
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+
+    // Request data
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(endpoint_port,
+                                       endpoint_port inside { [0:cfg.num_endpoints - 1] };)
+    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+
+    reg_name = "err_code";
+    csr = ral.get_reg_by_name(reg_name);
+    fld_name = cfg.which_err_code.name();
+
+    first_index = find_index("_", fld_name, "first");
+    last_index = find_index("_", fld_name, "last");
+
+    case (cfg.which_err_code) inside
+      sfifo_rescmd_err, sfifo_gencmd_err: begin
+        fld = csr.get_field_by_name(fld_name);
+        fifo_base_path = fld_name.substr(0, last_index-1);
+
+        foreach (path_exts[i]) begin
+          fifo_forced_paths[i] = cfg.edn_path_vif.fifo_err_path(fifo_base_path, path_exts[i]);
+        end
+        force_all_fifo_errs(fifo_forced_paths, fifo_forced_values, path_exts, fld,
+                            1'b1, cfg.which_fifo_err);
+      end
+      edn_ack_sm_err, edn_main_sm_err: begin
+        fld = csr.get_field_by_name(fld_name);
+        path = cfg.edn_path_vif.sm_err_path(fld_name.substr(0, last_index-1));
+        force_path_err(path, 6'b0, fld, 1'b1);
+      end
+      edn_cntr_err: begin
+        fld = csr.get_field_by_name(fld_name);
+        path = cfg.edn_path_vif.cntr_err_path();
+        force_path_err(path, 6'b000001, fld, 1'b1);
+        // Verify EDN.MAIN_SM.CTR.LOCAL_ESC
+        csr_rd_check(.ptr(ral.err_code.edn_main_sm_err), .compare_value(1'b1));
+      end
+      fifo_write_err, fifo_read_err, fifo_state_err: begin
+        fld = csr.get_field_by_name(fld_name);
+        fifo_name = cfg.which_fifo.name();
+        path_key = fld_name.substr(first_index+1, last_index-1);
+
+        path1 = cfg.edn_path_vif.fifo_err_path(fifo_name, fifo_err_path[0][path_key]);
+        path2 = cfg.edn_path_vif.fifo_err_path(fifo_name, fifo_err_path[1][path_key]);
+        value1 = fifo_err_value[0][path_key];
+        value2 = fifo_err_value[1][path_key];
+        force_fifo_err(path1, path2, value1, value2, fld, 1'b1);
+      end
+      sfifo_rescmd_err_test, sfifo_gencmd_err_test, edn_ack_sm_err_test, edn_main_sm_err_test,
+      edn_cntr_err_test, fifo_write_err_test, fifo_read_err_test, fifo_state_err_test: begin
+        fld = csr.get_field_by_name(fld_name.substr(0, last_index-1));
+        err_code_test_bit = fld.get_lsb_pos();
+        csr_wr(.ptr(ral.err_code_test.err_code_test), .value(err_code_test_bit));
+        cfg.clk_rst_vif.wait_clks(50);
+        csr_rd_check(.ptr(fld), .compare_value(1'b1));
+        if (cfg.which_err_code == edn_cntr_err_test) begin
+          // Verify EDN.MAIN_SM.CTR.LOCAL_ESC
+          csr_rd_check(.ptr(ral.err_code.edn_main_sm_err), .compare_value(1'b1));
+          // Clear interrupt_enable
+          csr_wr(.ptr(ral.intr_enable), .value(32'd0));
+          ral.ctrl.edn_enable.set(prim_mubi_pkg::MuBi4False);
+          ral.ctrl.cmd_fifo_rst.set(prim_mubi_pkg::MuBi4True);
+          csr_update(.csr(ral.ctrl));
+          // Expect/Clear interrupt bit
+          check_interrupts(.interrupts((1 << FifoErr)), .check_set(1'b1));
+        end
+      end
+      default: begin
+        `uvm_fatal(`gfn, "Invalid case! (bug in environment)")
+      end
+    endcase // case (cfg.which_err_code)
+
+    // Turn assertions back on
+    cfg.edn_assert_vif.assert_on();
+  endtask
+
+endclass : edn_err_vseq

--- a/hw/ip/edn/dv/env/seq_lib/edn_intr_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_intr_vseq.sv
@@ -1,0 +1,96 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test edn_cmd_req_done and edn_fatal_err interrupts fired as expected
+
+class edn_intr_vseq extends edn_base_vseq;
+  `uvm_object_utils(edn_intr_vseq)
+
+  `uvm_object_new
+
+  push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)   m_endpoint_pull_seq;
+
+  bit [csrng_pkg::GENBITS_BUS_WIDTH - 1:0]      genbits;
+  bit [entropy_src_pkg::FIPS_BUS_WIDTH - 1:0]   fips;
+  uint                                          endpoint_port;
+
+  task test_edn_cmd_req_done();
+    // Send INS cmd
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(0), .glen(0));
+
+    // Send GEN cmd w/ GLEN 1 (request single genbits)
+    wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(0), .glen(1));
+
+    // Load expected genbits data
+    m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
+        create("m_endpoint_pull_seq");
+    `DV_CHECK_STD_RANDOMIZE_FATAL(fips)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(genbits)
+    cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+
+    // Request data
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(endpoint_port,
+                                       endpoint_port inside { [0:cfg.num_endpoints - 1] };)
+    m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[endpoint_port]);
+  endtask // test_edn_cmd_req_done
+
+  task test_edn_fatal_err();
+    string        path;
+    string        fld_name;
+    int           last_index;
+    string        fifo_base_path;
+    string        path_exts [4] = {"push", "full", "pop", "not_empty"};
+    string        fifo_forced_paths [4];
+    bit           fifo_forced_values [4] = {1'b1, 1'b1, 1'b1, 1'b0};
+
+    // Turn off assertions
+    $assertoff(0, "tb.dut.u_edn_core.u_prim_fifo_sync_rescmd.DataKnown_A");
+    $assertoff(0, "tb.dut.u_edn_core.u_prim_fifo_sync_gencmd.DataKnown_A");
+    cfg.edn_assert_vif.assert_off();
+
+    // Enable intr_state
+    csr_wr(.ptr(ral.intr_enable), .value(32'd3));
+
+    fld_name = cfg.which_fatal_err.name();
+
+    last_index = find_index("_", fld_name, "last");
+
+    case (cfg.which_fatal_err) inside
+      sfifo_rescmd_error, sfifo_gencmd_error: begin
+        fifo_base_path = fld_name.substr(0, last_index-1);
+        foreach (path_exts[i]) begin
+          fifo_forced_paths[i] = cfg.edn_path_vif.fifo_err_path(fifo_base_path, path_exts[i]);
+        end
+        force_all_fifo_errs(fifo_forced_paths, fifo_forced_values, path_exts,
+                            ral.intr_state.edn_fatal_err, 1'b1, cfg.which_fifo_err);
+      end
+      edn_ack_sm_error, edn_main_sm_error: begin
+        path = cfg.edn_path_vif.sm_err_path(fld_name.substr(0, last_index-1));
+        force_path_err(path, 6'b0, ral.intr_state.edn_fatal_err, 1'b1);
+      end
+      edn_cntr_error: begin
+        path = cfg.edn_path_vif.cntr_err_path();
+        force_path_err(path, 6'b000001, ral.intr_state.edn_fatal_err, 1'b1);
+      end
+      default: begin
+        `uvm_fatal(`gfn, "Invalid case! (bug in environment)")
+      end
+    endcase // case (cfg.which_fatal_err)
+
+    // Turn assertions back on
+    cfg.edn_assert_vif.assert_on();
+  endtask // test_edn_fatal_err
+
+  task body();
+    // Turn off fatal alert check
+    expect_fatal_alerts = 1'b1;
+
+    // Test edn_cmd_req_done interrupt
+    test_edn_cmd_req_done();
+
+    // Test edn_fatal_err interrupt
+    test_edn_fatal_err();
+
+  endtask
+endclass : edn_intr_vseq

--- a/hw/ip/edn/dv/env/seq_lib/edn_vseq_list.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_vseq_list.sv
@@ -7,3 +7,6 @@
 `include "edn_smoke_vseq.sv"
 `include "edn_genbits_vseq.sv"
 `include "edn_stress_all_vseq.sv"
+`include "edn_intr_vseq.sv"
+`include "edn_alert_vseq.sv"
+`include "edn_err_vseq.sv"

--- a/hw/ip/edn/dv/sva/edn_assert_if.sv
+++ b/hw/ip/edn/dv/sva/edn_assert_if.sv
@@ -1,0 +1,68 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Interface: edn_assert_if
+// Description: Asserts interface to turn off assertions that have long paths
+
+`define PATH1 \
+    tb.dut.u_edn_core.u_prim_count_max_reqs_cntr.gen_cross_cnt_hardening
+`define PATH2 \
+    tb.dut.u_edn_core.u_prim_mubi4_sync_edn_enable
+`define PATH3 \
+    tb.dut.u_edn_core.u_prim_mubi4_sync_boot_req_mode
+`define PATH4 \
+    tb.dut.u_edn_core.u_prim_mubi4_sync_auto_req_mode
+`define PATH5 \
+    tb.dut.u_edn_core.u_prim_mubi4_sync_cmd_fifo_rst
+
+interface edn_assert_if
+(
+  input edn_i
+);
+
+  task automatic assert_off ();
+    $assertoff(0, `PATH1.CrossCntErrBackward_A);
+  endtask // assert_off
+
+  task automatic assert_on ();
+    $asserton(0, `PATH1.CrossCntErrBackward_A);
+  endtask // assert_on
+
+  task automatic assert_off_alert ();
+    $assertoff(0, `PATH2.PrimMubi4SyncCheckTransients_A);
+    $assertoff(0, `PATH2.PrimMubi4SyncCheckTransients0_A);
+    $assertoff(0, `PATH2.PrimMubi4SyncCheckTransients1_A);
+
+    $assertoff(0, `PATH3.PrimMubi4SyncCheckTransients_A);
+    $assertoff(0, `PATH3.PrimMubi4SyncCheckTransients0_A);
+    $assertoff(0, `PATH3.PrimMubi4SyncCheckTransients1_A);
+
+    $assertoff(0, `PATH4.PrimMubi4SyncCheckTransients_A);
+    $assertoff(0, `PATH4.PrimMubi4SyncCheckTransients0_A);
+    $assertoff(0, `PATH4.PrimMubi4SyncCheckTransients1_A);
+
+    $assertoff(0, `PATH5.PrimMubi4SyncCheckTransients_A);
+    $assertoff(0, `PATH5.PrimMubi4SyncCheckTransients0_A);
+    $assertoff(0, `PATH5.PrimMubi4SyncCheckTransients1_A);
+  endtask // assert_off_alert
+
+  task automatic assert_on_alert ();
+    $asserton(0, `PATH2.PrimMubi4SyncCheckTransients_A);
+    $asserton(0, `PATH2.PrimMubi4SyncCheckTransients0_A);
+    $asserton(0, `PATH2.PrimMubi4SyncCheckTransients1_A);
+
+    $asserton(0, `PATH3.PrimMubi4SyncCheckTransients_A);
+    $asserton(0, `PATH3.PrimMubi4SyncCheckTransients0_A);
+    $asserton(0, `PATH3.PrimMubi4SyncCheckTransients1_A);
+
+    $asserton(0, `PATH4.PrimMubi4SyncCheckTransients_A);
+    $asserton(0, `PATH4.PrimMubi4SyncCheckTransients0_A);
+    $asserton(0, `PATH4.PrimMubi4SyncCheckTransients1_A);
+
+    $asserton(0, `PATH5.PrimMubi4SyncCheckTransients_A);
+    $asserton(0, `PATH5.PrimMubi4SyncCheckTransients0_A);
+    $asserton(0, `PATH5.PrimMubi4SyncCheckTransients1_A);
+  endtask // assert_on_alert
+
+endinterface

--- a/hw/ip/edn/dv/sva/edn_sva.core
+++ b/hw/ip/edn/dv/sva/edn_sva.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:fpv:csr_assert_gen
     files:
       - edn_bind.sv
+      - edn_assert_if.sv
     file_type: systemVerilogSource
 
   files_formal:

--- a/hw/ip/edn/dv/tb.sv
+++ b/hw/ip/edn/dv/tb.sv
@@ -28,6 +28,8 @@ module tb;
   csrng_if csrng_if(.clk(clk), .rst_n(rst_n));
   push_pull_if#(.HostDataWidth(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH))
        endpoint_if[MAX_NUM_ENDPOINTS](.clk(clk), .rst_n(rst_n));
+  edn_path_if edn_path_if (.edn_i(edn_i));
+  edn_assert_if edn_assert_if (.edn_i(edn_i));
 
   `DV_ALERT_IF_CONNECT
 
@@ -74,7 +76,9 @@ module tb;
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual csrng_if)::set(null, "*.env.m_csrng_agent*", "vif", csrng_if);
-    uvm_config_db#(virtual edn_cov_if)::set(null, "*.env", "edn_cov_if", dut.u_edn_cov_if );
+    uvm_config_db#(virtual edn_cov_if)::set(null, "*.env", "edn_cov_if", dut.u_edn_cov_if);
+    uvm_config_db#(virtual edn_assert_if)::set(null, "*.env", "edn_assert_vif", edn_assert_if);
+    uvm_config_db#(virtual edn_path_if)::set(null, "*.env", "edn_path_vif", edn_path_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/edn/dv/tests/edn_alert_test.sv
+++ b/hw/ip/edn/dv/tests/edn_alert_test.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class edn_alert_test extends edn_base_test;
+
+  `uvm_component_utils(edn_alert_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+    cfg.en_scb            = 0;
+    cfg.enable_pct        = 100;
+    cfg.boot_req_mode_pct = 0;
+    cfg.cmd_fifo_rst      = 100;
+    cfg.use_invalid_mubi  = 1;
+    cfg.num_endpoints     = MIN_NUM_ENDPOINTS;
+
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
+  endfunction
+endclass : edn_alert_test

--- a/hw/ip/edn/dv/tests/edn_base_test.sv
+++ b/hw/ip/edn/dv/tests/edn_base_test.sv
@@ -24,7 +24,7 @@ class edn_base_test extends cip_base_test #(
   // the run_phase; as such, nothing more needs to be done
 
   virtual function void configure_env();
-    cfg.enable_pct = 100;
+    cfg.enable_pct                            = 100;
 
     cfg.m_csrng_agent_cfg.cmd_ack_zero_delays = 0; // Can't handle cmd ack too soon after req
     cfg.m_csrng_agent_cfg.min_cmd_ack_dly     = 4;

--- a/hw/ip/edn/dv/tests/edn_intr_test.sv
+++ b/hw/ip/edn/dv/tests/edn_intr_test.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class edn_intr_test extends edn_base_test;
+
+  `uvm_component_utils(edn_intr_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+    cfg.en_scb            = 0;
+    cfg.use_invalid_mubi  = 0;
+
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
+  endfunction
+endclass : edn_intr_test

--- a/hw/ip/edn/dv/tests/edn_smoke_test.sv
+++ b/hw/ip/edn/dv/tests/edn_smoke_test.sv
@@ -11,7 +11,9 @@ class edn_smoke_test extends edn_base_test;
     super.configure_env();
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
-    cfg.num_endpoints = MIN_NUM_ENDPOINTS;
+
+    cfg.num_endpoints    = MIN_NUM_ENDPOINTS;
+    cfg.use_invalid_mubi = 0;
 
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_HIGH)
   endfunction

--- a/hw/ip/edn/dv/tests/edn_test.core
+++ b/hw/ip/edn/dv/tests/edn_test.core
@@ -14,6 +14,8 @@ filesets:
       - edn_smoke_test.sv: {is_include_file: true}
       - edn_genbits_test.sv: {is_include_file: true}
       - edn_stress_all_test.sv: {is_include_file: true}
+      - edn_intr_test.sv: {is_include_file: true}
+      - edn_alert_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/edn/dv/tests/edn_test_pkg.sv
+++ b/hw/ip/edn/dv/tests/edn_test_pkg.sv
@@ -21,5 +21,7 @@ package edn_test_pkg;
   `include "edn_smoke_test.sv"
   `include "edn_genbits_test.sv"
   `include "edn_stress_all_test.sv"
+  `include "edn_intr_test.sv"
+  `include "edn_alert_test.sv"
 
 endpackage


### PR DESCRIPTION
  - Add vseqs for EDN interrupt, alert and error tests
  - Update related config files to include the interrupt, alert and error tests

Signed-off-by: Muqing Liu <muqing.liu@wdc.com>