### PR TITLE
[dv/pwrmgr] Fix coverage collection

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cov.sv
@@ -11,31 +11,23 @@
 // Wrapper class for wakeup control covergroup.
 class pwrmgr_wakeup_ctrl_cg_wrap;
   // This covers enable, capture, and status of wakeups.
-  covergroup wakeup_ctrl_cg(
-      string name
-  ) with function sample (
-      bit enable, bit capture, bit wakeup, bit status
-  );
+  covergroup wakeup_ctrl_cg(string name) with function sample (bit enable, bit capture, bit wakeup);
     option.name = name;
     option.per_instance = 1;
 
     enable_cp: coverpoint enable;
     capture_cp: coverpoint capture;
     wakeup_cp: coverpoint wakeup;
-    status_cp: coverpoint status;
 
-    wakeup_cross: cross enable_cp, capture_cp, wakeup_cp, status_cp{
-      ignore_bins disable_status = wakeup_cross with (enable_cp == 0 && status_cp == 1);
-      ignore_bins no_wakeup_status = wakeup_cross with (wakeup_cp == 0 && status_cp == 1);
-    }
+    wakeup_cross: cross enable_cp, capture_cp, wakeup_cp;
   endgroup
 
   function new(string name);
     wakeup_ctrl_cg = new(name);
   endfunction
 
-  function void sample (bit enable, bit capture, bit wakeup, bit status);
-    wakeup_ctrl_cg.sample(enable, capture, wakeup, status);
+  function void sample (bit enable, bit capture, bit wakeup);
+    wakeup_ctrl_cg.sample(enable, capture, wakeup);
   endfunction
 endclass
 
@@ -56,6 +48,7 @@ class pwrmgr_wakeup_intr_cg_wrap;
     interrupt_cp: coverpoint interrupt;
 
     interrupt_cross: cross enable_cp, status_cp, wakeup_cp, interrupt_cp{
+      ignore_bins no_wakeup = interrupt_cross with (wakeup_cp == 0 && interrupt_cp == 1);
       ignore_bins disable_pin = interrupt_cross with (enable_cp == 0 && interrupt_cp == 1);
       ignore_bins no_status_pin = interrupt_cross with (status_cp == 0 && interrupt_cp == 1);
     }
