### PR TITLE
Fix and waive lint errors in various modules

### DIFF
--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -195,23 +195,29 @@ module aes_control
 
   // To ease interfacing with the individual FSM rails, some signals need to be converted to packed
   // arrays.
-  logic [Sp2VWidth-1:0][NumSharesKey-1:0][NumRegsKey-1:0] int_key_init_we;
-  logic                [NumSharesKey-1:0][NumRegsKey-1:0] int_key_init_qe;
+  logic [Sp2VWidth-1:0][NumSharesKey-1:0][NumRegsKey-1:0]                int_key_init_we;
+  logic                [NumSharesKey-1:0][NumRegsKey-1:0][Sp2VWidth-1:0] log_key_init_we;
+  logic                [NumSharesKey-1:0][NumRegsKey-1:0]                int_key_init_qe;
   for (genvar s = 0; s < NumSharesKey; s++) begin : gen_conv_key_init_wqe_shares
     for (genvar i = 0; i < NumRegsKey; i++) begin : gen_conv_key_init_wqe_regs
       assign int_key_init_qe[s][i] = key_init_qe_i[s][i];
-      for (genvar j = 0; j < Sp2VWidth; j++) begin : gen_conv_key_init_wqe_sp2v
-        assign key_init_we_o[s][i][j] = int_key_init_we[j][s][i];
+      for (genvar j = 0; j < Sp2VWidth; j++) begin : gen_conv_key_init_wqe_log
+        assign log_key_init_we[s][i][j] = int_key_init_we[j][s][i];
       end
+      assign key_init_we_o[s][i] = sp2v_e'(log_key_init_we[s][i]);
     end
   end
-  logic [Sp2VWidth-1:0][NumSlicesCtr-1:0] int_ctr_we;
-  logic [Sp2VWidth-1:0][NumSlicesCtr-1:0] int_iv_we;
+  logic [Sp2VWidth-1:0][NumSlicesCtr-1:0]                int_ctr_we;
+  logic                [NumSlicesCtr-1:0][Sp2VWidth-1:0] log_ctr_we;
+  logic [Sp2VWidth-1:0][NumSlicesCtr-1:0]                int_iv_we;
+  logic                [NumSlicesCtr-1:0][Sp2VWidth-1:0] log_iv_we;
   for (genvar i = 0; i < NumSlicesCtr; i++) begin : gen_conv_ctr_iv_we_slices
-    for (genvar j = 0; j < Sp2VWidth; j++) begin : gen_conv_ctr_iv_we_sp2v
-      assign int_ctr_we[j][i] = ctr_we[i][j];
-      assign iv_we_o[i][j]    = int_iv_we[j][i];
+    assign log_ctr_we[i] = {ctr_we[i]};
+    for (genvar j = 0; j < Sp2VWidth; j++) begin : gen_conv_ctr_iv_we_log
+      assign int_ctr_we[j][i] = log_ctr_we[i][j];
+      assign log_iv_we[i][j]  = int_iv_we[j][i];
     end
+    assign iv_we_o[i] = sp2v_e'(log_iv_we[i]);
   end
 
   /////////

--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -25,11 +25,13 @@
 //      -- down_count is halted until set_i is set again
 //         Note: The up_count is still running.
 //      -- err_o is set to 0 (false),
-//      -- cnt_o is either all zero (OutSelDnCnt = 1) or the (running) up_count value (OutSelDnCnt = 0).
+//      -- cnt_o is either all zero (OutSelDnCnt = 1) or the (running) up_count value
+//         (OutSelDnCnt = 0).
 //    - set_i sets
 //      -- the up_count to 0 and the down_count to set_cnt_i,
 //      -- the up_count's maximum value to set_cnt_i.
-//    - en_i increments/decrements the up_count/down_count by step_i, if neither of the above is set.
+//    - en_i increments/decrements the up_count/down_count by step_i, if neither of the above is
+//      set.
 
 module prim_count import prim_count_pkg::*; #(
   parameter int Width = 2,

