### PR TITLE
[otbn,dv] Fix bug in fatal alert tracking

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -437,7 +437,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
       // busy to locked), so the scoreboard has no way of knowing whether the recoverable alert was
       // supposed to have happened. In practice, I suspect we don't care: if a fatal alert was
       // raised, a recoverable alert doesn't really matter.
-      expected = ((alert_name == "recov") && recov_alert_expected) || fatal_alert_expected;
+      expected = ((alert_name == "recov") && recov_alert_expected) || fatal_alert_allowed;
       if (expected || cfg.under_reset) begin
         break;
       end
@@ -502,7 +502,8 @@ class otbn_scoreboard extends cip_base_scoreboard #(
 
     if (alert_name == "fatal") begin
       // If this was a fatal alert then check the counter is positive and that the expected flag is
-      // set (but don't clear it).
+      // set. Clear the "expected" flag, but not "allowed" (so that we won't see a problem when the
+      // fatal alert is re-triggered).
       `DV_CHECK_FATAL((fatal_alert_count > 0) && fatal_alert_expected)
       fatal_alert_expected = 1'b0;
     end else begin


### PR DESCRIPTION
I fumbled the change in e40b429 that allowed a sequence to see whether
we were waiting for an alert. I correctly split `fatal_alert_expected`
into two signals ("allowed" and "expected"), but I forgot to use the
"allowed" flavour in `wait_for_expected_alert`.

The result is that a re-triggering fatal alert causes a test failure.

As well as fixing that, this commit also tidies up a comment next to
the logic that clears the `fatal_alert_expected` flag.
