### PR TITLE
[lc_ctrl] V2 Closure

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -177,4 +177,19 @@
       tests: ["lc_ctrl_stress_all"]
     }
   ]
+
+  covergroups: [
+    {
+      name: err_inj_cg
+      desc: '''
+        Indicates what error conditions have been injected.
+      '''
+    }
+    {
+      name: lc_ctrl_fsm_cg
+      desc: '''
+        lc_ctrl_fsm states and arcs
+      '''
+    }
+  ]
 }

--- a/hw/ip/lc_ctrl/doc/checklist.md
+++ b/hw/ip/lc_ctrl/doc/checklist.md
@@ -179,27 +179,27 @@ Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
-Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Not Started |
-Documentation | [DV_DOC_COMPLETED][]                    | Not Started |
-Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Not Started |
-Testbench     | [ALL_INTERFACES_EXERCISED][]            | Not Started |
-Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Not Started |
-Testbench     | [SIM_TB_ENV_COMPLETED][]                | Not Started |
-Tests         | [SIM_ALL_TESTS_PASSING][]               | Not Started |
-Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | Not Started |
-Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | Not Started |
-Tests         | [SIM_FW_SIMULATED][]                    | Not Started |
-Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Not Started |
-Coverage      | [SIM_CODE_COVERAGE_V2][]                | Not Started |
-Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Not Started |
-Coverage      | [FPV_CODE_COVERAGE_V2][]                | Not Started |
-Coverage      | [FPV_COI_COVERAGE_V2][]                 | Not Started |
-Code Quality  | [TB_LINT_PASS][]                        | Not Started |
-Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | Not Started |
-Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Not Started |
-Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Not Started |
-Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Not Started |
-Review        | [V3_CHECKLIST_SCOPED][]                 | Not Started |
+Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Done        |
+Documentation | [DV_DOC_COMPLETED][]                    | Done        |
+Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
+Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        |
+Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
+Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
+Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |
+Tests         | [FPV_ALL_ASSERTIONS_WRITTEN][]          | N/A         |
+Tests         | [FPV_ALL_ASSUMPTIONS_REVIEWED][]        | N/A         |
+Tests         | [SIM_FW_SIMULATED][]                    | N/A         |
+Regression    | [SIM_NIGHTLY_REGRESSION_V2][]           | Done        |
+Coverage      | [SIM_CODE_COVERAGE_V2][]                | Done        | RV_TAP excluded
+Coverage      | [SIM_FUNCTIONAL_COVERAGE_V2][]          | Done        |
+Coverage      | [FPV_CODE_COVERAGE_V2][]                | N/A         |
+Coverage      | [FPV_COI_COVERAGE_V2][]                 | N/A         |
+Code Quality  | [TB_LINT_PASS][]                        | Done        |
+Integration   | [PRE_VERIFIED_SUB_MODULES_V2][]         | N/A         | Exception for IP modules
+Issues        | [NO_HIGH_PRIORITY_ISSUES_PENDING][]     | Done        |
+Issues        | [ALL_LOW_PRIORITY_ISSUES_ROOT_CAUSED][] | Done        |
+Review        | [DV_DOC_TESTPLAN_REVIEWED][]            | Done        |
+Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
 
 [DESIGN_DELTAS_CAPTURED_V2]:          {{<relref "/doc/project/checklist.md#design_deltas_captured_v2" >}}
 [DV_DOC_COMPLETED]:                   {{<relref "/doc/project/checklist.md#dv_doc_completed" >}}
@@ -229,7 +229,7 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Not Started |
 --------------|-----------------------------------------|-------------|------------------
 Tests         | [FPV_SEC_CM_VERIFIED][]                 | Not Started |
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Not Started |
- 
+
 [FPV_SEC_CM_VERIFIED]:                {{<relref "/doc/project/checklist.md#fpv_sec_cm_verified" >}}
 [SIM_SEC_CM_VERIFIED]:                {{<relref "/doc/project/checklist.md#sim_sec_cm_verified" >}}
 

--- a/hw/ip/lc_ctrl/doc/dv/index.md
+++ b/hw/ip/lc_ctrl/doc/dv/index.md
@@ -43,28 +43,27 @@ The following utilities provide generic helper tasks and functions to perform ac
 
 ### Global types & methods
 All common types and methods defined at the package level can be found in
-`lc_ctrl_env_pkg`. Some of them in use are:
-```systemverilog
-[list a few parameters, types & methods; no need to mention all]
-```
+`lc_ctrl_env_pkg`.
+
 ### TL_agent
 LC_CTRL testbench instantiates (already handled in CIP base env) [tl_agent]({{< relref "hw/dv/sv/tl_agent/README.md" >}})
 which provides the ability to drive and independently monitor random traffic via
 TL host interface into LC_CTRL device.
 
-### UVC/agent 1
-[Describe here or add link to its README]
+### JTAG RISCV Agent
+[jtag_riscv_agent]({{< relref "hw/dv/sv/jtag_riscv_agent/README.md" >}}) is used to read and write LC_CTRL registers via
+the JTAG interface. It contains an embedded instance of [jtag_agent] {{< relref "hw/dv/sv/jtag_agent/README.md" >}} which
+uses the jtag_if interface in the testbench.
 
-### UVC/agent 2
-[Describe here or add link to its README]
+### PUSH/PULL Agent
+[push_pull_agent]({{< relref "hw/dv/sv/push_pull_agent/README.md" >}}) is used to emulate the Token and
+OTP programing interfaces.
 
 ### UVM RAL Model
 The LC_CTRL RAL model is created with the [`ralgen`]({{< relref "hw/dv/tools/ralgen/README.md" >}}) FuseSoC generator script automatically when the simulation is at the build stage.
 
 It can be created manually by invoking [`regtool`]({{< relref "util/reggen/README.md" >}}):
 
