### PR TITLE
[pinmux] d/mio_attr_o updates

### DIFF
--- a/hw/ip/pinmux/doc/_index.md
+++ b/hw/ip/pinmux/doc/_index.md
@@ -267,7 +267,7 @@ Signal               | Direction  | Type        | Description
 `attr_i[3]`          | `input`    | `logic`     | Pull select (0: pull-down, 1: pull-up)
 `attr_i[4]`          | `input`    | `logic`     | Keeper enable
 `attr_i[5]`          | `input`    | `logic`     | Schmitt trigger enable
-`attr_i[6]`          | `input`    | `logic`     | Open drain enable enable
+`attr_i[6]`          | `input`    | `logic`     | Open drain enable
 `attr_i[8:7]`        | `input`    | `logic`     | Slew rate (0x0: slowest, 0x3: fastest)
 `attr_i[12:9]`       | `input`    | `logic`     | Drive strength (0x0: weakest, 0xf: strongest)
 
@@ -290,12 +290,12 @@ The following pad attributes are supported by this register layout by default:
 ATTR Bits | Description                                   | Access
 ----------|-----------------------------------------------|---------
 0         | Input/output inversion                        | RW
-1         | Open drain enable                             | RW
+1         | Virtual open drain enable                     | RW
 2         | Pull enable                                   | WARL
 3         | Pull select (0: down, 1: up)                  | WARL
 4         | Keeper enable                                 | WARL
 5         | Schmitt trigger enable                        | WARL
-6         | Open drain enable enable                      | WARL
+6         | Open drain enable                             | WARL
 8:7       | Slew rate (0x0: slowest, 0x3: fastest)        | WARL
 12:9      | Drive strength (0x0: weakest, 0xf: strongest) | WARL
 

--- a/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -194,6 +194,49 @@ module pinmux_assert_fpv
           ##1 mio_pad_sleep_status.q |->
           $stable(mio_oe_o[mio_sel_i]))
 
+  // ------ Mio_attr_o ------
+  pinmux_reg_pkg::pinmux_reg2hw_mio_pad_attr_mreg_t mio_pad_attr;
+  assign mio_pad_attr = pinmux.mio_pad_attr_q[mio_sel_i];
+
+  pad_attr_t mio_pad_attr_mask;
+  pad_type_e bid_pad_types[4] = {BidirStd, BidirTol, DualBidirTol, BidirOd};
+  assign mio_pad_attr_mask.invert = TargetCfg.mio_pad_type[mio_sel_i] == AnalogIn0 ? 0 : 1;
+  assign mio_pad_attr_mask.virt_od_en = TargetCfg.mio_pad_type[mio_sel_i] inside {bid_pad_types} ?
+                                        1 : 0;
+  assign mio_pad_attr_mask.pull_en = TargetCfg.mio_pad_type[mio_sel_i] == AnalogIn0 ? 0 : 1;
+  assign mio_pad_attr_mask.pull_select = TargetCfg.mio_pad_type[mio_sel_i] == AnalogIn0 ? 0 : 1;
+  assign mio_pad_attr_mask.keep_en = TargetCfg.mio_pad_type[mio_sel_i] inside {bid_pad_types} ?
+                                     1 : 0;
+  assign mio_pad_attr_mask.drive_strength[0] = TargetCfg.mio_pad_type[mio_sel_i] inside
+                                               {bid_pad_types} ? 1 : 0;
+  assign mio_pad_attr_mask.schmitt_en = 0;
+  assign mio_pad_attr_mask.od_en = 0;
+  assign mio_pad_attr_mask.slew_rate = '0;
+  assign mio_pad_attr_mask.drive_strength[3:1] = '0;
+
+  `ASSERT(MioAttrO_A, mio_attr_o[mio_sel_i] == (mio_pad_attr & mio_pad_attr_mask))
+
+  // ------ Dio_attr_o ------
+  pinmux_reg_pkg::pinmux_reg2hw_dio_pad_attr_mreg_t dio_pad_attr;
+  assign dio_pad_attr = pinmux.dio_pad_attr_q[dio_sel_i];
+
+  pad_attr_t dio_pad_attr_mask;
+  assign dio_pad_attr_mask.invert = TargetCfg.dio_pad_type[dio_sel_i] == AnalogIn0 ? 0 : 1;
+  assign dio_pad_attr_mask.virt_od_en = TargetCfg.dio_pad_type[dio_sel_i] inside {bid_pad_types} ?
+                                        1 : 0;
+  assign dio_pad_attr_mask.pull_en = TargetCfg.dio_pad_type[dio_sel_i] == AnalogIn0 ? 0 : 1;
+  assign dio_pad_attr_mask.pull_select = TargetCfg.dio_pad_type[dio_sel_i] == AnalogIn0 ? 0 : 1;
+  assign dio_pad_attr_mask.keep_en     = TargetCfg.dio_pad_type[dio_sel_i] inside {bid_pad_types} ?
+                                         1 : 0;
+  assign dio_pad_attr_mask.drive_strength[0] = TargetCfg.dio_pad_type[dio_sel_i] inside
+                                               {bid_pad_types} ? 1 : 0;
+  assign dio_pad_attr_mask.schmitt_en = 0;
+  assign dio_pad_attr_mask.od_en = 0;
+  assign dio_pad_attr_mask.slew_rate = '0;
+  assign dio_pad_attr_mask.drive_strength[3:1] = '0;
+
+  `ASSERT(DioAttrO_A, dio_attr_o[dio_sel_i] == (dio_pad_attr & dio_pad_attr_mask))
+
   // ------ Output dedicated output assertions ------
   pinmux_reg_pkg::pinmux_reg2hw_dio_pad_sleep_status_mreg_t dio_pad_sleep_status;
   assign dio_pad_sleep_status = pinmux.reg2hw.dio_pad_sleep_status[dio_sel_i];


### PR DESCRIPTION
1). Update pinmux document naming related to open drains.
2). Add assertions to check d/mio_attr_o.