### PR TITLE
[sw,crypto] Copy silicon_creator OTBN driver for crypto library.

### DIFF
--- a/sw/device/lib/crypto/BUILD
+++ b/sw/device/lib/crypto/BUILD
@@ -1,0 +1,16 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "otbn_util",
+    srcs = ["otbn_util.c"],
+    hdrs = ["otbn_util.h"],
+    deps = [
+        "//sw/device/lib/crypto/drivers:otbn",
+    ],
+)

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -17,3 +17,13 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "otbn",
+    srcs = ["otbn.c"],
+    hdrs = ["otbn.h"],
+    deps = [
+        "//hw/ip/otbn/data:otbn_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+    ],
+)

--- a/sw/device/lib/crypto/drivers/meson.build
+++ b/sw/device/lib/crypto/drivers/meson.build
@@ -17,3 +17,19 @@ sw_lib_crypto_hmac = declare_dependency(
     ]
   )
 )
+
+# OTBN driver
+sw_lib_crypto_otbn = declare_dependency(
+  link_with: static_library(
+    'sw_lib_crypto_otbn',
+    sources: [
+      hw_ip_otbn_reg_h,
+      'otbn.c',
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_bitfield,
+      top_earlgrey,
+    ]
+  )
+)

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -1,0 +1,136 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otbn_regs.h"  // Generated.
+
+#define ASSERT_ERR_BIT_MATCH(enum_val, autogen_val) \
+  static_assert(enum_val == 1 << (autogen_val),     \
+                "OTBN register bit doesn't match autogen value.");
+
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBadDataAddr, OTBN_ERR_BITS_BAD_DATA_ADDR_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBadInsnAddr, OTBN_ERR_BITS_BAD_INSN_ADDR_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsCallStack, OTBN_ERR_BITS_CALL_STACK_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsIllegalInsn, OTBN_ERR_BITS_ILLEGAL_INSN_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsLoop, OTBN_ERR_BITS_LOOP_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsImemIntgViolation,
+                     OTBN_ERR_BITS_IMEM_INTG_VIOLATION_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsDmemIntgViolation,
+                     OTBN_ERR_BITS_DMEM_INTG_VIOLATION_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsRegIntgViolation,
+                     OTBN_ERR_BITS_REG_INTG_VIOLATION_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsBusIntgViolation,
+                     OTBN_ERR_BITS_BUS_INTG_VIOLATION_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsIllegalBusAccess,
+                     OTBN_ERR_BITS_ILLEGAL_BUS_ACCESS_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsLifecycleEscalation,
+                     OTBN_ERR_BITS_LIFECYCLE_ESCALATION_BIT);
+ASSERT_ERR_BIT_MATCH(kOtbnErrBitsFatalSoftware,
+                     OTBN_ERR_BITS_FATAL_SOFTWARE_BIT);
+
+const size_t kOtbnDMemSizeBytes = OTBN_DMEM_SIZE_BYTES;
+const size_t kOtbnIMemSizeBytes = OTBN_IMEM_SIZE_BYTES;
+
+enum { kBase = TOP_EARLGREY_OTBN_BASE_ADDR };
+
+/**
+ * Ensures that `offset_bytes` and `len` are valid for a given `mem_size`.
+ */
+static otbn_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
+                                     size_t mem_size) {
+  if (offset_bytes + num_words * sizeof(uint32_t) <
+          num_words * sizeof(uint32_t) ||
+      offset_bytes + num_words * sizeof(uint32_t) > mem_size) {
+    return kOtbnErrorBadOffsetLen;
+  }
+  return kOtbnErrorOk;
+}
+
+void otbn_execute(void) {
+  abs_mmio_write32(kBase + OTBN_CMD_REG_OFFSET, kOtbnCmdExecute);
+}
+
+bool otbn_is_busy() {
+  uint32_t status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
+  return status != kOtbnStatusIdle && status != kOtbnStatusLocked;
+}
+
+void otbn_get_err_bits(otbn_err_bits_t *err_bits) {
+  *err_bits = abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
+}
+
+otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t num_words) {
+  OTBN_RETURN_IF_ERROR(
+      check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
+
+  for (size_t i = 0; i < num_words; ++i) {
+    abs_mmio_write32(
+        kBase + OTBN_IMEM_REG_OFFSET + offset_bytes + i * sizeof(uint32_t),
+        src[i]);
+  }
+
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t num_words) {
+  OTBN_RETURN_IF_ERROR(
+      check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
+
+  for (size_t i = 0; i < num_words; ++i) {
+    abs_mmio_write32(
+        kBase + OTBN_DMEM_REG_OFFSET + offset_bytes + i * sizeof(uint32_t),
+        src[i]);
+  }
+
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
+                            size_t num_words) {
+  OTBN_RETURN_IF_ERROR(
+      check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
+
+  for (size_t i = 0; i < num_words; ++i) {
+    dest[i] = abs_mmio_read32(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes +
+                              i * sizeof(uint32_t));
+  }
+
+  return kOtbnErrorOk;
+}
+
+void otbn_zero_dmem(void) {
+  for (size_t i = 0; i < kOtbnDMemSizeBytes; i += sizeof(uint32_t)) {
+    abs_mmio_write32(kBase + OTBN_DMEM_REG_OFFSET + i, 0u);
+  }
+}
+
+otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+  // Only one bit in the CTRL register so no need to read current value.
+  uint32_t new_ctrl;
+
+  if (enable) {
+    new_ctrl = 1;
+  } else {
+    new_ctrl = 0;
+  }
+
+  abs_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET, new_ctrl);
+  if (abs_mmio_read32(kBase + OTBN_CTRL_REG_OFFSET) != new_ctrl) {
+    return kOtbnErrorUnavailable;
+  }
+
+  return kOtbnErrorOk;
+}

--- a/sw/device/lib/crypto/drivers/otbn.h
+++ b/sw/device/lib/crypto/drivers/otbn.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_OTBN_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_OTBN_H_
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -26,7 +26,7 @@ extern const size_t kOtbnIMemSizeBytes;
 /**
  * OTBN commands
  */
-typedef enum dif_otbn_cmd {
+typedef enum otbn_cmd {
   kOtbnCmdExecute = 0xd8,
   kOtbnCmdSecWipeDmem = 0xc3,
   kOtbnCmdSecWipeImem = 0x1e,
@@ -190,4 +190,4 @@ otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable);
 }
 #endif
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_DRIVERS_OTBN_H_

--- a/sw/device/lib/crypto/drivers/otbn.h
+++ b/sw/device/lib/crypto/drivers/otbn.h
@@ -1,0 +1,193 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The size of OTBN's data memory in bytes.
+ */
+extern const size_t kOtbnDMemSizeBytes;
+
+/**
+ * The size of OTBN's instruction memory in bytes.
+ */
+extern const size_t kOtbnIMemSizeBytes;
+
+/**
+ * OTBN commands
+ */
+typedef enum dif_otbn_cmd {
+  kOtbnCmdExecute = 0xd8,
+  kOtbnCmdSecWipeDmem = 0xc3,
+  kOtbnCmdSecWipeImem = 0x1e,
+} otbn_cmd_t;
+
+/**
+ * OTBN status
+ */
+typedef enum otbn_status {
+  kOtbnStatusIdle = 0x00,
+  kOtbnStatusBusyExecute = 0x01,
+  kOtbnStatusBusySecWipeDmem = 0x02,
+  kOtbnStatusBusySecWipeImem = 0x03,
+  kOtbnStatusLocked = 0xFF,
+} otbn_status_t;
+
+/**
+ * Error codes for the OTBN driver.
+ */
+typedef enum otbn_error_t {
+  /** No errors. */
+  kOtbnErrorOk = 0,
+  /** Invalid argument provided to OTBN interface function. */
+  kOtbnErrorInvalidArgument = 1,
+  /** Invalid offset provided. */
+  kOtbnErrorBadOffsetLen = 2,
+  /** OTBN internal error; use otbn_get_err_bits for specific error codes. */
+  kOtbnErrorExecutionFailed = 3,
+  /** Attempt to interact with OTBN while it was unavailable. */
+  kOtbnErrorUnavailable = 4,
+} otbn_error_t;
+
+/**
+ * Evaluate an expression and return if the result is an error.
+ *
+ * @param expr_ An expression which results in an otbn_error_t.
+ */
+#define OTBN_RETURN_IF_ERROR(expr_)     \
+  do {                                  \
+    otbn_error_t local_error_ = expr_;  \
+    if (local_error_ != kOtbnErrorOk) { \
+      return local_error_;              \
+    }                                   \
+  } while (0)
+
+/**
+ * Start the execution of the application loaded into OTBN.
+ */
+void otbn_execute(void);
+
+/**
+ * Is OTBN busy executing an application?
+ *
+ * @return OTBN is busy
+ */
+bool otbn_is_busy(void);
+
+/**
+ * OTBN Internal Errors
+ *
+ * OTBN uses a bitfield to indicate which errors have been seen. Multiple errors
+ * can be seen at the same time. This enum gives the individual bits that may be
+ * set for different errors.
+ */
+typedef enum otbn_err_bits {
+  kOtbnErrBitsNoError = 0,
+  /** A BAD_DATA_ADDR error was observed. */
+  kOtbnErrBitsBadDataAddr = (1 << 0),
+  /** A BAD_INSN_ADDR error was observed. */
+  kOtbnErrBitsBadInsnAddr = (1 << 1),
+  /** A CALL_STACK error was observed. */
+  kOtbnErrBitsCallStack = (1 << 2),
+  /** An ILLEGAL_INSN error was observed. */
+  kOtbnErrBitsIllegalInsn = (1 << 3),
+  /** A LOOP error was observed. */
+  kOtbnErrBitsLoop = (1 << 4),
+  /** A IMEM_INTG_VIOLATION error was observed. */
+  kOtbnErrBitsImemIntgViolation = (1 << 16),
+  /** A DMEM_INTG_VIOLATION error was observed. */
+  kOtbnErrBitsDmemIntgViolation = (1 << 17),
+  /** A REG_INTG_VIOLATION error was observed. */
+  kOtbnErrBitsRegIntgViolation = (1 << 18),
+  /** A BUS_INTG_VIOLATION error was observed. */
+  kOtbnErrBitsBusIntgViolation = (1 << 19),
+  /** A BAD_INTERNAL_STATE error was observed. */
+  kDifOtbnErrBitsBadInternalState = (1 << 20),
+  /** An ILLEGAL_BUS_ACCESS error was observed. */
+  kOtbnErrBitsIllegalBusAccess = (1 << 21),
+  /** A LIFECYCLE_ESCALATION error was observed. */
+  kOtbnErrBitsLifecycleEscalation = (1 << 22),
+  /** A FATAL_SOFTWARE error was observed. */
+  kOtbnErrBitsFatalSoftware = (1 << 23),
+} otbn_err_bits_t;
+
+/**
+ * Get the error bits set by the device if the operation failed.
+ *
+ * @param[out] err_bits The error bits returned by the hardware.
+ */
+void otbn_get_err_bits(otbn_err_bits_t *err_bits);
+
+/**
+ * Write an OTBN application into its instruction memory (IMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
+ * @param offset_bytes the byte offset in IMEM the first word is written to
+ * @param src the main memory location to start reading from.
+ * @param len number of words to copy.
+ * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
+ * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
+ */
+otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t len);
+
+/**
+ * Write to OTBN's data memory (DMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
+ * @param offset_bytes the byte offset in DMEM the first word is written to
+ * @param src the main memory location to start reading from.
+ * @param len number of words to copy.
+ * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
+ * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
+ */
+otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                             size_t len);
+
+/**
+ * Read from OTBN's data memory (DMEM)
+ *
+ * Only 32b-aligned 32b word accesses are allowed.
+ *
+ * @param offset_bytes the byte offset in DMEM the first word is read from
+ * @param[out] dest the main memory location to copy the data to (preallocated)
+ * @param len number of words to copy.
+ * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
+ * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
+ */
+otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest, size_t len);
+
+/**
+ * Zero out the contents of OTBN's data memory (DMEM).
+ */
+void otbn_zero_dmem(void);
+
+/**
+ * Sets the software errors are fatal bit in the control register.
+ *
+ * When set any software error becomes a fatal error. The bit can only be
+ * changed when the OTBN status is IDLE.
+ *
+ * @param enable Enable or disable whether software errors are fatal.
+ * @return `kOtbnErrorUnavailable` if the requested change cannot be made or
+ * `kOtbnErrorOk` otherwise.
+ */
+otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_OTBN_H_

