### PR TITLE
[fpv/pinmux] Add aon_wkup assertions

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -86,7 +86,7 @@ if {$env(DUT_TOP) == "rv_dm"} {
 
 } elseif {$env(DUT_TOP) == "pinmux_tb"} {
   clock clk_i -both_edges
-  clock clk_aon_i
+  clock clk_aon_i -factor 5
   clock -rate -default clk_i
   reset -expr {!rst_ni !rst_aon_ni}
 } else {


### PR DESCRIPTION
This PR adds aon_wkup_o assertions and changes aon_clk rate to be slower
than clk_i.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>