### PR TITLE
Revert "[bazel] Add bazel to CI and containers"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -716,19 +716,3 @@ jobs:
       command: build
       Dockerfile: ./site/redirector/Dockerfile
       buildContext: ./site/redirector
-
-
-- job: bazel_build_and_test
-  displayName: Bazel Build and Test
-  dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool:
-    vmImage: ubuntu-18.04
-  steps:
-  - template: ci/install-package-dependencies.yml
-    # The default timeout is too short to build verilator so let's skip it for the first pass
-  - bash: |
-          bazel query "rdeps(//..., //hw:verilator)" |
-          sed -e 's/^/-/' |
-          xargs bazel test --nobuild_tests_only --test_tag_filters=-cw310,-verilator -- //...
-    displayName: bazel test

--- a/ci/install-package-dependencies.sh
+++ b/ci/install-package-dependencies.sh
@@ -86,20 +86,6 @@ echo "$EDATOOLS_REPO" > "$TMPDIR/obs.list"
 sudo mv "$TMPDIR/obs.asc"  /etc/apt/trusted.gpg.d/obs.asc
 sudo mv "$TMPDIR/obs.list" /etc/apt/sources.list.d/edatools.list
 
-# Install gcc-9 and set it as the default
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo $APT_CMD update
-sudo $APT_CMD install -y gcc-9 g++-9
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 90
-sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-9 90
-
-# Install bazel from bazel's apt repository
-sudo $APT_CMD install -y apt-transport-https gnupg
-curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
-sudo mv bazel.gpg /etc/apt/trusted.gpg.d/
-echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-sudo $APT_CMD update && sudo $APT_CMD install -y bazel
-
 # Ensure apt package index is up-to-date.
 sudo $APT_CMD update || {
     error "Failed to run apt update"

--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -38,11 +38,10 @@ For packages listed below without a version number we have not determined a mini
 * Python 3.6 with pip.
   Additional Python dependencies are installed through pip.
 * A C++14 capable compiler.
-  GCC 8 or Clang 3.5 should meet this requirement.
+  GCC 5 or Clang 3.5 should meet this requirement.
 * clang-format.
   The use of clang-format 6.0 is recommended to match the formatting enforced when submitting a pull request.
 * [ninja](https://ninja-build.org/)  {{< tool_version "ninja" >}}
-* bazel 4.2.0
 * Bash
 * curl
 * xz tools

--- a/meson.build
+++ b/meson.build
@@ -20,7 +20,7 @@ project(
 )
 
 # We allow both GCC and Clang, but these minimum versions.
-required_gcc_version = '>=8'
+required_gcc_version = '>=5'
 required_clang_version = '>=3.5'
 
 ot_version = get_option('ot_version')

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -1,7 +1,5 @@
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU")
-
 cc_library(
     name = "device",
     hdrs = ["device.h"],

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -277,9 +277,9 @@ cc_library(
     name = "shutdown",
     srcs = ["shutdown.c"],
     deps = [
+        ":shutdown_intf",
         ":error",
         ":log",
-        ":shutdown_intf",
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
@@ -305,9 +305,9 @@ cc_test(
         "OT_OFF_TARGET_TEST",
     ],
     deps = [
+        ":shutdown_intf",
         ":error",
         ":log",
-        ":shutdown_intf",
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
@@ -422,8 +422,6 @@ opentitan_functest(
     ),
     deps = [
         ":sigverify",
-        ":sigverify_mod_exp_ibex",
-        ":sigverify_mod_exp_otbn",
         ":sigverify_testvectors",
         ":test_main",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
@@ -442,7 +440,6 @@ cc_library(
 cc_library(
     name = "sigverify_mod_exp_otbn",
     srcs = ["sigverify_mod_exp_otbn.c"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":error",
         ":otbn_util",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -56,16 +56,16 @@ opentitan_functest(
     name = "gpio_smoketest",
     srcs = ["gpio_smoketest.c"],
     verilator = verilator_params(
+        tags = [
+            "cpu:4",
+            "failing_verilator"
+        ],
         args = [
             "--verilator-args=--trace",
             "console",
             "--timeout=3600",
             "--exit-failure=FAIL",
             "--exit-success=PASS",
-        ],
-        tags = [
-            "cpu:4",
-            "failing_verilator",
         ],
     ),
     deps = [

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -46,13 +46,6 @@ RUN OBS_URL="https://download.opensuse.org/repositories"; \
     mv "$TMPDIR/obs.asc"  /etc/apt/trusted.gpg.d/obs.asc && \
     mv "$TMPDIR/obs.list" /etc/apt/sources.list.d/edatools.list
 
-# Add bazel repository to apt sources.
-RUN apt-get install -y apt-transport-https curl gnupg \
-    && curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg \
-    && mv bazel.gpg /etc/apt/trusted.gpg.d/ \
-    && echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list \
-    && apt-get update && apt-get install -y bazel
-
 # Install system packages
 #
 # Install (and cleanup) required packages (from apt-requirements.txt).


### PR DESCRIPTION
Hardware commits with no SW impacts whatsoever and no autogenerated files are now failing CI. (Case in point: #10305)
  
Furthermore, we at WDC as yet has no ability to run tests to help debug these issues in our data center.   
I request this a reversion of #10042 until these issues are resolved and our team can meet this new requirements.