### PR TITLE
[otp_ctrl] Anchor seeds and key output

### DIFF
--- a/hw/ip/otp_ctrl/otp_ctrl.core
+++ b/hw/ip/otp_ctrl/otp_ctrl.core
@@ -20,6 +20,7 @@ filesets:
       - lowrisc:prim:flop
       - lowrisc:prim:secded
       - lowrisc:prim:edn_req
+      - lowrisc:prim:sec_anchor
       - lowrisc:ip:pwrmgr_pkg
       - lowrisc:ip:edn_pkg
       - lowrisc:prim:sparse_fsm


### PR DESCRIPTION
- Partially address #8983
- Adds anchor buffers and flops to otp seeds, constants, scramble keys
  and derived keys

Signed-off-by: Timothy Chen <timothytim@google.com>