### PR TITLE
[hw/test] Enable use of entropy in mask ROM.

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -40,8 +40,7 @@
                     // Enable use of entropy for countermeasures. See the
                     // definition of `hardened_bool_t` in
                     // sw/device/lib/base/hardened.h.
-                    // TODO(#10177): Enable for integration testing.
-                    value: "0x0",
+                    value: "0x739",
                 },
             ],
         }


### PR DESCRIPTION
This is done by setting CREATOR_SW_CFG_RNG_EN to 0x739.

Tested by running: 

```console
bazelisk test //sw/device/silicon_creator/lib/drivers:rnd_functest \
  --test_tag_filters=-cw310 --disk_cache=~/bazel_cache
```

This issue closes #10177 