--- a/sw/device/lib/crypto/meson.build
+++ b/sw/device/lib/crypto/meson.build
@@ -3,3 +3,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 subdir('drivers')
+
+# OTBN interface
+sw_lib_crypto_otbn_util = declare_dependency(
+  link_with: static_library(
+    'sw_lib_crypto_otbn_util',
+    sources: [
+      'otbn_util.c',
+    ],
+    dependencies: [
+      sw_lib_crypto_otbn,
+    ]
+  )
+)

--- a/sw/device/lib/crypto/otbn_util.c
+++ b/sw/device/lib/crypto/otbn_util.c
@@ -2,17 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/silicon_creator/lib/otbn_util.h"
+#include "sw/device/lib/crypto/otbn_util.h"
 
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/bitfield.h"
-#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
-#include "sw/device/silicon_creator/lib/drivers/otbn.h"
-
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
 
 void otbn_init(otbn_t *ctx) {
   *ctx = (otbn_t){

--- a/sw/device/lib/crypto/otbn_util.c
+++ b/sw/device/lib/crypto/otbn_util.c
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/otbn_util.h"
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/silicon_creator/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+void otbn_init(otbn_t *ctx) {
+  *ctx = (otbn_t){
+      .app = {0},
+      .app_is_loaded = false,
+      .error_bits = kOtbnErrBitsNoError,
+  };
+}
+
+otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
+  while (otbn_is_busy()) {
+  }
+
+  otbn_err_bits_t err_bits;
+  otbn_get_err_bits(&err_bits);
+  if (err_bits != kOtbnErrBitsNoError) {
+    ctx->error_bits = err_bits;
+    return kOtbnErrorExecutionFailed;
+  }
+  return kOtbnErrorOk;
+}
+
+/**
+ * Checks if the OTBN application's IMEM and DMEM address parameters are valid.
+ *
+ * IMEM and DMEM ranges must not be "backwards" in memory, with the end address
+ * coming before the start address, and the IMEM range must additionally be
+ * non-empty. Finally, separate sections in DMEM must not overlap each other
+ * when converted to DMEM address space.
+ *
+ * @param app the OTBN application to check
+ * @return true if the addresses are valid, otherwise false.
+ */
+bool check_app_address_ranges(const otbn_app_t *app) {
+  // IMEM must have a strictly positive range (cannot be backwards or empty)
+  if (app->imem_end <= app->imem_start) {
+    return false;
+  }
+  // DMEM data section must not be backwards
+  if (app->dmem_data_end < app->dmem_data_start) {
+    return false;
+  }
+  return true;
+}
+
+otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
+  if (!check_app_address_ranges(&app)) {
+    return kOtbnErrorInvalidArgument;
+  }
+
+  const size_t imem_num_words = app.imem_end - app.imem_start;
+  const size_t data_num_words = app.dmem_data_end - app.dmem_data_start;
+
+  ctx->app_is_loaded = false;
+
+  OTBN_RETURN_IF_ERROR(otbn_imem_write(0, app.imem_start, imem_num_words));
+
+  otbn_zero_dmem();
+  if (data_num_words > 0) {
+    OTBN_RETURN_IF_ERROR(
+        otbn_dmem_write(0, app.dmem_data_start, data_num_words));
+  }
+
+  ctx->app = app;
+  ctx->app_is_loaded = true;
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_execute_app(otbn_t *ctx) {
+  if (!ctx->app_is_loaded) {
+    return kOtbnErrorInvalidArgument;
+  }
+
+  otbn_execute();
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
+                                    const uint32_t *src, otbn_addr_t dest) {
+  OTBN_RETURN_IF_ERROR(otbn_dmem_write(dest, src, len));
+
+  return kOtbnErrorOk;
+}
+
+otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
+                                      otbn_addr_t src, uint32_t *dest) {
+  OTBN_RETURN_IF_ERROR(otbn_dmem_read(src, dest, len_bytes));
+
+  return kOtbnErrorOk;
+}

