### PR TITLE
[usbdev] Fix up packet responses for compliance

### DIFF
--- a/hw/dv/dpi/usbdpi/usbdpi.h
+++ b/hw/dv/dpi/usbdpi/usbdpi.h
@@ -99,11 +99,37 @@
 extern "C" {
 #endif
 
+typedef enum usbdpi_bus_state {
+  kUsbIdle,
+  kUsbControlSetup,
+  kUsbControlSetupAck,
+  kUsbControlDataOut,
+  kUsbControlDataOutAck,
+  kUsbControlStatusInToken,
+  kUsbControlStatusInData,
+  kUsbControlStatusInAck,
+  kUsbControlDataInToken,
+  kUsbControlDataInData,
+  kUsbControlDataInAck,
+  kUsbControlStatusOut,
+  kUsbControlStatusOutAck,
+  kUsbIsoToken,
+  kUsbIsoDataIn,
+  kUsbIsoDataOut,
+  kUsbBulkOut,
+  kUsbBulkOutAck,
+  kUsbBulkInToken,
+  kUsbBulkInData,
+  kUsbBulkInAck,
+} usbdpi_bus_state_t;
+
 struct usbdpi_ctx {
+  usbdpi_bus_state_t bus_state;
   int loglevel;
   FILE *mon_file;
   char mon_pathname[PATH_MAX];
   void *mon;
+  int retries;
   int last_pu;
   int lastrxpid;
   int tick;

--- a/hw/dv/dpi/usbdpi/usbdpi.sv
+++ b/hw/dv/dpi/usbdpi/usbdpi.sv
@@ -52,6 +52,7 @@ module usbdpi #(
 
   initial begin
     ctx = usbdpi_create(NAME, LOG_LEVEL);
+    sense_p2d = 1'b0;
   end
 
   final begin
@@ -72,7 +73,7 @@ module usbdpi #(
 
   assign d2p = {dp_d2p, dp_en_d2p, dn_d2p, dn_en_d2p, d_d2p, d_en_d2p, se0_d2p, se0_en_d2p, pullupdp_d2p & pullupdp_en_d2p, pullupdn_d2p & pullupdn_en_d2p, txmode_d2p & txmode_en_d2p};
   always_ff @(posedge clk_48MHz_i) begin
-    if (pullup_detect) begin
+    if (!sense_p2d || pullup_detect) begin
       automatic byte p2d = usbdpi_host_to_device(ctx, d2p);
       d_int <= p2d[3];
       dp_int <= p2d[2];
@@ -87,7 +88,6 @@ module usbdpi #(
       d_int <= 0;
       dp_int <= 0;
       dn_int <= 0;
-      sense_p2d <= 0;
     end
   end
 

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
@@ -15,8 +15,13 @@
 module usb_fs_nb_in_pe #(
   parameter logic [4:0] NumInEps = 12,
   parameter int unsigned MaxInPktSizeByte = 32,
+  // Targeting 17 bit times for the timeout. The counter runs on the 48 MHz
+  // clock, the SOP delay to rx_pkt_start_i is 3 bit times, and the EOP delay
+  // to tx_pkt_end_i is essentially 0.
+  parameter int unsigned AckTimeoutCnt = (17 + 3) * 4,
   localparam int unsigned InEpW = $clog2(NumInEps), // derived parameter
-  localparam int unsigned PktW = $clog2(MaxInPktSizeByte) // derived parameter
+  localparam int unsigned PktW = $clog2(MaxInPktSizeByte), // derived parameter
+  localparam int unsigned AckTimeoutCntW = $clog2(AckTimeoutCnt) // derived parameter
 ) (
   input  logic               clk_48mhz_i,
   input  logic               rst_ni,
@@ -29,10 +34,11 @@ module usb_fs_nb_in_pe #(
   ////////////////////
   output logic [3:0]            in_ep_current_o, // Other signals addressed to this ep
   output logic                  in_ep_rollback_o, // Bad termination, rollback transaction
-  output logic                  in_ep_xfr_end_o, // good termination, transaction complete
+  output logic                  in_ep_xact_end_o, // good termination, transaction complete
   output logic [PktW - 1:0]     in_ep_get_addr_o, // Offset requested (0..pktlen)
   output logic                  in_ep_data_get_o, // Accept data (get_addr advances too)
   output logic                  in_ep_newpkt_o, // New IN packet starting (updates in_ep_current_o)
+  input  logic [NumInEps-1:0]   in_ep_enabled_i, // Endpoint is enabled and produces handshakes
   input  logic [NumInEps-1:0]   in_ep_stall_i, // Endpoint in a stall state
   input  logic [NumInEps-1:0]   in_ep_has_data_i, // Endpoint has data to supply
   input  logic [7:0]            in_ep_data_i, // Data for current get_addr
@@ -70,30 +76,28 @@ module usb_fs_nb_in_pe #(
   input  logic              tx_data_get_i,
   output logic [7:0]        tx_data_o
 );
-  // suppress warnings
-  logic                      unused_1, unused_2;
-  assign unused_1 = tx_pkt_end_i;
-  assign unused_2 = rx_pkt_start_i;
 
   ////////////////////////////////////////////////////////////////////////////////
-  // in transfer state machine
+  // in transaction state machine
   ////////////////////////////////////////////////////////////////////////////////
 
   import usb_consts_pkg::*;
 
-  typedef enum logic [1:0] {
+  typedef enum logic [2:0] {
     StIdle,
     StRcvdIn,
     StSendData,
+    StWaitTxEnd,
+    StWaitAckStart,
     StWaitAck
   } state_in_e;
 
-  state_in_e  in_xfr_state;
-  state_in_e  in_xfr_state_next;
+  state_in_e  in_xact_state;
+  state_in_e  in_xact_state_next;
 
-  logic in_xfr_end;
+  logic in_xact_end;
 
-  assign in_ep_xfr_end_o = in_xfr_end;
+  assign in_ep_xact_end_o = in_xact_end;
 
   // data toggle state
   logic [NumInEps-1:0] data_toggle_q, data_toggle_d;
@@ -101,7 +105,7 @@ module usb_fs_nb_in_pe #(
   // endpoint data buffer
   logic       token_received, setup_token_received, in_token_received, ack_received;
   logic       more_data_to_send;
-  logic       ep_impl_d, ep_impl_q;
+  logic       ep_in_hw, ep_active;
   logic [3:0] in_ep_current_d;
 
   // More syntax so can compare with enum
@@ -109,9 +113,6 @@ module usb_fs_nb_in_pe #(
   usb_pid_e      rx_pid;
   assign rx_pid_type = usb_pid_type_e'(rx_pid_i[1:0]);
   assign rx_pid      = usb_pid_e'(rx_pid_i);
-
-  // Is the specified endpoint actually implemented?
-  assign ep_impl_d = {1'b0, rx_endp_i} < NumInEps;
 
   assign token_received =
     rx_pkt_end_i &&
@@ -132,104 +133,142 @@ module usb_fs_nb_in_pe #(
     rx_pkt_valid_i &&
     rx_pid == UsbPidAck;
 
-  assign in_ep_current_d = ep_impl_d ? rx_endp_i : '0;
+  // Is the specified endpoint actually implemented in hardware?
+  assign ep_in_hw = {1'b0, rx_endp_i} < NumInEps;
+  assign in_ep_current_d = ep_in_hw ? rx_endp_i : '0;
 
   // Make widths work - in_ep_current_d/in_ep_current_o only hold implemented endpoint IDs.
   // These signals can be used to index signals of NumInEps width.
-  // They are only valid if ep_impl_d/q are set, i.e., if the specified endpoint is implemented.
+  // They are only valid if ep_active is set, i.e., if the specified endpoint is implemented.
   logic [InEpW-1:0] in_ep_index;
   logic [InEpW-1:0] in_ep_index_d;
   assign in_ep_index   = in_ep_current_o[0 +: InEpW];
   assign in_ep_index_d = in_ep_current_d[0 +: InEpW];
 
-  assign more_data_to_send = ep_impl_q &
+  // Is the endpoint active?
+  assign ep_active = in_ep_enabled_i[in_ep_index_d] & ep_in_hw;
+
+  assign more_data_to_send =
       in_ep_has_data_i[in_ep_index] & ~in_ep_data_done_i[in_ep_index];
 
-  assign tx_data_avail_o = logic'(in_xfr_state == StSendData) & more_data_to_send;
+  assign tx_data_avail_o = logic'(in_xact_state == StSendData) & more_data_to_send;
 
   ////////////////////////////////////////////////////////////////////////////////
-  // in transfer state machine
+  // in transaction state machine
   ////////////////////////////////////////////////////////////////////////////////
 
-  logic rollback_in_xfr;
+  logic [AckTimeoutCntW-1:0] timeout_cntdown_d, timeout_cntdown_q;
+  logic rollback_in_xact;
 
   always_comb begin
-    in_xfr_state_next = in_xfr_state;
-    in_xfr_end = 1'b0;
+    in_xact_state_next = in_xact_state;
+    in_xact_end = 1'b0;
     tx_pkt_start_o = 1'b0;
     tx_pid_o = 4'b0000;
-    rollback_in_xfr = 1'b0;
-    unique case (in_xfr_state)
+    rollback_in_xact = 1'b0;
+    timeout_cntdown_d = AckTimeoutCnt[AckTimeoutCntW-1:0];
+    unique case (in_xact_state)
       StIdle: begin
-        if (in_token_received) begin
-          in_xfr_state_next = StRcvdIn;
+        if (ep_active && in_token_received) begin
+          in_xact_state_next = StRcvdIn;
         end else begin
-          in_xfr_state_next = StIdle;
+          // Ignore tokens to inactive endpoints. Send no response.
+          in_xact_state_next = StIdle;
         end
       end
 
       StRcvdIn: begin
-        tx_pkt_start_o = 1'b1; // Need to transmit NACK/STALL or DATA
+        tx_pkt_start_o = 1'b1; // Need to transmit NAK/STALL or DATA
 
-        if (!ep_impl_q || in_ep_stall_i[in_ep_index]) begin
-          // We only send STALL for IN transfers if the specified EP:
-          // - is not implemented,
-          // - is not set up.
-          in_xfr_state_next = StIdle;
-          tx_pid_o = {UsbPidStall}; // STALL
-        end else if (in_ep_iso_i[in_ep_index]) begin
+        if (in_ep_iso_i[in_ep_index]) begin
           // ISO endpoint
           // We always need to transmit. When no data is available, we send
-          // a zero-length packet
-          in_xfr_state_next = StSendData;
-          tx_pid_o = {data_toggle_q[in_ep_index], 1'b0, {UsbPidTypeData}}; // DATA0/1
-
+          // a zero-length packet.
+          // DATA0 always for full-speed isochronous endpoints
+          in_xact_state_next = StSendData;
+          tx_pid_o = {UsbPidData0};
+        end else if (in_ep_stall_i[in_ep_index]) begin
+          in_xact_state_next = StIdle;
+          tx_pid_o = {UsbPidStall}; // STALL
         end else if (in_ep_has_data_i[in_ep_index]) begin
-          in_xfr_state_next = StSendData;
+          in_xact_state_next = StSendData;
           tx_pid_o = {data_toggle_q[in_ep_index], 1'b0, {UsbPidTypeData}}; // DATA0/1
         end else begin
-          in_xfr_state_next = StIdle;
+          in_xact_state_next = StIdle;
           tx_pid_o = {UsbPidNak}; // NAK
         end
       end
 
       StSendData: begin
-        // Note an unimplemented EP will never send data, no need to check ep_impl_q here.
         // Use &in_ep_get_addr so width can vary, looking for all ones
         if ((!more_data_to_send) || ((&in_ep_get_addr_o) && tx_data_get_i)) begin
           if (in_ep_iso_i[in_ep_index]) begin
-            in_xfr_state_next = StIdle; // no ACK for ISO EPs
-            in_xfr_end = 1'b1;
+            in_xact_state_next = StIdle; // no ACK for ISO EPs
+            in_xact_end = 1'b1;
           end else begin
-            in_xfr_state_next = StWaitAck;
+            if (tx_pkt_end_i) begin
+              in_xact_state_next = StWaitAckStart;
+            end else begin
+              in_xact_state_next = StWaitTxEnd;
+            end
           end
         end else begin
-          in_xfr_state_next = StSendData;
+          in_xact_state_next = StSendData;
+        end
+      end
+
+      StWaitTxEnd: begin
+        if (tx_pkt_end_i) begin
+          in_xact_state_next = StWaitAckStart;
+        end
+      end
+
+      StWaitAckStart: begin
+        // The spec says we have up to 18 bit times to wait for the host
+        // response. If it doesn't arrive in time, we must invalidate the
+        // transaction.
+        timeout_cntdown_d = timeout_cntdown_q - 1'b1;
+
+        if (rx_pkt_start_i) begin
+          in_xact_state_next = StWaitAck;
+        end else if (timeout_cntdown_q == '0) begin
+          in_xact_state_next = StIdle;
+          rollback_in_xact = 1'b1;
+        end else begin
+          in_xact_state_next = StWaitAckStart;
         end
       end
 
       StWaitAck: begin
-        // FIXME: need to handle smash/timeout
         if (ack_received) begin
-          in_xfr_state_next = StIdle;
-          in_xfr_end = 1'b1;
+          in_xact_state_next = StIdle;
+          in_xact_end = 1'b1;
         end else if (in_token_received) begin
-          in_xfr_state_next = StRcvdIn;
-          rollback_in_xfr = 1'b1;
+          in_xact_state_next = StRcvdIn;
+          rollback_in_xact = 1'b1;
         end else if (rx_pkt_end_i) begin
-          in_xfr_state_next = StIdle;
-          rollback_in_xfr = 1'b1;
+          in_xact_state_next = StIdle;
+          rollback_in_xact = 1'b1;
         end else begin
-          in_xfr_state_next = StWaitAck;
+          in_xact_state_next = StWaitAck;
         end
       end
 
-      default: in_xfr_state_next = StIdle;
+      default: in_xact_state_next = StIdle;
     endcase
   end
 
-  `ASSERT(InXfrStateValid_A,
-    in_xfr_state inside {StIdle, StRcvdIn, StSendData, StWaitAck}, clk_48mhz_i)
+  `ASSERT(InXactStateValid_A,
+    in_xact_state inside {StIdle, StRcvdIn, StSendData, StWaitTxEnd, StWaitAckStart, StWaitAck},
+    clk_48mhz_i)
+
+  always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      timeout_cntdown_q <= AckTimeoutCnt[AckTimeoutCntW-1:0];
+    end else begin
+      timeout_cntdown_q <= timeout_cntdown_d;
+    end
+  end
 
   always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -242,14 +281,14 @@ module usb_fs_nb_in_pe #(
 
   always_ff @(posedge clk_48mhz_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      in_xfr_state <= StIdle;
+      in_xact_state <= StIdle;
       in_ep_rollback_o <= 1'b0;
     end else if (link_reset_i) begin
-      in_xfr_state <= StIdle;
+      in_xact_state <= StIdle;
       in_ep_rollback_o <= 1'b0;
     end else begin
-      in_xfr_state <= in_xfr_state_next;
-      in_ep_rollback_o <= rollback_in_xfr;
+      in_xact_state <= in_xact_state_next;
+      in_ep_rollback_o <= rollback_in_xact;
     end
   end
 
@@ -257,9 +296,9 @@ module usb_fs_nb_in_pe #(
     if (!rst_ni) begin
       in_ep_get_addr_o <= '0;
     end else begin
-      if (in_xfr_state == StIdle) begin
+      if (in_xact_state == StIdle) begin
         in_ep_get_addr_o <= '0;
-      end else if ((in_xfr_state == StSendData) && tx_data_get_i) begin
+      end else if ((in_xact_state == StSendData) && tx_data_get_i) begin
         in_ep_get_addr_o <= in_ep_get_addr_o + 1'b1;
       end
     end
@@ -269,12 +308,10 @@ module usb_fs_nb_in_pe #(
     if (!rst_ni) begin
       in_ep_newpkt_o <= 1'b0;
       in_ep_current_o <= '0;
-      ep_impl_q <= 1'b0;
     end else begin
       if (in_token_received) begin
         in_ep_current_o <= in_ep_current_d;
         in_ep_newpkt_o <= 1'b1;
-        ep_impl_q <= ep_impl_d;
       end else begin
         in_ep_newpkt_o <= 1'b0;
       end
@@ -284,9 +321,9 @@ module usb_fs_nb_in_pe #(
   always_comb begin : proc_data_toggle_d
     data_toggle_d = data_toggle_q;
 
-    if (setup_token_received && ep_impl_d) begin
+    if (setup_token_received && ep_active) begin
       data_toggle_d[in_ep_index_d] = 1'b1;
-    end else if ((in_xfr_state == StWaitAck) && ack_received && ep_impl_q) begin
+    end else if ((in_xact_state == StWaitAck) && ack_received) begin
       data_toggle_d[in_ep_index] = ~data_toggle_q[in_ep_index];
     end
 
@@ -307,7 +344,7 @@ module usb_fs_nb_in_pe #(
     if (!rst_ni) begin
       in_ep_data_get_o <= 1'b0;
     end else begin
-      if ((in_xfr_state == StSendData) && tx_data_get_i) begin
+      if ((in_xact_state == StSendData) && tx_data_get_i) begin
         in_ep_data_get_o <= 1'b1;
       end else begin
         in_ep_data_get_o <= 1'b0;

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -46,6 +46,8 @@ module usb_fs_nb_pe #(
   output logic                   out_ep_acked_o, // good termination, device has acked
   output logic                   out_ep_rollback_o, // bad termination, discard data
   output logic [NumOutEps-1:0]   out_ep_setup_o,
+  input  logic [NumOutEps-1:0]   out_ep_enabled_i, // Endpoint is enabled and produces handshakes
+  input  logic [NumOutEps-1:0]   out_ep_control_i, // Is a control endpoint: Accepts SETUP packets
   input  logic [NumOutEps-1:0]   out_ep_full_i, // Cannot accept data
   input  logic [NumOutEps-1:0]   out_ep_stall_i, // Stalled
   input  logic [NumOutEps-1:0]   out_ep_iso_i, // Configure endpoint in isochronous mode
@@ -53,10 +55,11 @@ module usb_fs_nb_pe #(
   // in endpoint interfaces
   output logic [3:0]             in_ep_current_o, // Other signals addressed to this ep
   output logic                   in_ep_rollback_o, // Bad termination, rollback transaction
-  output logic                   in_ep_xfr_end_o, // good termination, transaction complete
+  output logic                   in_ep_xact_end_o, // good termination, transaction complete
   output logic [PktW - 1:0]      in_ep_get_addr_o, // Offset requested (0..pktlen)
   output logic                   in_ep_data_get_o, // Accept data (get_addr advances too)
   output logic                   in_ep_newpkt_o, // New IN pkt start (with in_ep_current_o update)
+  input  logic [NumInEps-1:0]    in_ep_enabled_i, // Endpoint is enabled and produces handshakes
   input  logic [NumInEps-1:0]    in_ep_stall_i, // Endpoint in a stall state
   input  logic [NumInEps-1:0]    in_ep_has_data_i, // Endpoint has data to supply
   input  logic [7:0]             in_ep_data_i, // Data for current get_addr
@@ -137,10 +140,11 @@ module usb_fs_nb_pe #(
     // endpoint interface
     .in_ep_current_o       (in_ep_current_o),
     .in_ep_rollback_o      (in_ep_rollback_o),
-    .in_ep_xfr_end_o       (in_ep_xfr_end_o),
+    .in_ep_xact_end_o      (in_ep_xact_end_o),
     .in_ep_get_addr_o      (in_ep_get_addr_o),
     .in_ep_data_get_o      (in_ep_data_get_o),
     .in_ep_newpkt_o        (in_ep_newpkt_o),
+    .in_ep_enabled_i       (in_ep_enabled_i),
     .in_ep_stall_i         (in_ep_stall_i),
     .in_ep_has_data_i      (in_ep_has_data_i),
     .in_ep_data_i          (in_ep_data_i),
@@ -184,6 +188,8 @@ module usb_fs_nb_pe #(
     .out_ep_acked_o         (out_ep_acked_o),
     .out_ep_rollback_o      (out_ep_rollback_o),
     .out_ep_setup_o         (out_ep_setup_o),
+    .out_ep_enabled_i       (out_ep_enabled_i),
+    .out_ep_control_i       (out_ep_control_i),
     .out_ep_full_i          (out_ep_full_i),
     .out_ep_stall_i         (out_ep_stall_i),
     .out_ep_iso_i           (out_ep_iso_i),

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -223,6 +223,50 @@
         }
       ]
     }
+    { multireg: {
+        name: "ep_out_enable",
+        count: "NEndpoints"
+        cname: "Endpoint"
+        desc: '''
+              Enable an endpoint to respond to transactions in the downstream direction.
+              Note that as the default endpoint, endpoint 0 must be enabled in both the IN and OUT directions before enabling the USB interface to connect.
+              '''
+        swaccess: "rw",
+        hwaccess: "hro",
+        fields: [
+          {
+            bits: "0",
+            name: "enable",
+            desc: '''
+                  This bit must be set to enable downstream transactions to be received on the endpoint and elicit responses.
+                  If the bit is clear, any SETUP or OUT packets sent to the endpoint will be ignored.
+                  '''
+          }
+        ]
+      }
+    }
+    { multireg: {
+        name: "ep_in_enable",
+        count: "NEndpoints"
+        cname: "Endpoint"
+        desc: '''
+              Enable an endpoint to respond to transactions in the upstream direction.
+              Note that as the default endpoint, endpoint 0 must be enabled in both the IN and OUT directions before enabling the USB interface to connect.
+              '''
+        swaccess: "rw",
+        hwaccess: "hro",
+        fields: [
+           {
+            bits: "0",
+            name: "enable",
+            desc: '''
+                  This bit must be set to enable upstream transactions to be received on the endpoint and elicit responses.
+                  If the bit is clear then any IN packets sent to the endpoint will be ignored.
+                  '''
+          }
+        ]
+      }
+    }
     { name: "usbstat",
       desc: "USB Status",
       swaccess: "ro",
@@ -396,7 +440,8 @@
             desc: '''
                   This bit must be set to enable SETUP transactions to be
                   received on the endpoint. If the bit is clear then a
-                  SETUP request will be responded to with a NACK.
+                  SETUP packet will be ignored. The bit should be set for
+                  control endpoints (and only control endpoints).
                   '''
           }
         ]
@@ -416,7 +461,8 @@
             desc: '''
                   This bit must be set to enable OUT transactions to be
                   received on the endpoint. If the bit is clear then an
-                  OUT request will be responded to with a NACK.
+                  OUT request will be responded to with a NAK, if the endpoint
+                  is enabled.
                   '''
           }
         ]
@@ -443,20 +489,44 @@
       }
     }
     { multireg: {
-        name: "stall",
+        name: "out_stall",
         count: "NEndpoints"
         cname: "Endpoint"
-        desc: "Endpoint STALL control",
+        desc: "OUT Endpoint STALL control",
         swaccess: "rw",
         hwaccess: "hrw",
         fields: [
           {
             bits: "0",
-            name: "stall",
+            name: "endpoint",
             desc: '''
-                  If this bit is set then an IN or OUT transaction to this endpoint will be responded to with a STALL return.
-                  This is used when the endpoint is disabled (functional stall) or when a control transfer is not supported (protocol stall).
-                  SETUP transactions are always accepted and a SETUP will clear the stall flag (this is necessary for protocol stalls, to avoid sending stalls on subsequent IN/OUT transfers).
+                  If this bit is set then an OUT transaction to this endpoint will elicit a STALL handshake, when a non-isochronous endpoint is enabled.
+                  If the configuration has both STALL and NAK enabled, the STALL handshake will take priority.
+
+                  Note that SETUP transactions are always either accepted or ignored.
+                  For endpoints that accept SETUP transactions, a SETUP packet will clear the STALL flag on endpoints for both the IN and OUT directions.
+                  '''
+          }
+        ]
+      }
+    }
+    { multireg: {
+        name: "in_stall",
+        count: "NEndpoints"
+        cname: "Endpoint"
+        desc: "IN Endpoint STALL control",
+        swaccess: "rw",
+        hwaccess: "hrw",
+        fields: [
+          {
+            bits: "0",
+            name: "endpoint",
+            desc: '''
+                  If this bit is set then an IN transaction to this endpoint will elicit a STALL handshake, when a non-isochronous endpoint is enabled.
+                  If the configuration has both STALL and NAK enabled, the STALL handshake will take priority.
+
+                  Note that SETUP transactions are always either accepted or ignored.
+                  For endpoints that accept SETUP transactions, a SETUP packet will clear the STALL flag on endpoints for both the IN and OUT directions.
                   '''
           }
         ]

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -211,6 +211,14 @@ package usbdev_reg_pkg;
   } usbdev_reg2hw_usbctrl_reg_t;
 
   typedef struct packed {
+    logic        q;
+  } usbdev_reg2hw_ep_out_enable_mreg_t;
+
+  typedef struct packed {
+    logic        q;
+  } usbdev_reg2hw_ep_in_enable_mreg_t;
+
+  typedef struct packed {
     logic [4:0]  q;
     logic        qe;
   } usbdev_reg2hw_avbuffer_reg_t;
@@ -244,7 +252,11 @@ package usbdev_reg_pkg;
 
   typedef struct packed {
     logic        q;
-  } usbdev_reg2hw_stall_mreg_t;
+  } usbdev_reg2hw_out_stall_mreg_t;
+
+  typedef struct packed {
+    logic        q;
+  } usbdev_reg2hw_in_stall_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -461,7 +473,12 @@ package usbdev_reg_pkg;
   typedef struct packed {
     logic        d;
     logic        de;
-  } usbdev_hw2reg_stall_mreg_t;
+  } usbdev_hw2reg_out_stall_mreg_t;
+
+  typedef struct packed {
+    logic        d;
+    logic        de;
+  } usbdev_hw2reg_in_stall_mreg_t;
 
   typedef struct packed {
     struct packed {
@@ -514,16 +531,19 @@ package usbdev_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    usbdev_reg2hw_intr_state_reg_t intr_state; // [362:346]
-    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [345:329]
-    usbdev_reg2hw_intr_test_reg_t intr_test; // [328:295]
-    usbdev_reg2hw_alert_test_reg_t alert_test; // [294:293]
-    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [292:285]
-    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [284:279]
-    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [278:258]
-    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [257:246]
-    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [245:234]
-    usbdev_reg2hw_stall_mreg_t [11:0] stall; // [233:222]
+    usbdev_reg2hw_intr_state_reg_t intr_state; // [398:382]
+    usbdev_reg2hw_intr_enable_reg_t intr_enable; // [381:365]
+    usbdev_reg2hw_intr_test_reg_t intr_test; // [364:331]
+    usbdev_reg2hw_alert_test_reg_t alert_test; // [330:329]
+    usbdev_reg2hw_usbctrl_reg_t usbctrl; // [328:321]
+    usbdev_reg2hw_ep_out_enable_mreg_t [11:0] ep_out_enable; // [320:309]
+    usbdev_reg2hw_ep_in_enable_mreg_t [11:0] ep_in_enable; // [308:297]
+    usbdev_reg2hw_avbuffer_reg_t avbuffer; // [296:291]
+    usbdev_reg2hw_rxfifo_reg_t rxfifo; // [290:270]
+    usbdev_reg2hw_rxenable_setup_mreg_t [11:0] rxenable_setup; // [269:258]
+    usbdev_reg2hw_rxenable_out_mreg_t [11:0] rxenable_out; // [257:246]
+    usbdev_reg2hw_out_stall_mreg_t [11:0] out_stall; // [245:234]
+    usbdev_reg2hw_in_stall_mreg_t [11:0] in_stall; // [233:222]
     usbdev_reg2hw_configin_mreg_t [11:0] configin; // [221:54]
     usbdev_reg2hw_iso_mreg_t [11:0] iso; // [53:42]
     usbdev_reg2hw_data_toggle_clear_mreg_t [11:0] data_toggle_clear; // [41:18]
@@ -534,12 +554,13 @@ package usbdev_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [192:159]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [158:151]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [150:127]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [126:110]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [109:86]
-    usbdev_hw2reg_stall_mreg_t [11:0] stall; // [85:62]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [216:183]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [182:175]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [174:151]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [150:134]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [133:110]
+    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [109:86]
+    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [85:62]
     usbdev_hw2reg_configin_mreg_t [11:0] configin; // [61:14]
     usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [13:4]
     usbdev_hw2reg_wake_debug_reg_t wake_debug; // [3:0]
@@ -551,32 +572,35 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_INTR_TEST_OFFSET = 12'h 8;
   parameter logic [BlockAw-1:0] USBDEV_ALERT_TEST_OFFSET = 12'h c;
   parameter logic [BlockAw-1:0] USBDEV_USBCTRL_OFFSET = 12'h 10;
-  parameter logic [BlockAw-1:0] USBDEV_USBSTAT_OFFSET = 12'h 14;
-  parameter logic [BlockAw-1:0] USBDEV_AVBUFFER_OFFSET = 12'h 18;
-  parameter logic [BlockAw-1:0] USBDEV_RXFIFO_OFFSET = 12'h 1c;
-  parameter logic [BlockAw-1:0] USBDEV_RXENABLE_SETUP_OFFSET = 12'h 20;
-  parameter logic [BlockAw-1:0] USBDEV_RXENABLE_OUT_OFFSET = 12'h 24;
-  parameter logic [BlockAw-1:0] USBDEV_IN_SENT_OFFSET = 12'h 28;
-  parameter logic [BlockAw-1:0] USBDEV_STALL_OFFSET = 12'h 2c;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_0_OFFSET = 12'h 30;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_1_OFFSET = 12'h 34;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_2_OFFSET = 12'h 38;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_3_OFFSET = 12'h 3c;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_4_OFFSET = 12'h 40;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_5_OFFSET = 12'h 44;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_6_OFFSET = 12'h 48;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_7_OFFSET = 12'h 4c;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_8_OFFSET = 12'h 50;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_9_OFFSET = 12'h 54;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_10_OFFSET = 12'h 58;
-  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_11_OFFSET = 12'h 5c;
-  parameter logic [BlockAw-1:0] USBDEV_ISO_OFFSET = 12'h 60;
-  parameter logic [BlockAw-1:0] USBDEV_DATA_TOGGLE_CLEAR_OFFSET = 12'h 64;
-  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_SENSE_OFFSET = 12'h 68;
-  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 6c;
-  parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 70;
-  parameter logic [BlockAw-1:0] USBDEV_WAKE_CONFIG_OFFSET = 12'h 74;
-  parameter logic [BlockAw-1:0] USBDEV_WAKE_DEBUG_OFFSET = 12'h 78;
+  parameter logic [BlockAw-1:0] USBDEV_EP_OUT_ENABLE_OFFSET = 12'h 14;
+  parameter logic [BlockAw-1:0] USBDEV_EP_IN_ENABLE_OFFSET = 12'h 18;
+  parameter logic [BlockAw-1:0] USBDEV_USBSTAT_OFFSET = 12'h 1c;
+  parameter logic [BlockAw-1:0] USBDEV_AVBUFFER_OFFSET = 12'h 20;
+  parameter logic [BlockAw-1:0] USBDEV_RXFIFO_OFFSET = 12'h 24;
+  parameter logic [BlockAw-1:0] USBDEV_RXENABLE_SETUP_OFFSET = 12'h 28;
+  parameter logic [BlockAw-1:0] USBDEV_RXENABLE_OUT_OFFSET = 12'h 2c;
+  parameter logic [BlockAw-1:0] USBDEV_IN_SENT_OFFSET = 12'h 30;
+  parameter logic [BlockAw-1:0] USBDEV_OUT_STALL_OFFSET = 12'h 34;
+  parameter logic [BlockAw-1:0] USBDEV_IN_STALL_OFFSET = 12'h 38;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_0_OFFSET = 12'h 3c;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_1_OFFSET = 12'h 40;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_2_OFFSET = 12'h 44;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_3_OFFSET = 12'h 48;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_4_OFFSET = 12'h 4c;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_5_OFFSET = 12'h 50;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_6_OFFSET = 12'h 54;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_7_OFFSET = 12'h 58;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_8_OFFSET = 12'h 5c;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_9_OFFSET = 12'h 60;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_10_OFFSET = 12'h 64;
+  parameter logic [BlockAw-1:0] USBDEV_CONFIGIN_11_OFFSET = 12'h 68;
+  parameter logic [BlockAw-1:0] USBDEV_ISO_OFFSET = 12'h 6c;
+  parameter logic [BlockAw-1:0] USBDEV_DATA_TOGGLE_CLEAR_OFFSET = 12'h 70;
+  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_SENSE_OFFSET = 12'h 74;
+  parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 78;
+  parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 7c;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_CONFIG_OFFSET = 12'h 80;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_DEBUG_OFFSET = 12'h 84;
 
   // Reset values for hwext registers and their fields
   parameter logic [16:0] USBDEV_INTR_TEST_RESVAL = 17'h 0;
@@ -615,13 +639,16 @@ package usbdev_reg_pkg;
     USBDEV_INTR_TEST,
     USBDEV_ALERT_TEST,
     USBDEV_USBCTRL,
+    USBDEV_EP_OUT_ENABLE,
+    USBDEV_EP_IN_ENABLE,
     USBDEV_USBSTAT,
     USBDEV_AVBUFFER,
     USBDEV_RXFIFO,
     USBDEV_RXENABLE_SETUP,
     USBDEV_RXENABLE_OUT,
     USBDEV_IN_SENT,
-    USBDEV_STALL,
+    USBDEV_OUT_STALL,
+    USBDEV_IN_STALL,
     USBDEV_CONFIGIN_0,
     USBDEV_CONFIGIN_1,
     USBDEV_CONFIGIN_2,
@@ -644,38 +671,41 @@ package usbdev_reg_pkg;
   } usbdev_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] USBDEV_PERMIT [31] = '{
