### PR TITLE
[sw,otbn] Add scripts for OTBN information-flow analysis.

### DIFF
--- a/hw/ip/otbn/util/analyze_information_flow.py
+++ b/hw/ip/otbn/util/analyze_information_flow.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+from typing import Dict, List, Optional, Set, Tuple
+
+from shared.control_flow import program_control_graph, subroutine_control_graph
+from shared.decode import decode_elf
+from shared.information_flow_analysis import (get_program_iflow,
+                                              get_subroutine_iflow,
+                                              stringify_control_deps)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=(
+        'Analyze the control flow and information flow of an OTBN '
+        'program or subroutine.'))
+    parser.add_argument('elf', help=('The .elf file to check.'))
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help=('Print full control-flow and information-flow graphs.'))
+    parser.add_argument(
+        '--subroutine',
+        required=False,
+        help=(
+            'The specific subroutine to check. If not provided, start point is '
+            '_imem_start (whole program).'))
+    parser.add_argument(
+        '--secrets',
+        nargs='+',
+        type=str,
+        required=False,
+        help=(
+            'Initially secret information-flow nodes. If provided, the final '
+            'secrets will be printed.'))
+    args = parser.parse_args()
+    program = decode_elf(args.elf)
+
+    # Compute control-flow graph.
+    if args.subroutine is None:
+        graph = program_control_graph(program)
+    else:
+        graph = subroutine_control_graph(program, args.subroutine)
+
+    # Only print the control-flow graph if --verbose is set.
+    if args.verbose:
+        print('Control-flow graph:')
+        print(graph.pretty(program, indent=2))
+
+    # Compute information-flow graph(s).
+    ret_iflow, end_iflow = None, None
+    if args.subroutine is None:
+        what = 'program'
+        end_iflow, control_deps = get_program_iflow(program, graph)
+    else:
+        what = 'subroutine'
+        ret_iflow, end_iflow, control_deps = get_subroutine_iflow(
+            program, graph, args.subroutine)
+
+    # If no secrets were given or the --verbose flag is set, then print the
+    # full information-flow graphs.
+    if (args.verbose or args.secrets is None):
+        if ret_iflow is not None:
+            print(
+                'Information flow for paths ending in a return to the caller:')
+            print(ret_iflow.pretty(indent=2))
+            if end_iflow is not None:
+                print('--------')
+
+        if end_iflow is not None:
+            print('Information flow for paths ending the program:')
+            print(end_iflow.pretty(indent=2))
+
+    if args.secrets is None:
+        # If no initial secrets were provided, we will print all nodes that
+        # could influence control flow.
+        control_what = 'information-flow nodes'
+    else:
+        # If secrets were provided, only show the ways in which those specific
+        # nodes could influence control flow.
+        control_what = 'secrets'
+        control_deps = {
+            name: pcs
+            for name, pcs in control_deps.items() if name in args.secrets
+        }
+
+    # Print any (secret) nodes that influence control flow, and the PCs of the
+    # control-flow instructions they influence.
+    if len(control_deps) == 0:
+        print('No {} were found to influence this {}\'s control flow.'.format(
+            control_what, what))
+    else:
+        print('The following {} may influence control flow in this {}:'.format(
+            control_what, what))
+        for node in stringify_control_deps(program, control_deps):
+            print(node)
+
+    # Print final secrets (if initial secrets were provided).
+    if args.secrets is not None:
+        if ret_iflow is not None:
+            final_secrets = {
+                sink
+                for node in args.secrets for sink in ret_iflow.sinks(node)
+            }
+            print('Final secrets for paths ending in a return to the caller:',
+                  ', '.join(sorted(final_secrets)))
+        if end_iflow is not None:
+            final_secrets = {
+                sink
+                for node in args.secrets for sink in end_iflow.sinks(node)
+            }
+            print('Final secrets for paths ending the program:',
+                  ', '.join(sorted(final_secrets)))
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hw/ip/otbn/util/check_const_time.py
+++ b/hw/ip/otbn/util/check_const_time.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import sys
+from typing import Dict, List, Optional, Set, Tuple
+
+from shared.check import CheckResult
+from shared.control_flow import program_control_graph, subroutine_control_graph
+from shared.decode import decode_elf
+from shared.information_flow_analysis import (get_program_iflow,
+                                              get_subroutine_iflow,
+                                              stringify_control_deps)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Analyze whether secret data affects the control flow of '
+        'an OTBN program or subroutine.')
+    parser.add_argument('elf', help=('The .elf file to check.'))
+    parser.add_argument('--verbose', action='store_true')
+    parser.add_argument(
+        '--subroutine',
+        required=False,
+        help=('The specific subroutine to check. If not provided, the start '
+              'point is _imem_start (whole program).'))
+    parser.add_argument(
+        '--secrets',
+        nargs='+',
+        type=str,
+        required=False,
+        help=('Initial secret information-flow nodes. If not provided, '
+              'assume everything is secret; check that the subroutine or '
+              'program has only one possible control-flow path regardless '
+              'of input.'))
+    args = parser.parse_args()
+
+    # Compute control graph and get all nodes that influence control flow.
+    program = decode_elf(args.elf)
+    if args.subroutine is None:
+        graph = program_control_graph(program)
+        to_analyze = 'entire program'
+        _, control_deps = get_program_iflow(program, graph)
+    else:
+        graph = subroutine_control_graph(program, args.subroutine)
+        to_analyze = 'subroutine {}'.format(args.subroutine)
+        _, _, control_deps = get_subroutine_iflow(program, graph,
+                                                  args.subroutine)
+
+    if args.secrets is None:
+        if args.verbose:
+            print(
+                'No specific secrets provided; checking that {} has only one '
+                'control-flow path'.format(to_analyze))
+        secret_control_deps = control_deps
+    else:
+        if args.verbose:
+            print('Analyzing {} with initial secrets {}'.format(
+                to_analyze, args.secrets))
+        # If secrets were provided, only show the ways in which those specific
+        # nodes could influence control flow.
+        secret_control_deps = {
+            node: pcs
+            for node, pcs in control_deps.items() if node in args.secrets
+        }
+
+    out = CheckResult()
+
+    if len(secret_control_deps) != 0:
+        msg = 'The following secrets may influence control flow:\n  '
+        msg += '\n  '.join(stringify_control_deps(program,
+                                                  secret_control_deps))
+        out.err(msg)
+
+    if args.verbose or out.has_errors() or out.has_warnings():
+        print(out.report())
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/hw/ip/otbn/util/shared/information_flow.py
+++ b/hw/ip/otbn/util/shared/information_flow.py
@@ -522,9 +522,15 @@ class InsnInformationFlow:
         for rule in self.rules:
             rule_graph = rule.evaluate(op_vals, constant_regs)
             graph = safe_update_iflow(graph, rule_graph)
