### PR TITLE
[dif/alert_handler] Add ping timer configuration and enable DIFs.

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -371,6 +371,32 @@ dif_result_t dif_alert_handler_configure_ping_timer(
   return kDifOk;
 }
 
+dif_result_t dif_alert_handler_ping_timer_set_enabled(
+    const dif_alert_handler_t *alert_handler, dif_toggle_t locked) {
+  if (alert_handler == NULL || !dif_is_valid_toggle(locked)) {
+    return kDifBadArg;
+  }
+
+  // Check if the ping timer is locked.
+  if (!mmio_region_read32(alert_handler->base_addr,
+                          ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
+  // Enable the ping timer.
+  mmio_region_write32_shadowed(alert_handler->base_addr,
+                               ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET,
+                               1);
+
+  // Lock the configuration.
+  if (locked == kDifToggleEnabled) {
+    mmio_region_write32(alert_handler->base_addr,
+                        ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
+  }
+
+  return kDifOk;
+}
+
 // TODO(#9899): make this a testutil function.
 dif_result_t dif_alert_handler_configure(
     const dif_alert_handler_t *alert_handler, dif_alert_handler_config_t config,

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -408,11 +408,28 @@ dif_alert_handler_configure_class(const dif_alert_handler_t *alert_handler,
  * @param ping_timeout The alert ping timeout, in cycles.
  * @param enabled The enablement state to configure the ping timer in.
  * @param locked The locked state to configure ping timer in.
- * @ return The result of the operation.
+ * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT dif_result_t dif_alert_handler_configure_ping_timer(
     const dif_alert_handler_t *alert_handler, uint32_t ping_timeout,
     dif_toggle_t enabled, dif_toggle_t locked);
+
+/**
+ * Enables the ping timer in the alert handler.
+ *
+ * This operation is lock-protected, meaning once the configuration is locked,
+ * it cannot be reconfigured until after a system reset.
+ *
+ * Note, the ping timer will only ping alerts that have been enabled AND locked.
+ * Therefore, this DIF should be invoked after configuring and enabling each
+ * (local) alert.
+ *
+ * @param handler An alert handler handle.
+ * @param locked The locked state to configure ping timer in after enabling it.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT dif_result_t dif_alert_handler_ping_timer_set_enabled(
+    const dif_alert_handler_t *alert_handler, dif_toggle_t locked);
 
 /**
  * Locks out alert handler ping timer configuration.

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -395,6 +395,26 @@ dif_alert_handler_configure_class(const dif_alert_handler_t *alert_handler,
                                   dif_toggle_t enabled, dif_toggle_t locked);
 
 /**
+ * Configures the ping timer in the alert handler.
+ *
+ * This operation is lock-protected, meaning once the configuration is locked,
+ * it cannot be reconfigured until after a system reset.
+ *
+ * Note, the ping timer will only ping alerts that have been enabled AND locked.
+ * Therefore, this DIF should be invoked after configuring and enabling each
+ * (local) alert.
+ *
+ * @param handler An alert handler handle.
+ * @param ping_timeout The alert ping timeout, in cycles.
+ * @param enabled The enablement state to configure the ping timer in.
+ * @param locked The locked state to configure ping timer in.
+ * @ return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT dif_result_t dif_alert_handler_configure_ping_timer(
+    const dif_alert_handler_t *alert_handler, uint32_t ping_timeout,
+    dif_toggle_t enabled, dif_toggle_t locked);
+
+/**
  * Locks out alert handler ping timer configuration.
  *
  * This operation cannot be undone, and should be performed at the end of

--- a/sw/device/lib/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/lib/dif/dif_alert_handler_unittest.cc
@@ -559,6 +559,45 @@ TEST_F(PingTimerConfigTest, ConfigureEnableAndLock) {
       kDifOk);
 }
 
+class PingTimerSetEnabledTest : public AlertHandlerTest {};
+
+TEST_F(PingTimerSetEnabledTest, BadArgs) {
+  EXPECT_EQ(
+      dif_alert_handler_ping_timer_set_enabled(nullptr, kDifToggleDisabled),
+      kDifBadArg);
+
+  EXPECT_EQ(dif_alert_handler_ping_timer_set_enabled(
+                &alert_handler_, static_cast<dif_toggle_t>(2)),
+            kDifBadArg);
+}
+
+TEST_F(PingTimerSetEnabledTest, Locked) {
+  EXPECT_READ32(ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_alert_handler_ping_timer_set_enabled(&alert_handler_,
+                                                     kDifToggleDisabled),
+            kDifLocked);
+}
+
+TEST_F(PingTimerSetEnabledTest, SetEnabled) {
+  EXPECT_READ32(ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32_SHADOWED(ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET, 1);
+
+  EXPECT_EQ(dif_alert_handler_ping_timer_set_enabled(&alert_handler_,
+                                                     kDifToggleDisabled),
+            kDifOk);
+}
+
+TEST_F(PingTimerSetEnabledTest, SetEnabledAndLock) {
+  EXPECT_READ32(ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32_SHADOWED(ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET, 1);
+  EXPECT_WRITE32(ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_alert_handler_ping_timer_set_enabled(&alert_handler_,
+                                                     kDifToggleEnabled),
+            kDifOk);
+}
+
 class PingTimerLockTest : public AlertHandlerTest {};
 
 TEST_F(PingTimerLockTest, IsPingTimerLocked) {


### PR DESCRIPTION
This PR contains two commits that:

1. adds a DIF to configure, lock, and enable the ping timer feature of the alert handler, and
2. adds another DIF that just enables (and locks, if requested) the ping timer.

This DIF allows more fine grain configuration of the alert handler than the previous implementation that configured all alert handler setting in a single shot.

Additionally, this PR fixes a bug in the checking of the REGWEN lock for the ping timer. Previously, the wrong CSR (the enable instead of the REGWEN) was checked.

This addresses two tasks in #9899.

**_Note: this PR depends on #10040, hence has duplicate commits that will be removed when the dependency merges._**

Signed-off-by: Timothy Trippel <ttrippel@google.com>