### PR TITLE
[sw,tests] Adding chip_sw_kmac_app_lc test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1672,7 +1672,7 @@
             X-ref'ed with LC_CTRL test/env.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_lc_ctrl_transition"]
     }
     {
       name: chip_sw_kmac_app_rom


### PR DESCRIPTION
Added entry to cross-reference with chip_sw_lc_ctrl_transition test.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>