### PR TITLE
[dv/top_earlgrey] jtag_csr_rw sequence

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -309,4 +309,11 @@ class dv_base_reg_block extends uvm_reg_block;
                                 .map(map));
   endfunction
 
+  // Set default map for this block and all its sub-blocks.
+  function void set_default_map_w_subblks(uvm_reg_map map);
+    dv_base_reg_block subblks[$];
+    set_default_map(map);
+    get_dv_base_reg_blocks(subblks);
+    foreach (subblks[i]) subblks[i].set_default_map_w_subblks(map);
+  endfunction
 endclass

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
@@ -25,6 +25,7 @@ package jtag_riscv_agent_pkg;
   // Bits to shift byte address to word address
   parameter uint DMI_WORD_SHIFT = $clog2(DMI_DATAW / 8);
 
+  uint default_jtag_timeout = 10_000_000;
   string msg_id = "jtag_riscv_agent_pkg";
 
   // local types

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
@@ -76,7 +76,7 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
     end else begin
       if (cfg.is_rv_dm) begin
         bit [DMI_DATAW-1:0] sbcs_val = 'b1<<SbBusy;
-        `DV_CHECK_FATAL(!rv_dm_activated, "Please activate rm_dm before accessing CSRs!")
+        `DV_CHECK_FATAL(rv_dm_activated, "Please activate rm_dm before accessing CSRs!")
 
         // If using rv_dm to access csr, need to send the following seq:
         // 1). Set busy bit in sbcs.

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_dm_activation_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_dm_activation_seq.sv
@@ -5,6 +5,9 @@
 // A RM_DM jtag sequence to activate DM mode.
 class jtag_riscv_dm_activation_seq extends jtag_riscv_base_seq;
 
+  `uvm_object_utils_begin(jtag_riscv_dm_activation_seq)
+  `uvm_object_utils_end
+
   function new(string name = "");
     super.new(name);
   endfunction

--- a/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_dm_activation_seq.sv
+++ b/hw/dv/sv/jtag_riscv_agent/seq_lib/jtag_riscv_dm_activation_seq.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// A RM_DM jtag sequence to activate DM mode.
+// A RV_DM jtag sequence to activate DM mode.
 class jtag_riscv_dm_activation_seq extends jtag_riscv_base_seq;
 
   `uvm_object_utils_begin(jtag_riscv_dm_activation_seq)

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -493,7 +493,7 @@
             - Accesses to CSRs external to `rv_dm` go through RV_DM SBA interface into the `xbar`.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_jtag_csr_rw"]
     }
     {
       name: chip_rv_dm_cpu_debug_mem_not_accessable

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -365,6 +365,12 @@
       sw_images: ["sw/device/tests/clkmgr_jitter_test:1"]
       en_run_modes: ["sw_test_mode"]
     }
+    {
+      name: chip_jtag_csr_rw
+      uvm_test_seq: "chip_jtag_csr_rw_vseq"
+      en_run_modes: ["stub_cpu_mode"]
+      run_opts: ["+en_scb=0", "+csr_rw", "+create_jtag_riscv_map=1"]
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/chip_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_stub_cpu_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_common_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_jtag_csr_rw_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_base_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_full_aon_reset_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_main_power_glitch_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -125,6 +125,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Apply RAL fixes before it is locked.
   protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
     RAL_T chip_ral;
+    super.post_build_ral_settings(ral);
     if (!$cast(chip_ral, ral)) return;
     // Out of reset, the link is in disconnected state.
     chip_ral.usbdev.intr_state.disconnected.set_reset(1'b1);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_csr_rw_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_jtag_csr_rw_vseq.sv
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Run chip csr_rw sequence via JTAG RV_DM interface.
+class chip_jtag_csr_rw_vseq extends chip_common_vseq;
+  `uvm_object_utils(chip_jtag_csr_rw_vseq)
+
+  `uvm_object_new
+
+  virtual task pre_start();
+    select_jtag = SelectRVJtagTap;
+    cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
+    super.pre_start();
+  endtask
+
+  virtual task body();
+    jtag_riscv_dm_activation_seq jtag_dm_activation_seq =
+        jtag_riscv_dm_activation_seq::type_id::create("jtag_dm_activation_seq");
+
+    cfg.m_jtag_riscv_agent_cfg.allow_errors = 1;
+    jtag_dm_activation_seq.start(p_sequencer.jtag_sequencer_h);
+    cfg.m_jtag_riscv_agent_cfg.allow_errors = 0;
+
+    run_common_vseq_wrapper(num_trans);
+  endtask : body
+
+  virtual task run_csr_vseq(string csr_test_type = "",
+                            int    num_test_csrs = 0,
+                            bit    do_rand_wr_and_reset = 1,
+                            string ral_name = "");
+    // JTAG cannot process outstanding access, so JTAG protocol will process one request at a time.
+    // However, still set this varible to 1 to avoid spinwait timeout when sequence sends all csrs
+    // transaction requests at .
+    max_outstanding_accesses = 1;
+
+    // Run 500 csrs at one sequence to avoid simulation timeout.
+    super.run_csr_vseq(csr_test_type, 500, do_rand_wr_and_reset, ral_name);
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -13,7 +13,8 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
   virtual task pre_start();
     super.pre_start();
     // Deselect JTAG interface.
-    cfg.tap_straps_vif.drive(DeselectJtagTap);
+    if (cfg.jtag_riscv_map != null) cfg.tap_straps_vif.drive(SelectRVJtagTap);
+    else                            cfg.tap_straps_vif.drive(DeselectJtagTap);
     enable_asserts_in_hw_reset_rand_wr = 0;
 
     // In top-level uart RX pin may be selected in pinmux. CSR tests may randomly enable line
@@ -44,7 +45,7 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     // make sure jtag rst triggers
     cfg.tap_straps_vif.drive(SelectRVJtagTap);
     super.dut_init(reset_kind);
-    cfg.tap_straps_vif.drive(DeselectJtagTap);
+    if (cfg.jtag_riscv_map == null) cfg.tap_straps_vif.drive(DeselectJtagTap);
   endtask
 
 endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -5,6 +5,7 @@
 `include "chip_base_vseq.sv"
 `include "chip_stub_cpu_base_vseq.sv"
 `include "chip_common_vseq.sv"
+`include "chip_jtag_csr_rw_vseq.sv"
 // This needs to be listed prior to all sequences that derive from it.
 `include "chip_sw_base_vseq.sv"
 `include "chip_sw_full_aon_reset_vseq.sv"
@@ -16,4 +17,3 @@
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"
 `include "chip_sw_rom_ctrl_integrity_check_vseq.sv"
-


### PR DESCRIPTION
This PR has four commits, first two are included in two separate PRs: #10100 #10101
So only the two last commit is relevant. 

This PR adds a jtag_csr_rw sequence that uses RV_DM to access chip's SBA bus.
This sequence will reuse chip_csr_rw sequence, but only changes the access point from TLUL to JTAG interface.

The last commit adds a `sbcs` field `sbbusy` checking before reading out the data register.
This is to ensure the transaction finished before we proceed to next item. 
This is implemented to fix an issue when reading out aon_clk IPs, the transaction is much slower compare to jtag clock.