### PR TITLE
[top] AST DFT pin mapping update

### DIFF
--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -824,8 +824,8 @@ module chip_earlgrey_asic (
 
   assign pad2ast = { manual_in_ast_misc,
                      mio_in_raw[MioPadIoc3],
-                     mio_in_raw[MioPadIob8],
-                     mio_in_raw[MioPadIob7],
+                     mio_in_raw[MioPadIoc2],
+                     mio_in_raw[MioPadIoc1],
                      mio_in_raw[MioPadIob2],
                      mio_in_raw[MioPadIob1],
                      mio_in_raw[MioPadIob0],

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -699,8 +699,8 @@ module chip_${top["name"]}_${target["name"]} (
 
   assign pad2ast = { manual_in_ast_misc,
                      mio_in_raw[MioPadIoc3],
-                     mio_in_raw[MioPadIob8],
-                     mio_in_raw[MioPadIob7],
+                     mio_in_raw[MioPadIoc2],
+                     mio_in_raw[MioPadIoc1],
                      mio_in_raw[MioPadIob2],
                      mio_in_raw[MioPadIob1],
                      mio_in_raw[MioPadIob0],


### PR DESCRIPTION
@arnonsha, this is for the pad2ast changes.

For the ast2pad direction, I believe this goes throught the pinmux anyways, right?
So that one should not really need an RTL change.
Please let me know if I am mistaken.

Signed-off-by: Michael Schaffner <msf@opentitan.org>