### PR TITLE
[keymgr, rom, sram] Add additional secure anchors

### DIFF
--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lfsr
       - lowrisc:prim:msb_extend
+      - lowrisc:prim:sec_anchor
       - lowrisc:prim:sparse_fsm
       - lowrisc:ip:flash_ctrl_pkg
       - lowrisc:ip:keymgr_pkg

--- a/hw/ip/rom_ctrl/rom_ctrl.core
+++ b/hw/ip/rom_ctrl/rom_ctrl.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:buf
       - lowrisc:prim:cipher
       - lowrisc:prim:rom_adv
+      - lowrisc:prim:sec_anchor
       - lowrisc:prim:sparse_fsm
       - lowrisc:prim:subreg
       - lowrisc:prim:util

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -56,6 +56,26 @@ module sram_ctrl
 
   `ASSERT_INIT(NonceWidthsLessThanSource_A, NonceWidth + LfsrWidth <= otp_ctrl_pkg::SramNonceWidth)
 
+
+  /////////////////////////////////////
+  // Anchor incoming seeds and constants
+  /////////////////////////////////////
+  localparam int TotalAnchorWidth = $bits(otp_ctrl_pkg::sram_key_t) +
+                                    $bits(otp_ctrl_pkg::sram_nonce_t);
+
+  otp_ctrl_pkg::sram_key_t cnst_sram_key;
+  otp_ctrl_pkg::sram_nonce_t cnst_sram_nonce;
+
+  prim_sec_anchor_buf #(
+    .Width(TotalAnchorWidth)
+  ) u_seed_anchor (
+    .in_i({RndCnstSramKey,
+           RndCnstSramNonce}),
+    .out_o({cnst_sram_key,
+            cnst_sram_nonce})
+  );
+
+
   //////////////////////////
   // CSR Node and Mapping //
   //////////////////////////
@@ -228,6 +248,8 @@ module sram_ctrl
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin
       key_req_pending_q <= 1'b0;
+      // reset case does not use buffered values as the
+      // reset value will be directly encoded into flop types
       key_q             <= RndCnstSramKey;
       nonce_q           <= RndCnstSramNonce;
     end else begin
@@ -238,8 +260,8 @@ module sram_ctrl
       end
       // This scraps the keys.
       if (local_esc) begin
-        key_q   <= RndCnstSramKey;
-        nonce_q <= RndCnstSramNonce;
+        key_q   <= cnst_sram_key;
+        nonce_q <= cnst_sram_nonce;
       end
     end
   end


### PR DESCRIPTION
- Partially addresses #8983
- Adds anchor buffers for default nonces, seeds and keys

Signed-off-by: Timothy Chen <timothytim@google.com>