### PR TITLE
[bazel] sigverify_dynamic_functest has more deps

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -277,9 +277,9 @@ cc_library(
     name = "shutdown",
     srcs = ["shutdown.c"],
     deps = [
-        ":shutdown_intf",
         ":error",
         ":log",
+        ":shutdown_intf",
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
@@ -305,9 +305,9 @@ cc_test(
         "OT_OFF_TARGET_TEST",
     ],
     deps = [
-        ":shutdown_intf",
         ":error",
         ":log",
+        ":shutdown_intf",
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
@@ -422,6 +422,8 @@ opentitan_functest(
     ),
     deps = [
         ":sigverify",
+        ":sigverify_mod_exp_ibex",
+        ":sigverify_mod_exp_otbn",
         ":sigverify_testvectors",
         ":test_main",
         "//sw/device/silicon_creator/lib/base:sec_mmio",


### PR DESCRIPTION
This part of https://github.com/lowRISC/opentitan/pull/10041 was
necessary to correct the building and testing of the
sigverify_dynamic_functest. Due to some recent changes it's no longer
sufficient.

Signed-off-by: Drew Macrae <drewmacrae@google.com>