### PR TITLE
[otbn,sw] Change how we expose OTBN symbols to Ibex

### DIFF
--- a/sw/device/lib/runtime/otbn.h
+++ b/sw/device/lib/runtime/otbn.h
@@ -41,33 +41,15 @@ typedef struct otbn_app {
    * End of initialized OTBN data memory.
    */
   const uint8_t *dmem_data_end;
-  /**
-   * Start of uninitialized OTBN data memory.
-   *
-   * Data in this section is initialized to zeroes in DMEM when the app is
-   * loaded.
-   */
-  const uint8_t *dmem_bss_start;
-  /**
-   * End of uninitialized OTBN data memory.
-   */
-  const uint8_t *dmem_bss_end;
-  /**
-   * Offset of the BSS section within DMEM.
-   */
-  uint32_t dmem_bss_offset;
 } otbn_app_t;
 
 /**
- * A pointer to a symbol in OTBN's instruction or data memory.
+ * The address of an OTBN symbol as seen by OTBN
  *
- * Use `OTBN_DECLARE_PTR_SYMBOL()` together with `OTBN_PTR_T_INIT()` to
+ * Use `OTBN_DECLARE_SYMBOL_ADDR()` together with `OTBN_ADDR_T_INIT()` to
  * initialize this type.
- *
- * The value of the pointer is an address in the normal CPU address space, and
- * must be first converted into OTBN address space before it can be used there.
  */
-typedef uint8_t *otbn_ptr_t;
+typedef uint32_t otbn_addr_t;
 
 /**
  * The result of an OTBN operation.
@@ -119,6 +101,56 @@ typedef struct otbn {
 } otbn_t;
 
 /**
+ * Generate the prefix to add to an OTBN symbol name used on the Ibex side
+ *
+ * The result is a pointer to Ibex's rodata that should be used to initialise
+ * memory for that symbol.
+ *
+ * This is needed by the OTBN driver to support DMEM/IMEM ranges but
+ * application code shouldn't need to use this. Use the `otbn_addr_t` type and
+ * supporting macros instead.
+ */
+#define OTBN_SYMBOL_PTR(app_name, sym) _otbn_local_app_##app_name##_##sym
+
+/**
+ * Generate the prefix to add to an OTBN symbol name used on the OTBN side
+ *
+ * The result is a pointer whose integer value is the address by which the
+ * symbol should be accessed in OTBN memory.
+ *
+ * This is an internal macro used in `OTBN_DECLARE_SYMBOL_ADDR` and
+ * `OTBN_ADDR_T_INIT` but application code shouldn't need to use it directly.
+ */
+#define OTBN_SYMBOL_ADDR(app_name, sym) _otbn_remote_app_##app_name##_##sym
+
+/**
+ * Makes a symbol in the OTBN application image available.
+ *
+ * This is needed by the OTBN driver to support DMEM/IMEM ranges but
+ * application code shouldn't need to use this. To get access to OTBN
+ * addresses, use `OTBN_DECLARE_SYMBOL_ADDR` instead.
+ */
+#define OTBN_DECLARE_SYMBOL_PTR(app_name, symbol_name) \
+  extern const uint8_t OTBN_SYMBOL_PTR(app_name, symbol_name)[]
+
+/**
+ * Makes the OTBN address of a symbol in the OTBN application available.
+ *
+ * Symbols are typically function or data pointers, i.e. labels in assembly
+ * code. Unlike OTBN_DECLARE_SYMBOL_PTR, this will work for symbols in the .bss
+ * section (which exist on the OTBN side, even though they don't have backing
+ * data on Ibex).
+ *
+ * Use this macro instead of manually declaring the symbols as symbol names
+ * might change.
+ *
+ * @param app_name    Name of the application the function is contained in.
+ * @param symbol_name Name of the symbol (function, label).
+ */
+#define OTBN_DECLARE_SYMBOL_ADDR(app_name, symbol_name) \
+  extern const uint8_t OTBN_SYMBOL_ADDR(app_name, symbol_name)[]
+
+/**
  * Makes an embedded OTBN application image available for use.
  *
  * Make symbols available that indicate the start and the end of instruction
@@ -130,14 +162,11 @@ typedef struct otbn {
  * @param app_name Name of the application to load, which is typically the
  *                 name of the main (assembly) source file.
  */
