### PR TITLE
[otbn,dv] Add test sequence for the lc_escalate signal

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -119,7 +119,7 @@
             Trigger the life cycle escalation input.
             '''
       milestone: V2
-      tests: []
+      tests: ["otbn_escalate"]
     }
   ]
 }

--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -465,6 +465,10 @@ void ISSWrapper::reset(bool gen_trace) {
   mirrored_.status = 0;
 }
 
+void ISSWrapper::send_lc_escalation() {
+  run_command("send_lc_escalation\n", nullptr);
+}
+
 void ISSWrapper::get_regs(std::array<uint32_t, 32> *gprs,
                           std::array<u256_t, 32> *wdrs) {
   assert(gprs && wdrs);

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -116,6 +116,9 @@ struct ISSWrapper {
   // mirrored registers to their initial states.
   void reset(bool gen_trace);
 
+  // Send a lifecycle controller escalation signal
+  void send_lc_escalation();
+
   const MirroredRegs &get_mirrored() const { return mirrored_; }
 
   // Read contents of the register file

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -502,6 +502,22 @@ void OtbnModel::reset() {
     iss->reset(has_rtl());
 }
 
+int OtbnModel::send_lc_escalation() {
+  ISSWrapper *iss = ensure_wrapper();
+  if (!iss)
+    return -1;
+
+  try {
+    iss->send_lc_escalation();
+  } catch (const std::exception &err) {
+    std::cerr << "Error when sending LC escalation signal to ISS: "
+              << err.what() << "\n";
+    return -1;
+  }
+
+  return 0;
+}
+
 ISSWrapper *OtbnModel::ensure_wrapper() {
   if (!iss_) {
     try {
@@ -757,10 +773,6 @@ unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned model_state,
     }
   }
 
-  // If the model isn't running, there's nothing more to do.
-  if (!(model_state & RUNNING_BIT))
-    return model_state;
-
   // Step the model once
   switch (model->step(status, insn_cnt, rnd_req, err_bits, stop_pc)) {
     case 0:
@@ -828,4 +840,9 @@ void otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
                                  svLogicVecVal *key1, unsigned char valid) {
   assert(model && key0 && key1);
   model->set_keymgr_value(key0, key1, valid);
+}
+
+int otbn_model_send_lc_escalation(OtbnModel *model) {
+  assert(model);
+  return model->send_lc_escalation();
 }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -89,6 +89,10 @@ class OtbnModel {
   // Flush any information in the model
   void reset();
 
+  // React to a lifecycle controller escalation signal. Returns 0 on
+  // success; -1 on failure.
+  int send_lc_escalation();
+
  private:
   // Constructs an ISS wrapper if necessary. If something goes wrong, this
   // function prints a message and then returns null. If ensure is true, it

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -102,6 +102,9 @@ void otbn_model_reset(OtbnModel *model);
 
 // Take loop warps from an OtbnMemUtil
 void otbn_take_loop_warps(OtbnModel *model, OtbnMemUtil *memutil);
+
+// React to a lifecycle controller escalation signal
+int otbn_model_send_lc_escalation(OtbnModel *model);
 }
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_MODEL_DPI_H_

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -54,5 +54,7 @@ package otbn_model_pkg;
 
   import "DPI-C" function void otbn_take_loop_warps(chandle model, chandle memutil);
 
+  import "DPI-C" function int otbn_model_send_lc_escalation(chandle model);
+
 endpackage
 `endif // SYNTHESIS

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -60,7 +60,7 @@ class FsmState(IntEnum):
     FETCH_WAIT = 11
     EXEC = 12
     POST_EXEC = 13
-    LOCKING = 13
+    LOCKING = 14
     LOCKED = 2550
 
 
@@ -267,9 +267,6 @@ class OTBNState:
         return self.fsm_state not in [FsmState.IDLE, FsmState.LOCKED]
 
     def commit(self, sim_stalled: bool) -> None:
-        # We shouldn't be running commit() in IDLE or LOCKED mode
-        assert self.running()
-
         if self._time_to_imem_invalidation is not None:
             self._time_to_imem_invalidation -= 1
             if self._time_to_imem_invalidation == 0:
@@ -330,8 +327,14 @@ class OTBNState:
             self.fsm_state = FsmState.LOCKED
             return
 
+        # If we are in LOCKED mode, commit external registers but do nothing
+        # else.
+        if self.fsm_state == FsmState.LOCKED:
+            self.ext_regs.commit()
+            return
+
         # Otherwise, we're in EXEC mode.
-        assert self.fsm_state == FsmState.EXEC
+        assert self.fsm_state in [FsmState.EXEC, FsmState.IDLE]
 
         # In case of a pending halt, commit the external registers, which
         # contain e.g. the ERR_BITS field, but nothing else. Switch to
@@ -342,7 +345,8 @@ class OTBNState:
                 self.ext_regs.write('INSN_CNT', 0, True)
                 self.fsm_state = FsmState.LOCKING
             else:
-                self.fsm_state = FsmState.POST_EXEC
+                if self.fsm_state == FsmState.EXEC:
+                    self.fsm_state = FsmState.POST_EXEC
             return
 
         # As pending_halt wasn't set, there shouldn't be any pending error bits

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -63,6 +63,8 @@ prefixed with "0x" if they are hexadecimal.
                          change of state (this is pure, but handled in Python
                          to simplify verification).
 
+    send_lc_escalation   React to lc_escalate_en_i going high
+
 '''
 
 import binascii
