### PR TITLE
[opentitantool] Adding I2C support to transport

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -7,6 +7,7 @@ pub mod command;
 pub mod conf;
 
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
+use crate::io::i2c::Bus;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
@@ -41,6 +42,7 @@ pub struct TransportWrapper {
     pin_map: HashMap<String, String>,
     uart_map: HashMap<String, String>,
     spi_map: HashMap<String, String>,
+    i2c_map: HashMap<String, String>,
     flash_map: HashMap<String, conf::FlashConfiguration>,
     pin_conf_map: HashMap<String, PinConfiguration>,
     strapping_conf_map: HashMap<String, HashMap<String, PinConfiguration>>,
@@ -53,6 +55,7 @@ impl TransportWrapper {
             pin_map: HashMap::new(),
             uart_map: HashMap::new(),
             spi_map: HashMap::new(),
+            i2c_map: HashMap::new(),
             flash_map: HashMap::new(),
             pin_conf_map: HashMap::new(),
             strapping_conf_map: HashMap::new(),
@@ -70,6 +73,13 @@ impl TransportWrapper {
         self.transport
             .borrow()
             .spi(Self::map_name(&self.spi_map, name).as_str())
+    }
+
+    /// Returns a I2C [`Bus`] implementation.
+    pub fn i2c(&self, name: &str) -> Result<Rc<dyn Bus>> {
+        self.transport
+            .borrow()
+            .i2c(Self::map_name(&self.i2c_map, name).as_str())
     }
 
     /// Returns a [`Uart`] implementation.
@@ -91,9 +101,9 @@ impl TransportWrapper {
         self.transport.borrow().dispatch(action)
     }
 
-    /// Given an pin/uart/spi port name, if the name is a known alias,
-    /// return the underlying name/number, otherwise return the string
-    /// as is.
+    /// Given an pin/uart/spi/i2c port name, if the name is a known
+    /// alias, return the underlying name/number, otherwise return the
+    /// string as is.
     fn map_name(map: &HashMap<String, String>, name: &str) -> String {
         let name = name.to_uppercase();
         // TODO(#8769): Support multi-level aliasing, either by

--- a/sw/host/opentitanlib/src/io/i2c.rs
+++ b/sw/host/opentitanlib/src/io/i2c.rs
@@ -1,0 +1,42 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use thiserror::Error;
+use std::rc::Rc;
+use structopt::StructOpt;
+
+use crate::app::TransportWrapper;
+
+#[derive(Debug, StructOpt)]
+pub struct I2cParams {
+    #[structopt(long, help = "I2C instance", default_value = "0")]
+    pub bus: String,
+}
+
+impl I2cParams {
+    pub fn create(&self, transport: &TransportWrapper) -> Result<Rc<dyn Bus>> {
+        let i2c = transport.i2c(&self.bus)?;
+        Ok(i2c)
+    }
+}
+
+/// Errors related to the I2C interface and I2C transactions.
+#[derive(Error, Debug)]
+pub enum I2cError {
+    #[error("Invalid data length: {0}")]
+    InvalidDataLength(usize),
+}
+
+/// Represents a I2C transfer.
+pub enum Transfer<'rd, 'wr> {
+    Read(&'rd mut [u8]),
+    Write(&'wr [u8]),
+}
+
+/// A trait which represents a I2C Bus.
+pub trait Bus {
+    /// Runs a I2C transaction composed from the slice of [`Transfer`] objects.
+    fn run_transaction(&self, addr: u8, transaction: &mut [Transfer]) -> Result<()>;
+}

--- a/sw/host/opentitanlib/src/io/mod.rs
+++ b/sw/host/opentitanlib/src/io/mod.rs
@@ -3,5 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod gpio;
+pub mod i2c;
 pub mod spi;
 pub mod uart;

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -1,0 +1,214 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{ensure, Result};
+use std::cmp;
+use std::rc::Rc;
+use zerocopy::{AsBytes, FromBytes};
+
+use crate::io::i2c::{I2cError, Bus, Transfer};
+use crate::transport::hyperdebug::{BulkInterface, Error, Hyperdebug, Inner};
+
+pub struct HyperdebugI2cBus {
+    inner: Rc<Inner>,
+    interface: BulkInterface,
+    bus_idx: u8,
+    max_write_size: usize,
+    max_read_size: usize,
+}
+
+const USB_MAX_SIZE: usize = 64;
+
+/// Wire format of USB packet to request a short I2C transaction
+/// (receiving at most 127 bytes).
+#[derive(AsBytes, FromBytes, Debug)]
+#[repr(C)]
+struct CmdTransferShort {
+    port: u8,
+    addr: u8,
+    write_count: u8,
+    read_count: u8,
+    data: [u8; USB_MAX_SIZE - 4],
+}
+
+/// Wire format of USB packet to request a long I2C transaction
+/// (receiving up to 32767 bytes).
+#[derive(AsBytes, FromBytes, Debug)]
+#[repr(C)]
+struct CmdTransferLong {
+    port: u8,
+    addr: u8,
+    write_count: u8,
+    read_count: u8,
+    read_count1: u8,
+    reserved: u8,
+    data: [u8; USB_MAX_SIZE - 6],
+}
+
+/// Wire format of USB packet containing I2C transaction response.
+#[derive(AsBytes, FromBytes, Debug)]
+#[repr(C)]
+struct RspTransfer {
+    status_code: u16,
+    reserved: u16,
+    data: [u8; USB_MAX_SIZE - 4],
+}
+impl RspTransfer {
+    fn new() -> Self {
+        Self {
+            status_code: 0,
+            reserved: 0,
+            data: [0; USB_MAX_SIZE - 4],
+        }
+    }
+}
+
+impl HyperdebugI2cBus {
+    pub fn open(hyperdebug: &Hyperdebug, idx: u8) -> Result<Self> {
+        let mut usb_handle = hyperdebug.inner.usb_device.borrow_mut();
+
+        // Exclusively claim I2C interface, preparing for bulk transfers.
+        usb_handle.claim_interface(hyperdebug.i2c_interface.interface)?;
+
+        Ok(Self {
+            inner: Rc::clone(&hyperdebug.inner),
+            interface: hyperdebug.i2c_interface,
+            bus_idx: idx,
+            max_read_size: 0x8000 as usize,
+            max_write_size: 0x1000 as usize,
+        })
+    }
+
+    /// Transmit data for a single I2C operation, using one or more USB packets.
+    fn transmit_then_receive(&self, addr: u8, wbuf: &[u8], rbuf: &mut [u8]) -> Result<()> {
+        ensure!(
+            rbuf.len() < self.max_read_size,
+            I2cError::InvalidDataLength(rbuf.len())
+        );
+        ensure!(
+            wbuf.len() < self.max_write_size,
+            I2cError::InvalidDataLength(wbuf.len())
+        );
+        let mut index = if rbuf.len() < 128 {
+            // Short format header
+            let mut req = CmdTransferShort {
+                port: self.bus_idx | (((wbuf.len() & 0x0F00) >> 4) as u8),
+                addr: addr,
+                write_count: (wbuf.len() & 0x00FF) as u8,
+                read_count: rbuf.len() as u8,
+                data: [0; USB_MAX_SIZE - 4],
+            };
+            let databytes = cmp::min(USB_MAX_SIZE - 4, wbuf.len());
+            req.data[..databytes].clone_from_slice(&wbuf[..databytes]);
+            self.usb_write_bulk(&req.as_bytes()[..4 + databytes])?;
+            databytes
+        } else {
+            // Long format header
+            let mut req = CmdTransferLong {
+                port: self.bus_idx | (((wbuf.len() & 0x0F00) >> 4) as u8),
+                addr: addr,
+                write_count: (wbuf.len() & 0x00FF) as u8,
+                read_count: (rbuf.len() & 0x007F) as u8,
+                read_count1: (rbuf.len() >> 7) as u8,
+                reserved: 0,
+                data: [0; USB_MAX_SIZE - 6],
+            };
+            let databytes = cmp::min(USB_MAX_SIZE - 6, wbuf.len());
+            req.data[..databytes].clone_from_slice(&wbuf[..databytes]);
+            self.usb_write_bulk(&req.as_bytes()[..6 + databytes])?;
+            databytes
+        };
+
+        // Transmit any more data without further header.
+        while index < wbuf.len() {
+            let databytes = cmp::min(USB_MAX_SIZE, wbuf.len() - index);
+            self.usb_write_bulk(&wbuf[index..index + databytes])?;
+            index += databytes;
+        }
+
+        let mut resp = RspTransfer::new();
+        let bytecount = self.usb_read_bulk(&mut resp.as_bytes_mut())?;
+        ensure!(
+            bytecount >= 4,
+            Error::CommunicationError("Unrecognized response to I2C request")
+        );
+        ensure!(
+            resp.status_code == 0,
+            Error::CommunicationError("I2C error")
+        );
+        let databytes = bytecount - 4;
+        rbuf[..databytes].clone_from_slice(&resp.data[..databytes]);
+        let mut index = databytes;
+        while index < rbuf.len() {
+            let databytes = self.usb_read_bulk(&mut resp.data[index..])?;
+            ensure!(
+                databytes > 0,
+                Error::CommunicationError("Unrecognized reponse to I2C request")
+            );
+            index += databytes;
+        }
+        Ok(())
+    }
+
+    /// Send one USB packet.
+    fn usb_write_bulk(&self, buf: &[u8]) -> Result<()> {
+        self.inner
+            .usb_device
+            .borrow()
+            .write_bulk(self.interface.out_endpoint, buf)?;
+        Ok(())
+    }
+
+    /// Receive one USB packet.
+    fn usb_read_bulk(&self, buf: &mut [u8]) -> Result<usize> {
+        Ok(self
+            .inner
+            .usb_device
+            .borrow()
+            .read_bulk(self.interface.in_endpoint, buf)?)
+    }
+}
+
+impl Bus for HyperdebugI2cBus {
+    fn run_transaction(&self, addr: u8, mut transaction: &mut [Transfer]) -> Result<()> {
+        while transaction.len() > 0 {
+            match transaction {
+                [Transfer::Write(wbuf), Transfer::Read(rbuf), ..] => {
+                    // Hyperdebug can do I2C write followed by I2C read as a single USB
+                    // request/reply.  Take advantage of that by detecting pairs of
+                    // Transfer::Write followed by Transfer::Read.
+                    ensure!(
+                        wbuf.len() <= self.max_write_size,
+                        I2cError::InvalidDataLength(wbuf.len())
+                    );
+                    ensure!(
+                        rbuf.len() <= self.max_read_size,
+                        I2cError::InvalidDataLength(rbuf.len())
+                    );
+                    self.transmit_then_receive(addr, wbuf, rbuf)?;
+                    // Skip two steps ahead, as two items were processed.
+                    transaction = &mut transaction[2..];
+                }
+                [Transfer::Write(wbuf), ..] => {
+                    ensure!(
+                        wbuf.len() <= self.max_write_size,
+                        I2cError::InvalidDataLength(wbuf.len())
+                    );
+                    self.transmit_then_receive(addr, wbuf, &mut [])?;
+                    transaction = &mut transaction[1..];
+                }
+                [Transfer::Read(rbuf), ..] => {
+                    ensure!(
+                        rbuf.len() <= self.max_read_size,
+                        I2cError::InvalidDataLength(rbuf.len())
+                    );
+                    self.transmit_then_receive(addr, &[], rbuf)?;
+                    transaction = &mut transaction[1..];
+                }
+                [] => (),
+            }
+        }
+        Ok(())
+    }
+}

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 use thiserror::Error;
 
 use crate::io::gpio::GpioPin;
+use crate::io::i2c::Bus;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
 
@@ -26,6 +27,7 @@ bitflags! {
         const UART = 0x00000001;
         const SPI = 0x00000002;
         const GPIO = 0x00000004;
+        const I2C = 0x00000008;
     }
 }
 
@@ -83,6 +85,10 @@ pub trait Transport {
 
     /// Returns a SPI [`Target`] implementation.
     fn spi(&self, _instance: &str) -> Result<Rc<dyn Target>> {
+        unimplemented!();
+    }
+    /// Returns a I2C [`Bus`] implementation.
+    fn i2c(&self, _instance: &str) -> Result<Rc<dyn Bus>> {
         unimplemented!();
     }
     /// Returns a [`Uart`] implementation.

--- a/sw/host/opentitantool/Cargo.toml
+++ b/sw/host/opentitantool/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
+hex = "0.4"
 thiserror = "1.0"
 opentitanlib = {path="../opentitanlib"}
 structopt = "0.3"

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -1,0 +1,99 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use erased_serde::Serialize;
+use std::any::Any;
+use structopt::StructOpt;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::io::i2c::{I2cParams, Transfer};
+use opentitanlib::transport::Capability;
+
+/// Read plain data bytes from a I2C device.
+#[derive(Debug, StructOpt)]
+pub struct I2cRawRead {
+    #[structopt(
+        short = "n",
+        long,
+        help = "Number of bytes to read."
+    )]
+    length: usize,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct I2cRawReadResponse {
+    hexdata: String,
+}
+
+impl CommandDispatch for I2cRawRead {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        transport.capabilities().request(Capability::I2C).ok()?;
+        let context = context.downcast_ref::<I2cCommand>().unwrap();
+        let i2c_bus = context.params.create(transport)?;
+        let mut v = vec![0u8; self.length];
+        i2c_bus.run_transaction(context.addr, &mut [Transfer::Read(&mut v)])?;
+        Ok(Some(Box::new(I2cRawReadResponse {
+            hexdata: hex::encode(v),
+        })))
+    }
+}
+
+/// Write plain data bytes to a I2C device.
+#[derive(Debug, StructOpt)]
+pub struct I2cRawWrite {
+    #[structopt(short, long, help = "Hex data bytes to write.")]
+    hexdata: String,
+}
+
+impl CommandDispatch for I2cRawWrite {
+    fn run(
+        &self,
+        context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        transport.capabilities().request(Capability::I2C).ok()?;
+        let context = context.downcast_ref::<I2cCommand>().unwrap();
+        let i2c_bus = context.params.create(transport)?;
+        i2c_bus.run_transaction(context.addr, &mut [Transfer::Write(&hex::decode(&self.hexdata)?)])?;
+        Ok(None)
+    }
+}
+
+
+/// Commands for interacting with a generic I2C bus.
+#[derive(Debug, StructOpt, CommandDispatch)]
+pub enum InternalI2cCommand {
+    RawRead(I2cRawRead),
+    RawWrite(I2cRawWrite),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct I2cCommand {
+    #[structopt(flatten)]
+    params: I2cParams,
+
+    #[structopt(short, long, help = "7-bit address of I2C device (0..0x7F).")]
+    addr: u8,
+
+    #[structopt(subcommand)]
+    command: InternalI2cCommand,
+}
+
+impl CommandDispatch for I2cCommand {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        // None of the I2C commands care about the prior context, but they do
+        // care about the `bus` parameter in the current node.
+        self.command.run(self, transport)
+    }
+}

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -5,6 +5,7 @@
 pub mod bootstrap;
 pub mod console;
 pub mod gpio;
+pub mod i2c;
 pub mod hello;
 pub mod image;
 pub mod load_bitstream;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -26,6 +26,7 @@ enum RootCommandHierarchy {
 
     Gpio(command::gpio::GpioCommand),
 
+    I2c(command::i2c::I2cCommand),
     Image(command::image::Image),
     LoadBitstream(command::load_bitstream::LoadBitstream),
     NoOp(command::NoOp),


### PR DESCRIPTION
Adding trait for I2C busses on transports, similar to SPI.

Adding implementation of above trait for HyperDebug.

Adding rudimentary commands to opentitantool to allow reading/writing
raw bytes on I2C bus.  Longer term plan is to add support for issuing
certain TPM commands via either SPI or I2C.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>

Change-Id: I3383e2e8d602adc4a38ab69519046378539c6660