### PR TITLE
[sw,rom_ext] Add address translation to rom_ext

### DIFF
--- a/sw/device/silicon_creator/rom_ext/meson.build
+++ b/sw/device/silicon_creator/rom_ext/meson.build
@@ -85,6 +85,7 @@ foreach slot, slot_link_args : rom_ext_link_info
     slot: declare_dependency(
       sources: [
         'rom_ext_start.S',
+        hw_ip_ibex_reg_h,
       ],
       link_args: slot_link_args[0],
       dependencies: [
@@ -109,6 +110,7 @@ foreach slot, slot_link_args : rom_ext_link_info
         slot + '_rom_ext_lib',
         sources: [
           'rom_ext.c',
+          hw_ip_ibex_reg_h,
         ],
         link_depends: [slot_link_args[1]],
     )

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -17,6 +17,12 @@ GROUP(-lgcc)
  */
 __DYNAMIC = 0;
 
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+MEMORY {
+  eflash_rom_ext(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000 
+}
+
 /**
  * Marking the entry point correctly for the ELF file. The signer tool will
  * transfer this value to the `entry_point` field of the manifest, which will
@@ -25,13 +31,28 @@ __DYNAMIC = 0;
 ENTRY(_rom_ext_start_boot)
 
 /**
+ * Reserving space at the top of the RAM for the stack.
+ */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/**
+ * These symbols will be used to setup the simple address translation
+ */
+_vflash_address = ORIGIN(eflash_rom_ext);
+_vflash_size = LENGTH(eflash_rom_ext);
+ASSERT((_vflash_size <= (LENGTH(eflash) / 2)), "Error: rom ext flash is bigger than slot");
+_addr_translation_crt_offset = _rom_ext_start_boot - _vflash_address;
+
+/**
  * NOTE: We have to align each section to word boundaries as our current
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
  */
 SECTIONS {
-  .manifest _slot_start_address : {
+  .manifest _vflash_address : {
     KEEP(*(.manifest))
-  } > eflash
+  } > eflash_rom_ext
 
   /**
    * Ibex interrupt vector.
@@ -42,14 +63,14 @@ SECTIONS {
   .vectors : ALIGN(256) {
     _text_start = .;
     KEEP(*(.vectors))
-  } > eflash
+  } > eflash_rom_ext
 
   /**
    * C runtime (CRT) section, containing program initialization code.
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-  } > eflash
+  } > eflash_rom_ext
 
   /**
    * Standard text section, containing program code.
@@ -60,7 +81,7 @@ SECTIONS {
 
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
-  } > eflash
+  } > eflash_rom_ext
 
   /**
    * Shutdown text section, containing shutdown function(s).
@@ -74,7 +95,7 @@ SECTIONS {
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _text_end = .;
-  } > eflash
+  } > eflash_rom_ext
 
   /**
    * Read-only data section, containing all large compile-time constants, like
@@ -87,7 +108,7 @@ SECTIONS {
     *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
-  } > eflash
+  } > eflash_rom_ext
 
   /**
    * Critical static data that is accessible by both the mask ROM and the ROM
@@ -145,7 +166,7 @@ SECTIONS {
      *
      * Using `AT>` means we don't have to keep track of the next free part of
      * flash, as we do in our other linker scripts. */
-  } > ram_main AT> eflash
+  } > ram_main AT> eflash_rom_ext
 
   /**
    * Standard BSS section. This will be zeroed at runtime by the CRT.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_a.ld
@@ -12,14 +12,4 @@
  * the upper half of flash), this linker script only targets Slot A.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
-
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
-/* Slot A starts at the start of the eFlash. */
-_slot_start_address = ORIGIN(eflash);
-
 INCLUDE sw/device/silicon_creator/rom_ext/rom_ext_common.ld

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
@@ -12,14 +12,4 @@
  * the upper half of flash), this linker script only targets Slot B.
  */
 
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
-
-/* Reserving space at the top of the RAM for the stack. */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
-/* Slot B starts at the half-size mark of the eFlash. */
-_slot_start_address = ORIGIN(eflash) + (LENGTH(eflash) / 2);
-
 INCLUDE sw/device/silicon_creator/rom_ext/rom_ext_common.ld

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
+#include "rv_core_ibex_regs.h"
+#include "sw/device/silicon_creator/lib/epmp_defs.h"
 
 /**
  * ROM_EXT Interrupt Vector
@@ -118,6 +120,9 @@ _rom_ext_interrupt_vector:
   .globl _rom_ext_start_boot
   .type _rom_ext_start_boot, @function
 _rom_ext_start_boot:
+  // Store the first address to compute the current slot being used.
+  // `a0 = pc`
+  auipc a0, 0
 
   /**
    * Disable Interrupts.
@@ -137,6 +142,158 @@ _rom_ext_start_boot:
   csrc mie, t0
 
   /**
+   * Initialize the Ibex simple address translation to run position dependent
+   * code in the virtual flash space.
+   * 
+   * Before the setup of the address translation the assembly code shall be 
+   * position independent, however we don't want to use the `.option pic` 
+   * directive as it requires a `got` (Global Offset Table) section. 
+   * Therefore pseudoinstructions such as `la` must be avoided because it is
+   * expanded differently for`pic` and `nopic` code.
+   * i.e:
+   *   `la rd, symbol` expands to: `pic`   -> `auipc rd, offsetHi`
+   *                                          `lw rd, offsetLo(rd)`
+   *
+   *                               `nopic` -> `auipc rd, offsetHi`
+   *                                          `addi rd, offsetLo`
+   *
+   * The `pic` expansion will use the GOT whilst the `nopic` expansion will
+   * assume we can generate the address as an offset from the PC. As
+   * this code is not yet executing in the target address space the PC value
+   * will not match what the linker expects and so an incorrect value will be
+   * loaded into `rd`.
+   * 
+   * Then the alternative to load an absolute address as a constant determined
+   * at link time (`my_symbol`) is:
+   *   `lui rd, %hi(my_symbol)`
+   *   `addi rd, rd, %lo(my_symbol)`
+   * rather than: 
+   *   `la rd, my_symbol`
+   */
+
+  // Compute the physical address of this image.
+  // `addr = pc - _addr_translation_crt_offset`
+  lui t0, %hi(_addr_translation_crt_offset)
+  addi t0, t0, %lo(_addr_translation_crt_offset)
+  sub a0, a0, t0 
+  
+  // Compute the matching NAPOT region.
+  // `a1 = virtual_addr | ((size - 1) >> 1);`
+  lui a1, %hi(_vflash_address)
+  addi a1, a1, %lo(_vflash_address)
+  lui t0, %hi(_vflash_size - 1)
+  addi t0, t0, %lo(_vflash_size - 1)
+  srli t0, t0, 1
+  or a1, a1,t0 
+
+  // Load ibex config base address.
+  li t0, TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR 
+
+  // Set ibus and dbus address matching.
+  sw a1, RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET(t0)
+  sw a1, RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET(t0)
+
+  // Set ibus and dbus address remap.
+  sw a0, RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET(t0)
+  sw a0, RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET(t0)
+
+  // Enable address translation.
+  li t1, 0x01
+  sw t1, RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET(t0)
+  sw t1, RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET(t0) 
+
+  #define EPMP_CFG_PMPCFG_MASK    (0XFF) 
+  #define EPMP_CFG_PMPCFG7_OFFSET ((7 * 8) % 32) 
+  #define EPMP_CFG_PMPCFG7_MASK   (EPMP_CFG_PMPCFG_MASK << EPMP_CFG_PMPCFG7_OFFSET)
+  #define EPMP_CFG_PMPCFG8_OFFSET ((8 * 8) % 32) 
+  #define EPMP_CFG_PMPCFG8_MASK   (EPMP_CFG_PMPCFG_MASK << EPMP_CFG_PMPCFG8_OFFSET)
+  #define EPMP_CFG_PMPCFG9_OFFSET ((9 * 8) % 32)
+  #define EPMP_CFG_PMPCFG9_MASK   (EPMP_CFG_PMPCFG_MASK << EPMP_CFG_PMPCFG9_OFFSET)
+  /**
+   * Asserting that the epmp entries as free by checking that the registers pmpaddr7,
+   * pmpaddr8, pmpaddr9, pmpcfg7, pmpcfg8 and  pmpcfg9 are all zeros.
+   *  ``` 
+   *  if ((pmpaddr7 | pmpaddr8 | pmpaddr9 | pmpcfg7 | pmpcfg8 | pmpcfg9) != 0){
+   *     _rom_ext_epmp_error();
+   *  }
+   *  ``` 
+   */
+  csrr t1, pmpaddr7
+  csrr t0, pmpaddr8
+  or t1, t1, t0
+  csrr t0, pmpaddr9
+  or t1, t1, t0
+  csrr t0, pmpcfg1
+  li t2, EPMP_CFG_PMPCFG7_MASK
+  and t0, t0, t2
+  or t1, t1, t0
+  csrr t0, pmpcfg2
+  li t2, (EPMP_CFG_PMPCFG8_MASK | EPMP_CFG_PMPCFG9_MASK)
+  and t0, t0, t2
+  or t1, t1, t0
+  bnez t1, _rom_ext_epmp_error 
+  /**
+   * Configure the epmp to enable execution in the text space only and
+   * read in the whole vFlash space.
+   *   | Entry | Description                   | Permissions | Addressing Mode |
+   *   |-------|-------------------------------|-------------|-----------------|
+   *   | 7     | vflash `ROM_EXT` text start   | RX          | OFF             |
+   *   | 8     | vflash `ROM_EXT` text end     | RX          | TOR             | 
+   *   | 9     | vFlash                        | R           | NAPOT           |
+   */
+_rom_ext_start_boot_set_epmp_:  
+  // `pmpaddr7 = (_text_start >> 2)` 
+  lui t0, %hi(_text_start)
+  addi t0, t0, %lo(_text_start) 
+  srli t0, t0, 2
+  csrw pmpaddr7,t0
+  
+  // `pmpaddr8 = (_text_end >> 2)`
+  lui t0, %hi(_text_end)
+  addi t0, t0, %lo(_text_end) 
+  srli t0, t0, 2
+  csrw pmpaddr8,t0
+  
+  // Set the bits for the 8th epmp config entry.
+  li t0, ((EPMP_CFG_A_TOR | EPMP_CFG_L | EPMP_CFG_R | EPMP_CFG_X) << EPMP_CFG_PMPCFG8_OFFSET)
+  csrs pmpcfg2, t0
+
+  lui a0, %hi(_vflash_address)
+  addi a0, a0, %lo(_vflash_address) 
+  lui a1, %hi(_vflash_size)
+  addi a1, a1, %lo(_vflash_size) 
+
+  // `pmpaddr9 = (_vflash_address >> 2) | ((_vflash_size - 1) >> 3)`
+  addi t0, a1, -1
+  srli t0, t0, 3
+  srli t1, a0, 2
+  or t1, t1, t0
+  csrw pmpaddr9,t1
+  
+  // Set the bits for the 9th pmp config entry.
+  li t0, ((EPMP_CFG_A_NAPOT | EPMP_CFG_L | EPMP_CFG_R) << EPMP_CFG_PMPCFG9_OFFSET)
+  csrs pmpcfg2, t0
+
+  /**
+   * Jump to the virtual address.
+   */
+  lui t0, %hi(_rom_ext_start_c)
+  addi t0, t0, %lo(_rom_ext_start_c) 
+  jr t0
+  // Set size so this function can be disassembled.
+  .size _rom_ext_start_boot, .-_rom_ext_start_boot
+
+
+_rom_ext_epmp_error:
+  unimp
+/**
+ * This subroutine initialize the C Runtime and jump to the `main`.
+ */
+  .globl _rom_ext_start_c
+  .type _rom_ext_start_c, @function
+_rom_ext_start_c:
+
+  /**
    * Set up the stack pointer.
    *
    * In RISC-V, the stack grows downwards, so we load the address of the highest
@@ -147,18 +304,11 @@ _rom_ext_start_boot:
    * If an exception fires, the handler is conventionaly only allowed to clobber
    * memory at addresses below `sp`.
    */
