### PR TITLE
[sysrst_ctrl] First doc update pass

### DIFF
--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.hjson
@@ -594,7 +594,7 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen: "REGWEN",
-      resval: "0",
+      resval: "2000",
       async: "clk_aon_i",
       fields: [
         { bits: "TimerWidth-1:0",
@@ -608,13 +608,12 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen: "REGWEN",
-      resval: "0",
       async: "clk_aon_i",
       fields: [
         { bits:   "TimerWidth-1:0",
           name:   "debounce_timer",
           desc:   "Define the timer value so that pwrb_in is not oscillating for 0-200ms, each step is 5us(200KHz clock)",
-          resval: "0",
+          resval: "2000",
         }
         { bits:   "16",
           name:   "auto_block_enable",

--- a/hw/ip/sysrst_ctrl/doc/_index.md
+++ b/hw/ip/sysrst_ctrl/doc/_index.md
@@ -4,7 +4,7 @@ title: "System Reset Control Technical Specification"
 
 # Overview
 
-This document specifies the functionality of the System Reset Controller (`sysrst_ctrl`) that provides programmable hardware-level responses to trusted path inputs and basic board-level reset sequencing capabilities.
+This document specifies the functionality of the System Reset Controller (`sysrst_ctrl`) that provides programmable hardware-level responses to trusted IOs and basic board-level reset sequencing capabilities.
 These capabilities include keyboard and button combination-triggered actions, reset stretching for system-level reset signals, and internal reset / wakeup requests that go to the OpenTitan reset and power manager blocks.
 This module conforms to the [Comportable guideline for peripheral functionality.]({{< relref "doc/rm/comportability_specification" >}}).
 See that document for integration overview within the broader top level system.
@@ -115,9 +115,11 @@ Software can program the `sysrst_ctrl` block to detect certain specific signal t
 As opposed to the combo detection and general key interrupt features above, this is a fixed function feature with limited configurability. 
 In particular, the transitions that can be detected are fixed to the following:
 
-- A high level on the (potentially inverted) `ac_present` signal
-- A H -> L transition on the (potentially inverted) `pwrb_in` signal
-- A L -> H transition on the (potentially inverted) `lid_open` signal
+- A high level on the `ac_present` signal
+- A H -> L transition on the `pwrb_in` signal
+- A L -> H transition on the `lid_open` signal
+
+Note that the signals may be potentially inverted due to the [input inversion feature]({{< relref "#inversion" >}}).
 
 In order to activate this feature, software should do the following:
 
@@ -141,7 +143,7 @@ This is needed because this register has to be syncronized over to the AON clock
 `sysrst_ctrl` allows the software to read the raw input pin values via the {{< regref PIN_IN_VALUE >}} register like GPIOs.
 To this end, the hardware samples the raw input values of `pwrb_in`, `key[0,1,2]_in`, `ac_present_in`, `ec_rst_in_l` before they are being inverted, and synchronizes them onto the bus clock domain.
 
-## Pin output and keyboard inversion control
+## Pin output and keyboard inversion control {#inversion}
 
 Software can optionally override all output signals, and change the signal polarity of some of the input and output signals.
 The output signal override feature always has higher priority than any of the combo pattern detection mechanisms described above.

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -775,7 +775,7 @@ module sysrst_ctrl_reg_top (
 
   prim_reg_cdc #(
     .DataWidth(16),
-    .ResetVal(16'h0),
+    .ResetVal(16'h7d0),
     .BitMask(16'hffff)
   ) u_key_intr_debounce_ctl_cdc (
     .clk_src_i    (clk_i),
@@ -813,7 +813,7 @@ module sysrst_ctrl_reg_top (
 
   prim_reg_cdc #(
     .DataWidth(17),
-    .ResetVal(17'h0),
+    .ResetVal(17'h7d0),
     .BitMask(17'h1ffff)
   ) u_auto_block_debounce_ctl_cdc (
     .clk_src_i    (clk_i),
@@ -3349,7 +3349,7 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h7d0)
   ) u_key_intr_debounce_ctl (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),
@@ -3376,7 +3376,7 @@ module sysrst_ctrl_reg_top (
   prim_subreg #(
     .DW      (16),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (16'h0)
+    .RESVAL  (16'h7d0)
   ) u_auto_block_debounce_ctl_debounce_timer (
     .clk_i   (clk_aon_i),
     .rst_ni  (rst_aon_ni),


### PR DESCRIPTION
This addresses #10099 and also corrects the default debounce timer configurations for some of the timers that were set to 0.

CC @patel-madhuri 