### PR TITLE
[dv/rstmgr] Add sw_rst SVA

### DIFF
--- a/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
@@ -49,4 +49,32 @@ module rstmgr_bind;
     .expected_cpu_info_attr(($bits(cpu_dump_i) + 31) / 32)
   );
 
+  bind rstmgr rstmgr_sw_rst_sva_if rstmgr_sw_rst_sva_if (
+    .clk_i,
+    .rst_ni,
+    .parent_rst_n(rst_sys_src_n[1]),
+    .enables(reg2hw.sw_rst_regwen),
+    .ctrl_ns(reg2hw.sw_rst_ctrl_n),
+    .rst_ens({
+      rst_en_o.i2c2[1],
+      rst_en_o.i2c1[1],
+      rst_en_o.i2c0[1],
+      rst_en_o.usbif[1],
+      rst_en_o.usb[1],
+      rst_en_o.spi_host1[1],
+      rst_en_o.spi_host0[1],
+      rst_en_o.spi_device[1]
+    }),
+    .rst_ns({
+      resets_o.rst_i2c2_n[1],
+      resets_o.rst_i2c1_n[1],
+      resets_o.rst_i2c0_n[1],
+      resets_o.rst_usbif_n[1],
+      resets_o.rst_usb_n[1],
+      resets_o.rst_spi_host1_n[1],
+      resets_o.rst_spi_host0_n[1],
+      resets_o.rst_spi_device_n[1]
+    })
+  );
+
 endmodule

--- a/hw/ip/rstmgr/dv/sva/rstmgr_sva_ifs.core
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_sva_ifs.core
@@ -12,8 +12,9 @@ filesets:
       - lowrisc:ip:rstmgr
 
     files:
-      - rstmgr_cascading_sva_if.sv
       - rstmgr_attrs_sva_if.sv
+      - rstmgr_cascading_sva_if.sv
+      - rstmgr_sw_rst_sva_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_sw_rst_sva_if.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This has assertions that check the output resets read-only value of the alert and cpu_info_attr.
+interface rstmgr_sw_rst_sva_if (
+  input logic                                   clk_i,
+  input logic                                   rst_ni,
+  input logic                                   parent_rst_n,
+  input logic [rstmgr_reg_pkg::NumSwResets-1:0] enables,
+  input logic [rstmgr_reg_pkg::NumSwResets-1:0] ctrl_ns,
+  input logic [rstmgr_reg_pkg::NumSwResets-1:0] rst_ens,
+  input logic [rstmgr_reg_pkg::NumSwResets-1:0] rst_ns
+);
+  logic disable_sva;
+
+  for (genvar i = 0; i < rstmgr_reg_pkg::NumSwResets; ++i) begin : gen_assertions
+    `ASSERT(RstNOn_A, !parent_rst_n || (enables[i] && !ctrl_ns[i]) |=> !rst_ns[i], clk_i,
+            !rst_ni || disable_sva)
+    `ASSERT(RstNOff_A, parent_rst_n && !(enables[i] && !ctrl_ns[i]) |=> rst_ns[i], clk_i,
+            !rst_ni || disable_sva)
+    `ASSERT(RstEnOn_A, !parent_rst_n || (enables[i] && !ctrl_ns[i]) |=> rst_ens[i], clk_i,
+            !rst_ni || disable_sva)
+    `ASSERT(RstEnOff_A, parent_rst_n && !(enables[i] && !ctrl_ns[i]) |=> !rst_ens[i], clk_i,
+            !rst_ni || disable_sva)
+  end
+endinterface


### PR DESCRIPTION
Added assertion to check the software controllable reset outputs
and enables respond to either a parent reset or the CSR controls.
Fix timimg that causes a dv deadlock in the rom interface control.
Minor formatting changes.

Signed-off-by: Guillermo Maturana <maturana@google.com>