### PR TITLE
[dv/jtag_rv_dm] Add tasks to support jtag rv_dm sba csr read/write

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
@@ -12,6 +12,11 @@ class jtag_riscv_agent_cfg extends dv_base_agent_cfg;
   // Allows JTAG to return error status.
   bit allow_errors = 0;
 
+  // RV_DM jtag connects to DM CSRs.
+  // Because LC jtag will normalize the input address for the last two bits,
+  // while RV_DM jtag uses the original DM CSR addresses without the normalization.
+  bit is_rv_dm = 0;
+
   // status to return if we assert in_reset
   logic [DMI_OPW-1:0] status_in_reset;
 

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
@@ -33,7 +33,7 @@ class jtag_riscv_csr_seq extends jtag_riscv_base_seq;
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
       op   == local::op;
       // convert byte address to word address
-      addr == local::addr >> DMI_WORD_SHIFT;
+      addr == (cfg.is_rv_dm ? local::addr : (local::addr >> DMI_WORD_SHIFT));
       data == local::data;)
 
     finish_item(req);


### PR DESCRIPTION
This PR adds two simple tasks to support read/write sba bus via rv_dm
jtag.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>