-#define OTBN_DECLARE_APP_SYMBOLS(app_name)                        \
-  extern const uint8_t _otbn_app_##app_name##__imem_start[];      \
-  extern const uint8_t _otbn_app_##app_name##__imem_end[];        \
-  extern const uint8_t _otbn_app_##app_name##__dmem_data_start[]; \
-  extern const uint8_t _otbn_app_##app_name##__dmem_data_end[];   \
-  extern const uint8_t _otbn_app_##app_name##__dmem_bss_start[];  \
-  extern const uint8_t _otbn_app_##app_name##__dmem_bss_end[];    \
-  extern const uint8_t _otbn_app_##app_name##__dmem_bss_offset[];
+#define OTBN_DECLARE_APP_SYMBOLS(app_name)             \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_start);      \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_end);        \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_start); \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_end)
 
 /**
  * Initializes the OTBN application information structure.
@@ -149,37 +178,19 @@ typedef struct otbn {
  * @param app_name Name of the application to load.
  * @see OTBN_DECLARE_APP_SYMBOLS()
  */
-#define OTBN_APP_T_INIT(app_name)                                           \
-  ((otbn_app_t){                                                            \
-      .imem_start = _otbn_app_##app_name##__imem_start,                     \
-      .imem_end = _otbn_app_##app_name##__imem_end,                         \
-      .dmem_data_start = _otbn_app_##app_name##__dmem_data_start,           \
-      .dmem_data_end = _otbn_app_##app_name##__dmem_data_end,               \
-      .dmem_bss_start = _otbn_app_##app_name##__dmem_bss_start,             \
-      .dmem_bss_end = _otbn_app_##app_name##__dmem_bss_end,                 \
-      .dmem_bss_offset = (uint32_t)_otbn_app_##app_name##__dmem_bss_offset, \
+#define OTBN_APP_T_INIT(app_name)                                     \
+  ((otbn_app_t){                                                      \
+      .imem_start = OTBN_SYMBOL_PTR(app_name, _imem_start),           \
+      .imem_end = OTBN_SYMBOL_PTR(app_name, _imem_end),               \
+      .dmem_data_start = OTBN_SYMBOL_PTR(app_name, _dmem_data_start), \
+      .dmem_data_end = OTBN_SYMBOL_PTR(app_name, _dmem_data_end),     \
   })
 
 /**
- * Makes a symbol in the OTBN application image available.
- *
- * Symbols are typically function or data pointers, i.e. labels in assembly
- * code.
- *
- * Use this macro instead of manually declaring the symbols as symbol names
- * might change.
- *
- * @param app_name    Name of the application the function is contained in.
- * @param symbol_name Name of the symbol (function, label).
+ * Initializes an `otbn_addr_t`.
  */
-#define OTBN_DECLARE_PTR_SYMBOL(app_name, symbol_name) \
-  extern const uint8_t _otbn_app_##app_name##_##symbol_name[]
-
-/**
- * Initializes an `otbn_ptr_t`.
- */
-#define OTBN_PTR_T_INIT(app_name, symbol_name) \
-  ((otbn_ptr_t)_otbn_app_##app_name##_##symbol_name)
+#define OTBN_ADDR_T_INIT(app_name, symbol_name) \
+  ((uint32_t)OTBN_SYMBOL_ADDR(app_name, symbol_name))
 
 /**
  * Initializes the OTBN context structure.
@@ -226,25 +237,25 @@ otbn_result_t otbn_busy_wait_for_done(otbn_t *ctx);
  *
  * @param ctx The context object.
  * @param len_bytes Number of bytes to copy.
- * @param dest Pointer to the destination in OTBN's data memory.
+ * @param dest Address of the destination in OTBN's data memory.
  * @param src Source of the data to copy.
  * @return The result of the operation.
  */
 otbn_result_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len_bytes,
-                                     const void *src, otbn_ptr_t dest);
+                                     const void *src, otbn_addr_t dest);
 
 /**
  * Copies data from OTBN's data memory to CPU memory.
  *
  * @param ctx The context object.
  * @param len_bytes The number of bytes to copy.
- * @param src The pointer in OTBN data memory to copy from.
+ * @param src The address in OTBN data memory to copy from.
  * @param[out] dest The destination of the copied data in main memory
  *                  (preallocated).
  * @return The result of the operation.
  */
 otbn_result_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
-                                       const otbn_ptr_t src, void *dest);
+                                       otbn_addr_t src, void *dest);
 
 /**
  * Overwrites all of OTBN's data memory with zeros.
@@ -256,18 +267,6 @@ otbn_result_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
  * @return The result of the operation.
  */
 otbn_result_t otbn_zero_data_memory(otbn_t *ctx);