+  parameter logic [3:0] USBDEV_PERMIT [34] = '{
     4'b 0111, // index[ 0] USBDEV_INTR_STATE
     4'b 0111, // index[ 1] USBDEV_INTR_ENABLE
     4'b 0111, // index[ 2] USBDEV_INTR_TEST
     4'b 0001, // index[ 3] USBDEV_ALERT_TEST
     4'b 0111, // index[ 4] USBDEV_USBCTRL
-    4'b 1111, // index[ 5] USBDEV_USBSTAT
-    4'b 0001, // index[ 6] USBDEV_AVBUFFER
-    4'b 0111, // index[ 7] USBDEV_RXFIFO
-    4'b 0011, // index[ 8] USBDEV_RXENABLE_SETUP
-    4'b 0011, // index[ 9] USBDEV_RXENABLE_OUT
-    4'b 0011, // index[10] USBDEV_IN_SENT
-    4'b 0011, // index[11] USBDEV_STALL
-    4'b 1111, // index[12] USBDEV_CONFIGIN_0
-    4'b 1111, // index[13] USBDEV_CONFIGIN_1
-    4'b 1111, // index[14] USBDEV_CONFIGIN_2
-    4'b 1111, // index[15] USBDEV_CONFIGIN_3
-    4'b 1111, // index[16] USBDEV_CONFIGIN_4
-    4'b 1111, // index[17] USBDEV_CONFIGIN_5
-    4'b 1111, // index[18] USBDEV_CONFIGIN_6
-    4'b 1111, // index[19] USBDEV_CONFIGIN_7
-    4'b 1111, // index[20] USBDEV_CONFIGIN_8
-    4'b 1111, // index[21] USBDEV_CONFIGIN_9
-    4'b 1111, // index[22] USBDEV_CONFIGIN_10
-    4'b 1111, // index[23] USBDEV_CONFIGIN_11
-    4'b 0011, // index[24] USBDEV_ISO
-    4'b 0011, // index[25] USBDEV_DATA_TOGGLE_CLEAR
-    4'b 0111, // index[26] USBDEV_PHY_PINS_SENSE
-    4'b 0111, // index[27] USBDEV_PHY_PINS_DRIVE
-    4'b 0001, // index[28] USBDEV_PHY_CONFIG
-    4'b 0001, // index[29] USBDEV_WAKE_CONFIG
-    4'b 0001  // index[30] USBDEV_WAKE_DEBUG
+    4'b 0011, // index[ 5] USBDEV_EP_OUT_ENABLE
+    4'b 0011, // index[ 6] USBDEV_EP_IN_ENABLE
+    4'b 1111, // index[ 7] USBDEV_USBSTAT
+    4'b 0001, // index[ 8] USBDEV_AVBUFFER
+    4'b 0111, // index[ 9] USBDEV_RXFIFO
+    4'b 0011, // index[10] USBDEV_RXENABLE_SETUP
+    4'b 0011, // index[11] USBDEV_RXENABLE_OUT
+    4'b 0011, // index[12] USBDEV_IN_SENT
+    4'b 0011, // index[13] USBDEV_OUT_STALL
+    4'b 0011, // index[14] USBDEV_IN_STALL
+    4'b 1111, // index[15] USBDEV_CONFIGIN_0
+    4'b 1111, // index[16] USBDEV_CONFIGIN_1
+    4'b 1111, // index[17] USBDEV_CONFIGIN_2
+    4'b 1111, // index[18] USBDEV_CONFIGIN_3
+    4'b 1111, // index[19] USBDEV_CONFIGIN_4
+    4'b 1111, // index[20] USBDEV_CONFIGIN_5
+    4'b 1111, // index[21] USBDEV_CONFIGIN_6
+    4'b 1111, // index[22] USBDEV_CONFIGIN_7
+    4'b 1111, // index[23] USBDEV_CONFIGIN_8
+    4'b 1111, // index[24] USBDEV_CONFIGIN_9
+    4'b 1111, // index[25] USBDEV_CONFIGIN_10
+    4'b 1111, // index[26] USBDEV_CONFIGIN_11
+    4'b 0011, // index[27] USBDEV_ISO
+    4'b 0011, // index[28] USBDEV_DATA_TOGGLE_CLEAR
+    4'b 0111, // index[29] USBDEV_PHY_PINS_SENSE
+    4'b 0111, // index[30] USBDEV_PHY_PINS_DRIVE
+    4'b 0001, // index[31] USBDEV_PHY_CONFIG
+    4'b 0001, // index[32] USBDEV_WAKE_CONFIG
+    4'b 0001  // index[33] USBDEV_WAKE_DEBUG
   };
 
 endpackage

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -257,6 +257,56 @@ module usbdev_reg_top (
   logic usbctrl_enable_wd;
   logic [6:0] usbctrl_device_address_qs;
   logic [6:0] usbctrl_device_address_wd;
+  logic ep_out_enable_we;
+  logic ep_out_enable_enable_0_qs;
+  logic ep_out_enable_enable_0_wd;
+  logic ep_out_enable_enable_1_qs;
+  logic ep_out_enable_enable_1_wd;
+  logic ep_out_enable_enable_2_qs;
+  logic ep_out_enable_enable_2_wd;
+  logic ep_out_enable_enable_3_qs;
+  logic ep_out_enable_enable_3_wd;
+  logic ep_out_enable_enable_4_qs;
+  logic ep_out_enable_enable_4_wd;
+  logic ep_out_enable_enable_5_qs;
+  logic ep_out_enable_enable_5_wd;
+  logic ep_out_enable_enable_6_qs;
+  logic ep_out_enable_enable_6_wd;
+  logic ep_out_enable_enable_7_qs;
+  logic ep_out_enable_enable_7_wd;
+  logic ep_out_enable_enable_8_qs;
+  logic ep_out_enable_enable_8_wd;
+  logic ep_out_enable_enable_9_qs;
+  logic ep_out_enable_enable_9_wd;
+  logic ep_out_enable_enable_10_qs;
+  logic ep_out_enable_enable_10_wd;
+  logic ep_out_enable_enable_11_qs;
+  logic ep_out_enable_enable_11_wd;
+  logic ep_in_enable_we;
+  logic ep_in_enable_enable_0_qs;
+  logic ep_in_enable_enable_0_wd;
+  logic ep_in_enable_enable_1_qs;
+  logic ep_in_enable_enable_1_wd;
+  logic ep_in_enable_enable_2_qs;
+  logic ep_in_enable_enable_2_wd;
+  logic ep_in_enable_enable_3_qs;
+  logic ep_in_enable_enable_3_wd;
+  logic ep_in_enable_enable_4_qs;
+  logic ep_in_enable_enable_4_wd;
+  logic ep_in_enable_enable_5_qs;
+  logic ep_in_enable_enable_5_wd;
+  logic ep_in_enable_enable_6_qs;
+  logic ep_in_enable_enable_6_wd;
+  logic ep_in_enable_enable_7_qs;
+  logic ep_in_enable_enable_7_wd;
+  logic ep_in_enable_enable_8_qs;
+  logic ep_in_enable_enable_8_wd;
+  logic ep_in_enable_enable_9_qs;
+  logic ep_in_enable_enable_9_wd;
+  logic ep_in_enable_enable_10_qs;
+  logic ep_in_enable_enable_10_wd;
+  logic ep_in_enable_enable_11_qs;
+  logic ep_in_enable_enable_11_wd;
   logic usbstat_re;
   logic [10:0] usbstat_frame_qs;
   logic usbstat_host_lost_qs;
@@ -348,31 +398,56 @@ module usbdev_reg_top (
   logic in_sent_sent_10_wd;
   logic in_sent_sent_11_qs;
   logic in_sent_sent_11_wd;
-  logic stall_we;
-  logic stall_stall_0_qs;
-  logic stall_stall_0_wd;
-  logic stall_stall_1_qs;
-  logic stall_stall_1_wd;
-  logic stall_stall_2_qs;
-  logic stall_stall_2_wd;
-  logic stall_stall_3_qs;
-  logic stall_stall_3_wd;
-  logic stall_stall_4_qs;
-  logic stall_stall_4_wd;
-  logic stall_stall_5_qs;
-  logic stall_stall_5_wd;
-  logic stall_stall_6_qs;
-  logic stall_stall_6_wd;
-  logic stall_stall_7_qs;
-  logic stall_stall_7_wd;
-  logic stall_stall_8_qs;
-  logic stall_stall_8_wd;
-  logic stall_stall_9_qs;
-  logic stall_stall_9_wd;
-  logic stall_stall_10_qs;
-  logic stall_stall_10_wd;
-  logic stall_stall_11_qs;
-  logic stall_stall_11_wd;
+  logic out_stall_we;
+  logic out_stall_endpoint_0_qs;
+  logic out_stall_endpoint_0_wd;
+  logic out_stall_endpoint_1_qs;
+  logic out_stall_endpoint_1_wd;
+  logic out_stall_endpoint_2_qs;
+  logic out_stall_endpoint_2_wd;
+  logic out_stall_endpoint_3_qs;
+  logic out_stall_endpoint_3_wd;
+  logic out_stall_endpoint_4_qs;
+  logic out_stall_endpoint_4_wd;
+  logic out_stall_endpoint_5_qs;
+  logic out_stall_endpoint_5_wd;
+  logic out_stall_endpoint_6_qs;
+  logic out_stall_endpoint_6_wd;
+  logic out_stall_endpoint_7_qs;
+  logic out_stall_endpoint_7_wd;
+  logic out_stall_endpoint_8_qs;
+  logic out_stall_endpoint_8_wd;
+  logic out_stall_endpoint_9_qs;
+  logic out_stall_endpoint_9_wd;
+  logic out_stall_endpoint_10_qs;
+  logic out_stall_endpoint_10_wd;
+  logic out_stall_endpoint_11_qs;
+  logic out_stall_endpoint_11_wd;
+  logic in_stall_we;
+  logic in_stall_endpoint_0_qs;
+  logic in_stall_endpoint_0_wd;
+  logic in_stall_endpoint_1_qs;
+  logic in_stall_endpoint_1_wd;
+  logic in_stall_endpoint_2_qs;
+  logic in_stall_endpoint_2_wd;
+  logic in_stall_endpoint_3_qs;
+  logic in_stall_endpoint_3_wd;
+  logic in_stall_endpoint_4_qs;
+  logic in_stall_endpoint_4_wd;
+  logic in_stall_endpoint_5_qs;
+  logic in_stall_endpoint_5_wd;
+  logic in_stall_endpoint_6_qs;
+  logic in_stall_endpoint_6_wd;
+  logic in_stall_endpoint_7_qs;
+  logic in_stall_endpoint_7_wd;
+  logic in_stall_endpoint_8_qs;
+  logic in_stall_endpoint_8_wd;
+  logic in_stall_endpoint_9_qs;
+  logic in_stall_endpoint_9_wd;
+  logic in_stall_endpoint_10_qs;
+  logic in_stall_endpoint_10_wd;
+  logic in_stall_endpoint_11_qs;
+  logic in_stall_endpoint_11_wd;
   logic configin_0_we;
   logic [4:0] configin_0_buffer_0_qs;
   logic [4:0] configin_0_buffer_0_wd;
@@ -1733,6 +1808,612 @@ module usbdev_reg_top (
   );
 
 
+  // Subregister 0 of Multireg ep_out_enable
+  // R[ep_out_enable]: V(False)
+  //   F[enable_0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[0].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_0_qs)
+  );
+
+  //   F[enable_1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[1].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_1_qs)
+  );
+
+  //   F[enable_2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[2].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_2_qs)
+  );
+
+  //   F[enable_3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[3].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_3_qs)
+  );
+
+  //   F[enable_4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[4].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_4_qs)
+  );
+
+  //   F[enable_5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[5].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_5_qs)
+  );
+
+  //   F[enable_6]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[6].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_6_qs)
+  );
+
+  //   F[enable_7]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[7].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_7_qs)
+  );
+
+  //   F[enable_8]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[8].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_8_qs)
+  );
+
+  //   F[enable_9]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[9].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_9_qs)
+  );
+
+  //   F[enable_10]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[10].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_10_qs)
+  );
+
+  //   F[enable_11]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_out_enable_enable_11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_out_enable_we),
+    .wd     (ep_out_enable_enable_11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_out_enable[11].q),
+
+    // to register interface (read)
+    .qs     (ep_out_enable_enable_11_qs)
+  );
+
+
+  // Subregister 0 of Multireg ep_in_enable
+  // R[ep_in_enable]: V(False)
+  //   F[enable_0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_0_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[0].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_0_qs)
+  );
+
+  //   F[enable_1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_1_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[1].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_1_qs)
+  );
+
+  //   F[enable_2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_2_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[2].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_2_qs)
+  );
+
+  //   F[enable_3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_3_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[3].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_3_qs)
+  );
+
+  //   F[enable_4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_4_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[4].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_4_qs)
+  );
+
+  //   F[enable_5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_5_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[5].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_5_qs)
+  );
+
+  //   F[enable_6]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_6_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[6].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_6_qs)
+  );
+
+  //   F[enable_7]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_7_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[7].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_7_qs)
+  );
+
+  //   F[enable_8]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_8_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[8].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_8_qs)
+  );
+
+  //   F[enable_9]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_9_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[9].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_9_qs)
+  );
+
+  //   F[enable_10]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_10_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[10].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_10_qs)
+  );
+
+  //   F[enable_11]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_ep_in_enable_enable_11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (ep_in_enable_we),
+    .wd     (ep_in_enable_enable_11_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.ep_in_enable[11].q),
+
+    // to register interface (read)
+    .qs     (ep_in_enable_enable_11_qs)
+  );
+
+
   // R[usbstat]: V(True)
   //   F[frame]: 10:0
   prim_subreg_ext #(
