### PR TITLE
[ entropy_src, dv ] Clean shutdown sequences

### DIFF
--- a/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
+++ b/hw/dv/sv/push_pull_agent/seq_lib/push_pull_indefinite_host_seq.sv
@@ -11,30 +11,48 @@
 
 class push_pull_indefinite_host_seq #(parameter int HostDataWidth = 32,
                                       parameter int DeviceDataWidth = HostDataWidth)
-  extends push_pull_base_seq #(HostDataWidth, DeviceDataWidth);
+  extends push_pull_host_seq #(HostDataWidth, DeviceDataWidth);
 
   `uvm_object_param_utils(push_pull_indefinite_host_seq#(HostDataWidth, DeviceDataWidth))
 
   `uvm_object_new
 
-  bit do_stop;
+  typedef enum int {
+    Continue = 0,
+    Stop     = 1,
+    HardStop = 2
+  } stop_status_e;
+
+  stop_status_e stop_status;
 
   virtual task body();
-    while (!do_stop) begin : send_req
-      `uvm_create(req)
-      start_item(req);
-      randomize_item(req);
-      finish_item(req);
-      get_response(rsp);
-    end : send_req
+    fork : isolation_fork
+      begin
+        fork
+          begin
+            wait(stop_status == HardStop);
+            `uvm_info(`gfn, "Rec'd stop message", UVM_FULL)
+          end
+          while (stop_status == Continue) begin : send_req
+            `uvm_create(req)
+            start_item(req);
+            randomize_item(req);
+            finish_item(req);
+            get_response(rsp);
+          end : send_req
+        join_any;
+        disable fork;
+      end
+    join : isolation_fork
+    `uvm_info(`gfn, "STOPPED", UVM_FULL)
   endtask
 
-  virtual task stop();
-    do_stop = 1;
+  virtual task stop(bit hard = 1);
+    stop_status = hard ? HardStop : Stop;
   endtask
 
   virtual task pre_start();
     super.pre_start();
-    do_stop = 0;
+    stop_status = Continue;
   endtask
 endclass

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -17,6 +17,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   rand push_pull_agent_cfg#(.HostDataWidth(FIPS_CSRNG_BUS_WIDTH))
        m_csrng_agent_cfg;
 
+  // Additional reset interface for the csrng.
+  virtual clk_rst_if    csrng_rst_vif;
   virtual pins_if#(8)   otp_en_es_fw_read_vif;
   virtual pins_if#(8)   otp_en_es_fw_over_vif;
 

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -74,11 +74,12 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
         // shutting down the the AST/RNG.  Otherwise the CSRNG pull agent
         // will stall waiting for entropy.
         `uvm_info(`gfn, "Stopping CSRNG seq", UVM_LOW)
-         m_csrng_pull_seq.stop();
-         m_csrng_pull_seq.wait_for_sequence_state(UVM_FINISHED);
-         `uvm_info(`gfn, "Stopping RNG seq", UVM_LOW)
-         m_rng_push_seq.stop();
-         m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
+        m_csrng_pull_seq.stop(.hard(1));
+        m_csrng_pull_seq.wait_for_sequence_state(UVM_FINISHED);
+        `uvm_info(`gfn, "Stopping RNG seq", UVM_LOW)
+        m_rng_push_seq.stop(.hard(0));
+        m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
+        `uvm_info(`gfn, "Exiting test body.", UVM_LOW)
       end
     join
   endtask : body

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_smoke_vseq.sv
@@ -33,7 +33,8 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
           // Update the count of remaining seeds to read
           seed_cnt -= available_seeds;
         end while (seed_cnt > 0);
-        m_rng_push_seq.stop();
+        m_rng_push_seq.stop(.hard(0));
+        m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
       end
     join
 


### PR DESCRIPTION
The entropy_src has a unique feature: Under certain conditions it must _stop_
honoring requests for more data.   This can happen, for instance, if it is
configured for very strict health check thresholds.  Furthermore,
it is possible for the testbench to instruct this DUT to adhere to completely
unrealistic thresholds, and in such cases it is also impossible for the testbench
to tell the `entropy_src` to relax.  So in these cases, no CSRNG data will likely be
released for the remainder of the test.

(Such conditions can also appear in directed alert tests.)

These conditions are directly at odds with the push-pull PULL sequences which expect
every request to be acknowledged once REQ is asserted.  In such cases, the
push_pull_host_seq's will not gracefully exit.  Furthermore, even after the sequence
has been aborted, the push_pull_monitor will continue to object because until both
REQ and ACK have been cleared.   This leads to interminable simulations.

This commit solves this problem in two steps:
1. The push_pull_indefinite_host_seq now has an option for a "hard" stop
which will interrupt and halt the sequence, even if a sequence item is incomplete.
2. The testbench adds a second _auxilliary_ reset for the CSRNG pull agent.
This reset is only applied at the very end of the sequence, and _only_ to the CSRNG
VIF.  (Applying a global testbench reset at the end of the sim, both alters the state of the
DUT and for some simulators it also causes errors in the RNG push agent.)
  - This later step is only needed for the unit test environment.  In the top-level environment
    the entropy_src would be connected directly to the CSRNG (no monitor).

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>