### PR TITLE
[AST] Add 2 DFT padmux2ast (remove 2 analog DFT inputs) and solve AST's Lint/Synth OSCs issue

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -16,26 +16,23 @@ module aon_osc (
 );
 
 `ifndef AST_BYPASS_CLK
+`ifndef SYNTHESIS
 // Behavioral Model
 ////////////////////////////////////////
 timeunit 1ns / 10ps;
 import ast_bhv_pkg::* ;
 
 localparam time AonClkPeriod = 5000ns; // 5000ns (200Khz)
-logic clk, en_dly;
+logic clk;
 
 initial begin
   clk = 1'b0;
   $display("\nAON Clock Period: %0dns", AonClkPeriod);
-  en_dly = 1'b0;  // to block init X
-  #(AON_EN_RDLY + VCAON_POK_RDLY +1) en_dly = 1'b1;
 end
 
-// Enable 5us RC Delay
-logic aon_en_dly, aon_clk_dly;
-
-assign #(AON_EN_RDLY) aon_en_dly = aon_en_i;
-assign aon_clk_dly = aon_en_dly && en_dly;
+// Enable 5us RC Delay on rise
+logic en_osc_re;
+buf #(AON_EN_RDLY, 0) b0 (en_osc_re, (vcore_pok_h_i && aon_en_i));
 
 // Clock Oscillator
 ////////////////////////////////////////
@@ -44,11 +41,20 @@ logic en_osc;
 always begin
   #(AonClkPeriod/2) clk = ~clk && en_osc;
 end
-`else  // of AST_BYPASS_CLK
-// SYNTHESIS/VERILATOR/LINTER/FPGA
+`else  // of SYBTHESIS
+// SYNTHESIS/LINTER
 ///////////////////////////////////////
-logic aon_clk_dly;
-assign aon_clk_dly = 1'b1;
+logic en_osc_re;
+assign en_osc_re = vcore_pok_h_i && aon_en_i;
+
+logic clk, en_osc;
+assign clk = 1'b0;
+`endif  // of SYBTHESIS
+`else  // of AST_BYPASS_CLK
+// VERILATOR/FPGA
+///////////////////////////////////////
+logic en_osc_re;
+assign en_osc_re = vcore_pok_h_i && aon_en_i;
 
 // Clock Oscillator
 ////////////////////////////////////////
@@ -64,9 +70,7 @@ prim_clock_gating #(
 );
 `endif
 
-logic en_osc_re, en_osc_fe;
-
-assign en_osc_re = vcore_pok_h_i && aon_en_i && aon_clk_dly;
+logic en_osc_fe;
 
 // Syncronize en_osc to clk FE for glitch free disable
 always_ff @( negedge clk, negedge vcore_pok_h_i ) begin

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -122,7 +122,7 @@ module ast #(
   input [8-1:0] fla_obs_i,                    // FLASH Observe Bus
   input [8-1:0] otp_obs_i,                    // OTP Observe Bus
   input [8-1:0] otm_obs_i,                    // OT Modules Observe Bus
-  output ast_pkg::obs_cnt_t obs_cnt_o,        // Observe Control
+  output ast_pkg::ast_obs_ctrl_t obs_ctrl_o,  // Observe Control
 
   // pad mux/pad related
   input [Pad2AstInWidth-1:0] padmux2ast_i,    // IO_2_DFT Input Signals
@@ -168,11 +168,11 @@ assign dft_scan_md_o    = prim_mubi_pkg::MuBi4False;
 assign scan_mode        = 1'b0;
 assign scan_shift_en_o  = 1'b0;
 assign scan_reset_no    = 1'b1;
-assign obs_cnt_o        = '{
-                             obgsl: 4'h0,
-                             obmsl: 4'h0,
-                             obmen: prim_mubi_pkg::MuBi4False
-                           };
+assign obs_ctrl_o = '{
+                       obgsl: 4'h0,
+                       obmsl: ast_pkg::ObsNon,
+                       obmen: prim_mubi_pkg::MuBi4False
+                     };
 
 
 ///////////////////////////////////////

--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -33,7 +33,7 @@ parameter int unsigned AdcChannels     = 2;
 parameter int unsigned AdcDataWidth    = 10;
 parameter int unsigned UsbCalibWidth   = 20;
 parameter int unsigned Ast2PadOutWidth = 9;
-parameter int unsigned Pad2AstInWidth  = 7;
+parameter int unsigned Pad2AstInWidth  = 9;
 
 // These LFSR parameters have been generated with
 // $ ./util/design/gen-lfsr-seed.py --width 64 --seed 691876113 --prefix ""
@@ -132,6 +132,31 @@ typedef struct packed {
   logic     io;
   logic     aon;
 } clks_osc_byp_t;
+
+typedef enum logic [4-1:0] {
+  Nmd    = 4'd0,
+  Ast    = 4'd1,
+  Fla    = 4'd2,
+  Otp    = 4'd3,
+  Ot0    = 4'd4,
+  Ot1    = 4'd5,
+  Ot2    = 4'd6,
+  Ot3    = 4'd7,
+  Rs0    = 4'd8,
+  Rs1    = 4'd9,
+  Rs2    = 4'd10,
+  Rs3    = 4'd11,
+  Rs4    = 4'd12,
+  Rs5    = 4'd13,
+  Rs6    = 4'd14,
+  Rs7    = 4'd15
+} ast_omdl_e;
+
+typedef struct packed {
+  logic [4-1:0]          obgsl;
+  ast_omdl_e             obmsl;
+  prim_mubi_pkg::mubi4_t obmen;
+} ast_obs_cnt_t;
 
 endpackage  // of ast_pkg
 `endif  // of __AST_PKG_SV

