### PR TITLE
[fpv/script] Update tcl script

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -9,10 +9,8 @@ source $env(COMMON_MSG_TCL_PATH)
 
 if {$env(COV) == 1} {
   check_cov -init -model {branch statement functional} \
-  -enable_prove_based_proof_core
+  -exclude_bind_hierarchies
 }
-set_task_compile_time_limit 1000s
-set_property_compile_time_limit 1000s
 
 #-------------------------------------------------------------------------
 # read design
@@ -24,13 +22,13 @@ analyze -sv09     \
   -f [glob *.scr]
 
 if {$env(DUT_TOP) == "prim_count_tb"} {
-  elaborate -bbox_a 4320 \
-            -top $env(DUT_TOP) \
+  elaborate -top $env(DUT_TOP) \
             -enable_sva_isunknown \
+            -disable_auto_bbox \
             -param OutSelDnCnt $OutSelDnCnt \
             -param CntStyle $CntStyle
 } else {
-  elaborate -bbox_a 4320 -top $env(DUT_TOP) -enable_sva_isunknown
+  elaborate -top $env(DUT_TOP) -enable_sva_isunknown -disable_auto_bbox
 }
 
 #-------------------------------------------------------------------------
@@ -155,15 +153,17 @@ if {[info exists ::env(CHECK)]} {
   }
 }
 
+# Uncomment "jg_auto_coi_cov_waivers" to automatically waive out COI cover items which cannot
+# propagate to "relevant signals" (by default, top instance outputs). If you need to specify
+# include/exclude relevant signals manually, run "jg_auto_coi_cov_waivers -help" for more
+# options.
+jg_auto_coi_cov_waivers
+
 #-------------------------------------------------------------------------
 # configure proofgrid
 #-------------------------------------------------------------------------
 
 set_proofgrid_per_engine_max_local_jobs 2
-
-# Uncomment below 2 lines when using LSF:
-# set_proofgrid_mode lsf
-# set_proofgrid_per_engine_max_jobs 16
 
 #-------------------------------------------------------------------------
 # prove all assertions & report

--- a/hw/formal/tools/jaspergold/jaspergold.hjson
+++ b/hw/formal/tools/jaspergold/jaspergold.hjson
@@ -3,10 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   build_cmd: "{job_prefix} jg"
-  build_opts: ["{batch_mode_prefix} {formal_root}/tools/{tool}/{sub_flow}.tcl",
+  build_opts: ["-batch {formal_root}/tools/{tool}/{sub_flow}.tcl",
                "-proj jgproject",
-               "-allow_unsupported_OS",
-               "-command exit"]
+               "-allow_unsupported_OS"]
 
   exports: [
     {COMMON_MSG_TCL_PATH: "{formal_root}/tools/{tool}/jaspergold_common_message_process.tcl"}

--- a/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
+++ b/hw/formal/tools/jaspergold/jaspergold_common_message_process.tcl
@@ -36,3 +36,4 @@ set_message -disable VERI-1796
 # "initial construct ignored"
 set_message -disable VERI-1060
 
+set_prove_verbosity 4


### PR DESCRIPTION
This PR updates fpv.tcl script with some latest jaspergold changes:
1). Remove the out-of-date tcl command.
2). Remove `command exit` because it is included in -batch mode.
3). Set verbosity so won't print out all log details.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>