### PR TITLE
[entropy_src/rtl] return ack sm to idle when disabled

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -89,7 +89,6 @@ module entropy_src_ack_sm (
       end
       AckWait: begin
         if (!enable_i) begin
-          ack_o = 1'b1;
           state_d = Idle;
         end else begin
           if (fifo_not_empty_i) begin


### PR DESCRIPTION
In the case the entropy_src is disabled and a request from CSRNG is pending, the state machine should return to idle and wait to be enabled again.
Fixes #10133.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>