### PR TITLE
[kmac_app_agt, dv] Randmoizing agent configuration

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent.sv
@@ -35,6 +35,7 @@ class kmac_app_agent extends dv_base_agent #(
     cfg.m_data_push_agent_cfg.agent_type = PushAgent;
     cfg.m_data_push_agent_cfg.if_mode    = cfg.if_mode;
     cfg.vif.if_mode = cfg.if_mode;
+    cfg.m_data_push_agent_cfg.zero_delays = cfg.zero_delays;
 
     // pass cfg and vif
     uvm_config_db#(push_pull_agent_cfg#(`CONNECT_DATA_WIDTH))::set(this, "m_data_push_agent*",

--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -32,7 +32,6 @@ class kmac_app_agent_cfg extends dv_base_agent_cfg;
   constraint zero_delays_c {
     zero_delays dist { 0 := 8,
                        1 := 2 };
-    m_data_push_agent_cfg.zero_delays == zero_delays;
   }
 
   // Setter method for the user digest share queues - must be called externally to place specific user-digest_share0

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env.sv
@@ -18,6 +18,7 @@ class rom_ctrl_env extends cip_base_env #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
     // Get the mem_bkdr interface
     if (!uvm_config_db#(mem_bkdr_util)::get(this, "", "mem_bkdr_util", cfg.mem_bkdr_util_h)) begin
       `uvm_fatal(`gfn, "failed to get mem_bkdr_util from uvm_config_db")
@@ -30,6 +31,8 @@ class rom_ctrl_env extends cip_base_env #(
     // Build the KMAC agent
     m_kmac_agent = kmac_app_agent::type_id::create("m_kmac_agent", this);
     uvm_config_db#(kmac_app_agent_cfg)::set(this, "m_kmac_agent", "cfg", cfg.m_kmac_agent_cfg);
+    cfg.m_kmac_agent_cfg.zero_delays = cfg.zero_delays;
+    cfg.m_kmac_agent_cfg.m_data_push_agent_cfg.device_delay_max = cfg.device_delay_max;
 
   endfunction
 

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -13,6 +13,31 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
   // ext interfaces
   rom_ctrl_vif rom_ctrl_vif;
 
+  // Enables/disable all protocol delays.
+  rand bit zero_delays;
+
+  // Bias randomization in favor of enabling zero delays less often.
+  constraint zero_delays_c {
+    zero_delays dist { 0 := 8,
+                       1 := 2 };
+  }
+
+  // Device-side delay for both push/pull protocols.
+  rand int unsigned device_delay_max;
+
+  constraint device_delay_max_c {
+    solve zero_delays before device_delay_max;
+    if (zero_delays) {
+      device_delay_max == 0;
+    } else {
+      device_delay_max dist {
+        [1:20] :/ 2,
+        [21:50] :/ 4
+      };
+    }
+  }
+
+
   `uvm_object_utils_begin(rom_ctrl_env_cfg)
   `uvm_object_utils_end
 


### PR DESCRIPTION
Many of the KMAC agent configuration variables are random variables. The
agent configuration needs to be randomized for the variables to be
initialised to hit all coverage corners.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>