--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -134,29 +134,29 @@ typedef struct packed {
 } clks_osc_byp_t;
 
 typedef enum logic [4-1:0] {
-  Nmd    = 4'd0,
-  Ast    = 4'd1,
-  Fla    = 4'd2,
-  Otp    = 4'd3,
-  Ot0    = 4'd4,
-  Ot1    = 4'd5,
-  Ot2    = 4'd6,
-  Ot3    = 4'd7,
-  Rs0    = 4'd8,
-  Rs1    = 4'd9,
-  Rs2    = 4'd10,
-  Rs3    = 4'd11,
-  Rs4    = 4'd12,
-  Rs5    = 4'd13,
-  Rs6    = 4'd14,
-  Rs7    = 4'd15
+  ObsNon = 4'h0,  // No module observed (disable)
+  ObsAst = 4'h1,  // Observe AST
+  ObsFla = 4'h2,  // Observe FLASH
+  ObsOtp = 4'h3,  // Observe OTP
+  ObsOt0 = 4'h4,  // Observe OT0
+  ObsOt1 = 4'h5,  // Observe OT1
+  ObsOt2 = 4'h6,  // Observe OT2
+  ObsOt3 = 4'h7,  // Observe OT3
+  ObsRs0 = 4'h8,  // RESERVED
+  ObsRs1 = 4'h9,  // RESERVED
+  ObsRs2 = 4'hA,  // RESERVED
+  ObsRs3 = 4'hB,  // RESERVED
+  ObsRs4 = 4'hC,  // RESERVED
+  ObsRs5 = 4'hD,  // RESERVED
+  ObsRs6 = 4'hE,  // RESERVED
+  ObsRs7 = 4'hF   // RESERVED
 } ast_omdl_e;
 
 typedef struct packed {
   logic [4-1:0]          obgsl;
   ast_omdl_e             obmsl;
   prim_mubi_pkg::mubi4_t obmen;
-} ast_obs_cnt_t;
+} ast_obs_ctrl_t;
 
 endpackage  // of ast_pkg
 `endif  // of __AST_PKG_SV

--- a/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
@@ -17,13 +17,14 @@ module usb_osc (
 );
 
 `ifndef AST_BYPASS_CLK
