### PR TITLE
[sram/dv] Update exec coverage

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -206,6 +206,7 @@
       name: executable_cg
       desc: '''
             Covers the various important scenarios that can enable SRAM executability.
+            Crosses CSR `exec`, input `lc_hw_debug_en` and input `sram_ifetch`.
             '''
     }
   ]

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cov.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cov.sv
@@ -107,7 +107,7 @@ class sram_ctrl_env_cov #(parameter int AddrWidth = 10)
     access_during_key_req_cg  = new();
     key_seed_valid_cg         = new();
     lc_escalation_idle_cg     = new();
-    if (`INSTR_EXEC) executable_cg = new();
+    executable_cg = new();
   endfunction : new
 
   virtual function void build_phase(uvm_phase phase);

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -167,16 +167,16 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     lc_ctrl_pkg::lc_tx_t hw_debug_en   = cfg.exec_vif.lc_hw_debug_en;
     prim_mubi_pkg::mubi4_t  csr_exec   = `gmv(ral.exec);
 
+    if (cfg.en_cov) begin
+      cov.executable_cg.sample(hw_debug_en,
+                               sram_ifetch,
+                               csr_exec);
+    end
     if (`INSTR_EXEC) begin
       allow_ifetch = (sram_ifetch  == prim_mubi_pkg::MuBi8True) ?
                      (csr_exec == prim_mubi_pkg::MuBi4True)     :
                      (hw_debug_en == lc_ctrl_pkg::On);
 
-      if (cfg.en_cov && `INSTR_EXEC) begin
-        cov.executable_cg.sample(hw_debug_en,
-                                 sram_ifetch,
-                                 csr_exec);
-      end
     end else begin
       allow_ifetch = 0;
     end


### PR DESCRIPTION
1. Update covergroup description
2. enable `executable_cg` for ret_sram, even if none of the settings will
enable executable instruction. Still worth testing all possible
combinations.

Signed-off-by: Weicai Yang <weicai@google.com>