### PR TITLE
[otbn,dv] Fix initialisation order in MirroredRegs class

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -21,7 +21,7 @@ struct TmpDir;
 class MirroredRegs {
  public:
   MirroredRegs()
-      : status(0), insn_cnt(0), err_bits(0), stop_pc(0), rnd_req(0) {}
+      : status(0), insn_cnt(0), err_bits(0), rnd_req(0), stop_pc(0) {}
 
   uint32_t status;
   uint32_t insn_cnt;


### PR DESCRIPTION
This has no functional effect but avoids a Wreorder warning with
recent versions of GCC.
