### PR TITLE
[dv] sec_cm verification for sparse_fsm

### DIFF
--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -13,8 +13,6 @@ interface prim_count_if #(
   input clk_i,
   input rst_ni);
 
-  localparam int ErrorToAlertMaxCycles = 5;
-
   string msg_id = $sformatf("%m");
 
   prim_count_pkg::prim_count_style_e cnt_style = CntStyle;
@@ -33,7 +31,7 @@ interface prim_count_if #(
       @(negedge clk_i);
       `DV_CHECK(uvm_hdl_read(signal_forced, orig_value))
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value, force_value != orig_value;)
-      uvm_hdl_deposit(signal_forced, force_value);
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, force_value))
       `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
                                   signal_forced, orig_value, force_value), UVM_LOW)
 
@@ -41,7 +39,7 @@ interface prim_count_if #(
     endtask
 
     virtual task restore_fault();
-      uvm_hdl_deposit(signal_forced, orig_value);
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
       `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
                 UVM_LOW)
     endtask

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Generic countermeasure interface for hardened FSM
+//
+// This contains a proxy class and store the object in sec_cm_pkg, which can be used in vseq to
+// control inject_fault and restore_fault
+interface prim_sparse_fsm_flop_if #(
+  parameter int Width = 2
+) (
+  input clk_i,
+  input rst_ni);
+
+  localparam int MaxFlipBits = 2;
+
+  string msg_id = $sformatf("%m");
+
+  string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
+  string signal_forced = $sformatf("%s.state_o", path);
+
+  class prim_sparse_fsm_flop_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
+    `uvm_object_new
+
+    logic[Width-1:0] orig_value;
+
+    virtual task inject_fault();
+      logic[Width-1:0] force_value;
+
+      @(negedge clk_i);
+      `DV_CHECK(uvm_hdl_read(signal_forced, orig_value))
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value,
+          $countones(force_value ^ orig_value) inside {[1: MaxFlipBits]};)
+
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, force_value))
+      `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
+                                  signal_forced, orig_value, force_value), UVM_LOW)
+
+      @(posedge clk_i);
+    endtask
+
+    virtual task restore_fault();
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
+      `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
+                UVM_LOW)
+    endtask
+  endclass
+
+  prim_sparse_fsm_flop_if_proxy if_proxy;
+
+  initial begin
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced), , msg_id)
+
+    // Store the proxy object for TB to use
+    if_proxy = new("if_proxy");
+    if_proxy.sec_cm_type = sec_cm_pkg::SecCmPrimSparseFsmFlop;
+    if_proxy.path = path;
+    sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
+
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+  end
+endinterface

--- a/hw/dv/sv/sec_cm/sec_cm.core
+++ b/hw/dv/sv/sec_cm/sec_cm.core
@@ -10,11 +10,13 @@ filesets:
     depend:
       - lowrisc:prim:alert
       - lowrisc:prim:count
+      - lowrisc:prim:sparse_fsm
       - lowrisc:dv:dv_utils
     files:
       - sec_cm_pkg.sv
       - sec_cm_base_if_proxy.sv: {is_include_file: true}
       - prim_count_if.sv
+      - prim_sparse_fsm_flop_if.sv
       - sec_cm_bind.sv
     file_type: systemVerilogSource
 

--- a/hw/dv/sv/sec_cm/sec_cm_bind.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_bind.sv
@@ -4,4 +4,7 @@
 
 module sec_cm_bind();
   bind prim_count prim_count_if #(.CntStyle(CntStyle), .Width(Width)) u_prim_count_if (.*);
+
+  bind prim_sparse_fsm_flop prim_sparse_fsm_flop_if #(
+         .Width(Width)) u_prim_sparse_fsm_flop_if (.*);
 endmodule

--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -16,7 +16,7 @@ package sec_cm_pkg;
 
   typedef enum int {
     SecCmPrimCount,
-    SecCmPrimFsm
+    SecCmPrimSparseFsmFlop
   } sec_cm_type_e;
 
   `include "sec_cm_base_if_proxy.sv"

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -88,11 +88,19 @@ class keymgr_common_vseq extends keymgr_base_vseq;
 
     super.check_sec_cm_fi_resp(if_proxy);
 
-    if (!uvm_re_match("*.u_reseed_ctrl*", if_proxy.path)) begin
-      exp[keymgr_pkg::FaultReseedCnt] = 1;
-    end else begin
-      exp[keymgr_pkg::FaultCtrlCnt] = 1;
-    end
+    case (if_proxy.sec_cm_type)
+      SecCmPrimCount: begin
+        if (!uvm_re_match("*.u_reseed_ctrl*", if_proxy.path)) begin
+          exp[keymgr_pkg::FaultReseedCnt] = 1;
+        end else begin
+          exp[keymgr_pkg::FaultCtrlCnt] = 1;
+        end
+      end
+      SecCmPrimSparseFsmFlop: begin
+        exp[keymgr_pkg::FaultCtrlFsm] = 1;
+      end
+      default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
+    endcase
     csr_rd_check(.ptr(ral.fault_status), .compare_value(exp));
 
     // after an advance, keymgr should enter StInvalid
@@ -126,8 +134,8 @@ class keymgr_common_vseq extends keymgr_base_vseq;
           $assertoff(0, "tb.dut.KmacDataKnownO_A");
         end
       end
-      SecCmPrimFsm: begin
-        // TODO
+      SecCmPrimSparseFsmFlop: begin
+        // No need to disable any assertion
       end
       default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
     endcase


### PR DESCRIPTION
First PR is some minor fix for prim_count_if.

Main updates are in the 2nd PR.
1. Add prim_sparse_fsm_flop_if for injecting fault by flipping up to 2
bits of FSM
2. bind the interface to all prim_sparse_fsm_flop
3. Enable this for keymgr

Signed-off-by: Weicai Yang <weicai@google.com>