### PR TITLE
[opentitantool] Add `fixed_size_bigint` macro

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -43,6 +43,7 @@ rust_library(
         "src/transport/verilator/subprocess.rs",
         "src/transport/verilator/transport.rs",
         "src/transport/verilator/uart.rs",
+        "src/util/bigint.rs",
         "src/util/bitfield.rs",
         "src/util/file.rs",
         "src/util/image.rs",

--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -30,6 +30,8 @@ hex = "0.4.3"
 # mundane as a dependency.  To regenerate the bazel dependency rules via
 # `cargo raze`, you'll have to temporarily comment out `mundane`.
 mundane = "0.5.0"
+num-bigint-dig = "0.7.0"
+num-traits = "0.2.14"
 
 serde = { version="1", features=["serde_derive"] }
 serde_json = "1"

--- a/sw/host/opentitanlib/src/util/bigint.rs
+++ b/sw/host/opentitanlib/src/util/bigint.rs
@@ -1,0 +1,312 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use num_bigint_dig::BigUint;
+use num_traits::Num;
+use std::cmp::Ordering;
+use std::fmt;
+use thiserror::Error;
+
+use crate::util::parse_int::ParseInt;
+
+#[derive(Error, Debug, Clone, PartialEq, Eq)]
+pub enum ParseBigIntError {
+    #[error("integer is too large")]
+    Overflow,
+    #[error("integer is too small")]
+    Underflow,
+    #[error(transparent)]
+    ParseBigIntError(#[from] num_bigint_dig::ParseBigIntError),
+}
+
+/// A fixed-size unsigned big integer.
+///
+/// This struct wraps a `BigUint` to facilitate defining new fixed-size unsigned integer types for
+/// better type safety.
+///
+/// An integer stored in this type is fixed-size in the sense that the minimum number of bits
+/// required to represent it, i.e. its bit length, is at most `BIT_LEN`. This size can be specified
+/// using the const parameters `BIT_LEN` and `EXACT_LEN` as follows:
+///   - When `EXACT_LEN` is `false`, the bit length of the integer can be at most `BIT_LEN` bits,
+///     e.g. SHA-256 digests (at most 256 bits) or RSA-3072 signatures (at most 3072 bits),
+///   - When `EXACT_LEN` is `true`, the number of bits required to represent the integer must be
+///     exactly `BIT_LEN` bits, e.g. RSA-3072 moduli (exactly 3072 bits).
+/// Note that while the type encapsulates the size information, the actual check is performed at
+/// runtime when an instance is created (see `check_len()`).
+///
+/// This struct is not meant to be used directly, please see the `fixed_size_bigint` macro which
+/// also generates the required boilerplate code for new types.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct FixedSizeBigInt<const BIT_LEN: usize, const EXACT_LEN: bool>(BigUint);
+
+impl<const BIT_LEN: usize, const EXACT_LEN: bool> FixedSizeBigInt<BIT_LEN, EXACT_LEN> {
+    const BYTE_LEN: usize = BIT_LEN.saturating_add(u8::BITS as usize - 1) / u8::BITS as usize;
+
+    /// Checks the bit length of the `FixedSizeBigInt`.
+    ///
+    /// Bit length of a `FixedSizeBigInt` can be at most `BIT_LEN` if `EXACT_LEN` is `false`, must
+    /// be exactly `BIT_LEN` otherwise.
+    fn new_from_biguint(biguint: BigUint) -> Result<Self, ParseBigIntError> {
+        match (biguint.bits().cmp(&BIT_LEN), EXACT_LEN) {
+            (Ordering::Greater, _) => Err(ParseBigIntError::Overflow),
+            (Ordering::Equal, _) => Ok(Self(biguint)),
+            (Ordering::Less, true) => Err(ParseBigIntError::Underflow),
+            (Ordering::Less, false) => Ok(Self(biguint)),
+        }
+    }
+
+    /// Creates a `FixedSizeBigInt` from little-endian bytes.
+    pub(crate) fn from_le_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, ParseBigIntError> {
+        Self::new_from_biguint(BigUint::from_bytes_le(bytes.as_ref()))
+    }
+
+    /// Creates a `FixedSizeBigInt` from big-endian bytes.
+    pub(crate) fn from_be_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, ParseBigIntError> {
+        Self::new_from_biguint(BigUint::from_bytes_be(bytes.as_ref()))
+    }
+
+    /// Returns the bit length.
+    ///
+    /// Bit length of `FixedSizeBigInt` is the minimum number of bits required to represent its
+    /// value. The underlying storage may be larger.
+    pub(crate) fn bit_len(&self) -> usize {
+        self.0.bits()
+    }
+
+    /// Returns the byte representation in little-endian order.
+    pub(crate) fn to_le_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes_le()
+    }
+
+    /// Returns the byte representation in big-endian order.
+    pub(crate) fn to_be_bytes(&self) -> Vec<u8> {
+        self.0.to_bytes_be()
+    }
+
+    /// Returns the underlying `BigUint`.
+    pub(crate) fn as_biguint(&self) -> &BigUint {
+        &self.0
+    }
+}
+
+impl<const BIT_LEN: usize, const EXACT_LEN: bool> ParseInt for FixedSizeBigInt<BIT_LEN, EXACT_LEN> {
+    type FromStrRadixErr = ParseBigIntError;
+
+    fn from_str_radix(src: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+        Self::new_from_biguint(
+            BigUint::from_str_radix(src, radix).map_err(ParseBigIntError::ParseBigIntError)?,
+        )
+    }
+}
+
+impl<const BIT_LEN: usize, const EXACT_LEN: bool> fmt::Display
+    for FixedSizeBigInt<BIT_LEN, EXACT_LEN>
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(
+            &format_args!("{:#0width$x}", self.0, width = Self::BYTE_LEN * 2 + 2),
+            f,
+        )
+    }
+}
+
+/// Helper macro for the `fixed_size_bigint` macro.
+macro_rules! fixed_size_bigint_impl {
+    ($struct_name:ident, $bit_len:expr, $exact_len:expr) => {
+        #[derive(Debug, Clone, Eq, PartialEq)]
+        pub struct $struct_name($crate::util::bigint::FixedSizeBigInt<$bit_len, $exact_len>);
+
+        const _: () = {
+            use num_bigint_dig::BigUint;
+            use std::fmt;
+
+            use $crate::util::bigint::{FixedSizeBigInt, ParseBigIntError};
+            use $crate::util::parse_int::ParseInt;
+
+            impl $struct_name {
+                pub fn from_le_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, ParseBigIntError> {
+                    Ok($struct_name(
+                        FixedSizeBigInt::<$bit_len, $exact_len>::from_le_bytes(bytes)?,
+                    ))
+                }
+
+                pub fn from_be_bytes(bytes: impl AsRef<[u8]>) -> Result<Self, ParseBigIntError> {
+                    Ok($struct_name(
+                        FixedSizeBigInt::<$bit_len, $exact_len>::from_be_bytes(bytes)?,
+                    ))
+                }
+
+                pub fn bit_len(&self) -> usize {
+                    self.0.bit_len()
+                }
+
+                pub fn to_le_bytes(&self) -> Vec<u8> {
+                    self.0.to_le_bytes()
+                }
+
+                pub fn to_be_bytes(&self) -> Vec<u8> {
+                    self.0.to_be_bytes()
+                }
+
+                pub(crate) fn as_biguint(&self) -> &BigUint {
+                    self.0.as_biguint()
+                }
+            }
+
+            impl ParseInt for $struct_name {
+                type FromStrRadixErr = ParseBigIntError;
+
+                fn from_str_radix(src: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+                    Ok($struct_name(
+                        FixedSizeBigInt::<$bit_len, $exact_len>::from_str_radix(src, radix)?,
+                    ))
+                }
+            }
+
+            impl fmt::Display for $struct_name {
+                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                    fmt::Display::fmt(&self.0, f)
+                }
+            }
+        };
+    };
+}
+
+pub(crate) use fixed_size_bigint_impl;
+
+/// Macro for defining a new fixed-size unsigned big integer type.
+///
+/// Defines a new type that wraps a `FixedSizeBigInt`. This macro is intended to be used within this
+/// crate to define types which can then be exported as needed:
+///
+/// ```
+/// use crate::util::bigint::fixed_size_bigint;
+///
+/// // Define a type for RSA-3072 moduli (exactly 3072 bits long):
+/// fixed_size_bigint!(Rsa3072Modulus, 3072);
+///
+/// // Define a type for SHA-256 digests (at most 256 bits long):
+/// fixed_size_bigint!(Sha256Digest, at_most 256);
+/// ```
+macro_rules! fixed_size_bigint {
+    ($struct_name:ident, $bit_len:expr) => {
+        $crate::util::bigint::fixed_size_bigint_impl!($struct_name, $bit_len, true);
+    };
+    ($struct_name:ident, at_most $bit_len:expr) => {
+        $crate::util::bigint::fixed_size_bigint_impl!($struct_name, $bit_len, false);
+    };
+}
+
+pub(crate) use fixed_size_bigint;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fixed_size_bigint!(TestArray, at_most 16);
+    fixed_size_bigint!(TestArrayExact, 16);
+
+    #[test]
+    fn test_from_to_le_bytes() {
+        fn check(slice: &[u8], data: &[u8]) {
+            assert_eq!(TestArray::from_le_bytes(slice).unwrap().to_le_bytes(), data);
+        }
+        check(&[], &[0]);
+        check(&[1], &[1]);
+        check(&[0, 1], &[0, 1]);
+        check(&[1, 0], &[1]);
+
+        assert!(TestArray::from_le_bytes([1, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn test_from_to_le_bytes_exact_len() {
+        fn check(slice: &[u8], data: &[u8]) {
+            assert_eq!(
+                TestArrayExact::from_le_bytes(slice).unwrap().to_le_bytes(),
+                data
+            );
+        }
+        check(&[0, 128], &[0, 128]);
+        check(&[255, 255, 0], &[255, 255]);
+
+        assert!(TestArrayExact::from_le_bytes([1]).is_err());
+        assert!(TestArrayExact::from_le_bytes([255, 127]).is_err());
+        assert!(TestArrayExact::from_le_bytes([0, 0, 1]).is_err());
+    }
+
+    #[test]
+    fn test_from_to_be_bytes() {
+        fn check(slice: &[u8], data: &[u8]) {
+            assert_eq!(TestArray::from_be_bytes(slice).unwrap().to_be_bytes(), data);
+        }
+        check(&[1], &[1]);
+        check(&[1, 0], &[1, 0]);
+        check(&[0, 1], &[1]);
+
+        assert!(TestArray::from_be_bytes([1, 2, 1]).is_err());
+    }
+
+    #[test]
+    fn test_from_to_be_bytes_exact_len() {
+        fn check(slice: &[u8], data: &[u8]) {
+            assert_eq!(
+                TestArrayExact::from_be_bytes(slice).unwrap().to_be_bytes(),
+                data
+            );
+        }
+        check(&[128, 1], &[128, 1]);
+        check(&[0, 255, 255], &[255, 255]);
+
+        assert!(TestArrayExact::from_be_bytes([1]).is_err());
+        assert!(TestArrayExact::from_be_bytes([127, 1]).is_err());
+        assert!(TestArrayExact::from_be_bytes([1, 0, 0]).is_err());
+    }
+
+    #[test]
+    fn test_bit_len() {
+        fn check(slice: &[u8], bit_len: usize) {
+            assert_eq!(TestArray::from_le_bytes(slice).unwrap().bit_len(), bit_len);
+        }
+        check(&[1], 1);
+        check(&[1, 0], 1);
+        check(&[255], 8);
+        check(&[0, 1], 9);
+        check(&[0, 128], 16);
+    }
+
+    #[test]
+    fn test_from_str() {
+        assert_eq!(TestArray::from_str("0x01").unwrap().to_le_bytes(), [1]);
+        assert_eq!(
+            TestArray::from_str("0x00201").unwrap().to_le_bytes(),
+            [1, 2]
+        );
+        assert!(TestArray::from_str("0x030201").is_err());
+    }
+
+    #[test]
+    fn test_from_str_exact_len() {
+        assert_eq!(
+            TestArrayExact::from_str("0x08001").unwrap().to_le_bytes(),
+            [1, 128]
+        );
+
+        assert!(TestArrayExact::from_str("0x01").is_err());
+        assert!(TestArrayExact::from_str("0x0201").is_err());
+        assert!(TestArrayExact::from_str("0x030201").is_err());
+    }
+
+    #[test]
+    fn test_fmt() {
+        let exact = TestArrayExact::from_str("0xabcd").unwrap();
+        assert_eq!(exact.to_string(), "0xabcd");
+
+        let at_most = TestArray::from_str("0xab").unwrap();
+        assert_eq!(at_most.to_string(), "0x00ab");
+
+        let at_most_full = TestArray::from_str("0xabcd").unwrap();
+        assert_eq!(at_most_full.to_string(), "0xabcd");
+    }
+}

--- a/sw/host/opentitanlib/src/util/mod.rs
+++ b/sw/host/opentitanlib/src/util/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod bigint;
 pub mod bitfield;
 pub mod file;
 pub mod image;

--- a/sw/host/opentitanlib/src/util/parse_int.rs
+++ b/sw/host/opentitanlib/src/util/parse_int.rs
@@ -5,10 +5,14 @@
 use std::num;
 use thiserror::Error;
 
+use crate::util::bigint;
+
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
 pub enum ParseIntError {
     #[error(transparent)]
     ParseIntError(#[from] num::ParseIntError),
+    #[error(transparent)]
+    ParseByteArrayError(#[from] bigint::ParseBigIntError),
 }
 
 /// Trait for parsing integers.

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -20,6 +20,8 @@ _DEPENDENCIES = {
         "lazy_static": "@raze__lazy_static__1_4_0//:lazy_static",
         "log": "@raze__log__0_4_14//:log",
         "nix": "@raze__nix__0_17_0//:nix",
+        "num-bigint-dig": "@raze__num_bigint_dig__0_7_0//:num_bigint_dig",
+        "num-traits": "@raze__num_traits__0_2_14//:num_traits",
         "num_enum": "@raze__num_enum__0_5_4//:num_enum",
         "regex": "@raze__regex__1_5_4//:regex",
         "rusb": "@raze__rusb__0_8_1//:rusb",
@@ -283,6 +285,24 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__autocfg__0_1_7",
+        url = "https://crates.io/api/v1/crates/autocfg/0.1.7/download",
+        type = "tar.gz",
+        strip_prefix = "autocfg-0.1.7",
+        build_file = Label("//third_party/cargo/remote:BUILD.autocfg-0.1.7.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__autocfg__1_0_1",
+        url = "https://crates.io/api/v1/crates/autocfg/1.0.1/download",
+        type = "tar.gz",
+        strip_prefix = "autocfg-1.0.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.autocfg-1.0.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__bitflags__1_3_2",
         url = "https://crates.io/api/v1/crates/bitflags/1.3.2/download",
         type = "tar.gz",
@@ -523,6 +543,15 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__libm__0_2_1",
+        url = "https://crates.io/api/v1/crates/libm/0.2.1/download",
+        type = "tar.gz",
+        strip_prefix = "libm-0.2.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.libm-0.2.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__libudev__0_2_0",
         url = "https://crates.io/api/v1/crates/libudev/0.2.0/download",
         type = "tar.gz",
@@ -619,6 +648,42 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__num_bigint_dig__0_7_0",
+        url = "https://crates.io/api/v1/crates/num-bigint-dig/0.7.0/download",
+        type = "tar.gz",
+        strip_prefix = "num-bigint-dig-0.7.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.num-bigint-dig-0.7.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__num_integer__0_1_44",
+        url = "https://crates.io/api/v1/crates/num-integer/0.1.44/download",
+        type = "tar.gz",
+        strip_prefix = "num-integer-0.1.44",
+        build_file = Label("//third_party/cargo/remote:BUILD.num-integer-0.1.44.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__num_iter__0_1_42",
+        url = "https://crates.io/api/v1/crates/num-iter/0.1.42/download",
+        type = "tar.gz",
+        strip_prefix = "num-iter-0.1.42",
+        build_file = Label("//third_party/cargo/remote:BUILD.num-iter-0.1.42.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__num_traits__0_2_14",
+        url = "https://crates.io/api/v1/crates/num-traits/0.2.14/download",
+        type = "tar.gz",
+        strip_prefix = "num-traits-0.2.14",
+        build_file = Label("//third_party/cargo/remote:BUILD.num-traits-0.2.14.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__num_enum__0_5_4",
         url = "https://crates.io/api/v1/crates/num_enum/0.5.4/download",
         type = "tar.gz",
@@ -665,6 +730,15 @@ def raze_fetch_remote_crates():
         sha256 = "12295df4f294471248581bc09bef3c38a5e46f1e36d6a37353621a0c6c357e1f",
         strip_prefix = "pkg-config-0.3.22",
         build_file = Label("//third_party/cargo/remote:BUILD.pkg-config-0.3.22.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ppv_lite86__0_2_16",
+        url = "https://crates.io/api/v1/crates/ppv-lite86/0.2.16/download",
+        type = "tar.gz",
+        strip_prefix = "ppv-lite86-0.2.16",
+        build_file = Label("//third_party/cargo/remote:BUILD.ppv-lite86-0.2.16.bazel"),
     )
 
     maybe(
@@ -735,6 +809,33 @@ def raze_fetch_remote_crates():
         sha256 = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05",
         strip_prefix = "quote-1.0.10",
         build_file = Label("//third_party/cargo/remote:BUILD.quote-1.0.10.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand__0_8_4",
+        url = "https://crates.io/api/v1/crates/rand/0.8.4/download",
+        type = "tar.gz",
+        strip_prefix = "rand-0.8.4",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand-0.8.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_chacha__0_3_1",
+        url = "https://crates.io/api/v1/crates/rand_chacha/0.3.1/download",
+        type = "tar.gz",
+        strip_prefix = "rand_chacha-0.3.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_chacha-0.3.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__rand_core__0_6_3",
+        url = "https://crates.io/api/v1/crates/rand_core/0.6.3/download",
+        type = "tar.gz",
+        strip_prefix = "rand_core-0.6.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand_core-0.6.3.bazel"),
     )
 
     maybe(
@@ -894,6 +995,24 @@ def raze_fetch_remote_crates():
         sha256 = "89e515aa4699a88148ed5ef96413ceef0048ce95b43fbc955a33bde0a70fcae6",
         strip_prefix = "shellwords-1.1.0",
         build_file = Label("//third_party/cargo/remote:BUILD.shellwords-1.1.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__smallvec__1_7_0",
+        url = "https://crates.io/api/v1/crates/smallvec/1.7.0/download",
+        type = "tar.gz",
+        strip_prefix = "smallvec-1.7.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.smallvec-1.7.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__spin__0_5_2",
+        url = "https://crates.io/api/v1/crates/spin/0.5.2/download",
+        type = "tar.gz",
+        strip_prefix = "spin-0.5.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.spin-0.5.2.bazel"),
     )
 
     maybe(

--- a/third_party/cargo/remote/BUILD.autocfg-0.1.7.bazel
+++ b/third_party/cargo/remote/BUILD.autocfg-0.1.7.bazel
@@ -26,17 +26,23 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 # Generated Targets
 
+# Unsupported target "integers" with type "example" omitted
+
+# Unsupported target "paths" with type "example" omitted
+
+# Unsupported target "traits" with type "example" omitted
+
+# Unsupported target "versions" with type "example" omitted
+
 rust_library(
-    name = "lazy_static",
+    name = "autocfg",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -48,13 +54,10 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.1.7",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
     ],
 )
 
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted
+# Unsupported target "rustflags" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -26,17 +26,23 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 # Generated Targets
 
+# Unsupported target "integers" with type "example" omitted
+
+# Unsupported target "paths" with type "example" omitted
+
+# Unsupported target "traits" with type "example" omitted
+
+# Unsupported target "versions" with type "example" omitted
+
 rust_library(
-    name = "lazy_static",
+    name = "autocfg",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -48,13 +54,10 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "1.0.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
     ],
 )
 
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted
+# Unsupported target "rustflags" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.libm-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.libm-0.2.1.bazel
@@ -30,17 +30,24 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
 
-rust_library(
-    name = "lazy_static",
+cargo_build_script(
+    name = "libm_build_script",
     srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
     crate_features = [
-        "spin",
-        "spin_no_std",
+        "default",
     ],
-    crate_root = "src/lib.rs",
-    data = [],
-    edition = "2015",
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -48,13 +55,31 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
-    # buildifier: leave-alone
+    version = "0.2.1",
+    visibility = ["//visibility:private"],
     deps = [
-        "@raze__spin__0_5_2//:spin",
     ],
 )
 
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted
+rust_library(
+    name = "libm",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.1",
+    # buildifier: leave-alone
+    deps = [
+        ":libm_build_script",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.num-bigint-dig-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.num-bigint-dig-0.7.0.bazel
@@ -1,0 +1,125 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "num_bigint_dig_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "i128",
+        "rand",
+        "serde",
+        "std",
+        "u64_digit",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__0_1_7//:autocfg",
+    ],
+)
+
+rust_library(
+    name = "num_bigint_dig",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "i128",
+        "rand",
+        "serde",
+        "std",
+        "u64_digit",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.7.0",
+    # buildifier: leave-alone
+    deps = [
+        ":num_bigint_dig_build_script",
+        "@raze__byteorder__1_4_3//:byteorder",
+        "@raze__lazy_static__1_4_0//:lazy_static",
+        "@raze__libm__0_2_1//:libm",
+        "@raze__num_integer__0_1_44//:num_integer",
+        "@raze__num_iter__0_1_42//:num_iter",
+        "@raze__num_traits__0_2_14//:num_traits",
+        "@raze__rand__0_8_4//:rand",
+        "@raze__serde__1_0_130//:serde",
+        "@raze__smallvec__1_7_0//:smallvec",
+    ],
+)
+
+# Unsupported target "bigint" with type "test" omitted
+
+# Unsupported target "bigint_bitwise" with type "test" omitted
+
+# Unsupported target "bigint_scalar" with type "test" omitted
+
+# Unsupported target "biguint" with type "test" omitted
+
+# Unsupported target "biguint_scalar" with type "test" omitted
+
+# Unsupported target "modpow" with type "test" omitted
+
+# Unsupported target "rand" with type "test" omitted
+
+# Unsupported target "roots" with type "test" omitted
+
+# Unsupported target "serde" with type "test" omitted
+
+# Unsupported target "torture" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -1,0 +1,99 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "num_integer_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "i128",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.44",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__1_0_1//:autocfg",
+    ],
+)
+
+# Unsupported target "average" with type "bench" omitted
+
+# Unsupported target "gcd" with type "bench" omitted
+
+# Unsupported target "roots" with type "bench" omitted
+
+rust_library(
+    name = "num_integer",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "i128",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.44",
+    # buildifier: leave-alone
+    deps = [
+        ":num_integer_build_script",
+        "@raze__num_traits__0_2_14//:num_traits",
+    ],
+)
+
+# Unsupported target "average" with type "test" omitted
+
+# Unsupported target "roots" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
+++ b/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
@@ -30,13 +30,41 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "num_iter_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.1.42",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__1_0_1//:autocfg",
+    ],
+)
 
 rust_library(
-    name = "lazy_static",
+    name = "num_iter",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -48,13 +76,11 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.1.42",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
+        ":num_iter_build_script",
+        "@raze__num_integer__0_1_44//:num_integer",
+        "@raze__num_traits__0_2_14//:num_traits",
     ],
 )
-
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -30,13 +30,47 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "num_traits_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+        "i128",
+        "std",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.14",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__1_0_1//:autocfg",
+    ],
+)
 
 rust_library(
-    name = "lazy_static",
+    name = "num_traits",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
+        "default",
+        "i128",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -48,13 +82,11 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.2.14",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
+        ":num_traits_build_script",
     ],
 )
 
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted
+# Unsupported target "cast" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.ppv-lite86-0.2.16.bazel
+++ b/third_party/cargo/remote/BUILD.ppv-lite86-0.2.16.bazel
@@ -32,15 +32,15 @@ licenses([
 # Generated Targets
 
 rust_library(
-    name = "lazy_static",
+    name = "ppv_lite86",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
+        "simd",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -48,13 +48,8 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.2.16",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
     ],
 )
-
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.rand-0.8.4.bazel
+++ b/third_party/cargo/remote/BUILD.rand-0.8.4.bazel
@@ -32,15 +32,20 @@ licenses([
 # Generated Targets
 
 rust_library(
-    name = "lazy_static",
+    name = "rand",
     srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
     crate_features = [
-        "spin",
-        "spin_no_std",
+        "alloc",
+        "getrandom",
+        "libc",
+        "rand_chacha",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -48,13 +53,25 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.8.4",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
-    ],
+        "@raze__rand_core__0_6_3//:rand_core",
+    ] + selects.with_or({
+        # cfg(not(target_os = "emscripten"))
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__rand_chacha__0_3_1//:rand_chacha",
+        ],
+        "//conditions:default": [],
+    }) + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_107//:libc",
+        ],
+        "//conditions:default": [],
+    }),
 )
