### PR TITLE
[dv/otp_ctrl] Fix prim_tl_agent close source monitor error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env.sv
@@ -64,8 +64,10 @@ class otp_ctrl_env #(
     // TODO: reggen tool optimization.
     // Temp build the prim_tl_agent.should be auto-generated via otp_ctrl_env_cfg once the reggen
     // tool is optimized.NCurrently this is an empty RAL so dv_base_reg_block will return an error.
-    prim_tl_agent = tl_agent::type_id::create({"prim_tl_agent"}, this);
-    uvm_config_db#(tl_agent_cfg)::set(this, "prim_tl_agent", "cfg", cfg.prim_tl_agent_cfg);
+    if (cfg.create_prim_tl_agent) begin
+      prim_tl_agent = tl_agent::type_id::create({"prim_tl_agent"}, this);
+      uvm_config_db#(tl_agent_cfg)::set(this, "prim_tl_agent", "cfg", cfg.prim_tl_agent_cfg);
+    end
 
     // config mem virtual interface
     if (!uvm_config_db#(mem_bkdr_util)::get(this, "", "mem_bkdr_util", cfg.mem_bkdr_util_h)) begin
@@ -96,7 +98,9 @@ class otp_ctrl_env #(
     virtual_sequencer.flash_data_pull_sequencer_h = m_flash_data_pull_agent.sequencer;
     virtual_sequencer.lc_prog_pull_sequencer_h    = m_lc_prog_pull_agent.sequencer;
     // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
-    virtual_sequencer.prim_tl_sequencer_h = prim_tl_agent.sequencer;
+    if (cfg.create_prim_tl_agent) begin
+      virtual_sequencer.prim_tl_sequencer_h = prim_tl_agent.sequencer;
+    end
     if (cfg.en_scb) begin
       m_otbn_pull_agent.monitor.analysis_port.connect(scoreboard.otbn_fifo.analysis_export);
       m_flash_addr_pull_agent.monitor.analysis_port.connect(

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -42,7 +42,9 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
   rand otp_ctrl_ast_inputs_cfg dut_cfg;
 
   // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
-  rand tl_agent_cfg            prim_tl_agent_cfg;
+  rand tl_agent_cfg prim_tl_agent_cfg;
+  // Introduce this flag to avoid close source conflict.
+  bit               create_prim_tl_agent = 1;
 
   `uvm_object_utils_begin(otp_ctrl_env_cfg)
   `uvm_object_utils_end
@@ -93,10 +95,12 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     m_lc_prog_pull_agent_cfg.agent_type = PullAgent;
 
     // TODO: reggen tool optimization. Temp mannual setup for prim_tl_agent.
-    prim_tl_agent_cfg = tl_agent_cfg::type_id::create("prim_tl_agent_cfg");
-    prim_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
-    prim_tl_agent_cfg.host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
-    prim_tl_agent_cfg.allow_a_valid_drop_wo_a_ready = $urandom_range(0, 1);
+    if (create_prim_tl_agent) begin
+      prim_tl_agent_cfg = tl_agent_cfg::type_id::create("prim_tl_agent_cfg");
+      prim_tl_agent_cfg.if_mode = dv_utils_pkg::Host;
+      prim_tl_agent_cfg.host_can_stall_rsp_when_a_valid_high = $urandom_range(0, 1);
+      prim_tl_agent_cfg.allow_a_valid_drop_wo_a_ready = $urandom_range(0, 1);
+    end
 
     // set num_interrupts & num_alerts
     begin
@@ -108,7 +112,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
 
     // only support 1 outstanding TL items in tlul_adapter
     m_tl_agent_cfg.max_outstanding_req = 1;
-    prim_tl_agent_cfg.max_outstanding_req = 1;
+    if (create_prim_tl_agent) prim_tl_agent_cfg.max_outstanding_req = 1;
 
     // create the inputs cfg instance
     dut_cfg = otp_ctrl_ast_inputs_cfg::type_id::create("dut_cfg");

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -522,14 +522,16 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // This test access OTP_CTRL's test_access memory. The open-sourced code only test if the access
   // is valid. Please override this task in proprietary OTP.
   virtual task otp_test_access();
-    repeat (10) begin
-      bit [TL_DW-1:0] wr_data, rd_data;
-      bit [TL_AW-1:0] rand_addr = $urandom_range(0, PRIM_ADDR_SIZE + 3);
-      `DV_CHECK_STD_RANDOMIZE_FATAL(wr_data)
-      tl_access(.addr(rand_addr), .write(1), .data(wr_data),
-                .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
-      tl_access(.addr(rand_addr), .write(0), .data(rd_data), .exp_data(wr_data),
-                .check_exp_data(1), .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
+    if (cfg.create_prim_tl_agent) begin
+      repeat (10) begin
+        bit [TL_DW-1:0] wr_data, rd_data;
+        bit [TL_AW-1:0] rand_addr = $urandom_range(0, PRIM_ADDR_SIZE + 3);
+        `DV_CHECK_STD_RANDOMIZE_FATAL(wr_data)
+        tl_access(.addr(rand_addr), .write(1), .data(wr_data),
+                  .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
+        tl_access(.addr(rand_addr), .write(0), .data(rd_data), .exp_data(wr_data),
+                  .check_exp_data(1), .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
+      end
     end
   endtask
 


### PR DESCRIPTION
Due to the current reggen tool, we have an empty prim_tl_o/i interface
without any CSRs for test_access. To ensure the connection for
read/write works, open source OTP tb creates a temp tl_agent. However,
because it hooks up same interface with close source, the monitor will
report some runtime error.
To avoid this, we introduced a cfg flag that can disable creating this temp
tl_agent.

Signed-off-by: Cindy Chen <chencindy@google.com>