### PR TITLE
[dv/otp] Fix otp regression error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
@@ -66,7 +66,7 @@ class otp_ctrl_background_chks_vseq extends otp_ctrl_dai_lock_vseq;
 
   virtual task post_start();
     expect_fatal_alerts = 1;
-    cfg.en_scb = 1;
     super.post_start();
+    cfg.en_scb = 1;
   endtask
 endclass


### PR DESCRIPTION
Fix otp_background_check error due to turn on scb too early.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>