+`ifndef SYNTHESIS
 // Behavioral Model
 ////////////////////////////////////////
 timeunit 1ns / 1ps;
 import ast_bhv_pkg::* ;
 
 localparam real UsbClkPeriod = 1000000/48;  // ~20833.33333ps (48Mhz)
-logic clk, en_dly;
+logic clk;
 integer rand32;
 
 initial begin
@@ -31,18 +32,14 @@ initial begin
   $display("\nUSB Clock Period: %0dps", UsbClkPeriod);
   rand32 = $urandom_range((9'd416), -(9'd416));  // +/-416ps (+/-2% max)
   $display("USB Clock Drift: %0dps", rand32);
-  en_dly = 1'b0;  // to block init X
-  #(USB_EN_RDLY + VCAON_POK_RDLY + 1) en_dly = 1'b1;
 end
 
-// Enable 5us RC Delay
-logic usb_en_dly, usb_clk_dly;
+// Enable 5us RC Delay on rise
+logic en_osc_re;
+buf #(IO_EN_RDLY, 0) b0 (en_osc_re, (vcore_pok_h_i && usb_en_i));
 
-assign #(USB_EN_RDLY) usb_en_dly = usb_en_i;
-assign usb_clk_dly = usb_en_dly && en_dly;
-
-wire ref_val;
-assign #(USB_VAL_RDLY, USB_VAL_FDLY) ref_val = usb_ref_val_i;
+logic ref_val;
+buf #(USB_VAL_RDLY, USB_VAL_FDLY) b1 (ref_val, usb_ref_val_i);
 
 // Clock Oscillator
 ////////////////////////////////////////
@@ -54,11 +51,20 @@ assign drift = ref_val ? 0 : rand32;
 always begin
   #((UsbClkPeriod + drift)/2000) clk = ~clk && en_osc;
 end
-`else  // of AST_BYPASS_CLK
-// SYNTHESIS/VERILATOR/LINTER/FPGA
+`else  // of SYBTHESIS
+// SYNTHESIS/LINTER
 ///////////////////////////////////////
-logic usb_clk_dly;
-assign usb_clk_dly = 1'b1;
+logic en_osc_re;
+assign en_osc_re = vcore_pok_h_i && usb_en_i;
+
+logic clk, en_osc;
+assign clk = 1'b0;
+`endif  // of SYBTHESIS
+`else  // of AST_BYPASS_CLK
+// VERILATOR/FPGA
+///////////////////////////////////////
+logic en_osc_re;
+assign en_osc_re = vcore_pok_h_i && usb_en_i;
 
 // Clock Oscillator
 ////////////////////////////////////////
@@ -74,9 +80,7 @@ prim_clock_gating #(
 );
 `endif
 
