### PR TITLE
[sw,tests] Add the chip level test `chip_sw_aon_timer_wdog_bark_irq`

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -606,7 +606,7 @@
             - Verify that the interrupt triggered only after the timeout elapsed.
             '''
       milestone: V2
-      tests: ["chip_sw_aon_timer_wakeup_irq"]
+      tests: ["chip_sw_aon_timer_irq"]
     }
     {
       name: chip_sw_aon_timer_sleep_wakeup
@@ -646,7 +646,7 @@
             - Service the bark interrupt upon reception.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_aon_timer_irq"]
     }
     {
       name: chip_sw_aon_timer_wdog_lc_escalate

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -295,9 +295,9 @@
       en_run_modes: ["sw_test_mode"]
     }
     {
-      name: chip_sw_aon_timer_wakeup_irq
+      name: chip_sw_aon_timer_irq
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/aon_timer_wakeup_irq_test:1"]
+      sw_images: ["sw/device/tests/aon_timer_irq_test:1"]
       en_run_modes: ["sw_test_mode"]
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -725,13 +725,13 @@ sw_tests += {
 }
 
 
-# AON Timer test wake up irq test.
-aon_timer_wakeup_irq_test = declare_dependency(
+# AON Timer irq test.
+aon_timer_irq_test = declare_dependency(
   link_with: static_library(
-    'aon_timer_wakeup_irq_test',
+    'aon_timer_irq_test',
     sources: [
       hw_ip_rstmgr_reg_h,
-      'aon_timer_wakeup_irq_test.c',
+      'aon_timer_irq_test.c',
     ],
     dependencies: [
       sw_lib_dif_rstmgr,
@@ -749,8 +749,8 @@ aon_timer_wakeup_irq_test = declare_dependency(
   ),
 )
 sw_tests += {
-  'aon_timer_wakeup_irq_test': {
-    'library': aon_timer_wakeup_irq_test,
+  'aon_timer_irq_test': {
+    'library': aon_timer_irq_test,
   }
 }
 


### PR DESCRIPTION
This PR:
- Add the test chip_sw_aon_timer_wdog_bark_irq listed in the chip-level testplan;
- Rename file `aon_timer_wakeup_irq_test.c` to `aon_timer_irq_test.c` 
