### PR TITLE
[adc_ctrl/dv] Added ADC push pull agents and smoke test

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
@@ -119,6 +119,28 @@
       tests: []
     }
     {
+      name: filters_both
+      desc: '''
+          Verify filter wakeup and interrupt function correctly together
+
+          **Stimulus**:
+
+          For a number of iterations:
+          - Configure DUT with randomized filter parameters, filters,
+          interrupt and wakeup enabled, randomized low/high power sampling mode.
+          - Generate ADC data stream.
+
+          **Checks**:
+
+          - From monitored ADC data predict when filters should be triggered.
+          - Confirm this by reading the filter status register and interrupt status register.
+          - Check wakeup signal operates as expected.
+          - Check interrupt signal operates as expected.
+          '''
+      milestone: V2
+      tests: []
+    }
+    {
       name: clock_gating
       desc: '''
           Verify filter wakeup and interrupts function correctly when fast clock is

--- a/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
+++ b/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
@@ -59,7 +59,7 @@
     {
       // TODO: Create smoke test and add back
       name: smoke
-      tests: []
+      tests: ["adc_ctrl_smoke"]
     }
   ]
 }

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.sv
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class adc_ctrl_env extends cip_base_env #(
-    .CFG_T              (adc_ctrl_env_cfg),
-    .COV_T              (adc_ctrl_env_cov),
-    .VIRTUAL_SEQUENCER_T(adc_ctrl_virtual_sequencer),
-    .SCOREBOARD_T       (adc_ctrl_scoreboard)
-  );
+  .CFG_T              (adc_ctrl_env_cfg),
+  .COV_T              (adc_ctrl_env_cov),
+  .VIRTUAL_SEQUENCER_T(adc_ctrl_virtual_sequencer),
+  .SCOREBOARD_T       (adc_ctrl_scoreboard)
+);
+
+  adc_push_pull_agent_t m_adc_push_pull_agent[ADC_CTRL_CHANNELS];
+
   `uvm_component_utils(adc_ctrl_env)
 
   `uvm_component_new
@@ -16,14 +19,31 @@ class adc_ctrl_env extends cip_base_env #(
     super.build_phase(phase);
 
     // get the vifs from config db
-    if (!uvm_config_db#(virtual clk_rst_if)::get(this, "", "clk_aon_rst_vif",
-        cfg.clk_aon_rst_vif)) begin
+    if (!uvm_config_db#(virtual clk_rst_if)::get(
+            this, "", "clk_aon_rst_vif", cfg.clk_aon_rst_vif
+        )) begin
       `uvm_fatal(`gfn, "failed to get clk_aon_rst_vif from uvm_config_db")
     end
+
+    for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+      string name = $sformatf("m_adc_push_pull_agent_%0d", idx);
+      m_adc_push_pull_agent[idx] = adc_push_pull_agent_t::type_id::create(name, this);
+      uvm_config_db#(adc_push_pull_config_t)::set(this, name, "cfg", cfg.m_adc_push_pull_cfg[idx]);
+    end
+
+    if (!uvm_config_db#(wakeup_vif_t)::get(this, "", "wakeup_vif", cfg.wakeup_vif)) begin
+      `uvm_fatal(`gfn, "failed to get wakeup_vif from uvm_config_db")
+    end
+
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
+    // Connect ADC push pull agent monitors to scoreboard
+    for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+      m_adc_push_pull_agent[idx].monitor.analysis_port.connect(
+          scoreboard.m_adc_push_pull_fifo[idx].analysis_export);
+    end
   endfunction
 
 endclass

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
@@ -5,12 +5,36 @@
 class adc_ctrl_env_cfg extends cip_base_env_cfg #(
   .RAL_T(adc_ctrl_reg_block)
 );
-
   virtual clk_rst_if clk_aon_rst_vif;
+  wakeup_vif_t wakeup_vif;
 
-  // ext component cfgs
+  // ADC push pull agent configs
+  adc_push_pull_config_t m_adc_push_pull_cfg[ADC_CTRL_CHANNELS];
+  // Events triggered by scoreboard when a push pull item is received
+  event m_adc_push_pull_ev[ADC_CTRL_CHANNELS];
+
+  // Test configuration
+
+  // Basic testing mode
+  adc_ctrl_testmode_e testmode;
+
+  // Power up / wake up time
+  rand int pwrup_time;
+  rand int wakeup_time;
+
+  // Filter values filter_cfg[channel][filter]
+  rand adc_ctrl_filter_cfg_t filter_cfg[][];
+
+  // Debouncing sample counts for normal and low power modes
+  rand int np_sample_cnt;
+  rand int lp_sample_cnt;
 
   `uvm_object_utils_begin(adc_ctrl_env_cfg)
+    `uvm_field_enum(adc_ctrl_testmode_e, testmode, UVM_DEFAULT)
+    `uvm_field_int(pwrup_time, UVM_DEFAULT)
+    `uvm_field_int(wakeup_time, UVM_DEFAULT)
+    `uvm_field_int(np_sample_cnt, UVM_DEFAULT)
+    `uvm_field_int(lp_sample_cnt, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -18,6 +42,25 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = adc_ctrl_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
+    // Create ADC push pull agent configs
+    for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+      string name = $sformatf("m_adc_push_pull_cfg_%0d", idx);
+      m_adc_push_pull_cfg[idx] = adc_push_pull_config_t::type_id::create(name);
+      m_adc_push_pull_cfg[idx].if_mode = Device;
+      m_adc_push_pull_cfg[idx].agent_type = push_pull_agent_pkg::PullAgent;
+      m_adc_push_pull_cfg[idx].pull_handshake_type = push_pull_agent_pkg::FourPhase;
+
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(m_adc_push_pull_cfg[idx],
+                                     if(local::zero_delays) {
+            zero_delays      == 1;
+          } else {
+            zero_delays      == 0;
+            ack_lo_delay_min == 0;
+            ack_lo_delay_max == 2;
+            device_delay_min == 0;
+            device_delay_max == 16;
+          })
+    end
 
     // set num_interrupts & num_alerts
     begin
@@ -26,6 +69,85 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
         num_interrupts = ral.intr_state.get_n_used_bits();
       end
     end
+  endfunction
+
+  // Constraints
+  // Set the size of the filter_cfg array
+  constraint filter_cfg_size_c {
+    // Size of first dimension
+    filter_cfg.size == ADC_CTRL_CHANNELS;
+
+    // Size of second dimension
+    foreach (filter_cfg[channel]) {filter_cfg[channel].size == ADC_CTRL_NUM_FILTERS;}
+
+  }
+
+  // Valid values
+  constraint valid_c {
+    pwrup_time inside {[0 : 2 ** 4 - 1]};
+    wakeup_time inside {[0 : 2 ** 24 - 1]};
+    np_sample_cnt inside {[0 : 2 ** 16 - 1]};
+    lp_sample_cnt inside {[0 : 2 ** 8 - 1]};
+  }
+
+  // Test defaults
+  constraint defaults_c {
+
+    // Power / wake up - different values to reset
+    soft pwrup_time == 5;
+    soft wakeup_time == 1599;
+    // Debouncing sample counts for normal and low power mode - different values to reset
+    soft np_sample_cnt == 111;
+    soft lp_sample_cnt == 3;
+
+    // Default filter configuration
+    // This is the one assumed for normal use
+    foreach (filter_cfg[channel]) {
+      foreach (filter_cfg[channel][filter]) {
+        soft filter_cfg[channel][filter] == FILTER_CFG_DEFAULTS[filter];
+      }
+    }
+  }
+
+  // Wait for an ADC push pull item received event.
+  virtual task wait_adc_rx_event(int channel);
+    @(m_adc_push_pull_ev[channel]);
+  endtask
+
+  // Trigger an ADC push pull item received event.
+  virtual function trigger_adc_rx_event(int channel);
+    ->m_adc_push_pull_ev[channel];
+  endfunction
+
+  // do_print, do_copy etc for types unsupported by the macros
+
+  virtual function void do_print(uvm_printer printer);
+    // These shoud come first
+    super.do_print(printer);
+
+    // Implement filter_cfg - 2d array of structs
+    printer.print_array_header("filter_cfg", filter_cfg.size);
+    for (int channel = $low(filter_cfg); channel <= $high(filter_cfg); channel++) begin
+      printer.print_array_header($sformatf("filter_cfg[%0d]", channel), filter_cfg[channel].size());
+      for (
+          int filter = $low(filter_cfg[channel]); filter <= $high(filter_cfg[channel]); filter++
+      ) begin
+        printer.print_generic($sformatf("filter_cfg[%0d][%0d]", channel, filter),
+                              "adc_ctrl_filter_cfg_t", $bits(filter_cfg[channel][filter]),
+                              $sformatf("%p", filter_cfg[channel][filter]));
+      end
+      printer.print_array_footer();
+    end
+    printer.print_array_footer();
+  endfunction
+
+  virtual function void do_copy(uvm_object rhs);
+    type_id::T rhs_;  // type_id::T == this class (set in `uvm_object_utils)
+    super.do_copy(rhs);
+    $cast(rhs_, rhs);
+
+    // Implement filter_cfg
+    filter_cfg = rhs_.filter_cfg;
   endfunction
 
 endclass

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
@@ -13,6 +13,7 @@ package adc_ctrl_env_pkg;
   import dv_base_reg_pkg::*;
   import csr_utils_pkg::*;
   import adc_ctrl_ral_pkg::*;
+  import push_pull_agent_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -22,10 +23,73 @@ package adc_ctrl_env_pkg;
   // alerts
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
+  // Number of ADC channels
+  parameter int unsigned ADC_CTRL_CHANNELS = ast_pkg::AdcChannels;
+  // ADC data width
+  parameter int ADC_CTRL_DATA_WIDTH = ast_pkg::AdcDataWidth;
+  // Number of filters in the ADC Ctrl block
+  parameter int unsigned ADC_CTRL_NUM_FILTERS = 8;
+  // Interrupt index in interrupts interface
+  parameter int ADC_CTRL_INTERRUPT_INDEX = 0;
 
   // types
 
-  // functions
+  //
+  // ADC Push/pull types
+  //
+  // ADC Push Pull virtual interface type
+  typedef virtual push_pull_if #(.DeviceDataWidth(ADC_CTRL_DATA_WIDTH)) adc_push_pull_vif_t;
+  // ADC Push Pull agent type
+  typedef push_pull_agent#(.DeviceDataWidth(ADC_CTRL_DATA_WIDTH)) adc_push_pull_agent_t;
+  // ADC Push Pull config type
+  typedef push_pull_agent_cfg#(.DeviceDataWidth(ADC_CTRL_DATA_WIDTH)) adc_push_pull_config_t;
+  // ADC Push Pull item type
+  typedef push_pull_item#(.DeviceDataWidth(ADC_CTRL_DATA_WIDTH)) adc_push_pull_item_t;
+  // ADC Push Pull fifo type
+  typedef uvm_tlm_analysis_fifo#(adc_push_pull_item_t) adc_push_pull_fifo_t;
+  // Single ADC value
+  typedef logic unsigned [ADC_CTRL_DATA_WIDTH - 1 : 0] adc_value_logic_t;
+  typedef bit unsigned [ADC_CTRL_DATA_WIDTH - 1 : 0] adc_value_t;
+  // Wakeup virtual interface
+  typedef virtual pins_if #(1) wakeup_vif_t;
+
+  // Type of test we are executing
+  typedef enum {
+    AdcCtrlOnehot,
+    AdcCtrlNormal,
+    AdcCtrlLowpower
+  } adc_ctrl_testmode_e;
+
+  // Filter condition coding
+  typedef enum bit {
+    ADC_CTRL_FILTER_OUT = 0,
+    ADC_CTRL_FILTER_IN  = 1
+  } adc_ctrl_filter_cond_e;
+
+  // Filter configurration
+  typedef struct packed {
+    adc_ctrl_filter_cond_e cond;  // Condition
+    int min_v;  // Minimum value
+    int max_v;  // Maximum value
+    bit en;  // Enable
+  } adc_ctrl_filter_cfg_t;
+
+  // Constants
+  // Filter defaults - applies to all channels
+  const
+  adc_ctrl_filter_cfg_t
+  FILTER_CFG_DEFAULTS[] = '{
+      '{min_v: 149, max_v: 279, cond: ADC_CTRL_FILTER_IN, en: 1},
+      '{min_v: 391, max_v: 524, cond: ADC_CTRL_FILTER_IN, en: 1},
+      '{min_v: 712, max_v: 931, cond: ADC_CTRL_FILTER_IN, en: 1},
+      '{min_v: 712, max_v: 847, cond: ADC_CTRL_FILTER_IN, en: 1},
+      '{min_v: 349, max_v: 512, cond: ADC_CTRL_FILTER_IN, en: 1},
+      '{min_v: 405, max_v: 503, cond: ADC_CTRL_FILTER_IN, en: 1},
+      '{min_v: 186, max_v: 279, cond: ADC_CTRL_FILTER_IN, en: 1},
+      '{min_v: 116, max_v: 954, cond: ADC_CTRL_FILTER_OUT, en: 1}
+  };
+  // functions and tasks
+
 
   // package sources
   `include "adc_ctrl_env_cfg.sv"

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_scoreboard.sv
@@ -3,10 +3,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
 class adc_ctrl_scoreboard extends cip_base_scoreboard #(
-    .CFG_T(adc_ctrl_env_cfg),
-    .RAL_T(adc_ctrl_reg_block),
-    .COV_T(adc_ctrl_env_cov)
-  );
+  .CFG_T(adc_ctrl_env_cfg),
+  .RAL_T(adc_ctrl_reg_block),
+  .COV_T(adc_ctrl_env_cov)
+);
+
+  // Analysis FIFOs for ADC push pull monitor transactions
+  adc_push_pull_fifo_t m_adc_push_pull_fifo[ADC_CTRL_CHANNELS];
+
+  // Latest value for each channel
+  protected adc_value_logic_t m_adc_latest_values[int];
+
+  // Interrupt value for each channel
+  protected adc_value_logic_t m_adc_interrupt_values[int];
+
+  // Sampled interrupts
+  protected logic [NUM_MAX_INTERRUPTS-1:0] m_interrupts;
+
+  // Our interrupt line
+  protected logic m_interrupt;
+
+  // Interrupt asserted this ADC sample
+  protected logic m_interrupt_posedge;
+
+
   `uvm_component_utils(adc_ctrl_scoreboard)
 
   // local variables
@@ -19,6 +39,11 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+    // Create ADC push pull FIFOs
+    for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+      string name = $sformatf("m_adc_push_pull_fifo_%0d", idx);
+      m_adc_push_pull_fifo[idx] = new(name, this);
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -26,28 +51,91 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
   endfunction
 
   task run_phase(uvm_phase phase);
+    int idx = 0;
     super.run_phase(phase);
     fork
+      monitor_intr_proc();
     join_none
+
+    for (idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+      // Local copy see LRM 9.3.2 for details
+      int idx_local = idx;
+      fork
+        adc_push_pull_fifo_proc(m_adc_push_pull_fifo[idx_local], idx_local);
+      join_none
+    end
   endtask
 
+
+  // Monitor interrupt line
+  protected virtual task monitor_intr_proc();
+    forever begin
+      cfg.clk_rst_vif.wait_clks(1);
+      // Sample the interrupt lines
+      m_interrupts = cfg.intr_vif.sample();
+      `uvm_info(`gfn, $sformatf("interrupts=%b", m_interrupts), UVM_DEBUG)
+
+      // Detect a positive edge on our interrupt line
+      m_interrupt_posedge = ~m_interrupt & m_interrupts[ADC_CTRL_INTERRUPT_INDEX];
+      m_interrupt         = m_interrupts[ADC_CTRL_INTERRUPT_INDEX];
+
+      // If we see a positive edge on the interrupt line capture the lastest values
+      if (m_interrupt_posedge) begin
+        foreach (m_adc_latest_values[channel]) begin
+          m_adc_interrupt_values[channel] = m_adc_latest_values[channel];
+        end
+      end
+
+    end
+  endtask
+
+  // Process ADC push pull fifos
+  protected virtual task adc_push_pull_fifo_proc(adc_push_pull_fifo_t fifo, int channel);
+    adc_push_pull_item_t item;
+    forever begin
+      fifo.get(item);
+      cfg.trigger_adc_rx_event(channel);
+      // Set latest value
+      m_adc_latest_values[channel] = item.d_data;
+      `uvm_info(
+          `gfn, $sformatf(
+          "adc_push_pull_fifo_proc channel %0d: %s", channel, item.sprint(uvm_default_line_printer)
+          ), UVM_LOW)
+    end
+  endtask
+
+  // Return the latest ADC value for the respective channel
+  virtual function adc_value_logic_t get_adc_latest_value(input int channel);
+    adc_value_logic_t value = m_adc_latest_values[channel];
+    `uvm_info(`gfn, $sformatf("get_adc_latest_value channel=%0d  value=%0h", channel, value),
+              UVM_HIGH)
+    return value;
+  endfunction
+
+  // Return the latest ADC interrupt value for the respective channel
+  virtual function adc_value_logic_t get_adc_interrupt_value(input int channel);
+    adc_value_logic_t value = m_adc_interrupt_values[channel];
+    `uvm_info(`gfn, $sformatf("get_adc_interrupt_value channel=%0d  value=%0h", channel, value),
+              UVM_HIGH)
+    return value;
+  endfunction
+
   virtual task process_tl_access(tl_seq_item item, tl_channels_e channel, string ral_name);
-    uvm_reg csr;
-    bit     do_read_check   = 1'b1;
-    bit     write           = item.is_write();
+    uvm_reg        csr;
+    bit            do_read_check = 1'b1;
+    bit            write = item.is_write();
     uvm_reg_addr_t csr_addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
 
-    bit addr_phase_read   = (!write && channel == AddrChannel);
-    bit addr_phase_write  = (write && channel == AddrChannel);
-    bit data_phase_read   = (!write && channel == DataChannel);
-    bit data_phase_write  = (write && channel == DataChannel);
+    bit            addr_phase_read = (!write && channel == AddrChannel);
+    bit            addr_phase_write = (write && channel == AddrChannel);
+    bit            data_phase_read = (!write && channel == DataChannel);
+    bit            data_phase_write = (write && channel == DataChannel);
 
     // if access was to a valid csr, get the csr handle
     if (csr_addr inside {cfg.ral_models[ral_name].csr_addrs}) begin
       csr = cfg.ral_models[ral_name].default_map.get_reg_by_offset(csr_addr);
       `DV_CHECK_NE_FATAL(csr, null)
-    end
-    else begin
+    end else begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end
 
@@ -71,16 +159,79 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
       "intr_test": begin
         // FIXME
       end
+      "adc_intr_status": begin
+        do_read_check = 1'b0;
+      end
+      "adc_intr_ctl": begin
+        // FIXME
+      end
+      "adc_en_ctl": begin
+        // FIXME
+      end
+
+      "adc_chn0_filter_ctl_0", "adc_chn0_filter_ctl_1", "adc_chn0_filter_ctl_2",
+          "adc_chn0_filter_ctl_3", "adc_chn0_filter_ctl_4", "adc_chn0_filter_ctl_5",
+          "adc_chn0_filter_ctl_6", "adc_chn0_filter_ctl_7", "adc_chn1_filter_ctl_0",
+          "adc_chn1_filter_ctl_1", "adc_chn1_filter_ctl_2", "adc_chn1_filter_ctl_3",
+          "adc_chn1_filter_ctl_4", "adc_chn1_filter_ctl_5", "adc_chn1_filter_ctl_6",
+          "adc_chn1_filter_ctl_7"
+          : begin
+        // FIXME
+      end
+
+      "adc_chn_val_0": begin
+        // Predict values
+        if (addr_phase_read) begin
+          // Latest ADC value
+          void'(ral.adc_chn_val[0].adc_chn_value.predict(
+              .value(get_adc_latest_value(0)), .kind(UVM_PREDICT_READ)
+          ));
+
+          // Interrupt ADC value
+          `uvm_info(`gfn, $sformatf(
+                    "adc_en_ctl.oneshot_mode=%0x", ral.adc_en_ctl.oneshot_mode.get_mirrored_value()
+                    ), UVM_HIGH)
+          if (ral.adc_en_ctl.oneshot_mode.get_mirrored_value() == 1) begin
+            // In oneshot mode latest and interrupt fields are the same
+            void'(ral.adc_chn_val[0].adc_chn_value_intr.predict(
+                .value(get_adc_latest_value(0)), .kind(UVM_PREDICT_READ)
+            ));
+          end else begin
+            `uvm_info(`gfn, "FIXME: Predict adc_chn_val_0.adc_chn_value_intr", UVM_NONE)
+          end
+        end
+      end
+      "adc_chn_val_1": begin
+        // Predict values
+        if (addr_phase_read) begin
+
+          void'(ral.adc_chn_val[1].adc_chn_value.predict(
+              .value(get_adc_latest_value(1)), .kind(UVM_PREDICT_READ)
+          ));
+
+          // Interrupt ADC value
+          if (ral.adc_en_ctl.oneshot_mode.get_mirrored_value() == 1) begin
+            // In oneshot mode latest and interrupt fields are the same
+            void'(ral.adc_chn_val[1].adc_chn_value_intr.predict(
+                .value(get_adc_latest_value(1)), .kind(UVM_PREDICT_READ)
+            ));
+          end else begin
+            `uvm_info(`gfn, "FIXME: Predict adc_chn_val_1.adc_chn_value_intr", UVM_NONE)
+          end
+        end
+      end
+
+
       default: begin
-        `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+        `uvm_error(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end
     endcase
 
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
     if (data_phase_read) begin
       if (do_read_check) begin
-        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
-                     $sformatf("reg name: %0s", csr.get_full_name()))
+        `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data, $sformatf(
+                     "reg name: %0s", csr.get_full_name()))
       end
       void'(csr.predict(.value(item.d_data), .kind(UVM_PREDICT_READ)));
     end
@@ -89,6 +240,9 @@ class adc_ctrl_scoreboard extends cip_base_scoreboard #(
   virtual function void reset(string kind = "HARD");
     super.reset(kind);
     // reset local fifos queues and variables
+    // Latest values
+    m_adc_latest_values.delete();
+    m_adc_interrupt_values.delete();
   endfunction
 
   function void check_phase(uvm_phase phase);

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_virtual_sequencer.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_virtual_sequencer.sv
@@ -7,8 +7,5 @@ class adc_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   .COV_T(adc_ctrl_env_cov)
 );
   `uvm_component_utils(adc_ctrl_virtual_sequencer)
-
-
   `uvm_component_new
-
 endclass

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_base_vseq.sv
@@ -8,6 +8,7 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
   .COV_T              (adc_ctrl_env_cov),
   .VIRTUAL_SEQUENCER_T(adc_ctrl_virtual_sequencer)
 );
+
   `uvm_object_utils(adc_ctrl_base_vseq)
 
   // various knobs to enable certain routines
@@ -43,4 +44,61 @@ class adc_ctrl_base_vseq extends cip_base_vseq #(
     cfg.clk_aon_rst_vif.drive_rst_pin(1);
   endtask
 
+  // Configure the filter registers using values in the config object
+  virtual task configure_filters();
+    uvm_reg r;
+    uvm_reg_field min_v_fld, max_v_fld, cond_fld, en_fld;
+    string regname;
+    for (int channel = 0; channel < ADC_CTRL_CHANNELS; channel++) begin
+      for (int filter = 0; filter < ADC_CTRL_NUM_FILTERS; filter++) begin
+        regname = $sformatf("adc_chn%0d_filter_ctl_%0d", channel, filter);
+        r = ral.get_reg_by_name(regname);
+        if (r == null) `uvm_fatal(`gfn, {"configure_filters: Couldn't find register ", regname})
+        // Get fields
+        min_v_fld = r.get_field_by_name("min_v");
+        max_v_fld = r.get_field_by_name("max_v");
+        cond_fld  = r.get_field_by_name("cond");
+        en_fld    = r.get_field_by_name("en");
+        // Check valid
+        if (min_v_fld == null) `uvm_fatal(`gfn, "configure_filters: Couldn't find field min_v")
+        if (max_v_fld == null) `uvm_fatal(`gfn, "configure_filters: Couldn't find field max_v")
+        if (cond_fld == null) `uvm_fatal(`gfn, "configure_filters: Couldn't find field cond")
+        if (en_fld == null) `uvm_fatal(`gfn, "configure_filters: Couldn't find field en")
+        // Set values from config object
+        min_v_fld.set(cfg.filter_cfg[channel][filter].min_v);
+        max_v_fld.set(cfg.filter_cfg[channel][filter].max_v);
+        cond_fld.set(cfg.filter_cfg[channel][filter].cond);
+        en_fld.set(cfg.filter_cfg[channel][filter].en);
+        // Write register
+        csr_wr(r, r.get());
+      end
+    end
+  endtask
+
+  //
+  // Wait for RX on all ADC channels by monitoring channel rx event
+  // these are triggered in the scoreboard as items are received
+  virtual task wait_all_rx;
+    fork
+      begin : guard_proc
+        for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+          // Local copy see LRM 9.3.2 for details
+          int idx_local = idx;
+          fork
+            cfg.wait_adc_rx_event(idx_local);
+          join_none
+        end
+        wait fork;
+      end
+    join
+  endtask
+
+  // Create a string with "called from (filename:line number)" to be used in csr checks etc.
+  virtual function string called_from(string filename, int lineno);
+    return $sformatf("called from (%s:%0d)", filename, lineno);
+  endfunction
+
 endclass : adc_ctrl_base_vseq
+
+
+

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_common_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_common_vseq.sv
@@ -12,6 +12,8 @@ class adc_ctrl_common_vseq extends adc_ctrl_base_vseq;
 
   virtual task body();
     run_common_vseq_wrapper(num_trans);
+    // Short delay to prevent register CDC assertions triggering at the end of test
+    cfg.clk_aon_rst_vif.wait_clks(3);
   endtask : body
 
 endclass

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_smoke_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_smoke_vseq.sv
@@ -1,15 +1,72 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
-
-// smoke test vseq
+// Smoke Test Vseq
+// Verify datapath between AST ADC interface and ADC sample registers.
+//
+// Stimulus:
+//
+// For a number of iterations:
+// - Configure DUT no filters or events.
+// - Generate ADC data.
+// - Sample into capture registers using oneshot mode.
+//
+// Checks:
+//
+// - From monitored ADC data predict the value of the ADC sample register
+// - Compare sample registers against expected.
+// - Check oneshot bit of interrupt status register works as expected.
+//
 class adc_ctrl_smoke_vseq extends adc_ctrl_base_vseq;
+
   `uvm_object_utils(adc_ctrl_smoke_vseq)
 
   `uvm_object_new
 
   task body();
-    `uvm_error(`gfn, "FIXME")
+    uvm_reg_data_t rdata;
+    // Vector with onehot interrupt status bit position = 1
+    const uvm_reg_data_t ONE_SHOT_INTR = 1 << ral.adc_intr_status.oneshot.get_lsb_pos();
+
+    // Make sure ADC is off
+    csr_wr(ral.adc_en_ctl, 'h0);
+
+    // Set one shot interrupt enable
+    csr_wr(ral.adc_intr_ctl, ONE_SHOT_INTR);
+
+    repeat (20) begin
+
+      // Clear interrupt status reg
+      csr_wr(ral.adc_intr_status, '1);
+
+      // Check interrupt status
+      csr_rd_check(.ptr(ral.adc_intr_status), .compare_value(0),
+                   .err_msg(called_from(`__FILE__, `__LINE__)));
+
+      // Trigger oneshot sample
+      ral.adc_en_ctl.adc_enable.set(1);
+      ral.adc_en_ctl.oneshot_mode.set(1);
+      csr_wr(ral.adc_en_ctl, ral.adc_en_ctl.get());
+
+      wait_all_rx();
+      // Give time to settle
+      #20us;
+
+      // Check interrupt status
+      csr_rd_check(.ptr(ral.adc_intr_status), .compare_value(ONE_SHOT_INTR),
+                   .err_msg(called_from(`__FILE__, `__LINE__)));
+
+      // Read and check ADC value registers - check performed in scoreboard
+      csr_rd(ral.adc_chn_val[0], rdata);
+      csr_rd(ral.adc_chn_val[1], rdata);
+
+      // Turn off ADC
+      csr_wr(ral.adc_en_ctl, 'h0);
+
+    end
+
+    // Allow time for sim to finish or we trigger an assertion
+    #100us;
   endtask : body
 
 endclass : adc_ctrl_smoke_vseq

--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -6,16 +6,25 @@ module tb;
   // dep packages
   import uvm_pkg::*;
   import dv_utils_pkg::*;
+
   import adc_ctrl_env_pkg::*;
   import adc_ctrl_test_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
+  `include "prim_assert.sv"
 
   wire clk, rst_n;
+  wire clk_aon, rst_aon_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
+  wire wakeup_req;
+  wire [ADC_CTRL_CHANNELS - 1 : 0] adc_channel_sel, adc_data_valid;
+  logic [ADC_CTRL_CHANNELS - 1 : 0] adc_if_reqs;
+  wire [ADC_CTRL_CHANNELS - 1 : 0][ADC_CTRL_DATA_WIDTH - 1 : 0] adc_data;
+  wire ast_pkg::adc_ast_req_t adc_o;
+  ast_pkg::adc_ast_rsp_t adc_i;
 
   `DV_ALERT_IF_CONNECT
 
@@ -29,12 +38,20 @@ module tb;
     .rst_n(rst_aon_n)
   );
   pins_if #(NUM_MAX_INTERRUPTS) intr_if (interrupts);
+  pins_if #(1) wakeup_if (wakeup_req);
   pins_if #(1) devmode_if (devmode);
   tl_if tl_if (
     .clk  (clk),
     .rst_n(rst_n)
   );
 
+  // Array of push pull interfaces, one per ADC channel
+  push_pull_if #(
+    .DeviceDataWidth(ADC_CTRL_DATA_WIDTH)
+  ) adc_if[ADC_CTRL_CHANNELS] (
+    .clk  (clk_aon),
+    .rst_n(rst_aon_n)
+  );
 
   // dut
   adc_ctrl dut (
@@ -46,10 +63,10 @@ module tb;
     .tl_o              (tl_if.d2h),
     .alert_rx_i        (alert_rx),
     .alert_tx_o        (alert_tx),
-    .adc_o             (),
-    .adc_i             ('0),
-    .intr_debug_cable_o(interrupts[0]),
-    .wkup_req_o        ()
+    .adc_o             (adc_o),
+    .adc_i             (adc_i),
+    .intr_debug_cable_o(interrupts[ADC_CTRL_INTERRUPT_INDEX]),
+    .wkup_req_o        (wakeup_req)
   );
 
   initial begin
@@ -60,10 +77,74 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_aon_rst_vif", clk_aon_rst_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
+    uvm_config_db#(wakeup_vif_t)::set(null, "*.env", "wakeup_vif", wakeup_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end
 
+  // Push pull agents
+  // Need to use generate loop as idx must be an elaborataion time constant
+  for (genvar idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin : g_adc_if_connections
+    initial begin
+      uvm_config_db#(adc_push_pull_vif_t)::set(null, $sformatf("*env.m_adc_push_pull_agent_%0d", idx
+                                               ), "vif", adc_if[idx]);
+    end
+
+    // Assign inputs and outputs
+
+    // Convert data valid and data into a packed arrays for the Mux below.
+    assign adc_data_valid[idx] = adc_if[idx].ack;
+    assign adc_data[idx]       = adc_if[idx].d_data;
+
+    // Connect requests
+    //assign adc_if[idx].req = adc_o.channel_sel[idx] & ~adc_o.pd;
+    assign adc_if[idx].req     = adc_if_reqs[idx];
+  end
+
+  // Output decode
+  // We assert an adc_if request if:
+  // 1. The coresponding channel is selected
+  // 2. Power Down is not asserted
+  // 3. No other channel has an acknowledge
+  always_comb begin : adc_o_decode
+    // default all off
+    adc_if_reqs = 0;
+    for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+      if (adc_o.channel_sel[idx] === 1 && adc_o.pd === 0) begin
+        adc_if_reqs[idx] = 1;
+        // Check no ack from another channel
+        for (int idx_1 = 0; idx_1 < ADC_CTRL_CHANNELS; idx_1++) begin
+          if (adc_data_valid[idx_1] === 1 && (idx_1 != idx)) adc_if_reqs[idx] = 0;
+        end
+      end
+    end
+  end
+
+  // Input mux
+  always_comb begin : adc_i_mux
+    // Just or the valids
+    adc_i.data_valid = |adc_data_valid;
+    adc_i.data       = 'X;
+    if (adc_o.pd === 0) begin
+      // Only if power down deasserted
+      for (int idx = 0; idx < ADC_CTRL_CHANNELS; idx++) begin
+        if (adc_data_valid[idx] === 1) begin
+          //adc_i.data_valid = adc_data_valid[idx];
+          adc_i.data = adc_data[idx];
+          break;
+        end
+      end
+    end
+  end
+
+  `ASSERT(ChannelSelOnehot_A, (adc_o.channel_sel != 0) -> $onehot(adc_o.channel_sel), clk_aon,
+          ~rst_aon_n)
+  `ASSERT_KNOWN(ChannelSelKnown_A, adc_o.channel_sel, clk_aon, ~rst_aon_n)
+  `ASSERT_KNOWN(PdKnown_A, adc_o.pd, clk_aon, ~rst_aon_n)
+
+
 endmodule
+
+

--- a/hw/ip/adc_ctrl/dv/tests/adc_ctrl_base_test.sv
+++ b/hw/ip/adc_ctrl/dv/tests/adc_ctrl_base_test.sv
@@ -16,5 +16,30 @@ class adc_ctrl_base_test extends cip_base_test #(
 
   // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
   // the run_phase; as such, nothing more needs to be done
+  virtual function void build_phase(uvm_phase phase);
+    bit print_ral = 0;
+
+    // Defaults - can be overridden by plusargs
+    test_timeout_ns = 600_000_000;  // 600ms
+
+    super.build_phase(phase);
+
+    // Enable RAL printout
+    void'($value$plusargs("print_ral=%0b", print_ral));
+
+    // Set zero delays if requested
+    if (cfg.zero_delays) begin
+      foreach (cfg.m_adc_push_pull_cfg[idx]) cfg.m_adc_push_pull_cfg[idx].zero_delays = 1;
+    end
+
+    // Print RAL if requested
+    if (print_ral) begin
+      `uvm_info(`gfn, cfg.ral.sprint(), UVM_LOW)
+    end
+
+    // Print test config
+    `uvm_info(`gfn, cfg.sprint(), UVM_LOW)
+
+  endfunction
 
 endclass : adc_ctrl_base_test

--- a/hw/ip/adc_ctrl/dv/tests/adc_ctrl_test_pkg.sv
+++ b/hw/ip/adc_ctrl/dv/tests/adc_ctrl_test_pkg.sv
@@ -8,6 +8,7 @@ package adc_ctrl_test_pkg;
   import cip_base_pkg::*;
   import adc_ctrl_env_pkg::*;
 
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"


### PR DESCRIPTION
- Added test sequence adc_ctrl_smoke_vseq.sv
Configures DUT in one-shot mode and ensures ADC data is stored in
the sample registers.
- Integrated push pull agents into environment to emulate the
AST ADC
- Added filter configuration fields to config object and configuration
task in preparation for other tests.
- Added filters_both testpoint to testplan
- Added a short delay at the end of adc_ctrl_common_vseq body to
allow register CDC to finish and avoid triggering assertions at the
end of the test.

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>