### PR TITLE
[all] various simple lint fixes

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -287,8 +287,7 @@ module flash_phy
     .InfoTypesWidth(InfoTypesWidth),
     .PagesPerBank(PagesPerBank),
     .WordsPerPage(WordsPerPage),
-    .DataWidth(flash_phy_pkg::FullDataWidth),
-    .MetaDataWidth(MetaDataWidth)
+    .DataWidth(flash_phy_pkg::FullDataWidth)
   ) u_flash (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/lint/prim_mubi.waiver
+++ b/hw/ip/prim/lint/prim_mubi.waiver
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_mubi modules
+
+waive -rules SAME_NAME_TYPE -location {prim_mubi4_sync.sv} -regexp {'ResetValue' is used as an enumeration value here, and as a parameter at prim_.*} \
+      -comment "Parameter name reuse"
+
+
+

--- a/hw/ip/prim_generic/rtl/prim_generic_flash.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash.sv
@@ -13,7 +13,6 @@ module prim_generic_flash #(
   parameter int PagesPerBank   = 256,// data pages per bank
   parameter int WordsPerPage   = 256,// words per page
   parameter int DataWidth      = 32, // bits per word
-  parameter int MetaDataWidth  = 12, // metadata such as ECC
   parameter int TestModeWidth  = 2
 ) (
   input clk_i,
@@ -69,8 +68,7 @@ module prim_generic_flash #(
       .InfoTypesWidth(InfoTypesWidth),
       .PagesPerBank(PagesPerBank),
       .WordsPerPage(WordsPerPage),
-      .DataWidth(DataWidth),
-      .MetaDataWidth(MetaDataWidth)
+      .DataWidth(DataWidth)
     ) u_prim_flash_bank (
       .clk_i,
       .rst_ni,

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -12,7 +12,6 @@ module prim_generic_flash_bank #(
   parameter int PagesPerBank   = 256, // data pages per bank
   parameter int WordsPerPage   = 256, // words per page
   parameter int DataWidth      = 32,  // bits per word
-  parameter int MetaDataWidth  = 12,  // this is a temporary parameter to work around ECC issues
 
   // Derived parameters
   localparam int PageW = $clog2(PagesPerBank),

--- a/hw/ip/rstmgr/lint/rstmgr.waiver
+++ b/hw/ip/rstmgr/lint/rstmgr.waiver
@@ -7,3 +7,6 @@
 # dedicated reset drivers / muxes
 set_reset_drivers prim_clock_mux2 prim_flop_2sync prim_flop
 set_clock_drivers prim_clock_buf
+
+waive -rules TERMINAL_STATE -location {rstmgr_cnsty_chk.sv} -regexp {Terminal state 'Error' is detected} \
+      -comment "Intentional terminal state"

--- a/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -120,6 +120,7 @@ module rstmgr_cnsty_chk
 
   logic sync_child_ack;
 
+  // TODO - make this a sparse fsm
   always_comb begin
     state_d = state_q;
     err_o = '0;

--- a/hw/ip/rstmgr/rtl/rstmgr_crash_info.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_crash_info.sv
@@ -12,7 +12,7 @@ module rstmgr_crash_info
 #(
   parameter  int CrashDumpWidth = 32,
   localparam int CrashRemainder = CrashDumpWidth % RdWidth > 0 ? 1 : 0,
-  localparam int CrashStoreSlot = CrashDumpWidth / RdWidth + CrashRemainder,
+  localparam int unsigned CrashStoreSlot = CrashDumpWidth / RdWidth + CrashRemainder,
   localparam int SlotCntWidth   = $clog2(CrashStoreSlot)
 ) (
   input clk_i,

--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -9,7 +9,7 @@
 
 module rstmgr_por #(
   parameter int FilterStages = 3,
-  parameter int StretchCount = 32
+  parameter int unsigned StretchCount = 32
 ) (
   input clk_i,
   input rst_ni,

--- a/hw/ip/tlul/rtl/tlul_err_resp.sv
+++ b/hw/ip/tlul/rtl/tlul_err_resp.sv
@@ -58,8 +58,6 @@ module tlul_err_resp (
 
   // Waive unused bits of tl_h_i
   logic unused_tl_h;
-  assign unused_tl_h = &{1'b0,
-                         tl_h_i.a_param, tl_h_i.a_address, tl_h_i.a_mask,
-                         tl_h_i.a_data, tl_h_i.a_user, tl_h_i.d_ready};
+  assign unused_tl_h = ^tl_h_i;
 
 endmodule

--- a/hw/ip/tlul/rtl/tlul_socket_1n.sv
+++ b/hw/ip/tlul/rtl/tlul_socket_1n.sv
@@ -185,7 +185,7 @@ module tlul_socket_1n #(
 
 
   // accept responses from devices when selected if upstream is accepting
-  for (genvar i = 0 ; i < N+1 ; i++) begin : gen_u_o_d_ready
+  for (genvar i = 0 ; i < N ; i++) begin : gen_u_o_d_ready
     assign tl_u_o[i].d_ready = tl_t_o.d_ready;
   end
 
@@ -212,6 +212,7 @@ module tlul_socket_1n #(
   // Instantiate the error responder. It's only needed if a value greater than
   // N-1 is actually representable in NWD bits.
   if ($clog2(N+1) <= NWD) begin : gen_err_resp
+    assign tl_u_o[N].d_ready     = tl_t_o.d_ready;
     assign tl_u_o[N].a_valid     = tl_t_o.a_valid &
                                    (dev_select_t >= NWD'(N)) &
                                    ~hold_all_requests;
@@ -229,6 +230,11 @@ module tlul_socket_1n #(
       .tl_h_i     (tl_u_o[N]),
       .tl_h_o     (tl_u_i[N])
     );
+  end else begin : gen_no_err_resp // block: gen_err_resp
+    assign tl_u_o[N] = '0;
+    assign tl_u_i[N] = '0;
+    logic unused_sig;
+    assign unused_sig = ^tl_u_o[N];
   end
 
 endmodule


### PR DESCRIPTION
- remove unused parameters in flash_ctrl
- add mubi waivers
- add reset waives and change parameters to unsigned
- handle undriven / unloaded signals in socket when there is no error responder

Signed-off-by: Timothy Chen <timothytim@google.com>