@@ -129,7 +122,7 @@ class pwrmgr_env_cov extends cip_base_env_cov #(
   // It is positive when reset happened after wakeup, and zero when they coincided in time.
   covergroup reset_wakeup_distance_cg with function sample (int cycles);
     cycles_cp: coverpoint cycles {
-      bins close[] = {[-4:4]};
+      bins close[] = {[-4 : 4]};
       bins far = default;
     }
   endgroup

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -72,15 +72,28 @@ interface pwrmgr_if (
   pwrmgr_pkg::fast_pwr_state_e fast_state;
   always_comb fast_state = `PATH_TO_DUT.u_fsm.state_q;
 
+  always_comb
+    wakeup_en = {
+      `PATH_TO_DUT.reg2hw.wakeup_en[5].q,
+      `PATH_TO_DUT.reg2hw.wakeup_en[4].q,
+      `PATH_TO_DUT.reg2hw.wakeup_en[3].q,
+      `PATH_TO_DUT.reg2hw.wakeup_en[2].q,
+      `PATH_TO_DUT.reg2hw.wakeup_en[1].q,
+      `PATH_TO_DUT.reg2hw.wakeup_en[0].q
+    };
+
   // Wakeup_status ro CSR.
   always_comb
     wakeup_status = {
+      `PATH_TO_DUT.hw2reg.wake_status[5].d,
       `PATH_TO_DUT.hw2reg.wake_status[4].d,
       `PATH_TO_DUT.hw2reg.wake_status[3].d,
       `PATH_TO_DUT.hw2reg.wake_status[2].d,
       `PATH_TO_DUT.hw2reg.wake_status[1].d,
       `PATH_TO_DUT.hw2reg.wake_status[0].d
     };
+
+  always_comb wakeup_capture_en = !`PATH_TO_DUT.u_reg.wake_info_capture_dis_qs;
 
   logic intr_enable;
   always_comb intr_enable = `PATH_TO_DUT.reg2hw.intr_enable.q;
@@ -125,24 +138,8 @@ interface pwrmgr_if (
     pwr_cpu.core_sleeping = value;
   endfunction
 
-  function automatic void update_wakeup_en_regwen(logic value);
-    wakeup_en_regwen &= value;
-  endfunction
-
-  function automatic void update_wakeup_en(logic [pwrmgr_reg_pkg::NumWkups-1:0] value);
-    wakeup_en = value;
-  endfunction
-
-  function automatic void update_wakeup_status(logic [pwrmgr_reg_pkg::NumWkups-1:0] value);
-    wakeup_status = value;
-  endfunction
-
   function automatic void update_wakeups(logic [pwrmgr_reg_pkg::NumWkups-1:0] wakeups);
     wakeups_i = wakeups;
-  endfunction
-
-  function automatic void update_wakeup_capture_dis(logic value);
-    wakeup_capture_en = !value;
   endfunction
 
   function automatic void update_resets(logic [pwrmgr_reg_pkg::NumRstReqs-1:0] resets);

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_scoreboard.sv
@@ -38,14 +38,14 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
   task wakeup_ctrl_coverage_collector();
     forever
-      @(posedge cfg.pwrmgr_vif.wakeups_i) begin
+      @(posedge (|cfg.pwrmgr_vif.wakeups_i)) begin
         if (cfg.en_cov) begin
           // Allow for synchronization delay.
           cfg.slow_clk_rst_vif.wait_clks(2);
           foreach (cov.wakeup_ctrl_cg_wrap[i]) begin
-            cov.wakeup_ctrl_cg_wrap[i].sample(
-                cfg.pwrmgr_vif.wakeup_en[i], cfg.pwrmgr_vif.wakeup_capture_en,
-                cfg.pwrmgr_vif.wakeups_i[i], cfg.pwrmgr_vif.wakeup_status[i]);
+            cov.wakeup_ctrl_cg_wrap[i].sample(cfg.pwrmgr_vif.wakeup_en[i],
+                                              cfg.pwrmgr_vif.wakeup_capture_en,
+                                              cfg.pwrmgr_vif.wakeups_i[i]);
           end
         end
       end
@@ -133,7 +133,7 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
 
     // if incoming access is a write to a valid csr, then make updates right away
     if (addr_phase_write) begin
-      `uvm_info(`gfn, $sformatf("Writing 0x%x to %s", item.a_data, csr.get_full_name()), UVM_LOW)
+      `uvm_info(`gfn, $sformatf("Writing 0x%x to %s", item.a_data, csr.get_full_name()), UVM_MEDIUM)
       void'(csr.predict(.value(item.a_data), .kind(UVM_PREDICT_WRITE), .be(item.a_mask)));
     end
 
@@ -209,15 +209,8 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       "wakeup_en_regwen": begin
-        // rw0c, so writing a 1 is a no-op.
-        if (data_phase_write) begin
-          cfg.pwrmgr_vif.update_wakeup_en_regwen(item.a_data);
-        end
       end
       "wakeup_en": begin
-        if (data_phase_write) begin
-          cfg.pwrmgr_vif.update_wakeup_en(item.a_data);
-        end
       end
       "wake_status": begin
         // Read-only.
@@ -240,9 +233,6 @@ class pwrmgr_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;
       end
       "wake_info_capture_dis": begin
-        if (data_phase_write) begin
-          cfg.pwrmgr_vif.update_wakeup_capture_dis(item.a_data);
-        end
       end
       "wake_info": begin
         // rw1c: write 1 clears, write 0 is no-op.


### PR DESCRIPTION
Remove redundant `status` in pwrmgr_wakeup_ctrl_cg_wrap.
Add ignore_bins for interrupt_cross when !wakeup && interrupt.
Fix missing wake_status[5].
Move more CSR sampling to happen in interface.

Signed-off-by: Guillermo Maturana <maturana@google.com>