### PR TITLE
[entropy_src/rtl] Modify enable registers

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -113,6 +113,20 @@
 
   regwidth: "32",
   registers: [
+    { name: "REGWEN_ME",
+      desc: "Register write enable for module enable control register",
+      swaccess: "rw0c",
+      hwaccess: "none",
+      fields: [
+        {
+            bits: "0",
+            desc: ''' When true, the !!MODULE_ENABLE register can be modified.
+            When false, it becomes read-only.
+            '''
+            resval: 1
+        }
+      ]
+    },
     { name: "REGWEN",
       desc: "Register write enable for all control registers",
       swaccess: "rw0c",
@@ -149,6 +163,25 @@
         }
       ]
     },
+    { name: "MODULE_ENABLE",
+      desc: "Module enable register",
+      swaccess: "rw",
+      hwaccess: "hro",
+      regwen:   "REGWEN_ME",
+      tags: [// Exclude from writes to these field because they cause side affects.
+             "excl:CsrAllTests:CsrExclAll"]
+      fields: [
+        { bits: "3:0",
+          mubi: true,
+          name: "MODULE_ENABLE",
+          desc: '''
+                Setting this field to kMuBi4True will enable the ENTROPY_SRC module. Setting
+                this field to kMuBi4False will effectively reset the module.
+                '''
+          resval: false,
+        },
+      ]
+    },
     { name: "CONF",
       desc: "Configuration register",
       swaccess: "rw",
@@ -158,10 +191,11 @@
              "excl:CsrAllTests:CsrExclAll"]
       fields: [
         { bits: "3:0",
-          name: "ENABLE",
+          name: "FIPS_ENABLE",
           mubi: true,
           desc: '''
-                Setting this field to kMuBi4True will enable the ENTROPY_SRC module.
+                Setting this field to kMuBi4True will enable FIPS qualified entropy to be
+                generated.
                 '''
           resval: false,
         },
@@ -1153,9 +1187,9 @@
       hwaccess: "hwo",
       fields: [
         { bits: "0",
-          name: "ENABLE_FIELD_ALERT",
+          name: "FIPS_ENABLE_FIELD_ALERT",
           desc: '''
-                This bit is set when the ENABLE field in the !!CONF register is set to
+                This bit is set when the FIPS_ENABLE field in the !!CONF register is set to
                 a value other than 0x5 or 0xA.
                 Writing a zero resets this status bit.
                 '''
@@ -1164,6 +1198,14 @@
           name: "ENTROPY_DATA_REG_EN_FIELD_ALERT",
           desc: '''
                 This bit is set when the ENTROPY_DATA_REG_ENABLE field in the !!CONF register is set to
+                a value other than 0x5 or 0xA.
+                Writing a zero resets this status bit.
+                '''
+        }
+        { bits: "2",
+          name: "MODULE_ENABLE_FIELD_ALERT",
+          desc: '''
+                This bit is set when the MODULE_ENABLE field in the !!MODULE_ENABLE register is set to
                 a value other than 0x5 or 0xA.
                 Writing a zero resets this status bit.
                 '''

--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -650,9 +650,9 @@ class entropy_src_scoreboard extends cip_base_scoreboard
         void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
         // Special handling for registers with broader impacts
         case (csr.get_name())
-          "conf": begin
+          "module_enable": begin
             bit do_disable, do_enable;
-            uvm_reg_field enable_field = csr.get_field_by_name("enable");
+            uvm_reg_field enable_field = csr.get_field_by_name("module_enable");
             prim_mubi_pkg::mubi4_t enable_mubi = enable_field.get_mirrored_value();
             // TODO: integrate this with invalid MuBi checks
             do_disable = (enable_mubi == prim_mubi_pkg::MuBi4False);
@@ -698,7 +698,11 @@ class entropy_src_scoreboard extends cip_base_scoreboard
       end
       "intr_test": begin
       end
+      "regwen_me": begin
+      end
       "regwen": begin
+      end
+      "module_enable": begin
       end
       "conf": begin
       end

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -81,13 +81,13 @@ class entropy_src_base_vseq extends cip_base_vseq #(
       `uvm_info(`gfn, $sformatf("Found %01d seeds", seeds_found), UVM_HIGH)
     end while (seeds_found > 0);
 
+    `uvm_info(`gfn, "Disabling DUT", UVM_MEDIUM)
+    ral.module_enable.module_enable.set(prim_mubi_pkg::MuBi4False);
+    csr_update(.csr(ral.module_enable));
+
     `uvm_info(`gfn, "Checking diagnostics", UVM_MEDIUM)
     check_ht_diagnostics();
-    `uvm_info(`gfn, "Disabling DUT", UVM_MEDIUM)
-    ral.conf.enable.set(prim_mubi_pkg::MuBi4False);
-    csr_update(.csr(ral.conf));
     `uvm_info(`gfn, "Clearing Alerts", UVM_MEDIUM)
-    ral.conf.enable.set(prim_mubi_pkg::MuBi4False);
     ral.recov_alert_sts.es_main_sm_alert.set(1'b0);
     csr_update(.csr(ral.recov_alert_sts));
     super.dut_shutdown();
@@ -108,12 +108,16 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     // Thresholds managed in derived vseq classes
 
     // Enables (should be done last)
-    ral.conf.enable.set(cfg.enable);
+    ral.conf.fips_enable.set(cfg.enable);
+
     ral.conf.entropy_data_reg_enable.set(cfg.entropy_data_reg_enable);
     ral.conf.boot_bypass_disable.set(cfg.boot_bypass_disable);
     ral.conf.rng_bit_enable.set(cfg.rng_bit_enable);
     ral.conf.rng_bit_sel.set(cfg.rng_bit_sel);
     csr_update(.csr(ral.conf));
+
+    ral.module_enable.set(cfg.enable); // TODO: Change config here?
+    csr_update(.csr(ral.module_enable));
 
     if (do_interrupt) begin
       ral.intr_enable.set(en_intr);

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -63,8 +63,8 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
 
   task enable_dut();
     `uvm_info(`gfn, "CSR Thread: Enabling DUT", UVM_MEDIUM)
-    ral.conf.enable.set(prim_mubi_pkg::MuBi4True);
-    csr_update(.csr(ral.conf));
+    ral.module_enable.set(prim_mubi_pkg::MuBi4True);
+    csr_update(.csr(ral.module_enable));
   endtask
 
   virtual task entropy_src_init();
@@ -155,7 +155,7 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
       `uvm_info(`gfn, "Identified main_sm alert", UVM_HIGH)
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(dly_to_access_alert_sts)
       cfg.clk_rst_vif.wait_clks(dly_to_access_alert_sts);
