### PR TITLE
[dv/hmac] Add sequence to reset during certain FSM states

### DIFF
--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -81,6 +81,20 @@
       tests: ["hmac_stress_all"]
     }
     {
+      name: stress_reset_during_process
+      desc: ''' This test complements `hmac_stress_all_with_rand_reset` test to issue reset at
+            special timing.
+
+            Certain FSM states are hard to interrupt by `hmac_stress_all_with_rand_reset`. For
+            example, the FSM state `StPushToMsgFifo` lasts for around 20 cycles out of the entire
+            hmac hashing process. To ensure these FSM states are interrupted by reset, this test
+            issues reset within a random range of cycles after hmac process command is issued, and
+            check if hmac functions correctly after reset is issued.
+            '''
+      milestone: V2
+      tests: ["stress_reset_during_process"]
+    }
+    {
       name: write_config_and_secret_key_during_msg_wr
       desc: "Change config registers and secret keys during msg write, make sure access is blocked."
       milestone: V3

--- a/hw/ip/hmac/dv/env/hmac_env.core
+++ b/hw/ip/hmac/dv/env/hmac_env.core
@@ -29,6 +29,7 @@ filesets:
       - seq_lib/hmac_burst_wr_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/hmac_stress_all_vseq.sv: {is_include_file: true}
+      - seq_lib/hmac_reset_during_process_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_reset_during_process_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_reset_during_process_vseq.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence generates a mix of short and long msgs,
+// and it injects reset during hmac process to try to interrupt hmac_core's `StPushToMsgFifo` FSM
+// state.
+// This sequence is not included in stress_all_with_rand_reset sequence, because stress_all
+// sequence might disable the reset in current sequence.
+
+class hmac_reset_during_process_vseq extends hmac_smoke_vseq;
+  `uvm_object_utils(hmac_reset_during_process_vseq)
+  `uvm_object_new
+
+  constraint msg_c {
+    msg.size() dist {
+        [65  :999]    :/ 1,
+        [1000:3000]   :/ 8, // 1KB - 2KB according to SW immediate usage
+        [3001:10_000] :/ 1  // temp set to 10KB as max length, spec max size is 2^64 bits
+    };
+  }
+
+  function void pre_randomize();
+    this.reset_during_hmac_process_c.constraint_mode(0);
+  endfunction
+
+endclass : hmac_reset_during_process_vseq

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_vseq_list.sv
@@ -12,4 +12,5 @@
 `include "hmac_common_vseq.sv"
 `include "hmac_datapath_stress_vseq.sv"
 `include "hmac_error_vseq.sv"
+`include "hmac_reset_during_process_vseq.sv"
 `include "hmac_stress_all_vseq.sv"

--- a/hw/ip/hmac/dv/hmac_sim_cfg.hjson
+++ b/hw/ip/hmac/dv/hmac_sim_cfg.hjson
@@ -81,6 +81,11 @@
     }
 
     {
+      name: hmac_reset_during_process
+      uvm_test_seq: hmac_reset_during_process_vseq
+    }
+
+    {
       name: hmac_test_sha_vectors
       uvm_test_seq: hmac_test_vectors_sha_vseq
       run_opts: ["+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]


### PR DESCRIPTION
For FSM coverage, it is hard for `hmac_stress_all_with_rand_reset` test
to hit certain FSM inside HMAC core. For example, `StPushToMsgFifo` only
last for around 20 clock cycles.
To ensure these FSMs are interrupted by reset, I create this special
sequence to issue reset with a higher chance to hit this FSM.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>