### PR TITLE
[keymgr/dv] fix constraint error

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
@@ -7,7 +7,7 @@ class keymgr_sideload_one_intf_vseq extends keymgr_sideload_vseq;
   `uvm_object_utils(keymgr_sideload_one_intf_vseq)
   `uvm_object_new
 
-  keymgr_pkg::keymgr_key_dest_e sideload_dest;
+  keymgr_pkg::keymgr_key_dest_e sideload_dest = keymgr_pkg::None;
   // also test HW sideload
   constraint gen_operation_c {
     gen_operation == keymgr_pkg::OpGenHwOut;


### PR DESCRIPTION
Assign a fixed value to `sideload_dest`, so that it can never be
unknown. This variable is used in constraint, so it can' be z/x.

Signed-off-by: Weicai Yang <weicai@google.com>