### PR TITLE
[ entropy_src, dv ] All seeds must pass one round of health checks

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -793,7 +793,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard
 
       if(cfg.type_bypass == prim_mubi_pkg::MuBi4True) begin
         retry_limit          = 2;
-        pass_requirement     = 0;
+        pass_requirement     = 1;
         ht_fips_mode         = 0;
       end else begin
         case (dut_fsm_phase)
@@ -808,7 +808,7 @@ class entropy_src_scoreboard extends cip_base_scoreboard
             ht_fips_mode     = 1;
           end
           CONTINUOUS: begin
-            pass_requirement = 0;
+            pass_requirement = 1;
             retry_limit      = 2;
             ht_fips_mode     = 1;
           end


### PR DESCRIPTION
The DUT does not allow any data to exit if the most recent health checks have failed.
This commit updates the scoreboard to reflect this.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>