-
-/**
- * Gets the address in OTBN data memory referenced by `ptr`.
- *
- * @param ctx The context object.
- * @param ptr The pointer to convert.
- * @param[out] dmem_addr_otbn The address of the data in OTBN's data memory.
- * @return The result of the operation; #kOtbnBadArg if `ptr` is not in the data
- *         memory space of the currently loaded application.
- */
-otbn_result_t otbn_data_ptr_to_dmem_addr(const otbn_t *ctx, otbn_ptr_t ptr,
-                                         uint32_t *dmem_addr_otbn);
 
 /**
  * Writes a LOG_INFO message with the contents of each 256b DMEM word.

--- a/sw/device/silicon_creator/lib/crypto/ecdsa_p256/ecdsa_p256.c
+++ b/sw/device/silicon_creator/lib/crypto/ecdsa_p256/ecdsa_p256.c
@@ -11,47 +11,47 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTBN_DECLARE_APP_SYMBOLS(p256_ecdsa);       // The OTBN ECDSA/P-256 app.
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, mode);  // ECDSA mode (sign or verify).
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, msg);   // Message digest.
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, r);     // The signature scalar R.
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, s);     // The signature scalar S.
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, x);     // The public key x-coordinate.
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, y);     // The public key y-coordinate.
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, d);     // The private key scalar d.
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, x_r);   // Verification result.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, mode);  // ECDSA mode (sign or verify).
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, msg);   // Message digest.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, r);     // The signature scalar R.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, s);     // The signature scalar S.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x);     // The public key x-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, y);     // The public key y-coordinate.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d);     // The private key scalar d.
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);   // Verification result.
 
 /* Declare symbols for DMEM pointers */
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_msg);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_r);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_s);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_x);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_y);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_d);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_x_r);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_msg);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_r);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_s);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_y);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_d);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x_r);
 
 static const otbn_app_t kOtbnAppEcdsa = OTBN_APP_T_INIT(p256_ecdsa);
-static const otbn_ptr_t kOtbnVarEcdsaMode = OTBN_PTR_T_INIT(p256_ecdsa, mode);
-static const otbn_ptr_t kOtbnVarEcdsaMsg = OTBN_PTR_T_INIT(p256_ecdsa, msg);
-static const otbn_ptr_t kOtbnVarEcdsaR = OTBN_PTR_T_INIT(p256_ecdsa, r);
-static const otbn_ptr_t kOtbnVarEcdsaS = OTBN_PTR_T_INIT(p256_ecdsa, s);
-static const otbn_ptr_t kOtbnVarEcdsaX = OTBN_PTR_T_INIT(p256_ecdsa, x);
-static const otbn_ptr_t kOtbnVarEcdsaY = OTBN_PTR_T_INIT(p256_ecdsa, y);
-static const otbn_ptr_t kOtbnVarEcdsaD = OTBN_PTR_T_INIT(p256_ecdsa, d);
-static const otbn_ptr_t kOtbnVarEcdsaXr = OTBN_PTR_T_INIT(p256_ecdsa, x_r);
-static const otbn_ptr_t kOtbnVarEcdsaDptrMsg =
-    OTBN_PTR_T_INIT(p256_ecdsa, dptr_msg);
-static const otbn_ptr_t kOtbnVarEcdsaDptrR =
-    OTBN_PTR_T_INIT(p256_ecdsa, dptr_r);
-static const otbn_ptr_t kOtbnVarEcdsaDptrS =
-    OTBN_PTR_T_INIT(p256_ecdsa, dptr_s);
-static const otbn_ptr_t kOtbnVarEcdsaDptrX =
-    OTBN_PTR_T_INIT(p256_ecdsa, dptr_x);
-static const otbn_ptr_t kOtbnVarEcdsaDptrY =
-    OTBN_PTR_T_INIT(p256_ecdsa, dptr_y);
-static const otbn_ptr_t kOtbnVarEcdsaDptrD =
-    OTBN_PTR_T_INIT(p256_ecdsa, dptr_d);
-static const otbn_ptr_t kOtbnVarEcdsaDptrXr =
-    OTBN_PTR_T_INIT(p256_ecdsa, dptr_x_r);
+static const otbn_addr_t kOtbnVarEcdsaMode = OTBN_ADDR_T_INIT(p256_ecdsa, mode);
+static const otbn_addr_t kOtbnVarEcdsaMsg = OTBN_ADDR_T_INIT(p256_ecdsa, msg);
+static const otbn_addr_t kOtbnVarEcdsaR = OTBN_ADDR_T_INIT(p256_ecdsa, r);
+static const otbn_addr_t kOtbnVarEcdsaS = OTBN_ADDR_T_INIT(p256_ecdsa, s);
+static const otbn_addr_t kOtbnVarEcdsaX = OTBN_ADDR_T_INIT(p256_ecdsa, x);
+static const otbn_addr_t kOtbnVarEcdsaY = OTBN_ADDR_T_INIT(p256_ecdsa, y);
+static const otbn_addr_t kOtbnVarEcdsaD = OTBN_ADDR_T_INIT(p256_ecdsa, d);
+static const otbn_addr_t kOtbnVarEcdsaXr = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
+static const otbn_addr_t kOtbnVarEcdsaDptrMsg =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_msg);
+static const otbn_addr_t kOtbnVarEcdsaDptrR =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_r);
+static const otbn_addr_t kOtbnVarEcdsaDptrS =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_s);
+static const otbn_addr_t kOtbnVarEcdsaDptrX =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x);
+static const otbn_addr_t kOtbnVarEcdsaDptrY =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_y);
+static const otbn_addr_t kOtbnVarEcdsaDptrD =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_d);
+static const otbn_addr_t kOtbnVarEcdsaDptrXr =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x_r);
 
 /* Mode is represented by a single word, 1 for sign and 2 for verify */
 static const uint32_t kOtbnEcdsaModeNumWords = 1;
