### PR TITLE
[otbn,dv] Commit GPR changes when stalled

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -349,6 +349,7 @@ class OTBNState:
         assert self._err_bits == 0
 
         self.ext_regs.commit()
+        self.gprs.commit()
 
         # If we're stalled, there's nothing more to do: we only commit the rest
         # of the architectural state when we finish our stall cycles.
@@ -356,7 +357,6 @@ class OTBNState:
             return
 
         self.dmem.commit()
-        self.gprs.commit()
         self.pc = self.get_next_pc()
         self._pc_next_override = None
         self.loop_stack.commit()


### PR DESCRIPTION
This only really makes a difference for BN.LID instructions like this:

    bn.lid x15++, 1184(x22)

Here, the RTL increments `x15` on the first cycle. If the load triggered
an error because the DMEM integrity bits were malformed, all
side-effects of the instruction will have been discarded except for
the write to `x15`.

Until this change, the ISS committed the GPR change on the second
cycle. Of course, this meant that the aborting instruction would not
commit the GPR change at all, resulting in a mismatch between RTL and
ISS for the final state.

Note that this difference isn't actually observable in the design:
there's no bus access to register values and we will wipe the register
file between operations. But it *did* cause test failures because we
have a comparison of post-run dumps. Those should be fixed now.

Fixes #9267.