### PR TITLE
[sysrst_ctrl,dv] Add sysrst_ctrl_flash_wr_prot_output testcase

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_base_vseq.sv
@@ -52,7 +52,10 @@ class sysrst_ctrl_base_vseq extends cip_base_vseq #(
         super.apply_reset(kind);
         cfg.clk_aon_rst_vif.apply_reset(0,400,0,1);
       join
-      `uvm_info(`gfn, "Driving from apply_reset", UVM_NONE)
+     // Ensure flash wp is in reset when opentitan is out of reset
+     `DV_CHECK_EQ(cfg.vif.flash_wp_l, 0);
+     // Ensure EC is in reset when OT is out of reset
+     `DV_CHECK_EQ(cfg.vif.ec_rst_l_out, 0);
     end
   endtask  // apply_reset
 

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_flash_wr_prot_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_flash_wr_prot_vseq.sv
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence will verify the flash_wp_l_out signal
+// It will be explicitly released from the reset by enabling and
+// disabling the override feature. The output, thus will have a transition from
+// 1->0 and 0->1
+class sysrst_ctrl_flash_wr_prot_vseq extends sysrst_ctrl_base_vseq;
+  `uvm_object_utils(sysrst_ctrl_flash_wr_prot_vseq)
+
+  `uvm_object_new
+
+   rand uvm_reg_data_t en_override_value, set_value, set_allowed;
+
+   constraint num_trans_c {num_trans == 20;}
+
+   task body();
+
+   bit en_override_flash_wp_value, override_val_flash_wp, allowed_flash_wp_0,
+       allowed_flash_wp_1;
+
+    `uvm_info(`gfn, "Starting the body from flash_wr_prot_vseq", UVM_LOW)
+
+    repeat (num_trans) begin
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+
+      // Enable the override function
+      csr_wr(ral.pin_out_ctl, en_override_value);
+
+      // Set the pin_override_value
+      csr_wr(ral.pin_out_value, set_value);
+
+      // Allow the output values to override
+      csr_wr(ral.pin_allowed_ctl, set_allowed);
+
+      // It takes 2-3 clock cycles to sync register values
+      cfg.clk_aon_rst_vif.wait_clks(3);
+
+      en_override_flash_wp_value = get_field_val(ral.pin_out_ctl.flash_wp_l, en_override_value);
+
+      override_val_flash_wp = get_field_val(ral.pin_out_value.flash_wp_l, set_value);
+
+      allowed_flash_wp_0 = get_field_val(ral.pin_allowed_ctl.flash_wp_l_0, set_allowed);
+      allowed_flash_wp_1 = get_field_val(ral.pin_allowed_ctl.flash_wp_l_1, set_allowed);
+
+      cfg.clk_aon_rst_vif.wait_clks(1);
+      if (en_override_flash_wp_value == 1) begin
+        if (override_val_flash_wp == 1 && allowed_flash_wp_1 == 1) begin
+          `DV_CHECK_EQ(cfg.vif.flash_wp_l, 1)
+        end else if (override_val_flash_wp == 0 && allowed_flash_wp_0 == 1) begin
+          `DV_CHECK_EQ(cfg.vif.flash_wp_l, 0)
+        end else begin
+          `DV_CHECK_EQ(cfg.vif.flash_wp_l, 0)
+        end
+      end else begin
+        `DV_CHECK_EQ(cfg.vif.flash_wp_l, 0)
+      end
+
+    end
+
+     cfg.clk_aon_rst_vif.wait_clks(20);
+   endtask : body
+
+endclass : sysrst_ctrl_flash_wr_prot_vseq
+

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_vseq_list.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_vseq_list.sv
@@ -9,4 +9,5 @@
 `include "sysrst_ctrl_combo_detect_ec_rst_vseq.sv"
 `include "sysrst_ctrl_pin_access_vseq.sv"
 `include "sysrst_ctrl_pin_override_vseq.sv"
+`include "sysrst_ctrl_flash_wr_prot_vseq.sv"
 

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/sysrst_ctrl_combo_detect_ec_rst_vseq.sv: {is_include_file: true}
       - seq_lib/sysrst_ctrl_pin_access_vseq.sv: {is_include_file: true}
       - seq_lib/sysrst_ctrl_pin_override_vseq.sv: {is_include_file: true}
+      - seq_lib/sysrst_ctrl_flash_wr_prot_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_if.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_if.sv
@@ -23,10 +23,7 @@ interface sysrst_ctrl_if (
   logic key2_out;
   logic pwrb_out;
   logic z3_wakeup;
-  logic z3_wakeup_in;
-  logic bat_disable_in;
-  logic ac_present_out;
-  logic lid_open_out;
+
 
   // reset value of input signals
   function automatic void reset_signals();
@@ -38,22 +35,20 @@ interface sysrst_ctrl_if (
     lid_open <= 0;
     ec_rst_l_in <= 1;
     flash_wp_l_in <= 1;
-    z3_wakeup_in <= 0;
-    bat_disable_in <= 0;
   endfunction
 
   task automatic randomize_input();
     // VCS doesn't support randomizing logic variable
     // so declare bit variable, randomize it and assigned it to logic
-    bit pwrb, key0, key1, key2, ec_rst_l, flash_wp_l;
-    `DV_CHECK_FATAL(std::randomize(pwrb, key0, key1, key2, ec_rst_l, flash_wp_l), ,
+    bit pwrb, key0, key1, key2, ec_rst_l, flash_wp;
+    `DV_CHECK_FATAL(std::randomize(pwrb, key0, key1, key2, ec_rst_l, flash_wp), ,
        "sysrst_ctrl_if")
     pwrb_in = pwrb;
     key0_in = key0;
     key1_in = key1;
     key2_in = key2;
     ec_rst_l_in = ec_rst_l;
-    flash_wp_l_in = flash_wp_l;
+    flash_wp_l_in = flash_wp;
   endtask
 
 endinterface : sysrst_ctrl_if

--- a/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
+++ b/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
@@ -66,6 +66,10 @@
       name: sysrst_ctrl_override_test
       uvm_test_seq: sysrst_ctrl_pin_override_vseq
     }
+    {
+      name: sysrst_ctrl_flash_wr_prot_out
+      uvm_test_seq: sysrst_ctrl_flash_wr_prot_vseq
+    }
 
   ]
 

--- a/hw/ip/sysrst_ctrl/dv/tb.sv
+++ b/hw/ip/sysrst_ctrl/dv/tb.sv
@@ -83,4 +83,7 @@ module tb;
     run_test();
   end
 
+  `ASSERT(CheckFlashWrProtRst, !rst_aon_n -> sysrst_ctrl_if.flash_wp_l == 0, clk_aon, 0)
+  `ASSERT(CheckEcPwrOnRst, !rst_aon_n -> sysrst_ctrl_if.ec_rst_l_out == 0, clk_aon, 0)
+
 endmodule


### PR DESCRIPTION
This test will verify the flash write protect output feature of sysrst_ctrl.

Signed-off-by: Madhuri Patel <madhuri.patel@ensilica.com>