@@ -61,12 +61,9 @@ static const uint32_t kOtbnEcdsaModeSign = 1;
 /**
  * Makes a single dptr in the P256 library point to where its value is stored.
  */
-static otbn_error_t setup_data_pointer(otbn_t *otbn, const otbn_ptr_t dptr,
-                                       const otbn_ptr_t value) {
-  uint32_t value_dmem_addr;
-  OTBN_RETURN_IF_ERROR(
-      otbn_data_ptr_to_dmem_addr(otbn, value, &value_dmem_addr));
-  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(otbn, 1, &value_dmem_addr, dptr));
+static otbn_error_t setup_data_pointer(otbn_t *otbn, otbn_addr_t dptr,
+                                       otbn_addr_t value) {
+  OTBN_RETURN_IF_ERROR(otbn_copy_data_to_otbn(otbn, 1, &value, dptr));
   return kOtbnErrorOk;
 }
 

--- a/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.c
+++ b/sw/device/silicon_creator/lib/crypto/rsa_3072/rsa_3072_verify.c
@@ -15,34 +15,34 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTBN_DECLARE_APP_SYMBOLS(run_rsa_verify_3072);  // The OTBN RSA-3072 app.
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        mode);  // Mode (constants or modexp).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        out_buf);  // Output buffer (message).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        in_exp);  // The RSA key exponent (n).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072, in_mod);  // The RSA modulus (n).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072, in_buf);  // The signature (s).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        rr);  // The Montgomery constant R^2.
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072,
-                        m0inv);  // The Montgomery constant m0_inv.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072,
+                         mode);  // Mode (constants or modexp).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072,
+                         out_buf);  // Output buffer (message).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072,
+                         in_exp);  // The RSA key exponent (n).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072, in_mod);  // The RSA modulus (n).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072, in_buf);  // The signature (s).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072,
+                         rr);  // The Montgomery constant R^2.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072,
+                         m0inv);  // The Montgomery constant m0_inv.
 
 static const otbn_app_t kOtbnAppRsa = OTBN_APP_T_INIT(run_rsa_verify_3072);
-static const otbn_ptr_t kOtbnVarRsaMode =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, mode);
-static const otbn_ptr_t kOtbnVarRsaOutBuf =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, out_buf);
-static const otbn_ptr_t kOtbnVarRsaInExp =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, in_exp);
-static const otbn_ptr_t kOtbnVarRsaInMod =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, in_mod);
-static const otbn_ptr_t kOtbnVarRsaInBuf =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, in_buf);
-static const otbn_ptr_t kOtbnVarRsaRR =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, rr);
-static const otbn_ptr_t kOtbnVarRsaM0Inv =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072, m0inv);
+static const otbn_addr_t kOtbnVarRsaMode =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072, mode);
+static const otbn_addr_t kOtbnVarRsaOutBuf =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072, out_buf);
+static const otbn_addr_t kOtbnVarRsaInExp =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072, in_exp);
+static const otbn_addr_t kOtbnVarRsaInMod =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072, in_mod);
+static const otbn_addr_t kOtbnVarRsaInBuf =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072, in_buf);
+static const otbn_addr_t kOtbnVarRsaRR =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072, rr);
+static const otbn_addr_t kOtbnVarRsaM0Inv =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072, m0inv);
 
 /* Mode is represented by a single word: 1=constant computation, 2=modexp */
 static const uint32_t kOtbnRsaModeNumWords = 1;
