### PR TITLE
[rv_core_ibex] Add edn connection to rv_core_ibex

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -38,7 +38,7 @@
       type:    "req_rsp",
       name:    "edn",
       act:     "rsp",
-      width:   "7",
+      width:   "8",
       default: "'0",
       desc:    '''
                The collection of peripheral ports supported by edn. The width (4)

--- a/hw/ip/edn/rtl/edn.sv
+++ b/hw/ip/edn/rtl/edn.sv
@@ -10,7 +10,7 @@ module edn
   import edn_pkg::*;
   import edn_reg_pkg::*;
 #(
-  parameter int NumEndPoints = 7,
+  parameter int NumEndPoints = 8,
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
 ) (
   input logic clk_i,

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 { name: "RV_CORE_IBEX",
   clocking: [{clock: "clk_i", reset: "rst_ni", primary: true},
+             {clock: "clk_edn_i", reset: "rst_edn_ni"}
              {clock: "clk_esc_i", reset: "rst_esc_ni"},
             ],
   bus_interfaces: [
@@ -134,6 +135,13 @@
       name:    "nmi_wdog",
       act:     "rcv",
       package: "",
+    },
+
+    { struct:  "edn",
+      type:    "req_rsp",
+      name:    "edn",
+      act:     "req",
+      package: "edn_pkg",
     },
 
   ],
@@ -666,7 +674,9 @@
       { name: "RND_DATA",
         desc: "Random data from EDN",
         swaccess: "ro",
-        hwaccess: "hwo",
+        hwaccess: "hrw",
+        hwext: "true",
+        hwre: "true",
         fields: [
           { bits: "31:0",
             name: "DATA",
@@ -696,6 +706,16 @@
             desc: '''
               When set, the data in !!RND_DATA is valid. When clear an EDN
               request for new data for !!RND_DATA is pending.
