### PR TITLE
[dv/clkmgr] Add stress test

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -232,7 +232,7 @@
             - The fast_o output should be set.
             '''
       milestone: V2
-      tests: []
+      tests: ["clkmgr_frequency"]
     }
     {
       name: stress
@@ -240,12 +240,14 @@
 
             Stress with the following sequences:
             - clkmgr_extclk_vseq,
+            - clkmgr_frequency_timeout_vseq,
+            - clkmgr_frequency_vseq,
             - clkmgr_peri_vseq,
             - clkmgr_smoke_vseq,
             - clkmgr_trans_vseq
             '''
       milestone: V2
-      tests: []
+      tests: ["clkmgr_stress_all"]
     }
     {
       name: stress_with_rand_reset

--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -32,8 +32,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                // Disable stress until the tests are created.
-                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
                 ]
 
   // Add additional tops for simulation.
@@ -46,7 +45,7 @@
   uvm_test: clkmgr_base_test
   uvm_test_seq: clkmgr_base_vseq
 
-  // Disable clearing interrupts since clkmgr doesn't yet have any.
+  // Disable clearing interrupts since clkmgr doesn't have any.
   run_opts: ["+do_clear_all_interrupts=0"]
 
   // List of test specifications.

--- a/hw/ip/clkmgr/dv/env/clkmgr_env.core
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/clkmgr_frequency_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_peri_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/clkmgr_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/clkmgr_trans_vseq.sv: {is_include_file: true}
       - clkmgr_if.sv
     file_type: systemVerilogSource

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -51,9 +51,16 @@ package clkmgr_env_pkg;
   typedef enum int {
     PeriDiv4,
     PeriDiv2,
-    PeriIo,
-    PeriUsb
+    PeriUsb,
+    PeriIo
   } peri_e;
+  typedef struct packed {
+    logic io_peri_en;
+    logic usb_peri_en;
+    logic io_div2_peri_en;
+    logic io_div4_peri_en;
+  } clk_enables_t;
+
   typedef enum int {
     TransAes,
     TransHmac,
@@ -61,6 +68,13 @@ package clkmgr_env_pkg;
     TransOtbnIoDiv4,
     TransOtbnMain
   } trans_e;
+  typedef struct packed {
+    logic otbn_main;
+    logic otbn_io_div4;
+    logic kmac;
+    logic hmac;
+    logic aes;
+  } clk_hints_t;
 
   typedef struct {
     logic valid;

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -274,24 +274,27 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
         if (addr_phase_write) extclk_ctrl_regwen = item.a_data;
       end
       "extclk_ctrl": begin
+        typedef logic [2*$bits(prim_mubi_pkg::mubi4_t) - 1:0] extclk_ctrl_t;
         if (addr_phase_write && extclk_ctrl_regwen) begin
-          cfg.clkmgr_vif.update_extclk_ctrl(item.a_data);
+          `DV_CHECK_EQ(extclk_ctrl_t'(item.a_data), {
+                       cfg.clkmgr_vif.extclk_ctrl_csr_step_down, cfg.clkmgr_vif.extclk_ctrl_csr_sel
+                       })
         end
       end
       "jitter_enable": begin
         if (addr_phase_write) begin
-          cfg.clkmgr_vif.update_jitter_enable(prim_mubi_pkg::mubi4_t'(item.a_data));
+          `DV_CHECK_EQ(prim_mubi_pkg::mubi4_t'(item.a_data), cfg.clkmgr_vif.jitter_enable_csr)
         end
       end
       "clk_enables": begin
         if (addr_phase_write) begin
-          cfg.clkmgr_vif.update_clk_enables(item.a_data);
+          `DV_CHECK_EQ(clk_enables_t'(item.a_data), cfg.clkmgr_vif.clk_enables_csr)
         end
       end
       "clk_hints": begin
         // Clearing a hint sets an expectation for the status to transition to zero.
         if (addr_phase_write) begin
-          cfg.clkmgr_vif.update_clk_hints(item.a_data);
+          `DV_CHECK_EQ(clk_hints_t'(item.a_data), cfg.clkmgr_vif.clk_hints_csr)
         end
       end
       "clk_hints_status": begin

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_clk_status_vseq.sv
@@ -20,7 +20,6 @@ class clkmgr_clk_status_vseq extends clkmgr_base_vseq;
   endfunction
 
   task body();
-    update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
       cfg.clk_rst_vif.wait_clks(4);
       `DV_CHECK_RANDOMIZE_FATAL(this)

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_peri_vseq.sv
@@ -19,7 +19,6 @@ class clkmgr_peri_vseq extends clkmgr_base_vseq;
   constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
 
   task body();
-    update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
       peri_enables_t flipped_enables;
       `DV_CHECK_RANDOMIZE_FATAL(this)

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -14,7 +14,6 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
   constraint all_busy {idle == '0;}
 
   task body();
-    update_csrs_with_reset_values();
     cfg.clk_rst_vif.wait_clks(10);
     test_jitter();
     test_peri_clocks();

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_stress_all_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_stress_all_vseq.sv
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all clkmgr seqs (except below seqs) in one seq to run sequentially
+// 1. csr seq, which requires scb to be disabled
+class clkmgr_stress_all_vseq extends clkmgr_base_vseq;
+  `uvm_object_utils(clkmgr_stress_all_vseq)
+
+  `uvm_object_new
+
+  task body();
+    string seq_names[] = {
+      "clkmgr_extclk_vseq",
+      "clkmgr_frequency_timeout_vseq",
+      "clkmgr_frequency_vseq",
+      "clkmgr_peri_vseq",
+      "clkmgr_smoke_vseq",
+      "clkmgr_trans_vseq"
+    };
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence     seq;
+      clkmgr_base_vseq clkmgr_vseq;
+      uint             seq_idx = $urandom_range(0, seq_names.size - 1);
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(clkmgr_vseq, seq)
+
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_apply_reset) clkmgr_vseq.do_apply_reset = $urandom_range(0, 1);
+      else clkmgr_vseq.do_apply_reset = 0;
+      clkmgr_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(clkmgr_vseq)
+      `uvm_info(`gfn, $sformatf("seq_idx = %0d, sequence is %0s", seq_idx, clkmgr_vseq.get_name()),
+                UVM_MEDIUM)
+
+      clkmgr_vseq.start(p_sequencer);
+      `uvm_info(`gfn, $sformatf(
+                "End of sequence %0s with seq_idx = %0d", clkmgr_vseq.get_name(), seq_idx),
+                UVM_MEDIUM)
+    end
+  endtask : body
+endclass

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -25,7 +25,6 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
   constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
 
   task body();
-    update_csrs_with_reset_values();
     for (int i = 0; i < num_trans; ++i) begin
       logic bit_value;
       hintables_t value;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_vseq_list.sv
@@ -10,4 +10,5 @@
 `include "clkmgr_extclk_vseq.sv"
 `include "clkmgr_peri_vseq.sv"
 `include "clkmgr_smoke_vseq.sv"
+`include "clkmgr_stress_all_vseq.sv"
 `include "clkmgr_trans_vseq.sv"


### PR DESCRIPTION
Fix for forks missing isolation forks.
Fix other minor issues caught by this test.
Move CSR value tracking to clkmgr interface.

Signed-off-by: Guillermo Maturana <maturana@google.com>