### PR TITLE
[otbn] Fix qualifying writes to registers by operational state

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -180,9 +180,10 @@ class otbn_scoreboard extends cip_base_scoreboard #(
       case (csr.get_name())
         // Spot writes to the "cmd" register that tell us to start
         "cmd": begin
-          // We start the execution when we see a write of the EXECUTE command. See the comment
-          // above pending_start_tl_trans to see how this tracking works.
-          if (item.a_data == otbn_pkg::CmdExecute) begin
+          // We start the execution when we see a write of the EXECUTE command and we are currently
+          // in the IDLE operational state. See the comment above pending_start_tl_trans to see how
+          // this tracking works.
+          if ((item.a_data == otbn_pkg::CmdExecute) && (model_status == otbn_pkg::StatusIdle)) begin
             // Set a flag: we're expecting the model to start on the next posedge. Also, spawn off a
             // checking thread that will make sure the flag has been cleared again by the following
             // posedge. Note that the reset() method is only called in the DV base class on the

--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -24,6 +24,7 @@ module otbn_bind;
     .clk_i    (clk_i),
     .rst_ni   (rst_ni),
     .reg2hw   (reg2hw),
+    .hw2reg   (hw2reg),
     .done_i   (done),
     .idle_o_i (idle_o)
   );

--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -11,18 +11,18 @@ module otbn_idle_checker
   input logic         rst_ni,
 
   input otbn_reg2hw_t reg2hw,
+  input otbn_hw2reg_t hw2reg,
   input logic         done_i,
 
   input logic         idle_o_i
 );
 
-  // Detect writes of CmdExecute to CMD
-  logic cmd_start;
-  assign cmd_start = reg2hw.cmd.qe && (reg2hw.cmd.q == otbn_pkg::CmdExecute);
+  // Detect writes of CmdExecute to CMD. They only take effect if we are in state IDLE
+  logic start_req, do_start;
+  assign start_req = reg2hw.cmd.qe && (reg2hw.cmd.q == otbn_pkg::CmdExecute);
+  assign do_start = start_req && (hw2reg.status.d == otbn_pkg::StatusIdle);
 
-  // Our model of whether OTBN is running or not. We start on cmd_start if we're not already running
-  // and stop on done if we are. Note that the "running" signal includes the cycle that we see
-  // cmd_start
+  // Our model of whether OTBN is running or not. We start on do_start and stop on done.
   logic running_q, running_d;
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -31,12 +31,13 @@ module otbn_idle_checker
       running_q <= running_d;
     end
   end
-  assign running_d = (cmd_start & ~running_q) | (running_q & ~done_i);
+  assign running_d = (do_start & ~running_q) | (running_q & ~done_i);
 
-  // We should never see done_i when we're not already running. (The converse assertion, that we
+  // We should never see done_i when we're not already running. The converse assertion, that we
   // never see cmd_start when we are running, need not be true: the host can do that if it likes and
-  // OTBN will ignore it).
+  // OTBN will ignore it. But we should never see do_start when we think we're running.
   `ASSERT(RunningIfDone_A, done_i |-> running_q)
+  `ASSERT(IdleIfStart_A, do_start |-> !running_q)
 
   // Check that we've modelled the running/not-running logic correctly. The idle_o pin from OTBN
   // should be true iff running is false

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -91,8 +91,7 @@ module otbn
 
   logic start_d, start_q;
   logic busy_execute_d, busy_execute_q;
-  logic done;
-  logic locked;
+  logic done, locked, idle;
   logic illegal_bus_access_d, illegal_bus_access_q;
 
   logic recoverable_err;
@@ -118,10 +117,17 @@ module otbn
   tlul_pkg::tl_h2d_t tl_win_h2d[2];
   tlul_pkg::tl_d2h_t tl_win_d2h[2];
 
+  // The clock can be gated and some registers can be updated as long as OTBN isn't currently
+  // running. Other registers can only be updated when OTBN is in the Idle state (which also implies
+  // !locked).
+  logic is_not_running;
+  assign is_not_running = ~busy_execute_q;
+
   // Inter-module signals ======================================================
 
