### PR TITLE
[CODEOWNERS] Replace DV code owners with DV reviewer pool

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -57,9 +57,9 @@ util/build_docs.py  @moidx
 
 
 # DV related common files
-dv/                 @sriyerg @weicaiyang
-fpv/                @cindychip
-formal/             @cindychip
+dv/                 @lowRISC/ot-dv-reviewers
+fpv/                @lowRISC/ot-dv-reviewers
+formal/             @lowRISC/ot-dv-reviewers
 # lint/             # TBD
 
 # SW related


### PR DESCRIPTION
Currently specific individuals are always assigned to review changes to DV code. After this change reviewers will be automatically assigned from the DV reviewer GitHub team.