-### Reference models
-[Describe reference models in use if applicable, example: SHA256/HMAC]
 
 ### Stimulus strategy
 #### Test sequences
@@ -72,29 +71,35 @@ All test sequences reside in `hw/ip/lc_ctrl/dv/env/seq_lib`.
 The `lc_ctrl_base_vseq` virtual sequence is extended from `cip_base_vseq` and serves as a starting point.
 All test sequences are extended from `lc_ctrl_base_vseq`.
 It provides commonly used handles, variables, functions and tasks that the test sequences can simple use / call.
-Some of the most commonly used tasks / functions are as follows:
-* task 1:
-* task 2:
+
 
 #### Functional coverage
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
 The following covergroups have been developed to prove that the test intent has been adequately met:
-* cg1:
-* cg2:
+*  err_inj_cg: indicates what error conditions have been injected.
+
 
 ### Self-checking strategy
 #### Scoreboard
 The `lc_ctrl_scoreboard` is primarily used for end to end checking.
-It creates the following analysis ports to retrieve the data monitored by corresponding interface agents:
-* analysis port1:
-* analysis port2:
-<!-- explain inputs monitored, flow of data and outputs checked -->
+It creates the following analysis exports to retrieve the data monitored by corresponding interface agents:
+* tl_[a_chan, d_chan, dir]_fifo_lc_ctrl_reg_block.analysis_export: Tile Link CSR reads/writes.
+* jtag_riscv_fifo.analysis_export: JTAG CSR reads/writes
+* alert_fifo[fatal_bus_integ_error, fatal_prog_error, fatal_state_error].analysis_export: Alert traffic from DUT
+* otp_prog_fifo.analysis_export:  OTP program data from LC_CTRL and response to LC_CTRL.
+* otp_token_fifo.analysis_export:  OTP token data from LC_CTRL and response to LC_CTRL.
+
+##### Scoreboard Checks
+* TL CSR data is used to check against expected values predicted by the scoreboard.
+It also updates the UVM register model.
+* JTAG CSR data is used to check against expected values predicted by the scoreboard.
+It also updates the UVM register model.
+* Alert data is decoded and used to indicate an alert has occured
 
 #### Assertions
 * TLUL assertions: The `tb/lc_ctrl_bind.sv` binds the `tlul_assert` [assertions]({{< relref "hw/ip/tlul/doc/TlulProtocolChecker.md" >}}) to the IP to ensure TileLink interface protocol compliance.
 * Unknown checks on DUT outputs: The RTL has assertions to ensure all outputs are initialized to known values after coming out of reset.
-* assert prop 1:
-* assert prop 2:
+
 
 ## Building and running tests
 We are using our in-house developed [regression tool]({{< relref "hw/dv/tools/README.md" >}}) for building and running our tests and regressions.

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov.core
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov.core
@@ -2,8 +2,8 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:lc_ctrl_sim:0.1"
-description: "LC_CTRL DV sim target"
+name: "lowrisc:dv:lc_ctrl_cov"
+description: "LC_CTRL functional coverage and bind files"
 filesets:
   files_rtl:
     depend:
@@ -11,20 +11,15 @@ filesets:
 
   files_dv:
     depend:
-      - lowrisc:dv:lc_ctrl_test
-      - lowrisc:dv:lc_ctrl_sva
-      - lowrisc:dv:lc_ctrl_cov
+      - lowrisc:dv:dv_utils
     files:
-      - tb.sv
+      - lc_ctrl_cov_if.sv
+      - lc_ctrl_fsm_cov_if.sv
+      - lc_ctrl_cov_bind.sv
     file_type: systemVerilogSource
 
 targets:
-  sim: &sim_target
-    toplevel: tb
+  default:
     filesets:
       - files_rtl
       - files_dv
