### PR TITLE
[dv/clkmgr] Enhance frequency tests and fix testplan

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -142,14 +142,14 @@
     {
       name: clk_status
       desc: '''
-            This tests the three `pwr_o.<clk>_status` output ports, for the
+            This tests the three `pwr_o.*_status` output ports, for the
             `io`, `main`, and `usb` clocks.
 
-            The `pwr_o.<clk>_status` output must track the correspponding
-            `pwr_i.<clk>_ip_clk_en` input.
+            The `pwr_o.*_status` output must track the correspponding
+            `pwr_i.*_ip_clk_en` input.
 
             **Stimulus**:
-            - Randomize the `pwr_i.<clk>_ip_clk_en` setting for each clock.
+            - Randomize the `pwr_i.*_ip_clk_en` setting for each clock.
 
             **Check**:
             - The checks are done in SVA at `clkmbf_pwrmgr_sva_if.sv`.
@@ -244,6 +244,19 @@
             - clkmgr_smoke_vseq,
             - clkmgr_trans_vseq
             '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: stress_with_rand_reset
+      desc: '''Create standard stress tests with random reset.
+
+            Stress with the following sequences:
+            - clkmgr_extclk_vseq,
+            - clkmgr_peri_vseq,
+            - clkmgr_smoke_vseq,
+            - clkmgr_trans_vseq
+            '''
       milestone: V3
       tests: []
     }
@@ -282,9 +295,10 @@
       desc: '''
             Collects coverage for the external clock selection.
 
-            The external clock selection depends on the `extclk_sel` CSR,
-            and the `lc_hw_debug_en_i`, `lc_clk_byp_req_i`, and `scanmode_i`
-            input pins. This covergroup collects their cross.
+            The external clock selection depends on the `extclk_ctrl` CSR
+            fields `sel` and `low_speed_sel`, and the `lc_hw_debug_en_i`,
+            `lc_clk_byp_req_i`, and `scanmode_i` input pins. This covergroup
+            collects their cross.
             '''
     }
     {
@@ -292,8 +306,8 @@
       desc: '''
             Collects coverage for the frequency measurement counters.
 
-            The relevant information is whether it got an okay, slow, and
-            fast measurement.
+            The relevant information is whether it got an okay, slow, or
+            fast measurement, or a timeout.
             '''
     }
   ]

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -69,12 +69,6 @@ interface clkmgr_if (
   lc_ctrl_pkg::lc_tx_t   extclk_ctrl_csr_step_down;
   prim_mubi_pkg::mubi4_t jitter_enable_csr;
 
-  // The expected and actual divided io clocks.
-  logic                  exp_clk_io_div2;
-  logic                  actual_clk_io_div2;
-  logic                  exp_clk_io_div4;
-  logic                  actual_clk_io_div4;
-
   // Internal DUT signals.
 `ifndef PATH_TO_DUT
   `define PATH_TO_DUT tb.dut
@@ -204,12 +198,15 @@ interface clkmgr_if (
     jitter_enable_csr = value;
   endfunction
 
-  function automatic void update_exp_clk_io_divs(logic exp_div2_value, logic actual_div2_value,
-                                                 logic exp_div4_value, logic actual_div4_value);
-    exp_clk_io_div2 = exp_div2_value;
-    actual_clk_io_div2 = actual_div2_value;
-    exp_clk_io_div4 = exp_div4_value;
-    actual_clk_io_div4 = actual_div4_value;
+  function automatic void force_high_starting_count(clk_mesr_e clk);
+    case (clk)
+      ClkMesrIo: `PATH_TO_DUT.u_io_meas.cnt = '1;
+      ClkMesrIoDiv2: `PATH_TO_DUT.u_io_div2_meas.cnt = '1;
+      ClkMesrIoDiv4: `PATH_TO_DUT.u_io_div4_meas.cnt = '1;
+      ClkMesrMain: `PATH_TO_DUT.u_main_meas.cnt = '1;
+      ClkMesrUsb: `PATH_TO_DUT.u_usb_meas.cnt = '1;
+      default: ;
+    endcase
   endfunction
 
   task automatic init(hintables_t idle, prim_mubi_pkg::mubi4_t scanmode,
@@ -345,10 +342,4 @@ interface clkmgr_if (
     input jitter_enable_csr;
   endclocking
 
-  clocking div_clks_cb @(posedge clocks_o.clk_io_powerup);
-    input exp_clk_io_div2;
-    input actual_clk_io_div2;
-    input exp_clk_io_div4;
-    input actual_clk_io_div4;
-  endclocking
 endinterface

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -246,7 +246,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
       end
     end
     `uvm_error(`gfn, $sformatf(
-               "Mismatch for %0s recoverable error, expected 0b%b, got 0x%b",
+               "Mismatch for %0s recoverable error, expected 0b%b, got 0b%b",
                error_type,
                expected,
                actual


### PR DESCRIPTION
Enhance clkmgr_frequency test by setting the measurement cnt to a high value
and test counter saturation.
Fix measurement timeout test to stop the clock after the measurements
start to make sure the CSRs are updated, and to expect all io derived
clocks to timeout when the primary io clock is stopped.
Make the stress test as V2 and stress with random resets as V3.
Make minor fixes to testplan, as pointed out in v2 review.

Signed-off-by: Guillermo Maturana <maturana@google.com>