### PR TITLE
[dv/otp_ctrl] Test access sequence

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -18,6 +18,8 @@ class otp_ctrl_env #(
 
   `uvm_component_new
 
+  // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
+  tl_agent prim_tl_agent;
 
   push_pull_agent#(.DeviceDataWidth(SRAM_DATA_SIZE))  m_sram_pull_agent[NumSramKeyReqSlots];
   push_pull_agent#(.DeviceDataWidth(OTBN_DATA_SIZE))  m_otbn_pull_agent;
@@ -59,6 +61,12 @@ class otp_ctrl_env #(
     uvm_config_db#(push_pull_agent_cfg#(.HostDataWidth(LC_PROG_DATA_SIZE), .DeviceDataWidth(1)))::
         set(this, "m_lc_prog_pull_agent", "cfg", cfg.m_lc_prog_pull_agent_cfg);
 
+    // TODO: reggen tool optimization.
+    // Temp build the prim_tl_agent.should be auto-generated via otp_ctrl_env_cfg once the reggen
+    // tool is optimized.NCurrently this is an empty RAL so dv_base_reg_block will return an error.
+    prim_tl_agent = tl_agent::type_id::create({"prim_tl_agent"}, this);
+    uvm_config_db#(tl_agent_cfg)::set(this, "prim_tl_agent", "cfg", cfg.prim_tl_agent_cfg);
+
     // config mem virtual interface
     if (!uvm_config_db#(mem_bkdr_util)::get(this, "", "mem_bkdr_util", cfg.mem_bkdr_util_h)) begin
       `uvm_fatal(`gfn, "failed to get mem_bkdr_util from uvm_config_db")
@@ -87,6 +95,8 @@ class otp_ctrl_env #(
     virtual_sequencer.flash_addr_pull_sequencer_h = m_flash_addr_pull_agent.sequencer;
     virtual_sequencer.flash_data_pull_sequencer_h = m_flash_data_pull_agent.sequencer;
     virtual_sequencer.lc_prog_pull_sequencer_h    = m_lc_prog_pull_agent.sequencer;
+    // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
+    virtual_sequencer.prim_tl_sequencer_h = prim_tl_agent.sequencer;
     if (cfg.en_scb) begin
       m_otbn_pull_agent.monitor.analysis_port.connect(scoreboard.otbn_fifo.analysis_export);
       m_flash_addr_pull_agent.monitor.analysis_port.connect(

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -41,6 +41,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
   // values for otp_ctrl_if signals connected to DUT
   rand otp_ctrl_ast_inputs_cfg dut_cfg;
 
+  // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
+  rand tl_agent_cfg            prim_tl_agent_cfg;
+
   `uvm_object_utils_begin(otp_ctrl_env_cfg)
   `uvm_object_utils_end
 
@@ -54,9 +57,16 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
   }
 
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
+    // TODO: reggen tool optimization.
+    // Enable these codes once prim_reg_block has register place holders.
+    // string prim_ral_name = "otp_ctrl_prim_reg_block";
+    // ral_model_names.push_back(prim_ral_name);
+    // clk_freqs_mhz[prim_ral_name] = clk_freq_mhz;
+
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
     num_edn = 1;
     tl_intg_alert_name = "fatal_bus_integ_error";
+
     super.initialize(csr_base_addr);
 
     // create push_pull agent config obj
@@ -81,6 +91,12 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     m_lc_prog_pull_agent_cfg = push_pull_agent_cfg#(.HostDataWidth(LC_PROG_DATA_SIZE),
                                .DeviceDataWidth(1))::type_id::create("m_lc_prog_pull_agent_cfg");
     m_lc_prog_pull_agent_cfg.agent_type = PullAgent;
+
+    // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
+    prim_tl_agent_cfg = tl_agent_cfg::type_id::create("prim_tl_agent_cfg");
+    prim_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
+    prim_tl_agent_cfg.host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
+    prim_tl_agent_cfg.allow_a_valid_drop_wo_a_ready = $urandom_range(0, 1);
 
     // set num_interrupts & num_alerts
     begin

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -37,6 +37,8 @@ package otp_ctrl_env_pkg;
   parameter uint DIGEST_SIZE             = 8;
   parameter uint SW_WINDOW_BASE_ADDR     = 'h1000;
   parameter uint SW_WINDOW_SIZE          = 512 * 4;
+  // Address size for prim_tl_i/o.
+  parameter uint PRIM_ADDR_SIZE          = 32 * 4;
 
   // convert byte into TLUL width size
   parameter uint VENDOR_TEST_START_ADDR  = VendorTestOffset / (TL_DW / 8);

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_virtual_sequencer.sv
@@ -16,4 +16,7 @@ class otp_ctrl_virtual_sequencer extends cip_base_virtual_sequencer #(
   push_pull_sequencer#(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_addr_pull_sequencer_h;
   push_pull_sequencer#(.DeviceDataWidth(1), .HostDataWidth(LC_PROG_DATA_SIZE))
                        lc_prog_pull_sequencer_h;
+
+  // TODO: reggen tool optimization. Temp set up a prim_tl_sequencer.
+  tl_sequencer prim_tl_sequencer_h;
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -518,8 +518,16 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   // This test access OTP_CTRL's test_access memory. The open-sourced code only test if the access
   // is valid. Please override this task in proprietary OTP.
-  // TODO: Add another TL interface to support this, and check if any conflict in close source.
   virtual task otp_test_access();
+    repeat (10) begin
+      bit [TL_DW-1:0] wr_data, rd_data;
+      bit [TL_AW-1:0] rand_addr = $urandom_range(0, PRIM_ADDR_SIZE + 3);
+      `DV_CHECK_STD_RANDOMIZE_FATAL(wr_data)
+      tl_access(.addr(rand_addr), .write(1), .data(wr_data),
+                .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
+      tl_access(.addr(rand_addr), .write(0), .data(rd_data), .exp_data(wr_data),
+                .check_exp_data(1), .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
+    end
   endtask
 
 endclass : otp_ctrl_base_vseq

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -60,6 +60,7 @@ module tb;
   push_pull_if #(.DeviceDataWidth(FLASH_DATA_SIZE)) flash_data_if(.clk(clk), .rst_n(rst_n));
 
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
+  tl_if prim_tl_if(.clk(clk), .rst_n(rst_n));
 
   otp_ctrl_if otp_ctrl_if(.clk_i(clk), .rst_ni(rst_n));
 
@@ -91,9 +92,8 @@ module tb;
     // bus interfaces
     .core_tl_i                  (tl_if.h2d  ),
     .core_tl_o                  (tl_if.d2h  ),
-    // TODO: add second TL interface
-    .prim_tl_i                  ('0         ),
-    .prim_tl_o                  (prim_tl_o  ),
+    .prim_tl_i                  (prim_tl_if.h2d),
+    .prim_tl_o                  (prim_tl_if.d2h),
     // interrupt
     .intr_otp_operation_done_o  (intr_otp_operation_done),
     .intr_otp_error_o           (intr_otp_error),
@@ -223,6 +223,7 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent_otp_ctrl_core_reg_block*",
                                        "vif", tl_if);
+    uvm_config_db#(virtual tl_if)::set(null, "*.env.prim_tl_agent*","vif", prim_tl_if);
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(OTBN_DATA_SIZE)))::set(null,
                    "*env.m_otbn_pull_agent*", "vif", otbn_if);
     uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(FLASH_DATA_SIZE)))::set(null,


### PR DESCRIPTION
This PR connects test access `prim_tl_i/o` to tl_agent.
The tool should automatically create this tl_agent, but currently the
auto-generated RAL block does not contain any registers, thus we will
run into a runtime error.
Until the reggen tool is optimized, the current solution is to only
manually create a tl_agent for this test_access area without an adapter
or RAL.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>