### PR TITLE
[flash_ctrl] Minor fixes for flash foundry failure

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -501,10 +501,13 @@ class mem_bkdr_util extends uvm_object;
   endfunction
 
   virtual function void set_mem();
+    bit res;
     `uvm_info(`gfn, "Set memory", UVM_LOW)
-    for (int i = 0; i < size_bytes; i++) begin
-      write8(i, '1);
+    for (int i = 0; i < depth; i++) begin
+      res = uvm_hdl_deposit($sformatf("%0s[%0d]", path, i), {default: '1});
+      `DV_CHECK_EQ(res, 1, $sformatf("set_mem uvm_hdl_deposit failed at index %0d", i))
     end
+
   endfunction
 
   // randomize the memory

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -1151,8 +1151,13 @@ module flash_ctrl
 
   `ASSERT_KNOWN(TlDValidKnownO_A,       core_tl_o.d_valid )
   `ASSERT_KNOWN(TlAReadyKnownO_A,       core_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(RspPayLoad_A,        core_tl_o, core_tl_o.d_valid)
   `ASSERT_KNOWN(PrimTlDValidKnownO_A,   prim_tl_o.d_valid )
   `ASSERT_KNOWN(PrimTlAReadyKnownO_A,   prim_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(PrimRspPayLoad_A,    prim_tl_o, prim_tl_o.d_valid)
+  `ASSERT_KNOWN(MemTlDValidKnownO_A,    mem_tl_o.d_valid )
+  `ASSERT_KNOWN(MemTlAReadyKnownO_A,    mem_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(MemRspPayLoad_A,     mem_tl_o, mem_tl_o.d_valid)
   `ASSERT_KNOWN(FlashKnownO_A,          {flash_phy_req.req, flash_phy_req.rd,
                                          flash_phy_req.prog, flash_phy_req.pg_erase,
                                          flash_phy_req.bk_erase})

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1152,8 +1152,13 @@ module flash_ctrl
 
   `ASSERT_KNOWN(TlDValidKnownO_A,       core_tl_o.d_valid )
   `ASSERT_KNOWN(TlAReadyKnownO_A,       core_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(RspPayLoad_A,        core_tl_o, core_tl_o.d_valid)
   `ASSERT_KNOWN(PrimTlDValidKnownO_A,   prim_tl_o.d_valid )
   `ASSERT_KNOWN(PrimTlAReadyKnownO_A,   prim_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(PrimRspPayLoad_A,    prim_tl_o, prim_tl_o.d_valid)
+  `ASSERT_KNOWN(MemTlDValidKnownO_A,    mem_tl_o.d_valid )
+  `ASSERT_KNOWN(MemTlAReadyKnownO_A,    mem_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(MemRspPayLoad_A,     mem_tl_o, mem_tl_o.d_valid)
   `ASSERT_KNOWN(FlashKnownO_A,          {flash_phy_req.req, flash_phy_req.rd,
                                          flash_phy_req.prog, flash_phy_req.pg_erase,
                                          flash_phy_req.bk_erase})

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1158,8 +1158,13 @@ module flash_ctrl
 
   `ASSERT_KNOWN(TlDValidKnownO_A,       core_tl_o.d_valid )
   `ASSERT_KNOWN(TlAReadyKnownO_A,       core_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(RspPayLoad_A,        core_tl_o, core_tl_o.d_valid)
   `ASSERT_KNOWN(PrimTlDValidKnownO_A,   prim_tl_o.d_valid )
   `ASSERT_KNOWN(PrimTlAReadyKnownO_A,   prim_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(PrimRspPayLoad_A,    prim_tl_o, prim_tl_o.d_valid)
+  `ASSERT_KNOWN(MemTlDValidKnownO_A,    mem_tl_o.d_valid )
+  `ASSERT_KNOWN(MemTlAReadyKnownO_A,    mem_tl_o.a_ready )
+  `ASSERT_KNOWN_IF(MemRspPayLoad_A,     mem_tl_o, mem_tl_o.d_valid)
   `ASSERT_KNOWN(FlashKnownO_A,          {flash_phy_req.req, flash_phy_req.rd,
                                          flash_phy_req.prog, flash_phy_req.pg_erase,
                                          flash_phy_req.bk_erase})


### PR DESCRIPTION
- open source fixes to #10326
- complete flash_ctrl tlul assertions
- tweak set_mem
  previous set_mem would leave parts of the flash memory unset, since
  it did not align to nice byte boundaries.  This led to some erase
  modeling issues of the foundry flash

Signed-off-by: Timothy Chen <timothytim@google.com>