### PR TITLE
[rom_ctrl, dv] Fixes regression failure relating to tl accesses

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl.sv
@@ -490,6 +490,8 @@ module rom_ctrl
   // This check ensures that all tl accesses are blocked until rom check is completed. You might
   // think we could check for a_ready, but that doesn't work because the TL to SRAM adapter has a
   // 1-entry cache that accepts the transaction (but doesn't reply)
-  `ASSERT(TlAccessChk_A, (pwrmgr_data_o.done == prim_mubi_pkg::MuBi4False) |-> !rom_tl_o.d_valid)
+  `ASSERT(TlAccessChk_A,
+          (pwrmgr_data_o.done == prim_mubi_pkg::MuBi4False) |->
+          (!rom_tl_o.d_valid || (rom_tl_o.d_valid && rom_tl_o.d_error)))
 
 endmodule


### PR DESCRIPTION
There were false failures relating to assertion that checks that all tl
accesses before rom check is done are blocked off.
This commit fixes the assertion by adding an additional check that if
at all d_valid is asserted before the rom check is completed, d_error also
must be asserted.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>