### PR TITLE
[dif/alert_handler] Add X macros to improve maintainability.

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -582,27 +582,27 @@ dif_result_t dif_alert_handler_alert_acknowledge(
  * Note that multiple alerts may be causes at the same time.
  *
  * @param alert_handler An alert handler handle.
- * @param alert The alert to check.
+ * @param local_alert The local alert to check.
  * @param is_cause Out-param for whether this alert is a cause.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_alert_handler_local_alert_is_cause(
     const dif_alert_handler_t *alert_handler,
-    dif_alert_handler_local_alert_t alert, bool *is_cause);
+    dif_alert_handler_local_alert_t local_alert, bool *is_cause);
 
 /**
  * Clears a local alert from the cause vector, similar to an IRQ
  * acknowledgement.
  *
  * @param alert_handler An alert handler handle.
- * @param alert The alert to acknowledge.
+ * @param local_alert The local alert to acknowledge.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_alert_handler_local_alert_acknowledge(
     const dif_alert_handler_t *alert_handler,
-    dif_alert_handler_local_alert_t alert);
+    dif_alert_handler_local_alert_t local_alert);
 
 /**
  * Checks whether software can clear escalations for this class.

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -663,13 +663,13 @@ dif_result_t dif_alert_handler_escalation_clear(
  *
  * @param alert_handler An alert handler handle.
  * @param alert_class The class to get the accumulator for.
- * @param alerts Out-param for the accumulator.
+ * @param num_alerts Out-param for the number of alerts that have accumulated.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_alert_handler_get_accumulator(
     const dif_alert_handler_t *alert_handler,
-    dif_alert_handler_class_t alert_class, uint16_t *alerts);
+    dif_alert_handler_class_t alert_class, uint16_t *num_alerts);
 
 /**
  * Gets the current value of the "escalation counter".

--- a/sw/device/lib/dif/dif_alert_handler_unittest.cc
+++ b/sw/device/lib/dif/dif_alert_handler_unittest.cc
@@ -972,23 +972,23 @@ TEST_F(LocalAlertCauseTest, NullArgs) {
 class EscalationTest : public AlertHandlerTest {};
 
 TEST_F(EscalationTest, CanClear) {
-  bool flag;
+  bool can_clear;
 
   EXPECT_READ32(ALERT_HANDLER_CLASSB_CLR_REGWEN_REG_OFFSET, true);
   EXPECT_EQ(dif_alert_handler_escalation_can_clear(
-                &alert_handler_, kDifAlertHandlerClassB, &flag),
+                &alert_handler_, kDifAlertHandlerClassB, &can_clear),
             kDifOk);
-  EXPECT_TRUE(flag);
+  EXPECT_TRUE(can_clear);
 
   EXPECT_READ32(ALERT_HANDLER_CLASSA_CLR_REGWEN_REG_OFFSET, false);
   EXPECT_EQ(dif_alert_handler_escalation_can_clear(
-                &alert_handler_, kDifAlertHandlerClassA, &flag),
+                &alert_handler_, kDifAlertHandlerClassA, &can_clear),
             kDifOk);
-  EXPECT_FALSE(flag);
+  EXPECT_FALSE(can_clear);
 }
 
 TEST_F(EscalationTest, Disable) {
-  EXPECT_WRITE32(ALERT_HANDLER_CLASSC_CLR_REGWEN_REG_OFFSET, true);
+  EXPECT_WRITE32(ALERT_HANDLER_CLASSC_CLR_REGWEN_REG_OFFSET, 0);
   EXPECT_EQ(dif_alert_handler_escalation_disable_clearing(
                 &alert_handler_, kDifAlertHandlerClassC),
             kDifOk);
@@ -1002,10 +1002,10 @@ TEST_F(EscalationTest, Clear) {
 }
 
 TEST_F(EscalationTest, NullArgs) {
-  bool flag;
+  bool can_clear;
 
   EXPECT_EQ(dif_alert_handler_escalation_can_clear(
-                nullptr, kDifAlertHandlerClassB, &flag),
+                nullptr, kDifAlertHandlerClassB, &can_clear),
             kDifBadArg);
   EXPECT_EQ(dif_alert_handler_escalation_can_clear(
                 &alert_handler_, kDifAlertHandlerClassB, nullptr),
@@ -1020,12 +1020,12 @@ TEST_F(EscalationTest, NullArgs) {
 class GetterTest : public AlertHandlerTest {};
 
 TEST_F(GetterTest, GetAcc) {
-  uint16_t alerts;
+  uint16_t num_alerts;
   EXPECT_READ32(ALERT_HANDLER_CLASSB_ACCUM_CNT_REG_OFFSET, 0xaaaa);
-  EXPECT_EQ(dif_alert_handler_get_accumulator(&alert_handler_,
-                                              kDifAlertHandlerClassB, &alerts),
+  EXPECT_EQ(dif_alert_handler_get_accumulator(
+                &alert_handler_, kDifAlertHandlerClassB, &num_alerts),
             kDifOk);
-  EXPECT_EQ(alerts, 0xaaaa);
+  EXPECT_EQ(num_alerts, 0xaaaa);
 }
 
 TEST_F(GetterTest, GetCycles) {


### PR DESCRIPTION
A previous PR (#10040) added some X macros to some alert handler DIFs to improve the maintainability, specifically, if the number of alerts, local alerts, or classes ever changes, it is easy to update the DIF to match (only a single macro list needs to be updated). This PR contains two commits that add X macros across the remaining DIFs in the alert handler IP, where appropriate.

This partially addresses a task in #9899.