### PR TITLE
[sw, host] Update Mundane version

### DIFF
--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -29,7 +29,7 @@ hex = "0.4.3"
 # In order to not break the current meson-based build system, we'll leave
 # mundane as a dependency.  To regenerate the bazel dependency rules via
 # `cargo raze`, you'll have to temporarily comment out `mundane`.
-mundane = "0.4.4"
+mundane = "0.5.0"
 
 serde = { version="1", features=["serde_derive"] }
 serde_json = "1"

--- a/sw/host/rom_ext_image_tools/signer/Cargo.toml
+++ b/sw/host/rom_ext_image_tools/signer/Cargo.toml
@@ -31,5 +31,5 @@ thiserror = "1.0.24"
 zerocopy = "0.5.0"
 
 [dependencies.mundane]
-version = "0.4.4"
+version = "0.5.0"
 features = ["rsa-pkcs1v15"]


### PR DESCRIPTION
This updates the dependency Mundane to version 0.5.0. That version includes the latest BoringSSL version, which fixes compilation errors with recent versions of GCC.

This fixes Issue #6978.

Signed-off-by: Luís Marques <luismarques@lowrisc.org>