### PR TITLE
[sram/dv] add sram_ctrl_regwen_vseq

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -147,6 +147,24 @@
       tests: ["{variant}_max_throughput", "{variant}_throughput_w_partial_write"]
     }
     {
+      name: regwen
+      desc: '''
+            This test is intended to test `exec_regwen` and `ctrl_regwen` as well as their related
+            CSRs.
+
+            `ctrl_regwen` related CSRs (renew_scr_key and init) are excluded from CSRs test as they
+            affects other CSRs.
+            `exec_regwen` and its related CSRs are tested in CSRs tests, but this `exec` relates to
+            other sram inputs (en_sram_ifetch and hw_debug_en), so also test it in this test.
+
+            Both `exec_regwen` and `ctrl_regwen` as well as their related CSRs will be programmed
+            at the beginning of each iteration. So when regwen is cleared, the related CSRs will be
+            locked.
+            '''
+      milestone: V2
+      tests: ["{variant}_regwen"]
+    }
+    {
       name: stress_all
       desc: '''
             - Combine above sequences in one test to run sequentially, except csr sequence and

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_regwen_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_regwen_vseq.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence tests exec_regwen and ctrl_regwen as well as their related CSRs.
+// ctrl_regwen related CSRs (renew_scr_key and init) are excluded from CSRs test as they affects
+// other CSRs
+// exec_regwen and its related CSRs are tested in CSRs tests, but this `exec` feature relates to
+// other sram inputs (en_sram_ifetch and hw_debug_en), so also test it in this vseq.
+class sram_ctrl_regwen_vseq extends sram_ctrl_executable_vseq;
+
+  `uvm_object_utils(sram_ctrl_regwen_vseq)
+  `uvm_object_new
+
+  task req_mem_init();
+    super.req_mem_init();
+    `DV_CHECK_RANDOMIZE_FATAL(ral.exec_regwen)
+    csr_update(ral.exec_regwen);
+    `DV_CHECK_RANDOMIZE_FATAL(ral.ctrl_regwen)
+    csr_update(ral.ctrl_regwen);
+    `uvm_info(`gfn, $sformatf("exec_regwen: %0d, ctrl_regwen: %0d",
+                              `gmv(ral.exec_regwen), `gmv(ral.ctrl_regwen)), UVM_MEDIUM)
+  endtask
+
+endclass

--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_vseq_list.sv
@@ -12,4 +12,5 @@
 `include "sram_ctrl_lc_escalation_vseq.sv"
 `include "sram_ctrl_access_during_key_req_vseq.sv"
 `include "sram_ctrl_executable_vseq.sv"
+`include "sram_ctrl_regwen_vseq.sv"
 `include "sram_ctrl_stress_all_vseq.sv"

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env.core
@@ -33,6 +33,7 @@ filesets:
       - seq_lib/sram_ctrl_lc_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_access_during_key_req_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_executable_vseq.sv: {is_include_file: true}
+      - seq_lib/sram_ctrl_regwen_vseq.sv: {is_include_file: true}
       - seq_lib/sram_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -130,6 +130,10 @@
       name: "{variant}_executable"
       uvm_test_seq: sram_ctrl_executable_vseq
     }
+    {
+      name: "{variant}_regwen"
+      uvm_test_seq: sram_ctrl_regwen_vseq
+    }
     // Below 2 tests are same as the tests in dvsim/tests/mem_tests.hjson
     // Replicate them here in order to enable scb
     {


### PR DESCRIPTION
This test is intended to test `exec_regwen` and `ctrl_regwen` as well as their related
CSRs.

`ctrl_regwen` related CSRs (renew_scr_key and init) are excluded from CSRs test as they
affects other CSRs.
`exec_regwen` and its related CSRs are tested in CSRs tests, but this `exec` relates to
other sram inputs (en_sram_ifetch and hw_debug_en), so also test it in this test.

  Both `exec_regwen` and `ctrl_regwen` as well as their related CSRs will be programmed
at the beginning of each iteration. So when regwen is cleared, the related CSRs will be
locked.

Signed-off-by: Weicai Yang <weicai@google.com>