-    default_tool: vcs
-
-  lint:
-    <<: *sim_target

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binds LC_CTRL functional coverage interaface to the top level LC_CTRL module.
+module lc_ctrl_cov_bind;
+  bind lc_ctrl lc_ctrl_cov_if u_lc_ctrl_cov_if (.*);
+  bind lc_ctrl_fsm lc_ctrl_fsm_cov_if u_lc_ctrl_fsm_cov_if (.*);
+endmodule

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_if.sv
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_if.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Implements functional coverage for LC_CTRL
+interface lc_ctrl_cov_if (
+  input clk_i,
+  input rst_ni
+);
+  int count;
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) count = 0;
+    else count++;
+  end
+
+endinterface

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cover.cfg
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cover.cfg
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Specific coverage configuration for the Lifecycle Controller
+
+// Exclude JTAG TAP
+-tree tb.dut.u_dmi_jtag

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_fsm_cov_if.sv
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_fsm_cov_if.sv
@@ -1,0 +1,63 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Implements functional coverage for LC_CTRL FSM
+interface lc_ctrl_fsm_cov_if
+  import lc_ctrl_pkg::*;
+(
+  input logic clk_i,
+  input logic rst_ni,
+  input fsm_state_e fsm_state_d,
+  input fsm_state_e fsm_state_q,
+  input logic esc_scrap_state0_i,
+  input logic esc_scrap_state1_i
+);
+  `include "dv_fcov_macros.svh"
+
+  covergroup lc_ctrl_fsm_cg @(posedge clk_i);
+    fsm_state_q_cp: coverpoint fsm_state_q {
+      bins ResetSt = {ResetSt};
+      bins IdleSt = {IdleSt};
+      bins ClkMuxSt = {ClkMuxSt};
+      bins CntIncrSt = {CntIncrSt};
+      bins CntProgSt = {CntProgSt};
+      bins TransCheckSt = {TransCheckSt};
+      bins TokenHashSt = {TokenHashSt};
+      bins FlashRmaSt = {FlashRmaSt};
+      bins TokenCheck0St = {TokenCheck0St};
+      bins TokenCheck1St = {TokenCheck1St};
+      bins TransProgSt = {TransProgSt};
+      bins PostTransSt = {PostTransSt};
+      bins ScrapSt = {ScrapSt};
+      bins EscalateSt = {EscalateSt};
+      bins InvalidSt = {InvalidSt};
+      bins IllegalEncoding = default;
+
+      bins arcs[] =
+        (ResetSt => IdleSt),
+        (IdleSt => ScrapSt, ClkMuxSt),
+        (ClkMuxSt => CntIncrSt),
+        (CntIncrSt => PostTransSt, CntProgSt),
+        (CntProgSt => PostTransSt, TransCheckSt),
+        (TransCheckSt => PostTransSt, TokenHashSt),
+        (TokenHashSt => PostTransSt, FlashRmaSt),
+        (FlashRmaSt => TokenCheck0St),
+        (TokenCheck0St, TokenCheck1St => PostTransSt, TokenCheck1St),
+        (TransProgSt => PostTransSt),
+        (IdleSt, ClkMuxSt, CntIncrSt, CntProgSt, TransCheckSt,
+          TokenHashSt, FlashRmaSt, TokenCheck0St, TokenCheck1St,
+          TransProgSt, PostTransSt, InvalidSt => EscalateSt);
+
+    }
+    esc_scrap_state0_i_cp: coverpoint esc_scrap_state0_i;
+    esc_scrap_state1_i_cp: coverpoint esc_scrap_state1_i;
+
+    // Check escalates are triggered during all states
+    scrap_state0_xp: cross esc_scrap_state0_i_cp, fsm_state_q;
+    scrap_state1_xp: cross esc_scrap_state1_i_cp, fsm_state_q;
+
+  endgroup
+
+  `DV_FCOV_INSTANTIATE_CG(lc_ctrl_fsm_cg)
+endinterface

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_dv_utils_pkg.sv
@@ -337,10 +337,21 @@ package lc_ctrl_dv_utils_pkg;
   endfunction
 
   //Convert a binary representation to a lc_state representation 0=Axx 1=Bxx
-  function static bit [LcStateWidth-1:0] bin_to_lc_state(lc_state_bin_t val);
+  function static bit [LcStateWidth-1:0] bin_to_lc_state(lc_state_bin_t val, bit err_inj = 0);
+    int err_inj_idx = -1;
     bin_to_lc_state = 0;
+    if (err_inj) begin
+      // Select a symbol to invert
+      err_inj_idx = $urandom_range(0, $size(A_VALUES) - 1);
+    end
     for (int i = 0; i < $size(A_VALUES); i++) begin
-      bin_to_lc_state[i*16+:16] = val[i] ? B_VALUES[i] : A_VALUES[i];
+      if (i != err_inj_idx) begin
+        // No error
+        bin_to_lc_state[i*16+:16] = val[i] ? B_VALUES[i] : A_VALUES[i];
+      end else begin
+        // Error inject - invert symbol
+        bin_to_lc_state[i*16+:16] = val[i] ? ~B_VALUES[i] : ~A_VALUES[i];
+      end
     end
   endfunction
 
@@ -358,11 +369,22 @@ package lc_ctrl_dv_utils_pkg;
     end
   endfunction
 
-  //Convert a binary representation to a lc_count representation 0=Cxx 1=Cxx
-  function static bit [LcCountWidth-1:0] bin_to_lc_count(lc_count_bin_t val);
+  //Convert a binary representation to a lc_count representation 0=Cxx 1=Dxx
+  function static bit [LcCountWidth-1:0] bin_to_lc_count(lc_count_bin_t val, bit err_inj = 0);
+    int err_inj_idx = -1;
     bin_to_lc_count = 0;
-    for (int i = 0; i < $size(A_VALUES); i++) begin
-      bin_to_lc_count[i*16+:16] = val[i] ? B_VALUES[i] : A_VALUES[i];
+    if (err_inj) begin
+      // Select a symbol to invert
+      err_inj_idx = $urandom_range(0, $size(C_VALUES) - 1);
+    end
+    for (int i = 0; i < $size(C_VALUES); i++) begin
+      if (i != err_inj_idx) begin
+        // No error
+        bin_to_lc_count[i*16+:16] = val[i] ? D_VALUES[i] : C_VALUES[i];
+      end else begin
+        // Error inject - invert symbol
+        bin_to_lc_count[i*16+:16] = val[i] ? ~D_VALUES[i] : ~C_VALUES[i];
+      end
     end
   endfunction
 
@@ -420,4 +442,54 @@ package lc_ctrl_dv_utils_pkg;
       lc_count_to_bin(LcCnt24)
   };
 
+
+  // States with OTP test registers active
+  parameter lc_state_e LC_CTRL_OTP_TEST_REG_ENABLED_STATES[17] = '{
+      LcStRaw,
+      LcStTestUnlocked0,
+      LcStTestLocked0,
+      LcStTestUnlocked1,
+      LcStTestLocked1,
+      LcStTestUnlocked2,
+      LcStTestLocked2,
+      LcStTestUnlocked3,
+      LcStTestLocked3,
+      LcStTestUnlocked4,
+      LcStTestLocked4,
+      LcStTestUnlocked5,
+      LcStTestLocked5,
+      LcStTestUnlocked6,
+      LcStTestLocked6,
+      LcStTestUnlocked7,
+      LcStRma
+  };
+
+  // Counts with OTP test registers enabled
+  parameter lc_cnt_e LC_CTRL_OTP_TEST_REG_ENABLED_COUNTS[25] = '{
+      LcCnt0,
+      LcCnt1,
+      LcCnt2,
+      LcCnt3,
+      LcCnt4,
+      LcCnt5,
+      LcCnt6,
+      LcCnt7,
+      LcCnt8,
+      LcCnt9,
+      LcCnt10,
+      LcCnt11,
+      LcCnt12,
+      LcCnt13,
+      LcCnt14,
+      LcCnt15,
+      LcCnt16,
+      LcCnt17,
+      LcCnt18,
+      LcCnt19,
+      LcCnt20,
+      LcCnt21,
+      LcCnt22,
+      LcCnt23,
+      LcCnt24
+  };
 endpackage

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -10,10 +10,12 @@ filesets:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
       - lowrisc:dv:jtag_riscv_agent
