### PR TITLE
[edn/dv] Moved genbits_push_agent load before host_seq start

### DIFF
--- a/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_smoke_vseq.sv
@@ -13,32 +13,40 @@ class edn_smoke_vseq extends edn_base_vseq;
   bit [entropy_src_pkg::FIPS_BUS_WIDTH - 1:0]   fips;
   bit [edn_pkg::ENDPOINT_BUS_WIDTH - 1:0]       edn_bus[edn_env_pkg::NUM_ENDPOINTS];
 
+  bit [3:0]                                     acmd, clen, flags;
+  bit [17:0]                                    glen;
+
   task body();
     // Wait for cmd_rdy
     csr_spinwait(.ptr(ral.sw_cmd_sts.cmd_rdy), .exp_data(1'b1));
 
-    // Send INS cmd
-    csr_wr(.ptr(ral.sw_cmd_req), .value(32'h1));
+    // Create/Send INS cmd
+    acmd  = csrng_pkg::INS;
+    flags = 4'h1;
+    csr_wr(.ptr(ral.sw_cmd_req), .value({glen, flags, clen, acmd}));
 
     // Expect/Clear interrupt bit
     csr_spinwait(.ptr(ral.intr_state.edn_cmd_req_done), .exp_data(1'b1));
     check_interrupts(.interrupts((1 << CmdReqDone)), .check_set(1'b1));
 
-    // Send GEN cmd w/ GLEN 1 (request single genbits)
-    csr_wr(.ptr(ral.sw_cmd_req), .value(32'h1003));
-
     // Load expected genbits data
-    m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
-        create("m_endpoint_pull_seq");
     `DV_CHECK_STD_RANDOMIZE_FATAL(fips)
     `DV_CHECK_STD_RANDOMIZE_FATAL(genbits)
     cfg.m_csrng_agent_cfg.m_genbits_push_agent_cfg.add_h_user_data({fips, genbits});
+
+    // Create/Send GEN cmd
+    acmd  = csrng_pkg::GEN;
+    flags = 4'h0;
+    glen  = 'h1;
+    csr_wr(.ptr(ral.sw_cmd_req), .value({glen, flags, clen, acmd}));
 
     // Expect/Clear interrupt bit
     csr_spinwait(.ptr(ral.intr_state.edn_cmd_req_done), .exp_data(1'b1));
     check_interrupts(.interrupts((1 << CmdReqDone)), .check_set(1'b1));
 
     // Request data
+    m_endpoint_pull_seq = push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)::type_id::
+        create("m_endpoint_pull_seq");
     m_endpoint_pull_seq.start(p_sequencer.endpoint_sequencer_h[0]);
 
     // Compare actual/expected data


### PR DESCRIPTION
Some regression failures because h_user_data load happening after request if random delay was short.

Signed-off-by: Steve Nelson <steve.nelson@wdc.com>