### PR TITLE
[dv/otp] Improve the code to use mem_bkdr_utils to detect ECC errors

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -32,9 +32,6 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
   otp_ctrl_vif otp_ctrl_vif;
   bit backdoor_clear_mem;
 
-  // This value is updated in sequence when backdoor inject ECC error
-  otp_ecc_err_e ecc_err = OtpNoEccErr;
-
   // Check ECC errors
   otp_ecc_err_e ecc_chk_err [NumPart] = '{default:OtpNoEccErr};
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -507,15 +507,34 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
     // SW CFG window
     end else if ((csr_addr & addr_mask) inside
         {[SW_WINDOW_BASE_ADDR : SW_WINDOW_BASE_ADDR + SW_WINDOW_SIZE]}) begin
-      if (data_phase_read && check_dai_rd_data) begin
-        bit [TL_AW-1:0] otp_addr = (csr_addr & addr_mask - SW_WINDOW_BASE_ADDR) >> 2;
-        // TODO: macro ecc uncorrectable error once mem_bkdr_util supports
-        //`DV_CHECK_EQ(item.d_data, 0,
-        //             $sformatf("mem read mismatch at TLUL addr %0h, csr_addr %0h",
-        //             csr_addr, otp_addr << 2))
-        `DV_CHECK_EQ(item.d_data, otp_a[otp_addr],
-                     $sformatf("mem read mismatch at TLUL addr %0h, csr_addr %0h",
-                     csr_addr, otp_addr << 2))
+      if (data_phase_read) begin
+        bit [TL_AW-1:0] dai_addr = (csr_addr & addr_mask - SW_WINDOW_BASE_ADDR);
+        bit [TL_AW-1:0] otp_addr = dai_addr >> 2;
+        int part_idx = get_part_index(dai_addr);
+        bit [TL_DW-1:0] read_out;
+        int ecc_err = read_a_word_with_ecc(dai_addr, read_out);
+
+        // ECC uncorrectable errors are gated by `is_tl_mem_access_allowed` function.
+        if (ecc_err != OtpNoEccErr) begin
+          predict_err(part_idx, OtpMacroEccCorrError);
+          if (ecc_err == OtpEccCorrErr) begin
+             `DV_CHECK_EQ(item.d_data, otp_a[otp_addr],
+                         $sformatf("mem read mismatch at TLUL addr %0h, csr_addr %0h",
+                         csr_addr, dai_addr))
+          end else begin
+            // This is an exception for vendor test partition, which reports uncorrectable errors
+            // as correctable ECC errors.
+            // Only check the first 16 bits because if ECC readout detects uncorrectable error, it
+            // won't continue read the remaining 16 bits.
+            `DV_CHECK_EQ(item.d_data & 16'hffff, read_out & 16'hffff,
+                       $sformatf("mem read mismatch at TLUL addr %0h, csr_addr %0h",
+                       csr_addr, dai_addr))
+          end
+        end else if (ecc_err == OtpNoEccErr) begin
+          `DV_CHECK_EQ(item.d_data, otp_a[otp_addr],
+                      $sformatf("mem read mismatch at TLUL addr %0h, csr_addr %0h",
+                      csr_addr, dai_addr))
+        end
       end
       return;
     end else begin
@@ -1179,8 +1198,12 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                                                 output bit mem_byte_access_err,
                                                 output bit mem_wo_err,
                                                 output bit mem_ro_err);
-    // If sw partition is read locked, then access policy changes from RO to no access
     uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+    uvm_reg_addr_t csr_addr   = cfg.ral_models[ral_name].get_word_aligned_addr(item.a_addr);
+    bit [TL_AW-1:0] addr_mask = ral.get_addr_mask();
+    bit [TL_AW-1:0] dai_addr = (csr_addr & addr_mask - SW_WINDOW_BASE_ADDR);
+
+    // If sw partition is read locked, then access policy changes from RO to no access
     if (`gmv(ral.vendor_test_read_lock) == 0 || cfg.otp_ctrl_vif.under_error_states()) begin
       if (addr inside {[cfg.ral_models[ral_name].mem_ranges[0].start_addr + VendorTestOffset :
                         cfg.ral_models[ral_name].mem_ranges[0].start_addr + VendorTestOffset +
@@ -1209,6 +1232,21 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
         `DV_CHECK_EQ(item.d_data, 0,
                      $sformatf("locked mem read mismatch at TLUL addr %0h in OwnerSwCfg", addr))
         return 0;
+      end
+    end
+
+    // Check ECC uncorrectable fatal error.
+    if (dai_addr < LifeCycleOffset) begin
+      int part_idx = get_part_index(dai_addr);
+      bit [TL_DW-1:0] read_out;
+      int ecc_err = read_a_word_with_ecc(dai_addr, read_out);
+      if (ecc_err == OtpEccUncorrErr && !ecc_corr_err_only_part(part_idx)) begin
+          predict_err(part_idx, OtpMacroEccUncorrError);
+          set_exp_alert("fatal_macro_error", 1, 20);
+          `DV_CHECK_EQ(item.d_data, 0,
+                       $sformatf("ECC uncorrectable error exp to readout all 0s at TLUL addr %0h",
+                       addr))
+       return 0;
       end
     end
     return super.is_tl_mem_access_allowed(item, ral_name, mem_byte_access_err, mem_wo_err,

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_init_fail_vseq.sv
@@ -65,7 +65,7 @@ class otp_ctrl_init_fail_vseq extends otp_ctrl_smoke_vseq;
       dai_wr(dai_addr, wdata0, wdata1);
 
       // OTP read via DAI, check data in scb
-      dai_rd(dai_addr, 0, wdata0, wdata1);
+      dai_rd(dai_addr, wdata0, wdata1);
 
       // If write sw partitions, check tlul window
       if (is_sw_part(dai_addr)) begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -144,7 +144,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
         if (rand_rd) begin
           // OTP read via DAI, check data in scb
-          dai_rd(dai_addr, ecc_otp_err, rdata0, rdata1);
+          dai_rd(dai_addr, rdata0, rdata1);
         end
 
         // if write sw partitions, check tlul window


### PR DESCRIPTION
These two commits detaches ECC injections from `dai_rd` task.
The otp_ctrl testbench was built before mem_bkdr_utils fully supports ECC read, so the previous code uses a cfg flag to inform scoreboard that there is a ECC error.
With the mem_bkdr_utils developed, we do not need this flag anymore. Scoreboard can just read out from mem_bkdr_utils and check if there is any ECC error.

So the two commits are:
1). Remove the input `ecc_err` from `dai_rd`, and remove the `cfg.ecc_err`.
2). Add support in sequence to inject ECC errors anytime before a read, and scoreboard can detect ECC errors from both DAI and TLUL interfaces.