### PR TITLE
[otbn,dv] Add a stress_all sequence

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -106,11 +106,10 @@
     {
       name: stress_all
       desc: '''
-            Run multiple sequences back-to-back while making invalid TL
-            accesses at the same time.
+            Run assorted sequences back-to-back.
             '''
       milestone: V2
-      tests: []
+      tests: ["otbn_stress_all"]
     }
     {
       name: lc_escalation

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/otbn_dmem_err_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stress_all_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stress_all_vseq.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs other sequences one after the other. This *always* re-loads binaries, which
+// is different from otbn_multi_vseq where we are cleverer about reloading things.
+
+class otbn_stress_all_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_stress_all_vseq)
+
+  `uvm_object_new
+
+  // The sequences that we'll run back-to-back
+  string vseq_names[$] = {
+    "otbn_dmem_err_vseq",
+    "otbn_imem_err_vseq",
+    "otbn_single_vseq"
+  };
+
+  task body();
+    `uvm_info(`gfn, $sformatf("Running %0d sub-sequences", num_trans), UVM_LOW)
+    for (int i = 0; i < num_trans; i++) begin
+      uvm_sequence   seq;
+      otbn_base_vseq otbn_vseq;
+      uint           seq_idx = $urandom_range(0, vseq_names.size() - 1);
+      string         cur_vseq_name = vseq_names[seq_idx];
+
+      seq = create_seq_by_name(cur_vseq_name);
+      `downcast(otbn_vseq, seq)
+
+      // Only force a reset at the start of the sequence if OTBN is currently locked (in which case,
+      // we wouldn't be able to do anything)
+      otbn_vseq.do_apply_reset = (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+      otbn_vseq.set_sequencer(p_sequencer);
+      otbn_vseq.start(p_sequencer);
+    end
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -11,3 +11,4 @@
 `include "otbn_smoke_vseq.sv"
 `include "otbn_imem_err_vseq.sv"
 `include "otbn_dmem_err_vseq.sv"
+`include "otbn_stress_all_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -179,16 +179,25 @@ name:
       en_run_modes: ["build_otbn_multi_err_binaries_mode"]
       reseed: 1
     }
+
     {
       name: "otbn_imem_err"
       uvm_test_seq: "otbn_imem_err_vseq"
       en_run_modes: ["build_otbn_rig_binary_mode"]
       reseed: 5
     }
+
     {
       name: "otbn_dmem_err"
       uvm_test_seq: "otbn_dmem_err_vseq"
       en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "otbn_stress_all"
+      uvm_test_seq: "otbn_stress_all_vseq"
+      en_run_modes: ["build_otbn_rig_binaries_mode"]
       reseed: 5
     }
 
@@ -204,7 +213,9 @@ name:
     {
       name: "core"
       tests: [
-        "otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset", "otbn_multi_err", "otbn_imem_err", "otbn_dmem_err"
+        "otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset",
+         "otbn_multi_err", "otbn_imem_err", "otbn_dmem_err",
+         "otbn_stress_all"
       ]
     }
   ]


### PR DESCRIPTION
This also tweaks the testpoint to remove the concurrent invalid TL
accesses. Let's do that with the standard stress_all_with_rand_reset
testpoint.
