### PR TITLE
[otbn,dv] Fix off-by-one error in otbn_base_vseq

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -454,9 +454,10 @@ class otbn_base_vseq extends cip_base_vseq #(
           timed_out = 1'b1;
         end else begin
           timed_out = 1'b0;
-          // The OTBN sequence finished so update wait_cycles. cycle_counter should always be less
-          // than wait_cycles (because of how we calculate wait cycles).
-          `DV_CHECK_FATAL(cycle_counter < wait_cycles);
+          // The OTBN sequence finished so update wait_cycles. cycle_counter should be at most equal
+          // to wait_cycles because we'll stop at that point. It can be equal if OTBN happens to
+          // complete its operation in wait_cycles cycles.
+          `DV_CHECK_LE_FATAL(cycle_counter, wait_cycles);
           longest_run_ = cycle_counter;
 
           // Wait for the run_otbn thread to finish. This will usually be instant, but might take


### PR DESCRIPTION
This fixes an occasional failure in the reset sequence where the
operation happens to take exactly the same number of cycles as we
decided to wait.
