### PR TITLE
[sw,tests] Chip level test `chip_sw_aon_timer_wdog_bite_reset`

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -688,7 +688,7 @@
               the wdog reset phase.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_aon_timer_wdog_bite_reset"]
     }
     {
       name: chip_sw_aon_timer_sleep_wdog_sleep_pause

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -674,7 +674,7 @@
               the wdog reset phase.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_aon_timer_wdog_bite_reset"]
     }
     {
       name: chip_sw_aon_timer_sleep_wdog_bite_reset

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -302,6 +302,13 @@
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }
     {
+      name: chip_sw_aon_timer_wdog_bite_reset
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/aon_timer_wdog_bite_reset_test:1"]
+      en_run_modes: ["sw_test_mode"]
+      run_opts: ["+sw_test_timeout_ns=18000000"]
+    }
+    {
       name: chip_sw_kmac_mode_cshake_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_cshake_test:1"]

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -87,6 +87,22 @@ typedef enum dif_rstmgr_reset_info {
    * escalation, watchdog or anything else.
    */
   kDifRstmgrResetInfoHwReq = (0xf << 4),
+  /**
+   * Device has reset due to the peripheral system reset control request.
+   */
+  kDifRstmgrResetInfoSysRstCtrl = (0x1 << 4),
+  /**
+   * Device has reset due to watchdog bite.
+   */
+  kDifRstmgrResetInfoWatchdog = (1 << 5),
+  /**
+   * Device has reset due to power unstable.
+   */
+  kDifRstmgrResetInfoPowerUnstable = (1 << 6),
+  /**
+   * Device has reset due to alert escalation.
+   */
+  kDifRstmgrResetInfoEscalation = (1 << 7),
 } dif_rstmgr_reset_info_t;
 
 /**

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -13,7 +13,7 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
+void aon_timer_testutils_wakeup_config(const dif_aon_timer_t *aon_timer,
                                        uint32_t cycles) {
   // Make sure that wake-up timer is stopped.
   CHECK_DIF_OK(dif_aon_timer_wakeup_stop(aon_timer));
@@ -31,7 +31,7 @@ void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
   CHECK_DIF_OK(dif_aon_timer_wakeup_start(aon_timer, cycles, 0));
 }
 
-void aon_timer_testutils_watchdog_config(dif_aon_timer_t *aon_timer,
+void aon_timer_testutils_watchdog_config(const dif_aon_timer_t *aon_timer,
                                          uint32_t bark_cycles,
                                          uint32_t bite_cycles) {
   // Make sure that watchdog timer is stopped.
@@ -40,7 +40,7 @@ void aon_timer_testutils_watchdog_config(dif_aon_timer_t *aon_timer,
   // Make sure the watchdog IRQ is cleared to avoid false positive.
   CHECK_DIF_OK(
       dif_aon_timer_irq_acknowledge(aon_timer, kDifAonTimerIrqWdogTimerBark));
-  bool is_pending;
+  bool is_pending = true;
   CHECK_DIF_OK(dif_aon_timer_irq_is_pending(
       aon_timer, kDifAonTimerIrqWdogTimerBark, &is_pending));
   CHECK(!is_pending);

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -13,7 +13,7 @@
  * Configure wakeup counter for a number of AON clock cycles.
  * @param cycles The number of AON clock cycles.
  */
-void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
+void aon_timer_testutils_wakeup_config(const dif_aon_timer_t *aon_timer,
                                        uint32_t cycles);
 
 /**
@@ -24,7 +24,7 @@ void aon_timer_testutils_wakeup_config(dif_aon_timer_t *aon_timer,
  * @param bark_cycles The number of AON clock cycles till barking.
  * @param bite_cycles The number of AON clock cycles till biting.
  */
-void aon_timer_testutils_watchdog_config(dif_aon_timer_t *aon_timer,
+void aon_timer_testutils_watchdog_config(const dif_aon_timer_t *aon_timer,
                                          uint32_t bark_cycles,
                                          uint32_t bite_cycles);
 

--- a/sw/device/lib/testing/pwrmgr_testutils.c
+++ b/sw/device/lib/testing/pwrmgr_testutils.c
@@ -12,7 +12,7 @@
 #include "sw/device/lib/testing/check.h"
 
 void pwrmgr_testutils_enable_low_power(
-    dif_pwrmgr_t *pwrmgr, dif_pwrmgr_request_sources_t wakeups,
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_request_sources_t wakeups,
     dif_pwrmgr_domain_config_t domain_config) {
   // Enable low power on the next WFI with clocks and power domains configured
   // per domain_config.
@@ -22,7 +22,7 @@ void pwrmgr_testutils_enable_low_power(
   CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(pwrmgr, kDifToggleEnabled));
 }
 
-bool pwrmgr_testutils_is_wakeup_reason(dif_pwrmgr_t *pwrmgr,
+bool pwrmgr_testutils_is_wakeup_reason(const dif_pwrmgr_t *pwrmgr,
                                        dif_pwrmgr_request_sources_t reasons) {
   dif_pwrmgr_wakeup_reason_t wakeup_reason;
   CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(pwrmgr, &wakeup_reason));

--- a/sw/device/lib/testing/pwrmgr_testutils.h
+++ b/sw/device/lib/testing/pwrmgr_testutils.h
@@ -21,7 +21,7 @@
  * domains.
  */
 void pwrmgr_testutils_enable_low_power(
-    dif_pwrmgr_t *pwrmgr, dif_pwrmgr_request_sources_t wakeups,
+    const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_request_sources_t wakeups,
     dif_pwrmgr_domain_config_t domain_config);
 
 /**
@@ -30,7 +30,7 @@ void pwrmgr_testutils_enable_low_power(
  * @param pwrmgr A power manager handle.
  * @param reasons A bit mask of reasons.
  */
-bool pwrmgr_testutils_is_wakeup_reason(dif_pwrmgr_t *pwrmgr,
+bool pwrmgr_testutils_is_wakeup_reason(const dif_pwrmgr_t *pwrmgr,
                                        dif_pwrmgr_request_sources_t reasons);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_PWRMGR_TESTUTILS_H_

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -1,0 +1,94 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/freestanding/limits.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+#include "sw/device/lib/testing/test_framework/test_status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define WDOG_BARK_TIME (5 * 1000)  // 5ms
+const test_config_t kTestConfig;
+
+/**
+ * Execute the aon timer wdog bite reset test.
+ */
+static void execute_test(const dif_aon_timer_t *aon_timer,
+                         const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us) {
+  uint64_t bark_cycles = (bark_time_us * kClockFreqAonHz / 1000000);
+  uint64_t bite_cycles = bark_cycles * 2;
+  uint64_t bite_time_us = bark_time_us * 2;
+
+  CHECK(bite_cycles < UINT32_MAX,
+        "The value %u can't fit into the 32 bits timer counter.", bite_cycles);
+
+  LOG_INFO("Wdog will bark after %u us and bite after %u us",
+           (uint32_t)bark_time_us, (uint32_t)bite_time_us);
+
+  // Set wdog as a reset source.
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
+      pwrmgr, kDifPwrmgrReqTypeReset, kDifPwrmgrWakeupRequestSourceTwo));
+
+  // Setup the wdog bark and bite timeouts.
+  aon_timer_testutils_watchdog_config(aon_timer, bark_cycles, bite_cycles);
+
+  // Wait bark time and check that the bark interrupt requested.
+  usleep(bark_time_us);
+  bool is_pending = false;
+  CHECK_DIF_OK(dif_aon_timer_irq_is_pending(
+      aon_timer, kDifAonTimerIrqWdogTimerBark, &is_pending));
+  CHECK(is_pending);
+
+  // Wait for the remaining time to the wdog bite.
+  usleep(bite_time_us - bark_time_us);
+  // If we arrive here the test must fail.
+  CHECK(false, "Timeout waiting for Wdog bite reset!");
+}
+
+bool test_main(void) {
+  // Initialize pwrmgr.
+  dif_pwrmgr_t pwrmgr;
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+
+  // Initialize rstmgr to check the reset reason.
+  dif_rstmgr_t rstmgr;
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  // Initialize aon timer to use the wdog.
+  dif_aon_timer_t aon_timer;
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
+  // Check if there was a HW reset caused by the wdog bite.
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &rst_info));
+  CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+
+  CHECK(rst_info == kDifRstmgrResetInfoPor ||
+            rst_info == kDifRstmgrResetInfoWatchdog,
+        "Wrong reset reason");
+
+  if (rst_info == kDifRstmgrResetInfoPor) {
+    LOG_INFO("Booting for the first time, setting wdog");
+    // Executing the test.
+
+    execute_test(&aon_timer, &pwrmgr, WDOG_BARK_TIME);
+  } else if (rst_info == kDifRstmgrResetInfoWatchdog) {
+    LOG_INFO("Booting for the second time due to wdog bite reset");
+  }
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -769,6 +769,7 @@ aon_timer_wdog_bite_reset_test = declare_dependency(
       sw_lib_runtime_log,
       sw_lib_testing_aon_timer_testutils,
       sw_lib_testing_rstmgr_testutils,
+      sw_lib_testing_pwrmgr_testutils,
       top_earlgrey,
     ],
   ),

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -754,6 +754,31 @@ sw_tests += {
   }
 }
 
