### PR TITLE
[sw/silicon_creator] Harden security_version check in boot_policy

### DIFF
--- a/sw/device/lib/base/testing/meson.build
+++ b/sw/device/lib/base/testing/meson.build
@@ -12,6 +12,16 @@ sw_lib_testing_bitfield = declare_dependency(
   )
 )
 
+sw_lib_testing_hardened = declare_dependency(
+  link_with: static_library(
+    'hardened',
+    sources: [
+      meson.source_root() / 'sw/device/lib/base/hardened.c',
+    ],
+    native: true,
+  )
+)
+
 sw_lib_base_testing_mock_mmio = declare_dependency(
   link_with: static_library(
     'mock_mmio',

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -253,10 +253,31 @@ cc_library(
 )
 
 cc_library(
-    name = "shutdown",
-    srcs = ["shutdown.c"],
+    name = "shutdown_intf",
     hdrs = ["shutdown.h"],
     deps = [
+        ":error",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+    ],
+)
+
+cc_library(
+    name = "mock_shutdown",
+    testonly = True,
+    hdrs = ["mock_shutdown.h"],
+    deps = [
+        ":shutdown_intf",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
+cc_library(
+    name = "shutdown",
+    srcs = ["shutdown.c"],
+    deps = [
+        ":shutdown_intf",
         ":error",
         ":log",
         "//hw/ip/keymgr/data:keymgr_regs",
@@ -277,13 +298,13 @@ cc_test(
     name = "shutdown_unittest",
     srcs = [
         "shutdown.c",
-        "shutdown.h",
         "shutdown_unittest.cc",
     ],
     defines = [
         "OT_OFF_TARGET_TEST",
     ],
     deps = [
+        ":shutdown_intf",
         ":error",
         ":log",
         "//hw/ip/keymgr/data:keymgr_regs",

--- a/sw/device/silicon_creator/lib/mock_shutdown.h
+++ b/sw/device/silicon_creator/lib/mock_shutdown.h
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SHUTDOWN_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SHUTDOWN_H_
+
+#include "sw/device/silicon_creator/lib/shutdown.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for shutdown.
+ */
+class MockShutdown : public GlobalMock<MockShutdown> {
+ public:
+  MOCK_METHOD(shutdown_error_redact_t, RedactPolicy, ());
+  MOCK_METHOD(uint32_t, Redact, (rom_error_t, shutdown_error_redact_t));
+  MOCK_METHOD(void, Finalize, (rom_error_t));
+};
+
+}  // namespace internal
+
+using MockShutdown = testing::StrictMock<internal::MockShutdown>;
+
+extern "C" {
+
+shutdown_error_redact_t shutdown_redact_policy(void) {
+  return MockShutdown::Instance().RedactPolicy();
+}
+
+uint32_t shutdown_redact(rom_error_t reason, shutdown_error_redact_t severity) {
+  return MockShutdown::Instance().Redact(reason, severity);
+}
+
+void shutdown_finalize(rom_error_t reason) {
+  return MockShutdown::Instance().Finalize(reason);
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SHUTDOWN_H_

--- a/sw/device/silicon_creator/lib/shutdown.h
+++ b/sw/device/silicon_creator/lib/shutdown.h
@@ -31,6 +31,28 @@ extern "C" {
   } while (false)
 
 /**
+ * Evaluate a manifestly true expression and call `shutdown_finalize` if the
+ * result is false.
+ *
+ * This macro is intended to be used along with `launder32()` to handle detected
+ * faults when implementing redundant checks, i.e. in places where the compiler
+ * could otherwise prove statically unreachable. For example:
+ * ```
+ * if (launder32(x) == 0) {
+ *   SHUTDOWN_CHECK(launder32(x) == 0);
+ * }
+ * ```
+ * See `launder32()` in `sw/device/lib/base/hardened.h` for more details.
+ * TODO(#10006): Improve this implementation.
+ */
+#define SHUTDOWN_CHECK(expr_)           \
+  do {                                  \
+    if (!(expr_)) {                     \
+      shutdown_finalize(kErrorUnknown); \
+    }                                   \
+  } while (false)
+
+/**
  * Initializes the Mask ROM shutdown infrastructure.
  *
  * Reads the shutdown policy from OTP, and initializes the alert handler.

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -14,9 +14,11 @@ cc_library(
         "boot_policy_ptrs.h",
     ],
     deps = [
+        "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib:boot_data",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:manifest_intf",
+        "//sw/device/silicon_creator/lib:shutdown",
     ],
 )
 
@@ -41,8 +43,10 @@ cc_test(
     defines = ["OT_OFF_TARGET_TEST"],
     deps = [
         ":mock_boot_policy_ptrs",
+        "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib:mock_boot_data",
         "//sw/device/silicon_creator/lib:mock_manifest",
+        "//sw/device/silicon_creator/lib:mock_shutdown",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/mask_rom/boot_policy_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/boot_policy_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/silicon_creator/lib/mock_boot_data.h"
 #include "sw/device/silicon_creator/lib/mock_manifest.h"
+#include "sw/device/silicon_creator/lib/mock_shutdown.h"
 #include "sw/device/silicon_creator/mask_rom/mock_boot_policy_ptrs.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -40,6 +40,8 @@ sw_silicon_creator_mask_rom_boot_policy = declare_dependency(
     dependencies: [
       sw_silicon_creator_lib_manifest,
       sw_silicon_creator_lib_boot_data,
+      sw_silicon_creator_lib_shutdown,
+      sw_lib_hardened,
     ],
   ),
 )
@@ -301,6 +303,7 @@ test('sw_silicon_creator_mask_rom_boot_policy_unittest', executable(
     ],
     dependencies: [
       sw_vendor_gtest,
+      sw_lib_testing_hardened,
     ],
     native: true,
     c_args: ['-DOT_OFF_TARGET_TEST'],


### PR DESCRIPTION
This PR
* Adds `SHUTDOWN_CHECK()` to be used along with `launder32()` to handle detected faults when implementing redundant checks, and
* Hardens the security_version check in boot_policy.

Implementation of `SHUTDOWN_CHECK()` is fairly simple, created #10006 for replacing it with a better one.

~I need a little more time for updating bazel build files but wanted to get your feedback while I'm working on that.~