### PR TITLE
[adc_ctrl] combine current status into new status

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_core.sv
@@ -110,8 +110,8 @@ module adc_ctrl_core import adc_ctrl_reg_pkg::* ; (
   end
 
   // adc filter status
-  assign aon_filter_status_o.d  = match_pulse;
-  assign aon_filter_status_o.de = 1'b1;
+  assign aon_filter_status_o.d  = match_pulse | reg2hw_i.filter_status.q;
+  assign aon_filter_status_o.de = |match_pulse;
 
   // generate wakeup to external power manager if filter status
   // and wakeup enable are set.


### PR DESCRIPTION
- or the existing status into the next update to ensure filter
  match status is not lost