### PR TITLE
[rtl] Add security countermeasures info

### DIFF
--- a/doc/rm/comportability_specification/index.md
+++ b/doc/rm/comportability_specification/index.md
@@ -259,26 +259,27 @@ The following standardised assets are defined:
 
 | Asset name | Intended meaning |
 | --- | --- |
-| KEY        | A key (secret data) |
-| ADDR       | An address |
-| DATA_REG   | A configuration data register that doesn't come from software (such as Keccak state) |
-| CTRL_FLOW  | The control flow of software or a module |
-| CTRL       | Logic used to steer hardware behavior |
-| CONFIG     | Software-supplied configuration, programmed through the comportable register interface |
-| LFSR       | A linear feedback shift register |
-| RNG        | A random number generator |
-| CTR        | A counter |
-| FSM        | A finite state machine |
-| MEM        | A generic data memory; volatile or non-volatile |
-| CLK        | A clock |
-| RST        | A reset signal |
-| BUS        | Data transferred on a bus |
-| INTERSIG   | A non-bus signal between two IP blocks |
-| MUX        | A multiplexer that controls propagation of sensitive data |
-| CONSTANTS  | A netlist constant |
-| STATE      | An internal state signal (other than FSM state, which is covered by the FSM label) |
-| TOKEN      | A cryptographic token |
-| LOGIC      | Any logic. This is a very broad category: avoid if possible and give an instance or net name if not. |
+| KEY         | A key (secret data) |
+| ADDR        | An address |
+| DATA_REG    | A configuration data register that doesn't come from software (such as Keccak state) |
+| DATA_REG_SW | A data holding register that is manipulated by software |
+| CTRL_FLOW   | The control flow of software or a module |
+| CTRL        | Logic used to steer hardware behavior |
+| CONFIG      | Software-supplied configuration, programmed through the comportable register interface |
+| LFSR        | A linear feedback shift register |
+| RNG         | A random number generator |
+| CTR         | A counter |
+| FSM         | A finite state machine |
+| MEM         | A generic data memory; volatile or non-volatile |
+| CLK         | A clock |
+| RST         | A reset signal |
+| BUS         | Data transferred on a bus |
+| INTERSIG    | A non-bus signal between two IP blocks |
+| MUX         | A multiplexer that controls propagation of sensitive data |
+| CONSTANTS   | A netlist constant |
+| STATE       | An internal state signal (other than FSM state, which is covered by the FSM label) |
+| TOKEN       | A cryptographic token |
+| LOGIC       | Any logic. This is a very broad category: avoid if possible and give an instance or net name if not. |
 
 The following standardised countermeasures are defined:
 
@@ -289,7 +290,7 @@ The following standardised countermeasures are defined:
 | DIFF           | A signal is differentially encoded | CTRL, CTR |
 | REDUN          | There are redundant versions of the asset | ADDR, CTRL, CONFIG, CTR
 | REGWEN         | A register write enable is used to protect the asset from write access | CONFIG, MEM
-| SHADOW         | A shadow register is used to store the asset | CONFIG
+| SHADOW         | The asset has a shadow replica to cross-check against | CONFIG
 | REGREN         | A register write enable is used to protect the asset from read access | CONFIG, MEM
 | SCRAMBLE       | The asset is scrambled | CONFIG, MEM
 | INTEGRITY      | The asset has integrity protection from a computed value such as a checksum | CONFIG, REG, MEM
@@ -307,8 +308,8 @@ The following standardised countermeasures are defined:
 | MASKING        | A more specific version of SCA where an asset is split into shares |
 | LOCAL_ESC      | A local escalation event is triggered when an attack is detected |
 | GLOBAL_ESC     | A global escalation event is triggered when an attack is detected |
+| UNPREDICTABLE  | Behaviour is unpredictable to frustrate repeatable FI attacks |
 | CM             | Catch-all for countermeasures that cannot be further specified. This is a very broad category: avoid if possible and give an instance or net name if not. |