+
         if graph is None:
             # If no rules are triggered, return an empty graph
             graph = InformationFlowGraph({})
+
+        # The x0 register is special and always zero; make sure the
+        # information-flow graph shows it having no dependencies.
+        graph.flow['x0'] = set()
+
         return graph
 
     @staticmethod


### PR DESCRIPTION
Follows up to #9716; adds two scripts to interface with the OTBN information-flow analysis machinery. One of them checks that programs are constant-time (with respect to certain inputs, if provided), and the other gives more detailed information (e.g. the full information-flow graph). Below are more specific usage examples.

### Constant-time checker: `check_const_time.py`

Pass in a `.elf` file and a subroutine name to find out if that subroutine is constant time:
```shell
$ ./check_const_time.py --verbose run_rsa_verify_3072.elf --subroutine mul256_w30xw25
No specific secrets provided; checking that subroutine mul256_w30xw25 has only one control-flow path
PASS
```

Pass in some initially-secret "information-flow nodes" (i.e. registers, flag
groups or individual flags, special registers) to see if the subroutine is
constant-time *with respect to those nodes*.
```
$ ./check_const_time.py run_rsa_verify_3072.elf --subroutine mont_loop --secrets w1 w2 w3 fg0 acc
Analyzing subroutine mont_loop with initial secrets ['w1', 'w2', 'w3', 'fg0', 'acc']
ERROR: The following secrets may influence control flow:
  w2 (via beq at PC 0x1a8)
  w3 (via beq at PC 0x1a8)
```