--- a/sw/device/lib/crypto/otbn_util.h
+++ b/sw/device/lib/crypto/otbn_util.h
@@ -1,0 +1,261 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OTBN_UTIL_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OTBN_UTIL_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Constants related to OTBN wide words
+ */
+enum {
+  /* Length of an OTBN wide word in bits */
+  kOtbnWideWordNumBits = 256,
+  /* Length of an OTBN wide word in words */
+  kOtbnWideWordNumWords = kOtbnWideWordNumBits / (sizeof(uint32_t) * 8),
+};
+
+/**
+ * Information about an embedded OTBN application image.
+ *
+ * All pointers reference data in the normal CPU address space.
+ * uint32_t values are addresses in the OTBN address space.
+ *
+ * Use `OTBN_DECLARE_APP_SYMBOLS()` together with `OTBN_APP_T_INIT()` to
+ * initialize this structure.
+ */
+typedef struct otbn_app {
+  /**
+   * Start of OTBN instruction memory.
+   */
+  const uint32_t *imem_start;
+  /**
+   * The first word after OTBN instruction memory.
+   *
+   * This address satifies `imem_len = imem_end - imem_start`.
+   */
+  const uint32_t *imem_end;
+  /**
+   * Start of initialized OTBN data.
+   *
+   * Data in between dmem_data_start and dmem_data_end will be copied to OTBN
+   * at app load time.
+   */
+  const uint32_t *dmem_data_start;
+  /**
+   * The first word after initialized OTBN data.
+   *
+   * Should satisfy `dmem_data_start <= dmem_data_end`.
+   */
+  const uint32_t *dmem_data_end;
+} otbn_app_t;
+
+/**
+ * The address of an OTBN symbol as seen by OTBN
+ *
+ * Use `OTBN_DECLARE_SYMBOL_ADDR()` together with `OTBN_ADDR_T_INIT()` to
+ * initialize this type.
+ */
+typedef uint32_t otbn_addr_t;
+
+/**
+ * OTBN context structure.
+ *
+ * Use `otbn_init()` to initialize.
+ */
+typedef struct otbn {
+  /**
+   * The application loaded or to be loaded into OTBN.
+   *
+   * Only valid if @p app_is_loaded is true.
+   */
+  otbn_app_t app;
+
+  /**
+   * Is the application loaded into OTBN?
+   */
+  bool app_is_loaded;
+
+  /**
+   * The error bits from the last execution of OTBN.
+   */
+  uint32_t error_bits;
+} otbn_t;
+
+/**
+ * Generate the prefix to add to an OTBN symbol name used on the Ibex side
+ *
+ * The result is a pointer to Ibex's rodata that should be used to initialise
+ * memory for that symbol.
+ *
+ * This is needed by the OTBN driver to support DMEM/IMEM ranges but
+ * application code shouldn't need to use this. Use the `otbn_addr_t` type and
+ * supporting macros instead.
+ */
+#define OTBN_SYMBOL_PTR(app_name, sym) _otbn_local_app_##app_name##_##sym
+
+/**
+ * Generate the prefix to add to an OTBN symbol name used on the OTBN side
+ *
+ * The result is a pointer whose integer value is the address by which the
+ * symbol should be accessed in OTBN memory.
+ *
+ * This is an internal macro used in `OTBN_DECLARE_SYMBOL_ADDR` and
+ * `OTBN_ADDR_T_INIT` but application code shouldn't need to use it directly.
+ */
+#define OTBN_SYMBOL_ADDR(app_name, sym) _otbn_remote_app_##app_name##_##sym
+
+/**
+ * Makes a symbol in the OTBN application image available.
+ *
+ * This is needed by the OTBN driver to support DMEM/IMEM ranges but
+ * application code shouldn't need to use this. To get access to OTBN
+ * addresses, use `OTBN_DECLARE_SYMBOL_ADDR` instead.
+ */
+#define OTBN_DECLARE_SYMBOL_PTR(app_name, symbol_name) \
+  extern const uint32_t OTBN_SYMBOL_PTR(app_name, symbol_name)[]
+
+/**
+ * Makes the OTBN address of a symbol in the OTBN application available.
+ *
+ * Symbols are typically function or data pointers, i.e. labels in assembly
+ * code. Unlike OTBN_DECLARE_SYMBOL_PTR, this will work for symbols in the .bss
+ * section (which exist on the OTBN side, even though they don't have backing
+ * data on Ibex).
+ *
+ * Use this macro instead of manually declaring the symbols as symbol names
+ * might change.
+ *
+ * @param app_name    Name of the application the function is contained in.
+ * @param symbol_name Name of the symbol (function, label).
+ */
+#define OTBN_DECLARE_SYMBOL_ADDR(app_name, symbol_name) \
+  extern const uint32_t OTBN_SYMBOL_ADDR(app_name, symbol_name)[]
+
+/**
+ * Makes an embedded OTBN application image available for use.
+ *
+ * Make symbols available that indicate the start and the end of instruction
+ * and data memory regions, as they are stored in the device memory.
+ *
+ * Use this macro instead of manually declaring the symbols as symbol names
+ * might change.
+ *
+ * @param app_name Name of the application to load, which is typically the
+ *                 name of the main (assembly) source file.
+ */
+#define OTBN_DECLARE_APP_SYMBOLS(app_name)             \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_start);      \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _imem_end);        \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_start); \
+  OTBN_DECLARE_SYMBOL_PTR(app_name, _dmem_data_end)
+
+/**
+ * Initializes the OTBN application information structure.
+ *
+ * After making all required symbols from the application image available
+ * through `OTBN_DECLARE_APP_SYMBOLS()`, use this macro to initialize an
+ * `otbn_app_t` struct with those symbols.
+ *
+ * @param app_name Name of the application to load.
+ * @see OTBN_DECLARE_APP_SYMBOLS()
+ */
+#define OTBN_APP_T_INIT(app_name)                                     \
+  ((otbn_app_t){                                                      \
+      .imem_start = OTBN_SYMBOL_PTR(app_name, _imem_start),           \
+      .imem_end = OTBN_SYMBOL_PTR(app_name, _imem_end),               \
+      .dmem_data_start = OTBN_SYMBOL_PTR(app_name, _dmem_data_start), \
+      .dmem_data_end = OTBN_SYMBOL_PTR(app_name, _dmem_data_end),     \
+  })
+
+/**
+ * Initializes an `otbn_addr_t`.
+ */
+#define OTBN_ADDR_T_INIT(app_name, symbol_name) \
+  ((uint32_t)OTBN_SYMBOL_ADDR(app_name, symbol_name))
+
+void otbn_init(otbn_t *ctx);
+
+/**
+ * (Re-)loads the RSA application into OTBN.
+ *
+ * Load the application image with both instruction and data segments into OTBN.
+ *
+ * @param ctx The context object.
+ * @param app The application to load into OTBN.
+ * @return The result of the operation.
+ */
+otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
+
+/**
+ * Start the OTBN application.
+ *
+ * Use `otbn_busy_wait_for_done()` to wait for the function call to complete.
+ *
+ * @param ctx The context object.
+ * @return The result of the operation.
+ */
+otbn_error_t otbn_execute_app(otbn_t *ctx);
+
+/**
+ * Busy waits for OTBN to be done with its operation.
+ *
+ * @param ctx The context object.
+ * @return The result of the operation.
+ */
+otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx);
+
+/**
+ * Copies data from the CPU memory to OTBN data memory.
+ *
+ * @param ctx The context object.
+ * @param len Number of 32b words to copy.
+ * @param dest Address of the destination in OTBN's data memory.
+ * @param src Source of the data to copy.
+ * @return The result of the operation.
+ */
+otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
+                                    const uint32_t *src, otbn_addr_t dest);
+
+/**
+ * Copies data from OTBN's data memory to CPU memory.
+ *
+ * @param ctx The context object.
+ * @param len The number of 32b words to copy.
+ * @param src The address in OTBN data memory to copy from.
+ * @param[out] dest The destination of the copied data in main memory
+ *                  (preallocated).
+ * @return The result of the operation.
+ */
+otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len,
+                                      const otbn_addr_t src, uint32_t *dest);
+
+/**
+ * Evaluate an expression and return a mask ROM error if the result is an
+ * OTBN error.
+ *
+ * @param expr_ An expression which results in an otbn_error_t.
+ */
+#define FOLD_OTBN_ERROR(expr_)          \
+  do {                                  \
+    otbn_error_t local_error_ = expr_;  \
+    if (local_error_ != kOtbnErrorOk) { \
+      return kErrorOtbnInternal;        \
+    }                                   \
+  } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OTBN_UTIL_H_