-  // TODO: Use STATUS == IDLE here.
-  assign idle_o = ~busy_execute_q;
+  // Note: This is not the same thing as STATUS == IDLE. For example, we want to allow clock gating
+  // when locked.
+  assign idle_o = is_not_running;
 
   // TODO: These two signals aren't technically in the same clock domain. Sort out how we do the
   // signalling properly.
@@ -616,7 +622,7 @@ module otbn
 
   // CMD register
   // start is flopped to avoid long timing paths from the TL fabric into OTBN internals.
-  assign start_d = reg2hw.cmd.qe & (reg2hw.cmd.q == CmdExecute);
+  assign start_d = reg2hw.cmd.qe & (reg2hw.cmd.q == CmdExecute) & idle;
   assign illegal_bus_access_d = dmem_illegal_bus_access | imem_illegal_bus_access;
 
   // Flop `illegal_bus_access_q` so we know an illegal bus access has happened and to break a timing
@@ -636,18 +642,21 @@ module otbn
     unique case (1'b1)
       busy_execute_q: hw2reg.status.d = StatusBusyExecute;
       locked:         hw2reg.status.d = StatusLocked;
-      // TODO: Add other busy flags, and assert onehot encoding.
-      default:        hw2reg.status.d = StatusIdle;
+      idle:           hw2reg.status.d = StatusIdle;
+      // TODO: Add other busy flags
+
+      // Default case should not be reachable (checked by OtbnStatesOneHot assertion below)
+      default:        hw2reg.status.d = StatusLocked;
     endcase
   end
   assign hw2reg.status.de = 1'b1;
 
-  `ASSERT(OtbnStatesOneHot, $onehot0({busy_execute_q, locked}))
+  `ASSERT(OtbnStatesOneHot, $onehot({busy_execute_q, locked, idle}))
 
   // CTRL register
   assign software_errs_fatal_d =
-    reg2hw.ctrl.qe && (hw2reg.status.d == StatusIdle) ? reg2hw.ctrl.q :
-                                                        software_errs_fatal_q;
+    reg2hw.ctrl.qe && idle ? reg2hw.ctrl.q :
+                             software_errs_fatal_q;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -678,7 +687,7 @@ module otbn
   assign hw2reg.err_bits.lifecycle_escalation.d = err_bits_q.lifecycle_escalation;
   assign hw2reg.err_bits.fatal_software.d = err_bits_q.fatal_software;
 
-  assign err_bits_clear = reg2hw.err_bits.bad_data_addr.qe & ~busy_execute_q;
+  assign err_bits_clear = reg2hw.err_bits.bad_data_addr.qe & is_not_running;
   assign err_bits_d = err_bits_clear ? '0 : err_bits;
   assign err_bits_en = err_bits_clear | done;
 
@@ -733,7 +742,7 @@ module otbn
   logic        insn_cnt_clear;
   logic        unused_insn_cnt_q;
   assign hw2reg.insn_cnt.d = insn_cnt;
-  assign insn_cnt_clear = (reg2hw.insn_cnt.qe & ~busy_execute_q) | lifecycle_escalation;
+  assign insn_cnt_clear = (reg2hw.insn_cnt.qe & is_not_running) | lifecycle_escalation;
   // Ignore all write data to insn_cnt. All writes zero the register.
   assign unused_insn_cnt_q = ^reg2hw.insn_cnt.q;
 
@@ -1029,6 +1038,9 @@ module otbn
       .sideload_key_shares_valid_i ({2{keymgr_key_i.valid}})
     );
   `endif
+
+  // We're idle if we're neither busy executing something nor locked
+  assign idle = ~(busy_execute_q | locked);
 
   // The core can never signal a write to IMEM
   assign imem_write_core = 1'b0;


### PR DESCRIPTION
We could write to CMD even when in the locked state (oops!). I've also
tidied things up a little, defining an '`idle`' signal so that the
current operational state is one-hot encoded in

    {busy_execute_q, locked, idle}

I've also defined an '`is_not_running`' signal that we use to for
`idle_o` ("clock gate me") and to qualify writes to ERR_BITS, INSN_CNT.

Amusingly, the DV code had the same problem so we have to do
corresponding updates for the scoreboard and a checker for the
"`idle_o`" output as well.
