### PR TITLE
[dif/alert_handler] Fix bug in ping timer lock DIFs.

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.c
+++ b/sw/device/lib/dif/dif_alert_handler.c
@@ -484,11 +484,8 @@ dif_result_t dif_alert_handler_lock_ping_timer(
     return kDifBadArg;
   }
 
-  uint32_t reg = bitfield_bit32_write(
-      1, ALERT_HANDLER_PING_TIMER_EN_SHADOWED_PING_TIMER_EN_SHADOWED_BIT, true);
-  mmio_region_write32_shadowed(alert_handler->base_addr,
-                               ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET,
-                               reg);
+  mmio_region_write32(alert_handler->base_addr,
+                      ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
 
   return kDifOk;
 }
@@ -498,11 +495,9 @@ dif_result_t dif_alert_handler_is_ping_timer_locked(
   if (alert_handler == NULL || is_locked == NULL) {
     return kDifBadArg;
   }
-  uint32_t reg =
-      mmio_region_read32(alert_handler->base_addr,
-                         ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET);
-  *is_locked = bitfield_bit32_read(
-      reg, ALERT_HANDLER_PING_TIMER_EN_SHADOWED_PING_TIMER_EN_SHADOWED_BIT);
+
+  *is_locked = !mmio_region_read32(alert_handler->base_addr,
+                                   ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET);
 
   return kDifOk;
 }

--- a/sw/device/lib/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/lib/dif/dif_alert_handler_unittest.cc
@@ -603,28 +603,19 @@ class PingTimerLockTest : public AlertHandlerTest {};
 TEST_F(PingTimerLockTest, IsPingTimerLocked) {
   bool flag;
 
-  EXPECT_READ32(
-      ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET,
-      {{ALERT_HANDLER_PING_TIMER_EN_SHADOWED_PING_TIMER_EN_SHADOWED_BIT,
-        false}});
+  EXPECT_READ32(ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 1);
   EXPECT_EQ(dif_alert_handler_is_ping_timer_locked(&alert_handler_, &flag),
             kDifOk);
   EXPECT_FALSE(flag);
 
-  EXPECT_READ32(
-      ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET,
-      {{ALERT_HANDLER_PING_TIMER_EN_SHADOWED_PING_TIMER_EN_SHADOWED_BIT,
-        true}});
+  EXPECT_READ32(ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
   EXPECT_EQ(dif_alert_handler_is_ping_timer_locked(&alert_handler_, &flag),
             kDifOk);
   EXPECT_TRUE(flag);
 }
 
 TEST_F(PingTimerLockTest, LockPingTimer) {
-  EXPECT_WRITE32_SHADOWED(
-      ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET,
-      {{ALERT_HANDLER_PING_TIMER_EN_SHADOWED_PING_TIMER_EN_SHADOWED_BIT,
-        true}});
+  EXPECT_WRITE32(ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
   EXPECT_EQ(dif_alert_handler_lock_ping_timer(&alert_handler_), kDifOk);
 }
 


### PR DESCRIPTION
The DIFs that checked whether the ping timer configuration was locked, and locked it, read-from/wrote-to the wrong CSR (the ping timer enable CSR). This commit fixes these two DIFs to write to the correct ping timer REGWEN CSR.

This partially addresses a task in #9899.

**_Note: this PR depends on #10077, and therefore contains duplicate commits that will be removed when the dependency is merged._**