### PR TITLE
Faster computation of R^2 for OTBN.

### DIFF
--- a/sw/otbn/crypto/meson.build
+++ b/sw/otbn/crypto/meson.build
@@ -96,12 +96,14 @@ sw_otbn_sources += {
     'rsa_verify_3072_consts_test.s',
     'rsa_verify_3072_rr.s',
     'rsa_verify_3072_m0inv.s',
+    'rsa_verify_3072.s',
   ),
   'rsa_verify_3072_m0inv': files(
     'rsa_verify_3072_m0inv.s',
   ),
   'rsa_verify_3072_rr': files(
     'rsa_verify_3072_rr.s',
+    'rsa_verify_3072.s',
   ),
   'rsa_verify_3072_test': files(
     'rsa_verify_3072_test.s',

--- a/sw/otbn/crypto/rsa_verify_3072.s
+++ b/sw/otbn/crypto/rsa_verify_3072.s
@@ -130,11 +130,11 @@ mul256_w30xw2:
  * @param[in]  w2:  current limb of operand B, b_i
  * @param[in]  w3:  Montgomery constant m0'
  * @param[in]  w31: all-zero
- * @param[in]  [w[4+N-1]:w4] intermediate result A
- * @param[out] [w[4+N-1]:w4] intermediate result A
+ * @param[in]  [w15:w4] intermediate result A
+ * @param[out] [w15:w4] intermediate result A
  *
- * clobbered registers: x8, x10, x12, x13, x16, x19
- *                      w24, w25, w26, w27, w28, w29, w30, w4 to w[4+N-1]
+ * clobbered registers: x2, x8, x10, x12, x13, x16, x19, x22
+ *                      w24, w25, w26, w27, w28, w29, w30, w4 to w15
  * clobbered Flag Groups: FG0, FG1
  */
 mont_loop:
@@ -299,10 +299,11 @@ mont_loop:
  * @param[in]  x11: pointer to temp reg, must be set to 2
  * @param[out] [w15:w4]: result C
  *
- * clobbered registers: x5, x6, x7, x8, x10, x12, x13, x17, x19, x20, x21
- *                      w2, to w15, w24 to w30
+ * clobbered registers: x2, x6 to x13, x22
+ *                      w2, w4 to w15, w24 to w30
  * clobbered Flag Groups: FG0, FG1
  */
+.globl montmul
 montmul:
   /* load Montgomery constant: w3 = dmem[x17] = dmem[dptr_m0d] = m0' */
   bn.lid    x9, 0(x17)
@@ -354,8 +355,8 @@ montmul:
  * @param[in]  dmem[in_buf] pointer to buffer with base bignum
  * @param[in]  dmem[out_buf] pointer to output buffer
  *
- * clobbered registers: x2, x5 to x13, x16 to x21, x29
-                        w2, to w15, w24 to w31
+ * clobbered registers: x2, x6 to x13, x16, x17, x19 to x22, x26,
+ *                      w2 to w31
  * clobbered Flag Groups: FG0, FG1
  */
  .globl modexp_var_3072_3
@@ -452,8 +453,8 @@ modexp_var_3072_3:
  * @param[in]  dmem[in_buf] pointer to buffer with base bignum
  * @param[in]  dmem[out_buf] pointer to output buffer
  *
- * clobbered registers: x2, x5 to x13, x16 to x21, x29
-                        w2, to w15, w24 to w31
+ * clobbered registers: x2, x6 to x13, x16, x17, x19 to x24, x26,
+                        w2 to w31
  * clobbered Flag Groups: FG0, FG1
  */
  .globl modexp_var_3072_f4

--- a/sw/otbn/crypto/rsa_verify_3072_consts_test.s
+++ b/sw/otbn/crypto/rsa_verify_3072_consts_test.s
@@ -11,11 +11,11 @@
  * w0). See comment at the end of the file for expected values.
  */
 run_rsa_verify_3072_consts_test:
-  /* Compute R^2 = (2^3072)^2 mod M */
-  jal      x1, compute_rr
-
   /* Compute m0_inv = (- (M^-1)) mod 2^256 */
   jal      x1, compute_m0_inv
+
+  /* Compute R^2 = (2^3072)^2 mod M */
+  jal      x1, compute_rr
 
   /* Copy m0_inv to w0 */
   li       x8, 0

--- a/sw/otbn/crypto/rsa_verify_3072_rr.s
+++ b/sw/otbn/crypto/rsa_verify_3072_rr.s
@@ -177,9 +177,9 @@ compute_rr:
   /* [w4:w15] <= [w4:w16] >> 1 = 2^3701 */
   bn.rshi   w15, w16, w15 >> 1
 
-  /* Compute T = (2^3 * R) mod M = 2^3 (montgomery form).
-     T = [w4:w15] = (2^4 * 2^3071) mod M = (2^3 * R) mod M */
-  loopi     4,2
+  /* Compute T = (2^96 * R) mod M = 2^96 (montgomery form).
+     T = [w4:w15] = (2^97 * 2^3071) mod M = (2^96 * R) mod M */
+  loopi     97,2
     jal x1, double_mod_var
     nop
 
@@ -199,8 +199,8 @@ compute_rr:
   /* Prepare a pointer to the w4 register for storing the result. */
   li        x8, 4
 
-  /* Ten montgomery squares to compute RR = (T^(2^10) * R) mod M. */
-  loopi     10,9
+  /* Five montgomery squares to compute RR = (T^(2^5) * R) mod M. */
+  loopi     5,9
     /* [w4:w15] <= montmul(dmem[rr], dmem[rr]) */
     addi      x19, x24, 0
     addi      x20, x24, 0