-  la   sp, (_stack_end - 16)
+  
+  la sp, (_stack_end - 16)
 
   /**
-   * Set well-defined interrupt/exception handlers
-   *
-   * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
-   */
-  la   t0, (_rom_ext_interrupt_vector + 1)
-  csrw mtvec, t0
-
-  /**
-   * Setup C Runtime
+   * Setup C Runtime.
    */
 
   /**
@@ -208,6 +358,14 @@ _rom_ext_start_boot:
    */
   la gp, __global_pointer$
 
+  /**
+   * Set well-defined interrupt/exception handlers.
+   *
+   * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
+   */
+  la   t0, (_rom_ext_interrupt_vector + 1)
+  csrw mtvec, t0
+
   // Re-enable linker relaxation.
   .option pop
 
@@ -218,4 +376,5 @@ _rom_ext_start_boot:
   tail rom_ext_main
 
   // Set size so this function can be disassembled.
-  .size _rom_ext_start_boot, .-_rom_ext_start_boot
+  .size _rom_ext_start_c, .-_rom_ext_start_c
+


### PR DESCRIPTION
# Introduction
Currently we generate two binaries for ROM_EXT, one statically linked for slot A and one statically linked for slot B. Ideally we would like to generate a single ROM_EXT binary that will work regardless of which position in flash it is placed in.

