### PR TITLE
[sram/dv] Fix unmapped test

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -171,7 +171,7 @@
               sequences that require zero_delays or invoke reset (such as lc_escalation).
             - Randomly add reset between each sequence'''
       milestone: V2
-      tests: ["{variant}_stress_all"]
+      tests: ["{name}_stress_all"]
     }
   ]
 


### PR DESCRIPTION
Use {name}_stress_all so that this test name matches with the test in
stress testplan
Signed-off-by: Weicai Yang <weicai@google.com>