### PR TITLE
[top_englishbreakfast] Disconnect system bus access of debug module

### DIFF
--- a/hw/top_englishbreakfast/data/xbar_main.hjson
+++ b/hw/top_englishbreakfast/data/xbar_main.hjson
@@ -22,12 +22,6 @@
       reset: "rst_main_ni",
       pipeline: "false"
     },
-    { name:      "rv_dm.sba",
-      type:      "host",
-      clock:     "clk_main_i",
-      reset:     "rst_main_ni",
-      pipeline_byp: "false"
-    },
     { name:      "rv_dm.regs",
       type:      "device",
       clock:     "clk_main_i",
@@ -122,12 +116,6 @@
       "aes", "hmac",
       "rv_plic", "sram_ctrl_main.ram", "sram_ctrl_main.regs",
       "rv_core_ibex.cfg"
-    ],
-    rv_dm.sba: [
-      "rom_ctrl.rom", "rom_ctrl.regs", "rv_dm.regs", "sram_ctrl_main.ram",
-      "flash_ctrl.mem", "peri", "flash_ctrl.core", "flash_ctrl.prim", "aes",
-      "hmac", "rv_plic",
-      "sram_ctrl_main.regs", "rv_core_ibex.cfg"
     ],
   },
 }


### PR DESCRIPTION
This commit removes the rv_dm.sba port on the main interconnect to free up some FPGA logic resources on the CW305.

On the CW305, we don't need this anyway but the main interconnect is among the largest blocks (besides aes and flash_ctrl).