--- a/hw/ip/prim/util/primgen/abstract_prim.sv.tpl
+++ b/hw/ip/prim/util/primgen/abstract_prim.sv.tpl
@@ -15,7 +15,7 @@
 // abstract prim wrapper. These warnings occur due to the .*
 // use. TODO: we may want to move these inline waivers
 // into a separate, generated waiver file for consistency.
-//ri lint_check_off OUTPUT_NOT_DRIVEN INPUT_NOT_READ
+//ri lint_check_off OUTPUT_NOT_DRIVEN INPUT_NOT_READ HIER_BRANCH_NOT_READ
 module prim_${prim_name}
 ${module_header_imports}
 #(
@@ -30,4 +30,4 @@ ${module_header_params}
 ${instances}
 
 endmodule
-//ri lint_check_on OUTPUT_NOT_DRIVEN INPUT_NOT_READ
+//ri lint_check_on OUTPUT_NOT_DRIVEN INPUT_NOT_READ HIER_BRANCH_NOT_READ

--- a/hw/ip/prim_generic/lint/prim_generic_ram_1p.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_ram_1p.waiver
@@ -7,4 +7,6 @@
 waive -rules ALWAYS_SPEC       -location {prim_generic_ram_*p.sv} -regexp {Edge triggered block may be more accurately modeled as always_ff} \
       -comment "Vivado requires here an always instead of always_ff"
 waive -rules HIER_NET_NOT_READ -regexp {Connected net '(addr|wdata)_i' at prim_generic_ram_1p.sv.* is not read from in module 'prim_generic_ram_1p'} \