-      csr_wr(.ptr(ral.conf.enable), .value(prim_mubi_pkg::MuBi4False));
+      csr_wr(.ptr(ral.module_enable.module_enable), .value(prim_mubi_pkg::MuBi4False));
       csr_wr(.ptr(ral.recov_alert_sts.es_main_sm_alert), .value(1'b1));
       `DV_CHECK_MEMBER_RANDOMIZE_FATAL(do_check_ht_diag)
       if (do_check_ht_diag) begin
@@ -164,9 +164,9 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
         // read all health check values
         `uvm_info(`gfn, "Checking_ht_values", UVM_HIGH)
         check_ht_diagnostics();
-        `uvm_info(`gfn, "ht value check complete", UVM_HIGH)
+        `uvm_info(`gfn, "HT value check complete", UVM_HIGH)
       end
-      csr_wr(.ptr(ral.conf.enable), .value(prim_mubi_pkg::MuBi4True));
+      csr_wr(.ptr(ral.module_enable.module_enable), .value(prim_mubi_pkg::MuBi4True));
     end
   endtask
 

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -77,9 +77,13 @@ package entropy_src_reg_pkg;
   } entropy_src_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
+    logic [3:0]  q;
+  } entropy_src_reg2hw_module_enable_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic [3:0]  q;
-    } enable;
+    } fips_enable;
     struct packed {
       logic [3:0]  q;
     } entropy_data_reg_enable;
@@ -549,11 +553,15 @@ package entropy_src_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
-    } enable_field_alert;
+    } fips_enable_field_alert;
     struct packed {
       logic        d;
       logic        de;
     } entropy_data_reg_en_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } module_enable_field_alert;
     struct packed {
       logic        d;
       logic        de;
@@ -637,10 +645,11 @@ package entropy_src_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    entropy_src_reg2hw_intr_state_reg_t intr_state; // [539:536]
-    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [535:532]
-    entropy_src_reg2hw_intr_test_reg_t intr_test; // [531:524]
-    entropy_src_reg2hw_alert_test_reg_t alert_test; // [523:520]
+    entropy_src_reg2hw_intr_state_reg_t intr_state; // [543:540]
+    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [539:536]
+    entropy_src_reg2hw_intr_test_reg_t intr_test; // [535:528]
+    entropy_src_reg2hw_alert_test_reg_t alert_test; // [527:524]
+    entropy_src_reg2hw_module_enable_reg_t module_enable; // [523:520]
     entropy_src_reg2hw_conf_reg_t conf; // [519:498]
     entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [497:490]
     entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [489:457]
@@ -664,41 +673,41 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1048:1041]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1040:1009]
-    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1008:977]
-    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [976:945]
-    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [944:913]
-    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [912:881]
-    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [880:849]
-    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [848:817]
-    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [816:785]
-    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [784:753]
-    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [752:721]
-    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [720:689]
-    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [688:657]
-    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [656:625]
-    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [624:593]
-    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [592:561]
-    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [560:529]
-    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [528:497]
-    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [496:465]
-    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [464:433]
-    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [432:401]
-    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [400:369]
-    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [368:337]
-    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [336:305]
-    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [304:273]
-    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [272:241]
-    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [240:209]
-    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [208:177]
-    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [176:145]
-    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [144:129]
-    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [128:101]
-    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [100:93]
-    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [92:61]
-    entropy_src_hw2reg_debug_status_reg_t debug_status; // [60:42]
-    entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [41:18]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1050:1043]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1042:1011]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1010:979]
+    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [978:947]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [946:915]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [914:883]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [882:851]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [850:819]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [818:787]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [786:755]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [754:723]
+    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [722:691]
+    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [690:659]
+    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [658:627]
+    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [626:595]
+    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [594:563]
+    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [562:531]
+    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [530:499]
+    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [498:467]
+    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [466:435]
+    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [434:403]
+    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [402:371]
+    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [370:339]
+    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [338:307]
+    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [306:275]
+    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [274:243]
+    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [242:211]
+    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [210:179]
+    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [178:147]
+    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [146:131]
+    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [130:103]
+    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [102:95]
+    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [94:63]
+    entropy_src_hw2reg_debug_status_reg_t debug_status; // [62:44]
+    entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [43:18]
     entropy_src_hw2reg_err_code_reg_t err_code; // [17:0]
   } entropy_src_hw2reg_t;
 
@@ -707,51 +716,53 @@ package entropy_src_reg_pkg;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_INTR_ENABLE_OFFSET = 8'h 4;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_INTR_TEST_OFFSET = 8'h 8;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_TEST_OFFSET = 8'h c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_OFFSET = 8'h 10;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REV_OFFSET = 8'h 14;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_CONF_OFFSET = 8'h 18;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_CONTROL_OFFSET = 8'h 1c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_DATA_OFFSET = 8'h 20;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET = 8'h 24;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET = 8'h 28;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET = 8'h 2c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET = 8'h 30;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET = 8'h 34;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET = 8'h 38;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET = 8'h 3c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET = 8'h 40;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET = 8'h 44;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET = 8'h 48;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET = 8'h 4c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET = 8'h 50;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET = 8'h 54;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET = 8'h 58;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET = 8'h 5c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET = 8'h 60;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET = 8'h 64;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET = 8'h 68;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET = 8'h 6c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET = 8'h 70;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET = 8'h 74;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET = 8'h 78;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET = 8'h 7c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET = 8'h 80;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET = 8'h 84;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET = 8'h 88;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET = 8'h 8c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET = 8'h 90;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_THRESHOLD_OFFSET = 8'h 94;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET = 8'h 98;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET = 8'h 9c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET = 8'h a0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h a4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h a8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h ac;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h b0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h b4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h b8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h bc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h c0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_ME_OFFSET = 8'h 10;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_OFFSET = 8'h 14;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REV_OFFSET = 8'h 18;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MODULE_ENABLE_OFFSET = 8'h 1c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_CONF_OFFSET = 8'h 20;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_CONTROL_OFFSET = 8'h 24;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_DATA_OFFSET = 8'h 28;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET = 8'h 2c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET = 8'h 30;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET = 8'h 34;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET = 8'h 38;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET = 8'h 3c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET = 8'h 40;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET = 8'h 44;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET = 8'h 48;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET = 8'h 4c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET = 8'h 50;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET = 8'h 54;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET = 8'h 5c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET = 8'h 60;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET = 8'h 64;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET = 8'h 68;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET = 8'h 6c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET = 8'h 70;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET = 8'h 74;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET = 8'h 78;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET = 8'h 7c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET = 8'h 80;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET = 8'h 84;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET = 8'h 88;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET = 8'h 8c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET = 8'h 90;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET = 8'h 94;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET = 8'h 98;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_THRESHOLD_OFFSET = 8'h 9c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET = 8'h a0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET = 8'h a4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET = 8'h a8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h ac;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h b0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h b4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h b8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h bc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h c0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h c4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h c8;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] ENTROPY_SRC_INTR_TEST_RESVAL = 4'h 0;
@@ -827,8 +838,10 @@ package entropy_src_reg_pkg;
     ENTROPY_SRC_INTR_ENABLE,
     ENTROPY_SRC_INTR_TEST,
     ENTROPY_SRC_ALERT_TEST,
+    ENTROPY_SRC_REGWEN_ME,
     ENTROPY_SRC_REGWEN,
     ENTROPY_SRC_REV,
+    ENTROPY_SRC_MODULE_ENABLE,
     ENTROPY_SRC_CONF,
     ENTROPY_SRC_ENTROPY_CONTROL,
     ENTROPY_SRC_ENTROPY_DATA,
@@ -875,56 +888,58 @@ package entropy_src_reg_pkg;
   } entropy_src_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] ENTROPY_SRC_PERMIT [49] = '{
+  parameter logic [3:0] ENTROPY_SRC_PERMIT [51] = '{
     4'b 0001, // index[ 0] ENTROPY_SRC_INTR_STATE
     4'b 0001, // index[ 1] ENTROPY_SRC_INTR_ENABLE
     4'b 0001, // index[ 2] ENTROPY_SRC_INTR_TEST
     4'b 0001, // index[ 3] ENTROPY_SRC_ALERT_TEST
-    4'b 0001, // index[ 4] ENTROPY_SRC_REGWEN
-    4'b 0111, // index[ 5] ENTROPY_SRC_REV
-    4'b 1111, // index[ 6] ENTROPY_SRC_CONF
-    4'b 0001, // index[ 7] ENTROPY_SRC_ENTROPY_CONTROL
-    4'b 1111, // index[ 8] ENTROPY_SRC_ENTROPY_DATA
-    4'b 1111, // index[ 9] ENTROPY_SRC_HEALTH_TEST_WINDOWS
-    4'b 1111, // index[10] ENTROPY_SRC_REPCNT_THRESHOLDS
-    4'b 1111, // index[11] ENTROPY_SRC_REPCNTS_THRESHOLDS
-    4'b 1111, // index[12] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS
-    4'b 1111, // index[13] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS
-    4'b 1111, // index[14] ENTROPY_SRC_BUCKET_THRESHOLDS
-    4'b 1111, // index[15] ENTROPY_SRC_MARKOV_HI_THRESHOLDS
-    4'b 1111, // index[16] ENTROPY_SRC_MARKOV_LO_THRESHOLDS
-    4'b 1111, // index[17] ENTROPY_SRC_EXTHT_HI_THRESHOLDS
-    4'b 1111, // index[18] ENTROPY_SRC_EXTHT_LO_THRESHOLDS
-    4'b 1111, // index[19] ENTROPY_SRC_REPCNT_HI_WATERMARKS
-    4'b 1111, // index[20] ENTROPY_SRC_REPCNTS_HI_WATERMARKS
-    4'b 1111, // index[21] ENTROPY_SRC_ADAPTP_HI_WATERMARKS
-    4'b 1111, // index[22] ENTROPY_SRC_ADAPTP_LO_WATERMARKS
-    4'b 1111, // index[23] ENTROPY_SRC_EXTHT_HI_WATERMARKS
-    4'b 1111, // index[24] ENTROPY_SRC_EXTHT_LO_WATERMARKS
-    4'b 1111, // index[25] ENTROPY_SRC_BUCKET_HI_WATERMARKS
-    4'b 1111, // index[26] ENTROPY_SRC_MARKOV_HI_WATERMARKS
-    4'b 1111, // index[27] ENTROPY_SRC_MARKOV_LO_WATERMARKS
-    4'b 1111, // index[28] ENTROPY_SRC_REPCNT_TOTAL_FAILS
-    4'b 1111, // index[29] ENTROPY_SRC_REPCNTS_TOTAL_FAILS
-    4'b 1111, // index[30] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS
-    4'b 1111, // index[31] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS
-    4'b 1111, // index[32] ENTROPY_SRC_BUCKET_TOTAL_FAILS
-    4'b 1111, // index[33] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS
-    4'b 1111, // index[34] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS
-    4'b 1111, // index[35] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS
-    4'b 1111, // index[36] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS
-    4'b 1111, // index[37] ENTROPY_SRC_ALERT_THRESHOLD
-    4'b 0011, // index[38] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS
-    4'b 1111, // index[39] ENTROPY_SRC_ALERT_FAIL_COUNTS
-    4'b 0001, // index[40] ENTROPY_SRC_EXTHT_FAIL_COUNTS
-    4'b 0001, // index[41] ENTROPY_SRC_FW_OV_CONTROL
-    4'b 1111, // index[42] ENTROPY_SRC_FW_OV_RD_DATA
-    4'b 1111, // index[43] ENTROPY_SRC_FW_OV_WR_DATA
-    4'b 0001, // index[44] ENTROPY_SRC_OBSERVE_FIFO_THRESH
-    4'b 1111, // index[45] ENTROPY_SRC_DEBUG_STATUS
-    4'b 0011, // index[46] ENTROPY_SRC_RECOV_ALERT_STS
-    4'b 1111, // index[47] ENTROPY_SRC_ERR_CODE
-    4'b 0001  // index[48] ENTROPY_SRC_ERR_CODE_TEST
+    4'b 0001, // index[ 4] ENTROPY_SRC_REGWEN_ME
+    4'b 0001, // index[ 5] ENTROPY_SRC_REGWEN
+    4'b 0111, // index[ 6] ENTROPY_SRC_REV
+    4'b 0001, // index[ 7] ENTROPY_SRC_MODULE_ENABLE
+    4'b 1111, // index[ 8] ENTROPY_SRC_CONF
+    4'b 0001, // index[ 9] ENTROPY_SRC_ENTROPY_CONTROL
+    4'b 1111, // index[10] ENTROPY_SRC_ENTROPY_DATA
+    4'b 1111, // index[11] ENTROPY_SRC_HEALTH_TEST_WINDOWS
+    4'b 1111, // index[12] ENTROPY_SRC_REPCNT_THRESHOLDS
+    4'b 1111, // index[13] ENTROPY_SRC_REPCNTS_THRESHOLDS
+    4'b 1111, // index[14] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS
+    4'b 1111, // index[15] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS
+    4'b 1111, // index[16] ENTROPY_SRC_BUCKET_THRESHOLDS
+    4'b 1111, // index[17] ENTROPY_SRC_MARKOV_HI_THRESHOLDS
+    4'b 1111, // index[18] ENTROPY_SRC_MARKOV_LO_THRESHOLDS
+    4'b 1111, // index[19] ENTROPY_SRC_EXTHT_HI_THRESHOLDS
+    4'b 1111, // index[20] ENTROPY_SRC_EXTHT_LO_THRESHOLDS
+    4'b 1111, // index[21] ENTROPY_SRC_REPCNT_HI_WATERMARKS
+    4'b 1111, // index[22] ENTROPY_SRC_REPCNTS_HI_WATERMARKS
+    4'b 1111, // index[23] ENTROPY_SRC_ADAPTP_HI_WATERMARKS
+    4'b 1111, // index[24] ENTROPY_SRC_ADAPTP_LO_WATERMARKS
+    4'b 1111, // index[25] ENTROPY_SRC_EXTHT_HI_WATERMARKS
+    4'b 1111, // index[26] ENTROPY_SRC_EXTHT_LO_WATERMARKS
+    4'b 1111, // index[27] ENTROPY_SRC_BUCKET_HI_WATERMARKS
+    4'b 1111, // index[28] ENTROPY_SRC_MARKOV_HI_WATERMARKS
+    4'b 1111, // index[29] ENTROPY_SRC_MARKOV_LO_WATERMARKS
+    4'b 1111, // index[30] ENTROPY_SRC_REPCNT_TOTAL_FAILS
+    4'b 1111, // index[31] ENTROPY_SRC_REPCNTS_TOTAL_FAILS
+    4'b 1111, // index[32] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS
+    4'b 1111, // index[33] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS
+    4'b 1111, // index[34] ENTROPY_SRC_BUCKET_TOTAL_FAILS
+    4'b 1111, // index[35] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS
+    4'b 1111, // index[36] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS
+    4'b 1111, // index[37] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS
+    4'b 1111, // index[38] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS
+    4'b 1111, // index[39] ENTROPY_SRC_ALERT_THRESHOLD
+    4'b 0011, // index[40] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS
+    4'b 1111, // index[41] ENTROPY_SRC_ALERT_FAIL_COUNTS
+    4'b 0001, // index[42] ENTROPY_SRC_EXTHT_FAIL_COUNTS
+    4'b 0001, // index[43] ENTROPY_SRC_FW_OV_CONTROL
+    4'b 1111, // index[44] ENTROPY_SRC_FW_OV_RD_DATA
+    4'b 1111, // index[45] ENTROPY_SRC_FW_OV_WR_DATA
+    4'b 0001, // index[46] ENTROPY_SRC_OBSERVE_FIFO_THRESH
+    4'b 1111, // index[47] ENTROPY_SRC_DEBUG_STATUS
+    4'b 0011, // index[48] ENTROPY_SRC_RECOV_ALERT_STS
+    4'b 1111, // index[49] ENTROPY_SRC_ERR_CODE
+    4'b 0001  // index[50] ENTROPY_SRC_ERR_CODE_TEST
   };
 
 endpackage

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -134,15 +134,21 @@ module entropy_src_reg_top (
   logic alert_test_we;
   logic alert_test_recov_alert_wd;
   logic alert_test_fatal_alert_wd;
+  logic regwen_me_we;
+  logic regwen_me_qs;
+  logic regwen_me_wd;
   logic regwen_we;
   logic regwen_qs;
   logic regwen_wd;
   logic [7:0] rev_abi_revision_qs;
   logic [7:0] rev_hw_revision_qs;
   logic [7:0] rev_chip_type_qs;
+  logic module_enable_we;
+  logic [3:0] module_enable_qs;
+  logic [3:0] module_enable_wd;
   logic conf_we;
-  logic [3:0] conf_enable_qs;
-  logic [3:0] conf_enable_wd;
+  logic [3:0] conf_fips_enable_qs;
+  logic [3:0] conf_fips_enable_wd;
   logic [3:0] conf_entropy_data_reg_enable_qs;
   logic [3:0] conf_entropy_data_reg_enable_wd;
   logic [3:0] conf_boot_bypass_disable_qs;
@@ -304,10 +310,12 @@ module entropy_src_reg_top (
   logic debug_status_main_sm_idle_qs;
   logic [7:0] debug_status_main_sm_state_qs;
   logic recov_alert_sts_we;
-  logic recov_alert_sts_enable_field_alert_qs;
-  logic recov_alert_sts_enable_field_alert_wd;
+  logic recov_alert_sts_fips_enable_field_alert_qs;
+  logic recov_alert_sts_fips_enable_field_alert_wd;
   logic recov_alert_sts_entropy_data_reg_en_field_alert_qs;
   logic recov_alert_sts_entropy_data_reg_en_field_alert_wd;
+  logic recov_alert_sts_module_enable_field_alert_qs;
+  logic recov_alert_sts_module_enable_field_alert_wd;
   logic recov_alert_sts_boot_bypass_disable_field_alert_qs;
   logic recov_alert_sts_boot_bypass_disable_field_alert_wd;
   logic recov_alert_sts_health_test_clr_field_alert_qs;
@@ -634,6 +642,32 @@ module entropy_src_reg_top (
   );
 
 
+  // R[regwen_me]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h1)
+  ) u_regwen_me (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (regwen_me_we),
+    .wd     (regwen_me_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (regwen_me_qs)
+  );
+
+
   // R[regwen]: V(False)
   prim_subreg #(
     .DW      (1),
@@ -674,19 +708,18 @@ module entropy_src_reg_top (
   assign rev_chip_type_qs = 8'h1;
 
 
-  // R[conf]: V(False)
-  //   F[enable]: 3:0
+  // R[module_enable]: V(False)
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (4'h5)
-  ) u_conf_enable (
+  ) u_module_enable (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (conf_we & regwen_qs),
-    .wd     (conf_enable_wd),
+    .we     (module_enable_we & regwen_me_qs),
+    .wd     (module_enable_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -694,10 +727,37 @@ module entropy_src_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.conf.enable.q),
+    .q      (reg2hw.module_enable.q),
 
     // to register interface (read)
-    .qs     (conf_enable_qs)
+    .qs     (module_enable_qs)
+  );
+
+
+  // R[conf]: V(False)
+  //   F[fips_enable]: 3:0
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h5)
+  ) u_conf_fips_enable (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (conf_we & regwen_qs),
+    .wd     (conf_fips_enable_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.conf.fips_enable.q),
+
+    // to register interface (read)
+    .qs     (conf_fips_enable_qs)
   );
 
   //   F[entropy_data_reg_enable]: 7:4
@@ -2040,29 +2100,29 @@ module entropy_src_reg_top (
 
 
   // R[recov_alert_sts]: V(False)
-  //   F[enable_field_alert]: 0:0
+  //   F[fips_enable_field_alert]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessW0C),
     .RESVAL  (1'h0)
-  ) u_recov_alert_sts_enable_field_alert (
+  ) u_recov_alert_sts_fips_enable_field_alert (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (recov_alert_sts_we),
-    .wd     (recov_alert_sts_enable_field_alert_wd),
+    .wd     (recov_alert_sts_fips_enable_field_alert_wd),
 
     // from internal hardware
-    .de     (hw2reg.recov_alert_sts.enable_field_alert.de),
-    .d      (hw2reg.recov_alert_sts.enable_field_alert.d),
+    .de     (hw2reg.recov_alert_sts.fips_enable_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.fips_enable_field_alert.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (recov_alert_sts_enable_field_alert_qs)
+    .qs     (recov_alert_sts_fips_enable_field_alert_qs)
   );
 
   //   F[entropy_data_reg_en_field_alert]: 1:1
@@ -2088,6 +2148,31 @@ module entropy_src_reg_top (
 
     // to register interface (read)
     .qs     (recov_alert_sts_entropy_data_reg_en_field_alert_qs)
+  );
+
+  //   F[module_enable_field_alert]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_module_enable_field_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_module_enable_field_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.module_enable_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.module_enable_field_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_module_enable_field_alert_qs)
   );
 
   //   F[boot_bypass_disable_field_alert]: 3:3
@@ -2595,58 +2680,60 @@ module entropy_src_reg_top (
 
 
 
-  logic [48:0] addr_hit;
+  logic [50:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ENTROPY_SRC_INTR_STATE_OFFSET);
     addr_hit[ 1] = (reg_addr == ENTROPY_SRC_INTR_ENABLE_OFFSET);
     addr_hit[ 2] = (reg_addr == ENTROPY_SRC_INTR_TEST_OFFSET);
     addr_hit[ 3] = (reg_addr == ENTROPY_SRC_ALERT_TEST_OFFSET);
-    addr_hit[ 4] = (reg_addr == ENTROPY_SRC_REGWEN_OFFSET);
-    addr_hit[ 5] = (reg_addr == ENTROPY_SRC_REV_OFFSET);
-    addr_hit[ 6] = (reg_addr == ENTROPY_SRC_CONF_OFFSET);
-    addr_hit[ 7] = (reg_addr == ENTROPY_SRC_ENTROPY_CONTROL_OFFSET);
-    addr_hit[ 8] = (reg_addr == ENTROPY_SRC_ENTROPY_DATA_OFFSET);
-    addr_hit[ 9] = (reg_addr == ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET);
-    addr_hit[10] = (reg_addr == ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET);
-    addr_hit[11] = (reg_addr == ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET);
-    addr_hit[12] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET);
-    addr_hit[13] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET);
-    addr_hit[14] = (reg_addr == ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET);
-    addr_hit[15] = (reg_addr == ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET);
-    addr_hit[16] = (reg_addr == ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET);
-    addr_hit[17] = (reg_addr == ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET);
-    addr_hit[18] = (reg_addr == ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET);
-    addr_hit[19] = (reg_addr == ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET);
-    addr_hit[20] = (reg_addr == ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET);
-    addr_hit[21] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET);
-    addr_hit[22] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET);
-    addr_hit[23] = (reg_addr == ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET);
-    addr_hit[24] = (reg_addr == ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET);
-    addr_hit[25] = (reg_addr == ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET);
-    addr_hit[26] = (reg_addr == ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET);
-    addr_hit[27] = (reg_addr == ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET);
-    addr_hit[28] = (reg_addr == ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET);
-    addr_hit[29] = (reg_addr == ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET);
-    addr_hit[30] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET);
-    addr_hit[31] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET);
-    addr_hit[32] = (reg_addr == ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET);
-    addr_hit[33] = (reg_addr == ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET);
-    addr_hit[34] = (reg_addr == ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET);
-    addr_hit[35] = (reg_addr == ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET);
-    addr_hit[36] = (reg_addr == ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET);
-    addr_hit[37] = (reg_addr == ENTROPY_SRC_ALERT_THRESHOLD_OFFSET);
-    addr_hit[38] = (reg_addr == ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET);
-    addr_hit[39] = (reg_addr == ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET);
-    addr_hit[40] = (reg_addr == ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET);
-    addr_hit[41] = (reg_addr == ENTROPY_SRC_FW_OV_CONTROL_OFFSET);
-    addr_hit[42] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
-    addr_hit[43] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
-    addr_hit[44] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
-    addr_hit[45] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
-    addr_hit[46] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
-    addr_hit[47] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
-    addr_hit[48] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
+    addr_hit[ 4] = (reg_addr == ENTROPY_SRC_REGWEN_ME_OFFSET);
+    addr_hit[ 5] = (reg_addr == ENTROPY_SRC_REGWEN_OFFSET);
+    addr_hit[ 6] = (reg_addr == ENTROPY_SRC_REV_OFFSET);
+    addr_hit[ 7] = (reg_addr == ENTROPY_SRC_MODULE_ENABLE_OFFSET);
+    addr_hit[ 8] = (reg_addr == ENTROPY_SRC_CONF_OFFSET);
+    addr_hit[ 9] = (reg_addr == ENTROPY_SRC_ENTROPY_CONTROL_OFFSET);
+    addr_hit[10] = (reg_addr == ENTROPY_SRC_ENTROPY_DATA_OFFSET);
+    addr_hit[11] = (reg_addr == ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET);
+    addr_hit[12] = (reg_addr == ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET);
+    addr_hit[13] = (reg_addr == ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET);
+    addr_hit[14] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET);
+    addr_hit[15] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET);
+    addr_hit[16] = (reg_addr == ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET);
+    addr_hit[17] = (reg_addr == ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET);
+    addr_hit[18] = (reg_addr == ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET);
+    addr_hit[19] = (reg_addr == ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET);
+    addr_hit[20] = (reg_addr == ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET);
+    addr_hit[21] = (reg_addr == ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET);
+    addr_hit[22] = (reg_addr == ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET);
+    addr_hit[23] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET);
+    addr_hit[24] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET);
+    addr_hit[25] = (reg_addr == ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET);
+    addr_hit[26] = (reg_addr == ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET);
+    addr_hit[27] = (reg_addr == ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET);
+    addr_hit[28] = (reg_addr == ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET);
+    addr_hit[29] = (reg_addr == ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET);
+    addr_hit[30] = (reg_addr == ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET);
+    addr_hit[31] = (reg_addr == ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET);
+    addr_hit[32] = (reg_addr == ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET);
+    addr_hit[33] = (reg_addr == ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET);
+    addr_hit[34] = (reg_addr == ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET);
+    addr_hit[35] = (reg_addr == ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET);
+    addr_hit[36] = (reg_addr == ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET);
+    addr_hit[37] = (reg_addr == ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET);
+    addr_hit[38] = (reg_addr == ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET);
+    addr_hit[39] = (reg_addr == ENTROPY_SRC_ALERT_THRESHOLD_OFFSET);
+    addr_hit[40] = (reg_addr == ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET);
+    addr_hit[41] = (reg_addr == ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET);
+    addr_hit[42] = (reg_addr == ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET);
+    addr_hit[43] = (reg_addr == ENTROPY_SRC_FW_OV_CONTROL_OFFSET);
+    addr_hit[44] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
+    addr_hit[45] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
+    addr_hit[46] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
+    addr_hit[47] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
+    addr_hit[48] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
+    addr_hit[49] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
+    addr_hit[50] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -2702,7 +2789,9 @@ module entropy_src_reg_top (
                (addr_hit[45] & (|(ENTROPY_SRC_PERMIT[45] & ~reg_be))) |
                (addr_hit[46] & (|(ENTROPY_SRC_PERMIT[46] & ~reg_be))) |
                (addr_hit[47] & (|(ENTROPY_SRC_PERMIT[47] & ~reg_be))) |
-               (addr_hit[48] & (|(ENTROPY_SRC_PERMIT[48] & ~reg_be)))));
+               (addr_hit[48] & (|(ENTROPY_SRC_PERMIT[48] & ~reg_be))) |
+               (addr_hit[49] & (|(ENTROPY_SRC_PERMIT[49] & ~reg_be))) |
+               (addr_hit[50] & (|(ENTROPY_SRC_PERMIT[50] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -2736,12 +2825,18 @@ module entropy_src_reg_top (
   assign alert_test_recov_alert_wd = reg_wdata[0];
 
   assign alert_test_fatal_alert_wd = reg_wdata[1];
-  assign regwen_we = addr_hit[4] & reg_we & !reg_error;
+  assign regwen_me_we = addr_hit[4] & reg_we & !reg_error;
+
+  assign regwen_me_wd = reg_wdata[0];
+  assign regwen_we = addr_hit[5] & reg_we & !reg_error;
 
   assign regwen_wd = reg_wdata[0];
-  assign conf_we = addr_hit[6] & reg_we & !reg_error;
+  assign module_enable_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign conf_enable_wd = reg_wdata[3:0];
+  assign module_enable_wd = reg_wdata[3:0];
+  assign conf_we = addr_hit[8] & reg_we & !reg_error;
+
+  assign conf_fips_enable_wd = reg_wdata[3:0];
 
   assign conf_entropy_data_reg_enable_wd = reg_wdata[7:4];
 
@@ -2752,115 +2847,117 @@ module entropy_src_reg_top (
   assign conf_rng_bit_enable_wd = reg_wdata[23:20];
 
   assign conf_rng_bit_sel_wd = reg_wdata[25:24];
-  assign entropy_control_we = addr_hit[7] & reg_we & !reg_error;
+  assign entropy_control_we = addr_hit[9] & reg_we & !reg_error;
 
   assign entropy_control_es_route_wd = reg_wdata[3:0];
 
   assign entropy_control_es_type_wd = reg_wdata[7:4];
-  assign entropy_data_re = addr_hit[8] & reg_re & !reg_error;
-  assign health_test_windows_we = addr_hit[9] & reg_we & !reg_error;
+  assign entropy_data_re = addr_hit[10] & reg_re & !reg_error;
+  assign health_test_windows_we = addr_hit[11] & reg_we & !reg_error;
 
   assign health_test_windows_fips_window_wd = reg_wdata[15:0];
 
   assign health_test_windows_bypass_window_wd = reg_wdata[31:16];
-  assign repcnt_thresholds_re = addr_hit[10] & reg_re & !reg_error;
-  assign repcnt_thresholds_we = addr_hit[10] & reg_we & !reg_error;
+  assign repcnt_thresholds_re = addr_hit[12] & reg_re & !reg_error;
+  assign repcnt_thresholds_we = addr_hit[12] & reg_we & !reg_error;
 
   assign repcnt_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign repcnt_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign repcnts_thresholds_re = addr_hit[11] & reg_re & !reg_error;
-  assign repcnts_thresholds_we = addr_hit[11] & reg_we & !reg_error;
+  assign repcnts_thresholds_re = addr_hit[13] & reg_re & !reg_error;
+  assign repcnts_thresholds_we = addr_hit[13] & reg_we & !reg_error;
 
   assign repcnts_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign repcnts_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign adaptp_hi_thresholds_re = addr_hit[12] & reg_re & !reg_error;
-  assign adaptp_hi_thresholds_we = addr_hit[12] & reg_we & !reg_error;
+  assign adaptp_hi_thresholds_re = addr_hit[14] & reg_re & !reg_error;
+  assign adaptp_hi_thresholds_we = addr_hit[14] & reg_we & !reg_error;
 
   assign adaptp_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign adaptp_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign adaptp_lo_thresholds_re = addr_hit[13] & reg_re & !reg_error;
-  assign adaptp_lo_thresholds_we = addr_hit[13] & reg_we & !reg_error;
+  assign adaptp_lo_thresholds_re = addr_hit[15] & reg_re & !reg_error;
+  assign adaptp_lo_thresholds_we = addr_hit[15] & reg_we & !reg_error;
 
   assign adaptp_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign adaptp_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign bucket_thresholds_re = addr_hit[14] & reg_re & !reg_error;
-  assign bucket_thresholds_we = addr_hit[14] & reg_we & !reg_error;
+  assign bucket_thresholds_re = addr_hit[16] & reg_re & !reg_error;
+  assign bucket_thresholds_we = addr_hit[16] & reg_we & !reg_error;
 
   assign bucket_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign bucket_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign markov_hi_thresholds_re = addr_hit[15] & reg_re & !reg_error;
-  assign markov_hi_thresholds_we = addr_hit[15] & reg_we & !reg_error;
+  assign markov_hi_thresholds_re = addr_hit[17] & reg_re & !reg_error;
+  assign markov_hi_thresholds_we = addr_hit[17] & reg_we & !reg_error;
 
   assign markov_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign markov_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign markov_lo_thresholds_re = addr_hit[16] & reg_re & !reg_error;
-  assign markov_lo_thresholds_we = addr_hit[16] & reg_we & !reg_error;
+  assign markov_lo_thresholds_re = addr_hit[18] & reg_re & !reg_error;
+  assign markov_lo_thresholds_we = addr_hit[18] & reg_we & !reg_error;
 
   assign markov_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign markov_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign extht_hi_thresholds_re = addr_hit[17] & reg_re & !reg_error;
-  assign extht_hi_thresholds_we = addr_hit[17] & reg_we & !reg_error;
+  assign extht_hi_thresholds_re = addr_hit[19] & reg_re & !reg_error;
+  assign extht_hi_thresholds_we = addr_hit[19] & reg_we & !reg_error;
 
   assign extht_hi_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign extht_hi_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign extht_lo_thresholds_re = addr_hit[18] & reg_re & !reg_error;
-  assign extht_lo_thresholds_we = addr_hit[18] & reg_we & !reg_error;
+  assign extht_lo_thresholds_re = addr_hit[20] & reg_re & !reg_error;
+  assign extht_lo_thresholds_we = addr_hit[20] & reg_we & !reg_error;
 
   assign extht_lo_thresholds_fips_thresh_wd = reg_wdata[15:0];
 
   assign extht_lo_thresholds_bypass_thresh_wd = reg_wdata[31:16];
-  assign repcnt_hi_watermarks_re = addr_hit[19] & reg_re & !reg_error;
-  assign repcnts_hi_watermarks_re = addr_hit[20] & reg_re & !reg_error;
-  assign adaptp_hi_watermarks_re = addr_hit[21] & reg_re & !reg_error;
-  assign adaptp_lo_watermarks_re = addr_hit[22] & reg_re & !reg_error;
-  assign extht_hi_watermarks_re = addr_hit[23] & reg_re & !reg_error;
-  assign extht_lo_watermarks_re = addr_hit[24] & reg_re & !reg_error;
-  assign bucket_hi_watermarks_re = addr_hit[25] & reg_re & !reg_error;
-  assign markov_hi_watermarks_re = addr_hit[26] & reg_re & !reg_error;
-  assign markov_lo_watermarks_re = addr_hit[27] & reg_re & !reg_error;
-  assign repcnt_total_fails_re = addr_hit[28] & reg_re & !reg_error;
-  assign repcnts_total_fails_re = addr_hit[29] & reg_re & !reg_error;
-  assign adaptp_hi_total_fails_re = addr_hit[30] & reg_re & !reg_error;
-  assign adaptp_lo_total_fails_re = addr_hit[31] & reg_re & !reg_error;
-  assign bucket_total_fails_re = addr_hit[32] & reg_re & !reg_error;
-  assign markov_hi_total_fails_re = addr_hit[33] & reg_re & !reg_error;
-  assign markov_lo_total_fails_re = addr_hit[34] & reg_re & !reg_error;
-  assign extht_hi_total_fails_re = addr_hit[35] & reg_re & !reg_error;
-  assign extht_lo_total_fails_re = addr_hit[36] & reg_re & !reg_error;
-  assign alert_threshold_we = addr_hit[37] & reg_we & !reg_error;
+  assign repcnt_hi_watermarks_re = addr_hit[21] & reg_re & !reg_error;
+  assign repcnts_hi_watermarks_re = addr_hit[22] & reg_re & !reg_error;
+  assign adaptp_hi_watermarks_re = addr_hit[23] & reg_re & !reg_error;
+  assign adaptp_lo_watermarks_re = addr_hit[24] & reg_re & !reg_error;
+  assign extht_hi_watermarks_re = addr_hit[25] & reg_re & !reg_error;
+  assign extht_lo_watermarks_re = addr_hit[26] & reg_re & !reg_error;
+  assign bucket_hi_watermarks_re = addr_hit[27] & reg_re & !reg_error;
+  assign markov_hi_watermarks_re = addr_hit[28] & reg_re & !reg_error;
+  assign markov_lo_watermarks_re = addr_hit[29] & reg_re & !reg_error;
+  assign repcnt_total_fails_re = addr_hit[30] & reg_re & !reg_error;
+  assign repcnts_total_fails_re = addr_hit[31] & reg_re & !reg_error;
+  assign adaptp_hi_total_fails_re = addr_hit[32] & reg_re & !reg_error;
+  assign adaptp_lo_total_fails_re = addr_hit[33] & reg_re & !reg_error;
+  assign bucket_total_fails_re = addr_hit[34] & reg_re & !reg_error;
+  assign markov_hi_total_fails_re = addr_hit[35] & reg_re & !reg_error;
+  assign markov_lo_total_fails_re = addr_hit[36] & reg_re & !reg_error;
+  assign extht_hi_total_fails_re = addr_hit[37] & reg_re & !reg_error;
+  assign extht_lo_total_fails_re = addr_hit[38] & reg_re & !reg_error;
+  assign alert_threshold_we = addr_hit[39] & reg_we & !reg_error;
 
   assign alert_threshold_alert_threshold_wd = reg_wdata[15:0];
 
   assign alert_threshold_alert_threshold_inv_wd = reg_wdata[31:16];
-  assign alert_summary_fail_counts_re = addr_hit[38] & reg_re & !reg_error;
-  assign alert_fail_counts_re = addr_hit[39] & reg_re & !reg_error;
-  assign extht_fail_counts_re = addr_hit[40] & reg_re & !reg_error;
-  assign fw_ov_control_we = addr_hit[41] & reg_we & !reg_error;
+  assign alert_summary_fail_counts_re = addr_hit[40] & reg_re & !reg_error;
+  assign alert_fail_counts_re = addr_hit[41] & reg_re & !reg_error;
+  assign extht_fail_counts_re = addr_hit[42] & reg_re & !reg_error;
+  assign fw_ov_control_we = addr_hit[43] & reg_we & !reg_error;
 
   assign fw_ov_control_fw_ov_mode_wd = reg_wdata[3:0];
 
   assign fw_ov_control_fw_ov_entropy_insert_wd = reg_wdata[7:4];
-  assign fw_ov_rd_data_re = addr_hit[42] & reg_re & !reg_error;
-  assign fw_ov_wr_data_we = addr_hit[43] & reg_we & !reg_error;
+  assign fw_ov_rd_data_re = addr_hit[44] & reg_re & !reg_error;
+  assign fw_ov_wr_data_we = addr_hit[45] & reg_we & !reg_error;
 
   assign fw_ov_wr_data_wd = reg_wdata[31:0];
-  assign observe_fifo_thresh_we = addr_hit[44] & reg_we & !reg_error;
+  assign observe_fifo_thresh_we = addr_hit[46] & reg_we & !reg_error;
 
   assign observe_fifo_thresh_wd = reg_wdata[6:0];
-  assign debug_status_re = addr_hit[45] & reg_re & !reg_error;
-  assign recov_alert_sts_we = addr_hit[46] & reg_we & !reg_error;
+  assign debug_status_re = addr_hit[47] & reg_re & !reg_error;
+  assign recov_alert_sts_we = addr_hit[48] & reg_we & !reg_error;
 
-  assign recov_alert_sts_enable_field_alert_wd = reg_wdata[0];
+  assign recov_alert_sts_fips_enable_field_alert_wd = reg_wdata[0];
 
   assign recov_alert_sts_entropy_data_reg_en_field_alert_wd = reg_wdata[1];
+
+  assign recov_alert_sts_module_enable_field_alert_wd = reg_wdata[2];
 
   assign recov_alert_sts_boot_bypass_disable_field_alert_wd = reg_wdata[3];
 
@@ -2881,7 +2978,7 @@ module entropy_src_reg_top (
   assign recov_alert_sts_es_bus_cmp_alert_wd = reg_wdata[13];
 
   assign recov_alert_sts_es_thresh_cfg_alert_wd = reg_wdata[14];
-  assign err_code_test_we = addr_hit[48] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[50] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
 
@@ -2916,17 +3013,25 @@ module entropy_src_reg_top (
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[0] = regwen_qs;
+        reg_rdata_next[0] = regwen_me_qs;
       end
 
       addr_hit[5]: begin
+        reg_rdata_next[0] = regwen_qs;
+      end
+
+      addr_hit[6]: begin
         reg_rdata_next[7:0] = rev_abi_revision_qs;
         reg_rdata_next[15:8] = rev_hw_revision_qs;
         reg_rdata_next[23:16] = rev_chip_type_qs;
       end
 
-      addr_hit[6]: begin
-        reg_rdata_next[3:0] = conf_enable_qs;
+      addr_hit[7]: begin
+        reg_rdata_next[3:0] = module_enable_qs;
+      end
+
+      addr_hit[8]: begin
+        reg_rdata_next[3:0] = conf_fips_enable_qs;
         reg_rdata_next[7:4] = conf_entropy_data_reg_enable_qs;
         reg_rdata_next[15:12] = conf_boot_bypass_disable_qs;
         reg_rdata_next[19:16] = conf_health_test_clr_qs;
@@ -2934,156 +3039,156 @@ module entropy_src_reg_top (
         reg_rdata_next[25:24] = conf_rng_bit_sel_qs;
       end
 
-      addr_hit[7]: begin
+      addr_hit[9]: begin
         reg_rdata_next[3:0] = entropy_control_es_route_qs;
         reg_rdata_next[7:4] = entropy_control_es_type_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[10]: begin
         reg_rdata_next[31:0] = entropy_data_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[11]: begin
         reg_rdata_next[15:0] = health_test_windows_fips_window_qs;
         reg_rdata_next[31:16] = health_test_windows_bypass_window_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[12]: begin
         reg_rdata_next[15:0] = repcnt_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = repcnt_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[11]: begin
+      addr_hit[13]: begin
         reg_rdata_next[15:0] = repcnts_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = repcnts_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[14]: begin
         reg_rdata_next[15:0] = adaptp_hi_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = adaptp_hi_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[15]: begin
         reg_rdata_next[15:0] = adaptp_lo_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = adaptp_lo_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[16]: begin
         reg_rdata_next[15:0] = bucket_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = bucket_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[17]: begin
         reg_rdata_next[15:0] = markov_hi_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = markov_hi_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[18]: begin
         reg_rdata_next[15:0] = markov_lo_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = markov_lo_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[19]: begin
         reg_rdata_next[15:0] = extht_hi_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = extht_hi_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[20]: begin
         reg_rdata_next[15:0] = extht_lo_thresholds_fips_thresh_qs;
         reg_rdata_next[31:16] = extht_lo_thresholds_bypass_thresh_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[21]: begin
         reg_rdata_next[15:0] = repcnt_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = repcnt_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[22]: begin
         reg_rdata_next[15:0] = repcnts_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = repcnts_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[23]: begin
         reg_rdata_next[15:0] = adaptp_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = adaptp_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[24]: begin
         reg_rdata_next[15:0] = adaptp_lo_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = adaptp_lo_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[25]: begin
         reg_rdata_next[15:0] = extht_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = extht_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[26]: begin
         reg_rdata_next[15:0] = extht_lo_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = extht_lo_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[27]: begin
         reg_rdata_next[15:0] = bucket_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = bucket_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[28]: begin
         reg_rdata_next[15:0] = markov_hi_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = markov_hi_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[29]: begin
         reg_rdata_next[15:0] = markov_lo_watermarks_fips_watermark_qs;
         reg_rdata_next[31:16] = markov_lo_watermarks_bypass_watermark_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[30]: begin
         reg_rdata_next[31:0] = repcnt_total_fails_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[31]: begin
         reg_rdata_next[31:0] = repcnts_total_fails_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = adaptp_hi_total_fails_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[33]: begin
         reg_rdata_next[31:0] = adaptp_lo_total_fails_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[34]: begin
         reg_rdata_next[31:0] = bucket_total_fails_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[35]: begin
         reg_rdata_next[31:0] = markov_hi_total_fails_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[36]: begin
         reg_rdata_next[31:0] = markov_lo_total_fails_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[37]: begin
         reg_rdata_next[31:0] = extht_hi_total_fails_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[38]: begin
         reg_rdata_next[31:0] = extht_lo_total_fails_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[39]: begin
         reg_rdata_next[15:0] = alert_threshold_alert_threshold_qs;
         reg_rdata_next[31:16] = alert_threshold_alert_threshold_inv_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[40]: begin
         reg_rdata_next[15:0] = alert_summary_fail_counts_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:4] = alert_fail_counts_repcnt_fail_count_qs;
         reg_rdata_next[11:8] = alert_fail_counts_adaptp_hi_fail_count_qs;
         reg_rdata_next[15:12] = alert_fail_counts_adaptp_lo_fail_count_qs;
@@ -3093,29 +3198,29 @@ module entropy_src_reg_top (
         reg_rdata_next[31:28] = alert_fail_counts_repcnts_fail_count_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[42]: begin
         reg_rdata_next[3:0] = extht_fail_counts_extht_hi_fail_count_qs;
         reg_rdata_next[7:4] = extht_fail_counts_extht_lo_fail_count_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[43]: begin
         reg_rdata_next[3:0] = fw_ov_control_fw_ov_mode_qs;
         reg_rdata_next[7:4] = fw_ov_control_fw_ov_entropy_insert_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[44]: begin
         reg_rdata_next[31:0] = fw_ov_rd_data_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[45]: begin
         reg_rdata_next[31:0] = '0;
       end
 
-      addr_hit[44]: begin
+      addr_hit[46]: begin
         reg_rdata_next[6:0] = observe_fifo_thresh_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[47]: begin
         reg_rdata_next[2:0] = debug_status_entropy_fifo_depth_qs;
         reg_rdata_next[5:3] = debug_status_sha3_fsm_qs;
         reg_rdata_next[6] = debug_status_sha3_block_pr_qs;
@@ -3126,9 +3231,10 @@ module entropy_src_reg_top (
         reg_rdata_next[31:24] = debug_status_main_sm_state_qs;
       end
 
-      addr_hit[46]: begin
-        reg_rdata_next[0] = recov_alert_sts_enable_field_alert_qs;
+      addr_hit[48]: begin
+        reg_rdata_next[0] = recov_alert_sts_fips_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_entropy_data_reg_en_field_alert_qs;
+        reg_rdata_next[2] = recov_alert_sts_module_enable_field_alert_qs;
         reg_rdata_next[3] = recov_alert_sts_boot_bypass_disable_field_alert_qs;
         reg_rdata_next[4] = recov_alert_sts_health_test_clr_field_alert_qs;
         reg_rdata_next[5] = recov_alert_sts_rng_bit_enable_field_alert_qs;
@@ -3141,7 +3247,7 @@ module entropy_src_reg_top (
         reg_rdata_next[14] = recov_alert_sts_es_thresh_cfg_alert_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[49]: begin
         reg_rdata_next[0] = err_code_sfifo_esrng_err_qs;
         reg_rdata_next[1] = err_code_sfifo_observe_err_qs;
         reg_rdata_next[2] = err_code_sfifo_esfinal_err_qs;
@@ -3153,7 +3259,7 @@ module entropy_src_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[50]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -28,10 +28,10 @@ index 8861f54ba..8442bb896 100644
 -  mmio_region_write32(reg32, reg_offset, reg_value & mask);
  }
 diff --git a/sw/device/lib/testing/test_rom/test_rom_start.S b/sw/device/lib/testing/test_rom/test_rom_start.S
-index e4b14eb84..d595aa757 100644
+index 480451ff5..d595aa757 100644
 --- a/sw/device/lib/testing/test_rom/test_rom_start.S
 +++ b/sw/device/lib/testing/test_rom/test_rom_start.S
-@@ -81,19 +81,6 @@ _reset_start:
+@@ -81,23 +81,6 @@ _reset_start:
  _start:
    .globl _start
 
@@ -39,6 +39,10 @@ index e4b14eb84..d595aa757 100644
 -  li   a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
 -  li   t0, 0x55505a
 -  sw   t0, ENTROPY_SRC_CONF_REG_OFFSET(a0)
+-
+-  li   a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
+-  li   t0, 0xa
+-  sw   t0, ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET(a0)
 -
 -  li   a0, TOP_EARLGREY_CSRNG_BASE_ADDR
 -  li   t0, 0xaaa

--- a/sw/device/lib/dif/dif_entropy_src_unittest.cc
+++ b/sw/device/lib/dif/dif_entropy_src_unittest.cc
@@ -121,8 +121,13 @@ TEST_P(ConfigTestAllParams, ValidConfigurationMode) {
           {ENTROPY_SRC_CONF_HEALTH_TEST_CLR_OFFSET, reset_ht},
           {ENTROPY_SRC_CONF_BOOT_BYPASS_DISABLE_OFFSET, kMultiBitBool4False},
           {ENTROPY_SRC_CONF_ENTROPY_DATA_REG_ENABLE_OFFSET, route_to_fw},
-          {ENTROPY_SRC_CONF_ENABLE_OFFSET, enable},
+          {ENTROPY_SRC_CONF_FIPS_ENABLE_OFFSET, enable},
       });
+
+  EXPECT_WRITE32(ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET,
+                 {
+                     {ENTROPY_SRC_MODULE_ENABLE_MODULE_ENABLE_OFFSET, enable},
+                 });
 
   EXPECT_EQ(dif_entropy_src_configure(&entropy_src_, config_), kDifOk);
 }

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -139,6 +139,10 @@ _start:
   li   t0, 0x55505a
   sw   t0, ENTROPY_SRC_CONF_REG_OFFSET(a0)
 
+  li   a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
+  li   t0, 0xa
+  sw   t0, ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET(a0)
+
   li   a0, TOP_EARLGREY_CSRNG_BASE_ADDR
   li   t0, 0xaaa
   sw   t0, CSRNG_CTRL_REG_OFFSET(a0)

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -187,12 +187,17 @@ _mask_rom_start_boot:
   // The following sequence enables the minimum level of entropy required to
   // initialize memory scrambling, as well as the entropy distribution network.
   li a0, TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR
-  li t0, (0xa << ENTROPY_SRC_CONF_ENABLE_OFFSET) | \
+  // Note for BOOT_ROM initialization the FIPS_ENABLE bit is set to MuBi4False
+  // to prevent the release of FIPS entropy until all the thresholds are set
+  li t0, (0x5 << ENTROPY_SRC_CONF_FIPS_ENABLE_OFFSET) | \
          (0x5 << ENTROPY_SRC_CONF_ENTROPY_DATA_REG_ENABLE_OFFSET) | \
          (0x5 << ENTROPY_SRC_CONF_BOOT_BYPASS_DISABLE_OFFSET) | \
          (0x5 << ENTROPY_SRC_CONF_HEALTH_TEST_CLR_OFFSET) | \
          (0x5 << ENTROPY_SRC_CONF_RNG_BIT_ENABLE_OFFSET)
   sw t0, ENTROPY_SRC_CONF_REG_OFFSET(a0)
+
+  li t0, (0xa << ENTROPY_SRC_MODULE_ENABLE_MODULE_ENABLE_OFFSET)
+  sw t0, ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET(a0)
 
   li a0, TOP_EARLGREY_CSRNG_BASE_ADDR
   li t0, (0xa << CSRNG_CTRL_ENABLE_OFFSET) | \

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -15,9 +15,15 @@ const test_config_t kTestConfig;
 
 const size_t kEntropyDataNumWords = 12;
 
+// This expected value seems to require frequent updating.  If it turns
+// out that changes to the overall system start causing race conditions
+// we may want to relax the requirement for exact binary equivalence.
+//
+// Issue #10092 has been opened to discuss this.
+
 const uint32_t kExpectedEntropyData[] = {
-    0xdaf90306, 0x0466d674, 0x9691df54, 0xd2e3c93f, 0xdcbc993e, 0x64bfd173,
-    0xaba04e99, 0xf8ae1105, 0xd01dc17a, 0x608c5480, 0x373c5dcc, 0xc4e6cd55,
+    0x7c7baa24, 0x4e3f30f8, 0xcae3aefe, 0x80197526, 0xbb8761a4, 0x18b5b15f,
+    0xe8126c66, 0x69efaf13, 0x8cc59ac2, 0xb7f3bcad, 0x06dc9089, 0x1f4c6ef2,
 };
 
 bool test_main() {
@@ -56,7 +62,7 @@ bool test_main() {
     // wait for entropy to become available
     while (dif_entropy_src_read(&entropy_src, &entropy_data[i]) != kDifOk)
       ;
-    LOG_INFO("received 0x%x, expectecd 0x%x", entropy_data[i],
+    LOG_INFO("received 0x%x, expected 0x%x", entropy_data[i],
              kExpectedEntropyData[i]);
     result |= entropy_data[i] ^ kExpectedEntropyData[i];
   }


### PR DESCRIPTION
For better solution of sequencing control, the module enable has been split out into its own register, with a separate write enable gage (REGWEN).
Fixes #9637.


Signed-off-by: Mark Branstad <mark.branstad@wdc.com>