### PR TITLE
[dv] Minor lint fixes in pwrmgr/rstmgr SVA interfaces

### DIFF
--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -56,7 +56,7 @@ module pwrmgr_bind;
     // Input resets.
     .rstreqs_i(rstreqs_i),
     .reset_en(reg2hw.reset_en),
-    .sw_rst_req_i(sw_rst_req_i),
+    .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
     .main_rst_req_i(rst_main_ni),
     .esc_rst_req_i(esc_rst_req),
     // The outputs from pwrmgr.

--- a/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
@@ -43,8 +43,8 @@ module rstmgr_bind;
 
   bind rstmgr rstmgr_attrs_sva_if rstmgr_attrs_sva_if (
     .rst_ni,
-    .actual_alert_info_attr({'0, hw2reg.alert_info_attr}),
-    .actual_cpu_info_attr({'0, hw2reg.cpu_info_attr}),
+    .actual_alert_info_attr(int'(hw2reg.alert_info_attr)),
+    .actual_cpu_info_attr(int'(hw2reg.cpu_info_attr)),
     .expected_alert_info_attr(($bits(alert_dump_i) + 31) / 32),
     .expected_cpu_info_attr(($bits(cpu_dump_i) + 31) / 32)
   );

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -105,7 +105,7 @@ interface rstmgr_cascading_sva_if (
           clk_aon_i, disable_sva)
 
   logic scan_reset_n;
-  always_comb scan_reset_n = scan_rst_ni || (scanmode_i != lc_ctrl_pkg::On);
+  always_comb scan_reset_n = scan_rst_ni || prim_mubi_pkg::mubi4_test_true_strict(scanmode_i);
 
   logic [rstmgr_pkg::PowerDomains-1:0] effective_aon_rst;
   always_comb effective_aon_rst = resets_o.rst_por_aon_n & {rstmgr_pkg::PowerDomains{scan_reset_n}};


### PR DESCRIPTION
These little errors cause warnings in the chip-level build (see #10083).