### PR TITLE
[dv/pwrmgr] Disable escalation ping fcov

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -35,6 +35,8 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
     m_esc_agent_cfg = alert_esc_agent_cfg::type_id::create("m_esc_agent_cfg");
     `DV_CHECK_RANDOMIZE_FATAL(m_esc_agent_cfg)
     m_esc_agent_cfg.is_alert = 0;
+    // Disable escalation ping coverage.
+    m_esc_agent_cfg.en_ping_cov = 0;
   endfunction
 
 endclass


### PR DESCRIPTION
This PR disable the fcov collected by escalation agent regarding the
ping coverage. Because pwrmgr stimulus doesn't send out ping request.
This feature is covered in alert_handler testbench.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>