### PR TITLE
[lc_ctrl/dv] Added test lc_ctrl_stress_all and lc_ctrl_security_escalation

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -116,7 +116,14 @@
                upon next power cycle
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_security_escalation",
+              "lc_ctrl_errors",
+              "lc_ctrl_state_failure",
+              "lc_ctrl_prog_failure",
+              "lc_ctrl_jtag_errors",
+              "lc_ctrl_jtag_state_failure",
+              "lc_ctrl_jtag_prog_failure"
+              ]
     }
     {
       name: jtag_access
@@ -163,10 +170,11 @@
       name: stress_all
       desc: '''
             - Combine above sequences in one test to run sequentially, except csr sequence.
+            - Random selection of Tilelink or JTAG CSR for each sequence
             - Randomly add reset between each sequence.
             '''
       milestone: V2
-      tests: []
+      tests: ["lc_ctrl_stress_all"]
     }
   ]
 }

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -28,9 +28,11 @@ filesets:
       - seq_lib/lc_ctrl_errors_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_state_post_trans_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_lc_errors_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_security_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_jtag_access_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_jtag_priority_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_regwen_during_op_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
@@ -8,6 +8,20 @@
  * Covergroups may also be wrapped inside helper classes if needed.
  */
 
+// verilog_format: off
+// Cross a particular error condition with JTAG CSR
+`ifndef LC_CTRL_JTAG_ERROR_CROSS
+`define LC_CTRL_JTAG_ERROR_CROSS(error) \
+  jtag_``error``_xp : cross jtag_csr_cp, error``_cp;
+`endif
+
+// Cross a particular error condition with post_trans_err
+`ifndef LC_CTRL_POST_TRANS_CROSS
+`define LC_CTRL_POST_TRANS_CROSS(error) \
+  post_trans_``error``_xp : cross post_trans_err_cp, error``_cp;
+`endif
+
+
 class lc_ctrl_env_cov extends cip_base_env_cov #(
   .CFG_T(lc_ctrl_env_cfg)
 );
@@ -16,24 +30,62 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
   // the base class provides the following handles for use:
   // lc_ctrl_env_cfg: cfg
 
+  // Select error injections to mask for err_inj_cp
+  const lc_ctrl_err_inj_t ErrInjMask = '{post_trans_err: 1, default:0};
+
   // covergroups
 
-  // State error injections
+  // Error injections
   covergroup err_inj_cg;
+
+    // Any error injection
+    // Ignore post_trans_err as this doesn't inject an error
+    // it just tries a second transition
+
+
+    err_inj_cp : coverpoint (cfg.err_inj & ~ErrInjMask) {
+      bins no_err_inj = {0};
+      bins err_inj    = {[1 : $]};
+    }
+
     clk_byp_error_rsp_cp: coverpoint cfg.err_inj.clk_byp_error_rsp;
     flash_rma_error_rsp_cp: coverpoint cfg.err_inj.flash_rma_error_rsp;
     otp_prog_err_cp: coverpoint cfg.err_inj.otp_prog_err;
+    otp_partition_err_cp: coverpoint cfg.err_inj.otp_partition_err;
     token_mismatch_err_cp: coverpoint cfg.err_inj.token_mismatch_err;
     state_err_cp: coverpoint cfg.err_inj.state_err;
     state_backdoor_err_cp: coverpoint cfg.err_inj.state_backdoor_err;
     count_err_cp: coverpoint cfg.err_inj.count_err;
     count_backdoor_err_cp: coverpoint cfg.err_inj.count_backdoor_err;
     transition_err_cp: coverpoint cfg.err_inj.transition_err;
+    transition_count_err_cp: coverpoint cfg.err_inj.transition_count_err;
     post_trans_err_cp: coverpoint cfg.err_inj.post_trans_err;
+    security_escalation_err_cp: coverpoint cfg.err_inj.security_escalation_err;
+    jtag_csr_cp: coverpoint cfg.jtag_csr;
 
