### PR TITLE
[sw/silicon_creator] Add dynamic functional tests for sigverify and sigverify_mod_exp_ibex

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -428,6 +428,24 @@ cc_library(
 )
 
 opentitan_functest(
+    name = "sigverify_mod_exp_ibex_functest",
+    srcs = ["sigverify_mod_exp_ibex_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+        tags = [
+            "manual",
+            "verilator",
+        ],
+    ),
+    deps = [
+        ":sigverify_mod_exp_ibex",
+        ":sigverify_testvectors",
+        ":test_main",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+opentitan_functest(
     name = "sigverify_mod_exp_otbn_functest",
     srcs = ["sigverify_mod_exp_otbn_functest.c"],
     verilator = verilator_params(

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -397,6 +397,24 @@ opentitan_functest(
     ],
 )
 
+opentitan_functest(
+    name = "sigverify_dynamic_functest",
+    srcs = ["sigverify_dynamic_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+        tags = [
+            "manual",
+            "verilator",
+        ],
+    ),
+    deps = [
+        ":sigverify",
+        ":sigverify_testvectors",
+        ":test_main",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
 cc_library(
     name = "sigverify_mod_exp_ibex",
     srcs = ["sigverify_mod_exp_ibex.c"],

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -311,6 +311,23 @@ mask_rom_tests += {
   }
 }
 
+sw_silicon_creator_lib_sigverify_dynamic_functest = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_sigverify_dynamic_functest',
+    sources: [
+      'sigverify_dynamic_functest.c'
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_sigverify,
+    ],
+  ),
+)
+mask_rom_tests += {
+  'sw_silicon_creator_lib_sigverify_dynamic_functest': {
+    'library': sw_silicon_creator_lib_sigverify_dynamic_functest,
+  }
+}
+
 sw_silicon_creator_lib_sigverify_mod_exp_ibex_functest = declare_dependency(
   link_with: static_library(
     'sw_silicon_creator_lib_sigverify_mod_exp_ibex_functest',

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -311,6 +311,23 @@ mask_rom_tests += {
   }
 }
 
+sw_silicon_creator_lib_sigverify_mod_exp_ibex_functest = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_sigverify_mod_exp_ibex_functest',
+    sources: [
+      'sigverify_mod_exp_ibex_functest.c'
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_sigverify,
+    ],
+  ),
+)
+mask_rom_tests += {
+  'sw_silicon_creator_lib_sigverify_mod_exp_ibex_functest': {
+    'library': sw_silicon_creator_lib_sigverify_mod_exp_ibex_functest,
+  }
+}
+
 sw_silicon_creator_lib_sigverify_mod_exp_otbn_functest = declare_dependency(
   link_with: static_library(
     'sw_silicon_creator_lib_sigverify_mod_exp_otbn_functest',

--- a/sw/device/silicon_creator/lib/sigverify_dynamic_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify_dynamic_functest.c
@@ -1,0 +1,65 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/lib/sigverify.h"
+#include "sw/device/silicon_creator/lib/sigverify_tests/sigverify_testvectors.h"
+#include "sw/device/silicon_creator/lib/test_main.h"
+
+// Index of the test vector currently under test
+static uint32_t test_index;
+
+rom_error_t sigverify_test(void) {
+  sigverify_test_vector_t testvec = sigverify_tests[test_index];
+
+  // Extract the digest from the encoded message
+  hmac_digest_t digest;
+  memcpy(digest.digest, testvec.encoded_msg,
+         kHmacDigestNumWords * sizeof(uint32_t));
+
+  uint32_t flash_exec = 0;
+  rom_error_t result = sigverify_rsa_verify(&testvec.sig, &testvec.key, &digest,
+                                            kLcStateRma, &flash_exec);
+
+  rom_error_t test_result;
+  if (testvec.valid) {
+    CHECK(flash_exec == kSigverifyFlashExec);
+    if (result == kErrorOk) {
+      test_result = kErrorOk;
+    } else {
+      // Signature verification failed when it was expected to pass.
+      LOG_ERROR("Error while attempting to verify a valid signature.");
+      LOG_INFO("Test notes: %s", testvec.comment);
+      test_result = result;
+    }
+  } else {
+    CHECK(flash_exec == UINT32_MAX);
+    if (result == kErrorOk) {
+      // Signature verification passed when it was expected to fail.
+      LOG_ERROR("Invalid signature passed verification.");
+      LOG_INFO("Test notes: %s", testvec.comment);
+      test_result = kErrorUnknown;
+    } else {
+      test_result = kErrorOk;
+    }
+  }
+
+  return test_result;
+}
+
+const test_config_t kTestConfig;
+
+bool test_main(void) {
+  rom_error_t result = kErrorOk;
+
+  for (uint32_t i = 0; i < SIGVERIFY_NUM_TESTS; i++) {
+    LOG_INFO("Starting test vector %d of %d...", i + 1, SIGVERIFY_NUM_TESTS);
+    test_index = i;
+    EXECUTE_TEST(result, sigverify_test);
+  }
+  return result == kErrorOk;
+}

--- a/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify_mod_exp_ibex_functest.c
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
+#include "sw/device/silicon_creator/lib/sigverify_tests/sigverify_testvectors.h"
+#include "sw/device/silicon_creator/lib/test_main.h"
+
+// Index of the test vector currently under test
+static uint32_t test_index;
+
+rom_error_t sigverify_mod_exp_ibex_test(void) {
+  sigverify_test_vector_t testvec = sigverify_tests[test_index];
+
+  sigverify_rsa_buffer_t recovered_message;
+  RETURN_IF_ERROR(
+      sigverify_mod_exp_ibex(&testvec.key, &testvec.sig, &recovered_message));
+
+  bool passed = memcmp(testvec.encoded_msg, recovered_message.data,
+                       sizeof(testvec.encoded_msg)) == 0;
+  if (testvec.valid && !passed) {
+    // Signature verification failed when it was expected to pass.
+    LOG_ERROR("Failed to verify a valid signature.");
+    LOG_INFO("Test notes: %s", testvec.comment);
+    return kErrorUnknown;
+  } else if (!testvec.valid && passed) {
+    // Signature verification passed when it was expected to fail.
+    LOG_ERROR("Invalid signature passed verification.");
+    LOG_INFO("Test notes: %s", testvec.comment);
+    return kErrorUnknown;
+  }
+
+  return kErrorOk;
+}
+
+const test_config_t kTestConfig;
+
+bool test_main(void) {
+  rom_error_t result = kErrorOk;
+
+  for (uint32_t i = 0; i < SIGVERIFY_NUM_TESTS; i++) {
+    LOG_INFO("Starting test vector %d of %d...", i + 1, SIGVERIFY_NUM_TESTS);
+    test_index = i;
+    EXECUTE_TEST(result, sigverify_mod_exp_ibex_test);
+  }
+  return result == kErrorOk;
+}


### PR DESCRIPTION
Follow-up to https://github.com/lowRISC/opentitan/pull/9811, which allows us to run large, random (once #10088 is merged), or external RSA signature test sets for `sigverify_mod_exp_otbn`, this PR adds similar files to run those tests sets on `sigverify_mod_exp_ibex` and the top-level `sigverify`. I checked locally that both pass on the Wycheproof set and on 100 random ones.

Quick reminder of the setup for running alternate test vectors:
- Generate a set of random test vectors or parse external test vectors by following the instructions in the main crypto library (`sw/device/silicon_creator/lib/crypto/tests/README.md`). The output is an HJSON file with the requested test vectors.
- Run `sigverify_set_testvectors.py <your hjson file>` to overwrite `sigverify_testvectors.h` with the new test vector set.