### PR TITLE
[sw/rom] Updates to sec_mmio hardening

### DIFF
--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -1,6 +1,7 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -44,6 +45,7 @@ cc_library(
         "abs_mmio.h",
         "mock_abs_mmio.h",
     ],
+    defines = ["MOCK_ABS_MMIO"],
     deps = [
         "//sw/device/lib/base/testing",
         "//sw/device/silicon_creator/testing:mask_rom_test",
@@ -55,6 +57,7 @@ cc_library(
     name = "sec_mmio",
     srcs = ["sec_mmio.c"],
     hdrs = ["sec_mmio.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":abs_mmio",
         "//sw/device/lib/base",
@@ -78,10 +81,15 @@ cc_library(
 
 cc_test(
     name = "sec_mmio_unittest",
-    srcs = ["sec_mmio_unittest.cc"],
+    srcs = [
+        "sec_mmio.h",
+        "sec_mmio.c",
+        "sec_mmio_unittest.cc",
+    ],
+    defines = ["OT_OFF_TARGET_TEST"],
     deps = [
         ":mock_abs_mmio",
-        ":sec_mmio",
+        "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib:error",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/base/meson.build
+++ b/sw/device/silicon_creator/lib/base/meson.build
@@ -91,11 +91,18 @@ test('sw_silicon_creator_lib_base_sec_mmio_unittest', executable(
     ],
     dependencies: [
       sw_vendor_gtest,
-      sw_silicon_creator_lib_base_mock_abs_mmio
+      sw_lib_testing_hardened,
+      sw_silicon_creator_lib_base_mock_abs_mmio,
     ],
     native: true,
-    c_args: ['-DMOCK_ABS_MMIO'],
-    cpp_args: ['-DMOCK_ABS_MMIO'],
+    c_args: [
+      '-DMOCK_ABS_MMIO',
+      '-DOT_OFF_TARGET_TEST',
+    ],
+    cpp_args: [
+      '-DMOCK_ABS_MMIO',
+      '-DOT_OFF_TARGET_TEST',
+    ],
   ),
   suite: 'mask_rom',
 )

--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -16,7 +16,7 @@ namespace internal {
  */
 class MockSecMmio : public GlobalMock<MockSecMmio> {
  public:
-  MOCK_METHOD(void, Init, (sec_mmio_shutdown_handler callee));
+  MOCK_METHOD(void, Init, ());
   MOCK_METHOD(uint32_t, Read32, (uint32_t addr));
   MOCK_METHOD(void, Write32, (uint32_t addr, uint32_t value));
   MOCK_METHOD(void, Write32Shadowed, (uint32_t addr, uint32_t value));
@@ -72,9 +72,7 @@ using MockSecMmio = testing::StrictMock<internal::MockSecMmio>;
 
 extern "C" {
 
-void sec_mmio_init(sec_mmio_shutdown_handler callee) {
-  MockSecMmio::Instance().Init(callee);
-}
+void sec_mmio_init(void) { MockSecMmio::Instance().Init(); }
 
 uint32_t sec_mmio_read32(uint32_t addr) {
   return MockSecMmio::Instance().Read32(addr);

--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/abs_mmio.h"
 
@@ -13,20 +14,15 @@
 // override its location.
 __attribute__((weak)) volatile sec_mmio_ctx_t sec_mmio_ctx;
 
-// FIXME: Replace for shutdown module handler.
-static sec_mmio_shutdown_handler sec_mmio_shutdown_cb;
-
 enum {
   // Value with good hamming weight used to mask the stored expected value.
   kSecMmioMaskVal = 0x21692436u,
 
-  // This must be set to a prime number greater than the number of items in
-  // `sec_mmio_ctx.addrs`. Used to generate random read order permutations.
-  kSecMmioRndStep = 211u,
+  // Constants used for hardened comparisons. kSecMmioValZero ==
+  // ~kSecMmioValOne.
+  kSecMmioValZero = 0x3ca5965a,
+  kSecMmioValOne = 0xc35a69a5,
 };
-
-static_assert((uint32_t)kSecMmioRndStep > (uint32_t)kSecMmioRegFileSize,
-              "kSecMmioRndStep not large enough");
 
 /**
  * Updates or inserts the register entry pointed to by MMIO `addr` with the
@@ -49,57 +45,52 @@ static void upsert_register(uint32_t addr, uint32_t value) {
   }
   // The following condition check serves as an additional fault detection
   // mechanism.
-  if (i >= kSecMmioRegFileSize) {
-    sec_mmio_shutdown_cb(kErrorSecMmioRegFileSize);
-    __builtin_unreachable();
-  }
+  HARDENED_CHECK_LT(i, kSecMmioRegFileSize);
 }
 
-void sec_mmio_init(sec_mmio_shutdown_handler cb) {
-  sec_mmio_shutdown_cb = cb;
-  sec_mmio_ctx.last_index = 0;
-  sec_mmio_ctx.write_count = 0;
-  sec_mmio_ctx.check_count = 0;
-  sec_mmio_ctx.expected_write_count = 0;
+void sec_mmio_init(void) {
+  sec_mmio_ctx.last_index = launder32(0);
+  sec_mmio_ctx.write_count = launder32(0);
+  sec_mmio_ctx.check_count = launder32(0);
+  sec_mmio_ctx.expected_write_count = launder32(0);
   for (size_t i = 0; i < ARRAYSIZE(sec_mmio_ctx.addrs); ++i) {
     sec_mmio_ctx.addrs[i] = UINT32_MAX;
     sec_mmio_ctx.values[i] = UINT32_MAX;
   }
+  uint32_t check = kSecMmioValZero ^ sec_mmio_ctx.last_index;
+  check ^= sec_mmio_ctx.write_count;
+  check ^= sec_mmio_ctx.check_count;
+  check ^= sec_mmio_ctx.expected_write_count;
+  HARDENED_CHECK_EQ(check, kSecMmioValZero);
 }
 
-void sec_mmio_next_stage_init(sec_mmio_shutdown_handler cb) {
-  sec_mmio_shutdown_cb = cb;
-  sec_mmio_ctx.check_count = 0;
+void sec_mmio_next_stage_init(void) {
+  sec_mmio_ctx.check_count = launder32(0);
   for (size_t i = sec_mmio_ctx.last_index; i < ARRAYSIZE(sec_mmio_ctx.addrs);
        ++i) {
     sec_mmio_ctx.addrs[i] = UINT32_MAX;
     sec_mmio_ctx.values[i] = UINT32_MAX;
   }
+  HARDENED_CHECK_EQ(sec_mmio_ctx.check_count, 0);
 }
 
 uint32_t sec_mmio_read32(uint32_t addr) {
   uint32_t value = abs_mmio_read32(addr);
   uint32_t masked_value = value ^ kSecMmioMaskVal;
-
+  barrier32(masked_value);
   upsert_register(addr, masked_value);
+  HARDENED_CHECK_EQ((abs_mmio_read32(addr) ^ kSecMmioMaskVal), masked_value);
 
-  if ((abs_mmio_read32(addr) ^ kSecMmioMaskVal) != masked_value) {
-    sec_mmio_shutdown_cb(kErrorSecMmioReadFault);
-    __builtin_unreachable();
-  }
   return value;
 }
 
 void sec_mmio_write32(uint32_t addr, uint32_t value) {
   abs_mmio_write32(addr, value);
   uint32_t masked_value = value ^ kSecMmioMaskVal;
-
+  barrier32(masked_value);
   upsert_register(addr, masked_value);
+  HARDENED_CHECK_EQ((abs_mmio_read32(addr) ^ kSecMmioMaskVal), masked_value);
 
-  if ((abs_mmio_read32(addr) ^ kSecMmioMaskVal) != masked_value) {
-    sec_mmio_shutdown_cb(kErrorSecMmioWriteFault);
-    __builtin_unreachable();
-  }
   ++sec_mmio_ctx.write_count;
 }
 
@@ -108,13 +99,10 @@ void sec_mmio_write32_shadowed(uint32_t addr, uint32_t value) {
   abs_mmio_write32(addr, value);
   abs_mmio_write32(addr, value);
   uint32_t masked_value = value ^ kSecMmioMaskVal;
-
+  barrier32(masked_value);
   upsert_register(addr, masked_value);
+  HARDENED_CHECK_EQ((abs_mmio_read32(addr) ^ kSecMmioMaskVal), masked_value);
 
-  if ((abs_mmio_read32(addr) ^ kSecMmioMaskVal) != masked_value) {
-    sec_mmio_shutdown_cb(kErrorSecMmioWriteFault);
-    __builtin_unreachable();
-  }
   ++sec_mmio_ctx.write_count;
 }
 
@@ -123,51 +111,39 @@ void sec_mmio_write_increment(uint32_t value) {
 }
 
 void sec_mmio_check_values(uint32_t rnd_offset) {
-  size_t offset = rnd_offset;
+  // Pick a random starting offset.
+  uint32_t offset =
+      ((uint64_t)rnd_offset * (uint64_t)sec_mmio_ctx.last_index) >> 32;
+  enum { kStep = 1 };
   size_t i;
-  for (i = 0; i < sec_mmio_ctx.last_index; ++i) {
-    // FIXME: Remove dependency on __udivdi3.
-    offset = (offset + kSecMmioRndStep) % sec_mmio_ctx.last_index;
+  for (i = 0; launder32(i) < sec_mmio_ctx.last_index; ++i) {
     uint32_t read_value = abs_mmio_read32(sec_mmio_ctx.addrs[offset]);
-    if ((read_value ^ kSecMmioMaskVal) != sec_mmio_ctx.values[offset]) {
-      sec_mmio_shutdown_cb(kErrorSecMmioCheckValueFault);
-      __builtin_unreachable();
+    HARDENED_CHECK_EQ(read_value ^ kSecMmioMaskVal,
+                      sec_mmio_ctx.values[offset]);
+    offset += kStep;
+    if (offset >= sec_mmio_ctx.last_index) {
+      offset -= sec_mmio_ctx.last_index;
     }
   }
   // Check for loop completion.
-  if (i != sec_mmio_ctx.last_index) {
-    sec_mmio_shutdown_cb(kErrorSecMmioCheckIndexFault);
-    __builtin_unreachable();
-  }
+  HARDENED_CHECK_EQ(i, sec_mmio_ctx.last_index);
   ++sec_mmio_ctx.check_count;
 }
 
 void sec_mmio_check_counters(uint32_t expected_check_count) {
-  // Generous use of volatile in critical variables to avoid compiler
-  // optimizations, and map "zero" to a value with good hamming weight
-  // and with a good hamming distance to "all-ones".
-  // TODO(#6610): Update based on implementation guidance.
-  static volatile const uint32_t kValZero = 0x3ca5965a;
-  static volatile const uint32_t kValOnes = 0xc35a69a5;
-
-  uint32_t result = kValZero ^ sec_mmio_ctx.write_count;
+  uint32_t result = launder32(kSecMmioValZero) ^ sec_mmio_ctx.write_count;
   result ^= sec_mmio_ctx.expected_write_count;
 
   // Check the expected write count. This is equivalent to
   // sec_mmio_ctx.write_count == sec_mmio_ctx.expected_write_count
-  if (result != kValZero) {
-    sec_mmio_shutdown_cb(kErrorSecMmioWriteCountFault);
-    __builtin_unreachable();
-  }
+  HARDENED_CHECK_EQ(result, kSecMmioValZero);
 
   // Check the expected check counts. This is equivalent to
   // sec_mmio_ctx.check_count == expected_check_count. This check is expected to
   // fail if the previous check failed.
   result ^= sec_mmio_ctx.check_count;
   result ^= expected_check_count;
-  if (~result != kValOnes) {
-    sec_mmio_shutdown_cb(kErrorSecMmioCheckCountFault);
-    __builtin_unreachable();
-  }
+  HARDENED_CHECK_EQ(~launder32(result), kSecMmioValOne);
+
   ++sec_mmio_ctx.check_count;
 }

--- a/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
+++ b/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
@@ -25,9 +25,7 @@ using ::testing::Eq;
 
 class SecMmioTest : public mask_rom_test::MaskRomTest {
  protected:
-  void SetUp() override {
-    sec_mmio_init(+[](rom_error_t) { std::abort(); });
-  }
+  void SetUp() override { sec_mmio_init(); }
   sec_mmio_ctx_t *ctx_ = &::sec_mmio_ctx;
   mask_rom_test::MockAbsMmio mmio_;
 };
@@ -39,7 +37,7 @@ TEST_F(SecMmioTest, Initialize) {
   ctx_->last_index = 1;
   ctx_->write_count = 1;
   ctx_->addrs[0] = 0;
-  sec_mmio_init(+[](rom_error_t) { std::abort(); });
+  sec_mmio_init();
 
   EXPECT_EQ(ctx_->check_count, 0);
   EXPECT_EQ(ctx_->expected_write_count, 0);
@@ -79,7 +77,7 @@ TEST_F(SecMmioTest, NextStageInitialize) {
     expected_values[i] = UINT32_MAX;
   }
 
-  sec_mmio_next_stage_init(+[](rom_error_t) { std::abort(); });
+  sec_mmio_next_stage_init();
 
   EXPECT_EQ(ctx_->write_count, 6);
   EXPECT_EQ(ctx_->expected_write_count, 6);
@@ -155,25 +153,25 @@ TEST_F(SecMmioTest, CheckValues) {
   EXPECT_ABS_READ32(8, 0xa5a5a5a5);
   EXPECT_EQ(sec_mmio_read32(8), 0xa5a5a5a5);
 
-  // The expected permutation order for rnd_offset=0 is {1, 2, 0}.
+  // The expected permutation order for rnd_offset=0
+  EXPECT_ABS_READ32(0, 0x12345678);
   EXPECT_ABS_READ32(4, 0x87654321);
   EXPECT_ABS_READ32(8, 0xa5a5a5a5);
-  EXPECT_ABS_READ32(0, 0x12345678);
   sec_mmio_check_values(/*rnd_offset=*/0);
   EXPECT_EQ(ctx_->check_count, 1);
 
-  // The expected permutation order for rnd_offset=1 is {2, 0, 1}.
+  // The expected permutation order for rnd_offset=0x80000000
+  EXPECT_ABS_READ32(4, 0x87654321);
   EXPECT_ABS_READ32(8, 0xa5a5a5a5);
   EXPECT_ABS_READ32(0, 0x12345678);
-  EXPECT_ABS_READ32(4, 0x87654321);
-  sec_mmio_check_values(/*rnd_offset=*/1);
+  sec_mmio_check_values(/*rnd_offset=*/0x80000000);
   EXPECT_EQ(ctx_->check_count, 2);
 
-  // The expected permutation order for rnd_offset=32 is {0, 1, 2}.
+  // The expected permutation order for rnd_offset=0xf0000000
+  EXPECT_ABS_READ32(8, 0xa5a5a5a5);
   EXPECT_ABS_READ32(0, 0x12345678);
   EXPECT_ABS_READ32(4, 0x87654321);
-  EXPECT_ABS_READ32(8, 0xa5a5a5a5);
-  sec_mmio_check_values(/*rnd_offset=*/32);
+  sec_mmio_check_values(/*rnd_offset=*/0xf0000000);
   EXPECT_EQ(ctx_->check_count, 3);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/alert_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/alert_functest.c
@@ -31,11 +31,6 @@ enum {
   kFlashBase = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR,
 };
 
-/** SEC MMIO error handler. */
-static void error_handler_cb(rom_error_t e) {
-  LOG_ERROR("Secure MMIO error: 0x%x", e);
-}
-
 rom_error_t alert_no_escalate_test(void) {
   // Configure class B alerts for phase 0 only and disable NMI signalling.
   alert_class_config_t config = {
@@ -101,7 +96,7 @@ bool test_main(void) {
   CHECK(bitfield_popcount32(reason) == 1, "Expected exactly 1 reset reason.");
 
   if (bitfield_bit32_read(reason, kRstmgrReasonPowerOn)) {
-    sec_mmio_init(error_handler_cb);
+    sec_mmio_init();
     EXECUTE_TEST(result, alert_no_escalate_test);
     EXECUTE_TEST(result, alert_escalate_test);
     LOG_ERROR("Test failure: should have reset before this line.");

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -91,11 +91,6 @@ const uint32_t kMaxVerBl0 = 2;
 
 const test_config_t kTestConfig;
 
-/** SEC MMIO error handler. */
-static void error_handler_cb(rom_error_t e) {
-  LOG_ERROR("Secure MMIO error: 0x%x", e);
-}
-
 /**
  * Writes `size` words of `data` into flash info page.
  *
@@ -310,7 +305,7 @@ bool test_main(void) {
   } else {
     LOG_INFO("Powered up for the second time, actuate keymgr");
 
-    sec_mmio_init(error_handler_cb);
+    sec_mmio_init();
     init_kmac_for_keymgr();
 
     EXECUTE_TEST(result, keymgr_rom_test);

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -65,7 +65,7 @@ static inline rom_error_t mask_rom_irq_error(void) {
  * Performs once-per-boot initialization of mask ROM modules and peripherals.
  */
 static rom_error_t mask_rom_init(void) {
-  sec_mmio_init(shutdown_finalize);
+  sec_mmio_init();
   // Initialize the shutdown policy according to lifecycle state.
   lc_state = lifecycle_state_get();
   RETURN_IF_ERROR(shutdown_init(lc_state));

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
@@ -63,15 +63,6 @@ typedef enum exception {
 } exception_t;
 
 /**
- * sec_mmio callback.
- *
- * @param error sec_mmio error.
- */
-static void sec_mmio_callback(rom_error_t error) {
-  LOG_ERROR("sec_mmio error: 0x%x", error);
-}
-
-/**
  * Get the value of the `mcause` register.
  *
  * @returns The encoded interrupt or exception cause.
@@ -377,7 +368,7 @@ static void test_unlock_exec_eflash(epmp_state_t *epmp) {
 
 void mask_rom_main(void) {
   // Initialize sec_mmio.
-  sec_mmio_init(sec_mmio_callback);
+  sec_mmio_init();
 
   // Initialize pinmux configuration so we can use the UART.
   pinmux_init();

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -56,7 +56,7 @@ static inline rom_error_t rom_ext_irq_error(void) {
 }
 
 void rom_ext_init(void) {
-  sec_mmio_next_stage_init(shutdown_finalize);
+  sec_mmio_next_stage_init();
 
   lc_state = lifecycle_state_get();
 


### PR DESCRIPTION
* Introduce launder32 and HARDENED_CHECK to sec_mmio.
* Remove shutdown callback function.
* Remove expensive modulus operation.
* Remove direct use of volatile.
* Add checks to sec_mmio_init function to ensure counters are properly
  initialized.

Closes #6610.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>