### PR TITLE
[dv] Update common_cov_excl to exclude d_user.rsp_intg[6]

### DIFF
--- a/hw/dv/tools/vcs/common_cov_excl.cfg
+++ b/hw/dv/tools/vcs/common_cov_excl.cfg
@@ -11,6 +11,8 @@
 -node tb.dut *tl_o.d_opcode[1]
 -node tb.dut *tl_o.d_opcode[2]
 -node tb.dut *tl_o.d_sink
+// [UNR] due to the ECC logics
+-node tb.dut *tl_o.d_user.rsp_intg[6]
 
 // [LOW_RISK] Verified in prim_alert_sender/receiver TB."
 -node tb.dut* *alert_rx_i*.ping_p


### PR DESCRIPTION
It's UNR due to the ECC logics
Signed-off-by: Weicai Yang <weicai@google.com>