### PR TITLE
[reggen] Add support for SEC_CM RTL annotations

### DIFF
--- a/util/dvsim/veriblelint-report-parser.py
+++ b/util/dvsim/veriblelint-report-parser.py
@@ -60,8 +60,11 @@ def main():
             # TODO(https://github.com/olofk/edalize/issues/90):
             # this is a workaround until we actually have native Edalize
             # support for JasperGold and "formal" targets
+            # TODO(#10071) remove countermeasure waiver.
             ("flow_warning",
-             r"^(?!WARNING: Unknown item formal in section Target)WARNING: .*"),
+             r"^(?!WARNING: Unknown item formal in section Target)"
+             r"(?!WARNING: Countermeasure.*)"
+             r"WARNING: .*"),
             ("flow_warning", r"^.*Warning: .* "),
             ("flow_warning", r"^W .*"),
             ("lint_warning", r"^.*\[Style:.*")

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
-from typing import Dict, List
+import logging as log
+from typing import Dict, List, Sequence, Tuple
 
 from .lib import check_keys, check_str, check_list
 
@@ -54,6 +55,9 @@ CM_TYPES = [
     'GLOBAL_ESC'
 ]
 
+# Tag to look for when extracting RTL annotations.
+CM_RTL_TAG = 'SEC_CM:'
+
 
 class CounterMeasure:
     """Object holding details for one countermeasure within an IP block."""
@@ -88,16 +92,16 @@ class CounterMeasure:
                 instance = ""
         except ValueError:
             raise ValueError(
-                f'Invalid format: {name} ({what}).')
+                f'Invalid countermeasure ID format: {name} ({what}).')
         if not re.fullmatch(r'^([a-zA-Z0-9_]*)', instance):
             raise ValueError(
-                f'Invalid instance name: {instance} ({what}).')
+                f'Invalid countermeasure instance name: {instance} ({what}).')
         if asset not in CM_ASSETS:
             raise ValueError(
-                f'Invalid asset: {asset} ({what}).')
+                f'Invalid countermeasure asset: {asset} ({what}).')
         if cm_type not in CM_TYPES:
             raise ValueError(
-                f'Invalid type: {cm_type} ({what}).')
+                f'Invalid countermeasure type: {cm_type} ({what}).')
         return CounterMeasure(instance, asset, cm_type, desc)
 
     @staticmethod
@@ -126,3 +130,77 @@ class CounterMeasure:
     def __str__(self) -> str:
         namestr = self.asset + '.' + self.cm_type
         return self.instance + '.' + namestr if self.instance else namestr
+
+    @staticmethod
+    def search_rtl_files(paths: Sequence[str]) -> Dict[str,
+                                                       List[Tuple[str, int]]]:
+        """Find countermeasures in the given list of RTL files.
+
+        The return value is a dictionary mapping countermeasure name to where
+        that countermeasure is found (as a (path, line_number) pair).
+        """
+        ret: Dict[str, List[Tuple[str, int]]] = {}
+        # Match things like "// SEC_CM: FOO" or "// SEC_CM: FOO, BAR"
+        regex = re.compile(r'//\s*' + CM_RTL_TAG + r'\s*(.*)')
+        good_name = re.compile(r'[A-Za-z0-9_.]+$')
+
+        for path in paths:
+            with open(path) as fd:
+                for idx, line in enumerate(fd):
+                    match = regex.search(line)
+                    if not match:
+                        continue
+
+                    # We've got a hit. The regex above is intentionally lax
+                    # because we want to see an error if someone writes
+                    # something horrible, rather than silently ignoring the
+                    # line. Split the match on commas to allow multiple entries
+                    # on a line.
+                    entries = match.group(1).split(',')
+                    for entry in entries:
+                        entry = entry.strip()
+
+                        if not good_name.match(entry):
+                            raise ValueError('Malformed countermeasure name, '
+                                             '{!r}, at {}, line {}.'
+                                             .format(entry, path, idx + 1))
+                        ret.setdefault(entry, []).append((path, idx + 1))
+
+        return ret
+
+    @staticmethod
+    def check_annotation_list(what: str,
+                              rtl_names: Dict[str, List[Tuple[str, int]]],
+                              hjson_list: List['CounterMeasure']) -> None:
+        """Compare found list of countermeasures against list from Hjson
+
+        This compares a dictionary of countermeasure names extracted from the
+        RTL against the list defined in the IP Hjson and checks that they
+        match: every name in the RTL should correspond to an entry in the Hjson
+        and every entry in the Hjson should have at least one matching name in
+        the RTL.
+
+        """
+        hjson_set = {str(cm) for cm in hjson_list}
+        rtl_set = set(rtl_names.keys())
+
+        # Is there anything in the RTL that doesn't correspond to an Hjson
+        # entry?
+        for name in rtl_set - hjson_set:
+            # Print out an error message for each hit and then raise a
+            # RuntimeError.
+            for path, line in rtl_names[name]:
+                log.error('Unknown countermeasure {!r} '
+                          'referenced at {}, line {}.'
+                          .format(name, path, line))
+            raise RuntimeError('One or more unknown countermeasures '
+                               'referenced in RTL.')
+
+        # Is there anything in the Hjson that isn't described in the RTL?
+        for name in hjson_set - rtl_set:
+            log.warning("Countermeasure {} is referenced in the Hjson, but "
+                        "doesn't appear in the RTL."
+                        .format(name))
+
+        # TODO(#10071): Once all designs are annotated, generate a RuntimeError
+        #               if we saw anything in the loop above.

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -383,3 +383,13 @@ class IpBlock:
         '''Return primary clock of an block'''
 
         return self.clocking.primary
+
+    def check_cm_annotations(self,
+                             rtl_names: Dict[str, List[Tuple[str, int]]],
+                             where: str) -> None:
+        '''Check RTL annotations against countermeasure list of this block'''
+
+        what = '{} block at {}'.format(self.name, where)
+        CounterMeasure.check_annotation_list(what,
+                                             rtl_names,
+                                             self.countermeasures)


### PR DESCRIPTION
This implements https://github.com/lowRISC/opentitan/issues/10071, and shows how this can be used with `sram_ctrl` as an example.