-    // Cross for attempted second transition with and without failure
-    state_post_trans_xp: cross post_trans_err_cp, state_err_cp, state_backdoor_err_cp,
-        count_err_cp, count_backdoor_err_cp;
+    // verilog_format: off - formatter doesnt like the macros here
+    // Crosses for attempted second transition with and without failure
+    `LC_CTRL_POST_TRANS_CROSS(err_inj)
+    `LC_CTRL_POST_TRANS_CROSS(state_err)
+    `LC_CTRL_POST_TRANS_CROSS(state_backdoor_err)
+    `LC_CTRL_POST_TRANS_CROSS(count_err)
+    `LC_CTRL_POST_TRANS_CROSS(count_backdoor_err)
+
+    // Crosses for error injection vs CSR access type  (JTAG/TL)- make sure we can detect
+    // the error by reading the status reg via both interfaces
+    `LC_CTRL_JTAG_ERROR_CROSS(clk_byp_error_rsp)
+    `LC_CTRL_JTAG_ERROR_CROSS(flash_rma_error_rsp)
+    `LC_CTRL_JTAG_ERROR_CROSS(otp_prog_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(otp_partition_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(token_mismatch_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(state_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(state_backdoor_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(count_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(count_backdoor_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(transition_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(transition_count_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(post_trans_err)
+     //verilog_format: on
 
   endgroup
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -78,6 +78,8 @@ package lc_ctrl_env_pkg;
     bit transition_err;
     // Invalid transition because count already at maximum
     bit transition_count_err;
+    // Randomly assert one or more escalate inputs
+    bit security_escalation_err;
   } lc_ctrl_err_inj_t;
 
   // Test phase - used to synchronise the scoreboard
@@ -87,6 +89,7 @@ package lc_ctrl_env_pkg;
     LcCtrlDutReady,
     LcCtrlBadNextState,
     LcCtrlWaitTransition,
+    LcCtrlRandomEscalate,
     LcCtrlTransitionComplete,
     LcCtrlReadState1,
     LcCtrlEscalate,

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -25,49 +25,50 @@ interface lc_ctrl_if (
   import otp_ctrl_pkg::*;
   import otp_ctrl_part_pkg::*;
 
-  logic                                 tdo_oe;  // TODO: add assertions
-  otp_lc_data_t                         otp_i;
-  otp_device_id_t                       otp_device_id_i;
-  otp_device_id_t                       otp_manuf_state_i;
-  lc_token_t                            hashed_token;
+  logic                                             tdo_oe;  // TODO: add assertions
+  otp_lc_data_t                                     otp_i;
+  otp_device_id_t                                   otp_device_id_i;
+  otp_device_id_t                                   otp_manuf_state_i;
+  lc_token_t                                        hashed_token;
 
-  lc_tx_t                               lc_dft_en_o;
-  lc_tx_t                               lc_nvm_debug_en_o;
-  lc_tx_t                               lc_hw_debug_en_o;
-  lc_tx_t                               lc_cpu_en_o;
-  lc_tx_t                               lc_creator_seed_sw_rw_en_o;
-  lc_tx_t                               lc_owner_seed_sw_rw_en_o;
-  lc_tx_t                               lc_iso_part_sw_rd_en_o;
-  lc_tx_t                               lc_iso_part_sw_wr_en_o;
-  lc_tx_t                               lc_seed_hw_rd_en_o;
-  lc_tx_t                               lc_keymgr_en_o;
-  lc_tx_t                               lc_escalate_en_o;
-  lc_tx_t                               lc_check_byp_en_o;
+  lc_tx_t                                           lc_dft_en_o;
+  lc_tx_t                                           lc_nvm_debug_en_o;
+  lc_tx_t                                           lc_hw_debug_en_o;
+  lc_tx_t                                           lc_cpu_en_o;
+  lc_tx_t                                           lc_creator_seed_sw_rw_en_o;
+  lc_tx_t                                           lc_owner_seed_sw_rw_en_o;
+  lc_tx_t                                           lc_iso_part_sw_rd_en_o;
+  lc_tx_t                                           lc_iso_part_sw_wr_en_o;
+  lc_tx_t                                           lc_seed_hw_rd_en_o;
+  lc_tx_t                                           lc_keymgr_en_o;
+  lc_tx_t                                           lc_escalate_en_o;
+  lc_tx_t                                           lc_check_byp_en_o;
 
-  lc_tx_t                               clk_byp_req_o;
-  lc_tx_t                               clk_byp_ack_i;
-  lc_tx_t                               flash_rma_req_o;
-  lc_tx_t                               flash_rma_ack_i;
+  lc_tx_t                                           clk_byp_req_o;
+  lc_tx_t                                           clk_byp_ack_i;
+  lc_tx_t                                           flash_rma_req_o;
+  lc_tx_t                                           flash_rma_ack_i;
 
-  lc_keymgr_div_t                       keymgr_div_o;
-  lc_flash_rma_seed_t                   flash_rma_seed_o;
+  lc_keymgr_div_t                                   keymgr_div_o;
+  lc_flash_rma_seed_t                               flash_rma_seed_o;
 
-  event                                 fsm_backdoor_state_write_ev;
-  event                                 fsm_backdoor_state_read_ev;
-  event                                 fsm_backdoor_count_write_ev;
-  event                                 fsm_backdoor_count_read_ev;
+  event                                             fsm_backdoor_state_write_ev;
+  event                                             fsm_backdoor_state_read_ev;
+  event                                             fsm_backdoor_count_write_ev;
+  event                                             fsm_backdoor_count_read_ev;
 
   //
   // Whitebox signals - these come from within the RTL
   //
 
   // Decoded mutex claim signal for JTAG and TL
-  logic                                 mutex_claim_jtag;
-  logic                                 mutex_claim_tl;
+  logic                                             mutex_claim_jtag;
+  logic                                             mutex_claim_tl;
 
   // Debug signals
-  lc_ctrl_env_pkg::lc_ctrl_err_inj_t    err_inj;
-  lc_ctrl_env_pkg::lc_ctrl_test_phase_e test_phase;
+  lc_ctrl_env_pkg::lc_ctrl_err_inj_t                err_inj;
+  lc_ctrl_env_pkg::lc_ctrl_test_phase_e             test_phase;
+  bit                                   [79:0][7:0] test_sequence_typename;
 
   task automatic init(lc_state_e lc_state = LcStRaw, lc_cnt_e lc_cnt = LcCnt0,
                       lc_tx_t clk_byp_ack = Off, lc_tx_t flash_rma_ack = Off,
@@ -141,6 +142,10 @@ interface lc_ctrl_if (
   function automatic logic [LcCountWidth-1:0] fsm_count_backdoor_read();
     ->fsm_backdoor_count_read_ev;
     return `LC_CTRL_FSM_COUNT_REGS_PATH;
+  endfunction
+
+  function automatic set_test_sequence_typename(string name);
+    test_sequence_typename = name;
   endfunction
 
 endinterface

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_regwen_during_op_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_regwen_during_op_vseq.sv
@@ -46,6 +46,7 @@ class lc_ctrl_regwen_during_op_vseq extends lc_ctrl_smoke_vseq;
             while(cfg.m_otp_prog_pull_agent_cfg.vif.req != 1) cfg.clk_rst_vif.wait_clks(1);,
             cfg.clk_rst_vif.wait_clks(max_wait);, wait_msg)
 
+        cfg.clk_rst_vif.wait_clks(100);
         // Read TRANSITION_REGWEN register - should be 0 by now
         csr_rd_check(.ptr(ral.transition_regwen), .compare_value(0));
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_security_escalation_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_security_escalation_vseq.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Attempt second transition before reset
+class lc_ctrl_security_escalation_vseq extends lc_ctrl_errors_vseq;
+
+  `uvm_object_utils(lc_ctrl_security_escalation_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[10 : 15]};}
+  constraint security_escalation_c {
+    err_inj.security_escalation_err == 1;
+    security_escalation_err_inj_delay inside {[0 : 100]};
+    security_escalation_err_inj_channels != 0;
+  }
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_stress_all_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_stress_all_vseq.sv
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all lc_ctrl seqs (except below seqs) in one seq to run sequentially
+// 1. csr seq, which requires scb to be disabled
+// 2. lc_ctrl_rx_oversample_vseq, which requires zero_delays as it's very timing sensitive
+class lc_ctrl_stress_all_vseq extends lc_ctrl_base_vseq;
+  `uvm_object_utils(lc_ctrl_stress_all_vseq)
+
+  `uvm_object_new
+
+  // Use JTAG for this test.
+  rand bit use_jtag;
+  uvm_reg_map jtag_map;
+  uvm_reg_map tl_map;
+
+
+  constraint num_trans_c {num_trans inside {[3 : 10]};}
+
+  virtual task pre_start();
+    super.pre_start();
+    // Find the jtag and tilelink adress map.
+    jtag_map = ral.get_map_by_name("jtag_riscv_map");
+    `DV_CHECK_NE_FATAL(jtag_map, null)
+    tl_map = ral.get_map_by_name("default_map");
+    `DV_CHECK_NE_FATAL(tl_map, null)
+  endtask
+
+  task body();
+    string seq_names[] = {"lc_ctrl_smoke_vseq",
+                          "lc_ctrl_lc_errors_vseq",
+                          "lc_ctrl_prog_failure_vseq",
+                          "lc_ctrl_regwen_during_op_vseq",
+                          "lc_ctrl_state_post_trans_vseq",
+                          "lc_ctrl_state_failure_vseq"};
+
+    // Short delay after initial reset
+    cfg.clk_rst_vif.wait_clks($urandom_range(10, 5));
+
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence      seq;
+      lc_ctrl_base_vseq lc_ctrl_vseq;
+      uint              seq_idx = $urandom_range(0, seq_names.size - 1);
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(lc_ctrl_vseq, seq)
+
+      // Randomly choose TL or JTAG for register access
+      if (use_jtag && (cfg.jtag_riscv_map != null)) begin
+        cfg.jtag_csr = 1;
+        cfg.alert_max_delay = 4000;
+        cfg.ral.set_default_map(jtag_map);
+      end else begin
+        cfg.jtag_csr = 0;
+        cfg.alert_max_delay = 1500;
+        cfg.ral.set_default_map(tl_map);
+      end
+
+
+      lc_ctrl_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(lc_ctrl_vseq)
+      if (seq_names[seq_idx] == "lc_ctrl_common_vseq") begin
+        lc_ctrl_common_vseq common_vseq;
+        `downcast(common_vseq, lc_ctrl_vseq);
+        common_vseq.common_seq_type = "intr_test";
+      end
+      `uvm_info(`gfn, $sformatf("body: executing sequence %s", lc_ctrl_vseq.get_type_name()),
+                UVM_MEDIUM)
+      lc_ctrl_vseq.start(p_sequencer);
+
+    end
+  endtask : body
+
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -10,8 +10,10 @@
 `include "lc_ctrl_state_failure_vseq.sv"
 `include "lc_ctrl_state_post_trans_vseq.sv"
 `include "lc_ctrl_lc_errors_vseq.sv"
+`include "lc_ctrl_security_escalation_vseq.sv"
 `include "lc_ctrl_jtag_access_vseq.sv"
 `include "lc_ctrl_jtag_priority_vseq.sv"
 `include "lc_ctrl_regwen_during_op_vseq.sv"
+`include "lc_ctrl_stress_all_vseq.sv"
 
 

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -72,6 +72,11 @@
     }
 
     {
+      name: lc_ctrl_security_escalation
+      uvm_test_seq: lc_ctrl_security_escalation_vseq
+    }
+
+    {
       name: lc_ctrl_regwen_during_op
       uvm_test_seq: lc_ctrl_regwen_during_op_vseq
       reseed: 10
@@ -193,6 +198,11 @@
       uvm_test_seq: "lc_ctrl_common_vseq"
       run_opts: ["+run_alert_test", "+en_scb=0", "+jtag_csr=1"]
       reseed: 10
+    }
+
+    {
+      name: "lc_ctrl_stress_all"
+      uvm_test_seq: lc_ctrl_stress_all_vseq
     }
 
   ]


### PR DESCRIPTION
- Added test sequences:
  - lc_ctrl_stress_all_vseq.sv
 Randomly cycles through the other sequences and randomly choosing
 TL or JTAG for CSR access for that sequence
  - lc_ctrl_security_escalation_vseq.sv
 Randomly triggers an escalation while the process to transition is
 occuring so as to exercise all the [state] -> escalate arcs of the FSM
- Fixed lc_ctrl_smoke_vseq which needed to set cfg.test_phase
- Fixed lc_ctrl_errors_vseq so it can be rerun by lc_ctrl_stress_all
- Fixed scoreboard for new escalate scenarios
to avoid scoreboard errors when run after another sequence.
- Added test_sequence_typename string to lc_ctrl_if to aid debugging
this is set to to the test sequence typename at the start of each sequence.

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>