### PR TITLE
[ entropy_src, dv ] Initial DV support for health-check thresholds

### DIFF
--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -37,6 +37,49 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     csr_update(.csr(ral.conf));
   endtask
 
+  virtual task entropy_src_init();
+    int hi_thresh, lo_thresh;
+
+    super.entropy_src_init();
+
+    // TODO: RepCnt and RepCntS thresholds
+    // TODO: Separate sigmas for bypass and FIPS operation
+    // TODO: cfg for threshold_rec per_line arguments
+
+    // AdaptP thresholds
+    m_rng_push_seq.threshold_rec(cfg.fips_window_size, entropy_src_base_rng_seq::AdaptP, 0,
+                                 cfg.adaptp_sigma, lo_thresh, hi_thresh);
+    ral.adaptp_hi_thresholds.fips_thresh.set(hi_thresh[15:0]);
+    ral.adaptp_lo_thresholds.fips_thresh.set(lo_thresh[15:0]);
+    m_rng_push_seq.threshold_rec(cfg.bypass_window_size, entropy_src_base_rng_seq::AdaptP, 0,
+                                 cfg.adaptp_sigma, lo_thresh, hi_thresh);
+    ral.adaptp_hi_thresholds.bypass_thresh.set(hi_thresh[15:0]);
+    ral.adaptp_lo_thresholds.bypass_thresh.set(lo_thresh[15:0]);
+    csr_update(.csr(ral.adaptp_hi_thresholds));
+    csr_update(.csr(ral.adaptp_lo_thresholds));
+
+    // Bucket thresholds
+    m_rng_push_seq.threshold_rec(cfg.fips_window_size, entropy_src_base_rng_seq::Bucket, 0,
+                                 cfg.bucket_sigma, lo_thresh, hi_thresh);
+    ral.bucket_thresholds.fips_thresh.set(hi_thresh[15:0]);
+    m_rng_push_seq.threshold_rec(cfg.bypass_window_size, entropy_src_base_rng_seq::Bucket, 0,
+                                 cfg.bucket_sigma, lo_thresh, hi_thresh);
+    ral.bucket_thresholds.bypass_thresh.set(hi_thresh[15:0]);
+    csr_update(.csr(ral.bucket_thresholds));
+
+    // TODO: Markov DUT is currently cofigured for per_line operation (see Issue #9759)
+    m_rng_push_seq.threshold_rec(cfg.fips_window_size, entropy_src_base_rng_seq::Markov, 1,
+                                 cfg.markov_sigma, lo_thresh, hi_thresh);
+    ral.markov_hi_thresholds.fips_thresh.set(hi_thresh[15:0]);
+    ral.markov_lo_thresholds.fips_thresh.set(lo_thresh[15:0]);
+    m_rng_push_seq.threshold_rec(cfg.bypass_window_size, entropy_src_base_rng_seq::Markov, 1,
+                                 cfg.markov_sigma, lo_thresh, hi_thresh);
+    ral.markov_hi_thresholds.bypass_thresh.set(hi_thresh[15:0]);
+    ral.markov_lo_thresholds.bypass_thresh.set(lo_thresh[15:0]);
+    csr_update(.csr(ral.markov_hi_thresholds));
+    csr_update(.csr(ral.markov_lo_thresholds));
+  endtask
+
   //
   // The csr_access seq task executes all csr accesses for enabling/disabling the DUT as needed,
   // clearing assertions
@@ -44,13 +87,17 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   task csr_access_seq();
     // Explicitly enable the DUT
     enable_dut();
-    #(cfg.sim_duration/2);
-    software_read_seed();
-    #(cfg.sim_duration/2);
+    #(cfg.sim_duration);
   endtask
 
-  task body();
-    super.body();
+  task pre_start();
+    //
+    // The DUT thresholds can be configured in coordination with the expected noise properties of
+    // the RNG (which can also be parametrized to introduce bias or other non-idealities).  However
+    // the RNG sequence then needs to be constructed before initializing the DUT, so that we can
+    // query it for recommended thresholds when calling entropy_src_init().   So these seqeunces
+    // are constructed before calling super.pre_start()
+    //
 
     // Create rng host sequence
     m_rng_push_seq = entropy_src_base_rng_seq::type_id::create("m_rng_push_seq");
@@ -62,9 +109,11 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     m_rng_push_seq.hard_mtbf = cfg.hard_mtbf;
     m_rng_push_seq.soft_mtbf = cfg.soft_mtbf;
 
-    // m_csrng_pull_seq.num_trans = cfg.seed_cnt;
-    // TODO: Enhance seq to work for hardware or software entropy consumer
+    super.pre_start();
+  endtask
 
+  task body();
+    super.body();
     // Start sequences
     fork
       m_rng_push_seq.start(p_sequencer.rng_sequencer_h);

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -17,9 +17,15 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.bypass_window_size          = 384;
     cfg.boot_mode_retry_limit       = 10;
     cfg.entropy_data_reg_enable_pct = 100;
-    cfg.sim_duration                = 10ms;
-    cfg.hard_mtbf                   = 500us;
+    cfg.sim_duration                = 100us;
+    cfg.hard_mtbf                   = 100ms;
     cfg.soft_mtbf                   = 7500us;
+    cfg.adaptp_sigma_min            = 1.0;
+    cfg.adaptp_sigma_max            = 2.0;
+    cfg.bucket_sigma_min            = 1.0;
+    cfg.bucket_sigma_max            = 2.0;
+    cfg.markov_sigma_min            = 1.0;
+    cfg.markov_sigma_max            = 2.0;
     cfg.alert_max_delay             = 5;
 
     // Allow for software reads, but let the vseq body do the enabling


### PR DESCRIPTION

- Sequences now apply thresholds with a particular standard deviation (likelihood of ht failure)
- push_pull_indefinite_host_sequences now have a "hard" stop which halts the sequence even
  if a transaction is still ongoing.  (This is especially important for pull sequences)
- Base sequence dut cleanup now has cleanup for health check failures
   - Note: This also requires final alert to deal with the fact that the push_pull_monitor will
     hang if the a host-pull sequence is aborted.
- Corrections to scoreboarding to deal with alerts caused by different types of consecutive
  healthcheck failures (e.g. a Bucket failure followed by a Markov failure)

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>