### PR TITLE
[sw/silicon_creator] Update flash_ctrl and sigverify after HW changes, harden encoded message check

### DIFF
--- a/sw/device/meson.build
+++ b/sw/device/meson.build
@@ -19,6 +19,7 @@ elf_to_dis_custom_target_args = {
     '--disassemble',
     '--headers',
     '--line-numbers',
+    '--disassemble-zeroes',
     '--source',
     '@INPUT@',
   ],

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -369,6 +369,7 @@ cc_test(
         ":mock_sigverify",
         ":sigverify",
         ":sigverify_intf",
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -362,12 +362,22 @@ cc_library(
     ],
 )
 
+filegroup(
+    name = "sigverify_src_for_keys_unittest",
+    srcs = ["sigverify.c"],
+)
+
 cc_test(
     name = "sigverify_unittest",
-    srcs = ["sigverify_unittest.cc"],
+    srcs = [
+        "sigverify.c",
+        "sigverify_unittest.cc",
+    ],
+    defines = [
+        "OT_OFF_TARGET_TEST",
+    ],
     deps = [
         ":mock_sigverify",
-        ":sigverify",
         ":sigverify_intf",
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -400,11 +400,8 @@ rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
   return wait_for_done(kErrorFlashCtrlInfoErase);
 }
 
-void flash_ctrl_exec_set(flash_ctrl_exec_t enable) {
-  // Enable or disable flash execution.
-  uint32_t exec_en =
-      (enable == kFlashCtrlExecEnable) ? FLASH_CTRL_PARAM_EXEC_EN : 0;
-  sec_mmio_write32(kBase + FLASH_CTRL_EXEC_REG_OFFSET, exec_en);
+void flash_ctrl_exec_set(uint32_t exec_val) {
+  sec_mmio_write32(kBase + FLASH_CTRL_EXEC_REG_OFFSET, exec_val);
   sec_mmio_write_increment(1);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -387,22 +387,17 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg);
  */
 void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page, flash_ctrl_cfg_t cfg);
 
-typedef enum flash_ctrl_exec {
-  kFlashCtrlExecDisable,
-  kFlashCtrlExecEnable,
-} flash_ctrl_exec_t;
-
 /**
  * Enable execution from flash.
  *
  * Note: a ePMP region must also be configured in order to execute code in
  * flash.
  *
- * @param `enable` Value to write to the `flash_ctrl.EXEC` register. The
- *                value `0xa` will enable execution, all other values will
- *                disable execution.
+ * @param exec_val Value to write to the `flash_ctrl.EXEC` register.
+ * `FLASH_CTRL_PARAM_EXEC_EN` will enable execution, all other values will
+ * disable execution.
  */
-void flash_ctrl_exec_set(flash_ctrl_exec_t enable);
+void flash_ctrl_exec_set(uint32_t exec_val);
 
 /**
  * Disables all access to silicon creator info pages until next reset.

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -335,19 +335,10 @@ TEST_F(TransferTest, TransferInternalError) {
 
 class ExecTest : public FlashCtrlTest {};
 
-TEST_F(ExecTest, Enable) {
-  EXPECT_SEC_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET,
-                     FLASH_CTRL_PARAM_EXEC_EN);
+TEST_F(ExecTest, Set) {
+  EXPECT_SEC_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET, UINT32_MAX);
   EXPECT_SEC_WRITE_INCREMENT(1);
-  flash_ctrl_exec_set(kFlashCtrlExecEnable);
-}
-
-TEST_F(ExecTest, Disable) {
-  // Note: any value that is not FLASH_CTRL_PARAM_EXEC_EN will disable
-  // execution.
-  EXPECT_SEC_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(1);
-  flash_ctrl_exec_set(kFlashCtrlExecDisable);
+  flash_ctrl_exec_set(UINT32_MAX);
 }
 
 struct PermsSetCase {

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -239,8 +239,11 @@ test('sw_silicon_creator_lib_sigverify_unittest', executable(
     dependencies: [
       sw_vendor_gtest,
       sw_lib_testing_bitfield,
+      sw_lib_testing_hardened,
     ],
     native: true,
+    c_args: ['-DOT_OFF_TARGET_TEST'],
+    cpp_args: ['-DOT_OFF_TARGET_TEST'],
   ),
   suite: 'mask_rom',
 )

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -234,6 +234,7 @@ test('sw_silicon_creator_lib_sigverify_unittest', executable(
       'sigverify_unittest.cc',
       'sigverify.c',
       hw_ip_otp_ctrl_reg_h,
+      hw_ip_flash_ctrl_reg_h,
     ],
     dependencies: [
       sw_vendor_gtest,

--- a/sw/device/silicon_creator/lib/sigverify.h
+++ b/sw/device/silicon_creator/lib/sigverify.h
@@ -21,8 +21,9 @@ extern "C" {
 enum {
   /**
    * Correct `flash_exec` value.
-   * TODO(#10022): Remove this and replace all usages from flash_ctrl_regs.h
-   * when hardware is updated.
+   *
+   * This value must be equal to `FLASH_CTRL_PARAM_EXEC_EN`. Defined here to be
+   * able to use in tests.
    */
   kSigverifyFlashExec = 0xa26a38f7,
 };

