### PR TITLE
Aon timer fixes

### DIFF
--- a/hw/ip/aon_timer/rtl/aon_timer_core.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_core.sv
@@ -54,7 +54,7 @@ module aon_timer_core import aon_timer_reg_pkg::*; (
   assign wkup_count_wr_data_o = (reg2hw_i.wkup_count.q + 32'd1);
 
   // Timer interrupt
-  assign wkup_intr_o = wkup_incr & (reg2hw_i.wkup_count.q == reg2hw_i.wkup_thold.q);
+  assign wkup_intr_o = wkup_incr & (reg2hw_i.wkup_count.q >= reg2hw_i.wkup_thold.q);
 
   ////////////////////
   // Watchdog Timer //
@@ -68,9 +68,9 @@ module aon_timer_core import aon_timer_reg_pkg::*; (
   assign wdog_count_wr_data_o = (reg2hw_i.wdog_count.q + 32'd1);
 
   // Timer interrupt
-  assign wdog_intr_o = wdog_incr & (reg2hw_i.wdog_count.q == reg2hw_i.wdog_bark_thold.q);
+  assign wdog_intr_o = wdog_incr & (reg2hw_i.wdog_count.q >= reg2hw_i.wdog_bark_thold.q);
   // Timer reset
-  assign wdog_reset_req_o = wdog_incr & (reg2hw_i.wdog_count.q == reg2hw_i.wdog_bite_thold.q);
+  assign wdog_reset_req_o = wdog_incr & (reg2hw_i.wdog_count.q >= reg2hw_i.wdog_bite_thold.q);
 
   assign unused_reg2hw = |{reg2hw_i.intr_state, reg2hw_i.intr_test, reg2hw_i.wkup_cause,
                            reg2hw_i.alert_test};

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -158,6 +158,13 @@ void ottf_external_isr(void) {
     irq = (dif_aon_timer_irq_t)(
         irq_id -
         (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+
+    if (irq_id == kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired) {
+      CHECK_DIF_OK(dif_aon_timer_wakeup_stop(&aon_timer));
+    } else if (irq_id == kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark) {
+      CHECK_DIF_OK(dif_aon_timer_watchdog_stop(&aon_timer));
+    }
+
     CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(&aon_timer, irq));
   }
 

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -216,14 +216,23 @@ bool test_main(void) {
       &plic, kPlicTarget, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
       kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
 
-  // Executing the test using a randon time between 100 and 1500 us to make sure
-  // the aon timer is generating the interrupt after the choosen time and theres
+  // Executing the test using randon time bounds calculated from the clock
+  // frequency to make sure the aon timer is generating the interrupt after the
+  // choosen time and there's no error in the reference time measurement. This
+  // calculation is required as the various platforms used for testing have
+  // differing clocks frequencies. A few hundred cycles is required for the
+  // interrupt to note the elapsed time so the test fails with an unacceptable
+  // time variance when the sleep time is too low.
+  uint64_t low_time_range = ((1000000 * 500) / kClockFreqCpuHz) * 20;
+  uint64_t high_time_range = ((1000000 * 500) / kClockFreqCpuHz) * 40;
+
   // no error in the reference time measurement.
-  uint64_t irq_time = rand_testutils_gen32_range(1, 15) * 100;
+  uint64_t irq_time =
+      rand_testutils_gen32_range(low_time_range, high_time_range);
   execute_test(&aon_timer, irq_time,
                /*expected_irq=*/kDifAonTimerIrqWkupTimerExpired);
 
-  irq_time = rand_testutils_gen32_range(1, 15) * 100;
+  irq_time = rand_testutils_gen32_range(low_time_range, high_time_range);
   execute_test(&aon_timer, irq_time,
                /*expected_irq=*/kDifAonTimerIrqWdogTimerBark);
 


### PR DESCRIPTION
Note the missed wakeup here is a generic problem with WFI usage. Producing a more generic solution that can be placed in lib/runtime (e.g. as part of the `wait_for_interrupt` function) may be a good idea.