### PR TITLE
[dv/lc_ctrl] Fix jtag_map related failure

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -204,6 +204,7 @@
     {
       name: "lc_ctrl_stress_all"
       uvm_test_seq: lc_ctrl_stress_all_vseq
+      run_opts: ["+create_jtag_riscv_map=1"]
     }
 
   ]


### PR DESCRIPTION
This PR fixes jtag_map null failure by adding a runtime switch.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>