### PR TITLE
[otbn,dv] Document how we cover integrity protection

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -79,8 +79,16 @@
       desc: '''
             Inject ECC errors into DMEM and IMEM and expect an alert
             '''
-      milestone: V2
+      milestone: V2S
       tests: ["otbn_imem_err", "otbn_dmem_err"]
+    }
+    {
+      name: internal_integrity
+      desc: '''
+        Corrupt internal state and expect an alert
+      '''
+      milestone: V2S
+      tests: []
     }
     {
       name: back_to_back

--- a/hw/ip/otbn/doc/dv/fcov.md
+++ b/hw/ip/otbn/doc/dv/fcov.md
@@ -81,7 +81,15 @@ See the instruction counter saturate.
 We expect to see reads from this interface (both when a key is present and when it is not).
 The coverage for these reads is tracked in the [BN.WSRR](#bnwsrr) instruction which does the reading.
 
-## External (bus-accessible) CSRs
+## Integrity protection
+
+The contents of IMEM and DMEM, the register file, and other pieces of internal state are protected by ECC integrity bits.
+We want to see errors/alerts caused by corrupting each of these pieces of state.
+Rather than tracking this with functional coverage, we rely on testplan entries.
+
+See the `mem_integrity` and `internal_integrity` entries in the testplan for more details.
+
+## External (bus-accessible) CSRs {#ext-csrs}
 
 The OTBN block exposes functionality to a bus host through bus-accessible CSRs.
 Behavior of some CSRs depends on [OTBN's operational state]({{< relref "..#design-details-operational-states" >}}).


### PR DESCRIPTION
Also mark the existing mem_integrity testpoint and the new
internal_integrity testpoint as V2S since they're testing fault
detection.
