### PR TITLE
[dv/otp] Two regression fixes

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -36,9 +36,7 @@ package otp_ctrl_env_pkg;
 
   parameter uint DIGEST_SIZE             = 8;
   parameter uint SW_WINDOW_BASE_ADDR     = 'h1000;
-  parameter uint TEST_ACCESS_BASE_ADDR   = 'h2000;
   parameter uint SW_WINDOW_SIZE          = 512 * 4;
-  parameter uint TEST_ACCESS_WINDOW_SIZE = 16 * 4;
 
   // convert byte into TLUL width size
   parameter uint VENDOR_TEST_START_ADDR  = VendorTestOffset / (TL_DW / 8);

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -514,10 +514,6 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                      csr_addr, otp_addr << 2))
       end
       return;
-    // TEST ACCESS window
-    end else if ((csr_addr & addr_mask) inside
-         {[TEST_ACCESS_BASE_ADDR : TEST_ACCESS_BASE_ADDR + TEST_ACCESS_WINDOW_SIZE]}) begin
-      return;
     end else begin
       `uvm_fatal(`gfn, $sformatf("Access unexpected addr 0x%0h", csr_addr))
     end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -518,18 +518,8 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   // This test access OTP_CTRL's test_access memory. The open-sourced code only test if the access
   // is valid. Please override this task in proprietary OTP.
+  // TODO: Add another TL interface to support this, and check if any conflict in close source.
   virtual task otp_test_access();
-    repeat($urandom_range(1, 20)) begin
-      bit [TL_DW-1:0] addr = $urandom_range(TEST_ACCESS_BASE_ADDR,
-                                            TEST_ACCESS_BASE_ADDR + TEST_ACCESS_WINDOW_SIZE - 1);
-      bit [TL_DW-1:0] data = $urandom();
-      bit [TL_DW-1:0] rdata;
-
-      addr = cfg.ral.get_addr_from_offset(addr);
-      `uvm_info(`gfn, $sformatf("write test access %0h with data %0h", addr, data), UVM_HIGH)
-      tl_access(.addr(addr), .write(1), .data(data));
-      tl_access(.addr(addr), .write(0), .data(rdata), .check_exp_data(1), .exp_data(data));
-    end
   endtask
 
 endclass : otp_ctrl_base_vseq

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -139,8 +139,8 @@ module tb;
     .scanmode_i                 (otp_ctrl_if.scanmode_i),
 
     // Test-related GPIO output
-    .cio_test_o                 (),
-    .cio_test_en_o              ()
+    .cio_test_o                 (otp_ctrl_if.cio_test_o),
+    .cio_test_en_o              (otp_ctrl_if.cio_test_en_o)
   );
 
   for (genvar i = 0; i < NumSramKeyReqSlots; i++) begin : gen_sram_pull_if


### PR DESCRIPTION
1). Remove test_access because it is replaced by another tlul interface.
Actual checking will be done in a separate PR, as we need to ensure it
does not break vendor tests.
2). Add a few assertion checks for vendor_test related I/Os. The main
check should be done in closed-source vendor test.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>