--- a/sw/otbn/crypto/rsa_verify_3072_rr.s
+++ b/sw/otbn/crypto/rsa_verify_3072_rr.s
@@ -138,32 +138,32 @@ sel_aa:
  *
  *   Returns RR = (2^3072)^2 mod M
  *
- * This implementation is based on section 2.3 of "Montgomery Arithmetic from a
- * Software Perspective" (https://eprint.iacr.org/2017/1057). For the purposes
- * of RSA 3072, the parameters w and n from the paper are fixed (w=256, n=12).
- *
- * A note on bounds: the algorithm from the paper states an assumption that
- * 2^wn-1 <= M < 2^wn (in our case, 2^3071 <= M < 2^3072). We make that
- * assumption here too, because it agrees with FIPS 186-4 section B.3.1 (page
- * 53), which states that the prime factors of the RSA modulus must be at least
- * sqrt(2)*2^(nlen/2-1) (where nlen is the key length, 3072 in this case).
+ * A note on bounds: This computation assumes that 2^3071 <= M < 2^3072. This
+ * agrees with FIPS 186-4 section B.3.1 (page 53), which states that the prime
+ * factors of the RSA modulus must be at least sqrt(2)*2^(nlen/2-1) (where nlen
+ * is the key length, 3072 in this case).
  *
  * The result is stored in dmem[rr]. This routine runs in variable time.
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
  * @param[in]  dmem[in_mod] pointer to first limb of modulus M in dmem
+ * @param[in]  dmem[m0inv]  Montgomery constant (-(M^-1) mod 2^256)
+ * @param[out] dmem[rr]     Montgomery constant (R^2) mod M
  *
- * clobbered registers: x9, x10, x16, w4 to w16, w31
- * clobbered Flag Groups: FG0
+ * clobbered registers: x0 to x3, x6 to x13, x16, x17, x19 to x22, x24,
+ *                      w2 to w31
+ * clobbered Flag Groups: FG0, FG1
  */
  .globl compute_rr
 compute_rr:
   /* Prepare all-zero register. */
   bn.xor    w31, w31, w31
 
-  /* Set pointer to modulus. */
+  /* Set pointers to DMEM buffers. */
   la        x16, in_mod
+  la        x17, m0inv
+  la        x24, rr
 
   /* Zero [w4:w15]. */
   li        x9, 4
@@ -174,29 +174,52 @@ compute_rr:
   /* w16 <= 1 */
   bn.addi   w16, w31, 1
 
-  /* Initialize c0.
-     c0 = [w4:w15] <= [w4:w16] >> 1 = 2^3701 */
+  /* [w4:w15] <= [w4:w16] >> 1 = 2^3701 */
   bn.rshi   w15, w16, w15 >> 1
 
-  /* One modular doubling to get c1 \equiv 2^3072 mod M.
-     c1 = [w4:w15] <= ([w4:w15] * 2) mod M = (2^3072) mod M */
-  jal     x1, double_mod_var
-
-  /* Compute (2^3072)^2 mod M by performing 3072 modular doublings. */
-  li      x9, 3072
-  loop     x9, 4
-    jal     x1, double_mod_var
-    /* Nop because loop can't end on a jump instruction. */
+  /* Compute T = (2^3 * R) mod M = 2^3 (montgomery form).
+     T = [w4:w15] = (2^4 * 2^3071) mod M = (2^3 * R) mod M */
+  loopi     4,2
+    jal x1, double_mod_var
     nop
 
-  /* Store result in dmem[rr]. */
-  li        x9, 4
-  la        x10, rr
+  /* Store T in output buffer (in preparation for montmul).
+     dmem[rr] <= [w4:w15] = T */
+  li        x8, 4
+  addi      x21, x24, 0
   loopi     12, 2
-    bn.sid    x9, 0(x10++)
-    addi      x9, x9, 1
+    bn.sid    x8, 0(x21++)
+    addi      x8, x8, 1
+
+  /* Prepare pointers to temp regs for montmul. */
+  li        x9, 3
+  li        x10, 4
+  li        x11, 2
+
+  /* Prepare a pointer to the w4 register for storing the result. */
+  li        x8, 4
+
+  /* Ten montgomery squares to compute RR = (T^(2^10) * R) mod M. */
+  loopi     10,9
+    /* [w4:w15] <= montmul(dmem[rr], dmem[rr]) */
+    addi      x19, x24, 0
+    addi      x20, x24, 0
+    jal       x1, montmul
+    /* Store result: dmem[rr] <= [w4:w15] */
+    addi      x21, x24, 0
+    addi      x22, x8, 0
+    loopi     12, 2
+      bn.sid    x22, 0(x21++)
+      addi      x22, x22, 1
+    nop
 
   ret
+
+/* Input buffer for the Montgomery constant m0_inv. */
+.section .data.m0inv
+.weak m0inv
+m0inv:
+  .zero 32
 
 /* Input buffer for the modulus. */
 .section .data.in_mod


### PR DESCRIPTION
Thanks to @davidben for this algorithm. This takes our R^2 computation from 431579 cycles to 55937 cycles (a 7.7x speedup)!

Note that this means R^2 computation includes montgomery multiplication, so I made `montmul` globally visible and moved the computation of `m0_inv` before it (since montgomery multiplication relies on that value).

As I was implementing this subroutine, I noticed that a few of the "clobbered register" comments for `montmul` and `mont_loop` were outdated, so I've updated them to match the current behavior.