### PR TITLE
[otbn,dv] Fix up key sideload support

### DIFF
--- a/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
+++ b/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
@@ -11,10 +11,11 @@ class key_sideload_set_seq extends key_sideload_base_seq;
   virtual task body();
     key_sideload_item item;
     item = key_sideload_item::type_id::create("item");
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(item,
+                                   item.valid == sideload_key.valid;
+                                   item.key0 == sideload_key.key[0];
+                                   item.key1 == sideload_key.key[1];)
     start_item(item);
-    item.valid = sideload_key.valid;
-    item.key0  = sideload_key.key[0];
-    item.key1  = sideload_key.key[1];
     finish_item(item);
     get_response(item);
   endtask

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -154,6 +154,10 @@ module otbn_core_model
       raw_err_bits_q <= 0;
       stop_pc_q <= 0;
     end else begin
+      if (!$stable(keymgr_key_i) || $rose(rst_ni)) begin
+        otbn_model_set_keymgr_value(model_handle, keymgr_key_i.key[0], keymgr_key_i.key[1],
+                                    keymgr_key_i.valid);
+      end
       if (edn_urnd_cdc_done_i) begin
         edn_model_urnd_cdc_done(model_handle);
       end
@@ -181,15 +185,6 @@ module otbn_core_model
     end
   end
 
