### PR TITLE
[ entropy_src, csrng, top_earlgrey, dv ] Add Known answer tests ...

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1767,6 +1767,17 @@
       milestone: V2
       tests: []
     }
+    {
+      name: chip_sw_entropy_src_known_answer_tests
+      desc: '''Verify our ability to run known-answer tests in SW.
+
+            - Configure the device in firmware-bypass mode.
+            - Feed NIST test-defined entropy sequences into the conditioner
+            - Read the entropy_data_fifo via SW; verify that it reads the expected values.
+            '''
+      milestone: V2
+      tests: []
+    }
 
     // CSRNG tests:
     {
@@ -1800,6 +1811,18 @@
       desc: '''Verify the effect of LC HW debug enable on CSRNG.
 
             TODO: This is pending SCA security review and might be removed.
+            '''
+      milestone: V2
+      tests: []
+    }
+    {
+      name: chip_sw_csrng_known_answer_tests
+      desc: '''Verify our ability to run known-answer tests in SW.
+
+            - Configure the software instance with the expected seed
+              (as per the NIST-specified test for CTR_DRBG operation)
+            - Perform several generate operations
+            - Compare the results to test expectations.
             '''
       milestone: V2
       tests: []


### PR DESCRIPTION
…to testplan

Adds new top-level tests for entropy_src and csrng to ensure that it is possible to run the
known-answer tests in firmware.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>