### PR TITLE
[adc_ctrl] Excluded adc_en_ctl.adc_enable field from CSR write tests

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -71,6 +71,10 @@
         { bits: "0",
           name: "adc_enable",
           desc: "1'b0: to power down ADC and ADC_CTRL FSM will enter the reset state; 1'b1: to power up ADC and ADC_CTRL FSM will start",
+          tags: [
+            // Writes to ADC_EN_CTRL.ADC_ENABLE will cause side effects
+            "excl:CsrNonInitTests:CsrExclWrite:CsrExclWriteCheck"
+          ]
         }
         { bits: "1",
           name: "oneshot_mode",


### PR DESCRIPTION
- Updated adc_ctrl.hjson to disable writing to adc_en_ctl.adc_enable
during CSR tests this is to prevent unpredictable side effects.

- solves #10113

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>