### PR TITLE
[dv/jtag] support rv_dm in jtag_riscv_reg_adapter

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.core
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent.core
@@ -22,6 +22,7 @@ filesets:
       - jtag_riscv_agent.sv: {is_include_file: true}
       - seq_lib/jtag_riscv_base_seq.sv: {is_include_file: true}
       - seq_lib/jtag_riscv_csr_seq.sv: {is_include_file: true}
+      - seq_lib/jtag_riscv_dm_activation_seq.sv: {is_include_file: true}
       - seq_lib/jtag_riscv_seq_list.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
@@ -99,45 +99,4 @@ package jtag_riscv_agent_pkg;
     jtag_csr_seq.start(seqr);
   endtask
 
-  task automatic activate_rv_dm_jtag(jtag_riscv_sequencer seqr);
-    bit [bus_params_pkg::BUS_DW-1:0] dmctrl_val, sbcs_val;
-
-    // Set dmcontrol's dmactive bit.
-    while (dmctrl_val == 0) begin
-      jtag_write_csr(DmControl, seqr, 1);
-      jtag_read_csr(DmControl, seqr, dmctrl_val);
-    end
-
-    // Read system bus access control and status register.
-    // Once the sbcs value is not 0, then RV_DM jtag is ready.
-    while (sbcs_val == 0) jtag_read_csr(Sbcs, seqr, sbcs_val);
-
-    // Ensure the RV_DM is set to correct bus width.
-    `DV_CHECK_EQ(sbcs_val[SbAccess32], 1, "expect SBA width to be 32 bits!", error, msg_id)
-  endtask
-
-  // Do not set cfg.rv_dm_csr_with_jtag_adapter when using this task.
-  task automatic rv_dm_jtag_read_csr(bit [bus_params_pkg::BUS_AW-1:0] csr_addr,
-                                     jtag_riscv_sequencer seqr,
-                                     output bit [bus_params_pkg::BUS_DW-1:0] csr_val);
-    // Write to Sbcs register to set the busy bit.
-    jtag_write_csr(Sbcs, seqr, ('b1 << SbBusy | 'b1 << SbReadOnAddr));
-    jtag_write_csr(SbAddress0, seqr, csr_addr);
-    jtag_read_csr(SbData0, seqr, csr_val);
-    `uvm_info(msg_id, $sformatf("rv_dm_jtag_read_csr addr: %0h, val: %0h", csr_addr, csr_val),
-              UVM_MEDIUM)
-  endtask
-
-  // Do not set cfg.rv_dm_csr_with_jtag_adapter when using this task.
-  task automatic rv_dm_jtag_write_csr(bit [bus_params_pkg::BUS_AW-1:0] csr_addr,
-                                      jtag_riscv_sequencer seqr,
-                                      bit [bus_params_pkg::BUS_DW-1:0] csr_val);
-    // Write to Sbcs register to set the busy bit.
-    jtag_write_csr(Sbcs, seqr, 'b1 << SbBusy);
-    jtag_write_csr(SbAddress0, seqr, csr_addr);
-    jtag_write_csr(SbData0, seqr, csr_val);
-    `uvm_info(msg_id, $sformatf("rv_dm_jtag_write_csr addr: %0h, val: %0h", csr_addr, csr_val),
-              UVM_MEDIUM)
-  endtask
-
 endpackage: jtag_riscv_agent_pkg

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
@@ -5,6 +5,11 @@
 class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_agent_cfg);
 
   protected bit do_hard_reset;
+  // An internal check to ensure in rv_dm mode, dm is activated before accessing csrs.
+  // However, in cases that user can switch between LC and RV_DM taps without issuing reset, user
+  // still need to re-activate rv_dm manually.
+  protected bit rv_dm_activated;
+
   `uvm_object_utils(jtag_riscv_driver)
 
   `uvm_object_new
@@ -18,6 +23,7 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
       // Assert JTAG TRST
       // This clears the DMI Request and Response FIFOs.
       cfg.m_jtag_agent_cfg.vif.do_trst_n(2);
+      rv_dm_activated = 0;
 
       wait (cfg.in_reset == 0);
       `uvm_info(`gfn, "reset_signals: cfg.in_reset=1'b0", UVM_MEDIUM)
@@ -65,15 +71,36 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
 
     send_riscv_ir_req(JtagDmiAccess);
 
-    // Drive DR with operation type, address, and data
-    send_csr_dr_req(.op(drive_req.op), .data(drive_req.data), .addr(drive_req.addr), .dout(dout));
+    if (drive_req.activate_rv_dm) begin
+      activate_rv_dm();
+    end else begin
+      if (cfg.is_rv_dm) begin
+        bit [DMI_DATAW-1:0] sbcs_val = 'b1<<SbBusy;
+        `DV_CHECK_FATAL(!rv_dm_activated, "Please activate rm_dm before accessing CSRs!")
 
-    // Get status of previous transfer
-    check_csr_req_status(.status(status), .rdata(rdata));
-    drive_req.status = status;
+        // If using rv_dm to access csr, need to send the following seq:
+        // 1). Set busy bit in sbcs.
+        // 2). Write address to SBAddress0.
+        // 3). Write/Read csr data via SbData0.
+        send_csr_dr_req(.op(DmiWrite), .data(sbcs_val), .addr(Sbcs), .dout(dout));
+        send_csr_dr_req(.op(DmiWrite), .data(drive_req.addr), .addr(SbAddress0), .dout(dout));
+        send_csr_dr_req(.op(drive_req.op), .data(drive_req.data), .addr(SbData0), .dout(dout));
+      end else begin
 
-    // Update CSR read data
-    if (drive_req.op == DmiRead) drive_req.data = rdata;
+        // Drive DR with operation type, address, and data.
+        send_csr_dr_req(.op(drive_req.op),
+                        .data(drive_req.data),
+                        .addr(drive_req.addr),
+                        .dout(dout));
+      end
+
+      // Get status of previous transfer
+      check_csr_req_status(.status(status), .rdata(rdata));
+      drive_req.status = status;
+
+      // Update CSR read data
+      if (drive_req.op == DmiRead) drive_req.data = rdata;
+    end
 
     // Mark end of transaction processing
     end_tr(drive_req);
@@ -134,4 +161,24 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
       end
     end
   endtask
+
+  protected virtual task activate_rv_dm();
+    bit [bus_params_pkg::BUS_DW-1:0] dmctrl_val, sbcs_val;
+
+    // Set dmcontrol's dmactive bit.
+    while (dmctrl_val == 0) begin
+      send_csr_dr_req(.op(DmiWrite), .data(1), .addr(DmControl), .dout(dmctrl_val));
+      send_csr_dr_req(.op(DmiRead), .data(0), .addr(DmControl), .dout(dmctrl_val));
+    end
+
+    // Read system bus access control and status register.
+    // Once the sbcs value is not 0, then RV_DM jtag is ready.
+    while (sbcs_val == 0)  send_csr_dr_req(.op(DmiRead), .data(0), .addr(Sbcs), .dout(sbcs_val));
+
+    // Ensure the RV_DM is set to correct bus width.
+    `DV_CHECK_EQ(sbcs_val[SbAccess32], 1, "expect SBA width to be 32 bits!", error, msg_id)
+
+    rv_dm_activated = 1;
+  endtask
+
 endclass

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_item.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_item.sv
@@ -14,8 +14,10 @@ class jtag_riscv_item extends uvm_sequence_item;
   // DMI variables
   rand logic [  DMI_OPW-1:0] op;  // operation or status
   rand logic [DMI_DATAW-1:0] data;
-  rand logic [DMI_ADDRW-1:0] addr;  // word address
+  rand logic [DMI_DATAW-1:0] addr;  // csr/bus address, may not be DMI_ADDR in rv_dm mode
   logic      [  DMI_OPW-1:0] status;  // status of DMI operation
+
+  rand bit activate_rv_dm; // Special sequqnce to activate RV_DM.
 
   constraint ir_len_c {ir_len <= JTAG_IRW;}
 
@@ -30,6 +32,7 @@ class jtag_riscv_item extends uvm_sequence_item;
     `uvm_field_int(data, UVM_DEFAULT)
     `uvm_field_int(addr, UVM_DEFAULT)
     `uvm_field_int(status, UVM_DEFAULT)
+    `uvm_field_int(activate_rv_dm, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_reg_adapter.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_reg_adapter.sv
@@ -5,6 +5,10 @@
 class jtag_riscv_reg_adapter extends uvm_reg_adapter;
   `uvm_object_utils(jtag_riscv_reg_adapter)
 
+  // Ensure that when an instance of this adapter is created, the cfg handle below is initialized
+  // to the `jtag_riscv_agent_cfg` instance associated with this adapter instance.
+  jtag_riscv_agent_cfg cfg;
+
   function new(string name = "jtag_riscv_reg_adapter");
     super.new(name);
     // We don't do byte enables
@@ -17,6 +21,9 @@ class jtag_riscv_reg_adapter extends uvm_reg_adapter;
     jtag_riscv_item jtag_item = jtag_riscv_item::type_id::create(
         "jtag_item", null, this.get_full_name()
     );
+    // RV_DM can input CSR address up to 128 bits.
+    bit [DMI_DATAW-1:0] rw_addr = cfg.is_rv_dm ? rw.addr[DMI_DATAW-1:0] :
+                                  rw.addr[DMI_ADDRW + DMI_WORD_SHIFT - 1 : DMI_WORD_SHIFT];
 
     `DV_CHECK_RANDOMIZE_WITH_FATAL(jtag_item,
         if (local::rw.kind == UVM_WRITE) {
@@ -25,14 +32,14 @@ class jtag_riscv_reg_adapter extends uvm_reg_adapter;
           op == DmiRead;
         }
         // Convert to word address by slicing
-        addr == local::rw.addr[DMI_ADDRW + DMI_WORD_SHIFT - 1 : DMI_WORD_SHIFT];
-        data == local::rw.data[DMI_DATAW-1:0];)
+        addr == rw_addr;
+        data == local::rw.data[DMI_DATAW-1:0];
+        activate_rv_dm == 0;)
     `uvm_info(`gfn, $sformatf("reg2bus: %s", jtag_item.sprint(uvm_default_line_printer)), UVM_HIGH)
     return jtag_item;
   endfunction
 
   virtual function void bus2reg(uvm_sequence_item bus_item, ref uvm_reg_bus_op rw);
-
     jtag_riscv_item jtag_item;
 
     `DV_CHECK_NE_FATAL(bus_item, null)
@@ -44,7 +51,7 @@ class jtag_riscv_reg_adapter extends uvm_reg_adapter;
       default:  `uvm_fatal(`gfn, $sformatf("Invalid operation code %h", jtag_item.op))
     endcase
 
-    rw.addr = jtag_item.addr << DMI_WORD_SHIFT;
+    rw.addr = cfg.is_rv_dm ? jtag_item.addr : (jtag_item.addr << DMI_WORD_SHIFT);
     // No byte enables
     rw.byte_en = '1;
     rw.data = jtag_item.data;

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_csr_seq.sv
@@ -7,7 +7,8 @@ class jtag_riscv_csr_seq extends jtag_riscv_base_seq;
 
   rand bit [  DMI_OPW-1:0] op;
   rand bit [DMI_DATAW-1:0] data;
-  rand bit [DMI_ADDRW+1:0] addr;  // Need to convert from csr(byte) address to word address
+  // Need to convert from csr(byte) address to word address if not in rv_dm mode.
+  rand bit [DMI_ADDRW+1:0] addr;
   rand bit                 do_write;
 
   constraint op_c {
@@ -34,7 +35,8 @@ class jtag_riscv_csr_seq extends jtag_riscv_base_seq;
       op   == local::op;
       // convert byte address to word address
       addr == (cfg.is_rv_dm ? local::addr : (local::addr >> DMI_WORD_SHIFT));
-      data == local::data;)
+      data == local::data;
+      activate_rv_dm == 0;)
 
     finish_item(req);
     get_response(rsp);

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_dm_activation_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_dm_activation_seq.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A RM_DM jtag sequence to activate DM mode.
+class jtag_riscv_dm_activation_seq extends jtag_riscv_base_seq;
+
+  function new(string name = "");
+    super.new(name);
+  endfunction
+
+  virtual task body();
+    `uvm_create_obj(REQ, req)
+    start_item(req);
+
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req, activate_rv_dm == 1;)
+
+    finish_item(req);
+    get_response(rsp);
+
+    if (!cfg.allow_errors) begin
+      `DV_CHECK_EQ(rsp.status, DmiNoErr, "jtag_csr_dm_activation failed!")
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_seq_list.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_seq_list.sv
@@ -4,3 +4,4 @@
 
 `include "jtag_riscv_base_seq.sv"
 `include "jtag_riscv_csr_seq.sv"
+`include "jtag_riscv_dm_activation_seq.sv"

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.sv
@@ -25,6 +25,7 @@ class lc_ctrl_env extends cip_base_env #(
 
     m_jtag_riscv_reg_adapter = jtag_riscv_reg_adapter::type_id::
         create("m_jtag_riscv_reg_adapter",null,this.get_full_name());
+    m_jtag_riscv_reg_adapter.cfg = cfg.m_jtag_riscv_agent_cfg;
 
     // config power manager pin
     if (!uvm_config_db#(pwr_lc_vif)::get(this, "", "pwr_lc_vif", cfg.pwr_lc_vif)) begin


### PR DESCRIPTION
This PR adds a flag in jtag_riscv_agent_cfg to support accessing jtag
csr_rd/wr via rv_dm.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>