### PR TITLE
[otbn,dv] Clear the URND running flag when starting an operation

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -132,7 +132,7 @@ class OTBNSim:
         if not self.state.running():
             return (None, [])
 
-        if self.state.fsm_state in [FsmState.PRE_EXEC]:
+        if self.state.fsm_state == FsmState.PRE_EXEC:
             # Zero INSN_CNT the cycle after we are told to start (and every
             # cycle after that until we start executing instructions, but that
             # doesn't really matter)
@@ -143,16 +143,13 @@ class OTBNSim:
             return (None, changes)
 
         # If we are not in PRE_EXEC, then we have a valid URND seed. So we
-        # should step URND nevertheless.
+        # should step URND regardless of whether we're actually executing
+        # instructions.
         self.state.wsrs.URND.commit()
         self.state.wsrs.URND.step()
 
-        if self.state.fsm_state in [FsmState.FETCH_WAIT]:
-            # Zero INSN_CNT the cycle after we are told to start (and every
-            # cycle after that until we start executing instructions, but that
-            # doesn't really matter)
+        if self.state.fsm_state == FsmState.FETCH_WAIT:
             changes = self._on_stall(verbose, fetch_next=False)
-            self.state.ext_regs.write('INSN_CNT', 0, True)
             return (None, changes)
 
         if self.state.fsm_state in [FsmState.POST_EXEC, FsmState.LOCKING]:

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -202,6 +202,9 @@ class URNDWSR(WSR):
         '''Writes to URND are ignored'''
         return
 
+    def on_start(self) -> None:
+        self.running = False
+
     def read_unsigned(self) -> int:
         assert self._value is not None
         return self._value


### PR DESCRIPTION
When writing the "WSR cleanup" commit 04984f2, I didn't bother to
reset URND when starting an operation on the basis that it would sort
itself out when the EDN data came in. Unfortunately, I forgot that
we're also tracking whether we're stalled waiting for that data.

The result is that sequences with more than one operation back-to-back
fail because the ISS steams ahead (causing an INSN_CNT mismatch).

Fix that.