### PR TITLE
[verilator,build] Support Verilator build on MacOS.

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -12,7 +12,7 @@
 
 #include "otbn_memutil.h"
 
-class ISSWrapper;
+struct ISSWrapper;
 
 class OtbnModel {
  public:


### PR DESCRIPTION
- Install build tools using brew
- Build Verible from source
- Build Verilator from source (install binutils ar using brew and configure verilator to use it)
        ./configure --prefix=/tools/verilator/$VERILATOR_VERSION AR=<absolute path to ar>/ar  