@@ -102,11 +102,11 @@ rom_error_t rsa_3072_encode_sha256(const uint8_t *msg, size_t msgLen,
  *
  * @param otbn The OTBN context object.
  * @param src Source of the data to copy.
- * @param dst Pointer to the destination in OTBN's data memory.
+ * @param dst Address of the destination in OTBN's data memory.
  * @return The result of the operation.
  */
 otbn_error_t write_rsa_3072_int_to_otbn(otbn_t *otbn, const rsa_3072_int_t *src,
-                                        otbn_ptr_t dst) {
+                                        otbn_addr_t dst) {
   return otbn_copy_data_to_otbn(otbn, kRsa3072NumWords, src->data, dst);
 }
 
@@ -114,11 +114,11 @@ otbn_error_t write_rsa_3072_int_to_otbn(otbn_t *otbn, const rsa_3072_int_t *src,
  * Copies a 3072-bit number from OTBN data memory to CPU memory.
  *
  * @param otbn The OTBN context object.
- * @param src The pointer in OTBN data memory to copy from.
+ * @param src The address in OTBN data memory to copy from.
  * @param dst The destination of the copied data in main memory (preallocated).
  * @return The result of the operation.
  */
-otbn_error_t read_rsa_3072_int_from_otbn(otbn_t *otbn, const otbn_ptr_t src,
+otbn_error_t read_rsa_3072_int_from_otbn(otbn_t *otbn, otbn_addr_t src,
                                          rsa_3072_int_t *dst) {
   return otbn_copy_data_from_otbn(otbn, kRsa3072NumWords, src, dst->data);
 }

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_otbn.c
@@ -15,40 +15,40 @@
 
 OTBN_DECLARE_APP_SYMBOLS(
     run_rsa_verify_3072_rr_modexp);  // The OTBN RSA-3072 app.
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072_rr_modexp,
-                        out_buf);  // Output buffer (message).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072_rr_modexp,
-                        in_exp);  // The RSA key exponent (e).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072_rr_modexp,
-                        in_mod);  // The RSA modulus (n).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072_rr_modexp,
-                        in_buf);  // The signature (s).
-OTBN_DECLARE_PTR_SYMBOL(run_rsa_verify_3072_rr_modexp,
-                        m0inv);  // The Montgomery constant m0_inv.
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072_rr_modexp,
+                         out_buf);  // Output buffer (message).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072_rr_modexp,
+                         in_exp);  // The RSA key exponent (e).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072_rr_modexp,
+                         in_mod);  // The RSA modulus (n).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072_rr_modexp,
+                         in_buf);  // The signature (s).
+OTBN_DECLARE_SYMBOL_ADDR(run_rsa_verify_3072_rr_modexp,
+                         m0inv);  // The Montgomery constant m0_inv.
 
 static const otbn_app_t kOtbnAppRsa =
     OTBN_APP_T_INIT(run_rsa_verify_3072_rr_modexp);
-static const otbn_ptr_t kOtbnVarRsaOutBuf =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072_rr_modexp, out_buf);
-static const otbn_ptr_t kOtbnVarRsaInExp =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072_rr_modexp, in_exp);
-static const otbn_ptr_t kOtbnVarRsaInMod =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072_rr_modexp, in_mod);
-static const otbn_ptr_t kOtbnVarRsaInBuf =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072_rr_modexp, in_buf);
-static const otbn_ptr_t kOtbnVarRsaM0Inv =
-    OTBN_PTR_T_INIT(run_rsa_verify_3072_rr_modexp, m0inv);
+static const otbn_addr_t kOtbnVarRsaOutBuf =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072_rr_modexp, out_buf);
+static const otbn_addr_t kOtbnVarRsaInExp =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072_rr_modexp, in_exp);
+static const otbn_addr_t kOtbnVarRsaInMod =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072_rr_modexp, in_mod);
+static const otbn_addr_t kOtbnVarRsaInBuf =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072_rr_modexp, in_buf);
+static const otbn_addr_t kOtbnVarRsaM0Inv =
+    OTBN_ADDR_T_INIT(run_rsa_verify_3072_rr_modexp, m0inv);
 
 /**
  * Copies a 3072-bit number from the CPU memory to OTBN data memory.
  *
  * @param otbn The OTBN context object.
  * @param src Source of the data to copy.
- * @param dst Pointer to the destination in OTBN's data memory.
+ * @param dst Address of the destination in OTBN's data memory.
  * @return The result of the operation.
  */
 static otbn_error_t write_rsa_3072_int_to_otbn(
-    otbn_t *otbn, const sigverify_rsa_buffer_t *src, otbn_ptr_t dst) {
+    otbn_t *otbn, const sigverify_rsa_buffer_t *src, otbn_addr_t dst) {
   return otbn_copy_data_to_otbn(otbn, kSigVerifyRsaNumWords, src->data, dst);
 }
 
