### PR TITLE
[util] updates to ensure make_new_dif points at the right hjson

### DIFF
--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2079,7 +2079,7 @@
           domain: "0"
         }
       }
-      attr: templated
+      attr: ipgen
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_secure
@@ -3548,7 +3548,6 @@
       [
         Aon
       ]
-      attr: templated
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_timers
@@ -4598,7 +4597,7 @@
           domain: "0"
         }
       }
-      attr: templated
+      attr: ipgen
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_secure

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -170,6 +170,7 @@
   // attr: There are a few types of modules supported
      //   normal(default): Normal, non-templated modules that will be instantiated
      //   templated:   These modules are templated and must be run through topgen
+     //   ipgen:       These modules are the same as templated but use the new ipgen flow
      //   reggen_top:  These modules are not templated, but need to have reggen run
      //                because they live exclusively in hw/top_* instead of hw/ip_*.
      //                These modules are also instantiated in the top level.
@@ -314,7 +315,7 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "lc_io_div4", rst_edn_ni: "sys"},
       base_addr: "0x40150000",
-      attr: "templated",
+      attr: "ipgen",
     },
     { name: "spi_host0",
       type: "spi_host",
@@ -448,7 +449,6 @@
       reset_connections: {rst_ni: "lc_io_div4", rst_aon_ni: "lc_aon"},
       domain: ["Aon"],
       base_addr: "0x40470000",
-      attr: "templated",
     },
     { name: "ast",
       type: "ast",
@@ -560,7 +560,7 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x48000000",
-      attr: "templated",
+      attr: "ipgen",
     },
     { name: "aes",
       type: "aes",

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -387,7 +387,7 @@
       clock_group: "secure",
       reset_connections: {rst_ni: "sys"},
       base_addr: "0x48000000",
-      attr: "templated",
+      attr: "ipgen",
     },
     { name: "aes",
       type: "aes",

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.c
@@ -20,3 +20,28 @@ dif_result_t dif_clkmgr_init(mmio_region_t base_addr, dif_clkmgr_t *clkmgr) {
 
   return kDifOk;
 }
+
+dif_result_t dif_clkmgr_alert_force(const dif_clkmgr_t *clkmgr,
+                                    dif_clkmgr_alert_t alert) {
+  if (clkmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifClkmgrAlertRecovFault:
+      alert_idx = CLKMGR_ALERT_TEST_RECOV_FAULT_BIT;
+      break;
+    case kDifClkmgrAlertFatalFault:
+      alert_idx = CLKMGR_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(clkmgr->base_addr, CLKMGR_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen.h
@@ -48,6 +48,33 @@ typedef struct dif_clkmgr {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_init(mmio_region_t base_addr, dif_clkmgr_t *clkmgr);
 
+/**
+ * A clkmgr alert type.
+ */
+typedef enum dif_clkmgr_alert {
+  /**
+   * This recoverable alert is triggered when there are measurement errors.
+   */
+  kDifClkmgrAlertRecovFault = 0,
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifClkmgrAlertFatalFault = 1,
+} dif_clkmgr_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param clkmgr A clkmgr handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_alert_force(const dif_clkmgr_t *clkmgr,
+                                    dif_clkmgr_alert_t alert);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
@@ -35,5 +35,32 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_clkmgr_init(dev().region(), &clkmgr_), kDifOk);
 }
 
+class AlertForceTest : public ClkmgrTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_clkmgr_alert_force(nullptr, kDifClkmgrAlertRecovFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_clkmgr_alert_force(nullptr, static_cast<dif_clkmgr_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(CLKMGR_ALERT_TEST_REG_OFFSET,
+                 {{CLKMGR_ALERT_TEST_RECOV_FAULT_BIT, true}});
+  EXPECT_EQ(dif_clkmgr_alert_force(&clkmgr_, kDifClkmgrAlertRecovFault),
+            kDifOk);
+
+  // Force last alert.
+  EXPECT_WRITE32(CLKMGR_ALERT_TEST_REG_OFFSET,
+                 {{CLKMGR_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_clkmgr_alert_force(&clkmgr_, kDifClkmgrAlertFatalFault),
+            kDifOk);
+}
+
 }  // namespace
 }  // namespace dif_clkmgr_autogen_unittest

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.c
@@ -21,6 +21,28 @@ dif_result_t dif_pwrmgr_init(mmio_region_t base_addr, dif_pwrmgr_t *pwrmgr) {
   return kDifOk;
 }
 
+dif_result_t dif_pwrmgr_alert_force(const dif_pwrmgr_t *pwrmgr,
+                                    dif_pwrmgr_alert_t alert) {
+  if (pwrmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifPwrmgrAlertFatalFault:
+      alert_idx = PWRMGR_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(pwrmgr->base_addr, PWRMGR_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}
+
 /**
  * Get the corresponding interrupt register bit offset of the IRQ. If the IP's
  * HJSON does NOT have a field "no_auto_intr_regs = true", then the

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen.h
@@ -49,6 +49,29 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_init(mmio_region_t base_addr, dif_pwrmgr_t *pwrmgr);
 
 /**
+ * A pwrmgr alert type.
+ */
+typedef enum dif_pwrmgr_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifPwrmgrAlertFatalFault = 0,
+} dif_pwrmgr_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param pwrmgr A pwrmgr handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwrmgr_alert_force(const dif_pwrmgr_t *pwrmgr,
+                                    dif_pwrmgr_alert_t alert);
+
+/**
  * A pwrmgr interrupt request type.
  */
 typedef enum dif_pwrmgr_irq {

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -35,6 +35,27 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_pwrmgr_init(dev().region(), &pwrmgr_), kDifOk);
 }
 
+class AlertForceTest : public PwrmgrTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_pwrmgr_alert_force(nullptr, kDifPwrmgrAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_pwrmgr_alert_force(nullptr, static_cast<dif_pwrmgr_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(PWRMGR_ALERT_TEST_REG_OFFSET,
+                 {{PWRMGR_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_pwrmgr_alert_force(&pwrmgr_, kDifPwrmgrAlertFatalFault),
+            kDifOk);
+}
+
 class IrqGetStateTest : public PwrmgrTest {};
 
 TEST_F(IrqGetStateTest, NullArgs) {

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen.c
@@ -20,3 +20,25 @@ dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *rstmgr) {
 
   return kDifOk;
 }
+
+dif_result_t dif_rstmgr_alert_force(const dif_rstmgr_t *rstmgr,
+                                    dif_rstmgr_alert_t alert) {
+  if (rstmgr == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifRstmgrAlertFatalFault:
+      alert_idx = RSTMGR_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(rstmgr->base_addr, RSTMGR_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen.h
@@ -48,6 +48,29 @@ typedef struct dif_rstmgr {
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_rstmgr_init(mmio_region_t base_addr, dif_rstmgr_t *rstmgr);
 
+/**
+ * A rstmgr alert type.
+ */
+typedef enum dif_rstmgr_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifRstmgrAlertFatalFault = 0,
+} dif_rstmgr_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param rstmgr A rstmgr handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rstmgr_alert_force(const dif_rstmgr_t *rstmgr,
+                                    dif_rstmgr_alert_t alert);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
@@ -35,5 +35,26 @@ TEST_F(InitTest, Success) {
   EXPECT_EQ(dif_rstmgr_init(dev().region(), &rstmgr_), kDifOk);
 }
 
+class AlertForceTest : public RstmgrTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_rstmgr_alert_force(nullptr, kDifRstmgrAlertFatalFault),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(
+      dif_rstmgr_alert_force(nullptr, static_cast<dif_rstmgr_alert_t>(32)),
+      kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(RSTMGR_ALERT_TEST_REG_OFFSET,
+                 {{RSTMGR_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_rstmgr_alert_force(&rstmgr_, kDifRstmgrAlertFatalFault),
+            kDifOk);
+}
+
 }  // namespace
 }  // namespace dif_rstmgr_autogen_unittest

--- a/util/make_new_dif.py
+++ b/util/make_new_dif.py
@@ -36,6 +36,7 @@ can be used.
 
 import argparse
 import glob
+import hjson
 import logging
 import shutil
 import subprocess
@@ -46,6 +47,7 @@ from mako.template import Template
 
 from autogen_banner import get_autogen_banner
 from make_new_dif.ip import Ip
+import topgen.lib as lib
 
 # This file is $REPO_TOP/util/make_new_dif.py, so it takes two parent()
 # calls to get back to the top.
@@ -67,6 +69,9 @@ def main():
         required=True,
         help="mode to generate DIF code. Use 'new' if no DIF code exists."
         "Use 'rege' to regenerate all auto-generated DIFs for all IPs.")
+    parser.add_argument("--topcfg",
+                        "-t",
+                        help="path of the top hjson file.")
     parser.add_argument("--ip-name-snake",
                         "-i",
                         help="the short name of the IP, in snake_case.")
@@ -83,6 +88,23 @@ def main():
     # Parse CMD line args.
     ips = []
 
+    # hjson path
+    topcfg_path = REPO_TOP / "hw/top_earlgrey/data/top_earlgrey.hjson"
+    if args.topcfg:
+        topcfg_path = args.topcfg
+
+    try:
+        with open(topcfg_path, 'r') as ftop:
+            topcfg = hjson.load(ftop,
+                                use_decimal=True)
+    except FileNotFoundError:
+        print(f"hjson {topcfg_path} could not be found")
+        sys.exit(1)
+
+    templated_modules = lib.get_templated_modules(topcfg)
+    ipgen_modules = lib.get_ipgen_modules(topcfg)
+    print (f"modules {templated_modules} {ipgen_modules}")
+
     # Check for regeneration mode (used in CI check:
     # ci/scripts/check-generated.sh)
     if args.mode == "regen":
@@ -98,7 +120,8 @@ def main():
             ip_name_snake = Path(autogen_src_filename).stem[4:-8]
             # NOTE: ip.name_long_* not needed for auto-generated files which
             # are the only files (re-)generated in regen mode.
-            ips.append(Ip(ip_name_snake, "AUTOGEN"))
+            ips.append(Ip(ip_name_snake, "AUTOGEN",
+                          templated_modules, ipgen_modules))
     else:
         assert args.ip_name_snake and args.ip_name_long, \
             "ERROR: pass --ip-name-snake and --ip-name-long when --mode=new."

--- a/util/topgen/lib.py
+++ b/util/topgen/lib.py
@@ -330,10 +330,24 @@ def get_unused_resets(top):
     return top['resets'].get_unused_resets(top['power']['domains'])
 
 
+def get_templated_modules(top):
+    return [m['type'] for m in top['module'] if is_templated(m)]
+
+
+def get_ipgen_modules(top):
+    return [m['type'] for m in top['module'] if is_ipgen(m)]
+
+
 def is_templated(module):
     """Returns an indication where a particular module is templated
     """
     return module.get('attr') in ["templated"]
+
+
+def is_ipgen(module):
+    """Returns an indication where a particular module is ipgen
+    """
+    return module.get('attr') in ["ipgen"]
 
 
 def is_top_reggen(module):
@@ -360,7 +374,7 @@ def is_inst(module):
 
     if "attr" not in module:
         top_level_module = True
-    elif module["attr"] in ["normal", "templated", "reggen_top"]:
+    elif module["attr"] in ["normal", "templated", "ipgen", "reggen_top"]:
         top_level_module = True
     elif module["attr"] in ["reggen_only"]:
         top_level_module = False


### PR DESCRIPTION
- re-use topgen routines to discover ipgen and templated modules
- remove hardcoding of IP_USE_IPGEN in both topgen and make_new_dif

Signed-off-by: Timothy Chen <timothytim@google.com>