### PR TITLE
[aes] Add list of countermeasures in preparation for D2S sign-off

### DIFF
--- a/doc/rm/comportability_specification/index.md
+++ b/doc/rm/comportability_specification/index.md
@@ -302,6 +302,7 @@ The following standardised countermeasures are defined:
 | SW_UNWRITABLE  | The asset is not writable by software | MEM, KEY
 | SW_NOACCESS    | The asset is not writable nor readable by software (SW_UNWRITABLE and SW_UNREADABLE at the same time) | MEM, KEY
 | SIDELOAD       | The asset can be loaded without exposing it to software | KEY
+| SEC_WIPE       | The asset is initialized or cleared using pseudo-random data | KEY, DATA_REG, MEM
 | SCA            | A countermeasure that provides side-channel attack resistance |
 | MASKING        | A more specific version of SCA where an asset is split into shares |
 | LOCAL_ESC      | A local escalation event is triggered when an attack is detected |

--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -12,6 +12,11 @@
   bus_interfaces: [
     { protocol: "tlul", direction: "device" }
   ],
+
+  ////////////////
+  // Parameters //
+  ////////////////
+
   param_list: [
     # Regular parameters
     { name:    "AES192Enable",
@@ -136,6 +141,11 @@
       local:   "true"
     }
   ],
+
+  /////////////////////////////
+  // Intermodule Connections //
+  /////////////////////////////
+
   inter_signal_list: [
     { name:    "idle",
       type:    "uni",
@@ -164,6 +174,11 @@
       package: "keymgr_pkg"
     }
   ],
