### PR TITLE
[dv/pwrmgr] Add stress test

### DIFF
--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_reset_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_wakeup_reset_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_wakeup_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_lowpower_wakeup_race_vseq.sv
@@ -31,8 +31,8 @@ class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
     wakeups_t prior_reasons = '0;
     bit prior_fall_through = '0;
     bit prior_abort = '0;
+    wait_for_fast_fsm_active();
 
-    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
     check_wake_status('0);
     for (int i = 0; i < num_trans; ++i) begin
       `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
@@ -114,12 +114,14 @@ class pwrmgr_lowpower_wakeup_race_vseq extends pwrmgr_base_vseq;
       // will remain active, preventing the device from going to sleep.
       cfg.pwrmgr_vif.update_wakeups('0);
       cfg.slow_clk_rst_vif.wait_clks(10);
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
       check_wake_status('0);
 
       // Wait for interrupt to be generated whether or not it is enabled.
       cfg.slow_clk_rst_vif.wait_clks(10);
       check_and_clear_interrupt(.expected(1'b1));
     end
+    clear_wake_info();
   endtask
 
 endclass : pwrmgr_lowpower_wakeup_race_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_reset_vseq.sv
@@ -23,8 +23,8 @@ class pwrmgr_reset_vseq extends pwrmgr_base_vseq;
   task body();
     logic [TL_DW-1:0] value;
     resets_t enabled_resets;
+    wait_for_fast_fsm_active();
 
-    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
     check_reset_status('0);
     for (int i = 0; i < num_trans; ++i) begin
       `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
@@ -74,6 +74,7 @@ class pwrmgr_reset_vseq extends pwrmgr_base_vseq;
       // And check interrupt is not set.
       check_and_clear_interrupt(.expected(1'b0));
     end
+    clear_wake_info();
   endtask
 
 endclass : pwrmgr_reset_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_smoke_vseq.sv
@@ -29,9 +29,10 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
     logic [TL_DW-1:0] value;
     wakeups_t wakeup_en;
     resets_t reset_en;
+    wait_for_fast_fsm_active();
     set_nvms_idle();
     setup_interrupt(.enable(1'b1));
-    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
+
     check_wake_status('0);
     check_reset_status('0);
 
@@ -55,6 +56,9 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
 
     check_wake_status(wakeups & wakeup_en);
     check_reset_status('0);
+    // And make the cpu active.
+    cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
+
     cfg.pwrmgr_vif.update_wakeups('0);
     check_and_clear_interrupt(.expected(1'b1));
 
@@ -76,6 +80,7 @@ class pwrmgr_smoke_vseq extends pwrmgr_base_vseq;
     // should have been reset, so the incoming reset should have cleared.
     check_reset_status('0);
     check_wake_status('0);
+    clear_wake_info();
 
     // Wait for interrupt to be generated whether or not it is enabled.
     cfg.slow_clk_rst_vif.wait_clks(10);

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_stress_all_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_stress_all_vseq.sv
@@ -1,0 +1,44 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all pwrmgr seqs (except below seqs) in one seq to run sequentially
+// 1. csr seq, which requires scb to be disabled
+class pwrmgr_stress_all_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_stress_all_vseq)
+
+  `uvm_object_new
+
+  task body();
+    string seq_names[] = {
+      "pwrmgr_aborted_low_power_vseq",
+      "pwrmgr_lowpower_wakeup_race_vseq",
+      "pwrmgr_reset_vseq",
+      "pwrmgr_smoke_vseq",
+      "pwrmgr_wakeup_reset_vseq",
+      "pwrmgr_wakeup_vseq"
+    };
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence     seq;
+      pwrmgr_base_vseq pwrmgr_vseq;
+      uint             seq_idx = $urandom_range(0, seq_names.size - 1);
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(pwrmgr_vseq, seq)
+
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_apply_reset) pwrmgr_vseq.do_apply_reset = $urandom_range(0, 1);
+      else pwrmgr_vseq.do_apply_reset = 0;
+      pwrmgr_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(pwrmgr_vseq)
+      `uvm_info(`gfn, $sformatf("seq_idx = %0d, sequence is %0s", seq_idx, pwrmgr_vseq.get_name()),
+                UVM_MEDIUM)
+
+      pwrmgr_vseq.start(p_sequencer);
+      `uvm_info(`gfn, $sformatf(
+                "End of sequence %0s with seq_idx = %0d", pwrmgr_vseq.get_name(), seq_idx),
+                UVM_MEDIUM)
+    end
+  endtask : body
+endclass

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -7,6 +7,7 @@
 `include "pwrmgr_lowpower_wakeup_race_vseq.sv"
 `include "pwrmgr_reset_vseq.sv"
 `include "pwrmgr_smoke_vseq.sv"
+`include "pwrmgr_stress_all_vseq.sv"
 `include "pwrmgr_wakeup_reset_vseq.sv"
 `include "pwrmgr_wakeup_vseq.sv"
 `include "pwrmgr_common_vseq.sv"

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_reset_vseq.sv
@@ -41,8 +41,8 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
     logic [TL_DW-1:0] value;
     resets_t enabled_resets;
     wakeups_t enabled_wakeups;
+    wait_for_fast_fsm_active();
 
-    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
     check_reset_status('0);
     check_wake_status('0);
     for (int i = 0; i < num_trans; ++i) begin
@@ -150,7 +150,10 @@ class pwrmgr_wakeup_reset_vseq extends pwrmgr_base_vseq;
       // Clear hardware resets: if they are enabled they are cleared when rst_lc_req[1] goes active,
       // but this makes sure they are cleared even if none is enabled for the next round.
       cfg.pwrmgr_vif.update_resets('0);
+      // And make the cpu active.
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
     end
+    clear_wake_info();
   endtask
 
 endclass : pwrmgr_wakeup_reset_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_wakeup_vseq.sv
@@ -25,7 +25,7 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
     bit prior_fall_through = '0;
     bit prior_abort = '0;
 
-    cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));
+    wait_for_fast_fsm_active();
     check_wake_status('0);
     for (int i = 0; i < num_trans; ++i) begin
       `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
@@ -101,10 +101,14 @@ class pwrmgr_wakeup_vseq extends pwrmgr_base_vseq;
       cfg.slow_clk_rst_vif.wait_clks(10);
       check_wake_status('0);
 
+      // And make the cpu active.
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
+
       // Wait for interrupt to be generated whether or not it is enabled.
       cfg.slow_clk_rst_vif.wait_clks(10);
       check_and_clear_interrupt(.expected(1'b1));
     end
+    clear_wake_info();
   endtask
 
 endclass : pwrmgr_wakeup_vseq

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -31,7 +31,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
-                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Overrides


### PR DESCRIPTION
Fix other tests so they don't break stress test, typically due to
lingering state.
Fix other dv corner-cases found in the process.

Signed-off-by: Guillermo Maturana <maturana@google.com>