### PR TITLE
[aes] Move to D2

### DIFF
--- a/hw/ip/aes/aes.core
+++ b/hw/ip/aes/aes.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ip:aes:0.6"
+name: "lowrisc:ip:aes:1.0"
 description: "AES unit"
 filesets:
   files_rtl:

--- a/hw/ip/aes/data/aes.prj.hjson
+++ b/hw/ip/aes/data/aes.prj.hjson
@@ -10,8 +10,8 @@
     sw_checklist:       "/sw/device/lib/dif/dif_aes",
     version:            "1.0",
     life_stage:         "L1",
-    design_stage:       "D1",
+    design_stage:       "D2",
     verification_stage: "V1",
     dif_stage:          "S0",
-    notes:              "D2 except for SEC_CM_IMPLEMENTED; SCA/FI hardening in progress",
+    notes:              "",
 }

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -43,14 +43,14 @@ Documentation | [FEATURE_FROZEN][]      | Done        |
 RTL           | [FEATURE_COMPLETE][]    | Done        |
 RTL           | [AREA_CHECK][]          | Done        |
 RTL           | [PORT_FROZEN][]         | Done        |
-RTL           | [ARCHITECTURE_FROZEN][] | In progress | SCA/FI hardening in progress
+RTL           | [ARCHITECTURE_FROZEN][] | Done        |
 RTL           | [REVIEW_TODO][]         | Done        |
 RTL           | [STYLE_X][]             | Done        |
 Code Quality  | [LINT_PASS][]           | Done        |
 Code Quality  | [CDC_SETUP][]           | Waived      | CDC flow is not available yet.
 Code Quality  | [FPGA_TIMING][]         | Done        |
 Code Quality  | [CDC_SYNCMACRO][]       | Done        |
-Security      | [SEC_CM_DOCUMENTED][]   | In progress | SCA/FI hardening in progress
+Security      | [SEC_CM_DOCUMENTED][]   | Done        |
 Security      | [SEC_RND_CNST][]        | Done        |
 
 [NEW_FEATURES]:        {{<relref "/doc/project/checklist.md#new_features" >}}

--- a/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
+++ b/hw/ip/aes/dv/aes_model_dpi/aes_model_dpi.core
@@ -2,13 +2,13 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:aes_model_dpi:0.6"
+name: "lowrisc:dv:aes_model_dpi"
 description: "AES model DPI"
 filesets:
   files_dv:
     depend:
-      - lowrisc:ip:aes:0.6
-      - lowrisc:model:aes:0.6
+      - lowrisc:ip:aes
+      - lowrisc:model:aes
 
     files:
       - aes_model_dpi.c: { file_type: cSource }

--- a/hw/ip/aes/dv/aes_sim.core
+++ b/hw/ip/aes/dv/aes_sim.core
@@ -7,7 +7,7 @@ description: "AES DV sim target"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:aes:0.6
+      - lowrisc:ip:aes
 
   files_dv:
     depend:

--- a/hw/ip/aes/dv/cov/aes_cov.core
+++ b/hw/ip/aes/dv/cov/aes_cov.core
@@ -9,7 +9,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_utils
-      - lowrisc:ip:aes:0.6
+      - lowrisc:ip:aes
     files:
       - aes_cov_if.sv
       - aes_cov_bind.sv

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -7,7 +7,7 @@ description: "AES DV UVM environment"
 filesets:
   files_rtl:
     depend:
-        - lowrisc:ip:aes:0.6
+        - lowrisc:ip:aes
   files_dv:
     depend:
       - lowrisc:dv:ralgen

--- a/hw/ip/aes/model/aes_model.core
+++ b/hw/ip/aes/model/aes_model.core
@@ -2,7 +2,7 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:model:aes:0.6"
+name: "lowrisc:model:aes:1.0"
 description: "AES Model"
 filesets:
   files_dv:

--- a/hw/ip/aes/model/aes_model_sim_opts.hjson
+++ b/hw/ip/aes/model/aes_model_sim_opts.hjson
@@ -4,18 +4,18 @@
 {
   // Additional build-time options for enabling the compilation of the C sources
   // with DV simulators such as VCS and Xcelium.
-  aes_mode_core: "lowrisc:model:aes:0.6"
-  aes_mode_src_dir: "{eval_cmd} echo \"{aes_mode_core}\" | tr ':' '_'"
+  aes_model_core: "lowrisc:model:aes:1.0"
+  aes_model_src_dir: "{eval_cmd} echo \"{aes_model_core}\" | tr ':' '_'"
 
   build_modes: [
     {
       name: vcs_aes_model_build_opts
-      build_opts: ["-CFLAGS -I{build_dir}/src/{aes_mode_src_dir}", "-lcrypto"]
+      build_opts: ["-CFLAGS -I{build_dir}/src/{aes_model_src_dir}", "-lcrypto"]
     }
 
     {
       name: xcelium_aes_model_build_opts
-      build_opts: ["-I{build_dir}/src/{aes_mode_src_dir}", "-lcrypto"]
+      build_opts: ["-I{build_dir}/src/{aes_model_src_dir}", "-lcrypto"]
     }
   ]
 }

--- a/hw/ip/aes/pre_dv/aes_sbox_tb/aes_sbox_tb.core
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/aes_sbox_tb.core
@@ -7,7 +7,7 @@ description: "AES SBox Verilator TB"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:aes:0.6
+      - lowrisc:ip:aes
     files:
       - rtl/aes_sbox_tb.sv
     file_type: systemVerilogSource

--- a/hw/ip/csrng/dv/env/csrng_env.core
+++ b/hw/ip/csrng/dv/env/csrng_env.core
@@ -7,7 +7,7 @@ description: "CSRNG DV UVM environment"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:aes:0.6
+      - lowrisc:ip:aes
   files_dv:
     depend:
       - lowrisc:dv:ralgen


### PR DESCRIPTION
This PR moves AES into D2. 

Note that before entering D2, this PR adding a CSR to control the PRNG reseeding rate needs to be merged: #9299

The implementation and verification of countermeasures have been moved to D2S and V2S, respectively. This means once PR #9299 is merged, we've got everything we need for D2.