@@ -2840,306 +3521,609 @@ module usbdev_reg_top (
   );
 
 
-  // Subregister 0 of Multireg stall
-  // R[stall]: V(False)
-  //   F[stall_0]: 0:0
+  // Subregister 0 of Multireg out_stall
+  // R[out_stall]: V(False)
+  //   F[endpoint_0]: 0:0
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_0 (
+  ) u_out_stall_endpoint_0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_0_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_0_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[0].de),
-    .d      (hw2reg.stall[0].d),
+    .de     (hw2reg.out_stall[0].de),
+    .d      (hw2reg.out_stall[0].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[0].q),
+    .q      (reg2hw.out_stall[0].q),
 
     // to register interface (read)
-    .qs     (stall_stall_0_qs)
+    .qs     (out_stall_endpoint_0_qs)
   );
 
-  //   F[stall_1]: 1:1
+  //   F[endpoint_1]: 1:1
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_1 (
+  ) u_out_stall_endpoint_1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_1_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_1_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[1].de),
-    .d      (hw2reg.stall[1].d),
+    .de     (hw2reg.out_stall[1].de),
+    .d      (hw2reg.out_stall[1].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[1].q),
+    .q      (reg2hw.out_stall[1].q),
 
     // to register interface (read)
-    .qs     (stall_stall_1_qs)
+    .qs     (out_stall_endpoint_1_qs)
   );
 
