### PR TITLE
[aes] Don't enter CLEAR state if triggers get zeroed during PRNG_UPDATE

### DIFF
--- a/hw/ip/aes/rtl/aes_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm.sv
@@ -457,7 +457,7 @@ module aes_control_fsm
           if (cipher_crypt_i) begin
             aes_ctrl_ns = FINISH;
 
-          end else begin // (key_iv_data_in_clear_i || data_out_clear_i)
+          end else if (key_iv_data_in_clear_i || data_out_clear_i) begin
             // To clear the output data registers, we re-use the muxing resources of the cipher
             // core. To clear all key material, some key registers inside the cipher core need to
             // be cleared.
@@ -469,6 +469,10 @@ module aes_control_fsm
             if (cipher_in_ready_i) begin
               aes_ctrl_ns = CLEAR;
             end
+          end else begin
+            // Another write to the trigger register must have overwritten the trigger bits that
+            // actually caused us to enter this state. Just return.
+            aes_ctrl_ns = IDLE;
           end // cipher_crypt_i
         end // prng_data_ack_i
       end


### PR DESCRIPTION
The trigger register can be written by software while AES is busy. Previously, it was possible for software to overwrite the triggers for register clearing while the FSM was busy initiating the clearing. As a result, the cipher core could get started without valid command resulting in the cipher core FSM to enter the terminal error state and signaling a fatal alert. With this commit, the main controller FSM will simply abort and return to the idle state instead of starting the cipher core FSM with an invalid command.