### PR TITLE
[otbn,dv] Teach ISS to handle secure wipe

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -406,7 +406,7 @@ int ISSWrapper::step(bool gen_trace) {
   bool error = false;
 
   run_command("step\n", &lines);
-  if (gen_trace) {
+  if (gen_trace && lines.size()) {
     if (!OtbnTraceChecker::get().OnIssTrace(lines)) {
       return -1;
     }

--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -237,7 +237,8 @@ static void read_ext_reg(const std::string &reg_name,
   }
 }
 
-ISSWrapper::ISSWrapper() : tmpdir(new TmpDir()) {
+ISSWrapper::ISSWrapper(bool enable_secure_wipe)
+    : tmpdir(new TmpDir()), enable_secure_wipe(enable_secure_wipe) {
   std::string model_path(find_otbn_model());
 
   // We want two pipes: one for writing to the child process, and the other for
@@ -352,7 +353,13 @@ void ISSWrapper::dump_d(const std::string &path) const {
   run_command(oss.str(), nullptr);
 }
 
-void ISSWrapper::start() { run_command("start\n", nullptr); }
+void ISSWrapper::start() {
+  std::ostringstream oss;
+  oss << "configure " << (int)enable_secure_wipe << "\n";
+
+  run_command("start\n", nullptr);
+  run_command(oss.str(), nullptr);
+}
 
 void ISSWrapper::edn_rnd_cdc_done() {
   run_command("edn_rnd_cdc_done\n", nullptr);

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -43,7 +43,7 @@ struct ISSWrapper {
     uint32_t words[256 / 32];
   };
 
-  ISSWrapper();
+  ISSWrapper(bool enable_secure_wipe);
   ~ISSWrapper();
 
   // Load new contents of DMEM / IMEM
@@ -148,6 +148,8 @@ struct ISSWrapper {
 
   // A temporary directory for communicating with the child process
   std::unique_ptr<TmpDir> tmpdir;
+
+  bool enable_secure_wipe;
 
   // Mirrored copies of registers
   MirroredRegs mirrored_;

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -23,7 +23,10 @@ module otbn_core_model
   // Scope of an RTL OTBN implementation (for DPI). If empty, this is a "standalone" model, which
   // should update DMEM on completion. If not empty, we assume it's the scope for the top-level of a
   // real implementation running alongside and we check DMEM contents on completion.
-  parameter string DesignScope = ""
+  parameter string DesignScope = "",
+
+  // Enable internal secure wipe
+  parameter bit SecWipeEn  = 1'b0
 )(
   input  logic               clk_i,
   input  logic               clk_edn_i,
@@ -57,7 +60,7 @@ module otbn_core_model
   // Create and destroy an object through which we can talk to the ISS.
   chandle model_handle;
   initial begin
-    model_handle = otbn_model_init(MemScope, DesignScope);
+    model_handle = otbn_model_init(MemScope, DesignScope, SecWipeEn);
     assert(model_handle != null);
   end
   final begin

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -220,8 +220,10 @@ static std::vector<T> get_stack(const std::string &stack_scope) {
 }
 
 OtbnModel::OtbnModel(const std::string &mem_scope,
-                     const std::string &design_scope)
-    : mem_util_(mem_scope), design_scope_(design_scope) {}
+                     const std::string &design_scope, bool enable_secure_wipe)
+    : mem_util_(mem_scope),
+      design_scope_(design_scope),
+      enable_secure_wipe_(enable_secure_wipe) {}
 
 OtbnModel::~OtbnModel() {}
 
@@ -521,7 +523,7 @@ int OtbnModel::send_lc_escalation() {
 ISSWrapper *OtbnModel::ensure_wrapper() {
   if (!iss_) {
     try {
-      iss_.reset(new ISSWrapper());
+      iss_.reset(new ISSWrapper(enable_secure_wipe_));
     } catch (const std::runtime_error &err) {
       std::cerr << "Error when constructing ISS wrapper: " << err.what()
                 << "\n";
@@ -706,9 +708,11 @@ bool OtbnModel::check_call_stack(ISSWrapper &iss) const {
   return good;
 }
 
-OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope) {
+OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope,
+                           int enable_secure_wipe) {
   assert(mem_scope && design_scope);
-  return new OtbnModel(mem_scope, design_scope);
+  assert(enable_secure_wipe == 0 || enable_secure_wipe == 1);
+  return new OtbnModel(mem_scope, design_scope, enable_secure_wipe != 0);
 }
 
 void otbn_model_destroy(OtbnModel *model) { delete model; }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -16,7 +16,8 @@ struct ISSWrapper;
 
 class OtbnModel {
  public:
-  OtbnModel(const std::string &mem_scope, const std::string &design_scope);
+  OtbnModel(const std::string &mem_scope, const std::string &design_scope,
+            bool enable_secure_wipe);
   ~OtbnModel();
 
   // Replace any current loop warps with those from memutil. Returns 0
@@ -124,10 +125,12 @@ class OtbnModel {
   // We want to create the model in an initial block in the SystemVerilog
   // simulation, but might not actually want to spawn the ISS. To handle that
   // in a non-racy way, the most convenient thing is to spawn the ISS the first
-  // time it's actually needed. Use ensure_iss() to create as needed.
+  // time it's actually needed. Use ensure_wrapper() to create as needed.
   std::unique_ptr<ISSWrapper> iss_;
+
   OtbnMemUtil mem_util_;
   std::string design_scope_;
+  bool enable_secure_wipe_;
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_MODEL_H_

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -16,7 +16,8 @@
 extern "C" {
 
 // Create an OtbnModel object. Will always succeed.
-OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope);
+OtbnModel *otbn_model_init(const char *mem_scope, const char *design_scope,
+                           int enable_secure_wipe);
 
 // Delete an OtbnModel
 void otbn_model_destroy(OtbnModel *model);

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -10,7 +10,8 @@ package otbn_model_pkg;
   import otbn_pkg::WLEN;
 
   import "DPI-C" context function chandle otbn_model_init(string mem_scope,
-                                                          string design_scope);
+                                                          string design_scope,
+                                                          bit    enable_secure_wipe);
 
   import "DPI-C" function void otbn_model_destroy(chandle model);
 

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.cc
@@ -49,7 +49,10 @@ void OtbnTraceChecker::AcceptTraceString(const std::string &trace,
 
   done_ = false;
   OtbnTraceEntry trace_entry;
-  trace_entry.from_rtl_trace(trace);
+  if (!trace_entry.from_rtl_trace(trace)) {
+    seen_err_ = true;
+    return;
+  }
   if (trace_entry.trace_type() == OtbnTraceEntry::Invalid) {
     std::cerr << "ERROR: Invalid RTL trace entry with invalid header:\n";
     trace_entry.print("  ", std::cerr);

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -82,10 +82,9 @@ class OtbnTraceChecker : public OtbnTraceListener {
   // message to stderr and return false.
   bool MatchPair();
 
+  bool rtl_started_;
   bool rtl_pending_;
-  bool rtl_stall_;
   OtbnTraceEntry rtl_entry_;
-  OtbnTraceEntry rtl_stalled_entry_;
 
   bool iss_started_;
   bool iss_pending_;

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.cc
@@ -13,6 +13,7 @@
 void OtbnTraceEntry::from_rtl_trace(const std::string &trace) {
   size_t eol = trace.find('\n');
   hdr_ = trace.substr(0, eol);
+  trace_type_ = hdr_to_trace_type(hdr_);
 
   while (eol != std::string::npos) {
     size_t bol = eol + 1;
@@ -50,12 +51,6 @@ void OtbnTraceEntry::take_writes(const OtbnTraceEntry &other) {
   }
 }
 
-bool OtbnTraceEntry::empty() const { return hdr_.empty(); }
-
-bool OtbnTraceEntry::is_stall() const { return !empty() && hdr_[0] == 'S'; }
-
-bool OtbnTraceEntry::is_exec() const { return !empty() && hdr_[0] == 'E'; }
-
 bool OtbnTraceEntry::is_compatible(const OtbnTraceEntry &prev) const {
   // Two entries are compatible if they might both come from the multi-cycle
   // execution of one instruction. For example, you might expect to see these
@@ -67,6 +62,8 @@ bool OtbnTraceEntry::is_compatible(const OtbnTraceEntry &prev) const {
   // which show an instruction at 0x10 stalling for a cycle and then managing
   // to execute.
   //
+  // Similarly, you might expect to see U followed by U or V.
+  //
   // As an added complication, if we see an IMEM fetch error, the entry will
   // become
   //
@@ -74,6 +71,7 @@ bool OtbnTraceEntry::is_compatible(const OtbnTraceEntry &prev) const {
   //
   // and that's fine. So the rule is:
   //
+  //   - Check the types are compatible (S then S or E; U then U or V)
   //   - Compare the two lines from character 1 onwards.
   //   - If they match: accept.
   //   - Otherwise, if the second line has no '?' then reject.
@@ -83,6 +81,20 @@ bool OtbnTraceEntry::is_compatible(const OtbnTraceEntry &prev) const {
   // (This wrongly accepts some malformed examples, but that's fine: it's just
   // meant as a quick check to make sure our trace machinery isn't dropping
   // entries)
+  bool matching_types;
+  switch (prev.trace_type()) {
+    case Stall:
+      matching_types = (trace_type_ == Stall || trace_type_ == Exec);
+      break;
+    case WipeInProgress:
+      matching_types =
+          (trace_type_ == WipeInProgress || trace_type_ == WipeComplete);
+      break;
+    default:
+      matching_types = false;
+  }
+  if (!matching_types)
+    return false;
 
   bool exact_match =
       0 == hdr_.compare(1, std::string::npos, prev.hdr_, 1, std::string::npos);
@@ -94,6 +106,36 @@ bool OtbnTraceEntry::is_compatible(const OtbnTraceEntry &prev) const {
     return false;
 
   return 0 == hdr_.compare(1, first_qm - 1, prev.hdr_, 1, first_qm - 1);
+}
+
+bool OtbnTraceEntry::is_partial() const {
+  return ((trace_type_ == OtbnTraceEntry::Stall) ||
+          (trace_type_ == OtbnTraceEntry::WipeInProgress));
+}
+
+bool OtbnTraceEntry::is_final() const {
+  return ((trace_type_ == OtbnTraceEntry::Exec) ||
+          (trace_type_ == OtbnTraceEntry::WipeComplete));
+}
+
+OtbnTraceEntry::trace_type_t OtbnTraceEntry::hdr_to_trace_type(
+    const std::string &hdr) {
+  if (hdr.empty()) {
+    return Invalid;
+  }
+
+  switch (hdr[0]) {
+    case 'S':
+      return Stall;
+    case 'E':
+      return Exec;
+    case 'U':
+      return WipeInProgress;
+    case 'V':
+      return WipeComplete;
+    default:
+      return Invalid;
+  }
 }
 
 bool OtbnIssTraceEntry::from_iss_trace(const std::vector<std::string> &lines) {
@@ -108,6 +150,7 @@ bool OtbnIssTraceEntry::from_iss_trace(const std::vector<std::string> &lines) {
     switch (state) {
       case 0:
         hdr_ = line;
+        trace_type_ = hdr_to_trace_type(hdr_);
         state = (!line.empty() && line[0] == 'E') ? 1 : 2;
         break;
 

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -9,6 +9,14 @@
 
 class OtbnTraceEntry {
  public:
+  enum trace_type_t {
+    Invalid,
+    Stall,
+    Exec,
+    WipeInProgress,
+    WipeComplete,
+  };
+
   virtual ~OtbnTraceEntry(){};
 
   void from_rtl_trace(const std::string &trace);
@@ -18,20 +26,22 @@ class OtbnTraceEntry {
 
   void take_writes(const OtbnTraceEntry &other);
 
-  // True if the entry is empty (no header or other text)
-  bool empty() const;
-
-  // True if this is a stall
-  bool is_stall() const;
-
-  // True if this is an execute line
-  bool is_exec() const;
+  trace_type_t trace_type() const { return trace_type_; }
 
   // True if this is an acceptable line to follow other (assumed to
-  // have been a stall)
+  // have been of type Stall or WipeInProgress)
   bool is_compatible(const OtbnTraceEntry &other) const;
 
+  // True if this entry is "partial" (Stall or WipeInProgress)
+  bool is_partial() const;
+
+  // True if this entry is "final" (Exec or WipeComplete)
+  bool is_final() const;
+
  protected:
+  static trace_type_t hdr_to_trace_type(const std::string &hdr);
+
+  trace_type_t trace_type_;
   std::string hdr_;
   std::vector<std::string> writes_;
 };

--- a/hw/ip/otbn/dv/otbnsim/sim/csr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/csr.py
@@ -103,3 +103,6 @@ class CSRFile:
             return
 
         raise RuntimeError('Unknown CSR index: {:#x}'.format(idx))
+
+    def wipe(self) -> None:
+        self.flags.write_unsigned(0)

--- a/hw/ip/otbn/dv/otbnsim/sim/gpr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/gpr.py
@@ -107,6 +107,16 @@ class GPRs(RegFile):
         self._x1.abort()
         self.call_stack_err = False
 
-    def start(self) -> None:
-        '''Executed on start of operation. Clears call stack.'''
+    def empty_call_stack(self) -> None:
+        '''Clear call stack.'''
         self._x1.start()
+
+    def wipe(self) -> None:
+        '''Wipe all registers to zero'''
+        # Wipe GPRs other than x0 (no effect) and x1 (not tracked like this at
+        # the moment).
+        #
+        # TODO: Check that we wipe the call stack in the RTL and make sure it
+        #       appears in a trace entry, then match that here.
+        for idx in range(2, 32):
+            self.get_reg(idx).write_unsigned(0)

--- a/hw/ip/otbn/dv/otbnsim/sim/reg.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/reg.py
@@ -126,3 +126,7 @@ class RegFile:
     def peek_unsigned_values(self) -> List[int]:
         '''Get a list of the (unsigned) values of the registers'''
         return [reg.read_unsigned(backdoor=True) for reg in self._registers]
+
+    def wipe(self) -> None:
+        for r in self._registers:
+            r.write_unsigned(0)

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -161,11 +161,14 @@ class OTBNSim:
         if self.state.fsm_state in [FsmState.WIPING_GOOD, FsmState.WIPING_BAD]:
             assert self.state.wipe_cycles > 0
             self.state.wipe_cycles -= 1
+            # Wipe all registers and set STATUS on the penultimate cycle.
             if self.state.wipe_cycles == 1:
                 next_status = (Status.IDLE
                                if self.state.fsm_state == FsmState.WIPING_GOOD
                                else Status.LOCKED)
                 self.state.ext_regs.write('STATUS', next_status, True)
+                self.state.wipe()
+
             return (None, self._on_stall(verbose, fetch_next=False))
 
         assert self.state.fsm_state == FsmState.EXEC

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -59,6 +59,9 @@ class OTBNSim:
         self._next_insn = None
         self.state.start()
 
+    def configure(self, enable_secure_wipe: bool) -> None:
+        self.state.secure_wipe_enabled = enable_secure_wipe
+
     def _fetch(self, pc: int) -> OTBNInsn:
         word_pc = pc >> 2
         if word_pc >= len(self.program):

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -113,6 +113,11 @@ class OTBNState:
         self._time_to_imem_invalidation = None  # type: Optional[int]
         self.invalidated_imem = False
 
+        # This flag controls whether we do the secure wipe sequence after
+        # finishing an operation. Eventually it will be unconditionally enabled
+        # (once everything works together properly).
+        self.secure_wipe_enabled = False
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -19,48 +19,49 @@ from .trace import Trace, TracePC
 from .wsr import WSRFile
 
 
+# The number of cycles spent in the 'WIPE' state. This takes constant time in
+# the RTL, mirrored here.
+_WIPE_CYCLES = 98
+
+
 class FsmState(IntEnum):
     r'''State of the internal start/stop FSM
 
     The FSM diagram looks like:
 
-          /----------------------------------------------------------\
-          |                                                          |
-          v                                         /->  POST_EXEC --/
-        IDLE  ->  PRE_EXEC  ->  FETCH_WAIT -> EXEC <
-                                                    \->  LOCKING   --\
-                                                                     |
-          /----------------------------------------------------------/
-          |
-          v
-        LOCKED
+
+          IDLE -> PRE_EXEC -> FETCH_WAIT -> EXEC
+            ^                                | |
+            \---------------- WIPING_GOOD <--/ |
+                                               |
+                  LOCKED <--  WIPING_BAD  <----/
 
     IDLE represents the state when nothing is going on but there have been no
     fatal errors. It matches Status.IDLE. LOCKED represents the state when
     there has been a fatal error. It matches Status.LOCKED.
 
-    PRE_EXEC, FETCH_WAIT, EXEC, POST_EXEC and LOCKING correspond to
+    PRE_EXEC, FETCH_WAIT, EXEC, WIPING_GOOD and WIPING_BAD correspond to
     Status.BUSY_EXECUTE. PRE_EXEC is the period after starting OTBN where we're
     still waiting for an EDN value to seed URND. FETCH_WAIT is the single cycle
     delay after seeding URND to fill the prefetch stage. EXEC is the period
     where we start fetching and executing instructions.
 
-    POST_EXEC and LOCKING are both used for the single cycle after we finish
-    executing where the STATUS register gets updated. The difference between
-    them is that POST_EXEC goes back to IDLE and LOCKING goes to LOCKED.
+    WIPING_GOOD and WIPING_BAD represent the time where we're performing a
+    secure wipe of internal state (ending in updating the STATUS register to
+    show we're done). The difference between them is that WIPING_GOOD goes back
+    to IDLE and WIPING_BAD goes to LOCKED.
 
     This is a refinement of the Status enum and the integer values are picked
     so that you can divide by 10 to get the corresponding Status entry. (This
     isn't used in the code, but makes debugging slightly more convenient when
     you just have the numeric values available).
-
     '''
     IDLE = 0
     PRE_EXEC = 10
     FETCH_WAIT = 11
     EXEC = 12
-    POST_EXEC = 13
-    LOCKING = 14
+    WIPING_GOOD = 13
+    WIPING_BAD = 14
     LOCKED = 2550
 
 
@@ -117,6 +118,11 @@ class OTBNState:
         # finishing an operation. Eventually it will be unconditionally enabled
         # (once everything works together properly).
         self.secure_wipe_enabled = False
+
+        # This is the number of cycles left for wiping. When we're in the
+        # WIPING_GOOD or WIPING_BAD state, this should be a non-negative
+        # number. Initialise to -1 to catch bugs if we forget to set it.
+        self.wipe_cycles = -1
 
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
@@ -316,20 +322,17 @@ class OTBNState:
 
             return
 
-        # If we are in POST_EXEC mode, this is the single cycle after the end
-        # of execution after either completion or a recoverable error. Commit
-        # external registers (to update STATUS) and then switch to IDLE.
-        if self.fsm_state == FsmState.POST_EXEC:
+        # If we are in either WIPING_GOOD or WIPING_BAD, we're busy wiping all
+        # internal state. Our wipe_cycles counter will have been decremented by
+        # Sim::step() and we're done if it gets to zero.
+        if self.fsm_state in [FsmState.WIPING_GOOD, FsmState.WIPING_BAD]:
             self.ext_regs.commit()
-            self.fsm_state = FsmState.IDLE
-            return
-
-        # If we are in LOCKING mode, this is the single cycle after the end of
-        # execution after a fatal error. Commit external registers (to update
-        # STATUS) and then switch to LOCKED.
-        if self.fsm_state == FsmState.LOCKING:
-            self.ext_regs.commit()
-            self.fsm_state = FsmState.LOCKED
+            assert self.wipe_cycles >= 0
+            if self.wipe_cycles == 0:
+                self.fsm_state = (FsmState.IDLE
+                                  if self.fsm_state == FsmState.WIPING_GOOD
+                                  else FsmState.LOCKED)
+                self.wipe_cycles = -1
             return
 
         # If we are in LOCKED mode, commit external registers but do nothing
@@ -346,12 +349,17 @@ class OTBNState:
         # POST_EXEC to allow one more cycle.
         if self.pending_halt:
             self.ext_regs.commit()
-            if self._err_bits >> 16:
+
+            should_lock = (self._err_bits >> 16) != 0
+            if should_lock:
                 self.ext_regs.write('INSN_CNT', 0, True)
-                self.fsm_state = FsmState.LOCKING
-            else:
-                if self.fsm_state == FsmState.EXEC:
-                    self.fsm_state = FsmState.POST_EXEC
+
+            if self.fsm_state == FsmState.EXEC:
+                self.fsm_state = (FsmState.WIPING_BAD if should_lock
+                                  else FsmState.WIPING_GOOD)
+                self.wipe_cycles = (_WIPE_CYCLES
+                                    if self.secure_wipe_enabled else 1)
+
             return
 
         # As pending_halt wasn't set, there shouldn't be any pending error bits
@@ -426,11 +434,12 @@ class OTBNState:
         # set) is the 'done' flag.
         self.ext_regs.set_bits('INTR_STATE', 1 << 0)
 
-        # STATUS is a status register. If there are any pending error bits
-        # greater than 16, this was a fatal error so we should lock ourselves.
-        # Otherwise, go back to IDLE.
-        new_status = Status.LOCKED if self._err_bits >> 16 else Status.IDLE
-        self.ext_regs.write('STATUS', new_status, True)
+        if not self.secure_wipe_enabled:
+            # STATUS is a status register. If there are any pending error bits
+            # greater than 16, this was a fatal error so we should lock
+            # ourselves. Otherwise, go back to IDLE.
+            new_status = Status.LOCKED if self._err_bits >> 16 else Status.IDLE
+            self.ext_regs.write('STATUS', new_status, True)
 
         # Make any error bits visible
         self.ext_regs.write('ERR_BITS', self._err_bits, True)

--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -417,3 +417,7 @@ class WSRFile:
                           key1: Optional[int]) -> None:
         self.KeyS0.set_unsigned(key0)
         self.KeyS1.set_unsigned(key1)
+
+    def wipe(self) -> None:
+        self.MOD.write_unsigned(0)
+        self.ACC.write_unsigned(0)

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -14,6 +14,9 @@ prefixed with "0x" if they are hexadecimal.
 
     start                Set the PC to zero and start OTBN
 
+    configure            Enable or disable the secure wipe machinery (this is a
+                         temporary feature until everything works together)
+
     step                 Run one instruction. Print trace information to
                          stdout.
 
@@ -117,6 +120,15 @@ def on_start(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     print('START')
     sim.state.ext_regs.commit()
     sim.start(collect_stats=False)
+
+    return None
+
+
+def on_configure(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('configure', 1, args)
+
+    enable = read_word('secure_wipe_en', args[0], 1) != 0
+    sim.configure(enable)
 
     return None
 
@@ -354,6 +366,7 @@ def on_send_lc_escalation(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 
 _HANDLERS = {
     'start': on_start,
+    'configure': on_configure,
     'step': on_step,
     'load_elf': on_load_elf,
     'add_loop_warp': on_add_loop_warp,

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -142,11 +142,12 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
 
     insn, changes = sim.step(verbose=False)
 
-    print('STALL' if insn is None else insn.rtl_trace(pc))
-    for change in changes:
-        entry = change.rtl_trace()
-        if entry is not None:
-            print(entry)
+    if insn is not None or changes:
+        print('STALL' if insn is None else insn.rtl_trace(pc))
+        for change in changes:
+            entry = change.rtl_trace()
+            if entry is not None:
+                print(entry)
 
     return None
 

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -74,7 +74,9 @@ interface otbn_trace_if
 
   input logic [otbn_pkg::WLEN-1:0] urnd_data,
 
-  input logic [1:0][otbn_pkg::SideloadKeyWidth-1:0] sideload_key_shares_i
+  input logic [1:0][otbn_pkg::SideloadKeyWidth-1:0] sideload_key_shares_i,
+
+  input logic secure_wipe_running
 );
   import otbn_pkg::*;
 
@@ -290,6 +292,18 @@ interface otbn_trace_if
 
     assign flags_read_data[i_fg] = u_otbn_alu_bignum.flags_q[i_fg];
   end
+
+  // Detect negative edges of the secure wipe signal
+  logic secure_wipe_running_r, secure_wipe_done;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      secure_wipe_running_r <= 0;
+    end else begin
+      secure_wipe_running_r <= secure_wipe_running;
+    end
+  end
+  assign secure_wipe_done = secure_wipe_running_r & ~secure_wipe_running;
+
 endinterface
 
 `endif // SYNTHESIS

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -49,6 +49,11 @@ interface otbn_trace_if
   input logic                      rf_bignum_rd_en_a,
   input logic                      rf_bignum_rd_en_b,
 
+  input logic [1:0]                   rf_bignum_wr_en,
+  input logic [otbn_pkg::WLEN-1:0]    rf_bignum_wr_data_no_intg,
+  input logic [otbn_pkg::ExtWLEN-1:0] rf_bignum_wr_data_intg,
+  input logic                         rf_bignum_wr_data_intg_sel,
+
   input logic [31:0]              insn_fetch_resp_data,
   input logic [ImemAddrWidth-1:0] insn_fetch_resp_addr,
   input logic                     insn_fetch_resp_valid,
@@ -102,7 +107,6 @@ interface otbn_trace_if
 
   logic [WLEN-1:0] rf_bignum_rd_data_a;
   logic [WLEN-1:0] rf_bignum_rd_data_b;
-  logic [WLEN-1:0] rf_bignum_wr_data_no_intg;
 
   assign rf_base_rd_data_a = u_otbn_controller.rf_base_rd_data_a_no_intg;
   assign rf_base_rd_data_b = u_otbn_controller.rf_base_rd_data_b_no_intg;
@@ -112,16 +116,16 @@ interface otbn_trace_if
   assign rf_bignum_rd_data_b = u_otbn_controller.rf_bignum_rd_data_b_no_intg;
 
   // The bignum register file is capable of half register writes. To avoid the tracer having to deal
-  // with this, slightly modified rf_bignum_wr_en and rf_bignum_wr_data signals are provided here.
-  // If there is a half-word write the other half of the register is taken directly from the
-  // register file and both halves are presented as the write data to the tracer. `rf_bignum_wr_en`
-  // becomes a single bit signal because of this.
-  logic            rf_bignum_wr_en;
+  // with this, it should just OR together the bits of rf_bignum_wr_en to get a single "there was a
+  // write" signal.
+  //
+  // We also clean up the (complicated) write data signals here and present them as
+  // rf_bignum_wr_data. Integrity is stripped. If there is a half-word write then the other half of
+  // the register is taken directly from the register file and both halves are presented as the
+  // write data to the tracer.
   logic [WLEN-1:0] rf_bignum_wr_data;
-
-  assign rf_bignum_wr_en = |u_otbn_controller.rf_bignum_wr_en_o;
-
-  logic [WLEN-1:0] rf_bignum_wr_old_data;
+  logic [WLEN-1:0] rf_bignum_wr_data_stripped_intg, rf_bignum_wr_new_data, rf_bignum_wr_old_data;
+  logic [BaseWordsPerWLEN-1:0] unused_bignum_intg_data;
 
   logic [ExtWLEN-1:0] bignum_rf [NWdr];
 
@@ -134,21 +138,32 @@ interface otbn_trace_if
   end
 
   for (genvar i = 0; i < BaseWordsPerWLEN; ++i) begin : g_bignum_rf_strip_intg
-    // u_otbn_rf_bignum.wr_data_no_intg is final write data heading to the register file, which
-    // includes the integrity, this needs to be stripped off for tracing.
-    assign rf_bignum_wr_data_no_intg[i*32 +: 32] =
-        u_otbn_rf_bignum.wr_data_intg_mux_out[i * BaseIntgWidth +: 32];
+    // Strip out integrity bits from rf_bignum_wr_data_intg so that we can use this as a source for
+    // rf_bignum_wr_data_for_trace when rf_bignum_wr_data_intg_sel is set.
+    assign rf_bignum_wr_data_stripped_intg[i*32 +: 32] =
+        rf_bignum_wr_data_intg[i * BaseIntgWidth +: 32];
+
     // Extract data currently in the register file for the current write address, stripping off
     // integrity. This is used to determine the final value for the whole register when doing half
     // register writes.
     assign rf_bignum_wr_old_data[i*32 +: 32] =
         bignum_rf[rf_bignum_wr_addr][i * BaseIntgWidth +: 32];
+
+    // Explicitly ignore the integrity bits
+    assign unused_bignum_intg_data[i] =
+        ^rf_bignum_wr_data_intg[i*BaseIntgWidth+32 +: (BaseIntgWidth - 32)];
   end
 
+  // Use the intg_sel signal to pick where the new write data should come from
+  assign rf_bignum_wr_new_data =
+      rf_bignum_wr_data_intg_sel ? rf_bignum_wr_data_stripped_intg : rf_bignum_wr_data_no_intg;
+
   for (genvar i = 0; i < 2; i++) begin : g_rf_bignum_wr_data
-    assign rf_bignum_wr_data[(WLEN/2)*i +: WLEN/2] = u_otbn_controller.rf_bignum_wr_en_o[i] ?
-      rf_bignum_wr_data_no_intg[(WLEN/2)*i +: WLEN/2] :
-      rf_bignum_wr_old_data[(WLEN/2)*i +: WLEN/2];
+    // Use the write-enable signal to pick whether to use new data or old.
+    assign rf_bignum_wr_data[(WLEN/2)*i +: WLEN/2] =
+        rf_bignum_wr_en[i] ?
+        rf_bignum_wr_new_data[(WLEN/2)*i +: WLEN/2] :
+        rf_bignum_wr_old_data[(WLEN/2)*i +: WLEN/2];
   end
 
   // Take Dmem interface and present it as two separate read and write sets of signals. To ease

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -120,7 +120,7 @@ module otbn_tracer
                                             otbn_trace.rf_base_rd_data_b));
     end
 
-    if (otbn_trace.rf_base_wr_en && otbn_trace.rf_base_wr_commit &&
+    if (|otbn_trace.rf_base_wr_en && otbn_trace.rf_base_wr_commit &&
         otbn_trace.rf_base_wr_addr != '0) begin
       output_trace(RegWritePrefix, $sformatf("x%02d: 0x%08x", otbn_trace.rf_base_wr_addr,
                                              otbn_trace.rf_base_wr_data));
@@ -138,7 +138,7 @@ module otbn_tracer
                                             otbn_wlen_data_str(otbn_trace.rf_bignum_rd_data_b)));
     end
 
-    if (otbn_trace.rf_bignum_wr_en) begin
+    if (|otbn_trace.rf_bignum_wr_en) begin
       output_trace(RegWritePrefix, $sformatf("w%02d: %s", otbn_trace.rf_bignum_wr_addr,
                                              otbn_wlen_data_str(otbn_trace.rf_bignum_wr_data)));
     end

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -24,6 +24,9 @@ module tb;
   wire idle, intr_done;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
+  // Configure internal secure wipe
+  localparam bit SecWipeEn  = 1'b0;
+
   // interfaces
   clk_rst_if                    clk_rst_if  (.clk(clk), .rst_n(rst_n));
   tl_if                         tl_if       (.clk(clk), .rst_n(rst_n));
@@ -107,7 +110,8 @@ module tb;
   // dut
   otbn # (
     .RndCnstOtbnKey(TestScrambleKey),
-    .RndCnstOtbnNonce(TestScrambleNonce)
+    .RndCnstOtbnNonce(TestScrambleNonce),
+    .SecWipeEn(SecWipeEn)
   ) dut (
     .clk_i (clk),
     .rst_ni(rst_n),
@@ -208,7 +212,8 @@ module tb;
 
   otbn_core_model #(
     .MemScope     ("..dut"),
-    .DesignScope  ("..dut.u_otbn_core")
+    .DesignScope  ("..dut.u_otbn_core"),
+    .SecWipeEn    (SecWipeEn)
   ) u_model (
     .clk_i        (model_if.clk_i),
     .clk_edn_i    (edn_clk),

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -153,7 +153,8 @@ module tb;
     .DmemAddrWidth (DmemAddrWidth)
   ) i_otbn_trace_if (.*);
 
-  bind dut.u_otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
+  bind dut.u_otbn_core otbn_tracer #(.SecWipeEn(SecWipeEn))
+    u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
   bind dut.u_otbn_core.u_otbn_controller otbn_controller_if i_otbn_controller_if (.*);
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -18,6 +18,9 @@ module otbn_top_sim (
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte);
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte);
 
+  // Enable internal secure wipe
+  localparam bit SecWipeEn  = 1'b0;
+
   // Fixed key and nonce for scrambling in verilator environment
   localparam logic [127:0] TestScrambleKey   = 128'h48ecf6c738f0f108a5b08620695ffd4d;
   localparam logic [63:0]  TestScrambleNonce = 64'hf88c2578fa4cd123;
@@ -65,7 +68,8 @@ module otbn_top_sim (
 
   otbn_core #(
     .ImemSizeByte ( ImemSizeByte ),
-    .DmemSizeByte ( DmemSizeByte )
+    .DmemSizeByte ( DmemSizeByte ),
+    .SecWipeEn    ( SecWipeEn    )
   ) u_otbn_core (
     .clk_i                       ( IO_CLK              ),
     .rst_ni                      ( IO_RST_N            ),
@@ -300,7 +304,8 @@ module otbn_top_sim (
 
   otbn_core_model #(
     .MemScope        ( ".." ),
-    .DesignScope     ( DesignScope )
+    .DesignScope     ( DesignScope ),
+    .SecWipeEn       ( SecWipeEn    )
   ) u_otbn_core_model (
     .clk_i                 ( IO_CLK ),
     .clk_edn_i             ( IO_CLK ),

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -165,7 +165,7 @@ module otbn_top_sim (
   assign edn_urnd_data_valid = edn_urnd_req & edn_urnd_ack;
 
   bind otbn_core otbn_trace_if #(.ImemAddrWidth, .DmemAddrWidth) i_otbn_trace_if (.*);
-  bind otbn_core otbn_tracer u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
+  bind otbn_core otbn_tracer #(.SecWipeEn) u_otbn_tracer(.*, .otbn_trace(i_otbn_trace_if));
 
   // Pulse otbn_start for 1 cycle immediately out of reset.
   // Flop `done_o` from otbn_core to match up with model done signal.

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -19,6 +19,9 @@ module otbn
   // Default seed for URND PRNG
   parameter urnd_prng_seed_t       RndCnstUrndPrngSeed      = RndCnstUrndPrngSeedDefault,
 
+  // Enable internal secure wipe
+  parameter bit SecWipeEn  = 1'b0,
+
   // Default seed and nonce for scrambling
   parameter otp_ctrl_pkg::otbn_key_t   RndCnstOtbnKey   = RndCnstOtbnKeyDefault,
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnNonce = RndCnstOtbnNonceDefault
@@ -873,7 +876,8 @@ module otbn
 
     otbn_core_model #(
       .MemScope(".."),
-      .DesignScope("")
+      .DesignScope(""),
+      .SecWipeEn(SecWipeEn)
     ) u_otbn_core_model (
       .clk_i,
       .clk_edn_i,
@@ -918,6 +922,7 @@ module otbn
       .RegFile(RegFile),
       .DmemSizeByte(DmemSizeByte),
       .ImemSizeByte(ImemSizeByte),
+      .SecWipeEn(SecWipeEn),
       .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed)
     ) u_otbn_core (
       .clk_i,
@@ -976,6 +981,7 @@ module otbn
       .RegFile(RegFile),
       .DmemSizeByte(DmemSizeByte),
       .ImemSizeByte(ImemSizeByte),
+      .SecWipeEn(SecWipeEn),
       .RndCnstUrndPrngSeed(RndCnstUrndPrngSeed)
     ) u_otbn_core (
       .clk_i,

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -134,8 +134,7 @@ module otbn_alu_bignum
       if (!rst_ni) begin
         flags_q[i_fg] <= '{Z : 1'b0, L : 1'b0, M : 1'b0, C : 1'b0};
       end else if (flags_en[i_fg]) begin
-        flags_q[i_fg] <= sec_wipe_zero_i ? '{Z : 1'b0, L : 1'b0, M : 1'b0, C : 1'b0} :
-                                           flags_d[i_fg];
+        flags_q[i_fg] <= flags_d[i_fg];
       end
     end
 
@@ -154,6 +153,7 @@ module otbn_alu_bignum
         logic_update_flags_en: flags_d[i_fg] = logic_update_flags;
         mac_update_flags_en:   flags_d[i_fg] = mac_update_flags;
         ispr_update_flags_en:  flags_d[i_fg] = ispr_base_wdata_i[i_fg*FlagsWidth+:FlagsWidth];
+        sec_wipe_zero_i:       flags_d[i_fg] = '0;
         default: ;
       endcase
     end


### PR DESCRIPTION
This PR is broken into several commits to try to make things a bit easier to review.

- [otbn,dv] Wire a secure wipe enable from RTL to ISS
- [otbn,dv] Define a new class of trace entry for secure wipe writes
- [otbn,dv] Update the ISS FSM to include a wiping state
- [otbn,dv] Represent trace entries as a map to merge them better
- [otbn,dv] Teach tracer to understand bignum writes when wiping
- [otbn,rtl] Tweak how we wipe flags
- [otbn,dv] Teach ISS to generate trace entries for secure wipe

The first commit doesn't do anything exciting, but allows the testbench top-levels to configure whether secure wipe is enabled and passes that configuration setting through to the ISS (where it's ignored, until later commits).

The following commits step gradually towards things working properly when secure wipe is enabled. With the final commit, we can run tests successfully with it enabled. We can't switch it on quite yet because the smoke test would fail (it checks for a known final state, which will have been zeroed!). But I *have* checked that every commit above works with secure wipe disabled.

The next step will be to define a "dump me now" hook that we can use for getting final values for the smoke test before the wipe has happened. That will also strengthen the end-of-operation checks that we do. Once *that* is done, we can ditch the configuration parameter (and a bit of slightly confusing code in the ISS) entirely.