+
+  ///////////////////////////
+  // Interrupts and Alerts //
+  ///////////////////////////
+
   alert_list: [
     //{ name: "informative",
     //  desc: '''
@@ -194,11 +209,122 @@
       '''
     }
   ],
+
+  /////////////////////
+  // Countermeasures //
+  /////////////////////
+
   countermeasures: [
     { name: "BUS.INTEGRITY",
       desc: "End-to-end bus integrity scheme."
     }
+    { name: "LC_ESCALATE_EN.INTERSIG.MUBI",
+      desc: "The global escalation input signal from life cycle is multibit encoded."
+    }
+    { name: "MAIN.CONFIG.SHADOW",
+      desc: "Main control register shadowed."
+    }
+    { name: "MAIN.CONFIG.SPARSE",
+      desc: "Critical fields in main control register one-hot encoded."
+    }
+    { name: "AUX.CONFIG.SHADOW",
+      desc: "Auxiliary control register shadowed."
+    }
+    { name: "AUX.CONFIG.REGWEN",
+      desc: "Auxiliary control register can be locked until reset."
+    }
+    { name: "KEY.SIDELOAD",
+      desc: "The key can be loaded from a key manager via sideload interface without exposing it to software."
+    }
+    { name: "KEY.SW_UNREADABLE",
+      desc: "Key registers are not readable by software."
+    }
+    { name: "IV.CONFIG.SW_UNREADABLE",
+      desc: "IV registers are not readable by software."
+    }
+    { name: "DATA_REG.SW_UNREADABLE",
+      desc: "Data input and internal state registers are not readable by software."
+    }
+    { name: "KEY.SEC_WIPE",
+      desc: "Key registers are cleared with pseudo-random data."
+    }
+    { name: "IV.CONFIG.SEC_WIPE",
+      desc: "IV registers are cleared with pseudo-random data."
+    }
+    { name: "DATA_REG.SEC_WIPE",
+      desc: "Data input/output and internal state registers are cleared with pseudo-random data."
+    }
+    { name: "DATA_REG.KEY.SCA",
+      desc: '''
+        Internal state register cleared with pseudo-random data at the end of the last round.
+        This uses the same mechanism as KEY.SEC_WIPE and is active independent of KEY.MASKING.
+      '''
+    }
+    { name: "KEY.MASKING",
+      desc: '''
+        1st-order domain-oriented masking of the cipher core including data path and key expand.
+        Can optionally be disabled via compile-time Verilog parameter for instantiations that don't need SCA hardening.
+      '''
+    }
+    { name: "MAIN.FSM.SPARSE",
+      desc: "The main control FSM uses a sparse state encoding."
+    }
+    { name: "MAIN.FSM.REDUN",
+      desc: "The main control FSM uses multiple, independent logic rails."
+    }
+    { name: "CIPHER.FSM.SPARSE",
+      desc: "The cipher core FSM uses a sparse state encoding."
+    }
+    { name: "CIPHER.FSM.REDUN",
+      desc: "The cipher core FSM uses multiple, independent logic rails."
+    }
+    { name: "CIPHER.CTR.REDUN",
+      desc: "The AES round counter inside the cipher core FSM is protected with multiple, independent logic rails."
+    }
+    { name: "CTR.FSM.SPARSE",
+      desc: "The CTR mode FSM uses a sparse state encoding."
+    }
+    { name: "CTR.FSM.REDUN",
+      desc: "The CTR mode FSM uses multiple, independent logic rails."
+    }
+    { name: "CTRL.SPARSE",
+      desc: "Critical control signals such as handshake and MUX control signals use sparse encodings."
+    }
+    { name: "MAIN.FSM.GLOBAL_ESC",
+      desc: "The main control FSM moves to a terminal error state upon global escalation."
+    }
+    { name: "MAIN.FSM.LOCAL_ESC",
+      desc: '''
+        The main control FSM moves to a terminal error state upon local escalation.
+        Can be triggered by MAIN.FSM.SPARSE, MAIN.FSM.REDUN, CTRL.SPARSE, as well as CIPHER.FSM.LOCAL_ESC, CTR.FSM.LOCAL_ESC.
+      '''
+    }
+    { name: "CIPHER.FSM.LOCAL_ESC",
+      desc: '''
+        The cipher core FSM moves to a terminal error state upon local escalation.
+        Can be triggered by CIPHER.FSM.SPARSE, CIPHER.FSM.REDUN, CIPHER.CTR.REDUN, CTRL.SPARSE as well as MAIN.FSM.LOCAL_ESC.
+      '''
+    }
+    { name: "CTR.FSM.LOCAL_ESC",
+      desc: '''
+        The CTR mode FSM moves to a terminal error state upon local escalation.
+        Can be triggered by CTR.FSM.SPARSE, CTR.FSM.REDUN, and CTRL.SPARSE.
+      '''
+    }
+    { name: "DATA_REG.LOCAL_ESC",
+      desc: "Upon local escalation, the module doesn't output intermediate state."
+    }
+    // This is work in progress.
+    // Datapath FI hardening hasn't been a strict requirement but with the current cipher core architecture it can be done at relatively low area/performance overhead and therefore is a nice-to-have.
+    //{ name: "DATA_REG.INTEGRITY",
+    //  desc: "Datapath FI hardening."
+    //}
   ]
+
+  ///////////////
+  // Registers //
+  ///////////////
+
   regwidth: "32",
   registers: [
 ##############################################################################
@@ -551,7 +677,7 @@
 
       This register is shadowed, meaning two subsequent write operations are required to change its content.
       If the two write operations try to set a different value, a recoverable alert is triggered (See Status Register).
-      A read operation clears the internal phase tracking: The next write operation is always considered a first write operation of an update sequence.              
+      A read operation clears the internal phase tracking: The next write operation is always considered a first write operation of an update sequence.
     '''
     swaccess: "rw",
     hwaccess: "hro",

--- a/hw/ip/aes/doc/checklist.md
+++ b/hw/ip/aes/doc/checklist.md
@@ -76,7 +76,7 @@ Security      | [SEC_RND_CNST][]        | Done        |
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
 Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | Datapath FI hardening in progress (not strictly required)
 Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
 Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
 

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -84,6 +84,11 @@ module aes
   // Inputs //
   ////////////
 
+  // SEC_CM: AUX.CONFIG.SHADOW
+  // SEC_CM: AUX.CONFIG.REGWEN
+  // SEC_CM: KEY.SW_UNREADABLE
+  // SEC_CM: IV.CONFIG.SW_UNREADABLE
+  // SEC_CM: DATA_REG.SW_UNREADABLE
   // Register interface
   logic intg_err_alert;
   aes_reg_top u_reg (
@@ -98,6 +103,7 @@ module aes
     .devmode_i(1'b1)
   );
 
+  // SEC_CM: LC_ESCALATE_EN.INTERSIG.MUBI
   // Synchronize life cycle input
   prim_lc_sync #(
     .NumCopies (2)

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -144,6 +144,8 @@ module aes_cipher_control import aes_pkg::*;
   assign sp_crypt_q            = {crypt_q};
   assign sp_dec_key_gen_q      = {dec_key_gen_q};
 
+  // SEC_CM: CIPHER.FSM.REDUN
+  // SEC_CM: CIPHER.CTR.REDUN
   // For every bit in the Sp2V signals, one separate rail is instantiated. The inputs and outputs
   // of every rail are buffered to prevent aggressive synthesis optimizations.
   for (genvar i = 0; i < Sp2VWidth; i++) begin : gen_fsm
@@ -374,10 +376,12 @@ module aes_cipher_control import aes_pkg::*;
   assign key_clear_o      = key_clear_q;
   assign data_out_clear_o = data_out_clear_q;
 
+
   //////////////////////////////
   // Sparsely Encoded Signals //
   //////////////////////////////
 
+  // SEC_CM: CTRL.SPARSE
   // We use sparse encodings for various critical signals and must ensure that:
   // 1. The synthesis tool doesn't optimize away the sparse encoding.
   // 2. The sparsely encoded signal is always valid. More precisely, an alert or SVA is triggered

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
@@ -365,10 +365,12 @@ module aes_cipher_control_fsm import aes_pkg::*;
         // Keep requesting PRNG reseeding until it is acknowledged.
         prng_reseed_req_o = Masking & prng_reseed_q_i & ~prng_reseed_done_q;
 
+        // SEC_CM: DATA_REG.KEY.SCA
         // Once we're done, we won't need the state anymore. We actually clear it when progressing
         // to the next state.
         state_sel_o = STATE_CLEAR;
 
+        // SEC_CM: DATA_REG.LOCAL_ESC
         // Advance in sync with SubBytes. Based on the S-Box implementation, it can take multiple
         // cycles to finish. Only indicate that we are done if:
         // - we have valid output (SubBytes finished),
@@ -436,6 +438,7 @@ module aes_cipher_control_fsm import aes_pkg::*;
         end
         if (data_out_clear_q_i) begin
           // Forward the state (previously cleared with psuedo-random data).
+          // SEC_CM: DATA_REG.SEC_WIPE
           add_rk_sel_o    = ADD_RK_INIT;
           key_words_sel_o = KEY_WORDS_ZERO;
           round_key_sel_o = ROUND_KEY_DIRECT;
@@ -450,6 +453,7 @@ module aes_cipher_control_fsm import aes_pkg::*;
       end
 
       ERROR: begin
+        // SEC_CM: CIPHER.FSM.LOCAL_ESC
         // Terminal error state
         alert_o = 1'b1;
       end
@@ -468,6 +472,7 @@ module aes_cipher_control_fsm import aes_pkg::*;
     end
   end
 
+  // SEC_CM: CIPHER.FSM.SPARSE
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
   logic [StateWidth-1:0] aes_cipher_ctrl_cs_raw;

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -261,6 +261,7 @@ module aes_cipher_core import aes_pkg::*;
   // Data //
   //////////
 
+  // SEC_CM: DATA_REG.SEC_WIPE
   // State registers
   always_comb begin : state_mux
     unique case (state_sel)
@@ -423,6 +424,7 @@ module aes_cipher_core import aes_pkg::*;
   // Key //
   /////////
 
+  // SEC_CM: KEY.SEC_WIPE
   // Full Key registers
   always_comb begin : key_full_mux
     unique case (key_full_sel)
@@ -442,6 +444,7 @@ module aes_cipher_core import aes_pkg::*;
     end
   end
 
+  // SEC_CM: KEY.SEC_WIPE
   // Decryption Key registers
   always_comb begin : key_dec_mux
     unique case (key_dec_sel)

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -239,6 +239,7 @@ module aes_control
   assign sp_in_cipher_crypt       = {cipher_crypt};
   assign sp_in_cipher_dec_key_gen = {cipher_dec_key_gen};
 
+  // SEC_CM: MAIN.FSM.REDUN
   // For every bit in the Sp2V signals, one separate rail is instantiated. The inputs and outputs
   // of every rail are buffered to prevent aggressive synthesis optimizations.
   for (genvar i = 0; i < Sp2VWidth; i++) begin : gen_fsm
@@ -503,6 +504,7 @@ module aes_control
   // Sparsely Encoded Signals //
   //////////////////////////////
 
+  // SEC_CM: CTRL.SPARSE
   // We use sparse encodings for various critical signals and must ensure that:
   // 1. The synthesis tool doesn't optimize away the sparse encoding.
   // 2. The sparsely encoded signal is always valid. More precisely, an alert or SVA is triggered

--- a/hw/ip/aes/rtl/aes_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm.sv
@@ -626,6 +626,7 @@ module aes_control_fsm
       end
 
       ERROR: begin
+        // SEC_CM: MAIN.FSM.LOCAL_ESC
         // Terminal error state
         alert_o = 1'b1;
       end
@@ -644,6 +645,7 @@ module aes_control_fsm
     end
   end
 
+  // SEC_CM: MAIN.FSM.SPARSE
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
   logic [StateWidth-1:0] aes_ctrl_cs_raw;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -261,6 +261,8 @@ module aes_core
   // Key, IV and Data //
   //////////////////////
 
+  // SEC_CM: KEY.SEC_WIPE
+  // SEC_CM: KEY.SIDELOAD
   // Initial Key registers
   always_comb begin : key_init_mux
     unique case (key_init_sel)
@@ -285,6 +287,7 @@ module aes_core
     end
   end
 
+  // SEC_CM: IV.CONFIG.SEC_WIPE
   // IV registers
   always_comb begin : iv_mux
     unique case (iv_sel)
@@ -310,6 +313,7 @@ module aes_core
     end
   end
 
+  // SEC_CM: DATA_REG.SEC_WIPE
   // Previous input data register
   always_comb begin : data_in_prev_mux
     unique case (data_in_prev_sel)
@@ -401,6 +405,7 @@ module aes_core
     assign key_init_cipher    = key_init_q;
   end
 
+  // SEC_CM: KEY.MASKING
   // Cipher core
   aes_cipher_core #(
     .AES192Enable           ( AES192Enable           ),
@@ -617,6 +622,7 @@ module aes_core
     .input_ready_we_o          ( hw2reg.status.input_ready.de           )
   );
 
+  // SEC_CM: DATA_REG.SEC_WIPE
   // Input data register clear
   always_comb begin : data_in_reg_clear
     for (int i = 0; i < NumRegsData; i++) begin

--- a/hw/ip/aes/rtl/aes_ctr.sv
+++ b/hw/ip/aes/rtl/aes_ctr.sv
@@ -72,6 +72,7 @@ module aes_ctr import aes_pkg::*;
   // Reverse byte order
   assign ctr_i_rev = aes_rev_order_byte(ctr_i);
 
+  // SEC_CM: CTRL.SPARSE
   // Check sparsely encoded incr signal.
   logic [Sp2VWidth-1:0] incr_raw;
   aes_sel_buf_chk #(
@@ -100,6 +101,7 @@ module aes_ctr import aes_pkg::*;
   // Convert sp2v_e signals to sparsified inputs.
   assign sp_incr = {incr};
 
+  // SEC_CM: CTR.FSM.REDUN
   // For every bit in the Sp2V signals, one separate rail is instantiated. The inputs and outputs
   // of every rail are buffered to prevent aggressive synthesis optimizations.
   for (genvar i = 0; i < Sp2VWidth; i++) begin : gen_fsm

--- a/hw/ip/aes/rtl/aes_ctr_fsm.sv
+++ b/hw/ip/aes/rtl/aes_ctr_fsm.sv
@@ -101,6 +101,7 @@ module aes_ctr_fsm import aes_pkg::*;
       end
 
       ERROR: begin
+        // SEC_CM: CTR.FSM.LOCAL_ESC
         // Terminal error state
         alert_o = 1'b1;
       end
@@ -129,6 +130,7 @@ module aes_ctr_fsm import aes_pkg::*;
     end
   end
 
+  // SEC_CM: CTR.FSM.SPARSE
   // This primitive is used to place a size-only constraint on the
   // flops in order to prevent FSM state encoding optimizations.
   logic [StateWidth-1:0] aes_ctr_cs_raw;

--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -132,6 +132,7 @@ module aes_ctrl_reg_shadowed
   assign ctrl_wd.force_zero_masks = SecAllowForcingMasks ? reg2hw_ctrl_i.force_zero_masks.q : 1'b0;
   assign unused_force_zero_masks = SecAllowForcingMasks ? 1'b0 : reg2hw_ctrl_i.force_zero_masks.q;
 
+  // SEC_CM: MAIN.CONFIG.SHADOW
   // Instantiate one shadowed register primitive per field. An update error in a field should
   // only prevent the update of the affected field.
   prim_subreg_shadow #(

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -82,11 +82,13 @@ parameter int AES_MODE_WIDTH           = 6;
 parameter int AES_KEYLEN_WIDTH         = 3;
 parameter int AES_PRNGRESEEDRATE_WIDTH = 3;
 
+// SEC_CM: MAIN.CONFIG.SPARSE
 typedef enum logic [AES_OP_WIDTH-1:0] {
   AES_ENC = 2'b01,
   AES_DEC = 2'b10
 } aes_op_e;
 
+// SEC_CM: MAIN.CONFIG.SPARSE
 typedef enum logic [AES_MODE_WIDTH-1:0] {
   AES_ECB  = 6'b00_0001,
   AES_CBC  = 6'b00_0010,
@@ -101,12 +103,14 @@ typedef enum logic [AES_OP_WIDTH-1:0] {
   CIPH_INV = 2'b10
 } ciph_op_e;
 
+// SEC_CM: MAIN.CONFIG.SPARSE
 typedef enum logic [AES_KEYLEN_WIDTH-1:0] {
   AES_128 = 3'b001,
   AES_192 = 3'b010,
   AES_256 = 3'b100
 } key_len_e;
 
+// SEC_CM: MAIN.CONFIG.SPARSE
 typedef enum logic [AES_PRNGRESEEDRATE_WIDTH-1:0] {
   PER_1  = 3'b001,
   PER_64 = 3'b010,

--- a/hw/ip/aes/rtl/aes_sbox.sv
+++ b/hw/ip/aes/rtl/aes_sbox.sv
@@ -61,6 +61,7 @@ module aes_sbox import aes_pkg::*;
 
   end else begin : gen_sbox_masked
 
+    // SEC_CM: KEY.MASKING
     if (SBoxImpl == SBoxImplDom) begin : gen_sbox_dom
 
       aes_sbox_dom u_aes_sbox (

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
@@ -430,6 +430,7 @@ module aes_masked_inverse_gf2p8 (
 
 endmodule
 
+// SEC_CM: KEY.MASKING
 module aes_sbox_canright_masked (
   input  aes_pkg::ciph_op_e op_i,
   input  logic [7:0]        data_i, // masked, the actual input data is data_i ^ mask_i

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
@@ -388,6 +388,7 @@ module aes_masked_inverse_gf2p8_noreuse (
 
 endmodule
 
+// SEC_CM: KEY.MASKING
 module aes_sbox_canright_masked_noreuse (
   input  aes_pkg::ciph_op_e op_i,
   input  logic        [7:0] data_i, // masked, the actual input data is data_i ^ mask_i

--- a/hw/ip/aes/rtl/aes_sbox_dom.sv
+++ b/hw/ip/aes/rtl/aes_sbox_dom.sv
@@ -980,6 +980,7 @@ module aes_dom_inverse_gf2p8 #(
 
 endmodule
 
+// SEC_CM: KEY.MASKING
 module aes_sbox_dom
 #(
   parameter bit PipelineMul = 1'b1

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -34,6 +34,7 @@ module aes_sub_bytes import aes_pkg::*;
   logic [3:0][3:0][WidthPRDSBox+19:0] in_prd;
   logic [3:0][3:0]             [19:0] out_prd;
 
+  // SEC_CM: CTRL.SPARSE
   // Check sparsely encoded signals.
   logic [Sp2VWidth-1:0] en_raw;
   aes_sel_buf_chk #(

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -52,6 +52,7 @@ CM_TYPES = [
     'SW_UNWRITABLE',
     'SW_NOACCESS',
     'SIDELOAD',
+    'SEC_WIPE',
     'SCA',
     'MASKING',
     'LOCAL_ESC',


### PR DESCRIPTION
This PR adds the list of countermeasures for AES in preparation for the D2S sign-off.

This requires #9816 to go in first.