Omit `--subroutine` to traverse the entire program's execution:
```shell
$ ./check_const_time.py --verbose run_rsa_verify_3072.elf --secrets w2 w3 w4
Analyzing entire program with initial secrets ['w2', 'w3', 'w4']
PASS
```

### More in-depth analysis: `analyze_information_flow.py`

Given some initial secrets, see not only which secrets influence control flow
but also which nodes are secret when the subroutine or program finishes.
```shell
$ ./analyze_information_flow.py run_rsa_verify_3072.elf --subroutine mul256_w30xw25 --secrets w25
No secrets were found to influence this subroutine's control flow.
Final secrets for paths ending in a return to the caller: acc, fg0-l, fg0-m, fg0-z, w25, w26, w27
```

Omit `--secrets` or pass `--verbose` to get a full information-flow graph for
the subroutine or program:
```shell
$ ./analyze_information_flow.py run_rsa_verify_3072.elf --subroutine mul256_w30xw25
Information flow for paths ending in a return to the caller:
  w25,w30       -> acc
  fg0-l,w25,w30 -> fg0-l
  fg0-m,w25,w30 -> fg0-m
  fg0-z,w25,w30 -> fg0-z
  w25,w30       -> w26
  w25,w30       -> w27
                -> x0
No control-flow nodes were found to influence this subroutine's control flow.
```

Passing `--verbose` also prints out the control-flow graph of the subroutine
program (which is not very interesting for this subroutine, but can be quite
useful when debugging):
```shell
$ ./analyze_information_flow.py --verbose run_rsa_verify_3072.elf --subroutine mul256_w30xw25
Control-flow graph:
  <mul256_w30xw25>
  0x88: bn.mulqacc.z   w30.0, w25.0, 0
  0x8c: bn.mulqacc     w30.1, w25.0, 64
  0x90: bn.mulqacc.so  w27.l, w30.0, w25.1, 64
  0x94: bn.mulqacc     w30.2, w25.0, 0
  0x98: bn.mulqacc     w30.1, w25.1, 0
  0x9c: bn.mulqacc     w30.0, w25.2, 0
  0xa0: bn.mulqacc     w30.3, w25.0, 64
  0xa4: bn.mulqacc     w30.2, w25.1, 64
  0xa8: bn.mulqacc     w30.1, w25.2, 64
  0xac: bn.mulqacc.so  w27.u, w30.0, w25.3, 64
  0xb0: bn.mulqacc     w30.3, w25.1, 0
  0xb4: bn.mulqacc     w30.2, w25.2, 0
  0xb8: bn.mulqacc     w30.1, w25.3, 0
  0xbc: bn.mulqacc     w30.3, w25.2, 64
  0xc0: bn.mulqacc.so  w26.l, w30.2, w25.3, 64
  0xc4: bn.mulqacc.so  w26.u, w30.3, w25.3, 0
  0xc8: jalr           x0, x1, 0
  ->
  RET
Information flow for paths ending in a return to the caller:
  w25,w30       -> acc
  fg0-l,w25,w30 -> fg0-l
  fg0-m,w25,w30 -> fg0-m
  fg0-z,w25,w30 -> fg0-z
  w25,w30       -> w26
  w25,w30       -> w27
                -> x0
No information-flow nodes were found to influence this subroutine's control flow.
```
