### PR TITLE
[chip dv] Enable logs to show up in waves

### DIFF
--- a/hw/dv/sv/sw_logger_if/sw_logger_if.sv
+++ b/hw/dv/sv/sw_logger_if/sw_logger_if.sv
@@ -93,7 +93,7 @@ interface sw_logger_if #(
 
   // Indicate when the log was printed and what was the final string.
   event  printed_log_event;
-  string printed_log;
+  arg_t  printed_log;
 
   // Sets the sw_name with the provided path.
   //


### PR DESCRIPTION
Being able to see logs from SW test directly in waves is useful for
debug. This capability existe, but got inadvertently disabled when we
disabled `debug_access` for VCS as a part of our sim optimations effort.

This PR reenables this capability by changing the datatype of the
printed log from string to integral, so that the logs can show up in
waves without requiring extra debug accesses.

In Verdi (or your favourite waveform viewer), the log can be added to
the waves from here:
```
 /tb/u_sim_sram/u_sim_sram_if/u_sw_test_status_if/printed_log
```

Signed-off-by: Srikrishna Iyer <sriyer@google.com>