-  always_ff @(posedge clk_i or posedge rst_ni)
-  begin
-    if (rst_ni) begin
-      if (!$stable(keymgr_key_i) || $rose(rst_ni)) begin
-        otbn_model_set_keymgr_value(model_handle, keymgr_key_i.key[0], keymgr_key_i.key[1],
-                                    keymgr_key_i.valid);
-      end
-    end
-  end
   // Assertion to ensure that keymgr key valid is never unknown.
   `ASSERT_KNOWN(KeyValidIsKnownChk_A, keymgr_key_i.valid)
   // Assertion to ensure that keymgr key values are never unknown if valid is high.

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -153,12 +153,6 @@ class OTBNState:
         # signal from RTL
         self.urnd_256b_counter = 0
 
-    def set_keymgr_value(self, key0: int, key1: int, valid: int) -> None:
-        assert 0 <= key0 < (1 << 384)
-        assert 0 <= key1 < (1 << 384)
-        self.wsrs.KeyS0.write_unsigned(key0 if valid else None)
-        self.wsrs.KeyS1.write_unsigned(key1 if valid else None)
-
     def edn_rnd_step(self, rnd_data: int) -> None:
         # Take the new data
         assert 0 <= rnd_data < (1 << 32)
@@ -391,18 +385,11 @@ class OTBNState:
 
         self.pc = 0
 
-        # Reset CSRs, WSRs, loop stack and call stack
+        # Reset CSRs, WSRs, loop stack and call stack. WSRs have special
+        # treatment because some of them have values that persist across
+        # operations.
         self.csrs = CSRFile()
-
-        # Save the RND value when starting another run because when a SW
-        # run finishes we still keep RND data.
-        self.rnd_reg_set()
-        old_rnd = self.wsrs.RND._random_value
-
-        self.wsrs = WSRFile()
-        if old_rnd is not None:
-            self.wsrs.RND.set_unsigned(old_rnd)
-
+        self.wsrs.on_start()
         self.loop_stack = LoopStack()
         self.gprs.start()
 

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -263,7 +263,7 @@ class KeyTrace(Trace):
 
 class SideloadKey:
     '''Represents a sideloaded key, with 384 bits of data and a valid signal'''
-    def __init__(self, name: str, val: Optional[int]):
+    def __init__(self, name: str):
         self.name = name
         self._value = None  # type: Optional[int]
         self._new_value = None  # type: Optional[Tuple[bool, int]]
@@ -321,17 +321,8 @@ class KeyWSR(WSR):
 class WSRFile:
     '''A model of the WSR file'''
     def __init__(self) -> None:
-        # Use fixed sideload keys for now. This matches the fixed keys used in
-        # the testbenches. Eventually the model will snoop the incoming key as
-        # it snoops the incoming EDN data for RND/URND now.
-        acc0 = 0
-        acc1 = 0
-        for i in range(384 // 32):
-            acc0 |= (0xDEADBEEF << (i * 32))
-            acc1 |= (0xBAADF00D << (i * 32))
-
-        self.KeyS0 = SideloadKey('KeyS0', acc0)
-        self.KeyS1 = SideloadKey('KeyS1', acc1)
+        self.KeyS0 = SideloadKey('KeyS0')
+        self.KeyS1 = SideloadKey('KeyS1')
 
         self.MOD = DumbWSR('MOD')
         self.RND = RandWSR('RND')

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -45,7 +45,7 @@ def main() -> int:
     exp_end_addr = load_elf(sim, args.elf)
     key0 = int((str("deadbeef") * 12), 16)
     key1 = int((str("badf00d") * 12), 16)
-    sim.state.set_keymgr_value(key0, key1, 1)
+    sim.state.wsrs.set_sideload_keys(key0, key1)
 
     sim.state.ext_regs.commit()
 

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -326,7 +326,8 @@ def on_set_keymgr_value(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     key0 = read_word('key0', args[0], 384)
     key1 = read_word('key1', args[1], 384)
     valid = read_word('valid', args[2], 1) == 1
-    sim.state.set_keymgr_value(key0, key1, valid)
+    sim.state.wsrs.set_sideload_keys(key0 if valid else None,
+                                     key1 if valid else None)
 
     return None
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -69,6 +69,11 @@ class otbn_env extends cip_base_env #(
     model_agent.monitor.analysis_port.connect(scoreboard.model_fifo.analysis_export);
     trace_monitor.analysis_port.connect(scoreboard.trace_fifo.analysis_export);
     cfg.scoreboard = scoreboard;
+    virtual_sequencer.key_sideload_sequencer_h = keymgr_sideload_agent.sequencer;
+
+    // Configure the key sideload sequencer to use UVM_SEQ_ARB_STRICT_FIFO arbitration. This makes
+    // sure that we can inject our own sequence if we need to override the default for a bit.
+    keymgr_sideload_agent.sequencer.set_arbitration(UVM_SEQ_ARB_STRICT_FIFO);
   endfunction
 
   function void final_phase(uvm_phase phase);

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -47,6 +47,11 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   // How often should we poll STATUS to detect completion, even though interrupts are enabled?
   int unsigned poll_despite_interrupts_pct = 10;
 
+  // Should we allow the sideload key not to be valid? If we do, we have to disable the exp_end_addr
+  // check (since we might stop in the middle of the operation by reading from the sideload key WSR
+  // when it isn't available).
+  int unsigned allow_no_sideload_key_pct = 50;
+
   // The hierarchical scope of the DUT instance in the testbench. This is used when constructing the
   // DPI wrapper (in otbn_env::build_phase) to tell it where to find the DUT for backdoor loading
   // memories. The default value matches the block-level testbench, but it can be overridden in a

--- a/hw/ip/otbn/dv/uvm/env/otbn_virtual_sequencer.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_virtual_sequencer.sv
@@ -9,4 +9,6 @@ class otbn_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(otbn_virtual_sequencer)
   `uvm_component_new
 
+  key_sideload_sequencer key_sideload_sequencer_h;
+
 endclass


### PR DESCRIPTION
This is causing lots of failures in the nightly tests. The commits in this PR are as follows:

1. **[dv] Correctly randomise rsp_delay in key_sideload_set_seq**
   This fixes a minor bug in how we randomise the items that we send in the sequence. Now we can have keys that last more than one cycle.
2. **[otbn,dv] Update sideload key value before running insn**
  We weren't ensuring that the key update was scheduled before the instruction execution
3. **[otbn,dv] WSR cleanups**
4. **[otbn,dv] Remove default-init for sideload keys in ISS**
   These two commits remove a double initialisation and fix up how we reset things at the start of the operation so that the initialisation at the start of `standalone.py` doesn't get thrown away.
5. **[otbn,dv] Only run the exp_end_addr check for some runs**
   Only run the check for expected end address for runs where we constrain the key sideload interface to always have a valid key.