### PR TITLE
[dv] Update reset probing to match ast update

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -37,8 +37,11 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     super.apply_reset(kind);
     // Backdoor load the OTP image.
     cfg.mem_bkdr_util_h[Otp].load_mem_from_file(cfg.otp_images[cfg.use_otp_image]);
+
+    // internal reset does not immediately go to 0 when external reset is applied
+    wait (cfg.rst_n_mon_vif.pins[0] === 0);
     wait (cfg.rst_n_mon_vif.pins[0] === 1);
-    cfg.clk_rst_vif.wait_clks(100);
+
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");


### PR DESCRIPTION
- por_ni no longer causes ast to asynchronously reset.
- Tweak the sequence to first look for reset de-assertion before
  looking for assertion

Should address failures in #10283 

