### PR TITLE
[sw,tests,pwrmgr] Improve synchronization

### DIFF
--- a/hw/dv/sv/mem_model/mem_model.sv
+++ b/hw/dv/sv/mem_model/mem_model.sv
@@ -38,13 +38,13 @@ class mem_model #(int AddrWidth = bus_params_pkg::BUS_AW,
   endfunction
 
   function void write_byte(mem_addr_t addr, bit [7:0] data);
-   `uvm_info(`gfn, $sformatf("Write Mem : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_MEDIUM)
+   `uvm_info(`gfn, $sformatf("Write Mem : Addr[0x%0h], Data[0x%0h]", addr, data), UVM_HIGH)
     system_memory[addr] = data;
   endfunction
 
   function void compare_byte(mem_addr_t addr, bit [7:0] act_data);
    `uvm_info(`gfn, $sformatf("Compare Mem : Addr[0x%0h], Act Data[0x%0h], Exp Data[0x%0h]",
-                             addr, act_data, system_memory[addr]), UVM_MEDIUM)
+                             addr, act_data, system_memory[addr]), UVM_HIGH)
     `DV_CHECK_EQ(act_data, system_memory[addr], $sformatf("addr 0x%0h read out mismatch", addr))
   endfunction
 

--- a/sw/device/lib/dif/dif_pwrmgr.h
+++ b/sw/device/lib/dif/dif_pwrmgr.h
@@ -180,16 +180,19 @@ typedef struct dif_pwrmgr_wakeup_reason {
  * corresponding bit automatically, this function must be called before each
  * transition to low power state.
  *
- * Note: This function also syncs changes to the slow clock domain for them to
- * take effect.
+ * This function can be configured to skip synchronization to the slow clock
+ * domain, under the assumption that timely synchronization will be performed
+ * by some of the other functions that can trigger it.
  *
  * @param pwrmgr A power manager handle.
  * @param new_state Whether low power state is enabled.
+ * @param sync_state Whether to wait for state to transfer to slow domain
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_low_power_set_enabled(const dif_pwrmgr_t *pwrmgr,
-                                              dif_toggle_t new_state);
+                                              dif_toggle_t new_state,
+                                              dif_toggle_t sync_state);
 
 /**
  * Checks whether low power state is enabled.
@@ -206,16 +209,19 @@ dif_result_t dif_pwrmgr_low_power_get_enabled(const dif_pwrmgr_t *pwrmgr,
  * Configures power manager to enable/disable various clock and power domains in
  * low and active power states.
  *
- * Note: This function also syncs changes to the slow clock domain for them to
- * take effect.
+ * This function can be configured to skip synchronization to the slow clock
+ * domain, under the assumption that timely synchronization will be performed
+ * by some of the other functions that can trigger it.
  *
  * @param pwrmgr A power manager handle.
  * @param config A domain configuration.
+ * @param sync_state Whether to wait for state to transfer to slow domain
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_set_domain_config(const dif_pwrmgr_t *pwrmgr,
-                                          dif_pwrmgr_domain_config_t config);
+                                          dif_pwrmgr_domain_config_t config,
+                                          dif_toggle_t sync_state);
 
 /**
  * Gets current power manager configuration.
@@ -235,18 +241,20 @@ dif_result_t dif_pwrmgr_get_domain_config(const dif_pwrmgr_t *pwrmgr,
  * watchdog timer, USB, etc. This function sets which sources are enabled for a
  * particular request type.
  *
- * Note: This function also syncs changes to the slow clock domain for them to
- * take effect.
+ * This function can be configured to skip synchronization to the slow clock
+ * domain, under the assumption that timely synchronization will be performed
+ * by some of the other functions that can trigger it.
  *
  * @param pwrmgr A power manager handle.
  * @param req_type A request type.
  * @param sources Sources enabled for the given request type.
+ * @param sync_state Whether to wait for state to transfer to slow domain
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_pwrmgr_set_request_sources(
     const dif_pwrmgr_t *pwrmgr, dif_pwrmgr_req_type_t req_type,
-    dif_pwrmgr_request_sources_t sources);
+    dif_pwrmgr_request_sources_t sources, dif_toggle_t sync_state);
 
 /**
  * Gets sources enabled for a request type.

--- a/sw/device/lib/testing/pwrmgr_testutils.c
+++ b/sw/device/lib/testing/pwrmgr_testutils.c
@@ -16,10 +16,12 @@ void pwrmgr_testutils_enable_low_power(
     dif_pwrmgr_domain_config_t domain_config) {
   // Enable low power on the next WFI with clocks and power domains configured
   // per domain_config.
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeWakeup,
+                                              wakeups, kDifToggleDisabled));
   CHECK_DIF_OK(
-      dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeWakeup, wakeups));
-  CHECK_DIF_OK(dif_pwrmgr_set_domain_config(pwrmgr, domain_config));
-  CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(pwrmgr, kDifToggleEnabled));
+      dif_pwrmgr_set_domain_config(pwrmgr, domain_config, kDifToggleDisabled));
+  CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(pwrmgr, kDifToggleEnabled,
+                                                kDifToggleEnabled));
 }
 
 bool pwrmgr_testutils_is_wakeup_reason(const dif_pwrmgr_t *pwrmgr,

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -171,6 +171,7 @@ cc_test(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "//sw/device/lib/testing:pwrmgr_testutils",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -16,6 +16,7 @@
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/runtime/print.h"
 #include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
@@ -223,10 +224,8 @@ static void soft_reboot(dif_pwrmgr_t *pwrmgr, dif_aon_timer_t *aon_timer) {
   dif_pwrmgr_domain_config_t config;
   config = kDifPwrmgrDomainOptionUsbClockInActivePower;
 
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
-      pwrmgr, kDifPwrmgrReqTypeWakeup, kDifPwrmgrWakeupRequestSourceFive));
-  CHECK_DIF_OK(dif_pwrmgr_set_domain_config(pwrmgr, config));
-  CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(pwrmgr, kDifToggleEnabled));
+  pwrmgr_testutils_enable_low_power(pwrmgr, kDifPwrmgrWakeupRequestSourceFive,
+                                    config);
 
   // Enter low power mode.
   LOG_INFO("Entering low power");

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -110,6 +110,7 @@ sw_silicon_creator_lib_driver_keymgr_functest = declare_dependency(
       sw_lib_dif_pwrmgr,
       sw_lib_dif_otp_ctrl,
       sw_lib_flash_ctrl,
+      sw_lib_testing_pwrmgr_testutils,
       sw_silicon_creator_lib_base_sec_mmio,
       sw_silicon_creator_lib_driver_keymgr,
       sw_silicon_creator_lib_driver_lifecycle,

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -38,8 +38,9 @@ static void config_wdog(const dif_aon_timer_t *aon_timer,
            (uint32_t)bark_time_us, (uint32_t)bite_time_us);
 
   // Set wdog as a reset source.
-  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
-      pwrmgr, kDifPwrmgrReqTypeReset, kDifPwrmgrWakeupRequestSourceTwo));
+  CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,
+                                              kDifPwrmgrWakeupRequestSourceTwo,
+                                              kDifToggleEnabled));
 
   // Setup the wdog bark and bite timeouts.
   aon_timer_testutils_watchdog_config(aon_timer, bark_cycles, bite_cycles);

--- a/sw/device/tests/pwrmgr_smoketest.c
+++ b/sw/device/tests/pwrmgr_smoketest.c
@@ -21,6 +21,20 @@ bool test_main(void) {
   dif_pwrmgr_t pwrmgr;
   dif_rstmgr_t rstmgr;
 
+  // Issue a wakeup signal in ~150us through the AON timer.
+  //
+  // At 200kHz, threshold of 30 is equal to 150us. There is an additional
+  // ~4 cycle overhead for the CSR value to synchronize with the AON clock.
+  // We should expect the wake up to trigger in ~170us. This is sufficient
+  // time to allow pwrmgr config and the low power entry on WFI to complete.
+  //
+  // Adjust the threshold for Verilator since it runs on different clock
+  // frequencies.
+  uint32_t wakeup_threshold = 30;
+  if (kDeviceType == kDeviceSimVerilator) {
+    wakeup_threshold = 300;
+  }
+
   // Initialize pwrmgr
   CHECK_DIF_OK(dif_pwrmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
@@ -34,43 +48,36 @@ bool test_main(void) {
   // Notice we are clearing rstmgr's RESET_INFO, so after the aon wakeup there
   // is only one bit set.
   if (pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) {
-    LOG_INFO("Powered up for the first time, begin test");
+    LOG_INFO("POR reset");
 
     CHECK(rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor));
 
     // Prepare rstmgr for a reset.
     rstmgr_testutils_pre_reset(&rstmgr);
 
-    // Issue a wakeup signal in ~150us through the AON timer.
-    //
-    // At 200kHz, threshold of 30 is equal to 150us. There is an additional
-    // ~4 cycle overhead for the CSR value to synchronize with the AON clock.
-    // We should expect the wake up to trigger in ~170us. This is sufficient
-    // time to allow pwrmgr config and the low power entry on WFI to complete.
-    //
-    // Adjust the threshold for Verilator since it runs on different clock
-    // frequencies.
-    uint32_t wakeup_threshold = 30;
-    if (kDeviceType == kDeviceSimVerilator) {
-      wakeup_threshold = 300;
-    }
     dif_aon_timer_t aon_timer;
     CHECK_DIF_OK(dif_aon_timer_init(
         mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR),
         &aon_timer));
     aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold);
+    // Deep sleep.
     pwrmgr_testutils_enable_low_power(&pwrmgr,
                                       kDifPwrmgrWakeupRequestSourceFive, 0);
+
     // Enter low power mode.
+    LOG_INFO("Issue WFI to enter sleep");
     wait_for_interrupt();
 
   } else if (pwrmgr_testutils_is_wakeup_reason(
                  &pwrmgr, kDifPwrmgrWakeupRequestSourceFive)) {
+    LOG_INFO("Wakeup reset");
+
+    CHECK(rstmgr_testutils_is_reset_info(&rstmgr,
+                                         kDifRstmgrResetInfoLowPowerExit));
     LOG_INFO("Aon timer wakeup detected");
     rstmgr_testutils_post_reset(&rstmgr, kDifRstmgrResetInfoLowPowerExit, 0, 0,
                                 0, 0);
     return true;
-
   } else {
     dif_pwrmgr_wakeup_reason_t wakeup_reason;
     CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason));

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -14,6 +14,7 @@ pwrmgr_usbdev_smoketest_lib = declare_dependency(
       sw_lib_usb,
       sw_lib_mmio,
       sw_lib_runtime_log,
+      sw_lib_testing_pwrmgr_testutils,
     ],
   ),
 )

--- a/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
+++ b/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
@@ -17,6 +17,7 @@
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf.h"
 #include "sw/device/lib/usbdev.h"
 
@@ -73,11 +74,9 @@ bool test_main(void) {
     usleep(20);  // 20us
 
     // Enable low power on the next WFI with default settings.
-    CHECK_DIF_OK(dif_pwrmgr_set_request_sources(
-        &pwrmgr, kDifPwrmgrReqTypeWakeup, kDifPwrmgrWakeupRequestSourceFour));
-    CHECK_DIF_OK(dif_pwrmgr_set_domain_config(
-        &pwrmgr, kDifPwrmgrDomainOptionUsbClockInActivePower));
-    CHECK_DIF_OK(dif_pwrmgr_low_power_set_enabled(&pwrmgr, kDifToggleEnabled));
+    pwrmgr_testutils_enable_low_power(
+        &pwrmgr, kDifPwrmgrWakeupRequestSourceFour,
+        kDifPwrmgrDomainOptionUsbClockInActivePower);
 
     // Enter low power mode.
     wait_for_interrupt();


### PR DESCRIPTION
Allow each CSR updates that need to transfer to the slow domain to make
synchronization optional.
This enables entry into low power to use a single synchronization when
it is done with the last update.

Signed-off-by: Guillermo Maturana <maturana@google.com>