### PR TITLE
[dv] Update tl_intg sequence

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.hjson
@@ -164,12 +164,6 @@
                   This condition is terminal.
                   ''',
             resval: 0,
-            tags: [// avoid checking this field. When sram_mem has received an item with integrity
-                   // error, in the meanwhile, the reg TLUL interface reads this status, tl_errors
-                   // sequence will update the status predict value but read TLUL interface may
-                   // latch the old value. So only read this status when sram TLUL has finished the
-                   // error integrity transaction.
-                   "excl:CsrNonInitTests:CsrExclCheck"]
           }
           { bits: "1"
             name: "INIT_ERROR"


### PR DESCRIPTION
Updated as follows to fix race conditon on tl integrity CSR
1. if it has multiple TLUL interface, exclude checking the CSR in
tl_intg_alert_fields for csr_rw thread.
2. read the CSR in tl_intg_alert_fields for check before inject integrity
fault, to ensure this CSR won't be changed.

Another commit is to remove the BUS_INTEG_ERROR exclusion in sram

Signed-off-by: Weicai Yang <weicai@google.com>