### PR TITLE
[sw/silicon_creator] Harden encoded message check in sigverify.c

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify.h
+++ b/sw/device/silicon_creator/lib/sigverify.h
@@ -18,6 +18,15 @@
 extern "C" {
 #endif  // __cplusplus
 
+enum {
+  /**
+   * Correct `flash_exec` value.
+   * TODO(#10022): Remove this and replace all usages from flash_ctrl_regs.h
+   * when hardware is updated.
+   */
+  kSigverifyFlashExec = 0xa26a38f7,
+};
+
 /**
  * Gets the ID of an RSA public key from its modulus.
  *
@@ -42,12 +51,14 @@ inline uint32_t sigverify_rsa_key_id_get(
  * @param key Signer's RSA public key.
  * @param act_digest Actual digest of the message being verified.
  * @param lc_state Life cycle state of the device.
+ * @param[out] flash_exec Value to write to the flash_ctrl EXEC register.
  * @return Result of the operation.
  */
 rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
                                  const sigverify_rsa_key_t *key,
                                  const hmac_digest_t *act_digest,
-                                 lifecycle_state_t lc_state);
+                                 lifecycle_state_t lc_state,
+                                 uint32_t *flash_exec);
 
 /**
  * Gets the usage constraints struct that is used for verifying a ROM_EXT.

--- a/sw/device/silicon_creator/lib/sigverify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify_functest.c
@@ -131,21 +131,30 @@ rom_error_t compute_digest(void) {
 }
 
 rom_error_t sigverify_test_exp_3(void) {
-  return sigverify_rsa_verify(&kSignatureExp3, &kKeyExp3, &act_digest,
-                              kLcStateRma);
+  uint32_t flash_exec = 0;
+  rom_error_t result = sigverify_rsa_verify(
+      &kSignatureExp3, &kKeyExp3, &act_digest, kLcStateRma, &flash_exec);
+  CHECK(flash_exec == kSigverifyFlashExec);
+  return result;
 }
 
 rom_error_t sigverify_test_exp_65537(void) {
-  return sigverify_rsa_verify(&kSignatureExp65537, &kKeyExp65537, &act_digest,
-                              kLcStateRma);
+  uint32_t flash_exec = 0;
+  rom_error_t result =
+      sigverify_rsa_verify(&kSignatureExp65537, &kKeyExp65537, &act_digest,
+                           kLcStateRma, &flash_exec);
+  CHECK(flash_exec == kSigverifyFlashExec);
+  return result;
 }
 
 rom_error_t sigverify_test_negative(void) {
+  uint32_t flash_exec = 0;
   // Signature verification should fail when using the wrong signature.
   if (sigverify_rsa_verify(&kSignatureExp65537, &kKeyExp3, &act_digest,
-                           kLcStateRma) == kErrorOk) {
+                           kLcStateRma, &flash_exec) == kErrorOk) {
     return kErrorUnknown;
   }
+  CHECK(flash_exec == UINT32_MAX);
   return kErrorOk;
 }
 

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
@@ -473,9 +473,11 @@ TEST_P(SigverifyRsaVerify, Ibex) {
               read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_USE_SW_RSA_VERIFY_OFFSET))
       .WillOnce(Return(kHardenedBoolTrue));
 
+  uint32_t flash_exec;
   EXPECT_EQ(sigverify_rsa_verify(&GetParam().sig, GetParam().key, &kDigest,
-                                 kLcStateProd),
+                                 kLcStateProd, &flash_exec),
             kErrorOk);
+  EXPECT_EQ(flash_exec, kSigverifyFlashExec);
 }
 
 INSTANTIATE_TEST_SUITE_P(AllCases, SigverifyRsaVerify,

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -87,8 +87,9 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest) {
   // Verify signature
   hmac_digest_t act_digest;
   RETURN_IF_ERROR(hmac_sha256_final(&act_digest));
-  RETURN_IF_ERROR(
-      sigverify_rsa_verify(&manifest->signature, key, &act_digest, lc_state));
+  uint32_t flash_exec = 0;
+  RETURN_IF_ERROR(sigverify_rsa_verify(&manifest->signature, key, &act_digest,
+                                       lc_state, &flash_exec));
   return kErrorOk;
 }
 


### PR DESCRIPTION
This PR hardens the encoded message check, i.e. the last step of signature verification, by producing the value that will unlock flash execution (written to the EXEC register of flash_ctrl) using shares (please see [here](https://docs.google.com/document/d/1kBvQV9B3hKIflwhVQjGAntPrRnYvnLeo3WEyfxcO1R4/edit#) for details).

In a nutshell, the first step replaces all words of `enc_msg` so that `enc_msg[i] == kSigverifyShares[i]` if `enc_msg[i]` is correct. The second step xors all words of `enc_msg` and produces the correct value for `flash_exec` if `enc_msg` is correct and `UINT32_MAX` otherwise.

I chose the correct value as `0xa26a38f7` so that it has a large hamming weight and we can obtain `kErrorOk` by xoring parts of it together when `enc_msg` is correct. Created #10022 to update the flash_ctrl.EXEC value that unlocks flash execution to this value.

While we currently don't do it in `rom_ext.c`, it looks like we can write to flash_ctrl.EXEC the same way we do in mask rom since it's a rw register.

We can also randomize the iteration order of the loops and should check for loop completion but this PR does not include these.

Signed-off-by: Alphan Ulusoy <alphan@google.com>