### PR TITLE
[aes] Add lockable bit to force PRNG reseeding upon touching the key

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -517,6 +517,45 @@
            // Exclude from write-read checks.
            "excl:CsrNonInitTests:CsrExclWriteCheck"]
   },
+  { name: "CTRL_AUX_SHADOWED",
+    desc: '''
+      Auxiliary Control Register.
+
+      This register is shadowed, meaning two subsequent write operations are required to change its content.
+      If the two write operations try to set a different value, a recoverable alert is triggered (See Status Register).
+      A read operation clears the internal phase tracking: The next write operation is always considered a first write operation of an update sequence.              
+    '''
+    swaccess: "rw",
+    hwaccess: "hro",
+    shadowed: "true",
+    update_err_alert: "recov_ctrl_update_err",
+    storage_err_alert: "fatal_fault",
+    fields: [
+    {   bits:   "0",
+        name:   "KEY_TOUCH_FORCES_RESEED",
+        desc:   '''
+                Controls whether providing a new key triggers the reseeding of internal pseudo-random number generators used for clearing and masking (1) or not (0).
+                ''',
+        resval: 1,
+      }
+    ]
+  },
+  { name:     "CTRL_AUX_REGWEN",
+    desc:     '''
+              Lock bit for Auxiliary Control Register.
+              '''
+    swaccess: "rw0c",
+    hwaccess: "none",
+    fields: [
+    {   bits:   "0",
+        desc:   '''
+                Auxiliary Control Register configuration enable bit.
+                If this is cleared to 0, the Auxiliary Control Register cannot be written anymore.
+                ''',
+        resval: 1,
+      }
+    ]
+  },
   { name: "TRIGGER",
     desc: '''
       Trigger Register.
@@ -566,6 +605,7 @@
         resval: "1"
         desc:  '''
           Keep continuing with the current states of the internal pseudo-random number generators used for register clearing and masking (0) or perform a reseed of the internal states from the connected entropy source (1).
+          If the KEY_TOUCH_FORCES_RESEED bit in the Auxiliary Control Register is set to one, this trigger will automatically get set after providing a new initial key.
         '''
         tags: ["excl:CsrAllTests:CsrExclCheck"]
       }

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -60,6 +60,10 @@ class aes_base_vseq extends cip_base_vseq #(
     aes_ctrl[6:1]  = aes_pkg::AES_ECB;   // 6'b00_0001
     aes_ctrl[9:7]  = aes_pkg::AES_128;   // set to 128b key
     csr_wr(.ptr(ral.ctrl_shadowed), .value(aes_ctrl), .en_shadow_wr(1'b1), .blocking(1));
+    // initialize aux control register and lock it
+    // This is a temporary workaround until the aux control register is properly supported.
+    csr_wr(.ptr(ral.ctrl_aux_shadowed), .value(0), .en_shadow_wr(1'b1), .blocking(1));
+    csr_wr(.ptr(ral.ctrl_aux_regwen), .value(0));
   endtask // aes_init
 
 

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -89,6 +89,7 @@ module aes
   aes_reg_top u_reg (
     .clk_i,
     .rst_ni,
+    .rst_shadowed_ni,
     .tl_i,
     .tl_o,
     .reg2hw,

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -26,6 +26,7 @@ module aes_control
   input  logic                      sideload_i,
   input  prs_rate_e                 prng_reseed_rate_i,
   input  logic                      manual_operation_i,
+  input  logic                      key_touch_forces_reseed_i,
   input  logic                      start_i,
   input  logic                      key_iv_data_in_clear_i,
   input  logic                      data_out_clear_i,
@@ -186,6 +187,7 @@ module aes_control
   logic          [Sp2VWidth-1:0] mr_start_we;
   logic          [Sp2VWidth-1:0] mr_key_iv_data_in_clear_we;
   logic          [Sp2VWidth-1:0] mr_data_out_clear_we;
+  logic          [Sp2VWidth-1:0] mr_prng_reseed;
   logic          [Sp2VWidth-1:0] mr_prng_reseed_we;
   logic          [Sp2VWidth-1:0] mr_idle;
   logic          [Sp2VWidth-1:0] mr_idle_we;
@@ -255,6 +257,7 @@ module aes_control
         .sideload_i                ( sideload_i                    ),
         .prng_reseed_rate_i        ( prng_reseed_rate_i            ),
         .manual_operation_i        ( manual_operation_i            ),
+        .key_touch_forces_reseed_i ( key_touch_forces_reseed_i     ),
         .start_i                   ( start_trigger                 ),
         .key_iv_data_in_clear_i    ( key_iv_data_in_clear_i        ),
         .data_out_clear_i          ( data_out_clear_i              ),
@@ -313,7 +316,8 @@ module aes_control
         .start_we_o                ( mr_start_we[i]                ), // OR-combine
         .key_iv_data_in_clear_we_o ( mr_key_iv_data_in_clear_we[i] ), // AND-combine
         .data_out_clear_we_o       ( mr_data_out_clear_we[i]       ), // AND-combine
-        .prng_reseed_we_o          ( mr_prng_reseed_we[i]          ), // AND-combine
+        .prng_reseed_o             ( mr_prng_reseed[i]             ), // OR-combine
+        .prng_reseed_we_o          ( mr_prng_reseed_we[i]          ), // OR-combine
 
         .idle_o                    ( mr_idle[i]                    ), // AND-combine
         .idle_we_o                 ( mr_idle_we[i]                 ), // AND-combine
@@ -343,6 +347,7 @@ module aes_control
         .sideload_i                ( sideload_i                    ),
         .prng_reseed_rate_i        ( prng_reseed_rate_i            ),
         .manual_operation_i        ( manual_operation_i            ),
+        .key_touch_forces_reseed_i ( key_touch_forces_reseed_i     ),
         .start_i                   ( start_trigger                 ),
         .key_iv_data_in_clear_i    ( key_iv_data_in_clear_i        ),
         .data_out_clear_i          ( data_out_clear_i              ),
@@ -401,7 +406,8 @@ module aes_control
         .start_we_o                ( mr_start_we[i]                ), // OR-combine
         .key_iv_data_in_clear_we_o ( mr_key_iv_data_in_clear_we[i] ), // AND-combine
         .data_out_clear_we_o       ( mr_data_out_clear_we[i]       ), // AND-combine
-        .prng_reseed_we_o          ( mr_prng_reseed_we[i]          ), // AND-combine
+        .prng_reseed_o             ( mr_prng_reseed[i]             ), // OR-combine
+        .prng_reseed_we_o          ( mr_prng_reseed_we[i]          ), // OR-combine
 
         .idle_o                    ( mr_idle[i]                    ), // AND-combine
         .idle_we_o                 ( mr_idle_we[i]                 ), // AND-combine
@@ -436,13 +442,14 @@ module aes_control
   assign prng_data_req_o           = |mr_prng_data_req;
   assign prng_reseed_req_o         = |mr_prng_reseed_req;
   assign start_we_o                = |mr_start_we;
+  assign prng_reseed_o             = |mr_prng_reseed;
+  assign prng_reseed_we_o          = |mr_prng_reseed_we;
 
   // AND: Only if all bits are high, the corresponding action should be triggered.
   assign ctrl_we_o                 = &mr_ctrl_we;
   assign data_in_we_o              = &mr_data_in_we;
   assign key_iv_data_in_clear_we_o = &mr_key_iv_data_in_clear_we;
   assign data_out_clear_we_o       = &mr_data_out_clear_we;
-  assign prng_reseed_we_o          = &mr_prng_reseed_we;
   assign idle_o                    = &mr_idle;
   assign idle_we_o                 = &mr_idle_we;
   assign stall_o                   = &mr_stall;
@@ -552,10 +559,9 @@ module aes_control
   //////////////////////
   // Trigger Register //
   //////////////////////
-  // Triggers are only ever cleared by control.
+  // Most triggers are only ever cleared by control.
   assign start_o                   = 1'b0;
   assign key_iv_data_in_clear_o    = 1'b0;
   assign data_out_clear_o          = 1'b0;
-  assign prng_reseed_o             = 1'b0;
 
 endmodule

--- a/hw/ip/aes/rtl/aes_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_n.sv
@@ -33,6 +33,7 @@ module aes_control_fsm_n
   input  logic                                    sideload_i,
   input  prs_rate_e                               prng_reseed_rate_i,
   input  logic                                    manual_operation_i,
+  input  logic                                    key_touch_forces_reseed_i,
   input  logic                                    start_i,
   input  logic                                    key_iv_data_in_clear_i,
   input  logic                                    data_out_clear_i,
@@ -100,6 +101,7 @@ module aes_control_fsm_n
   output logic                                    start_we_o,
   output logic                                    key_iv_data_in_clear_we_o,
   output logic                                    data_out_clear_we_o,
+  output logic                                    prng_reseed_o,
   output logic                                    prng_reseed_we_o,
 
   // Status register
@@ -129,6 +131,7 @@ module aes_control_fsm_n
     sideload_i,
     prng_reseed_rate_i,
     manual_operation_i,
+    key_touch_forces_reseed_i,
     start_i,
     key_iv_data_in_clear_i,
     data_out_clear_i,
@@ -167,6 +170,7 @@ module aes_control_fsm_n
     sideload_i,
     prng_reseed_rate_i,
     manual_operation_i,
+    key_touch_forces_reseed_i,
     start_i,
     key_iv_data_in_clear_i,
     data_out_clear_i,
@@ -211,10 +215,11 @@ module aes_control_fsm_n
   logic                                    sideload;
   prs_rate_e                               prng_reseed_rate;
   logic                                    manual_operation;
+  logic                                    key_touch_forces_reseed;
   logic                                    start;
   logic                                    key_iv_data_in_clear;
   logic                                    data_out_clear;
-  logic                                    prng_reseed;
+  logic                                    prng_reseed_in_buf;
   logic                                    mux_sel_err;
   logic                                    sp_enc_err;
   lc_ctrl_pkg::lc_tx_t                     lc_escalate_en;
@@ -245,10 +250,11 @@ module aes_control_fsm_n
           sideload,
           prng_reseed_rate,
           manual_operation,
+          key_touch_forces_reseed,
           start,
           key_iv_data_in_clear,
           data_out_clear,
-          prng_reseed,
+          prng_reseed_in_buf,
           mux_sel_err,
           sp_enc_err,
           lc_escalate_en,
@@ -298,6 +304,7 @@ module aes_control_fsm_n
   logic                                    start_we;
   logic                                    key_iv_data_in_clear_we;
   logic                                    data_out_clear_we;
+  logic                                    prng_reseed_out_buf;
   logic                                    prng_reseed_we;
   logic                                    idle;
   logic                                    idle_we;
@@ -333,10 +340,11 @@ module aes_control_fsm_n
     .sideload_i                ( sideload                      ),
     .prng_reseed_rate_i        ( prng_reseed_rate              ),
     .manual_operation_i        ( manual_operation              ),
+    .key_touch_forces_reseed_i ( key_touch_forces_reseed       ),
     .start_i                   ( start                         ),
     .key_iv_data_in_clear_i    ( key_iv_data_in_clear          ),
     .data_out_clear_i          ( data_out_clear                ),
-    .prng_reseed_i             ( prng_reseed                   ),
+    .prng_reseed_i             ( prng_reseed_in_buf            ),
     .mux_sel_err_i             ( mux_sel_err                   ),
     .sp_enc_err_i              ( sp_enc_err                    ),
     .lc_escalate_en_i          ( lc_escalate_en                ),
@@ -391,6 +399,7 @@ module aes_control_fsm_n
     .start_we_o                ( start_we                      ),
     .key_iv_data_in_clear_we_o ( key_iv_data_in_clear_we       ),
     .data_out_clear_we_o       ( data_out_clear_we             ),
+    .prng_reseed_o             ( prng_reseed_out_buf           ),
     .prng_reseed_we_o          ( prng_reseed_we                ),
 
     .idle_o                    ( idle                          ),
@@ -437,6 +446,7 @@ module aes_control_fsm_n
     start_we_o,
     key_iv_data_in_clear_we_o,
     data_out_clear_we_o,
+    prng_reseed_o,
     prng_reseed_we_o,
     idle_o,
     idle_we_o,
@@ -481,6 +491,7 @@ module aes_control_fsm_n
     start_we,
     key_iv_data_in_clear_we,
     data_out_clear_we,
+    prng_reseed_out_buf,
     prng_reseed_we,
     idle,
     idle_we,
@@ -529,6 +540,7 @@ module aes_control_fsm_n
           start_we_o,
           key_iv_data_in_clear_we_o,
           data_out_clear_we_o,
+          prng_reseed_o,
           prng_reseed_we_o,
           idle_o,
           idle_we_o,

--- a/hw/ip/aes/rtl/aes_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_p.sv
@@ -29,6 +29,7 @@ module aes_control_fsm_p
   input  logic                                    sideload_i,
   input  prs_rate_e                               prng_reseed_rate_i,
   input  logic                                    manual_operation_i,
+  input  logic                                    key_touch_forces_reseed_i,
   input  logic                                    start_i,
   input  logic                                    key_iv_data_in_clear_i,
   input  logic                                    data_out_clear_i,
@@ -96,6 +97,7 @@ module aes_control_fsm_p
   output logic                                    start_we_o,
   output logic                                    key_iv_data_in_clear_we_o,
   output logic                                    data_out_clear_we_o,
+  output logic                                    prng_reseed_o,
   output logic                                    prng_reseed_we_o,
 
   // Status register
@@ -125,6 +127,7 @@ module aes_control_fsm_p
     sideload_i,
     prng_reseed_rate_i,
     manual_operation_i,
+    key_touch_forces_reseed_i,
     start_i,
     key_iv_data_in_clear_i,
     data_out_clear_i,
@@ -163,6 +166,7 @@ module aes_control_fsm_p
     sideload_i,
     prng_reseed_rate_i,
     manual_operation_i,
+    key_touch_forces_reseed_i,
     start_i,
     key_iv_data_in_clear_i,
     data_out_clear_i,
@@ -207,10 +211,11 @@ module aes_control_fsm_p
   logic                                    sideload;
   prs_rate_e                               prng_reseed_rate;
   logic                                    manual_operation;
+  logic                                    key_touch_forces_reseed;
   logic                                    start;
   logic                                    key_iv_data_in_clear;
   logic                                    data_out_clear;
-  logic                                    prng_reseed;
+  logic                                    prng_reseed_in_buf;
   logic                                    mux_sel_err;
   logic                                    sp_enc_err;
   lc_ctrl_pkg::lc_tx_t                     lc_escalate_en;
@@ -241,10 +246,11 @@ module aes_control_fsm_p
           sideload,
           prng_reseed_rate,
           manual_operation,
+          key_touch_forces_reseed,
           start,
           key_iv_data_in_clear,
           data_out_clear,
-          prng_reseed,
+          prng_reseed_in_buf,
           mux_sel_err,
           sp_enc_err,
           lc_escalate_en,
@@ -294,6 +300,7 @@ module aes_control_fsm_p
   logic                                    start_we;
   logic                                    key_iv_data_in_clear_we;
   logic                                    data_out_clear_we;
+  logic                                    prng_reseed_out_buf;
   logic                                    prng_reseed_we;
   logic                                    idle;
   logic                                    idle_we;
@@ -325,10 +332,11 @@ module aes_control_fsm_p
     .sideload_i                ( sideload                      ),
     .prng_reseed_rate_i        ( prng_reseed_rate              ),
     .manual_operation_i        ( manual_operation              ),
+    .key_touch_forces_reseed_i ( key_touch_forces_reseed       ),
     .start_i                   ( start                         ),
     .key_iv_data_in_clear_i    ( key_iv_data_in_clear          ),
     .data_out_clear_i          ( data_out_clear                ),
-    .prng_reseed_i             ( prng_reseed                   ),
+    .prng_reseed_i             ( prng_reseed_in_buf            ),
     .mux_sel_err_i             ( mux_sel_err                   ),
     .sp_enc_err_i              ( sp_enc_err                    ),
     .lc_escalate_en_i          ( lc_escalate_en                ),
@@ -383,6 +391,7 @@ module aes_control_fsm_p
     .start_we_o                ( start_we                      ),
     .key_iv_data_in_clear_we_o ( key_iv_data_in_clear_we       ),
     .data_out_clear_we_o       ( data_out_clear_we             ),
+    .prng_reseed_o             ( prng_reseed_out_buf           ),
     .prng_reseed_we_o          ( prng_reseed_we                ),
 
     .idle_o                    ( idle                          ),
@@ -429,6 +438,7 @@ module aes_control_fsm_p
     start_we_o,
     key_iv_data_in_clear_we_o,
     data_out_clear_we_o,
+    prng_reseed_o,
     prng_reseed_we_o,
     idle_o,
     idle_we_o,
@@ -471,6 +481,7 @@ module aes_control_fsm_p
     start_we,
     key_iv_data_in_clear_we,
     data_out_clear_we,
+    prng_reseed_out_buf,
     prng_reseed_we,
     idle,
     idle_we,
@@ -519,6 +530,7 @@ module aes_control_fsm_p
           start_we_o,
           key_iv_data_in_clear_we_o,
           data_out_clear_we_o,
+          prng_reseed_o,
           prng_reseed_we_o,
           idle_o,
           idle_we_o,

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -13,7 +13,7 @@ package aes_reg_pkg;
   parameter int NumAlerts = 2;
 
   // Address widths within the block
-  parameter int BlockAw = 7;
+  parameter int BlockAw = 8;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -92,6 +92,12 @@ package aes_reg_pkg;
       logic        re;
     } force_zero_masks;
   } aes_reg2hw_ctrl_shadowed_reg_t;
+
+  typedef struct packed {
+    logic        q;
+    logic        err_update;
+    logic        err_storage;
+  } aes_reg2hw_ctrl_aux_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
@@ -211,13 +217,14 @@ package aes_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    aes_reg2hw_alert_test_reg_t alert_test; // [955:952]
-    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [951:688]
-    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [687:424]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [423:292]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [291:160]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [159:28]
-    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [27:5]
+    aes_reg2hw_alert_test_reg_t alert_test; // [956:953]
+    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [952:689]
+    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [688:425]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [424:293]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [292:161]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [160:29]
+    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [28:6]
+    aes_reg2hw_ctrl_aux_shadowed_reg_t ctrl_aux_shadowed; // [5:5]
     aes_reg2hw_trigger_reg_t trigger; // [4:1]
     aes_reg2hw_status_reg_t status; // [0:0]
   } aes_reg2hw_t;
@@ -235,38 +242,40 @@ package aes_reg_pkg;
   } aes_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] AES_ALERT_TEST_OFFSET = 7'h 0;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_0_OFFSET = 7'h 4;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_1_OFFSET = 7'h 8;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_2_OFFSET = 7'h c;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_3_OFFSET = 7'h 10;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_4_OFFSET = 7'h 14;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_5_OFFSET = 7'h 18;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_6_OFFSET = 7'h 1c;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_7_OFFSET = 7'h 20;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_0_OFFSET = 7'h 24;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_1_OFFSET = 7'h 28;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_2_OFFSET = 7'h 2c;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_3_OFFSET = 7'h 30;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_4_OFFSET = 7'h 34;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_5_OFFSET = 7'h 38;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_6_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_7_OFFSET = 7'h 40;
-  parameter logic [BlockAw-1:0] AES_IV_0_OFFSET = 7'h 44;
-  parameter logic [BlockAw-1:0] AES_IV_1_OFFSET = 7'h 48;
-  parameter logic [BlockAw-1:0] AES_IV_2_OFFSET = 7'h 4c;
-  parameter logic [BlockAw-1:0] AES_IV_3_OFFSET = 7'h 50;
-  parameter logic [BlockAw-1:0] AES_DATA_IN_0_OFFSET = 7'h 54;
-  parameter logic [BlockAw-1:0] AES_DATA_IN_1_OFFSET = 7'h 58;
-  parameter logic [BlockAw-1:0] AES_DATA_IN_2_OFFSET = 7'h 5c;
-  parameter logic [BlockAw-1:0] AES_DATA_IN_3_OFFSET = 7'h 60;
-  parameter logic [BlockAw-1:0] AES_DATA_OUT_0_OFFSET = 7'h 64;
-  parameter logic [BlockAw-1:0] AES_DATA_OUT_1_OFFSET = 7'h 68;
-  parameter logic [BlockAw-1:0] AES_DATA_OUT_2_OFFSET = 7'h 6c;
-  parameter logic [BlockAw-1:0] AES_DATA_OUT_3_OFFSET = 7'h 70;
-  parameter logic [BlockAw-1:0] AES_CTRL_SHADOWED_OFFSET = 7'h 74;
-  parameter logic [BlockAw-1:0] AES_TRIGGER_OFFSET = 7'h 78;
-  parameter logic [BlockAw-1:0] AES_STATUS_OFFSET = 7'h 7c;
+  parameter logic [BlockAw-1:0] AES_ALERT_TEST_OFFSET = 8'h 0;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_0_OFFSET = 8'h 4;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_1_OFFSET = 8'h 8;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_2_OFFSET = 8'h c;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_3_OFFSET = 8'h 10;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_4_OFFSET = 8'h 14;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_5_OFFSET = 8'h 18;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_6_OFFSET = 8'h 1c;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE0_7_OFFSET = 8'h 20;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_0_OFFSET = 8'h 24;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_1_OFFSET = 8'h 28;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_2_OFFSET = 8'h 2c;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_3_OFFSET = 8'h 30;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_4_OFFSET = 8'h 34;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_5_OFFSET = 8'h 38;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_6_OFFSET = 8'h 3c;
+  parameter logic [BlockAw-1:0] AES_KEY_SHARE1_7_OFFSET = 8'h 40;
+  parameter logic [BlockAw-1:0] AES_IV_0_OFFSET = 8'h 44;
+  parameter logic [BlockAw-1:0] AES_IV_1_OFFSET = 8'h 48;
+  parameter logic [BlockAw-1:0] AES_IV_2_OFFSET = 8'h 4c;
+  parameter logic [BlockAw-1:0] AES_IV_3_OFFSET = 8'h 50;
+  parameter logic [BlockAw-1:0] AES_DATA_IN_0_OFFSET = 8'h 54;
+  parameter logic [BlockAw-1:0] AES_DATA_IN_1_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] AES_DATA_IN_2_OFFSET = 8'h 5c;
+  parameter logic [BlockAw-1:0] AES_DATA_IN_3_OFFSET = 8'h 60;
+  parameter logic [BlockAw-1:0] AES_DATA_OUT_0_OFFSET = 8'h 64;
+  parameter logic [BlockAw-1:0] AES_DATA_OUT_1_OFFSET = 8'h 68;
+  parameter logic [BlockAw-1:0] AES_DATA_OUT_2_OFFSET = 8'h 6c;
+  parameter logic [BlockAw-1:0] AES_DATA_OUT_3_OFFSET = 8'h 70;
+  parameter logic [BlockAw-1:0] AES_CTRL_SHADOWED_OFFSET = 8'h 74;
+  parameter logic [BlockAw-1:0] AES_CTRL_AUX_SHADOWED_OFFSET = 8'h 78;
+  parameter logic [BlockAw-1:0] AES_CTRL_AUX_REGWEN_OFFSET = 8'h 7c;
+  parameter logic [BlockAw-1:0] AES_TRIGGER_OFFSET = 8'h 80;
+  parameter logic [BlockAw-1:0] AES_STATUS_OFFSET = 8'h 84;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] AES_ALERT_TEST_RESVAL = 2'h 0;
@@ -361,12 +370,14 @@ package aes_reg_pkg;
     AES_DATA_OUT_2,
     AES_DATA_OUT_3,
     AES_CTRL_SHADOWED,
+    AES_CTRL_AUX_SHADOWED,
+    AES_CTRL_AUX_REGWEN,
     AES_TRIGGER,
     AES_STATUS
   } aes_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] AES_PERMIT [32] = '{
+  parameter logic [3:0] AES_PERMIT [34] = '{
     4'b 0001, // index[ 0] AES_ALERT_TEST
     4'b 1111, // index[ 1] AES_KEY_SHARE0_0
     4'b 1111, // index[ 2] AES_KEY_SHARE0_1
@@ -397,8 +408,10 @@ package aes_reg_pkg;
     4'b 1111, // index[27] AES_DATA_OUT_2
     4'b 1111, // index[28] AES_DATA_OUT_3
     4'b 0011, // index[29] AES_CTRL_SHADOWED
-    4'b 0001, // index[30] AES_TRIGGER
-    4'b 0001  // index[31] AES_STATUS
+    4'b 0001, // index[30] AES_CTRL_AUX_SHADOWED
+    4'b 0001, // index[31] AES_CTRL_AUX_REGWEN
+    4'b 0001, // index[32] AES_TRIGGER
+    4'b 0001  // index[33] AES_STATUS
   };
 
 endpackage

--- a/hw/ip/aes/rtl/aes_reg_status.sv
+++ b/hw/ip/aes/rtl/aes_reg_status.sv
@@ -17,6 +17,7 @@ module aes_reg_status #(
   input  logic             clear_i,
   input  logic             arm_i,
   output logic             new_o,
+  output logic             new_pulse_o,
   output logic             clean_o
 );
 
@@ -71,7 +72,8 @@ module aes_reg_status #(
     end
   end
 
-  assign new_o   = new_q;
-  assign clean_o = clean_q;
+  assign new_o       = new_q;
+  assign new_pulse_o = new_d & ~new_q;
+  assign clean_o     = clean_q;
 
 endmodule


### PR DESCRIPTION
As proposed by @cdgori in #9299, this PR adds a configuration option to force the reseeding of the PRNGs upon providing a new key. To allow this new configuration bit to be locked, a new auxiliary control register has to be added as the regtool doesn't allow locking individual fields of a register but just entire registers.

This is the last PR needed before moving AES into D2.

I think it would make sense to move some more bits from the main control register into this aux control register to make use of the locking feature:
- manual mode: this is mainly of interest for testing only
- force_zero_masks: anyway only usable on FPGA, with the corresponding SV parameter set
But I think this is not so urgent and can happend post D2(S).