-
 
 ## Register Handling
 

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -23,10 +23,16 @@
       desc: "Software triggered Alert for recoverable faults",
     },
     { name: "fatal_hw_err",
-      desc: "Ibex core triggered alert for fatal faults, including integrity faults",
+      desc: '''
+        Triggered when
+          - Ibex raises `alert_major_internal_o`
+          - Ibex raises `alert_major_bus_o`
+          - A double fault is seen (Ibex raises `double_fault_seen_o`)
+          - A bus integrity error is seen
+      '''
     },
     { name: "recov_hw_err",
-      desc: "Ibex core triggered alert for recoverable faults",
+      desc: "Triggered when Ibex raises `alert_minor_o`",
     },
   ],
 
@@ -351,6 +357,49 @@
     }
     { name: "SCRAMBLE.KEY.SIDELOAD",
       desc: "The scrambling key for the icache is sideloaded from OTP and thus unreadable by SW."
+    }
+    { name: "CORE.DATA_REG_SW.SCA",
+      desc: "Data independent timing."
+    }
+    { name: "PC.CTRL_FLOW.CONSISTENCY"
+      desc: "Correct PC increment check."
+    }
+    { name: "CTRL_FLOW.UNPREDICTABLE"
+      desc: "Randomized dummy instruction insertion."
+    }
+    { name: "DATA_REG_SW.INTEGRITY"
+      desc: '''
+        Register file integrity checking. Note that whilst the core itself is
+        duplicated (see LOGIC.SHADOW) the register file is not. Protection is
+        provided by an ECC.
+      '''
+    }
+    { name: "LOGIC.SHADOW"
+      desc: '''
+        Shadow core run in lockstep to crosscheck CPU behaviour. This provides
+        broad protection for all assets with the the Ibex core.
+      '''
+    }
+    { name: "FETCH.CTRL.LC_GATED"
+      desc: "Fetch enable so core execution can be halted."
+    }
+    { name: "EXCEPTION.CTRL_FLOW.LOCAL_ESC"
+      desc: '''
+        A mechanism to detect and act on double faults. Local escalation shuts
+        down the core when a double fault is seen.
+      '''
+    }
+    { name: "EXCEPTION.CTRL_FLOW.GLOBAL_ESC"
+      desc:  '''
+        A mechanism to detect and act on double faults. Global escalation
+        sends a fatal alert when a double fault is seen.
+      '''
+    }
+    { name: "ICACHE.MEM.SCRAMBLE"
+      desc: "ICache memory scrambling."
+    }
+    { name: "ICACHE.MEM.INTEGRITY"
+      desc: "ICache memory integrity checking."
     }
   ]
 
@@ -694,6 +743,7 @@
             resval: "0x0"
             desc: '''
               rv_core_ibex detected a fatal internal error
+              (``alert_major_internal_o``` from Ibex seen)
             '''
           },
           { bits: "10",
@@ -701,6 +751,7 @@
             resval: "0x0"
             desc: '''
               rv_core_ibex detected a recoverable internal error
+              (``alert_minor`` from Ibex seen)
             '''
           },
         ]

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex_sec_cm_testplan.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex_sec_cm_testplan.hjson
@@ -25,15 +25,75 @@
   testpoints: [
     {
       name: sec_cm_bus_integrity
-      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY"
       milestone: V2S
-      tests: []
+      tests: {}
     }
     {
       name: sec_cm_scramble_key_sideload
-      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
+      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD"
       milestone: V2S
-      tests: []
+      tests: {}
+    }
+    {
+      name: sec_cm_core_data_reg_sw_sca
+      desc: "Verify the countermeasure(s) CORE.DATA_REG_SW.SCA"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_pc_ctrl_flow_consistency
+      desc: "Verify the countermeasure(s) PC.CTRL_FLOW.CONSISTENCY"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_ctrl_flow_unpredictable
+      desc: "Verify the countermeasure(s) CTRL_FLOW.UNPREDICTABLE"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_data_reg_sw_integrity
+      desc: "Verify the countermeasure(s) DATA_REG_SW.INTEGRITY"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_logic_shadow
+      desc: "Verify the countermeasure(s) LOGIC.SHADOW"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_fetch_ctrl_lc_gated
+      desc: "Verify the countermeasure(s) FETCH.CTRL.LC_GATED"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_exception_ctrl_flow_local_esc
+      desc: "Verify the countermeasure(s) EXCEPTION.CTRL_FLOW.LOCAL_ESC"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_exception_ctrl_flow_global_esc
+      desc: "Verify the countermeasure(s) EXCEPTION.CTRL_FLOW.GLOBAL_ESC"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_icache_mem_scramble
+      desc: "Verify the countermeasure(s) ICACHE.MEM.SCRAMBLE"
+      milestone: V2S
+      tests: {}
+    }
+    {
+      name: sec_cm_icache_mem_integrity
+      desc: "Verify the countermeasure(s) ICACHE.MEM.INTEGRITY"
+      milestone: V2S
+      tests: {}
     }
   ]
 }