-logic en_osc_re, en_osc_fe;
-
-assign en_osc_re = vcore_pok_h_i && usb_en_i && usb_clk_dly;
+logic en_osc_fe;
 
 // Syncronize en_osc to clk FE for glitch free disable
 always_ff @( negedge clk, negedge vcore_pok_h_i ) begin

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -822,15 +822,15 @@ module chip_earlgrey_asic (
   // external clock comes in at a fixed position
   assign ext_clk = mio_in_raw[MioPadIoc6];
 
-  assign pad2ast = { manual_in_ast_misc,      // Bond
-                     mio_in_raw[MioPadIoc3],  // 7 or is96M
-                     mio_in_raw[MioPadIob8],  // 6
-                     mio_in_raw[MioPadIob7],  // 5
-                     mio_in_raw[MioPadIob2],  // 4
-                     mio_in_raw[MioPadIob1],  // 3
-                     mio_in_raw[MioPadIob0],  // 2
-                     mio_in_raw[MioPadIoa5],  // 1
-                     mio_in_raw[MioPadIoa4]   // 0
+  assign pad2ast = { manual_in_ast_misc,
+                     mio_in_raw[MioPadIoc3],
+                     mio_in_raw[MioPadIob8],
+                     mio_in_raw[MioPadIob7],
+                     mio_in_raw[MioPadIob2],
+                     mio_in_raw[MioPadIob1],
+                     mio_in_raw[MioPadIob0],
+                     mio_in_raw[MioPadIoa5],
+                     mio_in_raw[MioPadIoa4]
                    };
 
   // AST does not use all clocks / resets forwarded to it
@@ -950,7 +950,7 @@ module chip_earlgrey_asic (
     .fla_obs_i             ( '0 ),
     .otp_obs_i             ( '0 ),
     .otm_obs_i             ( '0 ),
-    .obs_cnt_o             (  ),
+    .obs_ctrl_o            (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -822,13 +822,15 @@ module chip_earlgrey_asic (
   // external clock comes in at a fixed position
   assign ext_clk = mio_in_raw[MioPadIoc6];
 
-  assign pad2ast = { manual_in_ast_misc,
-                     mio_in_raw[MioPadIoc3],
-                     mio_in_raw[MioPadIob8],
-                     mio_in_raw[MioPadIob7],
-                     mio_in_raw[MioPadIob2],
-                     mio_in_raw[MioPadIob1],
-                     mio_in_raw[MioPadIob0]
+  assign pad2ast = { manual_in_ast_misc,      // Bond
+                     mio_in_raw[MioPadIoc3],  // 7 or is96M
+                     mio_in_raw[MioPadIob8],  // 6
+                     mio_in_raw[MioPadIob7],  // 5
+                     mio_in_raw[MioPadIob2],  // 4
+                     mio_in_raw[MioPadIob1],  // 3
+                     mio_in_raw[MioPadIob0],  // 2
+                     mio_in_raw[MioPadIoa5],  // 1
+                     mio_in_raw[MioPadIoa4]   // 0
                    };
 
   // AST does not use all clocks / resets forwarded to it
@@ -862,8 +864,6 @@ module chip_earlgrey_asic (
     .adc_a1_ai             ( CC2 ),
 
     // Direct short to PAD
-    .pad2ast_t0_ai         ( IOA4 ),
-    .pad2ast_t1_ai         ( IOA5 ),
     .ast2pad_t0_ao         ( IOA2 ),
     .ast2pad_t1_ao         ( IOA3 ),
     // clocks and resets supplied for detection
@@ -947,6 +947,10 @@ module chip_earlgrey_asic (
     // dft
     .dft_strap_test_i      ( dft_strap_test   ),
     .lc_dft_en_i           ( dft_en           ),
+    .fla_obs_i             ( '0 ),
+    .otp_obs_i             ( '0 ),
+    .otm_obs_i             ( '0 ),
+    .obs_cnt_o             (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -1026,7 +1026,7 @@ module chip_earlgrey_cw310 #(
     .fla_obs_i             ( '0 ),
     .otp_obs_i             ( '0 ),
     .otm_obs_i             ( '0 ),
-    .obs_cnt_o             (  ),
+    .obs_ctrl_o            (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -939,8 +939,6 @@ module chip_earlgrey_cw310 #(
     .adc_a1_ai             ( '0 ),
 
     // Direct short to PAD
-    .pad2ast_t0_ai         ( '0 ),
-    .pad2ast_t1_ai         ( '0 ),
     .ast2pad_t0_ao         (  ),
     .ast2pad_t1_ao         (  ),
 
@@ -1025,6 +1023,10 @@ module chip_earlgrey_cw310 #(
     // dft
     .dft_strap_test_i      ( dft_strap_test   ),
     .lc_dft_en_i           ( dft_en           ),
+    .fla_obs_i             ( '0 ),
+    .otp_obs_i             ( '0 ),
+    .otm_obs_i             ( '0 ),
+    .obs_cnt_o             (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -947,7 +947,7 @@ module chip_earlgrey_nexysvideo #(
     .fla_obs_i             ( '0 ),
     .otp_obs_i             ( '0 ),
     .otm_obs_i             ( '0 ),
-    .obs_cnt_o             (  ),
+    .obs_ctrl_o            (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -860,8 +860,6 @@ module chip_earlgrey_nexysvideo #(
     .adc_a1_ai             ( '0 ),
 
     // Direct short to PAD
-    .pad2ast_t0_ai         ( '0 ),
-    .pad2ast_t1_ai         ( '0 ),
     .ast2pad_t0_ao         (  ),
     .ast2pad_t1_ao         (  ),
 
@@ -946,6 +944,10 @@ module chip_earlgrey_nexysvideo #(
     // dft
     .dft_strap_test_i      ( dft_strap_test   ),
     .lc_dft_en_i           ( dft_en           ),
+    .fla_obs_i             ( '0 ),
+    .otp_obs_i             ( '0 ),
+    .otm_obs_i             ( '0 ),
+    .obs_cnt_o             (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -342,7 +342,7 @@ module chip_earlgrey_verilator (
     .fla_obs_i             ( '0 ),
     .otp_obs_i             ( '0 ),
     .otm_obs_i             ( '0 ),
-    .obs_cnt_o             (  ),
+    .obs_ctrl_o            (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -247,8 +247,6 @@ module chip_earlgrey_verilator (
     .adc_a0_ai             ( '0 ),
     .adc_a1_ai             ( '0 ),
     // Direct short to PAD
-    .pad2ast_t0_ai         ( '0 ),
-    .pad2ast_t1_ai         ( '0 ),
     .ast2pad_t0_ao         (  ),
     .ast2pad_t1_ao         (  ),
     // Memory configuration connections
@@ -341,6 +339,10 @@ module chip_earlgrey_verilator (
     // dft
     .dft_strap_test_i      ( dft_strap_test   ),
     .lc_dft_en_i           ( dft_en           ),
+    .fla_obs_i             ( '0 ),
+    .otp_obs_i             ( '0 ),
+    .otm_obs_i             ( '0 ),
+    .obs_cnt_o             (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -697,15 +697,15 @@ module chip_${top["name"]}_${target["name"]} (
   // external clock comes in at a fixed position
   assign ext_clk = mio_in_raw[MioPadIoc6];
 
-  assign pad2ast = { manual_in_ast_misc,      // Bond
-                     mio_in_raw[MioPadIoc3],  // 7 or is96M
-                     mio_in_raw[MioPadIob8],  // 6
-                     mio_in_raw[MioPadIob7],  // 5
-                     mio_in_raw[MioPadIob2],  // 4
-                     mio_in_raw[MioPadIob1],  // 3
-                     mio_in_raw[MioPadIob0],  // 2
-                     mio_in_raw[MioPadIoa5],  // 1
-                     mio_in_raw[MioPadIoa4]   // 0
+  assign pad2ast = { manual_in_ast_misc,
+                     mio_in_raw[MioPadIoc3],
+                     mio_in_raw[MioPadIob8],
+                     mio_in_raw[MioPadIob7],
+                     mio_in_raw[MioPadIob2],
+                     mio_in_raw[MioPadIob1],
+                     mio_in_raw[MioPadIob0],
+                     mio_in_raw[MioPadIoa5],
+                     mio_in_raw[MioPadIoa4]
                    };
 
   // AST does not use all clocks / resets forwarded to it
@@ -868,7 +868,7 @@ module chip_${top["name"]}_${target["name"]} (
     .fla_obs_i             ( '0 ),
     .otp_obs_i             ( '0 ),
     .otm_obs_i             ( '0 ),
-    .obs_cnt_o             (  ),
+    .obs_ctrl_o            (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -697,13 +697,15 @@ module chip_${top["name"]}_${target["name"]} (
   // external clock comes in at a fixed position
   assign ext_clk = mio_in_raw[MioPadIoc6];
 
-  assign pad2ast = { manual_in_ast_misc,
-                     mio_in_raw[MioPadIoc3],
-                     mio_in_raw[MioPadIob8],
-                     mio_in_raw[MioPadIob7],
-                     mio_in_raw[MioPadIob2],
-                     mio_in_raw[MioPadIob1],
-                     mio_in_raw[MioPadIob0]
+  assign pad2ast = { manual_in_ast_misc,      // Bond
+                     mio_in_raw[MioPadIoc3],  // 7 or is96M
+                     mio_in_raw[MioPadIob8],  // 6
+                     mio_in_raw[MioPadIob7],  // 5
+                     mio_in_raw[MioPadIob2],  // 4
+                     mio_in_raw[MioPadIob1],  // 3
+                     mio_in_raw[MioPadIob0],  // 2
+                     mio_in_raw[MioPadIoa5],  // 1
+                     mio_in_raw[MioPadIoa4]   // 0
                    };
 
   // AST does not use all clocks / resets forwarded to it
@@ -767,8 +769,6 @@ module chip_${top["name"]}_${target["name"]} (
     .adc_a1_ai             ( CC2 ),
 
     // Direct short to PAD
-    .pad2ast_t0_ai         ( IOA4 ),
-    .pad2ast_t1_ai         ( IOA5 ),
     .ast2pad_t0_ao         ( IOA2 ),
     .ast2pad_t1_ao         ( IOA3 ),
 % else:
@@ -786,8 +786,6 @@ module chip_${top["name"]}_${target["name"]} (
     .adc_a1_ai             ( '0 ),
 
     // Direct short to PAD
-    .pad2ast_t0_ai         ( '0 ),
-    .pad2ast_t1_ai         ( '0 ),
     .ast2pad_t0_ao         (  ),
     .ast2pad_t1_ao         (  ),
 
@@ -867,6 +865,10 @@ module chip_${top["name"]}_${target["name"]} (
     // dft
     .dft_strap_test_i      ( dft_strap_test   ),
     .lc_dft_en_i           ( dft_en           ),
+    .fla_obs_i             ( '0 ),
+    .otp_obs_i             ( '0 ),
+    .otm_obs_i             ( '0 ),
+    .obs_cnt_o             (  ),
     // pinmux related
     .padmux2ast_i          ( pad2ast    ),
     .ast2padmux_o          ( ast2pinmux ),


### PR DESCRIPTION
Signed-off-by: Jacob Levy <jacob.levy@opentitan.org>