### PR TITLE
[doc] Move all non-security D2 IP to D2S

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.prj.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.prj.hjson
@@ -9,7 +9,7 @@
     hw_checklist:       "../doc/checklist",
     version:            "1.0",
     life_stage:         "L1",
-    design_stage:       "D2",
+    design_stage:       "D2S",
     verification_stage: "V1",
     notes:              "DV resource allocation pending.",
 }

--- a/hw/ip/adc_ctrl/doc/checklist.md
+++ b/hw/ip/adc_ctrl/doc/checklist.md
@@ -80,10 +80,10 @@ Security      | [SEC_RND_CNST][]        | NA          |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/aon_timer/data/aon_timer.prj.hjson
+++ b/hw/ip/aon_timer/data/aon_timer.prj.hjson
@@ -10,7 +10,7 @@
     sw_checklist:       "/sw/device/lib/dif/dif_aon_timer",
     version:            "1.0",
     life_stage:         "L1",
-    design_stage:       "D2",
+    design_stage:       "D2S",
     verification_stage: "V0",
     dif_stage:          "S1",
 }

--- a/hw/ip/aon_timer/doc/checklist.md
+++ b/hw/ip/aon_timer/doc/checklist.md
@@ -75,10 +75,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/gpio/data/gpio.prj.hjson
+++ b/hw/ip/gpio/data/gpio.prj.hjson
@@ -20,7 +20,7 @@
       {
         version:            "1.1",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S1",
         notes:              "Rolled back to D2 as the register module is updated",

--- a/hw/ip/gpio/doc/checklist.md
+++ b/hw/ip/gpio/doc/checklist.md
@@ -79,10 +79,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/hmac/data/hmac.prj.hjson
+++ b/hw/ip/hmac/data/hmac.prj.hjson
@@ -18,9 +18,9 @@
         notes:              ""
       }
       {
-        version:            "0.6",
+        version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V1",
         dif_stage:          "S0",
         notes:              "Rolled back to D2 in order to add the first alert",

--- a/hw/ip/hmac/doc/checklist.md
+++ b/hw/ip/hmac/doc/checklist.md
@@ -79,10 +79,10 @@ Security      | [SEC_RND_CNST][]        | Not Started |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/i2c/data/i2c.prj.hjson
+++ b/hw/ip/i2c/data/i2c.prj.hjson
@@ -10,9 +10,9 @@
     sw_checklist:       "/sw/device/lib/dif/dif_i2c",
     revisions: [
       {
-        version:            "0.5",
+        version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V1",
         dif_stage:          "S0",
         notes:              ""

--- a/hw/ip/i2c/doc/checklist.md
+++ b/hw/ip/i2c/doc/checklist.md
@@ -77,10 +77,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/pattgen/data/pattgen.prj.hjson
+++ b/hw/ip/pattgen/data/pattgen.prj.hjson
@@ -11,7 +11,7 @@
       {
         version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V1",
         dif_stage:          "S0",
         notes:              ""

--- a/hw/ip/pattgen/doc/checklist.md
+++ b/hw/ip/pattgen/doc/checklist.md
@@ -75,10 +75,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/pinmux/data/pinmux.prj.hjson
+++ b/hw/ip/pinmux/data/pinmux.prj.hjson
@@ -9,7 +9,7 @@
     hw_checklist:       "../doc/checklist",
     version:            "0.5",
     life_stage:         "L1",
-    design_stage:       "D2",
+    design_stage:       "D2S",
     verification_stage: "V1",
     notes:              "Use FPV to perform block level verification.",
 }

--- a/hw/ip/pinmux/doc/checklist.md
+++ b/hw/ip/pinmux/doc/checklist.md
@@ -76,10 +76,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/pwm/data/pwm.prj.hjson
+++ b/hw/ip/pwm/data/pwm.prj.hjson
@@ -11,7 +11,7 @@
       {
         version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V1",
         dif_stage:          "S0",
         notes:              ""

--- a/hw/ip/pwm/doc/checklist.md
+++ b/hw/ip/pwm/doc/checklist.md
@@ -80,10 +80,10 @@ Security      | [SEC_RND_CNST][]        | NA          |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/rv_timer/data/rv_timer.prj.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.prj.hjson
@@ -18,9 +18,9 @@
         notes:              ""
       }
       {
-        version:            "0.6",
+        version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S0",
         notes:              "Rolled back to D2 as the register module is updated",

--- a/hw/ip/rv_timer/doc/checklist.md
+++ b/hw/ip/rv_timer/doc/checklist.md
@@ -79,10 +79,10 @@ Security      | [SEC_CM_DOCUMENTED][]   | N/A            |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/spi_device/data/spi_device.prj.hjson
+++ b/hw/ip/spi_device/data/spi_device.prj.hjson
@@ -20,10 +20,10 @@
       }
       { version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V1",
         dif_stage:          "S0",
-        commit_id:          "dae702d55b89a18621607b34f7ab8161be3706eb",
+        commit_id:          "",
         notes:              ""
       }
     ]

--- a/hw/ip/spi_device/doc/checklist.md
+++ b/hw/ip/spi_device/doc/checklist.md
@@ -77,10 +77,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/spi_host/data/spi_host.prj.hjson
+++ b/hw/ip/spi_host/data/spi_host.prj.hjson
@@ -11,7 +11,7 @@
       {
         version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V1",
         dif_stage:          "S0",
       }

--- a/hw/ip/spi_host/doc/checklist.md
+++ b/hw/ip/spi_host/doc/checklist.md
@@ -80,10 +80,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | N/A         |
-Security      | [SEC_CM_IMPLEMENTED][]       | N/A         |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
 Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.prj.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.prj.hjson
@@ -9,7 +9,7 @@
     hw_checklist:       "../doc/checklist",
     version:            "1.0",
     life_stage:         "L1",
-    design_stage:       "D2",
+    design_stage:       "D2S",
     verification_stage: "V1",
     notes:              "DV resource allocation pending.",
 }

--- a/hw/ip/sysrst_ctrl/doc/checklist.md
+++ b/hw/ip/sysrst_ctrl/doc/checklist.md
@@ -75,10 +75,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -20,7 +20,7 @@
       {
         version:            "1.1",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S1",
         notes:              "Rolled back to D2 as the register module is updated"

--- a/hw/ip/uart/doc/checklist.md
+++ b/hw/ip/uart/doc/checklist.md
@@ -83,10 +83,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/ip_templates/rv_plic/data/rv_plic.prj.hjson
+++ b/hw/ip_templates/rv_plic/data/rv_plic.prj.hjson
@@ -10,12 +10,12 @@
     sw_checklist:       "/sw/device/lib/dif/dif_rv_plic",
     revisions: [
       {
-        version:            "0.5",
+        version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S1",
-        commit_id:          "d1f3da165b6c43b20c38f9d3dabdfad8bc6e01a8",
+        commit_id:          "",
         notes:              "Use FPV to perform block level verification.",
       }
     ],

--- a/hw/ip_templates/rv_plic/doc/checklist.md
+++ b/hw/ip_templates/rv_plic/doc/checklist.md
@@ -77,10 +77,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.prj.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic.prj.hjson
@@ -10,12 +10,12 @@
     sw_checklist:       "/sw/device/lib/dif/dif_rv_plic",
     revisions: [
       {
-        version:            "0.5",
+        version:            "1.0",
         life_stage:         "L1",
-        design_stage:       "D2",
+        design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S1",
-        commit_id:          "d1f3da165b6c43b20c38f9d3dabdfad8bc6e01a8",
+        commit_id:          "",
         notes:              "Use FPV to perform block level verification.",
       }
     ],

--- a/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/doc/checklist.md
@@ -77,10 +77,10 @@ Security      | [SEC_RND_CNST][]        | N/A         |
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        | 
+Security      | [SEC_CM_RTL_REVIEWED][]      | N/A         |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | N/A         | This block only contains the bus-integrity CM.
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}


### PR DESCRIPTION
This mves all non-security IP currently at D2 to D2S.
All of these IPs only have one standardized countermeasure,
and that is the end-to-end bus integrity.

These IPs therefore technically have one countermeasure even though
these are not security IPs. This is reflected in the Hjson, and
in the Hjson checklist (`SEC_CM_ASSETS_LISTED` and
`SEC_CM_IMPLEMENTED`).

However, since these IPs are not security IPs, no further RTL and
security reviews are required (`SEC_CM_RTL_REVIEWED`,
`SEC_CM_COUNCIL_REVIEWED`).

Signed-off-by: Michael Schaffner <msf@opentitan.org>