### PR TITLE
[CODEOWNERS] Extra codeowners for CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,6 +71,6 @@ COPYING*            @asb
 /util/licence-checker.hjson  @asb
 
 # CI and testing
-/ci/                @mcy
+/ci/                @mcy @milesdai @rswarbrick
 /test/              @mcy
-azure_pipelines.yml @mcy
+azure-pipelines.yml @mcy @milesdai @rswarbrick


### PR DESCRIPTION
I solicited extra codeowners for CI tools before seeing that @mcy was
already assigned as an owner but a typo kept it from controlling the
file that should have assigned it. I've added in the volunteers because
I think that will just help with review and situational awareness and I
don't think it will change anyone's ability to submit code.

Signed-off-by: Drew Macrae <drewmacrae@google.com>