+            '''
+          },
+          { bits: "1",
+            resval: "0",
+            name: "RND_DATA_FIPS",
+            desc: '''
+              When !!RND_STATUS.RND_DATA_VALID is 1, this bit indicates whether
+              !!RND_DATA is fips quality.
+
+              When !!RND_STATUS.RND_DATA_VALID is 0, this bit has no meaning.
             '''
           },
         ]

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -88,6 +88,11 @@ package rv_core_ibex_reg_pkg;
   } rv_core_ibex_reg2hw_nmi_state_reg_t;
 
   typedef struct packed {
+    logic [31:0] q;
+    logic        re;
+  } rv_core_ibex_reg2hw_rnd_data_reg_t;
+
+  typedef struct packed {
     logic [3:0]  d;
     logic        de;
   } rv_core_ibex_hw2reg_sw_recov_err_reg_t;
@@ -124,26 +129,31 @@ package rv_core_ibex_reg_pkg;
 
   typedef struct packed {
     logic [31:0] d;
-    logic        de;
   } rv_core_ibex_hw2reg_rnd_data_reg_t;
 
   typedef struct packed {
-    logic        d;
+    struct packed {
+      logic        d;
+    } rnd_data_valid;
+    struct packed {
+      logic        d;
+    } rnd_data_fips;
   } rv_core_ibex_hw2reg_rnd_status_reg_t;
 
   // Register -> HW type for cfg interface
   typedef struct packed {
-    rv_core_ibex_reg2hw_alert_test_reg_t alert_test; // [279:272]
-    rv_core_ibex_reg2hw_sw_recov_err_reg_t sw_recov_err; // [271:268]
-    rv_core_ibex_reg2hw_sw_fatal_err_reg_t sw_fatal_err; // [267:264]
-    rv_core_ibex_reg2hw_ibus_addr_en_mreg_t [1:0] ibus_addr_en; // [263:262]
-    rv_core_ibex_reg2hw_ibus_addr_matching_mreg_t [1:0] ibus_addr_matching; // [261:198]
-    rv_core_ibex_reg2hw_ibus_remap_addr_mreg_t [1:0] ibus_remap_addr; // [197:134]
-    rv_core_ibex_reg2hw_dbus_addr_en_mreg_t [1:0] dbus_addr_en; // [133:132]
-    rv_core_ibex_reg2hw_dbus_addr_matching_mreg_t [1:0] dbus_addr_matching; // [131:68]
-    rv_core_ibex_reg2hw_dbus_remap_addr_mreg_t [1:0] dbus_remap_addr; // [67:4]
-    rv_core_ibex_reg2hw_nmi_enable_reg_t nmi_enable; // [3:2]
-    rv_core_ibex_reg2hw_nmi_state_reg_t nmi_state; // [1:0]
+    rv_core_ibex_reg2hw_alert_test_reg_t alert_test; // [312:305]
+    rv_core_ibex_reg2hw_sw_recov_err_reg_t sw_recov_err; // [304:301]
+    rv_core_ibex_reg2hw_sw_fatal_err_reg_t sw_fatal_err; // [300:297]
+    rv_core_ibex_reg2hw_ibus_addr_en_mreg_t [1:0] ibus_addr_en; // [296:295]
+    rv_core_ibex_reg2hw_ibus_addr_matching_mreg_t [1:0] ibus_addr_matching; // [294:231]
+    rv_core_ibex_reg2hw_ibus_remap_addr_mreg_t [1:0] ibus_remap_addr; // [230:167]
+    rv_core_ibex_reg2hw_dbus_addr_en_mreg_t [1:0] dbus_addr_en; // [166:165]
+    rv_core_ibex_reg2hw_dbus_addr_matching_mreg_t [1:0] dbus_addr_matching; // [164:101]
+    rv_core_ibex_reg2hw_dbus_remap_addr_mreg_t [1:0] dbus_remap_addr; // [100:37]
+    rv_core_ibex_reg2hw_nmi_enable_reg_t nmi_enable; // [36:35]
+    rv_core_ibex_reg2hw_nmi_state_reg_t nmi_state; // [34:33]
+    rv_core_ibex_reg2hw_rnd_data_reg_t rnd_data; // [32:0]
   } rv_core_ibex_cfg_reg2hw_t;
 
   // HW -> register type for cfg interface
@@ -151,8 +161,8 @@ package rv_core_ibex_reg_pkg;
     rv_core_ibex_hw2reg_sw_recov_err_reg_t sw_recov_err; // [50:46]
     rv_core_ibex_hw2reg_nmi_state_reg_t nmi_state; // [45:42]
     rv_core_ibex_hw2reg_err_status_reg_t err_status; // [41:34]
-    rv_core_ibex_hw2reg_rnd_data_reg_t rnd_data; // [33:1]
-    rv_core_ibex_hw2reg_rnd_status_reg_t rnd_status; // [0:0]
+    rv_core_ibex_hw2reg_rnd_data_reg_t rnd_data; // [33:2]
+    rv_core_ibex_hw2reg_rnd_status_reg_t rnd_status; // [1:0]
   } rv_core_ibex_cfg_hw2reg_t;
 
   // Register offsets for cfg interface
@@ -187,8 +197,11 @@ package rv_core_ibex_reg_pkg;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_SW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_FATAL_HW_ERR_RESVAL = 1'h 0;
   parameter logic [0:0] RV_CORE_IBEX_ALERT_TEST_RECOV_HW_ERR_RESVAL = 1'h 0;
-  parameter logic [0:0] RV_CORE_IBEX_RND_STATUS_RESVAL = 1'h 0;
+  parameter logic [31:0] RV_CORE_IBEX_RND_DATA_RESVAL = 32'h 0;
+  parameter logic [31:0] RV_CORE_IBEX_RND_DATA_DATA_RESVAL = 32'h 0;
+  parameter logic [1:0] RV_CORE_IBEX_RND_STATUS_RESVAL = 2'h 0;
   parameter logic [0:0] RV_CORE_IBEX_RND_STATUS_RND_DATA_VALID_RESVAL = 1'h 0;
+  parameter logic [0:0] RV_CORE_IBEX_RND_STATUS_RND_DATA_FIPS_RESVAL = 1'h 0;
 
   // Register index for cfg interface
   typedef enum int {

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -8,16 +8,17 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ibex:ibex_top
-      - lowrisc:prim:all
-      - lowrisc:prim:esc
-      - lowrisc:prim:clock_gating
-      - lowrisc:prim:mubi
-      - lowrisc:ip:tlul
-      - lowrisc:tlul:adapter_host
       - lowrisc:ip:lc_ctrl_pkg
-      - lowrisc:prim:lc_sync
-      - lowrisc:ip_interfaces:alert_handler_reg
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:ip:tlul
+      - lowrisc:ip_interfaces:alert_handler_reg
+      - lowrisc:prim:all
+      - lowrisc:prim:clock_gating
+      - lowrisc:prim:edn_req
+      - lowrisc:prim:esc
+      - lowrisc:prim:lc_sync
+      - lowrisc:prim:mubi
+      - lowrisc:tlul:adapter_host
 
     files:
       - rtl/rv_core_ibex_pkg.sv

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -6032,7 +6032,7 @@
           package: edn_pkg
           type: req_rsp
           act: rsp
-          width: 7
+          width: 8
           default: "'0"
           inst_name: edn0
           end_idx: -1
@@ -6114,7 +6114,7 @@
           package: edn_pkg
           type: req_rsp
           act: rsp
-          width: 7
+          width: 8
           default: "'0"
           inst_name: edn1
           end_idx: 1
@@ -6541,6 +6541,7 @@
       clock_srcs:
       {
         clk_i: main
+        clk_edn_i: main
         clk_esc_i:
         {
           clock: io_div4
@@ -6555,6 +6556,11 @@
           name: sys
           domain: "0"
         }
+        rst_edn_ni:
+        {
+          name: sys
+          domain: "0"
+        }
         rst_esc_ni:
         {
           name: lc_io_div4
@@ -6564,6 +6570,7 @@
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_infra
+        clk_edn_i: clkmgr_aon_clocks.clk_main_infra
         clk_esc_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain:
@@ -6917,6 +6924,18 @@
           index: -1
         }
         {
+          name: edn
+          struct: edn
+          package: edn_pkg
+          type: req_rsp
+          act: req
+          width: 1
+          inst_name: rv_core_ibex
+          default: ""
+          top_signame: edn0_edn
+          index: 7
+        }
+        {
           name: corei_tl_h
           struct: tl
           package: tlul_pkg
@@ -7191,6 +7210,7 @@
         alert_handler.edn
         aes.edn
         otbn.edn_urnd
+        rv_core_ibex.edn
       ]
       edn1.edn:
       [
@@ -17269,7 +17289,7 @@
         package: edn_pkg
         type: req_rsp
         act: rsp
-        width: 7
+        width: 8
         default: "'0"
         inst_name: edn0
         end_idx: -1
@@ -17317,7 +17337,7 @@
         package: edn_pkg
         type: req_rsp
         act: rsp
-        width: 7
+        width: 8
         default: "'0"
         inst_name: edn1
         end_idx: 1
@@ -17687,6 +17707,18 @@
         package: ""
         top_signame: aon_timer_aon_nmi_wdog_timer_bark
         index: -1
+      }
+      {
+        name: edn
+        struct: edn
+        package: edn_pkg
+        type: req_rsp
+        act: req
+        width: 1
+        inst_name: rv_core_ibex
+        default: ""
+        top_signame: edn0_edn
+        index: 7
       }
       {
         name: corei_tl_h
@@ -19415,7 +19447,7 @@
         package: edn_pkg
         struct: edn_req
         signame: edn0_edn_req
-        width: 7
+        width: 8
         type: req_rsp
         end_idx: -1
         act: rsp
@@ -19426,7 +19458,7 @@
         package: edn_pkg
         struct: edn_rsp
         signame: edn0_edn_rsp
-        width: 7
+        width: 8
         type: req_rsp
         end_idx: -1
         act: rsp
@@ -19437,7 +19469,7 @@
         package: edn_pkg
         struct: edn_req
         signame: edn1_edn_req
-        width: 7
+        width: 8
         type: req_rsp
         end_idx: 1
         act: rsp
@@ -19448,7 +19480,7 @@
         package: edn_pkg
         struct: edn_rsp
         signame: edn1_edn_rsp
-        width: 7
+        width: 8
         type: req_rsp
         end_idx: 1
         act: rsp

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -700,13 +700,14 @@
                   },
       clock_srcs: {
         clk_i: "main",
+        clk_edn_i: "main",
         clk_esc_i: {
           clock: "io_div4",
           group: "secure",
         }
       },
       clock_group: "infra",
-      reset_connections: {rst_ni: "sys", rst_esc_ni: "lc_io_div4"},
+      reset_connections: {rst_ni: "sys", rst_edn_ni: "sys", rst_esc_ni: "lc_io_div4"},
       base_addr: "0x411F0000",
     },
   ]
@@ -827,7 +828,8 @@
 
       // Edn connections
       'edn0.edn'              : ['keymgr.edn', 'otp_ctrl.edn', 'ast.edn', 'kmac.entropy',
-                                 'alert_handler.edn', 'aes.edn', 'otbn.edn_urnd'],
+                                 'alert_handler.edn', 'aes.edn', 'otbn.edn_urnd',
+                                 'rv_core_ibex.edn'],
       'edn1.edn'              : ['otbn.edn_rnd'],
 
       // OTBN OTP scramble key

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -562,10 +562,10 @@ module top_earlgrey #(
   logic       usbdev_usb_aon_wake_ack;
   logic       usbdev_usb_suspend;
   usbdev_pkg::awk_state_t       pinmux_aon_usb_state_debug;
-  edn_pkg::edn_req_t [6:0] edn0_edn_req;
-  edn_pkg::edn_rsp_t [6:0] edn0_edn_rsp;
-  edn_pkg::edn_req_t [6:0] edn1_edn_req;
-  edn_pkg::edn_rsp_t [6:0] edn1_edn_rsp;
+  edn_pkg::edn_req_t [7:0] edn0_edn_req;
+  edn_pkg::edn_rsp_t [7:0] edn0_edn_rsp;
+  edn_pkg::edn_req_t [7:0] edn1_edn_req;
+  edn_pkg::edn_rsp_t [7:0] edn1_edn_rsp;
   otp_ctrl_pkg::otbn_otp_key_req_t       otp_ctrl_otbn_otp_key_req;
   otp_ctrl_pkg::otbn_otp_key_rsp_t       otp_ctrl_otbn_otp_key_rsp;
   otp_ctrl_pkg::otp_keymgr_key_t       otp_ctrl_otp_keymgr_key;
@@ -751,6 +751,7 @@ module top_earlgrey #(
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp4;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp5;
   edn_pkg::edn_rsp_t unused_edn1_edn_rsp6;
+  edn_pkg::edn_rsp_t unused_edn1_edn_rsp7;
 
   // assign partial inter-module tie-off
   assign unused_edn1_edn_rsp1 = edn1_edn_rsp[1];
@@ -759,12 +760,14 @@ module top_earlgrey #(
   assign unused_edn1_edn_rsp4 = edn1_edn_rsp[4];
   assign unused_edn1_edn_rsp5 = edn1_edn_rsp[5];
   assign unused_edn1_edn_rsp6 = edn1_edn_rsp[6];
+  assign unused_edn1_edn_rsp7 = edn1_edn_rsp[7];
   assign edn1_edn_req[1] = '0;
   assign edn1_edn_req[2] = '0;
   assign edn1_edn_req[3] = '0;
   assign edn1_edn_req[4] = '0;
   assign edn1_edn_req[5] = '0;
   assign edn1_edn_req[6] = '0;
+  assign edn1_edn_req[7] = '0;
 
 
   // OTP HW_CFG Broadcast signals.
@@ -2516,6 +2519,8 @@ module top_earlgrey #(
       .pwrmgr_cpu_en_i(pwrmgr_aon_fetch_en),
       .pwrmgr_o(rv_core_ibex_pwrmgr),
       .nmi_wdog_i(aon_timer_aon_nmi_wdog_timer_bark),
+      .edn_o(edn0_edn_req[7]),
+      .edn_i(edn0_edn_rsp[7]),
       .corei_tl_h_o(main_tl_rv_core_ibex__corei_req),
       .corei_tl_h_i(main_tl_rv_core_ibex__corei_rsp),
       .cored_tl_h_o(main_tl_rv_core_ibex__cored_req),
@@ -2527,8 +2532,10 @@ module top_earlgrey #(
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_main_infra),
+      .clk_edn_i (clkmgr_aon_clocks.clk_main_infra),
       .clk_esc_i (clkmgr_aon_clocks.clk_io_div4_secure),
       .rst_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
+      .rst_edn_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
       .rst_esc_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   // interrupt assignments

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -469,9 +469,13 @@
                    DmExceptionAddr: "tl_main_pkg::ADDR_SPACE_RV_DM__ROM + dm::ExceptionAddress[31:0]",
                    PipeLine: "0"
                   }
-      clock_srcs: {clk_i: "main", clk_esc_i: "io_div4"},
+      clock_srcs: {clk_i: "main",
+                   clk_edn_i: "main",
+                   clk_esc_i: "io_div4"},
       clock_group: "infra",
-      reset_connections: {rst_ni: "sys", rst_esc_ni: "lc_io_div4"},
+      reset_connections: {rst_ni: "sys",
+                          rst_edn_ni: "sys",
+                          rst_esc_ni: "lc_io_div4"},
       base_addr: "0x411F0000",
     },
   ]


### PR DESCRIPTION
- continuation of #7946
- rv_core_ibex automatically talks to edn for random data, which is provided
  to ibex through a local register.

Signed-off-by: Timothy Chen <timothytim@google.com>