### PR TITLE
[edn/rtl] Fix for boot req mode

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -159,8 +159,8 @@
                 This bit reflects the status of the EDN command state machine. This bit is asserted
                 whenever the the state machine is actively managing commands in either auto
                 request mode, or boot-time request mode.  After the state machine has
-                been suspended, this status bit should be polled to know when the last remaining
-                state machine command has been completed, at which point is safe to issue custom
+                been suspended, this status bit will reflect that the hardware operations are
+                completed. At this point it is safe to issue custom
                 commands via the software command forwarding interface. A value of zero indicates
                 that all commands have completed, and the state machine is idle.
                 '''

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -98,7 +98,6 @@ module edn_main_sm (
         end
       end
       AckWait: begin
-        seq_auto_req_mode_o = 1'b0;
         if (csrng_cmd_ack_i) begin
           state_d = Dispatch;
         end


### PR DESCRIPTION
Need to make sure the software status bits are not affect by the
boot request hardware state machine.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>