### PR TITLE
[dv/rstmgr] Add reset test

### DIFF
--- a/hw/ip/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/rstmgr_base_vseq.sv: {is_include_file: true}
       - seq_lib/rstmgr_common_vseq.sv: {is_include_file: true}
       - seq_lib/rstmgr_por_stretcher_vseq.sv: {is_include_file: true}
+      - seq_lib/rstmgr_reset_vseq.sv: {is_include_file: true}
       - seq_lib/rstmgr_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/rstmgr_sw_rst_vseq.sv: {is_include_file: true}
       - rstmgr_if.sv

--- a/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -87,6 +87,8 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
         // Write only.
         do_read_check = 1'b0;
       end
+      "reset_req": begin
+      end
       "reset_info": begin
         // RW1C.
         do_read_check = 1'b0;

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests the reset_info CSR settings for random resets.
+class rstmgr_reset_vseq extends rstmgr_base_vseq;
+  `uvm_object_utils(rstmgr_reset_vseq)
+
+  `uvm_object_new
+
+  constraint sw_reset_c {
+    sw_reset dist {
+      1 := 1,
+      0 := 3
+    };
+  }
+  constraint scan_reset_c {
+    solve sw_reset before scan_reset;
+    if (sw_reset == 0) {
+      scan_reset dist {
+        1 := 1,
+        0 := 3
+      };
+    } else {
+      scan_reset == 0;
+    }
+  }
+  constraint low_power_reset_c {
+    solve scan_reset before low_power_reset;
+    if (scan_reset == 0) {
+      low_power_reset dist {
+        1 := 1,
+        0 := 3
+      };
+    } else {
+      low_power_reset == 0;
+    }
+  }
+  constraint ndm_reset_c {
+    solve low_power_reset before ndm_reset;
+    if (low_power_reset == 0) {
+      ndm_reset dist {
+        1 := 1,
+        0 := 3
+      };
+    } else {
+      ndm_reset == 0;
+    }
+  }
+  constraint rstreqs_c {
+    solve ndm_reset before rstreqs;
+    if (ndm_reset == 0) {rstreqs != '0;} else {rstreqs == '0;}
+  }
+
+  task body();
+    int expected_reset_info;
+    // Expect reset info to be POR.
+    check_reset_info(1, "expected reset_info to be POR");
+    check_alert_and_cpu_info_after_reset(.alert_dump('0), .cpu_dump('0), .enable(1'b0));
+
+    // Clear reset_info register, and enable cpu and alert info capture.
+    csr_wr(.ptr(ral.reset_info), .value('1));
+
+    for (int i = 0; i < num_trans; ++i) begin
+      logic [TL_DW-1:0] value;
+      `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      set_alert_and_cpu_info_for_capture(alert_dump, cpu_dump);
+      csr_wr(.ptr(ral.reset_info), .value('1));
+      if (scan_reset) begin
+        expected_reset_info = 1;
+        send_scan_reset();
+      end else if (low_power_reset) begin
+        expected_reset_info = 2;
+        send_reset(pwrmgr_pkg::LowPwrEntry, 0);
+      end else if (ndm_reset) begin
+        expected_reset_info = 4;
+        send_ndm_reset();
+      end else if (sw_reset) begin
+        expected_reset_info = 8;
+        send_sw_reset();
+      end else if (rstreqs) begin
+        expected_reset_info = {'0, rstreqs, 4'b0};
+        send_reset(pwrmgr_pkg::HwReq, rstreqs);
+      end
+
+      cfg.clk_rst_vif.wait_clks(8);
+      wait(cfg.rstmgr_vif.resets_o.rst_lc_n);
+      csr_rd_check(.ptr(ral.reset_info), .compare_value(expected_reset_info));
+    end
+  endtask
+
+endclass : rstmgr_reset_vseq

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -35,7 +35,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     csr_wr(.ptr(ral.reset_info), .value('1));
 
     // Send low power entry reset.
-    send_reset(pwrmgr_pkg::LowPwrEntry, rstreqs);
+    send_reset(pwrmgr_pkg::LowPwrEntry, '0);
     check_reset_info(2, "expected reset_info to indicate low power");
     check_alert_and_cpu_info_after_reset(alert_dump, cpu_dump, 1'b1);
 

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_vseq_list.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_vseq_list.sv
@@ -4,6 +4,7 @@
 
 `include "rstmgr_base_vseq.sv"
 `include "rstmgr_por_stretcher_vseq.sv"
+`include "rstmgr_reset_vseq.sv"
 `include "rstmgr_smoke_vseq.sv"
 `include "rstmgr_sw_rst_vseq.sv"
 `include "rstmgr_common_vseq.sv"

--- a/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -65,6 +65,10 @@
       uvm_test_seq: rstmgr_por_stretcher_vseq
     }
     {
+      name: rstmgr_reset
+      uvm_test_seq: rstmgr_reset_vseq
+    }
+    {
       name: rstmgr_sw_rst
       uvm_test_seq: rstmgr_sw_rst_vseq
     }

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -72,14 +72,13 @@ interface rstmgr_cascading_sva_if (
   // Macros to avoid excessive boiler-plate code below.
   `define FALL_ASSERT(_name, _from, _to, _cycles, _clk) \
     `ASSERT(_name``AboveFallBelowHigh_A, \
-            $fell(_from) && _to |-> ##[_cycles.fall.min:_cycles.fall.max] $fell(_to), _clk, \
+            $fell(_from) && _to |-> ##[_cycles.fall.min:_cycles.fall.max] _to, _clk, \
             disable_sva)
 
   `define RISE_ASSERTS(_name, _from, _to, _cycles, _clk) \
     `ASSERT(_name``AboveRise_A, \
-            $rose(_from) |-> ##[_cycles.rise.min:_cycles.rise.max] (!_from || $rose(_to)), _clk, \
+            $rose(_from) ##1 _from [* _cycles.rise.min] |=> ##[0:_cycles.rise.max-_cycles.rise.min] (!_from || _to), _clk, \
             disable_sva) \
-    `ASSERT(_name``BelowRise_A, $rose(_to) |-> _from == 1'b1, _clk, disable_sva)
 
   `define CASCADED_ASSERTS(_name, _from, _to, _cycles, _clk) \
       `FALL_ASSERT(_name, _from, _to, _cycles, _clk) \

--- a/hw/ip/rstmgr/dv/tb.sv
+++ b/hw/ip/rstmgr/dv/tb.sv
@@ -100,17 +100,17 @@ module tb;
     .pwr_i(rstmgr_if.pwr_i),
     .pwr_o(rstmgr_if.pwr_o),
 
+    .sw_rst_req_o(rstmgr_if.sw_rst_req_o),
     .rst_cpu_n_i(rstmgr_if.cpu_i.rst_cpu_n),
     .ndmreset_req_i(rstmgr_if.cpu_i.ndmreset_req),
 
     .alert_dump_i(rstmgr_if.alert_dump_i),
-
     .cpu_dump_i(rstmgr_if.cpu_dump_i),
-
-    .rst_en_o(),
 
     .scan_rst_ni(rstmgr_if.scan_rst_ni),
     .scanmode_i(rstmgr_if.scanmode_i),
+
+    .rst_en_o(rstmgr_if.rst_en_o),
     .resets_o(rstmgr_if.resets_o)
   );
 


### PR DESCRIPTION
Make changes to the base vseq class to help the reset test.
Other minor fixes in rstmgr dv.

Signed-off-by: Guillermo Maturana <maturana@google.com>