### PR TITLE
[clkmgr] various spec and parameter updates

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -262,8 +262,9 @@
         }
 % endfor
       ]
-      // the CLK_ENABLE register cannot be written, otherwise there is the potential clocks could be
-      // disabled and the system will hang
+      // the CLK_ENABLE register cannot be written.
+      // During top level randomized tests, it is possible to disable the clocks and then access
+      // a register in the disabled block.  This would lead to a top level hang.
       tags: ["excl:CsrAllTests:CsrExclAll"]
     },
 
@@ -296,8 +297,9 @@
         }
 % endfor
       ]
-      // the CLK_HINT register cannot be written, otherwise there is the potential clocks could be
-      // disabled and the system will hang
+      // the CLK_HINT register cannot be written.
+      // During top level randomized tests, it is possible to disable the clocks to transactional blocks
+      // and then access a register in the disabled block.  This would lead to a top level hang.
       tags: ["excl:CsrAllTests:CsrExclAll"]
     },
 
@@ -368,7 +370,7 @@
           desc: "Enable measurement for ${src}",
           resval: "0",
           // Measurements can cause recoverable errors depending on the
-          // thresholds which the CSR tests will not predict correctly.
+          // thresholds which randomized CSR tests will not predict correctly.
           // To provide better CSR coverage we allow writing the threshold
           // fields, but not enabling the counters.
           tags: ["excl:CsrNonInitTests:CsrExclWrite"]

--- a/hw/ip/prim/rtl/prim_clock_meas.sv
+++ b/hw/ip/prim/rtl/prim_clock_meas.sv
@@ -149,10 +149,10 @@ module prim_clock_meas #(
 
   // maximum cdc latency from the perspective of the reference clock
   // 1 ref cycle to output request
-  // 2 cycles to sync + 1 cycle to ack is less than 1 cycle of ref based on assertion requirement
+  // 2 cycles to sync + 1 cycle to ack are less than 1 cycle of ref based on assertion requirement
   // 2 ref cycles to sync ack
-  // Double for margin
-  localparam int MaxRefCdcLatency = (1 + 1 + 2)*2;
+  // 2 extra ref cycles for margin
+  localparam int MaxRefCdcLatency = 1 + 1 + 2 + 2;
 
   if (RefTimeOutChkEn) begin : gen_ref_timeout_chk
     // check whether reference clock has timed out

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -285,8 +285,9 @@
           '''
         }
       ]
-      // the CLK_ENABLE register cannot be written, otherwise there is the potential clocks could be
-      // disabled and the system will hang
+      // the CLK_ENABLE register cannot be written.
+      // During top level randomized tests, it is possible to disable the clocks and then access
+      // a register in the disabled block.  This would lead to a top level hang.
       tags: ["excl:CsrAllTests:CsrExclAll"]
     },
 
@@ -353,8 +354,9 @@
           '''
         }
       ]
-      // the CLK_HINT register cannot be written, otherwise there is the potential clocks could be
-      // disabled and the system will hang
+      // the CLK_HINT register cannot be written.
+      // During top level randomized tests, it is possible to disable the clocks to transactional blocks
+      // and then access a register in the disabled block.  This would lead to a top level hang.
       tags: ["excl:CsrAllTests:CsrExclAll"]
     },
 
@@ -449,7 +451,7 @@
           desc: "Enable measurement for io",
           resval: "0",
           // Measurements can cause recoverable errors depending on the
-          // thresholds which the CSR tests will not predict correctly.
+          // thresholds which randomized CSR tests will not predict correctly.
           // To provide better CSR coverage we allow writing the threshold
           // fields, but not enabling the counters.
           tags: ["excl:CsrNonInitTests:CsrExclWrite"]
@@ -488,7 +490,7 @@
           desc: "Enable measurement for io_div2",
           resval: "0",
           // Measurements can cause recoverable errors depending on the
-          // thresholds which the CSR tests will not predict correctly.
+          // thresholds which randomized CSR tests will not predict correctly.
           // To provide better CSR coverage we allow writing the threshold
           // fields, but not enabling the counters.
           tags: ["excl:CsrNonInitTests:CsrExclWrite"]
@@ -527,7 +529,7 @@
           desc: "Enable measurement for io_div4",
           resval: "0",
           // Measurements can cause recoverable errors depending on the
-          // thresholds which the CSR tests will not predict correctly.
+          // thresholds which randomized CSR tests will not predict correctly.
           // To provide better CSR coverage we allow writing the threshold
           // fields, but not enabling the counters.
           tags: ["excl:CsrNonInitTests:CsrExclWrite"]
@@ -566,7 +568,7 @@
           desc: "Enable measurement for main",
           resval: "0",
           // Measurements can cause recoverable errors depending on the
-          // thresholds which the CSR tests will not predict correctly.
+          // thresholds which randomized CSR tests will not predict correctly.
           // To provide better CSR coverage we allow writing the threshold
           // fields, but not enabling the counters.
           tags: ["excl:CsrNonInitTests:CsrExclWrite"]
@@ -605,7 +607,7 @@
           desc: "Enable measurement for usb",
           resval: "0",
           // Measurements can cause recoverable errors depending on the
-          // thresholds which the CSR tests will not predict correctly.
+          // thresholds which randomized CSR tests will not predict correctly.
           // To provide better CSR coverage we allow writing the threshold
           // fields, but not enabling the counters.
           tags: ["excl:CsrNonInitTests:CsrExclWrite"]


### PR DESCRIPTION
@matutem pointed out various shortcomings of the existing checks.
Since these gaps cannot be easily improved, the spec should at least
clearly explain what the minimal detection resolution is.

- Fixes #8164
- Fixes #9969

Also shrink the timeout margin to ensure timeout checks are not unnecessarily
large.

Signed-off-by: Timothy Chen <timothytim@google.com>