### PR TITLE
[keymgr/dv] minor update: remove unneeded core file dependency

### DIFF
--- a/hw/ip/keymgr/dv/keymgr_sim.core
+++ b/hw/ip/keymgr/dv/keymgr_sim.core
@@ -11,7 +11,6 @@ filesets:
 
   files_dv:
     depend:
-      - lowrisc:dv:sec_cm
       - lowrisc:dv:keymgr_test
       - lowrisc:dv:keymgr_sva
     files:


### PR DESCRIPTION
sec_cm is included in cip, so it can be removed
Signed-off-by: Weicai Yang <weicai@google.com>