### PR TITLE
Bazel rom updates

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -352,6 +352,7 @@ cc_library(
 cc_library(
     name = "sigverify",
     srcs = ["sigverify.c"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":sigverify_internal",
         ":sigverify_intf",
@@ -423,6 +424,8 @@ opentitan_functest(
     deps = [
         ":sigverify",
         ":sigverify_testvectors",
+        ":sigverify_mod_exp_ibex",
+        ":sigverify_mod_exp_otbn",
         ":test_main",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
@@ -440,6 +443,7 @@ cc_library(
 cc_library(
     name = "sigverify_mod_exp_otbn",
     srcs = ["sigverify_mod_exp_otbn.c"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":error",
         ":otbn_util",

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -40,9 +40,11 @@ cc_library(
 cc_library(
     name = "mock_abs_mmio",
     testonly = True,
-    hdrs = ["mock_abs_mmio.h"],
+    hdrs = [
+        "abs_mmio.h",
+        "mock_abs_mmio.h",
+    ],
     deps = [
-        ":abs_mmio",
         "//sw/device/lib/base/testing",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
@@ -63,9 +65,11 @@ cc_library(
 cc_library(
     name = "mock_sec_mmio",
     testonly = True,
-    hdrs = ["mock_sec_mmio.h"],
+    hdrs = [
+        "mock_sec_mmio.h",
+        "sec_mmio.h",
+    ],
     deps = [
-        ":sec_mmio",
         "//sw/device/lib/base/testing",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -89,8 +89,10 @@ cc_test(
     deps = [
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
@@ -261,9 +263,11 @@ cc_library(
 cc_library(
     name = "mock_otp",
     testonly = True,
-    hdrs = ["mock_otp.h"],
+    hdrs = [
+        "mock_otp.h",
+        "otp.h"
+    ],
     deps = [
-        ":otp",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],


### PR DESCRIPTION
Updates to silicon_creator and sw/host Bazel rules to simplify dependencies and fix build/test issues.