### PR TITLE
[util,reggen] Format enum fields in hex

### DIFF
--- a/util/reggen/gen_html.py
+++ b/util/reggen/gen_html.py
@@ -204,14 +204,19 @@ def gen_html_register(outfile: TextIO,
 
         if field.enum is not None:
             desc_parts.append('<table>')
+
+            # Add two to include the "0x" part
+            hex_width = 2 + ((field.bits.width() + 3) // 4)
+
             for enum in field.enum:
                 enum_desc_paras = expand_paras(enum.desc, rnames)
                 desc_parts.append('<tr>'
-                                  '<td>{val}</td>'
+                                  '<td>{val:#0{hex_width}x}</td>'
                                   '<td>{name}</td>'
                                   '<td>{desc}</td>'
                                   '</tr>\n'
                                   .format(val=enum.value,
+                                          hex_width=hex_width,
                                           name=enum.name,
                                           desc=''.join(enum_desc_paras)))
             desc_parts.append('</table>')


### PR DESCRIPTION
As well as showing them in hex (which might make more sense for some
constants), we also pad out to the correct width. This makes tables
line up nicely and might also make it easier to interpret values in
waves/debug prints.

Spotted in the LC_CTRL D2S review meeting, where @cdgori noticed that some the constants for `TRANSITION_STATE` and `LC_STATE` were enormous decimal numbers. They're actually very regular values, but sadly are grouped into 5-bit chunks, so still don't look very clear here. :-)