### PR TITLE
[dv/otp_ctrl] Enhance OTP testbench by avoiding hardcoded constants

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -70,7 +70,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   bit lc_check_byp_en = 1;
 
   // Internal veriable to track which sw partitions have ECC reg error.
-  bit [2:0] force_sw_parts_ecc_reg;
+  bit [NUM_UNBUFF_PARTS-1:0] force_sw_parts_ecc_reg;
 
   // DUT configuration object
   otp_ctrl_ast_inputs_cfg dut_cfg;
@@ -129,7 +129,8 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
 
   // SW partitions do not have any internal checks.
   // Here we force internal ECC check to fail.
-  task automatic force_sw_check_fail(bit[1:0] fail_idx = $urandom_range(1, 4));
+  task automatic force_sw_check_fail(
+      bit[NUM_UNBUFF_PARTS-1:0] fail_idx = $urandom_range(1, (1'b1 << NUM_UNBUFF_PARTS) - 1));
     @(posedge clk_i);
     if (fail_idx[VendorTestIdx]) begin
       force tb.dut.gen_partitions[VendorTestIdx].gen_unbuffered.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -123,7 +123,7 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
 
         // Randomly force ECC reg in sw partitions to create a check failure.
         // Totaly three sw partitions, and each bit indexes a partition.
-        bit [2:0] sw_check_fail = $urandom_range(1, 7);
+        bit [NUM_UNBUFF_PARTS-1:0] sw_check_fail = $urandom_range(1, (1'b1<<NUM_UNBUFF_PARTS)-1);
         cfg.otp_ctrl_vif.force_sw_check_fail(sw_check_fail);
         `uvm_info(`gfn, $sformatf("OTP_init SW ECC check failure with index %0h", sw_check_fail),
                   UVM_LOW)


### PR DESCRIPTION
This PR removes the hard-coded constants and replace it with parameters.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>