### PR TITLE
[bazel] fixup #10041 conflict

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -48,6 +48,7 @@ rust_library(
         "src/util/file.rs",
         "src/util/image.rs",
         "src/util/mod.rs",
+        "src/util/present.rs",
         "src/util/parse_int.rs",
         "src/util/usb.rs",
         "src/util/voltage.rs",


### PR DESCRIPTION
it looks like we see a conflict in CI between
https://github.com/lowRISC/opentitan/pull/10041 and
https://github.com/lowRISC/opentitan/pull/10148

this should resolve it and I've tested by building on my workstation

Signed-off-by: Drew Macrae <drewmacrae@google.com>