### PR TITLE
[rom_ctrl, dv] Fixes regression failures in rom_ctrl_passthru_mem_tl_intg_err

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -410,7 +410,6 @@ virtual task test_intg_err_in_passthru_mem(const ref dv_base_mem mems[$]);
     offset = $urandom_range(0, mems[i].get_n_bytes() - 1);
     addr = mems[i].get_address(offset);
     ral_name = mems[i].get_parent().get_name();
-
     // Before inject faults, this read should have correct integrity
     tl_access_sub(.addr(addr), .write(0), .data(data), .completed(completed), .saw_err(saw_err),
                   .check_rsp(1),  .rsp(tl_access_rsp),

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
@@ -119,53 +119,6 @@ virtual function void rom_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:
   for (int i = 0; i < addr_width; i++) begin
     bus_addr[addr_lsb + i] = scrambled_addr[i];
   end
-
   // Write the scrambled data to memory
   write39integ(bus_addr, scrambled_data);
-endfunction
-
-virtual function logic [38:0] rom_encrypt_read32_integ(logic [bus_params_pkg::BUS_AW-1:0] addr,
-                                                        logic [SRAM_KEY_WIDTH-1:0]        key,
-                                                        logic [SRAM_BLOCK_WIDTH-1:0]      nonce,
-                                                        bit   unscramble_data);
-  logic [bus_params_pkg::BUS_AW-1:0] bus_addr = '0;
-  logic [38:0]                       rdata = '0;
-
-  logic rdata_arr     [] = new[39];
-  logic scrambled_addr[] = new[addr_width];
-  logic sram_addr     [] = new[addr_width];
-  logic key_arr       [] = new[SRAM_KEY_WIDTH];
-  logic nonce_arr     [] = new[SRAM_BLOCK_WIDTH];
-
-  key_arr   = {<<{key}};
-  nonce_arr = {<<{nonce}};
-  for (int i = 0; i < addr_width; i++) begin
-    sram_addr[i] = addr[addr_lsb + i];
-  end
-
-  // Calculate the scrambled address
-  scrambled_addr = sram_scrambler_pkg::encrypt_sram_addr(sram_addr, addr_width, nonce_arr);
-
-  // Construct bus representation of the address
-  for (int i = 0; i < addr_lsb; i++) begin
-    bus_addr[i] = addr[i];
-  end
-  for (int i = 0; i < addr_width; i++) begin
-    bus_addr[addr_lsb + i] = scrambled_addr[i];
-  end
-
-  // Read memory and return the decrypted data
-  rdata = read39integ(bus_addr);
-  `uvm_info(`gfn, $sformatf("scr data: 0x%0x", rdata), UVM_HIGH)
-  if(!unscramble_data) begin
-    return rdata;
-  end
-  rdata_arr = {<<{rdata}};
-  rdata_arr = sram_scrambler_pkg::decrypt_sram_data(
-      rdata_arr, 39, 39, sram_addr, addr_width, key_arr, nonce_arr
-  );
-  rdata = {<<{rdata_arr}};
-  // Only return the data payload without ECC bits.
-  return rdata[31:0];
-
 endfunction

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -16,11 +16,11 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
 
   virtual function void inject_intg_fault_in_passthru_mem(dv_base_mem mem,
                                                           bit [bus_params_pkg::BUS_AW-1:0] addr);
-    bit[bus_params_pkg::BUS_DW-1:0] rdata;
+    bit[tlul_pkg::DataIntgWidth+bus_params_pkg::BUS_DW-1:0] rdata;
     bit[tlul_pkg::DataIntgWidth+bus_params_pkg::BUS_DW-1:0] flip_bits;
 
-    rdata = cfg.mem_bkdr_util_h.rom_encrypt_read32_integ(addr, RND_CNST_SCR_KEY,
-                                                         RND_CNST_SCR_NONCE, 1'b0);
+    rdata = cfg.mem_bkdr_util_h.rom_encrypt_read32(addr, RND_CNST_SCR_KEY,
+                                                   RND_CNST_SCR_NONCE, 1'b1);
 
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bits,
         $countones(flip_bits) inside {[1:cip_base_pkg::MAX_TL_ECC_ERRORS]};)
@@ -29,6 +29,6 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
                               addr, rdata, flip_bits), UVM_LOW)
 
     cfg.mem_bkdr_util_h.rom_encrypt_write32_integ(addr, rdata, RND_CNST_SCR_KEY, RND_CNST_SCR_NONCE,
-                                                  1'b0, flip_bits);
+                                                  1'b1, flip_bits);
   endfunction
 endclass


### PR DESCRIPTION
Fixes regression failures in rom_ctrl_passthru_mem_tl_intg_err testcase.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>