### PR TITLE
[sysrst_ctrl] Trigger wakeup interrupt only when wkup_req rises

### DIFF
--- a/hw/ip/sysrst_ctrl/sysrst_ctrl.core
+++ b/hw/ip/sysrst_ctrl/sysrst_ctrl.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
+      - lowrisc:prim:edge_detector
       - lowrisc:ip:tlul
     files:
       - rtl/sysrst_ctrl_reg_pkg.sv


### PR DESCRIPTION
Without this, the wakeup request status needs to be cleared first before the interrupt can be cleared.

See also: https://github.com/lowRISC/opentitan/pull/10034/files#r783573203

Signed-off-by: Michael Schaffner <msf@opentitan.org>