-
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.rand_chacha-0.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.rand_chacha-0.3.1.bazel
@@ -32,15 +32,14 @@ licenses([
 # Generated Targets
 
 rust_library(
-    name = "lazy_static",
+    name = "rand_chacha",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -48,13 +47,10 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.3.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
+        "@raze__ppv_lite86__0_2_16//:ppv_lite86",
+        "@raze__rand_core__0_6_3//:rand_core",
     ],
 )
-
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.rand_core-0.6.3.bazel
+++ b/third_party/cargo/remote/BUILD.rand_core-0.6.3.bazel
@@ -32,15 +32,16 @@ licenses([
 # Generated Targets
 
 rust_library(
-    name = "lazy_static",
+    name = "rand_core",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
+        "alloc",
+        "getrandom",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -48,13 +49,9 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.6.3",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
+        "@raze__getrandom__0_2_3//:getrandom",
     ],
 )
-
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.smallvec-1.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.smallvec-1.7.0.bazel
@@ -31,16 +31,17 @@ licenses([
 
 # Generated Targets
 
+# Unsupported target "bench" with type "bench" omitted
+
 rust_library(
-    name = "lazy_static",
+    name = "smallvec",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
+        "write",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -48,13 +49,10 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "1.7.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
     ],
 )
 
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted
+# Unsupported target "macro" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.spin-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.spin-0.5.2.bazel
@@ -26,17 +26,17 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT"
 ])
 
 # Generated Targets
 
+# Unsupported target "debug" with type "example" omitted
+
 rust_library(
-    name = "lazy_static",
+    name = "spin",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "spin",
-        "spin_no_std",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -48,13 +48,8 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "1.4.0",
+    version = "0.5.2",
     # buildifier: leave-alone
     deps = [
-        "@raze__spin__0_5_2//:spin",
     ],
 )
-
-# Unsupported target "no_std" with type "test" omitted
-
-# Unsupported target "test" with type "test" omitted


### PR DESCRIPTION
This PR adds a macro (`fixed_size_bigint`) for defining fixed-size biginteger types for better type safety. Using these new types in opentitanlib's interface could also make changing our dependencies easier by decoupling opentitantool from what opentitanlib uses internally.

Examples:
```
use crate::util::bigint::fixed_size_bigint;

// Define a type for SHA-256 digests (at most 256 bits long):
fixed_size_bigint!(Sha256Digest, 256, exact_len = false);

// Define a type for RSA-3072 moduli (exactly 3072 bits long):
fixed_size_bigint!(Rsa3072Modulus, 3072, exact_len = true);
// or (exact_len is true by default):
fixed_size_bigint!(Rsa3072Modulus, 3072);
```