### PR TITLE
[rtl, usbdev] Fix style issues

### DIFF
--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
@@ -228,6 +228,9 @@ module usb_fs_nb_in_pe #(
     endcase
   end
 
+  `ASSERT(InXfrStateValid_A,
+    in_xfr_state inside {StIdle, StRcvdIn, StSendData, StWaitAck}, clk_48mhz_i)
+
   always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin
     if (!rst_ni) begin
       tx_data_o <= '0;

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
@@ -285,6 +285,10 @@ module usb_fs_nb_out_pe #(
     endcase
   end
 
+  `ASSERT(OutXfrStateValid_A,
+    out_xfr_state inside {StIdle, StRcvdOut, StRcvdDataStart, StRcvdDataEnd, StRcvdIsoDataEnd},
+    clk_48mhz_i)
+
   // could flop this if needed
   assign out_ep_rollback_o = rollback_data;
 

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_tx.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_tx.sv
@@ -262,6 +262,8 @@ module usb_fs_tx (
     end
   end
 
+  `ASSERT(StateValid_A, state_q inside {Idle, Sync, Pid, DataOrCrc160, Crc161, Eop, OscTest})
+
   always_comb begin : proc_byte_str
     if (bit_strobe_i && !bitstuff && !pkt_start_i) begin
       byte_strobe_d = (bit_count_q == 3'b000);
@@ -363,6 +365,8 @@ module usb_fs_tx (
       default : out_state_d = OsIdle;
     endcase
   end
+
+  `ASSERT(OutStateValid_A, out_state_q inside {OsIdle, OsWaitByte, OsTransmit})
 
   always_comb begin : proc_diff
     usb_d_d   = usb_d_q;

--- a/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
+++ b/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
@@ -152,6 +152,9 @@ module usbdev_aon_wake import usbdev_pkg::*;(
     endcase
   end
 
+  `ASSERT(StateValid_A, astate_q inside {AwkIdle, AwkTrigUon, AwkWokenUon, AwkTrigUoff, AwkWoken},
+    clk_aon_i, !rst_aon_ni)
+
   always_ff @(posedge clk_aon_i or negedge rst_aon_ni) begin : proc_reg_awk
     if (!rst_aon_ni) begin
       astate_q <= AwkIdle;

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -190,6 +190,9 @@ module usbdev_linkstate (
     end
   end
 
+  `ASSERT(LinkStateValid_A, link_state_q inside {LinkDisconnect, LinkPowered, LinkPoweredSuspend,
+    LinkActiveNoSOF, LinkActive, LinkSuspend}, clk_48mhz_i)
+
   always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin
     if (!rst_ni) begin
       link_state_q <= LinkDisconnect;
@@ -247,6 +250,8 @@ module usbdev_linkstate (
     endcase
   end
 
+  `ASSERT(LinkRstStateValid_A, link_rst_state_q inside {NoRst, RstCnt, RstPend}, clk_48mhz_i)
+
   assign link_reset_o = link_reset;
 
   always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin : proc_reg_rst
@@ -302,6 +307,8 @@ module usbdev_linkstate (
       default : link_inac_state_d = Active;
     endcase
   end
+
+  `ASSERT(LincInacStateValid_A, link_inac_state_q inside {Active, InactCnt, InactPend}, clk_48mhz_i)
 
   always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin : proc_reg_idle_det
     if (!rst_ni) begin


### PR DESCRIPTION
- Add asserts to check signals used by case statements are all within
  expected set of  values that case statement covers as recommened by
  the style guide.
- Adds an always_comb block to seperate out combinational and
  synchronous logic.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>