-      -comment "Ascentlint blackboxes very deep RAMs to speed up runtime. This blacboxing causes above lint errors."
+      -comment "Ascentlint blackboxes very deep RAMs to speed up runtime. This blackboxing causes above lint errors."
+waive -rules IFDEF_CODE -location {prim_generic_ram_1p.sv} -regexp {Assignment to 'unused_cfg' contained within `ifndef} \
+      -comment "Declaration of signal and assignment to it are in same `ifndef"

--- a/hw/ip/prim_generic/lint/prim_generic_ram_2p.waiver
+++ b/hw/ip/prim_generic/lint/prim_generic_ram_2p.waiver
@@ -9,4 +9,6 @@ waive -rules MULTI_PROC_ASSIGN -location {prim_generic_ram_2p.sv} -regexp {Assig
 waive -rules ALWAYS_SPEC       -location {prim_generic_ram_*p.sv} -regexp {Edge triggered block may be more accurately modeled as always_ff} \
       -comment "Vivado requires here an always instead of always_ff"
 waive -rules HIER_NET_NOT_READ -regexp {Connected net '(addr|wdata)_i' at prim_generic_ram_1p.sv.* is not read from in module 'prim_generic_ram_1p'} \
-      -comment "Ascentlint blackboxes very deep RAMs to speed up runtime. This blacboxing causes above lint errors."
+      -comment "Ascentlint blackboxes very deep RAMs to speed up runtime. This blackboxing causes above lint errors."
+waive -rules IFDEF_CODE -location {prim_generic_ram_2p.sv} -regexp {Assignment to 'unused_cfg' contained within `ifndef} \
+      -comment "Declaration of signal and assignment to it are in same `ifndef"

--- a/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
+++ b/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
@@ -42,10 +42,6 @@ waive -rules HIER_NET_NOT_READ    -location {rv_core_ibex.sv} -regexp {Net 'tl_.
       -comment "Not all bits of instruction response needed"
 waive -rules NOT_READ             -location {rv_core_ibex.sv} -regexp {Signal 'tl_._fifo2ibex.d_(error|opcode|param|sink|size|source|user).*' is not read} \
       -comment "Not all bits of instruction response needed"
-waive -rules NOT_READ             -location {ibex_cs_registers.sv} -regexp {Signal 'mstatus_n.mpp' is not read from} \
-      -comment "Cleaner to write this way even if currently fixed at M mode"
-waive -rules CONST_FF             -location {ibex_cs_registers.sv} -regexp {Flip.flop 'mstatus_q.mpp' is driven by constant ones} \
-      -comment "Cleaner to write this way even if currently fixed at M mode"
 waive -rules NOT_READ             -location {ibex_if_stage.sv} -regexp {Signal 'fetch_addr_n.0.' is not read from} \
       -comment "cleaner to write all bits even if not all are used"
 waive -rules NOT_READ             -location {ibex_multdiv_fast.sv} -regexp {Signal 'mac_res_ext.34.' is not read from} \
@@ -56,6 +52,8 @@ waive -rules MULTIPLY             -location {ibex_multdiv_fast.sv} -regexp {Mult
       -comment "got to pay the price for the multiplier"
 waive -rules CONST_OUTPUT         -location {rv_core_ibex.sv} -regexp {Output 'tl_(i|d)_o..*' is driven by constant} \
       -comment "not all bus constructs are used"
+waive -rules SIGNED_RANGE         -location {ibex_controller.sv} -msg {Part select of signed signal 'i[3:0]' encountered} \
+      -comment "switching the loop variable i to unsigned would require loop restructuring to not change interrupt priorities, making the code less readable"
 waive -rules CONST_OUTPUT         -location {ibex_controller.sv} -regexp {Output 'exc_cause_o.5.' is driven by constant} \
       -comment "easier to write with enum, not all causes used yet"
 waive -rules CONST_OUTPUT         -location {ibex_decoder.sv} -regexp {Output 'data_reg_offset_o' is driven by constant} \
@@ -84,7 +82,7 @@ waive -rules ONE_BIT_MEM_WIDTH             -location {ibex_core.sv} -regexp {Mem
       -comment "For consistency with related signals, we use an unpacked array for this signal."
 waive -rules HIER_BRANCH_NOT_READ -location {ibex_branch_predict.sv ibex_decoder.sv ibex_compressed_decoder.sv} -regexp {Net '(clk_i|rst_ni)' is not read from in module '(ibex_branch_predict|ibex_decoder|ibex_compressed_decoder)'.*} \
       -comment "These signals are only used for assertions inside these three modules"
-waive -rules INPUT_NOT_READ -location {ibex_decoder.sv ibex_compressed_decoder.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from in module '(ibex_decoder|ibex_compressed_decoder)'.*} \
+waive -rules INPUT_NOT_READ -location {ibex_branch_predict.sv ibex_decoder.sv ibex_compressed_decoder.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from in module '(ibex_branch_predict|ibex_decoder|ibex_compressed_decoder)'.*} \
       -comment "These signals are only used for assertions inside these two modules"
 waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_new_id' contained within `else block} \
       -comment "Declaration of signal and assignment to it are in same `else block"
@@ -98,14 +96,26 @@ waive -rules CLOCK_USE -location {ibex_id_stage.sv} -regexp {'clk_i' is connecte
       -comment "clk_i is unused in ibex_decoder configurations without RV32B and isn't connected to logic"
 waive -rules RESET_USE -location {ibex_id_stage.sv} -regexp {'rst_ni' is connected to 'ibex_decoder' port 'rst_ni'} \
       -comment "rst_ni is unused in ibex_decoder configurations without RV32B and isn't connected to logic"
-waive -rules {ZERO_REP} -location {ibex_icache.sv} -regexp {Replication count is zero in '{22-IC_TAG_SIZE{1'b0}}'} \
+waive -rules {ZERO_REP} -location {ibex_icache.sv} -regexp {Replication count is zero in '{22 - IC_TAG_SIZE{1'b0}}'} \
       -comment "if IC_TAG_SIZE=22, no padding is needed"
-waive -rules {ZERO_REP} -location {ibex_icache.sv} -regexp {Replication count is zero in '{IC_LINE_BEATS_W-1{1'b0}}'} \
+waive -rules {ZERO_REP} -location {ibex_icache.sv} -regexp {Replication count is zero in '{IC_LINE_BEATS_W - 1{1'b0}}'} \
       -comment "if IC_LINE_BEATS=2, IC_LINE_BEATS_W=1 and no padding is needed"
+waive -rules {ARITH_CONTEXT} -location {ibex_icache.sv} -msg {Bitlength of arithmetic operation '(output_addr_q[IC_LINE_W - 1:BUS_W] + {{IC_LINE_BEATS_W - 1{1'b0}},skid_valid_q})' is self-determined in this context} \
+      -comment "The bitlengths are determined but the zero replication count (IC_LINE_BEATS_W=1) seems to confuse the tool"
 waive -rules MIXED_SIGN           -location {ibex_lockstep.sv} -regexp {Unsigned operand 'rst_shadow_cnt_q' and signed 'LockstepOffsetW'(1)' encountered in a binary expression} \
       -comment "In line with our style guide, LockstepOffsetW'(1) results in a signed operand"
 waive -rules UNSIZED_BIT_CONTEXT  -location {ibex_lockstep.sv} -regexp {Bitlength of unsized bit literal "'0" is self determined in this context} \
       -comment {In line with our style guide, writing this as {$bits(delayed_inputs_t){1'b0}} would be much less readable}
+waive -rules CONST_FF             -location {ibex_icache.sv} -regexp {Flip-flop 'reset_inval_q' is driven by constant one} \
+      -comment "The only purpose of the flop is to initiate the cache invalidation after reset"
+waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'(rst_shadow_set_q|rst_shadow_n)' is driven here, and used as an asynchronous reset 'rst_ni' at}
+      -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles"
+waive -rules RESET_DRIVER         -location {ibex_lockstep.sv} -regexp {'(rst_shadow_set_q|rst_shadow_n)' driven in module 'ibex_lockstep'}
+      -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles"
+waive -rules RESET_MUX            -location {ibex_lockstep.sv} -regexp {Asynchronous reset 'rst_shadow_n' is driven by a multiplexer here}
+      -comment "The test enable input used to control the bypass can be considered static"
+waive -rules RESET_USE            -location {ibex_lockstep.sv} -regexp {'rst_shadow_set_q' is used for some other purpose, and as asynchronous reset 'rst_ni' at}
+      -comment "A synchronous counter is needed to release the shadow core reset with a delay of LockstepOffset clock cycles and start the comparison logic one clock cycle later"
 
 # Highlighting my main concerns here, documenting areas to review in next dive
 #

--- a/hw/ip/tlul/lint/tlul_adapter_sram.vlt
+++ b/hw/ip/tlul/lint/tlul_adapter_sram.vlt
@@ -7,3 +7,11 @@
 
 // This signal is only used by an assertion.
 lint_off -rule UNUSED -file "*/rtl/tlul_adapter_sram.sv" -match "Signal is not used: 'rspfifo_wready'"
+
+// Signal is not used: clk_i
+// leaving clk and reset connected in-case we want to add assertions
+lint_off -rule UNUSED -file "*/rtl/tlul_sram_byte.sv" -match "*clk_i*"
+
+// Signal is not used: rst_ni
+// leaving clk and reset connected in-case we want to add assertions
+lint_off -rule UNUSED -file "*/rtl/tlul_sram_byte.sv" -match "*rst_ni*"

--- a/hw/ip/tlul/lint/tlul_adapter_sram.waiver
+++ b/hw/ip/tlul/lint/tlul_adapter_sram.waiver
@@ -25,3 +25,7 @@ waive -rules NOT_READ -msg {Signal 'rspfifo_wready' is not read from in module '
 waive -rules VAR_INDEX_RANGE -regexp {.*woffset' of length 1 is larger than the 0 bits required to address.*} \
       -comment "The woffset signal is tied to constant 0 in this case. Fixing this warning in RTL would complicate \
       the design since multiple generate blocks would be needed with almost identical content."
+waive -rules HIER_BRANCH_NOT_READ -location {tlul_sram_byte.sv} -regexp {Net '(clk_i|rst_ni)' is not read from in module 'tlul_sram_byte'} \
+      -comment "If EnableIntg=0, the module is just passed through"
+waive -rules INPUT_NOT_READ -location {tlul_sram_byte.sv} -regexp {Input port '(clk_i|rst_ni)' is not read from} \
+      -comment "If EnableIntg=0, the module is just passed through"


### PR DESCRIPTION
This PR fixes and waives lint errors in various modules. Since I need someone to check that some of the waivers work in AscentLint, I decided to collect all commits in a single PR.

@msfschaffner , could you please check the following modules:
- aes: 3 errors are expected to remain
- rv_core_ibex: 0 errors expected to remain
- flash_ctrl: 1 error is expected to remain