### PR TITLE
[otbn] Fatal alert for URND lockup

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -125,6 +125,7 @@ module otbn_controller
   output logic rnd_req_o,
   output logic rnd_prefetch_req_o,
   input  logic rnd_valid_i,
+  input  logic urnd_state_err_i,
 
   // Secure Wipe
   input  logic secure_wipe_running_i,
@@ -442,7 +443,7 @@ module otbn_controller
   assign err_bits.lifecycle_escalation = lifecycle_escalation_i;
   assign err_bits.illegal_bus_access   = illegal_bus_access_i;
   assign err_bits.bad_internal_state   = start_stop_state_error_i | state_error |
-                                          otbn_scramble_state_error_i;
+                                         otbn_scramble_state_error_i | urnd_state_err_i;
   assign err_bits.bus_intg_violation   = bus_intg_violation_i;
   assign err_bits.reg_intg_violation   = rf_base_rd_data_err_i | rf_bignum_rd_data_err;
   assign err_bits.dmem_intg_violation  = lsu_rdata_err_i;
@@ -474,7 +475,7 @@ module otbn_controller
   assign fatal_err = |{err_bits.fatal_software,
                        err_bits.lifecycle_escalation,
                        err_bits.illegal_bus_access,
-                       err_bits.bad_internal_state ,
+                       err_bits.bad_internal_state,
                        err_bits.bus_intg_violation,
                        err_bits.reg_intg_violation,
                        err_bits.dmem_intg_violation,

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -192,6 +192,7 @@ module otbn_core
   logic            urnd_reseed_busy;
   logic            urnd_advance;
   logic [WLEN-1:0] urnd_data;
+  logic            urnd_all_zero;
 
   logic        controller_start;
 
@@ -416,6 +417,7 @@ module otbn_core
     .rnd_req_o         (rnd_req),
     .rnd_prefetch_req_o(rnd_prefetch_req),
     .rnd_valid_i       (rnd_valid),
+    .urnd_state_err_i  (urnd_all_zero),
 
     // Secure wipe
     .secure_wipe_running_i(secure_wipe_running),
@@ -639,6 +641,7 @@ module otbn_core
     .urnd_reseed_busy_o(urnd_reseed_busy),
     .urnd_advance_i    (urnd_advance),
     .urnd_data_o       (urnd_data),
+    .urnd_all_zero_o   (urnd_all_zero),
 
     .edn_rnd_req_o,
     .edn_rnd_ack_i,

--- a/hw/ip/otbn/rtl/otbn_rnd.sv
+++ b/hw/ip/otbn/rtl/otbn_rnd.sv
@@ -42,6 +42,8 @@ module otbn_rnd import otbn_pkg::*;
   input  logic            urnd_advance_i,
   // URND data from PRNG
   output logic [WLEN-1:0] urnd_data_o,
+  // URND lockup state detected
+  output logic            urnd_all_zero_o,
 
   // Entropy distribution network (EDN)
   output logic                    edn_rnd_req_o,
@@ -140,7 +142,7 @@ module otbn_rnd import otbn_pkg::*;
     .xoshiro_en_i (urnd_advance_i),
     .entropy_i    ('0),
     .data_o       (urnd_data_o),
-    .all_zero_o   ()
+    .all_zero_o   (urnd_all_zero_o)
   );
 
   `ASSERT(rnd_clear_on_req_complete, rnd_req_complete |=> ~rnd_valid_q)


### PR DESCRIPTION
Connects all_zero alert from xoshiro PRNG to
bad_internal_state error.
This raises a fatal error in case of a URND lockup.
Resolves #9667

Signed-off-by: Vladimir Rozic <vrozic@lowrisc.org>