There are at least two approaches we could use for this:

1. Generate position independent code (PIC) for the ROM_EXT;
2. Use the simple address translation feature on Ibex to map ROM_EXT to a single virtual address regardless of which slot it is in;

See issue #9930 
 
# Changes
This PR:

1. Changes the ROM_EXT crt setup to be position independent;
2. Enables the simple address translation feature before jump to the C code which is position dependent (as PIC codegen is not available);
3. Add an new entry on the ePMP to the eFlash_virtual.


# Theory of operation
The ROM_EXT is being linked to a virtual space address (0x9000_0000), the MASK_ROM is jumping to a physical address on flash in the range from `0x2000_0000` to `0x2000_0000 + flash size` to be chosen by the update service at runtime. Making the address translation setup code position independent (PIC), it can run in any address, providing freedom to the update service. After the address translation is configured we can finally jump to a position-dependent code which will be mapped to the virtual address 0x900X_XXXX. 
## Memory layout
![image](https://user-images.githubusercontent.com/92785679/156340822-d30de330-b483-4696-b212-e2ae6e6f9cd0.png)

## Flowchart
![image](https://user-images.githubusercontent.com/92785679/156340927-09e49d5e-f151-4ed6-9bb1-c9d03795c41a.png)

Obs: We may want to remove the generation of two binaries (slot a and slot b) in a future PR.