### PR TITLE
[dif/alert_handler] Add local alert configuration DIF.

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -331,7 +331,8 @@ dif_result_t dif_alert_handler_configure(
 /**
  * Configures an alert in the alert handler.
  *
- * This operation is lock-protected.
+ * This operation is lock-protected, meaning once the configuration is locked,
+ * it cannot be reconfigured until after a system reset.
  *
  * @param handler An alert handler handle.
  * @param alert The alert to be configured.
@@ -343,6 +344,26 @@ dif_result_t dif_alert_handler_configure(
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_alert_handler_configure_alert(
     const dif_alert_handler_t *alert_handler, dif_alert_handler_alert_t alert,
+    dif_alert_handler_class_t alert_class, dif_toggle_t enabled,
+    dif_toggle_t locked);
+
+/**
+ * Configures a local alert in the alert handler.
+ *
+ * This operation is lock-protected, meaning once the configuration is locked,
+ * it cannot be reconfigured until after a system reset.
+ *
+ * @param handler An alert handler handle.
+ * @param local_alert The local alert to be configured.
+ * @param alert_class The class to assign the alert to.
+ * @param enabled The enablement state to configure the alert in.
+ * @param locked The locked state to configure the alert in.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_configure_local_alert(
+    const dif_alert_handler_t *alert_handler,
+    dif_alert_handler_local_alert_t local_alert,
     dif_alert_handler_class_t alert_class, dif_toggle_t enabled,
     dif_toggle_t locked);
 


### PR DESCRIPTION
Previously, the only way to configure a **local** alert within the alert handler was to build a rather large struct that would configure all **local** alerts within a class. (Re)Configuring a single local alert had the side of effect of reconfiguring the class too.

This commit adds a DIF to configure a single **local** alert, i.e., enable it, set its class, and lock it. This partially addresses #9899.

**_Note: this depends on #9948, and therefore has a duplicate commit that will be removed when the dependency merges._**