+# AON Timer wdog bite reset test.
+aon_timer_wdog_bite_reset_test = declare_dependency(
+  link_with: static_library(
+    'aon_timer_wdog_bite_reset_test',
+    sources: [
+      hw_ip_rstmgr_reg_h,
+      'aon_timer_wdog_bite_reset_test.c',
+    ],
+    dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_dif_aon_timer,
+      sw_lib_dif_pwrmgr,
+      sw_lib_runtime_log,
+      sw_lib_testing_aon_timer_testutils,
+      sw_lib_testing_rstmgr_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'aon_timer_wdog_bite_reset_test': {
+    'library': aon_timer_wdog_bite_reset_test,
+  }
+}
+
 ###############################################################################
 # Auto-generated tests
 ###############################################################################


### PR DESCRIPTION
# This PR add two tests listed in the chip-level testplan:
## chip_sw_aon_timer_wdog_bite_reset:
 - Read the reset cause register in rstmgr to confirm that the SW is in the POR reset phase.
 - Program the AON timer wdog to 'bark' after some time.
 - Let the bark escalate to bite, which should result in a reset request.
 - After reset, read the reset cause register in rstmgr to confirm that the SW is now in the wdog reset phase.

## chip_sw_aon_timer_sleep_wdog_bite_reset:
- Repeat the steps in chip_aon_timer_wdog_bite_reset test, but with following changes:
- Program the pwrmgr to go to deep sleep state (clocks off, power off).
- Issue a WFI after programming the wdog, so that the reset request due to bite occurs during deep sleep state.
- After reset, read the reset cause register in rstmgr to confirm that the SW is now in the wdog reset phase.