### PR TITLE
[dv/clkmgr] Add frequency measurement timeout test

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -28,6 +28,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   local bit exp_alert[string];
   local bit is_fatal_alert[string];
   local int alert_chk_max_delay[string];
+  local int alert_count[string];
 
   // intg check
   bit en_d_user_intg_chk = 1;
@@ -221,12 +222,17 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     if (item.alert_handshake_sta == AlertReceived) begin
       under_alert_handshake[alert_name] = 1;
       on_alert(alert_name, item);
+      ++alert_count[alert_name];
     end else begin
       if (!cfg.under_reset && under_alert_handshake[alert_name] == 0) begin
         `uvm_error(`gfn, $sformatf("alert %0s is not received!", alert_name))
       end
       under_alert_handshake[alert_name] = 0;
     end
+  endfunction
+
+  virtual function int get_alert_count(string alert_name);
+    return alert_count[alert_name];
   endfunction
 
   // this task is implemented to check if expected alert is triggered within certain clock cycles

--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -178,7 +178,7 @@
     }
     {
       name: frequency
-      desc: '''This tests the frequency counters functionality.
+      desc: '''This tests the frequency counters measured count functionality.
 
             These counters compute the number of cycles of some clock relative
             to the aon timer. It should trigger a recoverable alert when the
@@ -196,6 +196,25 @@
             '''
       milestone: V2
       tests: ["clkmgr_frequency"]
+    }
+    {
+      name: frequency_timeout
+      desc: '''This tests the frequency counters timeout functionality.
+
+            These counters compute the number of cycles of some clock relative
+            to the aon timer. It should trigger a recoverable alert when there
+            is no valid measurement when enabled, leading to a timeout. This is
+            separate from the `frequenty` testpoint to simplify the test checks.
+
+            **Stimulus**:
+            - Randomly stop measured clocks to trigger a timeout.
+
+            **Check**:
+            - Timeout should cause a recoverable alert.
+            - Coverage collected per clock.
+            '''
+      milestone: V2
+      tests: ["clkmgr_frequency_timeout"]
     }
     {
       name: frequency_overflow

--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -64,6 +64,10 @@
       uvm_test_seq: clkmgr_frequency_vseq
     }
     {
+      name: clkmgr_frequency_timeout
+      uvm_test_seq: clkmgr_frequency_timeout_vseq
+    }
+    {
       name: clkmgr_peri
       uvm_test_seq: clkmgr_peri_vseq
     }

--- a/hw/ip/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.core
@@ -21,6 +21,7 @@ filesets:
       - seq_lib/clkmgr_clk_status_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_extclk_vseq.sv: {is_include_file: true}
+      - seq_lib/clkmgr_frequency_timeout_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_frequency_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_peri_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_smoke_vseq.sv: {is_include_file: true}

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_cov.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_cov.sv
@@ -64,21 +64,26 @@ endclass
 // Wrapper class for frequency measurement covergroup.
 class freq_measure_cg_wrap;
   // This covergroup collects outcomes of clock frequency measurements.
-  covergroup freq_measure_cg(string name) with function sample (bit okay, bit slow, bit fast);
+  covergroup freq_measure_cg(
+      string name
+  ) with function sample (
+      bit okay, bit slow, bit fast, bit timeout
+  );
     option.name = name;
     option.per_instance = 1;
 
     okay_cp: coverpoint okay;
     slow_cp: coverpoint slow;
     fast_cp: coverpoint fast;
+    timeout_cp: coverpoint timeout;
   endgroup
 
   function new(string name);
     freq_measure_cg = new(name);
   endfunction
 
-  function void sample (bit okay, bit slow, bit fast);
-    freq_measure_cg.sample(okay, slow, fast);
+  function void sample (bit okay, bit slow, bit fast, bit timeout);
+    freq_measure_cg.sample(okay, slow, fast, timeout);
   endfunction
 endclass
 

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -26,17 +26,17 @@ package clkmgr_env_pkg;
   typedef virtual clk_rst_if clk_rst_vif;
 
   // parameters
-  localparam int NUM_PERI = 4;
-  localparam int NUM_TRANS = 5;
+  parameter int NUM_PERI = 4;
+  parameter int NUM_TRANS = 5;
 
   typedef logic [NUM_PERI-1:0] peri_enables_t;
   typedef logic [NUM_TRANS-1:0] hintables_t;
 
-  localparam int MainClkHz = 100_000_000;
-  localparam int IoClkHz = 96_000_000;
-  localparam int UsbClkHz = 48_000_000;
-  localparam int AonClkHz = 200_000;
-  localparam int FakeAonClkHz = 7_000_000;
+  parameter int MainClkHz = 100_000_000;
+  parameter int IoClkHz = 96_000_000;
+  parameter int UsbClkHz = 48_000_000;
+  parameter int AonClkHz = 200_000;
+  parameter int FakeAonClkHz = 7_000_000;
 
   // alerts
   parameter uint NUM_ALERTS = 2;
@@ -44,14 +44,8 @@ package clkmgr_env_pkg;
 
   // types
 
-  // These are ordered per the bits in the recov_err_code register.
-  typedef enum int {
-    ClkMesrIo,
-    ClkMesrIoDiv2,
-    ClkMesrIoDiv4,
-    ClkMesrMain,
-    ClkMesrUsb
-  } clk_mesr_e;
+  // Forward class decl to enable cfg to hold a scoreboard handle.
+  typedef class clkmgr_scoreboard;
 
   // The enum values for these match the bit order in the CSRs.
   typedef enum int {
@@ -68,12 +62,28 @@ package clkmgr_env_pkg;
     TransOtbnMain
   } trans_e;
 
-  // Forward class decl to enable cfg to hold a scoreboard handle.
-  typedef class clkmgr_scoreboard;
+  typedef struct {
+    logic valid;
+    logic slow;
+    logic fast;
+  } freq_measurement_t;
 
-  localparam int ClkInHz[ClkMesrUsb+1] = {IoClkHz, IoClkHz / 2, IoClkHz / 4, MainClkHz, UsbClkHz};
+  // These are ordered per the bits in the recov_err_code register.
+  typedef enum int {
+    ClkMesrIo,
+    ClkMesrIoDiv2,
+    ClkMesrIoDiv4,
+    ClkMesrMain,
+    ClkMesrUsb
+  } clk_mesr_e;
 
-  localparam int ExpectedCounts[ClkMesrUsb+1] = {
+  // This is to examine separately the measurement and timeout recoverable error bits.
+  typedef logic [ClkMesrUsb:0] recov_bits_t;
+
+  // These must be after the declaration of clk_mesr_e for sizing.
+  parameter int ClkInHz[ClkMesrUsb+1] = {IoClkHz, IoClkHz / 2, IoClkHz / 4, MainClkHz, UsbClkHz};
+
+  parameter int ExpectedCounts[ClkMesrUsb+1] = {
     ClkInHz[ClkMesrIo] / AonClkHz - 1,
     ClkInHz[ClkMesrIoDiv2] / AonClkHz - 1,
     ClkInHz[ClkMesrIoDiv4] / AonClkHz - 1,

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -75,18 +75,13 @@ interface clkmgr_if (
   logic                  exp_clk_io_div4;
   logic                  actual_clk_io_div4;
 
-  typedef struct {
-    logic valid;
-    logic slow;
-    logic fast;
-  } freq_measurement_t;
-
   // Internal DUT signals.
 `ifndef PATH_TO_DUT
   `define PATH_TO_DUT tb.dut
 `endif
 
   freq_measurement_t io_freq_measurement;
+  logic io_timeout_err;
   always @(posedge `PATH_TO_DUT.u_io_meas.clk_i) begin
     if (`PATH_TO_DUT.u_io_meas.valid_o) begin
       io_freq_measurement = '{valid: `PATH_TO_DUT.u_io_meas.valid_o,
@@ -96,8 +91,10 @@ interface clkmgr_if (
                 UVM_MEDIUM)
     end
   end
+  always_comb io_timeout_err = `PATH_TO_DUT.io_timeout_err;
 
   freq_measurement_t io_div2_freq_measurement;
+  logic io_div2_timeout_err;
   always @(posedge `PATH_TO_DUT.u_io_div2_meas.clk_i) begin
     if (`PATH_TO_DUT.u_io_div2_meas.valid_o) begin
       io_div2_freq_measurement = '{valid: `PATH_TO_DUT.u_io_div2_meas.valid_o,
@@ -107,8 +104,10 @@ interface clkmgr_if (
                 "Sampled coverage for ClkMesrIoDiv2 as %p", io_div2_freq_measurement), UVM_MEDIUM)
     end
   end
+  always_comb io_div2_timeout_err = `PATH_TO_DUT.io_div2_timeout_err;
 
   freq_measurement_t io_div4_freq_measurement;
+  logic io_div4_timeout_err;
   always @(posedge `PATH_TO_DUT.u_io_div4_meas.clk_i) begin
     if (`PATH_TO_DUT.u_io_div4_meas.valid_o) begin
       io_div4_freq_measurement = '{valid: `PATH_TO_DUT.u_io_div4_meas.valid_o,
@@ -118,8 +117,10 @@ interface clkmgr_if (
                 "Sampled coverage for ClkMesrIoDiv4 as %p", io_div4_freq_measurement), UVM_MEDIUM)
     end
   end
+  always_comb io_div4_timeout_err = `PATH_TO_DUT.io_div4_timeout_err;
 
   freq_measurement_t main_freq_measurement;
+  logic main_timeout_err;
   always @(posedge `PATH_TO_DUT.u_main_meas.clk_i) begin
     if (`PATH_TO_DUT.u_main_meas.valid_o) begin
       main_freq_measurement = '{valid: `PATH_TO_DUT.u_main_meas.valid_o,
@@ -129,8 +130,10 @@ interface clkmgr_if (
                 "Sampled coverage for ClkMesrMain as %p", main_freq_measurement), UVM_MEDIUM)
     end
   end
+  always_comb main_timeout_err = `PATH_TO_DUT.main_timeout_err;
 
   freq_measurement_t usb_freq_measurement;
+  logic usb_timeout_err;
   always @(posedge `PATH_TO_DUT.u_usb_meas.clk_i) begin
     if (`PATH_TO_DUT.u_usb_meas.valid_o) begin
       usb_freq_measurement = '{valid: `PATH_TO_DUT.u_usb_meas.valid_o,
@@ -140,6 +143,7 @@ interface clkmgr_if (
                 ), UVM_MEDIUM)
     end
   end
+  always_comb usb_timeout_err = `PATH_TO_DUT.usb_timeout_err;
 
   function automatic void update_extclk_ctrl(logic [2*LcTxTWidth-1:0] value);
     {extclk_ctrl_csr_step_down, extclk_ctrl_csr_sel} = value;

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -188,85 +188,48 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     end
   endtask
 
+  local task sample_freq_measurement_cov(clk_mesr_e clk, ref freq_measurement_t measurement,
+                                         logic timeout);
+    if (cfg.en_cov) begin
+      cov.freq_measure_cg_wrap[clk].sample(!measurement.slow && !measurement.fast, measurement.slow,
+                                           measurement.fast, timeout);
+      `uvm_info(`gfn, $sformatf(
+                "Cov for %0s: %0s",
+                clk.name(),
+                measurement.slow ? "slow" : measurement.fast ? "fast" : "okay"
+                ), UVM_MEDIUM)
+      measurement = '{default: 0};
+    end
+  endtask
+
   task sample_freq_measurement_covs();
     fork
       forever
-        @(posedge cfg.clkmgr_vif.io_freq_measurement.valid) begin
-          if (cfg.en_cov) begin
-            cov.freq_measure_cg_wrap[ClkMesrIo].sample(
-                !cfg.clkmgr_vif.io_freq_measurement.slow &&
-                !cfg.clkmgr_vif.io_freq_measurement.fast,
-                cfg.clkmgr_vif.io_freq_measurement.slow, cfg.clkmgr_vif.io_freq_measurement.fast);
-            `uvm_info(`gfn, $sformatf(
-                      "Cov for ClkMesrIo: %0s",
-                      cfg.clkmgr_vif.io_freq_measurement.slow ? "slow" :
-                      cfg.clkmgr_vif.io_freq_measurement.fast ? "fast" : "okay"
-                      ), UVM_MEDIUM)
-            cfg.clkmgr_vif.io_freq_measurement = '{default: 0};
-          end
+        @(posedge cfg.clkmgr_vif.io_freq_measurement.valid or posedge cfg.clkmgr_vif.io_timeout_err) begin
+          sample_freq_measurement_cov(ClkMesrIo, cfg.clkmgr_vif.io_freq_measurement,
+                                      cfg.clkmgr_vif.io_timeout_err);
+        end
+
+      forever
+        @(posedge cfg.clkmgr_vif.io_div2_freq_measurement.valid or posedge cfg.clkmgr_vif.io_div2_timeout_err) begin
+          sample_freq_measurement_cov(ClkMesrIoDiv2, cfg.clkmgr_vif.io_div2_freq_measurement,
+                                      cfg.clkmgr_vif.io_div2_timeout_err);
+
         end
       forever
-        @(posedge cfg.clkmgr_vif.io_div2_freq_measurement.valid) begin
-          if (cfg.en_cov) begin
-            cov.freq_measure_cg_wrap[ClkMesrIoDiv2].sample(
-                !cfg.clkmgr_vif.io_div2_freq_measurement.slow &&
-                !cfg.clkmgr_vif.io_div2_freq_measurement.fast,
-                cfg.clkmgr_vif.io_div2_freq_measurement.slow,
-                cfg.clkmgr_vif.io_div2_freq_measurement.fast);
-            `uvm_info(`gfn, $sformatf(
-                      "Cov for ClkMesrIoDiv2: %0s",
-                      cfg.clkmgr_vif.io_div2_freq_measurement.slow ? "slow" :
-                      cfg.clkmgr_vif.io_div2_freq_measurement.fast ? "fast" : "okay"
-                      ), UVM_MEDIUM)
-            cfg.clkmgr_vif.io_div2_freq_measurement = '{default: 0};
-          end
+        @(posedge cfg.clkmgr_vif.io_div4_freq_measurement.valid or posedge cfg.clkmgr_vif.io_div4_timeout_err) begin
+          sample_freq_measurement_cov(ClkMesrIoDiv4, cfg.clkmgr_vif.io_div4_freq_measurement,
+                                      cfg.clkmgr_vif.io_div4_timeout_err);
         end
       forever
-        @(posedge cfg.clkmgr_vif.io_div4_freq_measurement.valid) begin
-          if (cfg.en_cov) begin
-            cov.freq_measure_cg_wrap[ClkMesrIoDiv4].sample(
-                !cfg.clkmgr_vif.io_div4_freq_measurement.slow &&
-                !cfg.clkmgr_vif.io_div4_freq_measurement.fast,
-                cfg.clkmgr_vif.io_div4_freq_measurement.slow,
-                cfg.clkmgr_vif.io_div4_freq_measurement.fast);
-            `uvm_info(`gfn, $sformatf(
-                      "Cov for ClkMesrIoDiv4: %0s",
-                      cfg.clkmgr_vif.io_div4_freq_measurement.slow ? "slow" :
-                      cfg.clkmgr_vif.io_div4_freq_measurement.fast ? "fast" : "okay"
-                      ), UVM_MEDIUM)
-            cfg.clkmgr_vif.io_div4_freq_measurement = '{default: 0};
-          end
+        @(posedge cfg.clkmgr_vif.main_freq_measurement.valid or posedge cfg.clkmgr_vif.main_timeout_err) begin
+          sample_freq_measurement_cov(ClkMesrMain, cfg.clkmgr_vif.main_freq_measurement,
+                                      cfg.clkmgr_vif.main_timeout_err);
         end
       forever
-        @(posedge cfg.clkmgr_vif.main_freq_measurement.valid) begin
-          if (cfg.en_cov) begin
-            cov.freq_measure_cg_wrap[ClkMesrMain].sample(
-                !cfg.clkmgr_vif.main_freq_measurement.slow &&
-                !cfg.clkmgr_vif.main_freq_measurement.fast,
-                cfg.clkmgr_vif.main_freq_measurement.slow,
-                cfg.clkmgr_vif.main_freq_measurement.fast);
-            `uvm_info(`gfn, $sformatf(
-                      "Cov for ClkMesrMain: %0s",
-                      cfg.clkmgr_vif.main_freq_measurement.slow ? "slow" :
-                      cfg.clkmgr_vif.main_freq_measurement.fast ? "fast" : "okay"
-                      ), UVM_MEDIUM)
-            cfg.clkmgr_vif.main_freq_measurement = '{default: 0};
-          end
-        end
-      forever
-        @(posedge cfg.clkmgr_vif.usb_freq_measurement.valid) begin
-          if (cfg.en_cov) begin
-            cov.freq_measure_cg_wrap[ClkMesrUsb].sample(
-                !cfg.clkmgr_vif.usb_freq_measurement.slow &&
-                !cfg.clkmgr_vif.usb_freq_measurement.fast,
-                cfg.clkmgr_vif.usb_freq_measurement.slow, cfg.clkmgr_vif.usb_freq_measurement.fast);
-            `uvm_info(`gfn, $sformatf(
-                      "Cov for ClkMesrUsb: %0s",
-                      cfg.clkmgr_vif.usb_freq_measurement.slow ? "slow" :
-                      cfg.clkmgr_vif.usb_freq_measurement.fast ? "fast" : "okay"
-                      ), UVM_MEDIUM)
-            cfg.clkmgr_vif.usb_freq_measurement = '{default: 0};
-          end
+        @(posedge cfg.clkmgr_vif.usb_freq_measurement.valid or posedge cfg.clkmgr_vif.usb_timeout_err) begin
+          sample_freq_measurement_cov(ClkMesrUsb, cfg.clkmgr_vif.usb_freq_measurement,
+                                      cfg.clkmgr_vif.usb_timeout_err);
         end
     join_none
   endtask

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_timeout_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_frequency_timeout_vseq.sv
@@ -1,0 +1,111 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The frequency vseq exercises the frequency measurement counters. More details
+// in the clkmgr_testplan.hjson file.
+class clkmgr_frequency_timeout_vseq extends clkmgr_base_vseq;
+  `uvm_object_utils(clkmgr_frequency_timeout_vseq)
+
+  `uvm_object_new
+
+  // This is measured in aon clocks. We need to have a few rounds of measurement for timeouts to
+  // trigger, since they synchronize to the aon clock.
+  localparam int CyclesToGetOneMeasurement = 6;
+
+  // This is measured in clkmgr clk_i clocks. It is set to cover worst case delays.
+  // The clk_i frequency is randomized for IPs, but the clkmgr is hooked to io_div4, which would
+  // allow a tighter number of cycles. Leaving the clk_i random probably provides more cases,
+  // so leaving it as is.
+  localparam int CyclesForErrUpdate = 16;
+
+  // If cause_timeout is set, turn off clk_timeout so it gets a timeout.
+  rand bit cause_timeout;
+  constraint cause_timeout_c {cause_timeout dist {1 := 4, 0 := 1};}
+  rand int clk_timeout;
+  constraint clk_timeout_c {clk_timeout inside {[ClkMesrIo : ClkMesrUsb]};}
+
+  // This waits a number of cycles so that:
+  // - only one measurement completes, or we could end up with multiple alerts which cause trouble
+  //   for the cip exp_alert functionality, and,
+  // - the measurement has had time to update the recov_err_code CSR.
+  task wait_before_read_recov_err_code();
+    cfg.aon_clk_rst_vif.wait_clks(CyclesToGetOneMeasurement);
+    cfg.clk_rst_vif.wait_clks(CyclesForErrUpdate);
+  endtask
+
+  task body();
+    logic [TL_DW-1:0] value;
+    int prior_alert_count;
+    int current_alert_count;
+    update_csrs_with_reset_values();
+    csr_wr(.ptr(ral.measure_ctrl_regwen), .value(1));
+
+    // Make sure the aon clock is running as slow as it is meant to.
+    cfg.aon_clk_rst_vif.set_freq_khz(AonClkHz / 1_000);
+    // Disable cip scoreboard exp_alert checks since they need very fine control, making checks
+    // really cumbersome. Instead we rely on the alert count to detect if alert were triggered.
+    cfg.scoreboard.do_alert_check = 0;
+
+    `uvm_info(`gfn, $sformatf("Will run %0d rounds", num_trans), UVM_MEDIUM)
+    for (int i = 0; i < num_trans; ++i) begin
+      logic [2*(ClkMesrUsb+1)-1:0] actual_recov_err = '0;
+      logic [ClkMesrUsb:0] expected_recov_timeout_err = '0;
+      bit expect_alert = 0;
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      `uvm_info(`gfn, "New round", UVM_MEDIUM)
+
+      foreach (ExpectedCounts[clk]) begin
+        clk_mesr_e clk_mesr = clk_mesr_e'(clk);
+        int min_threshold;
+        int max_threshold;
+        int expected = ExpectedCounts[clk];
+        min_threshold = expected - 1;
+        max_threshold = expected + 1;
+        enable_frequency_measurement(clk_mesr, min_threshold, max_threshold);
+      end
+
+      prior_alert_count = cfg.scoreboard.get_alert_count("recov_fault");
+      if (cause_timeout) begin
+        clk_mesr_e clk_mesr_timeout = clk_mesr_e'(clk_timeout);
+        `uvm_info(`gfn, $sformatf("Will cause a timeout for clk %0s", clk_mesr_timeout.name()),
+                  UVM_MEDIUM)
+        expected_recov_timeout_err[clk_timeout] = 1;
+        disturb_measured_clock(.clk(clk_mesr_e'(clk_timeout)), .enable(1'b0));
+      end
+      wait_before_read_recov_err_code();
+      if (cause_timeout) disturb_measured_clock(.clk(clk_mesr_e'(clk_timeout)), .enable(1'b1));
+
+      csr_rd(.ptr(ral.recov_err_code), .value(actual_recov_err));
+      `uvm_info(`gfn, $sformatf("Got recov err register=0x%x", actual_recov_err), UVM_MEDIUM)
+      if (actual_recov_err[ClkMesrUsb:0]) begin
+        report_recov_error_mismatch("measurement", recov_bits_t'(0),
+                                    actual_recov_err[ClkMesrUsb:0]);
+      end
+      if (actual_recov_err[ClkMesrUsb+1+:ClkMesrUsb+1] != expected_recov_timeout_err) begin
+        report_recov_error_mismatch("timeout", expected_recov_timeout_err,
+                                    actual_recov_err[ClkMesrUsb+1+:ClkMesrUsb+1]);
+      end
+      // And check that the alert count increased if there was a timeout.
+      current_alert_count = cfg.scoreboard.get_alert_count("recov_fault");
+      if (cause_timeout) begin
+        `DV_CHECK_NE(current_alert_count, prior_alert_count, "expected some alerts to fire")
+      end else begin
+        `DV_CHECK_EQ(current_alert_count, prior_alert_count, "expected no alerts to fire")
+      end
+
+      foreach (ExpectedCounts[clk]) begin
+        clk_mesr_e clk_mesr = clk_mesr_e'(clk);
+        disable_frequency_measurement(clk_mesr);
+      end
+
+      // Wait enough time for measurements to complete, and for alerts to get processed
+      // by the alert agents so expected alerts are properly wound down.
+      cfg.aon_clk_rst_vif.wait_clks(6);
+      // And clear errors.
+      csr_wr(.ptr(ral.recov_err_code), .value('1));
+      cfg.aon_clk_rst_vif.wait_clks(2);
+    end
+  endtask
+
+endclass

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -25,12 +25,16 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
   // This needs to be done outside the various CSR tests, since they update the jitter_enable
   // CSR, but the scoreboard is disabled for those tests.
   task test_jitter();
-    csr_wr(.ptr(ral.jitter_enable), .value(prim_mubi_pkg::MuBi4True));
-    csr_rd_check(.ptr(ral.jitter_enable), .compare_value(prim_mubi_pkg::MuBi4True));
-    // And set it back.
-    cfg.clk_rst_vif.wait_clks(6);
-    csr_wr(.ptr(ral.jitter_enable), .value('0));
-    csr_rd_check(.ptr(ral.jitter_enable), .compare_value('0));
+    prim_mubi_pkg::mubi4_t jitter_value;
+    for (int i = 0; i < (1 << $bits(prim_mubi_pkg::mubi4_t)); ++i) begin
+      jitter_value = prim_mubi_pkg::mubi4_t'(i);
+      csr_wr(.ptr(ral.jitter_enable), .value(jitter_value));
+      csr_rd_check(.ptr(ral.jitter_enable), .compare_value(jitter_value));
+      // And set it back.
+      cfg.clk_rst_vif.wait_clks(6);
+      csr_wr(.ptr(ral.jitter_enable), .value('0));
+      csr_rd_check(.ptr(ral.jitter_enable), .compare_value('0));
+    end
   endtask
 
   // Flips all clk_enables bits from the reset value with all enabled. All is checked

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
@@ -5,6 +5,7 @@
 `include "clkmgr_base_vseq.sv"
 `include "clkmgr_clk_status_vseq.sv"
 `include "clkmgr_common_vseq.sv"
+`include "clkmgr_frequency_timeout_vseq.sv"
 `include "clkmgr_frequency_vseq.sv"
 `include "clkmgr_extclk_vseq.sv"
 `include "clkmgr_peri_vseq.sv"

--- a/hw/ip/clkmgr/dv/sva/clkmgr_gated_clock_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_gated_clock_sva_if.sv
@@ -11,10 +11,13 @@ interface clkmgr_gated_clock_sva_if (
   input logic scanmode,
   input logic gated_clk
 );
-  // This fires at negedges, so check $past(clk*) as activity.
+  // This fires at negedges, so check $past(clk*) as activity. The assertion is okay if gating
+  // changes, either at the next clock event or between them.
   logic gating;
   always_comb gating = sw_clk_en && ip_clk_en || scanmode;
 
-  `ASSERT(GateOpen_A, $rose(gating) |-> ##[1:3] !gating || gated_clk, !clk, !rst_n)
-  `ASSERT(GateClose_A, $fell(gating) |-> ##[1:3] gating || !gated_clk, !clk, !rst_n)
+  `ASSERT(GateOpen_A, $rose(gating) |-> ##[0:3] !gating || $changed(gating) || gated_clk, !clk,
+          !rst_n)
+  `ASSERT(GateClose_A, $fell(gating) |-> ##[0:3] gating || $changed(gating) || !gated_clk, !clk,
+          !rst_n)
 endinterface


### PR DESCRIPTION
Wait some extra cycles after each frequency measurement round for alerts
to settle.
Enhance jitter enable test to check all values in mubi bits.
Tighten up gated clock SVA to fix infrequent failure.

Signed-off-by: Guillermo Maturana <maturana@google.com>