### PR TITLE
[dv/hmac] Add wipe secret checking

### DIFF
--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -75,6 +75,25 @@
       tests: ["hmac_error"]
     }
     {
+      name: wipe_secret
+      desc: '''This test issues wipe_secret on hmac process datapath.
+            Based on the smoke sequence, this sequence increases the message length, and randomly
+            issues wipe_secret in one of the following scenarios:
+            - Before entering HMAC secret keys.
+              This scenario represents wiping secrets when HMAC is idle.
+            - Before issuing HMAC start command.
+              This scenario represents wiping secrets when HMAC entered secret keys.
+            - Before issuing HMAC process command.
+              This scenario represents wiping secrets when HMAC is streaming in message data.
+            - Before HMAC finishes hashing process.
+              This scenario represents wiping secrets when HMAC is hashing messages and keys.
+            **Checks**:
+            The scoreboard will check if digest data are corrupted.
+            '''
+      milestone: V2
+      tests: ["hmac_wipe_secret"]
+    }
+    {
       name: stress_all
       desc: "Stress_all test is a random mix of all the test above except csr tests."
       milestone: V2

--- a/hw/ip/hmac/dv/env/hmac_env.core
+++ b/hw/ip/hmac/dv/env/hmac_env.core
@@ -28,6 +28,7 @@ filesets:
       - seq_lib/hmac_test_vectors_sha_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_burst_wr_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_error_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_wipe_secret_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -4,6 +4,9 @@
 
 class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
 
+  // A flag to nofity scoreboard if digest is corrupted by wipe_secret command.
+  bit wipe_secret_triggered;
+
   `uvm_object_utils(hmac_env_cfg)
   `uvm_object_new
 

--- a/hw/ip/hmac/dv/env/hmac_env_pkg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_pkg.sv
@@ -33,6 +33,9 @@ package hmac_env_pkg;
   // 1 cycles to write a msg word to hmac_msg_fifo
   parameter uint32 HMAC_WR_WORD_CYCLE        = 1;
 
+  parameter uint NUM_DIGESTS = 8;
+  parameter uint NUM_KEYS = 8;
+
   // alerts
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
@@ -70,12 +73,34 @@ package hmac_env_pkg;
     SwPushMsgWhenIdle          = 32'h 0000_0005
   } err_code_e;
 
+  // Enum for the timing when issue wipe_secret CSR.
+  typedef enum bit [2:0] {
+    NoWipeSecret,
+    WipeSecretBeforeKey,
+    WipeSecretBeforeStart,
+    WipeSecretBeforeProcess,
+    WipeSecretBeforeDone
+  } wipe_secret_req_e;
+
   typedef class hmac_env_cfg;
   typedef class hmac_env_cov;
   typedef cip_base_virtual_sequencer #(hmac_env_cfg, hmac_env_cov) hmac_virtual_sequencer;
   typedef virtual pins_if #(1) d2h_a_ready_vif;
 
   // functions
+  function automatic int get_digest_index(string csr_name);
+    case (csr_name)
+      "digest_0": return 0;
+      "digest_1": return 1;
+      "digest_2": return 2;
+      "digest_3": return 3;
+      "digest_4": return 4;
+      "digest_5": return 5;
+      "digest_6": return 6;
+      "digest_7": return 7;
+      default: `uvm_fatal("get_digest_index", $sformatf("invalid digest csr name: %0s", csr_name))
+    endcase
+  endfunction
 
   // package sources
   `include "hmac_env_cfg.sv"

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_stress_all_vseq.sv
@@ -17,6 +17,7 @@ class hmac_stress_all_vseq extends hmac_base_vseq;
                           "hmac_datapath_stress_vseq",
                           "hmac_long_msg_vseq",
                           "hmac_error_vseq",
+                          "hmac_wipe_secret_vseq",
                           "hmac_test_vectors_sha_vseq",
                           "hmac_test_vectors_hmac_vseq"};
     for (int i = 1; i <= num_trans; i++) begin

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
@@ -12,4 +12,5 @@
 `include "hmac_common_vseq.sv"
 `include "hmac_datapath_stress_vseq.sv"
 `include "hmac_error_vseq.sv"
+`include "hmac_wipe_secret_vseq.sv"
 `include "hmac_stress_all_vseq.sv"

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_wipe_secret_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_wipe_secret_vseq.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence generates a mix of short and long msgs.
+// During the transaction, this sequence randomly trigger wipe_secret and use scb to check if
+// digest value has been updated.
+
+class hmac_wipe_secret_vseq extends hmac_smoke_vseq;
+  `uvm_object_utils(hmac_wipe_secret_vseq)
+  `uvm_object_new
+
+  constraint msg_c {
+    msg.size() dist {
+        0             :/ 1,
+        [1   :64]     :/ 1, // 64 bytes is the FIFO depth
+        [65  :999]    :/ 1,
+        [1000:3000]   :/ 7 // 1KB - 2KB according to SW immediate usage
+    };
+  }
+
+  function void pre_randomize();
+    this.wipe_secret_c.constraint_mode(0);
+  endfunction
+
+endclass : hmac_wipe_secret_vseq

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -81,6 +81,11 @@
     }
 
     {
+      name: hmac_wipe_secret
+      uvm_test_seq: hmac_wipe_secret_vseq
+    }
+
+    {
       name: hmac_test_sha_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]


### PR DESCRIPTION
This PR adds a sequence to check the wipe secret functionality.
The sequence will randomly issue wipe secret in the following four
conditions:
1). Before hmac key was input.
2). Before hmac start command.
3). Before hmac process command.
4). Before hmac process is done.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>