### PR TITLE
[dv/otp_ctrl] OTP reaches V2

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.prj.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.prj.hjson
@@ -22,9 +22,9 @@
         version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2S",
-        verification_stage: "V1",
+        verification_stage: "V2",
         dif_stage:          "S1",
-        notes:              "Rolled back to V1 due test_memory change.",
+        notes:              "Will fully support test_access tl_if once reggen tool is optimized.",
       }
     ]
 }

--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -49,6 +49,11 @@
             - read back and verify the digest
             - perform a system-level reset to verify the corresponding CSRs exposing the digests
               have been populated
+
+            **Checks**:
+            - Assertion checks to ensure vendor specific I/Os: `otp_vendor_test_status_o`,
+              `otp_vendor_test_ctrl_i`, `cio_test_o`, and `cio_test_en_o` are connected currently
+              with `lc_dft_en_i` On and Off.
             '''
       milestone: V1
       tests: ["otp_ctrl_smoke"]
@@ -199,7 +204,8 @@
             This test checks if the test access to OTP macro is connected correctly.
 
             **Stimulus and Checks**:
-            - read out from the test access window and ensure no error occurs
+            - Write and check read results from the prim_tl_i/o.
+            - Ensure no error or alert occurs from DUT.
             '''
       milestone: V2
       tests: ["otp_ctrl_test_access"]

--- a/hw/ip/otp_ctrl/doc/checklist.md
+++ b/hw/ip/otp_ctrl/doc/checklist.md
@@ -182,7 +182,7 @@ Review        | [V2_CHECKLIST_SCOPED][]               | Done        |
 Documentation | [DESIGN_DELTAS_CAPTURED_V2][]           | Done        |
 Documentation | [DV_DOC_COMPLETED][]                    | Done        |
 Testbench     | [FUNCTIONAL_COVERAGE_IMPLEMENTED][]     | Done        |
-Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        |
+Testbench     | [ALL_INTERFACES_EXERCISED][]            | Done        | `prim_tl_o/i` has a simple prim_tl_agent support, but needto be replaced with auto-generated tl_agent once reggen tool is optimized.
 Testbench     | [ALL_ASSERTION_CHECKS_ADDED][]          | Done        |
 Testbench     | [SIM_TB_ENV_COMPLETED][]                | Done        |
 Tests         | [SIM_ALL_TESTS_PASSING][]               | Done        |


### PR DESCRIPTION
As discussed in the meeting, we plan to wavie prim_tl_o/i until the
reggen tool is optmized.

From the previous V2 status, here are the design changes and what we
have covered:
- prim_tl_i/o: add basic support. But not a complete support because we expect some reggen related change.
  - DV open source currently supports read/write only.
    Merged PR: https://github.com/lowRISC/opentitan/pull/10234
- Vendor test partition
  - DV change: treat exactly same as other sw partition except uncorrectable ECC does not trigger fatal alerts
  Merged PR: https://github.com/lowRISC/opentitan/pull/10268
- Output Cio_test_o, cio_test_en_o
  - DV changes: Assertion checks
    https://github.com/lowRISC/opentitan/pull/10229/files
- lc_otp_vendor_test_i/o
  - DV changes: Assertion checks
    https://github.com/lowRISC/opentitan/pull/10229/files
- UNR updates:
  Added a partition (vendor test partition, so all previous partition related UNR is misaligned)
  Vendor related I/Os are tied to 0.
  V2S related assertions not covered and not detected by UNR.
  UNRs that needs to be reviewed again are filed here:  https://github.com/lowRISC/opentitan/issues/10313

Above items have been reviewed with designer Michael and there is one
pending issue: https://github.com/lowRISC/opentitan/pull/10317 but we
believe it does not affect our V2 progress because it is a small
alignment.

Regression status: https://reports.opentitan.org/hw/ip/otp_ctrl/dv/latest/results.html 
![image](https://user-images.githubusercontent.com/11466553/151032134-458c5c9f-8487-428c-b487-fe90cec4f5ad.png)


Signed-off-by: Cindy Chen <chencindy@opentitan.org>