-  //   F[stall_2]: 2:2
+  //   F[endpoint_2]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_2 (
+  ) u_out_stall_endpoint_2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_2_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_2_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[2].de),
-    .d      (hw2reg.stall[2].d),
+    .de     (hw2reg.out_stall[2].de),
+    .d      (hw2reg.out_stall[2].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[2].q),
+    .q      (reg2hw.out_stall[2].q),
 
     // to register interface (read)
-    .qs     (stall_stall_2_qs)
+    .qs     (out_stall_endpoint_2_qs)
   );
 
-  //   F[stall_3]: 3:3
+  //   F[endpoint_3]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_3 (
+  ) u_out_stall_endpoint_3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_3_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_3_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[3].de),
-    .d      (hw2reg.stall[3].d),
+    .de     (hw2reg.out_stall[3].de),
+    .d      (hw2reg.out_stall[3].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[3].q),
+    .q      (reg2hw.out_stall[3].q),
 
     // to register interface (read)
-    .qs     (stall_stall_3_qs)
+    .qs     (out_stall_endpoint_3_qs)
   );
 
-  //   F[stall_4]: 4:4
+  //   F[endpoint_4]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_4 (
+  ) u_out_stall_endpoint_4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_4_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_4_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[4].de),
-    .d      (hw2reg.stall[4].d),
+    .de     (hw2reg.out_stall[4].de),
+    .d      (hw2reg.out_stall[4].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[4].q),
+    .q      (reg2hw.out_stall[4].q),
 
     // to register interface (read)
-    .qs     (stall_stall_4_qs)
+    .qs     (out_stall_endpoint_4_qs)
   );
 
-  //   F[stall_5]: 5:5
+  //   F[endpoint_5]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_5 (
+  ) u_out_stall_endpoint_5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_5_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_5_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[5].de),
-    .d      (hw2reg.stall[5].d),
+    .de     (hw2reg.out_stall[5].de),
+    .d      (hw2reg.out_stall[5].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[5].q),
+    .q      (reg2hw.out_stall[5].q),
 
     // to register interface (read)
-    .qs     (stall_stall_5_qs)
+    .qs     (out_stall_endpoint_5_qs)
   );
 
-  //   F[stall_6]: 6:6
+  //   F[endpoint_6]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_6 (
+  ) u_out_stall_endpoint_6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_6_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_6_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[6].de),
-    .d      (hw2reg.stall[6].d),
+    .de     (hw2reg.out_stall[6].de),
+    .d      (hw2reg.out_stall[6].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[6].q),
+    .q      (reg2hw.out_stall[6].q),
 
     // to register interface (read)
-    .qs     (stall_stall_6_qs)
+    .qs     (out_stall_endpoint_6_qs)
   );
 
-  //   F[stall_7]: 7:7
+  //   F[endpoint_7]: 7:7
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_7 (
+  ) u_out_stall_endpoint_7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_7_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_7_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[7].de),
-    .d      (hw2reg.stall[7].d),
+    .de     (hw2reg.out_stall[7].de),
+    .d      (hw2reg.out_stall[7].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[7].q),
+    .q      (reg2hw.out_stall[7].q),
 
     // to register interface (read)
-    .qs     (stall_stall_7_qs)
+    .qs     (out_stall_endpoint_7_qs)
   );
 
-  //   F[stall_8]: 8:8
+  //   F[endpoint_8]: 8:8
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_8 (
+  ) u_out_stall_endpoint_8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_8_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_8_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[8].de),
-    .d      (hw2reg.stall[8].d),
+    .de     (hw2reg.out_stall[8].de),
+    .d      (hw2reg.out_stall[8].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[8].q),
+    .q      (reg2hw.out_stall[8].q),
 
     // to register interface (read)
-    .qs     (stall_stall_8_qs)
+    .qs     (out_stall_endpoint_8_qs)
   );
 
-  //   F[stall_9]: 9:9
+  //   F[endpoint_9]: 9:9
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_9 (
+  ) u_out_stall_endpoint_9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_9_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_9_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[9].de),
-    .d      (hw2reg.stall[9].d),
+    .de     (hw2reg.out_stall[9].de),
+    .d      (hw2reg.out_stall[9].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[9].q),
+    .q      (reg2hw.out_stall[9].q),
 
     // to register interface (read)
-    .qs     (stall_stall_9_qs)
+    .qs     (out_stall_endpoint_9_qs)
   );
 
-  //   F[stall_10]: 10:10
+  //   F[endpoint_10]: 10:10
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_10 (
+  ) u_out_stall_endpoint_10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_10_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_10_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[10].de),
-    .d      (hw2reg.stall[10].d),
+    .de     (hw2reg.out_stall[10].de),
+    .d      (hw2reg.out_stall[10].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[10].q),
+    .q      (reg2hw.out_stall[10].q),
 
     // to register interface (read)
-    .qs     (stall_stall_10_qs)
+    .qs     (out_stall_endpoint_10_qs)
   );
 
-  //   F[stall_11]: 11:11
+  //   F[endpoint_11]: 11:11
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_stall_stall_11 (
+  ) u_out_stall_endpoint_11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (stall_we),
-    .wd     (stall_stall_11_wd),
+    .we     (out_stall_we),
+    .wd     (out_stall_endpoint_11_wd),
 
     // from internal hardware
-    .de     (hw2reg.stall[11].de),
-    .d      (hw2reg.stall[11].d),
+    .de     (hw2reg.out_stall[11].de),
+    .d      (hw2reg.out_stall[11].d),
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.stall[11].q),
+    .q      (reg2hw.out_stall[11].q),
 
     // to register interface (read)
