### PR TITLE
[sw/silicon_creator] Harden sigverify_keys

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -236,7 +236,6 @@ cc_test(
     defines = ["OT_OFF_TARGET_TEST"],
     deps = [
         ":mock_sigverify_keys_ptrs",
-        ":sigverify_keys",
         ":sigverify_keys_ptrs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//sw/device/lib/base",
@@ -247,6 +246,7 @@ cc_test(
         "//sw/device/silicon_creator/lib:sigverify_mod_exp_ibex",
         "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
+        "//sw/device/silicon_creator/mask_rom/keys:test_keys",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h
@@ -24,6 +24,51 @@ enum {
  * Key types.
  *
  * The life cycle states in which a key can be used depend on its type.
+ *
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 3 -n 32 \
+ *     -s 1985033815 --language=c
+ *
+ * Hamming distance histogram:
+ *
+ *  0: --
+ *  1: --
+ *  2: --
+ *  3: --
+ *  4: --
+ *  5: --
+ *  6: --
+ *  7: --
+ *  8: --
+ *  9: --
+ * 10: --
+ * 11: --
+ * 12: --
+ * 13: --
+ * 14: --
+ * 15: |||||||||||||||||||| (33.33%)
+ * 16: --
+ * 17: |||||||||||||||||||| (33.33%)
+ * 18: |||||||||||||||||||| (33.33%)
+ * 19: --
+ * 20: --
+ * 21: --
+ * 22: --
+ * 23: --
+ * 24: --
+ * 25: --
+ * 26: --
+ * 27: --
+ * 28: --
+ * 29: --
+ * 30: --
+ * 31: --
+ * 32: --
+ *
+ * Minimum Hamming distance: 15
+ * Maximum Hamming distance: 18
+ * Minimum Hamming weight: 13
+ * Maximum Hamming weight: 16
  */
 typedef enum sigverify_key_type {
   /**
@@ -32,20 +77,20 @@ typedef enum sigverify_key_type {
    * Keys of this type can be used only in TEST_UNLOCKED* and RMA life cycle
    * states.
    */
-  kSigverifyKeyTypeTest,
+  kSigverifyKeyTypeTest = 0x3ff0c819,
   /**
    * A production key.
    *
    * Keys of this type can be used in all operational life cycle states, i.e.
    * states in which CPU execution is enabled.
    */
-  kSigverifyKeyTypeProd,
+  kSigverifyKeyTypeProd = 0x43a839ad,
   /**
    * A development key.
    *
    * Keys of this type can be used only in the DEV life cycle state.
    */
-  kSigverifyKeyTypeDev,
+  kSigverifyKeyTypeDev = 0x7a01a471,
 } sigverify_key_type_t;
 
 /**


### PR DESCRIPTION
This change hardens sigverify_keys by
* adding redundant checks for the life cycle state, key type, and OTP read value, 
* adding a final redundant key validity check before returning the key, and
* updating the values of the `sigverify_key_type_t` constants.

The order in which a key is checked is changed such that we first check the life cycle state followed by the key type. This allows us to have a single switch statement for the life cycle state which is a bit easier to harden.

Signed-off-by: Alphan Ulusoy <alphan@google.com>