@@ -56,12 +56,12 @@ static otbn_error_t write_rsa_3072_int_to_otbn(
  * Copies a 3072-bit number from OTBN data memory to CPU memory.
  *
  * @param otbn The OTBN context object.
- * @param src The pointer in OTBN data memory to copy from.
+ * @param src The address in OTBN data memory to copy from.
  * @param dst The destination of the copied data in main memory (preallocated).
  * @return The result of the operation.
  */
 static otbn_error_t read_rsa_3072_int_from_otbn(otbn_t *otbn,
-                                                const otbn_ptr_t src,
+                                                const otbn_addr_t src,
                                                 sigverify_rsa_buffer_t *dst) {
   return otbn_copy_data_from_otbn(otbn, kSigVerifyRsaNumWords, src, dst->data);
 }

--- a/sw/device/tests/otbn_ecdsa_p256_test.c
+++ b/sw/device/tests/otbn_ecdsa_p256_test.c
@@ -34,41 +34,43 @@
 
 OTBN_DECLARE_APP_SYMBOLS(p256_ecdsa);
 
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_msg);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_r);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_s);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_x);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_y);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_d);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, dptr_x_r);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_msg);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_r);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_s);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_y);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_d);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, dptr_x_r);
 
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, mode);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, msg);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, r);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, s);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, x);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, y);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, d);
-OTBN_DECLARE_PTR_SYMBOL(p256_ecdsa, x_r);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, mode);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, msg);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, r);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, s);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, y);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, d);
+OTBN_DECLARE_SYMBOL_ADDR(p256_ecdsa, x_r);
 
 static const otbn_app_t kOtbnAppP256Ecdsa = OTBN_APP_T_INIT(p256_ecdsa);
 
-static const otbn_ptr_t kOtbnVarDptrMsg = OTBN_PTR_T_INIT(p256_ecdsa, dptr_msg);
-static const otbn_ptr_t kOtbnVarDptrR = OTBN_PTR_T_INIT(p256_ecdsa, dptr_r);
-static const otbn_ptr_t kOtbnVarDptrS = OTBN_PTR_T_INIT(p256_ecdsa, dptr_s);
-static const otbn_ptr_t kOtbnVarDptrX = OTBN_PTR_T_INIT(p256_ecdsa, dptr_x);
-static const otbn_ptr_t kOtbnVarDptrY = OTBN_PTR_T_INIT(p256_ecdsa, dptr_y);
-static const otbn_ptr_t kOtbnVarDptrD = OTBN_PTR_T_INIT(p256_ecdsa, dptr_d);
-static const otbn_ptr_t kOtbnVarDptrXR = OTBN_PTR_T_INIT(p256_ecdsa, dptr_x_r);
+static const otbn_addr_t kOtbnVarDptrMsg =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_msg);
+static const otbn_addr_t kOtbnVarDptrR = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_r);
+static const otbn_addr_t kOtbnVarDptrS = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_s);
+static const otbn_addr_t kOtbnVarDptrX = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x);
+static const otbn_addr_t kOtbnVarDptrY = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_y);
+static const otbn_addr_t kOtbnVarDptrD = OTBN_ADDR_T_INIT(p256_ecdsa, dptr_d);
+static const otbn_addr_t kOtbnVarDptrXR =
+    OTBN_ADDR_T_INIT(p256_ecdsa, dptr_x_r);
 
