### PR TITLE
[sw, dv, device.h] Add symbol for AON clock freq

### DIFF
--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -76,6 +76,14 @@ extern const uint64_t kClockFreqPeripheralHz;
 extern const uint64_t kClockFreqUsbHz;
 
 /**
+ * The always on clock frequency of the device, in hertz.
+ * This is the operating clock used by the always on timer,
+ * power manager and other peripherals that continue to
+ * operate after the device is in sleep state.
+ */
+extern const uint64_t kClockFreqAonHz;
+
+/**
  * The baudrate of the UART peripheral (if such a thing is present).
  */
 extern const uint64_t kUartBaudrate;

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -17,6 +17,8 @@ const uint64_t kClockFreqPeripheralHz = 25 * 100 * 1000;  // 2.5MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
+const uint64_t kClockFreqAonHz = 200 * 1000;  // 200kHz
+
 const uint64_t kUartBaudrate = 115200;
 
 const uint32_t kUartNCOValue =

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -17,6 +17,8 @@ const uint64_t kClockFreqPeripheralHz = 25 * 100 * 1000;  // 2.5MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
+const uint64_t kClockFreqAonHz = 200 * 1000;  // 200kHz
+
 const uint64_t kUartBaudrate = 115200;
 
 const uint32_t kUartNCOValue =

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -19,6 +19,8 @@ const uint64_t kClockFreqPeripheralHz = 24 * 1000 * 1000;  // 24MHz
 
 const uint64_t kClockFreqUsbHz = 48 * 1000 * 1000;  // 48MHz
 
+const uint64_t kClockFreqAonHz = 200 * 1000;  // 200kHz
+
 const uint64_t kUartBaudrate = 1 * 1000 * 1000;  // 1Mbps
 
 const uint32_t kUartNCOValue =

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -20,6 +20,8 @@ const uint64_t kClockFreqPeripheralHz = 125 * 1000;  // 125kHz
 
 const uint64_t kClockFreqUsbHz = 500 * 1000;  // 500kHz
 
+const uint64_t kClockFreqAonHz = 125 * 1000;  // 125kHz
+
 const uint64_t kUartBaudrate = 7200;
 
 const uint32_t kUartNCOValue =


### PR DESCRIPTION
This PR adds a `device.h` symbol representing AON clock frequency, which
is set differently in each simulation platform.

Fixes #9927.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>