-    .qs     (stall_stall_11_qs)
+    .qs     (out_stall_endpoint_11_qs)
+  );
+
+
+  // Subregister 0 of Multireg in_stall
+  // R[in_stall]: V(False)
+  //   F[endpoint_0]: 0:0
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_0 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_0_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[0].de),
+    .d      (hw2reg.in_stall[0].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[0].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_0_qs)
+  );
+
+  //   F[endpoint_1]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_1 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_1_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[1].de),
+    .d      (hw2reg.in_stall[1].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[1].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_1_qs)
+  );
+
+  //   F[endpoint_2]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_2 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_2_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[2].de),
+    .d      (hw2reg.in_stall[2].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[2].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_2_qs)
+  );
+
+  //   F[endpoint_3]: 3:3
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_3 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_3_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[3].de),
+    .d      (hw2reg.in_stall[3].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[3].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_3_qs)
+  );
+
+  //   F[endpoint_4]: 4:4
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_4 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_4_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[4].de),
+    .d      (hw2reg.in_stall[4].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[4].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_4_qs)
+  );
+
+  //   F[endpoint_5]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_5 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_5_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[5].de),
+    .d      (hw2reg.in_stall[5].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[5].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_5_qs)
+  );
+
+  //   F[endpoint_6]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_6 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_6_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[6].de),
+    .d      (hw2reg.in_stall[6].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[6].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_6_qs)
+  );
+
+  //   F[endpoint_7]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_7 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_7_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[7].de),
+    .d      (hw2reg.in_stall[7].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[7].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_7_qs)
+  );
+
+  //   F[endpoint_8]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_8 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_8_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[8].de),
+    .d      (hw2reg.in_stall[8].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[8].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_8_qs)
+  );
+
+  //   F[endpoint_9]: 9:9
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_9 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_9_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[9].de),
+    .d      (hw2reg.in_stall[9].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[9].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_9_qs)
+  );
+
+  //   F[endpoint_10]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_10 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_10_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[10].de),
+    .d      (hw2reg.in_stall[10].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[10].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_10_qs)
+  );
+
+  //   F[endpoint_11]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_in_stall_endpoint_11 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (in_stall_we),
+    .wd     (in_stall_endpoint_11_wd),
+
+    // from internal hardware
+    .de     (hw2reg.in_stall[11].de),
+    .d      (hw2reg.in_stall[11].d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.in_stall[11].q),
+
+    // to register interface (read)
+    .qs     (in_stall_endpoint_11_qs)
   );
 
 
