### PR TITLE
[dv/clkmgr] Declare V2

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.prj.hjson
+++ b/hw/ip/clkmgr/data/clkmgr.prj.hjson
@@ -13,7 +13,7 @@
         version:            "0.1",
         life_stage:         "L1",
         design_stage:       "D2",
-        verification_stage: "V1",
+        verification_stage: "V2",
         dif_stage:          "S1",
       }
     ]

--- a/hw/ip/clkmgr/doc/checklist.md
+++ b/hw/ip/clkmgr/doc/checklist.md
@@ -198,7 +198,7 @@ Code Quality  | [TB_LINT_PASS][]                        | Done        |
 Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | NA          |
 Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Done        |
 Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
-Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Not Started |
+Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
 Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
 [DESIGN_DELTAS_CAPTURED_V2]:          {{<relref "/doc/project/checklist.md#design_deltas_captured_v2" >}}


### PR DESCRIPTION
The action items from the clkmgr v2 review are taken care of, except
the following:
- Disable exclusions related to full chip: I coded disabling these
  exclusions and found many common csr tests failing because of
  other missing exclusions. It seems due to a bug in exclusion management.
- Fix missing coverage in prim_mubi4_sync: I can take care of this once
  the UNR flow is up, and the missing coverage is obviously unreachable.
- Add a test that holds the clock and then releases. It seems unnecessary,
  since nothing new will really be tested.

Signed-off-by: Guillermo Maturana <maturana@google.com>