--- a/hw/ip/rv_core_ibex/doc/_index.md
+++ b/hw/ip/rv_core_ibex/doc/_index.md
@@ -98,6 +98,18 @@ When the CPU encounters a double fault, the current crash dump is moved to previ
 
 This allows the software to see both fault locations and debug accordingly.
 
+## Fetch Enable
+
+Ibex has a top-level fetch enable input (``fetch_enable_i``), which uses the same multi-bit encoding used by the lifecycle controller.
+When Ibex fetch is disabled it will cease to execute, but will complete instructions currently in the pipeline.
+Ibex fetch is enabled when all of the following conditions are met:
+  - The lifecycle controller has enabled it
+  - The power manager has enabled it
+  - A ``fatal_hw_err`` alert hasn't been raised
+
+### Local Escalation Path
+
+When the ``fatal_hw_err`` alert is raised Ibex fetch is disabled and will remain disabled until ``rv_core_ibex`` is reset.
 
 ## Register Table
 

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -195,6 +195,7 @@ module rv_core_ibex
   logic fatal_intg_event;
   logic fatal_core_event;
   logic recov_core_event;
+  // SEC_CM: BUS.INTEGRITY
   assign fatal_intg_event = ibus_intg_err | dbus_intg_err | alert_major_bus;
   assign fatal_core_event = alert_major_internal | double_fault;
   assign recov_core_event = alert_minor;
@@ -434,6 +435,7 @@ module rv_core_ibex
     .rvfi_mem_rdata,
     .rvfi_mem_wdata,
 `endif
+    // SEC_CM: FETCH.CTRL.LC_GATED
     .fetch_enable_i         (fetch_enable),
     .alert_minor_o          (alert_minor),
     .alert_major_internal_o (alert_major_internal),
@@ -477,6 +479,7 @@ module rv_core_ibex
   logic [top_pkg::TL_DW-1:0] unused_data;
   // tl_adapter_host_i_ibex only reads instruction. a_data is always 0
   assign {instr_wdata_intg, unused_data} = prim_secded_pkg::prim_secded_inv_39_32_enc('0);
+  // SEC_CM: BUS.INTEGRITY
   tlul_adapter_host #(
     .MAX_REQS(NumOutstandingReqs),
     // if secure ibex is not set, data integrity is not generated
@@ -531,6 +534,7 @@ module rv_core_ibex
     .addr_o(data_addr_trans)
   );
 
+  // SEC_CM: BUS.INTEGRITY
   tlul_adapter_host #(
     .MAX_REQS(2),
     .EnableDataIntgGen(~SecureIbex)

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -14,6 +14,7 @@ CM_ASSETS = [
     'KEY',
     'ADDR',
     'DATA_REG',
+    'DATA_REG_SW',
     'CTRL_FLOW',
     'CTRL',
     'CONFIG',
@@ -57,6 +58,7 @@ CM_TYPES = [
     'MASKING',
     'LOCAL_ESC',
     'GLOBAL_ESC',
+    'UNPREDICTABLE',
     'CM'
 ]
 


### PR DESCRIPTION
Draft for now as this will fail CI as reggen doesn't like the countermeasure names.

SEC_CM labels for the Ibex RTL itself are being added in the Ibex
repository and the changes will be vendored in (as opposed to patching
Ibex to them exclusively in OpenTitan).

Signed-off-by: Greg Chadwick <gac@lowrisc.org>