### PR TITLE
[otbn,dv] Avoid spurious MOD read entries in trace

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -216,8 +216,10 @@ interface otbn_trace_if
                                             u_otbn_alu_bignum.mod_q[i_word*32+:32];
   end
 
-  assign ispr_read[IsprMod] = (any_ispr_read & (ispr_addr == IsprMod)) |
-    (alu_bignum_operation.op inside {AluOpBignumAddm, AluOpBignumSubm});
+  assign ispr_read[IsprMod] =
+    (any_ispr_read & (ispr_addr == IsprMod)) |
+    (insn_fetch_resp_valid &
+     (alu_bignum_operation.op inside {AluOpBignumAddm, AluOpBignumSubm}));
 
   assign ispr_read_data[IsprMod] = u_otbn_alu_bignum.mod_q;
 


### PR DESCRIPTION
If OTBN reset in the middle of a BN.ADDM or BN.SUBM then the second
term of the expression for `ispr_read[IsprMod]` stayed true while we
were in reset (because it depends on a non-reset flop), causing a
spurious

    < MOD: 0x00000000_000...0000

line once we started OTBN again after the reset. The fix is simple:
just qualify that term by `insn_fetch_resp_valid`. (Other terms are
qualified with that already because it's part of `any_ispr_read`).

Fixes #9488.