### PR TITLE
[prim_xilinx] Replace KEEP with DONT_TOUCH attributes

### DIFF
--- a/hw/ip/aes/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/aes/pre_syn/tcl/yosys_run_synth.tcl
@@ -27,8 +27,8 @@ if { $lr_synth_top_module != "aes_sbox" && $lr_synth_top_module != "aes_sub_byte
 }
 yosys "chparam -set SBoxImpl $lr_synth_s_box_impl $lr_synth_top_module"
 
-# Remap Xilinx Vivado "keep" attributes to Yosys style.
-yosys "attrmap -tocase keep -imap keep=\"true\" keep=1 -imap keep=\"false\" keep=0 -remove keep=0"
+# Remap Xilinx Vivado "dont_touch" attributes to Yosys "keep" attributes.
+yosys "attrmap -tocase keep -imap dont_touch=\"yes\" keep=1 -imap dont_touch=\"no\" keep=0 -remove keep=0"
 
 # Place keep_hierarchy contraints on relevant modules to prevent aggressive synthesis optimzations
 # across the boundaries of these modules.

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_buf.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_buf.sv
@@ -2,11 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+// Prevent Vivado from performing optimizations on/across this module.
+(* DONT_TOUCH = "yes" *)
 module prim_xilinx_buf #(
   parameter int Width = 1
 ) (
   input [Width-1:0] in_i,
-  (* keep = "true" *) output logic [Width-1:0] out_o
+  output logic [Width-1:0] out_o
 );
 
   assign out_o = in_i;

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_flop.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_flop.sv
@@ -4,6 +4,8 @@
 
 `include "prim_assert.sv"
 
+// Prevent Vivado from performing optimizations on/across this module.
+(* DONT_TOUCH = "yes" *)
 module prim_xilinx_flop #(
   parameter int               Width      = 1,
   parameter logic [Width-1:0] ResetValue = 0
@@ -11,8 +13,7 @@ module prim_xilinx_flop #(
   input clk_i,
   input rst_ni,
   input [Width-1:0] d_i,
-  // Prevent Vivado from optimizing this signal away.
-  (* keep = "true" *) output logic [Width-1:0] q_o
+  output logic [Width-1:0] q_o
 );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_flop_en.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_flop_en.sv
@@ -4,17 +4,17 @@
 
 `include "prim_assert.sv"
 
+// Prevent Vivado from performing optimizations on/across this module.
+(* DONT_TOUCH = "yes" *)
 module prim_xilinx_flop_en #(
   parameter int               Width      = 1,
   parameter logic [Width-1:0] ResetValue = 0
 ) (
   input clk_i,
   input rst_ni,
-  // Prevent Vivado from optimizing this signal away.
-  (* keep = "true" *) input en_i,
+  input en_i,
   input [Width-1:0] d_i,
-  // Prevent Vivado from optimizing this signal away.
-  (* keep = "true" *) output logic [Width-1:0] q_o
+  output logic [Width-1:0] q_o
 );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_xor2.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_xor2.sv
@@ -4,13 +4,14 @@
 
 `include "prim_assert.sv"
 
+// Prevent Vivado from performing optimizations on/across this module.
+(* DONT_TOUCH = "yes" *)
 module prim_xilinx_xor2 #(
   parameter int Width = 1
 ) (
   input [Width-1:0] in0_i,
   input [Width-1:0] in1_i,
-  // Prevent Vivado from optimizing this signal away.
-  (* keep = "true" *) output logic [Width-1:0] out_o
+  output logic [Width-1:0] out_o
 );
 
   assign out_o = in0_i ^ in1_i;


### PR DESCRIPTION
Previously, we have been using KEEP attributes to prevent synthesis optimizations across these primitives to ensure that FI and SCA countermeasures are not optimized away. However, according to the Vivado Design Suite User Guide: Synthesis (UG901), the KEEP attribute is commonly used in conjunction with timing constraints but doesn't force place and route to keep the signal. Instead, the DONT_TOUCH attribute is recommended for this purpose (see Chapter 2):

"Unlike KEEP and KEEP_HIERARCHY, DONT_TOUCH is forward-annotated to place and route to prevent logic optimization."

In addition, the KEEP/DONT_TOUCH attributes are not supported on ports of modules and instead should be applied to the module itself.

I successfully ran some FPGA experiments as well as formal experiments using the Yosys flow (uses Xilinx primitives with attribute remapping) to verify that this change doesn't introduce SCA leakage.