--- a/sw/device/silicon_creator/lib/sigverify_unittest.cc
+++ b/sw/device/silicon_creator/lib/sigverify_unittest.cc
@@ -16,8 +16,12 @@
 #include "sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
+#include "flash_ctrl_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "otp_ctrl_regs.h"
+
+static_assert(kSigverifyFlashExec == FLASH_CTRL_PARAM_EXEC_EN,
+              "kSigverifyFlashExec must be equal to FLASH_CTRL_PARAM_EXEC_EN");
 
 namespace sigverify_unittest {
 namespace {

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -228,6 +228,7 @@ cc_library(
 cc_test(
     name = "sigverify_keys_unittest",
     srcs = [
+        "//sw/device/silicon_creator/lib:sigverify_src_for_keys_unittest",
         "sigverify_keys.c",
         "sigverify_keys.h",
         "sigverify_keys_unittest.cc",
@@ -241,7 +242,6 @@ cc_test(
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:mock_sigverify",
-        "//sw/device/silicon_creator/lib:sigverify",
         "//sw/device/silicon_creator/lib:sigverify_internal",
         "//sw/device/silicon_creator/lib:sigverify_intf",
         "//sw/device/silicon_creator/lib:sigverify_mod_exp_ibex",

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -146,6 +146,7 @@ opentitan_functest(
         "//hw/ip/csrng/data:csrng_regs",
         "//hw/ip/edn/data:edn_regs",
         "//hw/ip/entropy_src/data:entropy_src_regs",
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/ip/pwrmgr/data/autogen:pwrmgr_regs",
         "//hw/ip/sram_ctrl/data:sram_ctrl_regs",

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -154,8 +154,7 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
   keymgr_creator_max_ver_set(manifest->max_key_version);
 
   // Enable execution of code from flash if signature is verified.
-  // TODO: Replace kFlashCtrlExecEnable with flash_exec when HW is updated.
-  flash_ctrl_exec_set(kFlashCtrlExecEnable);
+  flash_ctrl_exec_set(flash_exec);
 
   sec_mmio_check_values(rnd_uint32());
   sec_mmio_check_counters(/*expected_check_count=*/3);

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
@@ -23,6 +23,7 @@
 #include "sw/device/silicon_creator/lib/epmp_test_unlock.h"
 #include "sw/device/silicon_creator/mask_rom/mask_rom_epmp.h"
 
+#include "flash_ctrl_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sram_ctrl_regs.h"  // Generated.
 
@@ -383,7 +384,7 @@ void mask_rom_main(void) {
 
   // Enable execution of code in flash.
   flash_ctrl_init();
-  flash_ctrl_exec_set(kFlashCtrlExecEnable);
+  flash_ctrl_exec_set(FLASH_CTRL_PARAM_EXEC_EN);
 
   // Configure UART0 as stdout.
   uart_init(kUartNCOValue);

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -326,6 +326,7 @@ test('sw_silicon_creator_mask_rom_sigverify_keys_unittest', executable(
     dependencies: [
       sw_vendor_gtest,
       sw_lib_testing_bitfield,
+      sw_lib_testing_hardened,
     ],
     native: true,
     c_args: ['-DOT_OFF_TARGET_TEST'],

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -93,6 +93,7 @@ mask_rom_epmp_test_lib = declare_dependency(
     'mask_rom_epmp_test_lib',
     sources: [
       hw_ip_sram_ctrl_reg_h,
+      hw_ip_flash_ctrl_reg_h,
       'mask_rom_epmp_test.c',
     ],
     link_depends: [rom_linkfile],


### PR DESCRIPTION
This PR updates flash_ctrl and sigverify after HW changes in #10061 and adds redundant checks to `sigverify_encoded_message_check()`.