+      - lowrisc:dv:kmac_app_agent
       - lowrisc:dv:lc_ctrl_dv_utils
     files:
       - lc_ctrl_env_pkg.sv
       - lc_ctrl_if.sv
+      - lc_ctrl_parameters_cfg.sv: {is_include_file: true}
       - lc_ctrl_env_cfg.sv: {is_include_file: true}
       - lc_ctrl_env_cov.sv: {is_include_file: true}
       - lc_ctrl_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
@@ -53,9 +53,16 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
     otp_prog_err_cp: coverpoint cfg.err_inj.otp_prog_err;
     otp_partition_err_cp: coverpoint cfg.err_inj.otp_partition_err;
     token_mismatch_err_cp: coverpoint cfg.err_inj.token_mismatch_err;
+    token_invalid_err_cp:  coverpoint cfg.err_inj.token_invalid_err;
+    token_response_err_cp:  coverpoint cfg.err_inj.token_response_err;
+    otp_lc_data_i_valid_err_cp: coverpoint cfg.err_inj.otp_lc_data_i_valid_err;
     state_err_cp: coverpoint cfg.err_inj.state_err;
+    state_illegal_err_cp: coverpoint cfg.err_inj.state_illegal_err;
     state_backdoor_err_cp: coverpoint cfg.err_inj.state_backdoor_err;
+    lc_fsm_backdoor_err_cp: coverpoint cfg.err_inj.lc_fsm_backdoor_err;
+    kmac_fsm_backdoor_err_cp: coverpoint cfg.err_inj.kmac_fsm_backdoor_err;
     count_err_cp: coverpoint cfg.err_inj.count_err;
+    count_illegal_err_cp: coverpoint cfg.err_inj.count_illegal_err;
     count_backdoor_err_cp: coverpoint cfg.err_inj.count_backdoor_err;
     transition_err_cp: coverpoint cfg.err_inj.transition_err;
     transition_count_err_cp: coverpoint cfg.err_inj.transition_count_err;
@@ -67,8 +74,10 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
     // Crosses for attempted second transition with and without failure
     `LC_CTRL_POST_TRANS_CROSS(err_inj)
     `LC_CTRL_POST_TRANS_CROSS(state_err)
-    `LC_CTRL_POST_TRANS_CROSS(state_backdoor_err)
+    `LC_CTRL_POST_TRANS_CROSS(lc_fsm_backdoor_err)
+    `LC_CTRL_POST_TRANS_CROSS(state_illegal_err)
     `LC_CTRL_POST_TRANS_CROSS(count_err)
+    `LC_CTRL_POST_TRANS_CROSS(count_illegal_err)
     `LC_CTRL_POST_TRANS_CROSS(count_backdoor_err)
 
     // Crosses for error injection vs CSR access type  (JTAG/TL)- make sure we can detect
@@ -80,6 +89,8 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
     `LC_CTRL_JTAG_ERROR_CROSS(token_mismatch_err)
     `LC_CTRL_JTAG_ERROR_CROSS(state_err)
     `LC_CTRL_JTAG_ERROR_CROSS(state_backdoor_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(lc_fsm_backdoor_err)
+    `LC_CTRL_JTAG_ERROR_CROSS(kmac_fsm_backdoor_err)
     `LC_CTRL_JTAG_ERROR_CROSS(count_err)
     `LC_CTRL_JTAG_ERROR_CROSS(count_backdoor_err)
     `LC_CTRL_JTAG_ERROR_CROSS(transition_err)

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -19,6 +19,7 @@ package lc_ctrl_env_pkg;
   import push_pull_agent_pkg::*;
   import alert_esc_agent_pkg::*;
   import jtag_riscv_agent_pkg::*;
+  import kmac_app_agent_pkg::*;
   import lc_ctrl_dv_utils_pkg::*;
   import prim_mubi_pkg::MuBi8True;
 
@@ -37,6 +38,9 @@ package lc_ctrl_env_pkg;
   // lc_otp_program host data width: lc_state_e width + lc_cnt_e width
   parameter uint OTP_PROG_HDATA_WIDTH = LcStateWidth + LcCountWidth;
   parameter uint OTP_PROG_DDATA_WIDTH = 1;
+
+  // KMAC FSM state width
+  parameter uint KMAC_FSM_WIDTH = 8;
 
   typedef struct packed {
     lc_ctrl_pkg::lc_tx_t lc_dft_en_o;
@@ -64,13 +68,27 @@ package lc_ctrl_env_pkg;
     bit otp_partition_err;
     // Incorrect token for state change
     bit token_mismatch_err;
+    // Bit error in token from KMAC App interface
+    bit token_invalid_err;
+    // Error response from KMAC app
+    bit token_response_err;
+    // otp_lc_data_i.valid == 0
+    bit otp_lc_data_i_valid_err;
     // Invalid state driven via OTP interface
     bit state_err;
+    // Illegal (bad symbol encoding) state driven via OTP interface
+    bit state_illegal_err;
     // Invalid count driven via OTP interface
     bit count_err;
-    // Invalid fsm state - via force in lc_ctrl_if
+    // Illegal (bad symbol encoding) count driven via OTP interface
+    bit count_illegal_err;
+    // Invalid LC fsm state - via force in lc_ctrl_if
+    bit lc_fsm_backdoor_err;
+    // Invalid KMAC IF fsm state - via force in lc_ctrl_if
+    bit kmac_fsm_backdoor_err;
+    // Invalid state - via force in lc_ctrl_if
     bit state_backdoor_err;
-    // Invalid count      - via force in lc_ctrl_if
+    // Invalid count - via force in lc_ctrl_if
     bit count_backdoor_err;
     // Send a transition request in post_trans state
     bit post_trans_err;
@@ -86,6 +104,8 @@ package lc_ctrl_env_pkg;
   typedef enum {
     LcCtrlTestInit,
     LcCtrlIterStart,
+    LcCtrlLcInit,
+    LcCtrlDutInitComplete,
     LcCtrlDutReady,
     LcCtrlBadNextState,
     LcCtrlWaitTransition,
@@ -253,6 +273,7 @@ package lc_ctrl_env_pkg;
   endfunction
 
   // package sources
+  `include "lc_ctrl_parameters_cfg.sv"
   `include "lc_ctrl_env_cfg.sv"
   `include "lc_ctrl_env_cov.sv"
   `include "lc_ctrl_virtual_sequencer.sv"

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -6,14 +6,23 @@
 
 `ifndef LC_CTRL_FSM_STATE_REGS_PATH
 `define LC_CTRL_FSM_STATE_REGS_PATH \
-    tb.dut.u_lc_ctrl_fsm.u_fsm_state_regs.u_state_flop.gen_generic.u_impl_generic.d_i
+    tb.dut.u_lc_ctrl_fsm.u_fsm_state_regs.u_state_flop.gen_generic.u_impl_generic.q_o
 `endif
 
