### PR TITLE
[docs] Add bazel to the list of OT requirements

### DIFF
--- a/doc/ug/install_instructions/index.md
+++ b/doc/ug/install_instructions/index.md
@@ -38,11 +38,12 @@ For packages listed below without a version number we have not determined a mini
 * Python 3.6 with pip.
   Additional Python dependencies are installed through pip.
 * A C++14 capable compiler.
-  GCC 5 or Clang 3.5 should meet this requirement.
+  GCC 8 or Clang 3.5 should meet this requirement.
 * clang-format.
   The use of clang-format 6.0 is recommended to match the formatting enforced when submitting a pull request.
 * [ninja](https://ninja-build.org/)  {{< tool_version "ninja" >}}
 * Bash
+* [Bazel](https://docs.bazel.build/versions/main/install.html) 4.2.0
 * curl
 * xz tools
 * LSB core packages (only the `lsb_release` tool must be available)


### PR DESCRIPTION
This is work from https://github.com/lowRISC/opentitan/pull/10041 that's
important to helping people set up to run OT

It also contains a bump in the described requirement for GCC8+, it's not
enforced by meson because I don't want this to depend on upgrading GCC
in CI

Signed-off-by: Drew Macrae <drewmacrae@google.com>