-static const otbn_ptr_t kOtbnVarMode = OTBN_PTR_T_INIT(p256_ecdsa, mode);
-static const otbn_ptr_t kOtbnVarMsg = OTBN_PTR_T_INIT(p256_ecdsa, msg);
-static const otbn_ptr_t kOtbnVarR = OTBN_PTR_T_INIT(p256_ecdsa, r);
-static const otbn_ptr_t kOtbnVarS = OTBN_PTR_T_INIT(p256_ecdsa, s);
-static const otbn_ptr_t kOtbnVarX = OTBN_PTR_T_INIT(p256_ecdsa, x);
-static const otbn_ptr_t kOtbnVarY = OTBN_PTR_T_INIT(p256_ecdsa, y);
-static const otbn_ptr_t kOtbnVarD = OTBN_PTR_T_INIT(p256_ecdsa, d);
-static const otbn_ptr_t kOtbnVarXR = OTBN_PTR_T_INIT(p256_ecdsa, x_r);
+static const otbn_addr_t kOtbnVarMode = OTBN_ADDR_T_INIT(p256_ecdsa, mode);
+static const otbn_addr_t kOtbnVarMsg = OTBN_ADDR_T_INIT(p256_ecdsa, msg);
+static const otbn_addr_t kOtbnVarR = OTBN_ADDR_T_INIT(p256_ecdsa, r);
+static const otbn_addr_t kOtbnVarS = OTBN_ADDR_T_INIT(p256_ecdsa, s);
+static const otbn_addr_t kOtbnVarX = OTBN_ADDR_T_INIT(p256_ecdsa, x);
+static const otbn_addr_t kOtbnVarY = OTBN_ADDR_T_INIT(p256_ecdsa, y);
+static const otbn_addr_t kOtbnVarD = OTBN_ADDR_T_INIT(p256_ecdsa, d);
+static const otbn_addr_t kOtbnVarXR = OTBN_ADDR_T_INIT(p256_ecdsa, x_r);
 
 const test_config_t kTestConfig;
 
