### PR TITLE
[sysrst_ctrl,dv] Fix tl access handling in scoreboard

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -75,11 +75,7 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
       end
       "key_invert_ctl": begin
       end
-      "com_out_ctl[0]": begin
-      end
-      "com_sel_ctl[0]": begin
-      end
-      "com_det_ctl[0]": begin
+      "com_out_ctl_0", "com_sel_ctl_0", "com_det_ctl_0": begin
       end
       "ec_rst_ctl": begin
       end
@@ -89,6 +85,9 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
       "key_intr_status": begin
       end
       "pin_in_value": begin
+        do_read_check = 1'b0;  //This check is done in sequence
+      end
+      "wkup_status": begin
         do_read_check = 1'b0;  //This check is done in sequence
       end
       default: begin


### PR DESCRIPTION
The sysrst_ctrl_combo_detect_ec_rst test fails in V1 regression due to wrong register name in scoreboard. This PR corrects the names in scoreboard. 

Signed-off-by: Madhuri Patel <madhuri.patel@ensilica.com>