@@ -5610,7 +6594,7 @@ module usbdev_reg_top (
 
 
 
-  logic [30:0] addr_hit;
+  logic [33:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == USBDEV_INTR_STATE_OFFSET);
@@ -5618,32 +6602,35 @@ module usbdev_reg_top (
     addr_hit[ 2] = (reg_addr == USBDEV_INTR_TEST_OFFSET);
     addr_hit[ 3] = (reg_addr == USBDEV_ALERT_TEST_OFFSET);
     addr_hit[ 4] = (reg_addr == USBDEV_USBCTRL_OFFSET);
-    addr_hit[ 5] = (reg_addr == USBDEV_USBSTAT_OFFSET);
-    addr_hit[ 6] = (reg_addr == USBDEV_AVBUFFER_OFFSET);
-    addr_hit[ 7] = (reg_addr == USBDEV_RXFIFO_OFFSET);
-    addr_hit[ 8] = (reg_addr == USBDEV_RXENABLE_SETUP_OFFSET);
-    addr_hit[ 9] = (reg_addr == USBDEV_RXENABLE_OUT_OFFSET);
-    addr_hit[10] = (reg_addr == USBDEV_IN_SENT_OFFSET);
-    addr_hit[11] = (reg_addr == USBDEV_STALL_OFFSET);
-    addr_hit[12] = (reg_addr == USBDEV_CONFIGIN_0_OFFSET);
-    addr_hit[13] = (reg_addr == USBDEV_CONFIGIN_1_OFFSET);
-    addr_hit[14] = (reg_addr == USBDEV_CONFIGIN_2_OFFSET);
-    addr_hit[15] = (reg_addr == USBDEV_CONFIGIN_3_OFFSET);
-    addr_hit[16] = (reg_addr == USBDEV_CONFIGIN_4_OFFSET);
-    addr_hit[17] = (reg_addr == USBDEV_CONFIGIN_5_OFFSET);
-    addr_hit[18] = (reg_addr == USBDEV_CONFIGIN_6_OFFSET);
-    addr_hit[19] = (reg_addr == USBDEV_CONFIGIN_7_OFFSET);
-    addr_hit[20] = (reg_addr == USBDEV_CONFIGIN_8_OFFSET);
-    addr_hit[21] = (reg_addr == USBDEV_CONFIGIN_9_OFFSET);
-    addr_hit[22] = (reg_addr == USBDEV_CONFIGIN_10_OFFSET);
-    addr_hit[23] = (reg_addr == USBDEV_CONFIGIN_11_OFFSET);
-    addr_hit[24] = (reg_addr == USBDEV_ISO_OFFSET);
-    addr_hit[25] = (reg_addr == USBDEV_DATA_TOGGLE_CLEAR_OFFSET);
-    addr_hit[26] = (reg_addr == USBDEV_PHY_PINS_SENSE_OFFSET);
-    addr_hit[27] = (reg_addr == USBDEV_PHY_PINS_DRIVE_OFFSET);
-    addr_hit[28] = (reg_addr == USBDEV_PHY_CONFIG_OFFSET);
-    addr_hit[29] = (reg_addr == USBDEV_WAKE_CONFIG_OFFSET);
-    addr_hit[30] = (reg_addr == USBDEV_WAKE_DEBUG_OFFSET);
+    addr_hit[ 5] = (reg_addr == USBDEV_EP_OUT_ENABLE_OFFSET);
+    addr_hit[ 6] = (reg_addr == USBDEV_EP_IN_ENABLE_OFFSET);
+    addr_hit[ 7] = (reg_addr == USBDEV_USBSTAT_OFFSET);
+    addr_hit[ 8] = (reg_addr == USBDEV_AVBUFFER_OFFSET);
+    addr_hit[ 9] = (reg_addr == USBDEV_RXFIFO_OFFSET);
+    addr_hit[10] = (reg_addr == USBDEV_RXENABLE_SETUP_OFFSET);
+    addr_hit[11] = (reg_addr == USBDEV_RXENABLE_OUT_OFFSET);
+    addr_hit[12] = (reg_addr == USBDEV_IN_SENT_OFFSET);
+    addr_hit[13] = (reg_addr == USBDEV_OUT_STALL_OFFSET);
+    addr_hit[14] = (reg_addr == USBDEV_IN_STALL_OFFSET);
+    addr_hit[15] = (reg_addr == USBDEV_CONFIGIN_0_OFFSET);
+    addr_hit[16] = (reg_addr == USBDEV_CONFIGIN_1_OFFSET);
+    addr_hit[17] = (reg_addr == USBDEV_CONFIGIN_2_OFFSET);
+    addr_hit[18] = (reg_addr == USBDEV_CONFIGIN_3_OFFSET);
+    addr_hit[19] = (reg_addr == USBDEV_CONFIGIN_4_OFFSET);
+    addr_hit[20] = (reg_addr == USBDEV_CONFIGIN_5_OFFSET);
+    addr_hit[21] = (reg_addr == USBDEV_CONFIGIN_6_OFFSET);
+    addr_hit[22] = (reg_addr == USBDEV_CONFIGIN_7_OFFSET);
+    addr_hit[23] = (reg_addr == USBDEV_CONFIGIN_8_OFFSET);
+    addr_hit[24] = (reg_addr == USBDEV_CONFIGIN_9_OFFSET);
+    addr_hit[25] = (reg_addr == USBDEV_CONFIGIN_10_OFFSET);
+    addr_hit[26] = (reg_addr == USBDEV_CONFIGIN_11_OFFSET);
+    addr_hit[27] = (reg_addr == USBDEV_ISO_OFFSET);
+    addr_hit[28] = (reg_addr == USBDEV_DATA_TOGGLE_CLEAR_OFFSET);
+    addr_hit[29] = (reg_addr == USBDEV_PHY_PINS_SENSE_OFFSET);
+    addr_hit[30] = (reg_addr == USBDEV_PHY_PINS_DRIVE_OFFSET);
+    addr_hit[31] = (reg_addr == USBDEV_PHY_CONFIG_OFFSET);
+    addr_hit[32] = (reg_addr == USBDEV_WAKE_CONFIG_OFFSET);
+    addr_hit[33] = (reg_addr == USBDEV_WAKE_DEBUG_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -5681,7 +6668,10 @@ module usbdev_reg_top (
                (addr_hit[27] & (|(USBDEV_PERMIT[27] & ~reg_be))) |
                (addr_hit[28] & (|(USBDEV_PERMIT[28] & ~reg_be))) |
                (addr_hit[29] & (|(USBDEV_PERMIT[29] & ~reg_be))) |
-               (addr_hit[30] & (|(USBDEV_PERMIT[30] & ~reg_be)))));
+               (addr_hit[30] & (|(USBDEV_PERMIT[30] & ~reg_be))) |
+               (addr_hit[31] & (|(USBDEV_PERMIT[31] & ~reg_be))) |
+               (addr_hit[32] & (|(USBDEV_PERMIT[32] & ~reg_be))) |
+               (addr_hit[33] & (|(USBDEV_PERMIT[33] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -5796,12 +6786,62 @@ module usbdev_reg_top (
   assign usbctrl_enable_wd = reg_wdata[0];
 
   assign usbctrl_device_address_wd = reg_wdata[22:16];
-  assign usbstat_re = addr_hit[5] & reg_re & !reg_error;
-  assign avbuffer_we = addr_hit[6] & reg_we & !reg_error;
+  assign ep_out_enable_we = addr_hit[5] & reg_we & !reg_error;
+
+  assign ep_out_enable_enable_0_wd = reg_wdata[0];
+
+  assign ep_out_enable_enable_1_wd = reg_wdata[1];
+
+  assign ep_out_enable_enable_2_wd = reg_wdata[2];
+
+  assign ep_out_enable_enable_3_wd = reg_wdata[3];
+
+  assign ep_out_enable_enable_4_wd = reg_wdata[4];
+
+  assign ep_out_enable_enable_5_wd = reg_wdata[5];
+
+  assign ep_out_enable_enable_6_wd = reg_wdata[6];
+
+  assign ep_out_enable_enable_7_wd = reg_wdata[7];
+
+  assign ep_out_enable_enable_8_wd = reg_wdata[8];
+
+  assign ep_out_enable_enable_9_wd = reg_wdata[9];
+
+  assign ep_out_enable_enable_10_wd = reg_wdata[10];
+
+  assign ep_out_enable_enable_11_wd = reg_wdata[11];
+  assign ep_in_enable_we = addr_hit[6] & reg_we & !reg_error;
+
+  assign ep_in_enable_enable_0_wd = reg_wdata[0];
+
+  assign ep_in_enable_enable_1_wd = reg_wdata[1];
+
+  assign ep_in_enable_enable_2_wd = reg_wdata[2];
+
+  assign ep_in_enable_enable_3_wd = reg_wdata[3];
+
+  assign ep_in_enable_enable_4_wd = reg_wdata[4];
+
+  assign ep_in_enable_enable_5_wd = reg_wdata[5];
+
+  assign ep_in_enable_enable_6_wd = reg_wdata[6];
+
+  assign ep_in_enable_enable_7_wd = reg_wdata[7];
+
+  assign ep_in_enable_enable_8_wd = reg_wdata[8];
+
+  assign ep_in_enable_enable_9_wd = reg_wdata[9];
+
+  assign ep_in_enable_enable_10_wd = reg_wdata[10];
+
+  assign ep_in_enable_enable_11_wd = reg_wdata[11];
+  assign usbstat_re = addr_hit[7] & reg_re & !reg_error;
+  assign avbuffer_we = addr_hit[8] & reg_we & !reg_error;
 
   assign avbuffer_wd = reg_wdata[4:0];
-  assign rxfifo_re = addr_hit[7] & reg_re & !reg_error;
-  assign rxenable_setup_we = addr_hit[8] & reg_we & !reg_error;
+  assign rxfifo_re = addr_hit[9] & reg_re & !reg_error;
+  assign rxenable_setup_we = addr_hit[10] & reg_we & !reg_error;
 
   assign rxenable_setup_setup_0_wd = reg_wdata[0];
 
@@ -5826,7 +6866,7 @@ module usbdev_reg_top (
   assign rxenable_setup_setup_10_wd = reg_wdata[10];
 
   assign rxenable_setup_setup_11_wd = reg_wdata[11];
-  assign rxenable_out_we = addr_hit[9] & reg_we & !reg_error;
+  assign rxenable_out_we = addr_hit[11] & reg_we & !reg_error;
 
   assign rxenable_out_out_0_wd = reg_wdata[0];
 
@@ -5851,7 +6891,7 @@ module usbdev_reg_top (
   assign rxenable_out_out_10_wd = reg_wdata[10];
 
   assign rxenable_out_out_11_wd = reg_wdata[11];
-  assign in_sent_we = addr_hit[10] & reg_we & !reg_error;
+  assign in_sent_we = addr_hit[12] & reg_we & !reg_error;
 
   assign in_sent_sent_0_wd = reg_wdata[0];
 
@@ -5876,32 +6916,57 @@ module usbdev_reg_top (
   assign in_sent_sent_10_wd = reg_wdata[10];
 
   assign in_sent_sent_11_wd = reg_wdata[11];
-  assign stall_we = addr_hit[11] & reg_we & !reg_error;
+  assign out_stall_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign stall_stall_0_wd = reg_wdata[0];
+  assign out_stall_endpoint_0_wd = reg_wdata[0];
 
-  assign stall_stall_1_wd = reg_wdata[1];
+  assign out_stall_endpoint_1_wd = reg_wdata[1];
 
-  assign stall_stall_2_wd = reg_wdata[2];
+  assign out_stall_endpoint_2_wd = reg_wdata[2];
 
-  assign stall_stall_3_wd = reg_wdata[3];
+  assign out_stall_endpoint_3_wd = reg_wdata[3];
 
-  assign stall_stall_4_wd = reg_wdata[4];
+  assign out_stall_endpoint_4_wd = reg_wdata[4];
 
-  assign stall_stall_5_wd = reg_wdata[5];
+  assign out_stall_endpoint_5_wd = reg_wdata[5];
 
-  assign stall_stall_6_wd = reg_wdata[6];
+  assign out_stall_endpoint_6_wd = reg_wdata[6];
 
-  assign stall_stall_7_wd = reg_wdata[7];
+  assign out_stall_endpoint_7_wd = reg_wdata[7];
 
-  assign stall_stall_8_wd = reg_wdata[8];
+  assign out_stall_endpoint_8_wd = reg_wdata[8];
 
-  assign stall_stall_9_wd = reg_wdata[9];
+  assign out_stall_endpoint_9_wd = reg_wdata[9];
 
-  assign stall_stall_10_wd = reg_wdata[10];
+  assign out_stall_endpoint_10_wd = reg_wdata[10];
 
-  assign stall_stall_11_wd = reg_wdata[11];
-  assign configin_0_we = addr_hit[12] & reg_we & !reg_error;
+  assign out_stall_endpoint_11_wd = reg_wdata[11];
+  assign in_stall_we = addr_hit[14] & reg_we & !reg_error;
+
+  assign in_stall_endpoint_0_wd = reg_wdata[0];
+
+  assign in_stall_endpoint_1_wd = reg_wdata[1];
+
+  assign in_stall_endpoint_2_wd = reg_wdata[2];
+
+  assign in_stall_endpoint_3_wd = reg_wdata[3];
+
+  assign in_stall_endpoint_4_wd = reg_wdata[4];
+
+  assign in_stall_endpoint_5_wd = reg_wdata[5];
+
+  assign in_stall_endpoint_6_wd = reg_wdata[6];
+
+  assign in_stall_endpoint_7_wd = reg_wdata[7];
+
+  assign in_stall_endpoint_8_wd = reg_wdata[8];
+
+  assign in_stall_endpoint_9_wd = reg_wdata[9];
+
+  assign in_stall_endpoint_10_wd = reg_wdata[10];
+
+  assign in_stall_endpoint_11_wd = reg_wdata[11];
+  assign configin_0_we = addr_hit[15] & reg_we & !reg_error;
 
   assign configin_0_buffer_0_wd = reg_wdata[4:0];
 
@@ -5910,7 +6975,7 @@ module usbdev_reg_top (
   assign configin_0_pend_0_wd = reg_wdata[30];
 
   assign configin_0_rdy_0_wd = reg_wdata[31];
-  assign configin_1_we = addr_hit[13] & reg_we & !reg_error;
+  assign configin_1_we = addr_hit[16] & reg_we & !reg_error;
 
   assign configin_1_buffer_1_wd = reg_wdata[4:0];
 
@@ -5919,7 +6984,7 @@ module usbdev_reg_top (
   assign configin_1_pend_1_wd = reg_wdata[30];
 
   assign configin_1_rdy_1_wd = reg_wdata[31];
-  assign configin_2_we = addr_hit[14] & reg_we & !reg_error;
+  assign configin_2_we = addr_hit[17] & reg_we & !reg_error;
 
   assign configin_2_buffer_2_wd = reg_wdata[4:0];
 
@@ -5928,7 +6993,7 @@ module usbdev_reg_top (
   assign configin_2_pend_2_wd = reg_wdata[30];
 
   assign configin_2_rdy_2_wd = reg_wdata[31];
-  assign configin_3_we = addr_hit[15] & reg_we & !reg_error;
+  assign configin_3_we = addr_hit[18] & reg_we & !reg_error;
 
   assign configin_3_buffer_3_wd = reg_wdata[4:0];
 
@@ -5937,7 +7002,7 @@ module usbdev_reg_top (
   assign configin_3_pend_3_wd = reg_wdata[30];
 
   assign configin_3_rdy_3_wd = reg_wdata[31];
-  assign configin_4_we = addr_hit[16] & reg_we & !reg_error;
+  assign configin_4_we = addr_hit[19] & reg_we & !reg_error;
 
   assign configin_4_buffer_4_wd = reg_wdata[4:0];
 
@@ -5946,7 +7011,7 @@ module usbdev_reg_top (
   assign configin_4_pend_4_wd = reg_wdata[30];
 
   assign configin_4_rdy_4_wd = reg_wdata[31];
-  assign configin_5_we = addr_hit[17] & reg_we & !reg_error;
+  assign configin_5_we = addr_hit[20] & reg_we & !reg_error;
 
   assign configin_5_buffer_5_wd = reg_wdata[4:0];
 
@@ -5955,7 +7020,7 @@ module usbdev_reg_top (
   assign configin_5_pend_5_wd = reg_wdata[30];
 
   assign configin_5_rdy_5_wd = reg_wdata[31];
-  assign configin_6_we = addr_hit[18] & reg_we & !reg_error;
+  assign configin_6_we = addr_hit[21] & reg_we & !reg_error;
 
   assign configin_6_buffer_6_wd = reg_wdata[4:0];
 
@@ -5964,7 +7029,7 @@ module usbdev_reg_top (
   assign configin_6_pend_6_wd = reg_wdata[30];
 
   assign configin_6_rdy_6_wd = reg_wdata[31];
-  assign configin_7_we = addr_hit[19] & reg_we & !reg_error;
+  assign configin_7_we = addr_hit[22] & reg_we & !reg_error;
 
   assign configin_7_buffer_7_wd = reg_wdata[4:0];
 
@@ -5973,7 +7038,7 @@ module usbdev_reg_top (
   assign configin_7_pend_7_wd = reg_wdata[30];
 
   assign configin_7_rdy_7_wd = reg_wdata[31];
-  assign configin_8_we = addr_hit[20] & reg_we & !reg_error;
+  assign configin_8_we = addr_hit[23] & reg_we & !reg_error;
 
   assign configin_8_buffer_8_wd = reg_wdata[4:0];
 
@@ -5982,7 +7047,7 @@ module usbdev_reg_top (
   assign configin_8_pend_8_wd = reg_wdata[30];
 
   assign configin_8_rdy_8_wd = reg_wdata[31];
-  assign configin_9_we = addr_hit[21] & reg_we & !reg_error;
+  assign configin_9_we = addr_hit[24] & reg_we & !reg_error;
 
   assign configin_9_buffer_9_wd = reg_wdata[4:0];
 
@@ -5991,7 +7056,7 @@ module usbdev_reg_top (
   assign configin_9_pend_9_wd = reg_wdata[30];
 
   assign configin_9_rdy_9_wd = reg_wdata[31];
-  assign configin_10_we = addr_hit[22] & reg_we & !reg_error;
+  assign configin_10_we = addr_hit[25] & reg_we & !reg_error;
 
   assign configin_10_buffer_10_wd = reg_wdata[4:0];
 
@@ -6000,7 +7065,7 @@ module usbdev_reg_top (
   assign configin_10_pend_10_wd = reg_wdata[30];
 
   assign configin_10_rdy_10_wd = reg_wdata[31];
-  assign configin_11_we = addr_hit[23] & reg_we & !reg_error;
+  assign configin_11_we = addr_hit[26] & reg_we & !reg_error;
 
   assign configin_11_buffer_11_wd = reg_wdata[4:0];
 
@@ -6009,7 +7074,7 @@ module usbdev_reg_top (
   assign configin_11_pend_11_wd = reg_wdata[30];
 
   assign configin_11_rdy_11_wd = reg_wdata[31];
-  assign iso_we = addr_hit[24] & reg_we & !reg_error;
+  assign iso_we = addr_hit[27] & reg_we & !reg_error;
 
   assign iso_iso_0_wd = reg_wdata[0];
 
@@ -6034,7 +7099,7 @@ module usbdev_reg_top (
   assign iso_iso_10_wd = reg_wdata[10];
 
   assign iso_iso_11_wd = reg_wdata[11];
-  assign data_toggle_clear_we = addr_hit[25] & reg_we & !reg_error;
+  assign data_toggle_clear_we = addr_hit[28] & reg_we & !reg_error;
 
   assign data_toggle_clear_clear_0_wd = reg_wdata[0];
 
@@ -6059,8 +7124,8 @@ module usbdev_reg_top (
   assign data_toggle_clear_clear_10_wd = reg_wdata[10];
 
   assign data_toggle_clear_clear_11_wd = reg_wdata[11];
-  assign phy_pins_sense_re = addr_hit[26] & reg_re & !reg_error;
-  assign phy_pins_drive_we = addr_hit[27] & reg_we & !reg_error;
+  assign phy_pins_sense_re = addr_hit[29] & reg_re & !reg_error;
+  assign phy_pins_drive_we = addr_hit[30] & reg_we & !reg_error;
 
   assign phy_pins_drive_dp_o_wd = reg_wdata[0];
 
@@ -6081,7 +7146,7 @@ module usbdev_reg_top (
   assign phy_pins_drive_suspend_o_wd = reg_wdata[8];
 
   assign phy_pins_drive_en_wd = reg_wdata[16];
-  assign phy_config_we = addr_hit[28] & reg_we & !reg_error;
+  assign phy_config_we = addr_hit[31] & reg_we & !reg_error;
 
   assign phy_config_rx_differential_mode_wd = reg_wdata[0];
 
@@ -6094,7 +7159,7 @@ module usbdev_reg_top (
   assign phy_config_usb_ref_disable_wd = reg_wdata[6];
 
   assign phy_config_tx_osc_test_mode_wd = reg_wdata[7];
-  assign wake_config_we = addr_hit[29] & reg_we & !reg_error;
+  assign wake_config_we = addr_hit[32] & reg_we & !reg_error;
 
   assign wake_config_wake_en_wd = reg_wdata[0];
 
@@ -6174,6 +7239,36 @@ module usbdev_reg_top (
       end
 
       addr_hit[5]: begin
+        reg_rdata_next[0] = ep_out_enable_enable_0_qs;
+        reg_rdata_next[1] = ep_out_enable_enable_1_qs;
+        reg_rdata_next[2] = ep_out_enable_enable_2_qs;
+        reg_rdata_next[3] = ep_out_enable_enable_3_qs;
+        reg_rdata_next[4] = ep_out_enable_enable_4_qs;
+        reg_rdata_next[5] = ep_out_enable_enable_5_qs;
+        reg_rdata_next[6] = ep_out_enable_enable_6_qs;
+        reg_rdata_next[7] = ep_out_enable_enable_7_qs;
+        reg_rdata_next[8] = ep_out_enable_enable_8_qs;
+        reg_rdata_next[9] = ep_out_enable_enable_9_qs;
+        reg_rdata_next[10] = ep_out_enable_enable_10_qs;
+        reg_rdata_next[11] = ep_out_enable_enable_11_qs;
+      end
+
+      addr_hit[6]: begin
+        reg_rdata_next[0] = ep_in_enable_enable_0_qs;
+        reg_rdata_next[1] = ep_in_enable_enable_1_qs;
+        reg_rdata_next[2] = ep_in_enable_enable_2_qs;
+        reg_rdata_next[3] = ep_in_enable_enable_3_qs;
+        reg_rdata_next[4] = ep_in_enable_enable_4_qs;
+        reg_rdata_next[5] = ep_in_enable_enable_5_qs;
+        reg_rdata_next[6] = ep_in_enable_enable_6_qs;
+        reg_rdata_next[7] = ep_in_enable_enable_7_qs;
+        reg_rdata_next[8] = ep_in_enable_enable_8_qs;
+        reg_rdata_next[9] = ep_in_enable_enable_9_qs;
+        reg_rdata_next[10] = ep_in_enable_enable_10_qs;
+        reg_rdata_next[11] = ep_in_enable_enable_11_qs;
+      end
+
+      addr_hit[7]: begin
         reg_rdata_next[10:0] = usbstat_frame_qs;
         reg_rdata_next[11] = usbstat_host_lost_qs;
         reg_rdata_next[14:12] = usbstat_link_state_qs;
@@ -6184,18 +7279,18 @@ module usbdev_reg_top (
         reg_rdata_next[31] = usbstat_rx_empty_qs;
       end
 
-      addr_hit[6]: begin
+      addr_hit[8]: begin
         reg_rdata_next[4:0] = '0;
       end
 
-      addr_hit[7]: begin
+      addr_hit[9]: begin
         reg_rdata_next[4:0] = rxfifo_buffer_qs;
         reg_rdata_next[14:8] = rxfifo_size_qs;
         reg_rdata_next[19] = rxfifo_setup_qs;
         reg_rdata_next[23:20] = rxfifo_ep_qs;
       end
 
-      addr_hit[8]: begin
+      addr_hit[10]: begin
         reg_rdata_next[0] = rxenable_setup_setup_0_qs;
         reg_rdata_next[1] = rxenable_setup_setup_1_qs;
         reg_rdata_next[2] = rxenable_setup_setup_2_qs;
@@ -6210,7 +7305,7 @@ module usbdev_reg_top (
         reg_rdata_next[11] = rxenable_setup_setup_11_qs;
       end
 
-      addr_hit[9]: begin
+      addr_hit[11]: begin
         reg_rdata_next[0] = rxenable_out_out_0_qs;
         reg_rdata_next[1] = rxenable_out_out_1_qs;
         reg_rdata_next[2] = rxenable_out_out_2_qs;
@@ -6225,7 +7320,7 @@ module usbdev_reg_top (
         reg_rdata_next[11] = rxenable_out_out_11_qs;
       end
 
-      addr_hit[10]: begin
+      addr_hit[12]: begin
         reg_rdata_next[0] = in_sent_sent_0_qs;
         reg_rdata_next[1] = in_sent_sent_1_qs;
         reg_rdata_next[2] = in_sent_sent_2_qs;
@@ -6240,106 +7335,121 @@ module usbdev_reg_top (
         reg_rdata_next[11] = in_sent_sent_11_qs;
       end
 
-      addr_hit[11]: begin
-        reg_rdata_next[0] = stall_stall_0_qs;
-        reg_rdata_next[1] = stall_stall_1_qs;
-        reg_rdata_next[2] = stall_stall_2_qs;
-        reg_rdata_next[3] = stall_stall_3_qs;
-        reg_rdata_next[4] = stall_stall_4_qs;
-        reg_rdata_next[5] = stall_stall_5_qs;
-        reg_rdata_next[6] = stall_stall_6_qs;
-        reg_rdata_next[7] = stall_stall_7_qs;
-        reg_rdata_next[8] = stall_stall_8_qs;
-        reg_rdata_next[9] = stall_stall_9_qs;
-        reg_rdata_next[10] = stall_stall_10_qs;
-        reg_rdata_next[11] = stall_stall_11_qs;
+      addr_hit[13]: begin
+        reg_rdata_next[0] = out_stall_endpoint_0_qs;
+        reg_rdata_next[1] = out_stall_endpoint_1_qs;
+        reg_rdata_next[2] = out_stall_endpoint_2_qs;
+        reg_rdata_next[3] = out_stall_endpoint_3_qs;
+        reg_rdata_next[4] = out_stall_endpoint_4_qs;
+        reg_rdata_next[5] = out_stall_endpoint_5_qs;
+        reg_rdata_next[6] = out_stall_endpoint_6_qs;
+        reg_rdata_next[7] = out_stall_endpoint_7_qs;
+        reg_rdata_next[8] = out_stall_endpoint_8_qs;
+        reg_rdata_next[9] = out_stall_endpoint_9_qs;
+        reg_rdata_next[10] = out_stall_endpoint_10_qs;
+        reg_rdata_next[11] = out_stall_endpoint_11_qs;
       end
 
-      addr_hit[12]: begin
+      addr_hit[14]: begin
+        reg_rdata_next[0] = in_stall_endpoint_0_qs;
+        reg_rdata_next[1] = in_stall_endpoint_1_qs;
+        reg_rdata_next[2] = in_stall_endpoint_2_qs;
+        reg_rdata_next[3] = in_stall_endpoint_3_qs;
+        reg_rdata_next[4] = in_stall_endpoint_4_qs;
+        reg_rdata_next[5] = in_stall_endpoint_5_qs;
+        reg_rdata_next[6] = in_stall_endpoint_6_qs;
+        reg_rdata_next[7] = in_stall_endpoint_7_qs;
+        reg_rdata_next[8] = in_stall_endpoint_8_qs;
+        reg_rdata_next[9] = in_stall_endpoint_9_qs;
+        reg_rdata_next[10] = in_stall_endpoint_10_qs;
+        reg_rdata_next[11] = in_stall_endpoint_11_qs;
+      end
+
+      addr_hit[15]: begin
         reg_rdata_next[4:0] = configin_0_buffer_0_qs;
         reg_rdata_next[14:8] = configin_0_size_0_qs;
         reg_rdata_next[30] = configin_0_pend_0_qs;
         reg_rdata_next[31] = configin_0_rdy_0_qs;
       end
 
-      addr_hit[13]: begin
+      addr_hit[16]: begin
         reg_rdata_next[4:0] = configin_1_buffer_1_qs;
         reg_rdata_next[14:8] = configin_1_size_1_qs;
         reg_rdata_next[30] = configin_1_pend_1_qs;
         reg_rdata_next[31] = configin_1_rdy_1_qs;
       end
 
-      addr_hit[14]: begin
+      addr_hit[17]: begin
         reg_rdata_next[4:0] = configin_2_buffer_2_qs;
         reg_rdata_next[14:8] = configin_2_size_2_qs;
         reg_rdata_next[30] = configin_2_pend_2_qs;
         reg_rdata_next[31] = configin_2_rdy_2_qs;
       end
 
-      addr_hit[15]: begin
+      addr_hit[18]: begin
         reg_rdata_next[4:0] = configin_3_buffer_3_qs;
         reg_rdata_next[14:8] = configin_3_size_3_qs;
         reg_rdata_next[30] = configin_3_pend_3_qs;
         reg_rdata_next[31] = configin_3_rdy_3_qs;
       end
 
-      addr_hit[16]: begin
+      addr_hit[19]: begin
         reg_rdata_next[4:0] = configin_4_buffer_4_qs;
         reg_rdata_next[14:8] = configin_4_size_4_qs;
         reg_rdata_next[30] = configin_4_pend_4_qs;
         reg_rdata_next[31] = configin_4_rdy_4_qs;
       end
 
-      addr_hit[17]: begin
+      addr_hit[20]: begin
         reg_rdata_next[4:0] = configin_5_buffer_5_qs;
         reg_rdata_next[14:8] = configin_5_size_5_qs;
         reg_rdata_next[30] = configin_5_pend_5_qs;
         reg_rdata_next[31] = configin_5_rdy_5_qs;
       end
 
-      addr_hit[18]: begin
+      addr_hit[21]: begin
         reg_rdata_next[4:0] = configin_6_buffer_6_qs;
         reg_rdata_next[14:8] = configin_6_size_6_qs;
         reg_rdata_next[30] = configin_6_pend_6_qs;
         reg_rdata_next[31] = configin_6_rdy_6_qs;
       end
 
-      addr_hit[19]: begin
+      addr_hit[22]: begin
         reg_rdata_next[4:0] = configin_7_buffer_7_qs;
         reg_rdata_next[14:8] = configin_7_size_7_qs;
         reg_rdata_next[30] = configin_7_pend_7_qs;
         reg_rdata_next[31] = configin_7_rdy_7_qs;
       end
 
-      addr_hit[20]: begin
+      addr_hit[23]: begin
         reg_rdata_next[4:0] = configin_8_buffer_8_qs;
         reg_rdata_next[14:8] = configin_8_size_8_qs;
         reg_rdata_next[30] = configin_8_pend_8_qs;
         reg_rdata_next[31] = configin_8_rdy_8_qs;
       end
 
-      addr_hit[21]: begin
+      addr_hit[24]: begin
         reg_rdata_next[4:0] = configin_9_buffer_9_qs;
         reg_rdata_next[14:8] = configin_9_size_9_qs;
         reg_rdata_next[30] = configin_9_pend_9_qs;
         reg_rdata_next[31] = configin_9_rdy_9_qs;
       end
 
-      addr_hit[22]: begin
+      addr_hit[25]: begin
         reg_rdata_next[4:0] = configin_10_buffer_10_qs;
         reg_rdata_next[14:8] = configin_10_size_10_qs;
         reg_rdata_next[30] = configin_10_pend_10_qs;
         reg_rdata_next[31] = configin_10_rdy_10_qs;
       end
 
-      addr_hit[23]: begin
+      addr_hit[26]: begin
         reg_rdata_next[4:0] = configin_11_buffer_11_qs;
         reg_rdata_next[14:8] = configin_11_size_11_qs;
         reg_rdata_next[30] = configin_11_pend_11_qs;
         reg_rdata_next[31] = configin_11_rdy_11_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = iso_iso_0_qs;
         reg_rdata_next[1] = iso_iso_1_qs;
         reg_rdata_next[2] = iso_iso_2_qs;
@@ -6354,7 +7464,7 @@ module usbdev_reg_top (
         reg_rdata_next[11] = iso_iso_11_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = '0;
         reg_rdata_next[1] = '0;
         reg_rdata_next[2] = '0;
@@ -6369,7 +7479,7 @@ module usbdev_reg_top (
         reg_rdata_next[11] = '0;
       end
 
-      addr_hit[26]: begin
+      addr_hit[29]: begin
         reg_rdata_next[0] = phy_pins_sense_rx_dp_i_qs;
         reg_rdata_next[1] = phy_pins_sense_rx_dn_i_qs;
         reg_rdata_next[2] = phy_pins_sense_rx_d_i_qs;
@@ -6382,7 +7492,7 @@ module usbdev_reg_top (
         reg_rdata_next[16] = phy_pins_sense_pwr_sense_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[30]: begin
         reg_rdata_next[0] = phy_pins_drive_dp_o_qs;
         reg_rdata_next[1] = phy_pins_drive_dn_o_qs;
         reg_rdata_next[2] = phy_pins_drive_d_o_qs;
@@ -6395,7 +7505,7 @@ module usbdev_reg_top (
         reg_rdata_next[16] = phy_pins_drive_en_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[31]: begin
         reg_rdata_next[0] = phy_config_rx_differential_mode_qs;
         reg_rdata_next[1] = phy_config_tx_differential_mode_qs;
         reg_rdata_next[2] = phy_config_eop_single_bit_qs;
@@ -6404,12 +7514,12 @@ module usbdev_reg_top (
         reg_rdata_next[7] = phy_config_tx_osc_test_mode_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[32]: begin
         reg_rdata_next[0] = wake_config_wake_en_qs;
         reg_rdata_next[1] = wake_config_wake_ack_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[33]: begin
         reg_rdata_next[2:0] = wake_debug_qs;
       end
 

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-uart
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-uart
@@ -1,9 +1,9 @@
-I00000 boot_rom.c:52] Version:    opentitan-snapshot-20191101-1-3257-g1690ca0
-Build Date: 2020-11-23, 17:36:40
+I00000 test_rom.c:54] Version:    opentitan-earlgrey_silver_release_v5-2931-g929a928fb
+Build Date: 2022-01-21, 12:59:36
 
-I00001 boot_rom.c:61] Boot ROM initialisation has completed, jump into flash!
-I00000 hello_usbdev.c:146] Hello, USB!
-I00001 hello_usbdev.c:147] Built at: Nov 27 2020, 14:21:54
+I00001 test_rom.c:70] Boot ROM initialisation has completed, jump into flash!
+I00000 hello_usbdev.c:145] Hello, USB!
+I00001 hello_usbdev.c:146] Built at: Jan 28 2022, 21:24:06
 I00002 demos.c:18] Watch the LEDs!
-I00003 hello_usbdev.c:159] PHY settings: pinflip=0 differential=0 USB Phy=0
-Hi!Hi!I00004 hello_usbdev.c:209] PASS!
+I00003 hello_usbdev.c:158] PHY settings: pinflip=0 differential=0 USB Phy=0
+Hi!Hi!I00004 hello_usbdev.c:221] PASS!

--- a/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-usb
+++ b/hw/top_earlgrey/util/opentitan_earlgrey_usbdev_expected-usb
@@ -16,7 +16,8 @@ mon:    19248 --    19360: (H) SOP, PID IN 2.0 (CRC5 15 OK), EOP
 mon:    19396 --    20080: (D) SOP, PID DATA1, EOP
 mon:     d->h: 12, 01, 00, 02, 00, 00, 00, 40, d1, 18, 3a, 50, 00, 01, 00, 00
 mon:           00, 01, 7d, 34 CRCOK
-mon:    20200 --    20248: (H) SOP, PID ACK EOP
+mon:    20124 --    20236: (H) SOP, PID ACK 02, a8 (CRC5 OK), EOP
+mon:    20928 --    21040: (H) SOP, PID OUT 2.0 (CRC5 15 OK), EOP
 mon:    24608 --    24720: (H) SOP, PID SOF 003 (CRC5 0a OK), EOP
 mon:    32800 --    32912: (H) SOP, PID SOF 004 (CRC5 05 OK), EOP
 mon:    40992 --    41104: (H) SOP, PID SOF 005 (CRC5 1a OK), EOP
@@ -34,16 +35,15 @@ mon:    65868 --    65912: (D) SOP, PID NAK EOP
 mon:    73760 --    73872: (H) SOP, PID SOF 009 (CRC5 13 OK), EOP
 mon:    73912 --    74024: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
 mon:    74060 --    74104: (D) SOP, PID NAK EOP
-mon:    74280 --    74392: (H) SOP, PID OUT 2.1 (CRC5 03 OK), EOP
-mon:    74424 --    74632: (H) SOP, PID DATA0, EOP
+mon:    74148 --    74260: (H) SOP, PID OUT 2.1 (CRC5 03 OK), EOP
+mon:    74292 --    74500: (H) SOP, PID DATA0, EOP
 mon:     h->d: 48, 69, 21, e0, 61 CRCOK
 mon:          Hi!
-mon:    74668 --    74712: (D) SOP, PID ACK EOP
+mon:    74536 --    74580: (D) SOP, PID ACK EOP
 mon:    81952 --    82064: (H) SOP, PID SOF 00a (CRC5 1b OK), EOP
 mon:    82104 --    82216: (H) SOP, PID SETUP 2.1 (CRC5 03 OK), EOP
 mon:    82248 --    82616: (H) SOP, PID DATA0, EOP
 mon:     h->d: c2, 02, 00, 00, 00, 00, 02, 00, 10, dd CRCOK
-mon:    82652 --    82696: (D) SOP, PID NAK EOP
 mon:    82784 --    82896: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
 mon:    82932 --    83552: (D) SOP, PID DATA1, EOP
 mon:     d->h: 48, 65, 6c, 6c, 6f, 20, 55, 53, 42, 20, 57, 6f, 72, 6c, 64, 21
@@ -55,29 +55,43 @@ mon:    83968 --    84080: (H) SOP, PID DATA1 00, 00 (NULL), EOP
 mon:    84112 --    84156: (D) SOP, PID ACK EOP
 mon:    90144 --    90256: (H) SOP, PID SOF 00b (CRC5 04 OK), EOP
 mon:    90296 --    90408: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
-mon:    90444 --    90488: (D) SOP, PID NAK EOP
+mon:    90444 --    91064: (D) SOP, PID DATA1, EOP
+mon:     d->h: 48, 65, 6c, 6c, 6f, 20, 55, 53, 42, 20, 57, 6f, 72, 6c, 64, 21
+mon:           a6, 9c CRCOK
+mon:          Hello USB World!
 mon:    98336 --    98448: (H) SOP, PID SOF 00c (CRC5 0b OK), EOP
 mon:    98488 --    98600: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
-mon:    98636 --    98680: (D) SOP, PID NAK EOP
+mon:    98636 --    99256: (D) SOP, PID DATA1, EOP
+mon:     d->h: 48, 65, 6c, 6c, 6f, 20, 55, 53, 42, 20, 57, 6f, 72, 6c, 64, 21
+mon:           a6, 9c CRCOK
+mon:          Hello USB World!
 mon:   106528 --   106640: (H) SOP, PID SOF 00d (CRC5 14 OK), EOP
 mon:   106680 --   106792: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
-mon:   106828 --   106872: (D) SOP, PID NAK EOP
+mon:   106828 --   107448: (D) SOP, PID DATA1, EOP
+mon:     d->h: 48, 65, 6c, 6c, 6f, 20, 55, 53, 42, 20, 57, 6f, 72, 6c, 64, 21
+mon:           a6, 9c CRCOK
+mon:          Hello USB World!
 mon:   114720 --   114832: (H) SOP, PID SOF 00e (CRC5 1c OK), EOP
 mon:   114872 --   114984: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
-mon:   115020 --   115064: (D) SOP, PID NAK EOP
-mon:   115240 --   115352: (H) SOP, PID OUT 2.1 (CRC5 03 OK), EOP
-mon:   115384 --   115592: (H) SOP, PID DATA0, EOP
+mon:   115020 --   115640: (D) SOP, PID DATA1, EOP
+mon:     d->h: 48, 65, 6c, 6c, 6f, 20, 55, 53, 42, 20, 57, 6f, 72, 6c, 64, 21
+mon:           a6, 9c CRCOK
+mon:          Hello USB World!
+mon:   115684 --   115796: (H) SOP, PID OUT 2.1 (CRC5 03 OK), EOP
+mon:   115828 --   116036: (H) SOP, PID DATA0, EOP
 mon:     h->d: 48, 69, 21, e0, 61 CRCOK
 mon:          Hi!
-mon:   115628 --   115672: (D) SOP, PID ACK EOP
+mon:   116072 --   116116: (D) SOP, PID ACK EOP
 mon:   122912 --   123024: (H) SOP, PID SOF 00f (CRC5 03 OK), EOP
 mon:   123064 --   123176: (H) SOP, PID SETUP 2.1 (CRC5 03 OK), EOP
 mon:   123208 --   123576: (H) SOP, PID DATA0, EOP
 mon:     h->d: 42, 03, 60, 00, 00, 00, 00, 00, 00, bd CRCOK
-mon:   123612 --   123656: (D) SOP, PID NAK EOP
 mon:   123744 --   123856: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
-mon:   123892 --   123936: (D) SOP, PID NAK EOP
-mon:   124056 --   124104: (H) SOP, PID ACK EOP
+mon:   123892 --   124512: (D) SOP, PID DATA1, EOP
+mon:     d->h: 48, 65, 6c, 6c, 6f, 20, 55, 53, 42, 20, 57, 6f, 72, 6c, 64, 21
+mon:           a6, 9c CRCOK
+mon:          Hello USB World!
+mon:   124556 --   124604: (H) SOP, PID ACK EOP
 mon:   131104 --   131216: (H) SOP, PID SOF 010 (CRC5 1e OK), EOP
 mon:   131256 --   131368: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
 mon:   131404 --   131448: (D) SOP, PID NAK EOP
@@ -85,16 +99,12 @@ mon:   139296 --   139408: (H) SOP, PID SOF 011 (CRC5 01 OK), EOP
 mon:   139448 --   139560: (H) SOP, PID OUT 2.3 (CRC5 06 OK), EOP
 mon:   139592 --   139960: (H) SOP, PID DATA0, EOP
 mon:     h->d: 42, 03, 60, 00, 00, 00, 00, 00, 00, bd CRCOK
-mon:   139996 --   140040: (D) SOP, PID NAK EOP
 mon:   140128 --   140240: (H) SOP, PID IN 2.3 (CRC5 06 OK), EOP
-mon:   140276 --   140320: (D) SOP, PID NAK EOP
 mon:   147488 --   147600: (H) SOP, PID SOF 012 (CRC5 09 OK), EOP
 mon:   147640 --   147752: (H) SOP, PID OUT 2.3 (CRC5 06 OK), EOP
 mon:   147784 --   148152: (H) SOP, PID DATA0, EOP
 mon:     h->d: 42, 03, 60, 00, 00, 00, 00, 00, 00, bd CRCOK
-mon:   148188 --   148232: (D) SOP, PID NAK EOP
 mon:   148320 --   148432: (H) SOP, PID IN 2.3 (CRC5 06 OK), EOP
-mon:   148468 --   148512: (D) SOP, PID NAK EOP
 mon:   155680 --   155792: (H) SOP, PID SOF 013 (CRC5 16 OK), EOP
 mon:   155832 --   155944: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
 mon:   155980 --   156024: (D) SOP, PID NAK EOP
@@ -104,18 +114,4 @@ mon:     h->d: 00, 05, 02, 00, ff, 00, 00, 00, db, 02 CRCOK
 mon:   172068 --   172180: (H) SOP, PID OUT 2.15 (CRC5 18 OK), EOP
 mon:   172212 --   172584: (H) SOP, PID DATA0, EOP
 mon:     h->d: 00, 05, 02, 00, ff, 00, 00, 00, db, 02 CRCOK
-mon:   172620 --   172664: (D) SOP, PID STALL EOP
 mon:   180260 --   180372: (H) SOP, PID IN 2.15 (CRC5 18 OK), EOP
-mon:   180408 --   180452: (D) SOP, PID STALL EOP
-mon:   245792 --   245904: (H) SOP, PID SOF 01e (CRC5 00 OK), EOP
-mon:   253984 --   254100: (H) SOP, PID SOF 01f (CRC5 1f OK), EOP
-mon:   262176 --   262288: (H) SOP, PID SOF 020 (CRC5 13 OK), EOP
-mon:   270368 --   270480: (H) SOP, PID SOF 021 (CRC5 0c OK), EOP
-mon:   270520 --   270632: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
-mon:   270668 --   270712: (D) SOP, PID NAK EOP
-mon:   278560 --   278672: (H) SOP, PID SOF 022 (CRC5 04 OK), EOP
-mon:   278712 --   278824: (H) SOP, PID IN 2.1 (CRC5 03 OK), EOP
-mon:   278860 --   279064: (D) SOP, PID DATA1, EOP
-mon:     d->h: 21, 21, 21, 06, 7d CRCOK
-mon:          !!!
-mon:   279236 --   279284: (H) SOP, PID ACK EOP

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -167,16 +167,19 @@ int main(int argc, char **argv) {
         &pinmux, kTopEarlgreyPinmuxPeripheralInUsbdevSense,
         kTopEarlgreyPinmuxInselIor1));
   }
+  CHECK_DIF_OK(
+      dif_spi_device_send(&spi, &spi_config, "SPI!", 4, /*bytes_sent=*/NULL));
+
   // The TI phy always uses single ended TX
   usbdev_init(&usbdev, pinflip, differential, differential && !uphy);
 
   usb_controlep_init(&usbdev_control, &usbdev, 0, config_descriptors,
                      sizeof(config_descriptors));
+  while (usbdev_control.device_state != kUsbDeviceConfigured) {
+    usbdev_poll(&usbdev);
+  }
   usb_simpleserial_init(&simple_serial0, &usbdev, 1, usb_receipt_callback_0);
   usb_simpleserial_init(&simple_serial1, &usbdev, 2, usb_receipt_callback_1);
-
-  CHECK_DIF_OK(
-      dif_spi_device_send(&spi, &spi_config, "SPI!", 4, /*bytes_sent=*/NULL));
 
   bool say_hello = true;
   bool pass_signaled = false;

--- a/sw/device/lib/usb_controlep.c
+++ b/sw/device/lib/usb_controlep.c
@@ -71,6 +71,7 @@ static ctstate_t setup_req(usb_controlep_ctx_t *ctctx, void *ctx,
       ctctx->usb_config = wValue;
       // send zero length packet for status phase
       usbdev_sendbuf_byid(ctx, buf, 0, ctctx->ep);
+      ctctx->device_state = kUsbDeviceConfigured;
       return kCtStatIn;
 
     case kUsbSetupReqGetConfiguration:
@@ -166,6 +167,9 @@ static void ctrl_tx_done(void *ctctx_v) {
       usbdev_set_deviceid(ctx, ctctx->new_dev);
       TRC_I(ctctx->new_dev, 8);
       ctctx->ctrlstate = kCtIdle;
+      // Should be kUsbDeviceAddressed only, but test controller is borked
+      // ctctx->device_state = kUsbDeviceAddressed;
+      ctctx->device_state = kUsbDeviceConfigured;
       return;
     case kCtStatIn:
       ctctx->ctrlstate = kCtIdle;
@@ -247,4 +251,6 @@ void usb_controlep_init(usb_controlep_ctx_t *ctctx, usbdev_ctx_t *ctx, int ep,
   ctctx->ctrlstate = kCtIdle;
   ctctx->cfg_dscr = cfg_dscr;
   ctctx->cfg_dscr_len = cfg_dscr_len;
+  usbdev_connect(ctx);
+  ctctx->device_state = kUsbDeviceDefault;
 }

--- a/sw/device/lib/usb_controlep.h
+++ b/sw/device/lib/usb_controlep.h
@@ -19,10 +19,20 @@ typedef enum ctstate {
   kCtError        // Something bad
 } ctstate_t;
 
+typedef enum usbdevice_state {
+  kUsbDeviceAttached,
+  kUsbDevicePowered,
+  kUsbDeviceDefault,
+  kUsbDeviceAddressed,
+  kUsbDeviceConfigured,
+  kUsbDeviceSuspended,
+} usb_device_state_t;
+
 typedef struct usb_controlep_ctx {
   usbdev_ctx_t *ctx;
   int ep;
   ctstate_t ctrlstate;
+  usb_device_state_t device_state;
   uint32_t new_dev;
   uint8_t usb_config;
   const uint8_t *cfg_dscr;

--- a/sw/device/lib/usbdev.h
+++ b/sw/device/lib/usbdev.h
@@ -225,7 +225,17 @@ void usbdev_endpoint_setup(usbdev_ctx_t *ctx, int ep, int enableout,
                            void (*flush)(void *), void (*reset)(void *));
 
 /**
+ * Connect the device to the bus.
+ *
+ * @param ctx the usbdev context.
+ */
+void usbdev_connect(usbdev_ctx_t *ctx);
+
+/**
  * Initialize the usbdev interface
+ *
+ * Does not connect the device, since the default endpoint is not yet enabled.
+ * See usbdev_connect().
  *
  * @param ctx uninitialized usbdev context pointer
  * @param pinflip boolean to indicate if PHY should be configured for D+/D- flip
@@ -253,10 +263,10 @@ void usbdev_wake(bool set);
 // when simulating with the USB DPI module.
 //#define ENABLE_TRC
 #ifdef ENABLE_TRC
-#include "sw/device/lib/uart.h"
-#define TRC_S(s) uart_send_str(s)
-#define TRC_I(i, b) uart_send_uint(i, b)
-#define TRC_C(c) uart_send_char(c)
+#include "sw/device/lib/runtime/log.h"
+#define TRC_S(s) LOG_INFO("%s", s)
+#define TRC_I(i, b) LOG_INFO("0x%x", i)
+#define TRC_C(c) LOG_INFO("%c", c)
 #else
 #define TRC_S(s)
 #define TRC_I(i, b)

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -653,6 +653,8 @@ usbdev_test_lib = declare_dependency(
     sources: ['usbdev_test.c'],
     dependencies: [
       sw_lib_usb,
+      sw_lib_dif_pinmux,
+      sw_lib_pinmux,
       sw_lib_runtime_log,
     ],
   ),


### PR DESCRIPTION
Add endpoint enable and stall registers, and correct responses for
unimplemented or disabled endpoints. Also correct behavior for SETUP
packets coming on non-control endpoints.

IN and OUT endpoints can be independently stalled, so they get
independent software control. Likewise, distinguish between endpoints
that are disabled (i.e. ignore transactions) and those that simply NAK.

Also add the spec-provided timeout for host responses. Detect the
start-of-packet (idle-to-K transition) and ensure it occurs within 18
bit times (with some fudging of numbers, since this should be at the
device's pins and is likely more liberal).

Clean up the register documentation for handling transaction handshakes.
Clean up the signal naming to reflect the correct terms, such as
referring to transactions instead of transfers.

Adjust the DIF and legacy usb code to use the new registers. Also delay
connecting the USB device to the bus until the default endpoint is set
up.

Tweak hello_usbdev to wait for the host to configure the USB device
before proceeding to the main loop.

Adjust the DPI code to better track the timing of responses to some
control requests.

Tested hello_usbdev on FPGA and Verilator.