### PR TITLE
[flash_ctrl] Export number of info types to sw

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -255,7 +255,13 @@
     },
 
     // The following parameters are derived from topgen and should not be
-    // direclty modified.
+    // directly modified.
+    { name: "NumInfoTypes",
+      desc: "Number of info partition types",
+      type: "int",
+      default: "3",
+      local: "true"
+    },
     { name: "NumInfos0",
       desc: "Number of configurable flash info pages for info type 0",
       type: "int",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -262,7 +262,13 @@
     },
 
     // The following parameters are derived from topgen and should not be
-    // direclty modified.
+    // directly modified.
+    { name: "NumInfoTypes",
+      desc: "Number of info partition types",
+      type: "int",
+      default: "${cfg.info_types}",
+      local: "true"
+    },
     % for type in range(cfg.info_types):
     { name: "NumInfos${type}",
       desc: "Number of configurable flash info pages for info type ${type}",

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -11,11 +11,12 @@ package flash_ctrl_pkg;
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
   parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
   parameter int unsigned BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
+  // How many types of info per bank
+  parameter int InfoTypes                = flash_ctrl_reg_pkg::NumInfoTypes;
 
   // fixed parameters of flash derived from topgen parameters
   parameter int DataWidth       = ${cfg.data_width};
   parameter int MetaDataWidth   = ${cfg.metadata_width};
-  parameter int InfoTypes       = ${cfg.info_types}; // How many types of info per bank
 
 // The following hard-wired values are there to work-around verilator.
 // For some reason if the values are assigned through parameters verilator thinks

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -11,11 +11,12 @@ package flash_ctrl_pkg;
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
   parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
   parameter int unsigned BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
+  // How many types of info per bank
+  parameter int InfoTypes                = flash_ctrl_reg_pkg::NumInfoTypes;
 
   // fixed parameters of flash derived from topgen parameters
   parameter int DataWidth       = 64;
   parameter int MetaDataWidth   = 12;
-  parameter int InfoTypes       = 3; // How many types of info per bank
 
 // The following hard-wired values are there to work-around verilator.
 // For some reason if the values are assigned through parameters verilator thinks

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -13,6 +13,7 @@ package flash_ctrl_reg_pkg;
   parameter int RegPageWidth = 8;
   parameter int RegBankWidth = 1;
   parameter int NumRegions = 8;
+  parameter int NumInfoTypes = 3;
   parameter int NumInfos0 = 10;
   parameter int NumInfos1 = 1;
   parameter int NumInfos2 = 2;

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -261,7 +261,13 @@
     },
 
     // The following parameters are derived from topgen and should not be
-    // direclty modified.
+    // directly modified.
+    { name: "NumInfoTypes",
+      desc: "Number of info partition types",
+      type: "int",
+      default: "3",
+      local: "true"
+    },
     { name: "NumInfos0",
       desc: "Number of configurable flash info pages for info type 0",
       type: "int",

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -17,11 +17,12 @@ package flash_ctrl_pkg;
   parameter int unsigned NumBanks        = flash_ctrl_reg_pkg::RegNumBanks;
   parameter int unsigned PagesPerBank    = flash_ctrl_reg_pkg::RegPagesPerBank;
   parameter int unsigned BusPgmResBytes  = flash_ctrl_reg_pkg::RegBusPgmResBytes;
+  // How many types of info per bank
+  parameter int InfoTypes                = flash_ctrl_reg_pkg::NumInfoTypes;
 
   // fixed parameters of flash derived from topgen parameters
   parameter int DataWidth       = 64;
   parameter int MetaDataWidth   = 12;
-  parameter int InfoTypes       = 3; // How many types of info per bank
 
 // The following hard-wired values are there to work-around verilator.
 // For some reason if the values are assigned through parameters verilator thinks

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -13,6 +13,7 @@ package flash_ctrl_reg_pkg;
   parameter int RegPageWidth = 8;
   parameter int RegBankWidth = 1;
   parameter int NumRegions = 8;
+  parameter int NumInfoTypes = 3;
   parameter int NumInfos0 = 10;
   parameter int NumInfos1 = 1;
   parameter int NumInfos2 = 2;


### PR DESCRIPTION
Create a parameter in the reg package for the number of info types
instead of in flash_ctrl_pkg, so software can see the value in the
exported C header.

Signed-off-by: Alexander Williams <awill@google.com>