### PR TITLE
[otbn,dv] Various cleanups and bugfixes in our vseqs

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -268,12 +268,19 @@ class otbn_base_vseq extends cip_base_vseq #(
 
   // How should we wait until OTBN has finished?
   //
-  // Use polling if the interrupt is disabled or if the interrupt pin is already high. If enabled,
-  // wait on the interrupt pin except occasionally (poll_despite_interrupts_pct). This exceptional
-  // case is to spot any weirdness in updating the STATUS register when interrupts are enabled.
+  // Use polling if OTBN is not idle, the interrupt is disabled or if the interrupt pin is already
+  // high. If enabled, wait on the interrupt pin except occasionally (poll_despite_interrupts_pct).
+  // This exceptional case is to spot any weirdness in updating the STATUS register when interrupts
+  // are enabled.
   protected function bit _pick_use_interrupt();
     uvm_status_e peek_status;
     uvm_reg_data_t peek_value;
+
+    // If OTBN is not in the IDLE state, starting an operation won't actually do anything, and we
+    // won't get a follow-up interrupt. So we shouldn't wait for an interrupt in this case!
+    if (cfg.model_agent_cfg.vif.status != otbn_pkg::StatusIdle) begin
+      return 1'b0;
+    end
 
     // We can just use the RAL prediction for the enable register (since it's only updated by TL
     // accesses).

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
@@ -57,7 +57,6 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
           repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
         end
       join
-      dut_init("HARD");
     end
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -58,9 +58,6 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
         repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
       end
     join
-
-    // Finally, reset the DUT (otherwise we won't be able to chain another vseq after this one)
-    dut_init("HARD");
   endtask
 
 endclass


### PR DESCRIPTION
These changes are needed to get a new OTBN stress test working properly but I've split them out from that patch so that we can merge fixes/cleanups independently of the new functionality.