@@ -344,6 +346,12 @@ def on_step_crc(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
+def on_send_lc_escalation(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('send_lc_escalation', 0, args)
+    sim.on_lc_escalation()
+    return None
+
+
 _HANDLERS = {
     'start': on_start,
     'step': on_step,
@@ -364,7 +372,8 @@ _HANDLERS = {
     'invalidate_imem': on_invalidate_imem,
     'invalidate_dmem': on_invalidate_dmem,
     'set_keymgr_value': on_set_keymgr_value,
-    'step_crc': on_step_crc
+    'step_crc': on_step_crc,
+    'send_lc_escalation': on_send_lc_escalation
 }
 
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -24,6 +24,7 @@ filesets:
       - otbn_insn_cnt_if.sv
       - otbn_controller_if.sv
       - otbn_rnd_if.sv
+      - otbn_escalate_if.sv
       - otbn_trace_item.sv: {is_include_file: true}
       - otbn_trace_monitor.sv: {is_include_file: true}
       - otbn_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -44,6 +44,7 @@ filesets:
       - seq_lib/otbn_single_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_escalate_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -52,6 +52,10 @@ class otbn_env extends cip_base_env #(
                                                       cfg.controller_vif)) begin
       `uvm_fatal(`gfn, "failed to get otbn_controller_if handle from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual otbn_escalate_if)::get(this, "", "escalate_vif",
+                                                       cfg.escalate_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otbn_escalate_if handle from uvm_config_db")
+    end
     if (!uvm_config_db#(mem_bkdr_util)::get(this, "", "imem_util", cfg.imem_util)) begin
       `uvm_fatal(`gfn, "failed to get imem_util from uvm_config_db")
     end

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -20,6 +20,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   virtual otbn_mac_bignum_if mac_bignum_vif;
   virtual otbn_rf_base_if    rf_base_vif;
   virtual otbn_controller_if controller_vif;
+  virtual otbn_escalate_if   escalate_vif;
 
   mem_bkdr_util imem_util;
   mem_bkdr_util dmem_util;

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -45,8 +45,9 @@ package otbn_env_pkg;
   parameter uint NUM_EDN = 2;
 
   // typedefs
-  typedef virtual pins_if #(1) idle_vif;
-  typedef logic [TL_AIW-1:0]   tl_source_t;
+  typedef virtual pins_if #(1)     idle_vif;
+  typedef virtual otbn_escalate_if escalate_vif;
+  typedef logic [TL_AIW-1:0]       tl_source_t;
 
   // Expected data for a pending read (see exp_read_values in otbn_scoreboard.sv)
   typedef struct packed {

--- a/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
@@ -11,4 +11,19 @@ interface otbn_escalate_if (
 
   lc_ctrl_pkg::lc_tx_t enable;
 
+  function automatic void reset_signals();
+    enable = lc_ctrl_pkg::Off;
+  endfunction
+
+  task automatic set_after_n_clocks(int unsigned n);
+    `DV_SPINWAIT_EXIT(
+      begin
+        repeat (n) @(posedge clk_i);
+        enable = lc_ctrl_pkg::On;
+      end,
+      @(negedge rst_ni);,
+      "Not setting enable signal because we've gone into reset",
+      "otbn_escalate_if")
+  endtask
+
 endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// A one-signal interface for escalation signals
+
+interface otbn_escalate_if (
+  input logic clk_i,
+  input logic rst_ni
+);
+
+  lc_ctrl_pkg::lc_tx_t enable;
+
+endinterface

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -38,7 +38,7 @@ class otbn_base_vseq extends cip_base_vseq #(
   // Overridden from dv_base_vseq
   task dut_init(string reset_kind = "HARD");
     // Always drive the lifecycle escalation signal to off at the start of the sequence.
-    cfg.escalate_vif.enable = lc_ctrl_pkg::Off;
+    cfg.escalate_vif.reset_signals();
 
     super.dut_init(reset_kind);
   endtask

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -35,6 +35,14 @@ class otbn_base_vseq extends cip_base_vseq #(
   // sideload sequencer will get upset if we kill a process that's waiting for a grant from it).
   protected int unsigned stop_tokens = 0;
 
+  // Overridden from dv_base_vseq
+  task dut_init(string reset_kind = "HARD");
+    // Always drive the lifecycle escalation signal to off at the start of the sequence.
+    cfg.escalate_vif.enable = lc_ctrl_pkg::Off;
+
+    super.dut_init(reset_kind);
+  endtask
+
   // Load the contents of an ELF file into the DUT's memories, either by a DPI backdoor (if backdoor
   // is true) or with TL transactions. Also, pass loop warp rules to the ISS through the model.
   protected task load_elf(string path, bit backdoor);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
@@ -57,6 +57,8 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
           repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
         end
       join
+      do_apply_reset = 1'b1;
+      dut_init("HARD");
     end
   endtask
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_escalate_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_escalate_vseq.sv
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program, asserting the lc_escalate_en_i at some point during the run.
+// Occasionally, it will assert just before or just after.
+
+class otbn_escalate_vseq extends otbn_base_vseq;
+  `uvm_object_utils(otbn_escalate_vseq)
+
+  `uvm_object_new
+
+  task body();
+    string       elf_path;
+    int unsigned bda_idx;
+    bit          go_before, go_during, go_after;
+
+    elf_path = pick_elf_path();
+    `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+
+    // Pick whether we're going before (5%), during (90%), or after (5%).
+    bda_idx = $urandom_range(100);
+    go_before = bda_idx < 5;
+    go_during = 5 <= bda_idx && bda_idx < 95;
+    go_after = 95 <= bda_idx;
+
+    fork
+      load_elf(elf_path, .backdoor(1'b0));
+      if (go_before) send_escalation_signal(100);
+    join
+
+    if (go_before) begin
+      // At this point, we've sent our escalation signal already. Wait for the fatal alert to
+      // trigger and then return.
+      wait_alert_and_reset();
+      return;
+    end
+
+    if (go_after) begin
+      // We want to send the escalation signal after OTBN is finished. Run an operation, send the
+      // signal, then wait for the fatal alert.
+      run_otbn();
+      send_escalation_signal(10);
+      wait_alert_and_reset();
+      return;
+    end
+
+    // This is the interesting case. Start OTBN running. When this task returns, we'll be in the
+    // middle of a run.
+    start_running_otbn(.check_end_addr(1'b0));
+
+    // Send an escalation signal immediately (the randomisation about where we should strike has
+    // already been done inside start_running_otbn())
+    send_escalation_signal(1);
+
+    // Wait for an alert to come out before returning
+    wait_alert_and_reset();
+  endtask
+
+  // Wait between zero and max_cycles clock cycles and then set the escalation signal to enabled.
+  // Return immediately if we go into reset.
+  task send_escalation_signal(int unsigned max_cycles);
+    cfg.escalate_vif.set_after_n_clocks($urandom_range(max_cycles));
+  endtask
+
+  // Wait for a fatal alert to come out and retrigger at least once. Then reset the DUT. This is
+  // needed at the end of the sequence because otherwise the monitor that sees the re-triggering
+  // fatal alert will stop the test from ever finishing.
+  task wait_alert_and_reset();
+    repeat (2) wait_alert_trigger("fatal", .wait_complete(1));
+
+    do_apply_reset = 1'b1;
+    dut_init("HARD");
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -58,6 +58,8 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
         repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
       end
     join
+    do_apply_reset = 1'b1;
+    dut_init("HARD");
   endtask
 
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -12,3 +12,4 @@
 `include "otbn_imem_err_vseq.sv"
 `include "otbn_dmem_err_vseq.sv"
 `include "otbn_stress_all_vseq.sv"
+`include "otbn_escalate_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -197,6 +197,13 @@ name:
     }
 
     {
+      name: "otbn_escalate"
+      uvm_test_seq: "otbn_escalate_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
+    {
       name: "otbn_stress_all"
       uvm_test_seq: "otbn_stress_all_vseq"
       en_run_modes: ["build_otbn_rig_binaries_mode"]

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -217,6 +217,8 @@ module tb;
 
     .start_i      (model_if.start),
 
+    .lc_escalate_en_i (escalate_if.enable == lc_ctrl_pkg::On),
+
     .err_bits_o   (model_if.err_bits),
 
     .edn_rnd_i             ({edn_if[0].ack, edn_if[0].d_data}),

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -25,10 +25,11 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // interfaces
-  clk_rst_if                    clk_rst_if (.clk(clk), .rst_n(rst_n));
-  tl_if                         tl_if      (.clk(clk), .rst_n(rst_n));
-  pins_if #(1)                  idle_if    (idle);
-  pins_if #(NUM_MAX_INTERRUPTS) intr_if    (interrupts);
+  clk_rst_if                    clk_rst_if  (.clk(clk), .rst_n(rst_n));
+  tl_if                         tl_if       (.clk(clk), .rst_n(rst_n));
+  pins_if #(1)                  idle_if     (idle);
+  otbn_escalate_if              escalate_if (.clk_i (clk), .rst_ni (rst_n));
+  pins_if #(NUM_MAX_INTERRUPTS) intr_if     (interrupts);
   assign interrupts[0] = {intr_done};
 
   // A hook to allow sequences to enable or disable the MatchingStatus_A assertion below. This is
@@ -123,7 +124,7 @@ module tb;
     .alert_rx_i(alert_rx),
     .alert_tx_o(alert_tx),
 
-    .lc_escalate_en_i (lc_ctrl_pkg::Off),
+    .lc_escalate_en_i (escalate_if.enable),
 
     .ram_cfg_i('0),
 
@@ -282,6 +283,7 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(idle_vif)::set(null, "*.env", "idle_vif", idle_if);
+    uvm_config_db#(escalate_vif)::set(null, "*.env", "escalate_vif", escalate_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual otbn_model_if)::set(null, "*.env.model_agent", "vif", model_if);
     uvm_config_db#(virtual key_sideload_if)::set(null, "*.env.keymgr_sideload_agent",

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -309,6 +309,8 @@ module otbn_top_sim (
 
     .start_i               ( otbn_start ),
 
+    .lc_escalate_en_i      ( 1'b0 ),
+
     .err_bits_o            ( otbn_model_err_bits ),
 
     .edn_rnd_i             ( rnd_rsp ),

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -733,7 +733,7 @@ module otbn
   logic        insn_cnt_clear;
   logic        unused_insn_cnt_q;
   assign hw2reg.insn_cnt.d = insn_cnt;
-  assign insn_cnt_clear = reg2hw.insn_cnt.qe & ~busy_execute_q;
+  assign insn_cnt_clear = (reg2hw.insn_cnt.qe & ~busy_execute_q) | lifecycle_escalation;
   // Ignore all write data to insn_cnt. All writes zero the register.
   assign unused_insn_cnt_q = ^reg2hw.insn_cnt.q;
 

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -883,6 +883,8 @@ module otbn
 
       .start_i               (start_model),
 
+      .lc_escalate_en_i      (lc_escalate_en_i == lc_ctrl_pkg::On),
+
       .err_bits_o            (err_bits_model),
 
       .edn_rnd_i             (edn_rnd_model_i),


### PR DESCRIPTION
There are two interesting commits here:

- **[otbn,rtl] Clear INSN_CNT on a lifecycle escalation signal**
  This fixes a (minor) RTL bug!
- **[otbn,dv] Add ISS support for the lc_ctrl escalate signal**
  This is mostly fiddly wiring, but we have to handle the possibility that something happens when we aren't expecting to step the ISS. I've done something really simple and stupid, but that's slightly perturbed how we were handling RND requests. @ctopal: Could you take a look to make sure this makes sense to you?