--- a/sw/device/lib/crypto/otbn_util.h
+++ b/sw/device/lib/crypto/otbn_util.h
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OTBN_UTIL_H_
-#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OTBN_UTIL_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_OTBN_UTIL_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_OTBN_UTIL_H_
 
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/silicon_creator/lib/drivers/otbn.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -240,22 +240,8 @@ otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
 otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len,
                                       const otbn_addr_t src, uint32_t *dest);
 
-/**
- * Evaluate an expression and return a mask ROM error if the result is an
- * OTBN error.
- *
- * @param expr_ An expression which results in an otbn_error_t.
- */
-#define FOLD_OTBN_ERROR(expr_)          \
-  do {                                  \
-    otbn_error_t local_error_ = expr_;  \
-    if (local_error_ != kOtbnErrorOk) { \
-      return kErrorOtbnInternal;        \
-    }                                   \
-  } while (0)
-
 #ifdef __cplusplus
 }
 #endif
 
-#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_OTBN_UTIL_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_OTBN_UTIL_H_


### PR DESCRIPTION
Related: #9764, https://github.com/lowRISC/opentitan/pull/10190#issuecomment-1017618142, #10249

The crypto library needs to move out of `silicon_creator`, and to do that it needs to have its own OTBN driver. This PR creates a starting point by copying over the `silicon_creator` driver and making the minimal edits necessary for it to build without `silicon_creator` dependencies.