### PR TITLE
[bazel] start running in CI and warning

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -716,3 +716,19 @@ jobs:
       command: build
       Dockerfile: ./site/redirector/Dockerfile
       buildContext: ./site/redirector
+
+
+- job: bazel_build_and_test
+  displayName: Bazel Build and Test
+  dependsOn: lint
+  pool:
+    vmImage: ubuntu-18.04
+  steps:
+    - template: ci/install-package-dependencies.yml
+      # The default timeout is too short to build verilator so let's skip it for the first pass
+    - bash: |
+            bazel query "rdeps(//..., //hw:verilator)" |
+            sed -e 's/^/-/' |
+            xargs bazel test --nobuild_tests_only --test_tag_filters=-cw310,-verilator -- //...
+      displayName: bazel test
+      continueOnError: true


### PR DESCRIPTION
This adds bazel to the azure pipelines but it continues on error which I expect will generate warnings like the verible step in the linting phase.

Signed-off-by: Drew Macrae <drewmacrae@google.com>