### PR TITLE
[dv/clkmgr] Add SVA for cg_en_o outputs

### DIFF
--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -64,6 +64,18 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     control_ip_clocks();
   endtask
 
+  local function void disable_unnecessary_exclusions();
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.clk_enables", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.clk_hints", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_measure_ctrl.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_div2_measure_ctrl.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_div4_measure_ctrl.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.main_measure_ctrl.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.usb_measure_ctrl.en", 0);
+    `uvm_info(`gfn, "Adjusted exclusions", UVM_MEDIUM)
+    ral.get_excl_item().print_exclusions(UVM_MEDIUM);
+  endfunction
+
   task pre_start();
     cfg.clkmgr_vif.init(.idle('1), .scanmode(scanmode), .lc_debug_en(Off));
     cfg.clkmgr_vif.update_io_ip_clk_en(1'b0);
@@ -71,6 +83,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     cfg.clkmgr_vif.update_usb_ip_clk_en(1'b0);
     cfg.clkmgr_vif.update_all_clk_byp_ack(prim_mubi_pkg::MuBi4False);
     cfg.clkmgr_vif.update_io_clk_byp_ack(prim_mubi_pkg::MuBi4False);
+    // There is something strange with exclusions. Don't disable for now.
+    // disable_unnecessary_exclusions();
     clkmgr_init();
     super.pre_start();
   endtask

--- a/hw/ip/clkmgr/dv/sva/clkmgr_aon_cg_en_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_aon_cg_en_sva_if.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This contains SVA assertions for clock gating output to alert_handler for
+// AON clocks: they are never gated off.
+interface clkmgr_aon_cg_en_sva_if (
+  input logic clk,
+  input logic rst_n,
+  input logic cg_en
+);
+
+  bit disable_sva;
+
+  `ASSERT_INIT_NET(CgEn_A, !cg_en)
+endinterface

--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -26,7 +26,7 @@ module clkmgr_bind;
     .rst_n(rst_io_div4_ni),
     .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_io_div4_peri_en.q),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_io_div4_peri)
   );
 
@@ -35,7 +35,7 @@ module clkmgr_bind;
     .rst_n(rst_io_div2_ni),
     .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_io_div2_peri_en.q),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_io_div2_peri)
   );
 
@@ -44,7 +44,7 @@ module clkmgr_bind;
     .rst_n(rst_io_ni),
     .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_io_peri_en.q),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_io_peri)
   );
 
@@ -53,7 +53,7 @@ module clkmgr_bind;
     .rst_n(rst_usb_ni),
     .ip_clk_en(pwr_i.usb_ip_clk_en),
     .sw_clk_en(reg2hw.clk_enables.clk_usb_peri_en.q),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_usb_peri)
   );
 
@@ -62,7 +62,7 @@ module clkmgr_bind;
     .rst_n(rst_main_ni),
     .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_aes_hint.q || !idle_i[0]),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_main_aes)
   );
 
@@ -71,7 +71,7 @@ module clkmgr_bind;
     .rst_n(rst_main_ni),
     .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_hmac_hint.q || !idle_i[1]),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_main_hmac)
   );
 
@@ -80,7 +80,7 @@ module clkmgr_bind;
     .rst_n(rst_main_ni),
     .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_kmac_hint.q || !idle_i[2]),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_main_kmac)
   );
 
@@ -89,7 +89,7 @@ module clkmgr_bind;
     .rst_n(rst_io_div4_ni),
     .ip_clk_en(pwr_i.io_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_io_div4_otbn_hint.q || !idle_i[3]),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_io_div4_otbn)
   );
 
@@ -98,7 +98,7 @@ module clkmgr_bind;
     .rst_n(rst_main_ni),
     .ip_clk_en(pwr_i.main_ip_clk_en),
     .sw_clk_en(reg2hw.clk_hints.clk_main_otbn_hint.q || !idle_i[4]),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On),
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
     .gated_clk(clocks_o.clk_main_otbn)
   );
 
@@ -115,7 +115,7 @@ module clkmgr_bind;
                        reg2hw.extclk_ctrl.low_speed_sel.q == prim_mubi_pkg::MuBi4True),
     .sw_step_down_ack(all_clk_byp_ack_i == prim_mubi_pkg::MuBi4True),
     .sw_step_up_ack(all_clk_byp_ack_i == prim_mubi_pkg::MuBi4False),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On)
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True)
   );
 
   // The div2 clk also steps, so not a good reference. Instead, check it always tracks io_div2.
@@ -132,7 +132,205 @@ module clkmgr_bind;
                        reg2hw.extclk_ctrl.low_speed_sel.q == prim_mubi_pkg::MuBi4True),
     .sw_step_down_ack(all_clk_byp_ack_i == prim_mubi_pkg::MuBi4True),
     .sw_step_up_ack(all_clk_byp_ack_i == prim_mubi_pkg::MuBi4False),
-    .scanmode(scanmode_i == lc_ctrl_pkg::On)
+    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True)
   );
 
+  // AON clock gating enables.
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_aon_infra (
+    .clk(clk_aon_i), .rst_n(rst_aon_ni), .cg_en(cg_en_o.aon_infra == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_aon_peri (
+    .clk(clk_aon_i), .rst_n(rst_aon_ni), .cg_en(cg_en_o.aon_peri == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_aon_powerup (
+    .clk(clk_aon_i), .rst_n(rst_aon_ni), .cg_en(cg_en_o.aon_powerup == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_aon_secure (
+    .clk(clk_aon_i), .rst_n(rst_aon_ni), .cg_en(cg_en_o.aon_secure == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_aon_timers (
+    .clk(clk_aon_i), .rst_n(rst_aon_ni), .cg_en(cg_en_o.aon_timers == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_io_powerup (
+    .clk(clk_io_i), .rst_n(rst_io_ni), .cg_en(cg_en_o.io_powerup == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_io_div2_powerup (
+    .clk(clk_io_div2_i),
+    .rst_n(rst_io_div2_ni),
+    .cg_en(cg_en_o.io_div2_powerup == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_io_div4_powerup (
+    .clk(clk_io_div4_i),
+    .rst_n(rst_io_div4_ni),
+    .cg_en(cg_en_o.io_div4_powerup == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_main_powerup (
+    .clk(clk_main_i), .rst_n(rst_main_ni), .cg_en(cg_en_o.main_powerup == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_aon_cg_en_sva_if clkmgr_aon_cg_usb_powerup (
+    .clk(clk_usb_i), .rst_n(rst_usb_ni), .cg_en(cg_en_o.usb_powerup == prim_mubi_pkg::MuBi4True)
+  );
+
+  // Non-AON clock gating enables.
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div2_infra (
+    .clk(clk_io_div2_i),
+    .rst_n(rst_io_div2_ni),
+    .ip_clk_en(clk_io_div2_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_div2_infra == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div4_infra (
+    .clk(clk_io_div4_i),
+    .rst_n(rst_io_div4_ni),
+    .ip_clk_en(clk_io_div4_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_div4_infra == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_infra (
+    .clk(clk_io_i),
+    .rst_n(rst_io_ni),
+    .ip_clk_en(clk_io_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_infra == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_main_infra (
+    .clk(clk_main_i),
+    .rst_n(rst_main_ni),
+    .ip_clk_en(clk_main_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.main_infra == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div4_secure (
+    .clk(clk_io_div4_i),
+    .rst_n(rst_io_div4_ni),
+    .ip_clk_en(clk_io_div4_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_div4_secure == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_main_secure (
+    .clk(clk_main_i),
+    .rst_n(rst_main_ni),
+    .ip_clk_en(clk_main_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.main_secure == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_usb_secure (
+    .clk(clk_usb_i),
+    .rst_n(rst_usb_ni),
+    .ip_clk_en(clk_usb_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.usb_secure == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div4_timers (
+    .clk(clk_io_div4_i),
+    .rst_n(rst_io_div4_ni),
+    .ip_clk_en(clk_io_div4_en),
+    .sw_clk_en(1'b1),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_div4_timers == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div2_peri (
+    .clk(clk_io_div2_i),
+    .rst_n(rst_io_div2_ni),
+    .ip_clk_en(clk_io_div2_en),
+    .sw_clk_en(clk_io_div2_peri_sw_en),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_div2_peri == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div4_peri (
+    .clk(clk_io_div4_i),
+    .rst_n(rst_io_div4_ni),
+    .ip_clk_en(clk_io_div4_en),
+    .sw_clk_en(clk_io_div4_peri_sw_en),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_div4_peri == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_peri (
+    .clk(clk_io_i),
+    .rst_n(rst_io_ni),
+    .ip_clk_en(clk_io_en),
+    .sw_clk_en(clk_io_peri_sw_en),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_peri == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_usb_peri (
+    .clk(clk_usb_i),
+    .rst_n(rst_usb_ni),
+    .ip_clk_en(clk_usb_en),
+    .sw_clk_en(clk_usb_peri_sw_en),
+    .scanmode(0),
+    .cg_en(cg_en_o.usb_peri == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div4_otbn (
+    .clk(clk_io_div4_i),
+    .rst_n(rst_io_div4_ni),
+    .ip_clk_en(clk_io_div4_en),
+    .sw_clk_en(clk_io_div4_otbn_hint || !idle_i[HintIoDiv4Otbn]),
+    .scanmode(0),
+    .cg_en(cg_en_o.io_div4_otbn == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_main_aes (
+    .clk(clk_main_i),
+    .rst_n(rst_main_ni),
+    .ip_clk_en(clk_main_en),
+    .sw_clk_en(clk_main_aes_hint || !idle_i[HintMainAes]),
+    .scanmode(0),
+    .cg_en(cg_en_o.main_aes == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_main_hmac (
+    .clk(clk_main_i),
+    .rst_n(rst_main_ni),
+    .ip_clk_en(clk_main_en),
+    .sw_clk_en(clk_main_hmac_hint || !idle_i[HintMainHmac]),
+    .scanmode(0),
+    .cg_en(cg_en_o.main_hmac == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_main_kmac (
+    .clk(clk_main_i),
+    .rst_n(rst_main_ni),
+    .ip_clk_en(clk_main_en),
+    .sw_clk_en(clk_main_kmac_hint || !idle_i[HintMainKmac]),
+    .scanmode(0),
+    .cg_en(cg_en_o.main_kmac == prim_mubi_pkg::MuBi4True)
+  );
+
+  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_main_otbn (
+    .clk(clk_main_i),
+    .rst_n(rst_main_ni),
+    .ip_clk_en(clk_main_en),
+    .sw_clk_en(clk_main_otbn_hint || !idle_i[HintMainOtbn]),
+    .scanmode(0),
+    .cg_en(cg_en_o.main_otbn == prim_mubi_pkg::MuBi4True)
+  );
 endmodule

--- a/hw/ip/clkmgr/dv/sva/clkmgr_cg_en_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_cg_en_sva_if.sv
@@ -1,0 +1,28 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This contains SVA assertions for clock gating output to alert_handler.
+// - cg_en corresponds to clock gating enabled, which means the clock is gated,
+//   thus inactive.
+// - ip_clk_en and sw_clk_en have the opposite polarity: when they are active
+//   the clock is enabled.
+interface clkmgr_cg_en_sva_if (
+  input logic clk,
+  input logic rst_n,
+  input logic ip_clk_en,
+  input logic sw_clk_en,
+  input logic scanmode,
+  input logic cg_en
+);
+
+  bit   disable_sva;
+
+  logic clk_enable;
+  always_comb clk_enable = ip_clk_en && sw_clk_en;
+
+  `ASSERT(CgEnOn_A, $fell(clk_enable) |=> ##[0:2] clk_enable || cg_en, clk,
+          !rst_n || scanmode || disable_sva)
+  `ASSERT(CgEnOff_A, $rose(clk_enable) |=> ##[0:2] !clk_enable || !cg_en, clk,
+          !rst_n || scanmode || disable_sva)
+endinterface

--- a/hw/ip/clkmgr/dv/sva/clkmgr_gated_clock_sva_if.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_gated_clock_sva_if.sv
@@ -11,8 +11,9 @@ interface clkmgr_gated_clock_sva_if (
   input logic scanmode,
   input logic gated_clk
 );
-  // This fires at negedges, so check $past(clk*) as activity. The assertion is okay if gating
-  // changes, either at the next clock event or between them.
+  // This fires at negedges: if the gated clock is inactive its value is expected to be low,
+  // and viceversa. The assertions pass if gating is not stable to avoid cycle accuracy, and
+  // these gated clocks are expected to be changed infrequently.
   logic gating;
   always_comb gating = sw_clk_en && ip_clk_en || scanmode;
 

--- a/hw/ip/clkmgr/dv/sva/clkmgr_sva_ifs.core
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_sva_ifs.core
@@ -12,6 +12,8 @@ filesets:
     files:
       - clkmgr_div_sva_if.sv
       - clkmgr_gated_clock_sva_if.sv
+      - clkmgr_aon_cg_en_sva_if.sv
+      - clkmgr_cg_en_sva_if.sv
     file_type: systemVerilogSource
 
 targets:


### PR DESCRIPTION
Add code to disable exclusions from clkmgr.hjson for IP testing, since
they are intended for full chip tests.
- Don't call that code since there are unexpected side-effects from
exclusion management.

Also minor fix in clkmgr_bind.

Fixes #9946

Signed-off-by: Guillermo Maturana <maturana@google.com>