-`ifndef LC_CTRL_FSM_COUNT_REGS_PATH
-`define LC_CTRL_FSM_COUNT_REGS_PATH \
-    tb.dut.u_lc_ctrl_fsm.u_cnt_regs.gen_generic.u_impl_generic.d_i
+`ifndef LC_CTRL_KMAC_FSM_STATE_REGS_PATH
+`define LC_CTRL_KMAC_FSM_STATE_REGS_PATH \
+    tb.dut.u_lc_ctrl_kmac_if.u_state_regs.u_state_flop.gen_generic.u_impl_generic.q_o
 `endif
 
+`ifndef LC_CTRL_STATE_PATH
+`define LC_CTRL_STATE_PATH \
+    tb.dut.otp_lc_data_i.state
+`endif
+
+`ifndef LC_CTRL_COUNT_PATH
+`define LC_CTRL_COUNT_PATH \
+    tb.dut.otp_lc_data_i.count
+`endif
 
 interface lc_ctrl_if (
   input clk,
@@ -25,55 +34,68 @@ interface lc_ctrl_if (
   import otp_ctrl_pkg::*;
   import otp_ctrl_part_pkg::*;
 
-  logic                                             tdo_oe;  // TODO: add assertions
-  otp_lc_data_t                                     otp_i;
-  otp_device_id_t                                   otp_device_id_i;
-  otp_device_id_t                                   otp_manuf_state_i;
-  lc_token_t                                        hashed_token;
 
-  lc_tx_t                                           lc_dft_en_o;
-  lc_tx_t                                           lc_nvm_debug_en_o;
-  lc_tx_t                                           lc_hw_debug_en_o;
-  lc_tx_t                                           lc_cpu_en_o;
-  lc_tx_t                                           lc_creator_seed_sw_rw_en_o;
-  lc_tx_t                                           lc_owner_seed_sw_rw_en_o;
-  lc_tx_t                                           lc_iso_part_sw_rd_en_o;
-  lc_tx_t                                           lc_iso_part_sw_wr_en_o;
-  lc_tx_t                                           lc_seed_hw_rd_en_o;
-  lc_tx_t                                           lc_keymgr_en_o;
-  lc_tx_t                                           lc_escalate_en_o;
-  lc_tx_t                                           lc_check_byp_en_o;
+  logic tdo_oe;  // TODO: add assertions
+  otp_lc_data_t otp_i;
+  otp_device_id_t otp_device_id_i = 0;
+  otp_device_id_t otp_manuf_state_i = 0;
+  lc_token_t hashed_token;
+  prim_mubi_pkg::mubi4_t scanmode_i = prim_mubi_pkg::MuBi4False;
+  logic scan_rst_ni = 1;
+  lc_tx_t lc_dft_en_o;
+  lc_tx_t lc_nvm_debug_en_o;
+  lc_tx_t lc_hw_debug_en_o;
+  lc_tx_t lc_cpu_en_o;
+  lc_tx_t lc_creator_seed_sw_rw_en_o;
+  lc_tx_t lc_owner_seed_sw_rw_en_o;
+  lc_tx_t lc_iso_part_sw_rd_en_o;
+  lc_tx_t lc_iso_part_sw_wr_en_o;
+  lc_tx_t lc_seed_hw_rd_en_o;
+  lc_tx_t lc_keymgr_en_o;
+  lc_tx_t lc_escalate_en_o;
+  lc_tx_t lc_check_byp_en_o;
 
-  lc_tx_t                                           clk_byp_req_o;
-  lc_tx_t                                           clk_byp_ack_i;
-  lc_tx_t                                           flash_rma_req_o;
-  lc_tx_t                                           flash_rma_ack_i;
+  lc_tx_t clk_byp_req_o;
+  lc_tx_t clk_byp_ack_i;
+  lc_tx_t flash_rma_req_o;
+  lc_tx_t flash_rma_ack_i;
 
-  lc_keymgr_div_t                                   keymgr_div_o;
-  lc_flash_rma_seed_t                               flash_rma_seed_o;
+  lc_keymgr_div_t keymgr_div_o;
+  lc_flash_rma_seed_t flash_rma_seed_o;
 
-  event                                             fsm_backdoor_state_write_ev;
-  event                                             fsm_backdoor_state_read_ev;
-  event                                             fsm_backdoor_count_write_ev;
-  event                                             fsm_backdoor_count_read_ev;
+  // OTP test signals
+  logic [OtpTestCtrlWidth-1:0] otp_vendor_test_ctrl_o;
+  logic [OtpTestStatusWidth-1:0] otp_vendor_test_status_i;
+
+  event lc_fsm_state_backdoor_write_ev;
+  event lc_fsm_state_backdoor_read_ev;
+  event kmac_fsm_state_backdoor_write_ev;
+  event kmac_fsm_state_backdoor_read_ev;
+  event state_backdoor_write_ev;
+  event state_backdoor_read_ev;
+  event count_backdoor_write_ev;
+  event count_backdoor_read_ev;
+
 
   //
   // Whitebox signals - these come from within the RTL
   //
 
   // Decoded mutex claim signal for JTAG and TL
-  logic                                             mutex_claim_jtag;
-  logic                                             mutex_claim_tl;
+  logic mutex_claim_jtag;
+  logic mutex_claim_tl;
 
   // Debug signals
-  lc_ctrl_env_pkg::lc_ctrl_err_inj_t                err_inj;
-  lc_ctrl_env_pkg::lc_ctrl_test_phase_e             test_phase;
-  bit                                   [79:0][7:0] test_sequence_typename;
+  lc_ctrl_env_pkg::lc_ctrl_err_inj_t err_inj;
+  lc_ctrl_env_pkg::lc_ctrl_test_phase_e test_phase;
+  bit [79:0][7:0] test_sequence_typename;
 
   task automatic init(lc_state_e lc_state = LcStRaw, lc_cnt_e lc_cnt = LcCnt0,
                       lc_tx_t clk_byp_ack = Off, lc_tx_t flash_rma_ack = Off,
-                      logic otp_partition_err = 0);
-    otp_i.valid             = 1;
+                      logic otp_partition_err = 0, otp_device_id_t otp_device_id = 0,
+                      logic otp_lc_data_i_valid = 1, otp_device_id_t otp_manuf_state = 0,
+                      logic [OtpTestStatusWidth-1:0] otp_vendor_test_status = 0);
+    otp_i.valid             = otp_lc_data_i_valid;
     otp_i.error             = otp_partition_err;
     otp_i.state             = lc_state;
     otp_i.count             = lc_cnt;
@@ -85,13 +107,22 @@ interface lc_ctrl_if (
     otp_i.test_tokens_valid = On;
     otp_i.rma_token_valid   = On;
 
-    otp_device_id_i         = 0;
-    otp_manuf_state_i       = 0;
 
     clk_byp_ack_i           = clk_byp_ack;
     flash_rma_ack_i         = flash_rma_ack;
 
+    // Make sure we get a transition
+    fork
+      begin
+        @(posedge clk);
+        otp_device_id_i          = otp_device_id;
+        otp_manuf_state_i        = otp_manuf_state;
+        otp_vendor_test_status_i = otp_vendor_test_status;
+      end
+    join_none
+
     release `LC_CTRL_FSM_STATE_REGS_PATH;
