### PR TITLE
[dv/otp_ctrl] Fix dai_err regression timeout

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_errs_vseq.sv
@@ -46,6 +46,8 @@ class otp_ctrl_dai_errs_vseq extends otp_ctrl_dai_lock_vseq;
 
   virtual task post_start();
     expect_fatal_alerts = 1;
+    do_apply_reset = 1;
+    do_otp_ctrl_init = 1;
     super.post_start();
   endtask
 endclass


### PR DESCRIPTION
This PR fixes timeout in dai_err in post_start. The post_start in
cip_base_vseq uses dut_init which will start the otp_init. The OTP init
won't work in this seq due to the errors, so we will have to re-backdoor
program the entire OTP.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>