### PR TITLE
[sw/silicon_creator] Add hardened assembly routine for redundant checks

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -210,14 +210,14 @@ static rom_error_t write(uint32_t addr, flash_ctrl_partition_t partition,
 static uint32_t info_page_addr(flash_ctrl_info_page_t info_page) {
 #define INFO_PAGE_ADDR_CASE_(name_, value_, bank_, page_)       \
   case (name_):                                                 \
-    SHUTDOWN_CHECK(launder32(info_page) == (name_));            \
+    HARDENED_CHECK_EQ(launder32(info_page), (name_));           \
     return kMemBase + (bank_)*FLASH_CTRL_PARAM_BYTES_PER_BANK + \
            (page_)*FLASH_CTRL_PARAM_BYTES_PER_PAGE;
 
   switch (launder32(info_page)) {
     FLASH_CTRL_INFO_PAGES_DEFINE(INFO_PAGE_ADDR_CASE_)
     default:
-      SHUTDOWN_CHECK(false);
+      HARDENED_UNREACHABLE();
   }
 
 #undef INFO_PAGE_ADDR_CASE_
@@ -249,7 +249,7 @@ typedef struct info_cfg_regs {
 static info_cfg_regs_t info_cfg_regs(flash_ctrl_info_page_t info_page) {
 #define INFO_CFG_REGS_CASE_(name_, value_, bank_, page_)                           \
   case (name_):                                                                    \
-    SHUTDOWN_CHECK(launder32(info_page) == (name_));                               \
+    HARDENED_CHECK_EQ(launder32(info_page), (name_));                              \
     return (info_cfg_regs_t){                                                      \
         .cfg_wen_addr =                                                            \
             kBase +                                                                \
@@ -262,7 +262,7 @@ static info_cfg_regs_t info_cfg_regs(flash_ctrl_info_page_t info_page) {
   switch (launder32(info_page)) {
     FLASH_CTRL_INFO_PAGES_DEFINE(INFO_CFG_REGS_CASE_)
     default:
-      SHUTDOWN_CHECK(false);
+      HARDENED_UNREACHABLE();
   }
 
 #undef INFO_CFG_REGS_CASE_

--- a/sw/device/silicon_creator/mask_rom/boot_policy.c
+++ b/sw/device/silicon_creator/mask_rom/boot_policy.c
@@ -39,8 +39,8 @@ rom_error_t boot_policy_manifest_check(lifecycle_state_t lc_state,
 
   if (launder32(manifest->security_version) >=
       boot_data.min_security_version_rom_ext) {
-    SHUTDOWN_CHECK(launder32(manifest->security_version) >=
-                   boot_data.min_security_version_rom_ext);
+    HARDENED_CHECK_GE(launder32(manifest->security_version),
+                      boot_data.min_security_version_rom_ext);
     return kErrorOk;
   }
   return kErrorBootPolicyRollback;


### PR DESCRIPTION
Resolves https://github.com/lowRISC/opentitan/issues/10006.

I've had to go with a somewhat... cute API in order to avoid an explosion of macros while supporting both punctuation-based comparisons for host-side testing and instruction-based comparisons on the device side.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>