### PR TITLE
[dv/otp_ctrl] OTP regression fixes

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -293,7 +293,7 @@
     }
     { // TODO: this is an array of covergroups, confirm if this is the correct format
       name: unbuf_err_code_cg
-      desc: '''This is an array of covergroups to cover all applicable error codes in two
+      desc: '''This is an array of covergroups to cover all applicable error codes in three
             unbuffered partitions.'''
     }
     { // TODO: this is an array of covergroups, confirm if this is the correct format

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -108,6 +108,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
     // only support 1 outstanding TL items in tlul_adapter
     m_tl_agent_cfg.max_outstanding_req = 1;
+    prim_tl_agent_cfg.max_outstanding_req = 1;
 
     // create the inputs cfg instance
     dut_cfg = otp_ctrl_ast_inputs_cfg::type_id::create("dut_cfg");

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -133,17 +133,17 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     @(posedge clk_i);
     if (fail_idx[VendorTestIdx]) begin
       force tb.dut.gen_partitions[VendorTestIdx].gen_unbuffered.
-            u_part_unbuf.`ECC_REG_PATH.syndrome_o[0] = 1;
+            u_part_unbuf.`ECC_REG_PATH.data_i[0] = 1;
       force_sw_parts_ecc_reg[VendorTestIdx] = 1;
     end
     if (fail_idx[CreatorSwCfgIdx]) begin
       force tb.dut.gen_partitions[CreatorSwCfgIdx].gen_unbuffered.
-            u_part_unbuf.`ECC_REG_PATH.syndrome_o[0] = 1;
+            u_part_unbuf.`ECC_REG_PATH.data_i[0] = 1;
       force_sw_parts_ecc_reg[CreatorSwCfgIdx] = 1;
     end
     if (fail_idx[OwnerSwCfgIdx]) begin
       force tb.dut.gen_partitions[OwnerSwCfgIdx].gen_unbuffered.
-            u_part_unbuf.`ECC_REG_PATH.syndrome_o[0] = 1;
+            u_part_unbuf.`ECC_REG_PATH.data_i[0] = 1;
       force_sw_parts_ecc_reg[OwnerSwCfgIdx] = 1;
     end
   endtask
@@ -152,17 +152,17 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     @(posedge clk_i);
     if (force_sw_parts_ecc_reg[VendorTestIdx]) begin
       release tb.dut.gen_partitions[VendorTestIdx].gen_unbuffered.
-              u_part_unbuf.`ECC_REG_PATH.syndrome_o[0];
+              u_part_unbuf.`ECC_REG_PATH.data_i[0];
       force_sw_parts_ecc_reg[VendorTestIdx] = 0;
     end
     if (force_sw_parts_ecc_reg[CreatorSwCfgIdx]) begin
       release tb.dut.gen_partitions[CreatorSwCfgIdx].gen_unbuffered.
-              u_part_unbuf.`ECC_REG_PATH.syndrome_o[0];
+              u_part_unbuf.`ECC_REG_PATH.data_i[0];
       force_sw_parts_ecc_reg[CreatorSwCfgIdx] = 0;
     end
     if (force_sw_parts_ecc_reg[OwnerSwCfgIdx]) begin
       release tb.dut.gen_partitions[OwnerSwCfgIdx].gen_unbuffered.
-              u_part_unbuf.`ECC_REG_PATH.syndrome_o[0];
+              u_part_unbuf.`ECC_REG_PATH.data_i[0];
       force_sw_parts_ecc_reg[OwnerSwCfgIdx] = 0;
     end
   endtask

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -121,8 +121,9 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
         check_otp_fatal_err("fatal_macro_error", exp_status);
       end else if ($urandom_range(0, 1)) begin
 
-        // Randomly force ECC reg in sw partitions to create a check failure
-        bit [1:0] sw_check_fail = $urandom_range(1, 4);
+        // Randomly force ECC reg in sw partitions to create a check failure.
+        // Totaly three sw partitions, and each bit indexes a partition.
+        bit [2:0] sw_check_fail = $urandom_range(1, 7);
         cfg.otp_ctrl_vif.force_sw_check_fail(sw_check_fail);
         `uvm_info(`gfn, $sformatf("OTP_init SW ECC check failure with index %0h", sw_check_fail),
                   UVM_LOW)


### PR DESCRIPTION
This PR has two commits:
1). Fix otp_init_fail sequence related to force a wire.
     To ensure the force works, I changed to force a reg instead.
2). Fix prim_tl interface max outstanding access, and vendor test partition documentation issue.