### PR TITLE
[dv/top_level] Update top-level kmac testplan

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1695,11 +1695,11 @@
 
             Requires `EnMasking` parameter to be enabled.
             SW randomly configures the KMAC in any hashing mode/strength, and enable EDN mode.
-            Randomly enable/disable the `entropy_timer`.
+            Randomly enable/disable the `entropy_refresh`.
             // TODO - error handling is not complete, do not enable `wait_timer` yet.
             KMAC should send request to EDN once `CmdStart` is written, and should send out another
             request to EDN when either:
-              - `entropy_timer` runs down (assuming it is non-zero)
+              - kmac hash counter hits the configured threshold (assuming it is non-zero)
               - a hash operation is completed, KMAC will refresh its internal entropy state
             SW verifies that KMAC produces the correct digest value.
 
@@ -1715,7 +1715,7 @@
       name: chip_sw_kmac_edn_reset
       desc: '''Verify that the EDN clock / reset is connected to KMAC.
 
-            - Ensure that the `entropy_timer` resets when the EDN logic is held in reset.
+            // TODO: check if this can use connectivity test.
             '''
       milestone: V2
       tests: []


### PR DESCRIPTION
As the email discussion with @davebwil, @msfschaffner, and @weicaiyang
(please correct me if I misunderstood anything :)
This PR updates top-level kmac testplan related to `entropy_timer`.
This is replaced by EDN and `entropy_refresh` registers.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>