@@ -116,13 +118,10 @@ static void profile_end(uint64_t t_start, const char *msg) {
 /**
  * Makes a single dptr in the P256 library point to where its value is stored.
  */
-static void setup_data_pointer(otbn_t *otbn_ctx, const otbn_ptr_t dptr,
-                               const otbn_ptr_t value) {
-  uint32_t value_dmem_addr;
-  CHECK(otbn_data_ptr_to_dmem_addr(otbn_ctx, value, &value_dmem_addr) ==
+static void setup_data_pointer(otbn_t *otbn_ctx, otbn_addr_t dptr,
+                               otbn_addr_t value) {
+  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(value), &value, dptr) ==
         kOtbnOk);
-  CHECK(otbn_copy_data_to_otbn(otbn_ctx, sizeof(value_dmem_addr),
-                               &value_dmem_addr, dptr) == kOtbnOk);
 }
 
 /**

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -14,23 +14,23 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 OTBN_DECLARE_APP_SYMBOLS(randomness);
-OTBN_DECLARE_PTR_SYMBOL(randomness, rv);
-OTBN_DECLARE_PTR_SYMBOL(randomness, fail_idx);
-OTBN_DECLARE_PTR_SYMBOL(randomness, rnd_out);
-OTBN_DECLARE_PTR_SYMBOL(randomness, urnd_out);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, rv);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, fail_idx);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, rnd_out);
+OTBN_DECLARE_SYMBOL_ADDR(randomness, urnd_out);
 
 static const otbn_app_t kOtbnAppCfiTest = OTBN_APP_T_INIT(randomness);
-static const otbn_ptr_t kVarRv = OTBN_PTR_T_INIT(randomness, rv);
-static const otbn_ptr_t kVarFailIdx = OTBN_PTR_T_INIT(randomness, fail_idx);
-static const otbn_ptr_t kVarRndOut = OTBN_PTR_T_INIT(randomness, rnd_out);
-static const otbn_ptr_t kVarUrndOut = OTBN_PTR_T_INIT(randomness, urnd_out);
+static const otbn_addr_t kVarRv = OTBN_ADDR_T_INIT(randomness, rv);
+static const otbn_addr_t kVarFailIdx = OTBN_ADDR_T_INIT(randomness, fail_idx);
+static const otbn_addr_t kVarRndOut = OTBN_ADDR_T_INIT(randomness, rnd_out);
+static const otbn_addr_t kVarUrndOut = OTBN_ADDR_T_INIT(randomness, urnd_out);
 
 const test_config_t kTestConfig;
 
 /**
  * LOG_INFO with a 256b unsigned integer as hexadecimal number with a prefix.
  */
-static void print_uint256(otbn_t *ctx, const otbn_ptr_t var,
+static void print_uint256(otbn_t *ctx, const otbn_addr_t var,
                           const char *prefix) {
   uint32_t data[32 / sizeof(uint32_t)];
   CHECK(otbn_copy_data_from_otbn(ctx, /*len_bytes=*/32, var, &data) == kOtbnOk);

--- a/sw/device/tests/otbn_rsa_test.c
+++ b/sw/device/tests/otbn_rsa_test.c
@@ -67,18 +67,18 @@ static const bool kTestDecrypt = true;
 static const bool kTestRsaGreater1k = false;
 
 OTBN_DECLARE_APP_SYMBOLS(rsa);
-OTBN_DECLARE_PTR_SYMBOL(rsa, mode);
-OTBN_DECLARE_PTR_SYMBOL(rsa, n_limbs);
-OTBN_DECLARE_PTR_SYMBOL(rsa, inout);
-OTBN_DECLARE_PTR_SYMBOL(rsa, modulus);
-OTBN_DECLARE_PTR_SYMBOL(rsa, exp);
+OTBN_DECLARE_SYMBOL_ADDR(rsa, mode);
+OTBN_DECLARE_SYMBOL_ADDR(rsa, n_limbs);
+OTBN_DECLARE_SYMBOL_ADDR(rsa, inout);
+OTBN_DECLARE_SYMBOL_ADDR(rsa, modulus);
+OTBN_DECLARE_SYMBOL_ADDR(rsa, exp);
 
 static const otbn_app_t kOtbnAppRsa = OTBN_APP_T_INIT(rsa);
-static const otbn_ptr_t kOtbnVarRsaMode = OTBN_PTR_T_INIT(rsa, mode);
-static const otbn_ptr_t kOtbnVarRsaNLimbs = OTBN_PTR_T_INIT(rsa, n_limbs);
-static const otbn_ptr_t kOtbnVarRsaInOut = OTBN_PTR_T_INIT(rsa, inout);
-static const otbn_ptr_t kOtbnVarRsaModulus = OTBN_PTR_T_INIT(rsa, modulus);
-static const otbn_ptr_t kOtbnVarRsaExp = OTBN_PTR_T_INIT(rsa, exp);
+static const otbn_addr_t kOtbnVarRsaMode = OTBN_ADDR_T_INIT(rsa, mode);
+static const otbn_addr_t kOtbnVarRsaNLimbs = OTBN_ADDR_T_INIT(rsa, n_limbs);
+static const otbn_addr_t kOtbnVarRsaInOut = OTBN_ADDR_T_INIT(rsa, inout);
+static const otbn_addr_t kOtbnVarRsaModulus = OTBN_ADDR_T_INIT(rsa, modulus);
+static const otbn_addr_t kOtbnVarRsaExp = OTBN_ADDR_T_INIT(rsa, exp);
 
 enum {
   kRsa512SizeBytes = 512 / 8,


### PR DESCRIPTION
Before this commit, we made this work by linking against the OTBN ELF
file, after dropping the sections that couldn't be seen (`.scratchpad`)
and fiddling around with names and section flags. Once that was done,
Ibex code could get initialised OTBN data by looking at the special
symbol. What's more, we could convert one of these symbols into an
OTBN address by subtracting the base of DMEM. (There are some other
wrinkles to do with `.bss` sections, but that's the basic idea).

This commit simplifies what Ibex does by putting a bit more of the
"symbol relocation" logic into the build system. We still link against
a mangled OTBN ELF file, but this now exposes symbols in two different
ways:

  - Any code or initialised data (`.text` or `.data`) gets copied across
    as before. Symbols pointing into these sections get a prefix that
    looks like "`_otbn_local_app_APPNAME_`". (Here, local because the
    value of the symbol is an Ibex address).

  - Zero-initialised data (`.bss`) now gets dropped and doesn't appear
    in the Ibex image at all. In particular, this means that Ibex
    won't allocate an unused chunk of zeros in its own `.bss` section.

  - All visible symbols get added a second time, but this time with
    the "`_otbn_remote_app_APPNAME_`" prefix. These have been turned
    into ABS symbols, which means that they will keep their (OTBN)
    addresses and won't get relocated when linking.

Ibex code can get pointers to the OTBN `.text`/`.data` sections (which are
`.rodata` as far as Ibex is concerned) with a similar set of macros as
before. The only change is that I've switched the name from
`OTBN_DECLARE_PTR_SYMBOL` to `OTBN_DECLARE_SYMBOL_PTR` because it seems to
make a bit more sense (this is a pointer based on a symbol). Also, it
means compile errors if I missed anything!

However, most Ibex code that's interacting with OTBN *really* wants to
copy stuff from the OTBN address space. So we've now got a new
type (`addr_t`, which is just a `uint32_t`) and a couple of new
macros (`OTBN_DECLARE_SYMBOL_ADDR`, `OTBN_ADDR_T_INIT`) to initialise it.
This works with the second sort of symbol described above and is just
an integer holding an OTBN address.

The `otbn_copy_data_to_otbn` and `otbn_copy_data_from_otbn` functions have
been switched to use `otbn_addr_t` instead of `otbn_ptr_t`, which makes a
bit more sense since we fundamentally want an OTBN address.

Finally, `otbn_data_ptr_to_dmem_addr` can now be removed! If code
actually wants to know how to map between the addresses of two
symbols, it should just use both of the macro types above and
everything will get resolved at link time, with no computation needed
at runtime.