+
   endtask
 
   task automatic set_clk_byp_ack(lc_tx_t val);
@@ -102,15 +133,25 @@ interface lc_ctrl_if (
     flash_rma_ack_i = val;
   endtask
 
-  // This must be static because of the force statement
-  function static void fsm_state_backdoor_write(input logic [FsmStateWidth-1:0] val = 'hdead,
-                                                input int delay_clocks = 0,
-                                                input int force_clocks = 5);
+  function automatic clear_static_signals();
+    otp_device_id_i = 0;
+    otp_manuf_state_i = 0;
+    otp_vendor_test_status_i = 0;
+  endfunction
+
+  //
+  // The functions below must be static because of the force statement
+  //
+
+  // Force lc_ctrl_fsm state registers
+  function static void lc_fsm_state_backdoor_write(input logic [FsmStateWidth-1:0] val = 'hdead,
+                                                   input int delay_clocks = 0,
+                                                   input int force_clocks = 5);
     `dv_info($sformatf("Backdoor write to state registers"))
     fork
       begin : force_state_proc
         repeat (delay_clocks) @(posedge clk);
-        ->fsm_backdoor_state_write_ev;
+        ->lc_fsm_state_backdoor_write_ev;
         force `LC_CTRL_FSM_STATE_REGS_PATH = val;
         repeat (force_clocks) @(posedge clk);
         release `LC_CTRL_FSM_STATE_REGS_PATH;
@@ -118,30 +159,74 @@ interface lc_ctrl_if (
     join_none
   endfunction
 
-  function automatic logic [FsmStateWidth-1:0] fsm_state_backdoor_read();
-    ->fsm_backdoor_state_read_ev;
+  // Read lc_ctrl_fsm state registers
+  function automatic logic [FsmStateWidth-1:0] lc_fsm_state_backdoor_read();
+    ->lc_fsm_state_backdoor_read_ev;
     return `LC_CTRL_FSM_STATE_REGS_PATH;
   endfunction
 
-  // This must be static because of the force statement
-  function static void fsm_count_backdoor_write(input logic [LcCountWidth-1:0] val = 'hdead,
-                                                input int delay_clocks = 0,
-                                                input int force_clocks = 5);
-    `dv_info($sformatf("Backdoor write to state registers"))
+  // Force kmac i/f fsm state registers
+  function static void kmac_fsm_state_backdoor_write(
+      input logic [lc_ctrl_env_pkg::KMAC_FSM_WIDTH-1:0] val = 'hde, input int delay_clocks = 0,
+      input int force_clocks = 5);
+    `dv_info($sformatf("Backdoor write to kmac i/f state registers = %h", val))
+    fork
+      begin : force_state_proc
+        repeat (delay_clocks) @(posedge clk);
+        ->kmac_fsm_state_backdoor_write_ev;
+        force `LC_CTRL_FSM_STATE_REGS_PATH = val;
+        repeat (force_clocks) @(posedge clk);
+        release `LC_CTRL_FSM_STATE_REGS_PATH;
+      end : force_state_proc
+    join_none
+  endfunction
+
+  // Read  kmac i/f fsm state registers
+  function automatic logic [lc_ctrl_env_pkg::KMAC_FSM_WIDTH-1:0] kmac_fsm_state_backdoor_read();
+    ->kmac_fsm_state_backdoor_read_ev;
+    return `LC_CTRL_FSM_STATE_REGS_PATH;
+  endfunction
+
+  // Force OTP state input
+  function static void state_backdoor_write(input logic [LcStateWidth-1:0] val = 'hdead,
+                                            input int delay_clocks = 0, input int force_clocks = 5);
+    `dv_info($sformatf("Backdoor write to OTP state input = %h", val))
+    fork
+      begin : force_state_proc
+        repeat (delay_clocks) @(posedge clk);
+        ->state_backdoor_write_ev;
+        force `LC_CTRL_STATE_PATH = val;
+        repeat (force_clocks) @(posedge clk);
+        release `LC_CTRL_STATE_PATH;
+      end : force_state_proc
+    join_none
+  endfunction
+
+  // Read OTP state input
+  function automatic logic [LcStateWidth-1:0] state_backdoor_read();
+    ->state_backdoor_read_ev;
+    return `LC_CTRL_STATE_PATH;
+  endfunction
+
+  // Force OTP count input
+  function static void count_backdoor_write(input logic [LcCountWidth-1:0] val = 'hdead,
+                                            input int delay_clocks = 0, input int force_clocks = 5);
+    `dv_info($sformatf("Backdoor write to OTP count input = %h", val))
     fork
       begin : force_count_proc
         repeat (delay_clocks) @(posedge clk);
-        ->fsm_backdoor_count_write_ev;
-        force `LC_CTRL_FSM_COUNT_REGS_PATH = val;
+        ->count_backdoor_write_ev;
+        force `LC_CTRL_COUNT_PATH = val;
         repeat (force_clocks) @(posedge clk);
-        release `LC_CTRL_FSM_COUNT_REGS_PATH;
+        release `LC_CTRL_COUNT_PATH;
       end : force_count_proc
     join_none
   endfunction
 
-  function automatic logic [LcCountWidth-1:0] fsm_count_backdoor_read();
-    ->fsm_backdoor_count_read_ev;
-    return `LC_CTRL_FSM_COUNT_REGS_PATH;
+  // Read OTP count input
+  function automatic logic [LcCountWidth-1:0] count_backdoor_read();
+    ->count_backdoor_read_ev;
+    return `LC_CTRL_COUNT_PATH;
   endfunction
 
   function automatic set_test_sequence_typename(string name);
@@ -151,4 +236,4 @@ interface lc_ctrl_if (
 endinterface
 
 `undef LC_CTRL_FSM_STATE_REGS_PATH
-`undef LC_CTRL_FSM_COUNT_REGS_PATH
+`undef LC_CTRL_COUNT_PATH

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_parameters_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_parameters_cfg.sv
@@ -1,0 +1,24 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Object to store LC_CTRL parameter values to be sent from TB to environament
+class lc_ctrl_parameters_cfg extends uvm_object;
+  // LC_CTRL parameters
+  // Enable asynchronous transitions on alerts.
+  logic           [NUM_ALERTS-1:0] alert_async_on          = {NUM_ALERTS{1'b1}};
+  // Idcode value for the JTAG.
+  logic           [          31:0] id_code_value           = 32'h00000001;
+  // Random netlist constants
+  lc_keymgr_div_t                  keymgr_div_invalid      = LcKeymgrDivWidth'(0);
+  lc_keymgr_div_t                  keymgr_div_test_dev_rma = LcKeymgrDivWidth'(1);
+  lc_keymgr_div_t                  keymgr_div_production   = LcKeymgrDivWidth'(2);
+  `uvm_object_utils_begin(lc_ctrl_parameters_cfg)
+    `uvm_field_int(alert_async_on, UVM_DEFAULT)
+    `uvm_field_int(id_code_value, UVM_DEFAULT)
+    `uvm_field_int(keymgr_div_invalid, UVM_DEFAULT)
+    `uvm_field_int(keymgr_div_test_dev_rma, UVM_DEFAULT)
+    `uvm_field_int(keymgr_div_production, UVM_DEFAULT)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+endclass : lc_ctrl_parameters_cfg

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_priority_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_jtag_priority_vseq.sv
@@ -60,7 +60,7 @@ class lc_ctrl_jtag_priority_vseq extends lc_ctrl_jtag_access_vseq;
 
         begin
           cfg.clk_rst_vif.wait_clks(tl_delay);
-          csr_wr(.ptr(m_claim_transition_if), .value(CLAIM_TRANS_VAL), .map(m_map[0]),
+          csr_wr(.ptr(m_claim_transition_if), .value(CLAIM_TRANS_VAL), .map(m_map[LcCtrlTLUL]),
                  .blocking(1));
         end
 

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_lc_errors_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_lc_errors_vseq.sv
@@ -25,6 +25,8 @@ class lc_ctrl_lc_errors_vseq extends lc_ctrl_errors_vseq;
           err_inj.clk_byp_error_rsp,
           err_inj.flash_rma_error_rsp,
           err_inj.token_mismatch_err,
+          err_inj.token_invalid_err,
+          err_inj.token_response_err,
           err_inj.otp_partition_err
         }
     );

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_regwen_during_op_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_regwen_during_op_vseq.sv
@@ -15,13 +15,13 @@ class lc_ctrl_regwen_during_op_vseq extends lc_ctrl_smoke_vseq;
     // This is to give us time to try some reads and writes to
     // transition_regwen locked registers while the transition is in progress
     if (!cfg.jtag_csr) begin  // TL access
-      cfg.m_otp_token_pull_agent_cfg.device_delay_min = 3000;
-      cfg.m_otp_token_pull_agent_cfg.device_delay_max = 4000;
+      cfg.m_kmac_app_agent_cfg.rsp_delay_min = 3000;
+      cfg.m_kmac_app_agent_cfg.rsp_delay_max = 4000;
     end else begin  // JTAG Access - give us some more time for JTAG
-      cfg.m_otp_token_pull_agent_cfg.device_delay_min = 10000;
-      cfg.m_otp_token_pull_agent_cfg.device_delay_max = 12000;
+      cfg.m_kmac_app_agent_cfg.rsp_delay_min = 10000;
+      cfg.m_kmac_app_agent_cfg.rsp_delay_max = 12000;
     end
-    cfg.m_otp_token_pull_agent_cfg.zero_delays = 0;
+    cfg.m_kmac_app_agent_cfg.zero_delays = 0;
   endtask
 
   virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*4-1:0] token_val);

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_failure_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_state_failure_vseq.sv
@@ -13,10 +13,16 @@ class lc_ctrl_state_failure_vseq extends lc_ctrl_errors_vseq;
     $onehot(
         {
           err_inj.state_err,
-          err_inj.count_err,
+          err_inj.state_illegal_err,
           err_inj.state_backdoor_err,
-          err_inj.count_backdoor_err
+          err_inj.count_err,
+          err_inj.count_illegal_err,
+          err_inj.count_backdoor_err,
+          err_inj.lc_fsm_backdoor_err,
+          err_inj.kmac_fsm_backdoor_err,
+          err_inj.otp_lc_data_i_valid_err
         }
     );
+
   }
 endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_stress_all_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_stress_all_vseq.sv
@@ -51,11 +51,11 @@ class lc_ctrl_stress_all_vseq extends lc_ctrl_base_vseq;
       // Randomly choose TL or JTAG for register access
       if (use_jtag && (cfg.jtag_riscv_map != null)) begin
         cfg.jtag_csr = 1;
-        cfg.alert_max_delay = 4000;
+        cfg.alert_max_delay = 15000;
         cfg.ral.set_default_map(jtag_map);
       end else begin
         cfg.jtag_csr = 0;
-        cfg.alert_max_delay = 1500;
+        cfg.alert_max_delay = 2000;
         cfg.ral.set_default_map(tl_map);
       end
 

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -35,10 +35,20 @@
                 // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
 
   // Add additional tops for simulation.
-  sim_tops: ["lc_ctrl_bind"]
+  sim_tops: ["lc_ctrl_bind", "lc_ctrl_cov_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
+
+  overrides: [
+    //
+    // Override coverage config files to add our elaboration time coverage exclusions etc.
+    //
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {dv_root}/tools/vcs/cover.cfg+{dv_root}/tools/vcs/common_cov_excl.cfg+{proj_root}/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cover.cfg"
+    }
+  ]
 
   // Default UVM test and seq class name.
   uvm_test: lc_ctrl_base_test

--- a/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
+++ b/hw/ip/lc_ctrl/dv/tests/lc_ctrl_base_test.sv
@@ -17,7 +17,7 @@ class lc_ctrl_base_test extends cip_base_test #(
     void'($value$plusargs("jtag_csr=%0b", cfg.jtag_csr));
 
     // Increase alert wait time if using JTAG
-    if (cfg.jtag_csr) cfg.alert_max_delay = 4000;
+    if (cfg.jtag_csr) cfg.alert_max_delay = 15000;
 
   endfunction : build_phase
 


### PR DESCRIPTION
- Updated V2 checklist
- Updated documentation
- Added covergroup err_inj_cg to testplan
- Added DUT parameters and lc_ctrl_parameters_cfg
- Added random initialisation of otp_device_id_i and otp_manuf_state_i and
checking via scoreboard.
- Integrated kmac_app_agent
- Removed token pull agent (Replaced by kmac app request)
- Added helper function to create consistent digests
- Added otp_vendor_test_status_i drive in lc_ctrl_if with a test in
the scoreboard
- Added otp_vendor_test_ctrl_q sampling in lc_ctrl_if with a test in
the scoreboard
- Added scanmode_i and scan_rst_ni to lc_ctrl_if
- Randomly asserting scan_rst_ni in lc_ctrl_jtag_access_vseq
Should not affect the test unless scanmode == MuBi4True
- Added extra error injection types:
  - state_illegal_err - Illegal coding of lc_state_i by inverting a
  random symbol
  - count_illegal_err - Illegal coding of lc_cnt_i by inverting a
  random symbol
  - kmac_fsm_state_backdoor_err - flip bits in kmac I/F state regs
  - state_backdoor_err - flip bits of OTP state input
  - count_backdoor_err - flip bits of OTP count input
  - token_invalid_err - Bit error in token from KMAC App interface
  - token_response_err - Error response from KMAC App interface
  - otp_lc_data_i_valid_err - otp_lc_data_i.valid held at 0
  status register checked for not ready.
- Added whitebox coverage
- Added coverage configuration file lc_ctrl_cover.cfg
- Cleaned up compilation and elaboration warnings

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>