### PR TITLE
[spi_device] Lint fix

### DIFF
--- a/hw/ip/spi_device/rtl/spi_cmdparse.sv
+++ b/hw/ip/spi_device/rtl/spi_cmdparse.sv
@@ -180,7 +180,7 @@ module spi_cmdparse
     if (!rst_ni) begin
       cmd_info_q <= '{
         payload_dir: payload_dir_e'(PayloadIn),
-        addr_mode: addr_mode_e'('0),
+        addr_mode: addr_mode_e'(0),
         default: '0
       };
       cmd_info_idx_q <= '0;
@@ -193,7 +193,7 @@ module spi_cmdparse
   always_comb begin
     cmd_info_d = '{
       payload_dir: payload_dir_e'(PayloadIn),
-      addr_mode: addr_mode_e'('0),
+      addr_mode: addr_mode_e'(0),
       default: '0
     };
     cmd_info_idx_d = '0;

--- a/hw/ip/spi_device/rtl/spid_jedec.sv
+++ b/hw/ip/spi_device/rtl/spid_jedec.sv
@@ -106,12 +106,12 @@ module spid_jedec
       p2s_byte = jedec.cc;
     end else if (st_q == StJedecId) begin
       p2s_byte = jedec.jedec_id;
-    end else if (byte_sel_q == 2'h 2) begin
-      // End of the transfer but host keep toggles SCK. Sending out 0 always
-      p2s_byte = 8'h 0;
     end else begin
       // based on byte_sel_q
-      p2s_byte = jedec.device_id[8*byte_sel_q+:8];
+      // End of the transfer but host keep toggles SCK. Sending out 0 always
+      p2s_byte = (byte_sel_q >= 2'b 10) ? 8'h 0 :
+                 (byte_sel_q == 2'b 01) ? jedec.device_id[15:8] :
+                                          jedec.device_id[7:0] ;
     end
   end : p2s_byte_logic
 


### PR DESCRIPTION
use constant 0 for lint tool to assume the correct bit size

To avoid Out of Bound lint error, logic is changed to explicit
assignment in jedec.sv
