### PR TITLE
[sw/silicon_creator] Remove dedicated OTBN error type.

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -47,14 +47,14 @@ enum { kBase = TOP_EARLGREY_OTBN_BASE_ADDR };
 /**
  * Ensures that `offset_bytes` and `len` are valid for a given `mem_size`.
  */
-static otbn_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
-                                     size_t mem_size) {
+static rom_error_t check_offset_len(uint32_t offset_bytes, size_t num_words,
+                                    size_t mem_size) {
   if (offset_bytes + num_words * sizeof(uint32_t) <
           num_words * sizeof(uint32_t) ||
       offset_bytes + num_words * sizeof(uint32_t) > mem_size) {
-    return kOtbnErrorBadOffsetLen;
+    return kErrorOtbnBadOffsetLen;
   }
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
 void otbn_execute(void) {
@@ -70,9 +70,9 @@ void otbn_get_err_bits(otbn_err_bits_t *err_bits) {
   *err_bits = abs_mmio_read32(kBase + OTBN_ERR_BITS_REG_OFFSET);
 }
 
-otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
-                             size_t num_words) {
-  OTBN_RETURN_IF_ERROR(
+rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t num_words) {
+  RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
@@ -81,12 +81,12 @@ otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
         src[i]);
   }
 
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
-otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
-                             size_t num_words) {
-  OTBN_RETURN_IF_ERROR(
+rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t num_words) {
+  RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
@@ -95,12 +95,12 @@ otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
         src[i]);
   }
 
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
-otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
-                            size_t num_words) {
-  OTBN_RETURN_IF_ERROR(
+rom_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
+                           size_t num_words) {
+  RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
 
   for (size_t i = 0; i < num_words; ++i) {
@@ -108,7 +108,7 @@ otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
                               i * sizeof(uint32_t));
   }
 
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
 void otbn_zero_dmem(void) {
@@ -117,7 +117,7 @@ void otbn_zero_dmem(void) {
   }
 }
 
-otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
   // Only one bit in the CTRL register so no need to read current value.
   uint32_t new_ctrl;
 
@@ -129,8 +129,8 @@ otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
 
   abs_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET, new_ctrl);
   if (abs_mmio_read32(kBase + OTBN_CTRL_REG_OFFSET) != new_ctrl) {
-    return kOtbnErrorUnavailable;
+    return kErrorOtbnUnavailable;
   }
 
-  return kOtbnErrorOk;
+  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -9,6 +9,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/error.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -42,35 +44,6 @@ typedef enum otbn_status {
   kOtbnStatusBusySecWipeImem = 0x03,
   kOtbnStatusLocked = 0xFF,
 } otbn_status_t;
-
-/**
- * Error codes for the OTBN driver.
- */
-typedef enum otbn_error_t {
-  /** No errors. */
-  kOtbnErrorOk = 0,
-  /** Invalid argument provided to OTBN interface function. */
-  kOtbnErrorInvalidArgument = 1,
-  /** Invalid offset provided. */
-  kOtbnErrorBadOffsetLen = 2,
-  /** OTBN internal error; use otbn_get_err_bits for specific error codes. */
-  kOtbnErrorExecutionFailed = 3,
-  /** Attempt to interact with OTBN while it was unavailable. */
-  kOtbnErrorUnavailable = 4,
-} otbn_error_t;
-
-/**
- * Evaluate an expression and return if the result is an error.
- *
- * @param expr_ An expression which results in an otbn_error_t.
- */
-#define OTBN_RETURN_IF_ERROR(expr_)     \
-  do {                                  \
-    otbn_error_t local_error_ = expr_;  \
-    if (local_error_ != kOtbnErrorOk) { \
-      return local_error_;              \
-    }                                   \
-  } while (0)
 
 /**
  * Start the execution of the application loaded into OTBN.
@@ -136,11 +109,11 @@ void otbn_get_err_bits(otbn_err_bits_t *err_bits);
  * @param offset_bytes the byte offset in IMEM the first word is written to
  * @param src the main memory location to start reading from.
  * @param len number of words to copy.
- * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
- * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
+ * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
+ * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
  */
-otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
-                             size_t len);
+rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t len);
 
 /**
  * Write to OTBN's data memory (DMEM)
@@ -150,11 +123,11 @@ otbn_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
  * @param offset_bytes the byte offset in DMEM the first word is written to
  * @param src the main memory location to start reading from.
  * @param len number of words to copy.
- * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
- * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
+ * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
+ * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
  */
-otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
-                             size_t len);
+rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
+                            size_t len);
 
 /**
  * Read from OTBN's data memory (DMEM)
@@ -164,10 +137,10 @@ otbn_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
  * @param offset_bytes the byte offset in DMEM the first word is read from
  * @param[out] dest the main memory location to copy the data to (preallocated)
  * @param len number of words to copy.
- * @return `kOtbnErrorBadOffset` if `offset_bytes` isn't word aligned,
- * `kOtbnErrorBadOffsetLen` if `len` is invalid , `kOtbnErrorOk` otherwise.
+ * @return `kErrorOtbnBadOffset` if `offset_bytes` isn't word aligned,
+ * `kErrorOtbnBadOffsetLen` if `len` is invalid , `kErrorOk` otherwise.
  */
-otbn_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest, size_t len);
+rom_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest, size_t len);
 
 /**
  * Zero out the contents of OTBN's data memory (DMEM).
@@ -181,10 +154,10 @@ void otbn_zero_dmem(void);
  * changed when the OTBN status is IDLE.
  *
  * @param enable Enable or disable whether software errors are fatal.
- * @return `kOtbnErrorUnavailable` if the requested change cannot be made or
- * `kOtbnErrorOk` otherwise.
+ * @return `kErrorOtbnUnavailable` if the requested change cannot be made or
+ * `kErrorOk` otherwise.
  */
-otbn_error_t otbn_set_ctrl_software_errs_fatal(bool enable);
+rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -60,14 +60,14 @@ TEST_F(ImemWriteTest, BadAddressBeyondMemorySize) {
   std::array<uint32_t, 2> test_data = {0};
 
   EXPECT_EQ(otbn_imem_write(OTBN_IMEM_SIZE_BYTES, test_data.data(), 1),
-            kOtbnErrorBadOffsetLen);
+            kErrorOtbnBadOffsetLen);
 }
 
 TEST_F(ImemWriteTest, BadAddressIntegerOverflow) {
   std::array<uint32_t, 4> test_data = {0};
 
   EXPECT_EQ(otbn_imem_write(0xFFFFFFFC, test_data.data(), 1),
-            kOtbnErrorBadOffsetLen);
+            kErrorOtbnBadOffsetLen);
 }
 
 TEST_F(ImemWriteTest, SuccessWithoutOffset) {
@@ -79,7 +79,7 @@ TEST_F(ImemWriteTest, SuccessWithoutOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[1]);
 
-  EXPECT_EQ(otbn_imem_write(0, test_data.data(), 2), kOtbnErrorOk);
+  EXPECT_EQ(otbn_imem_write(0, test_data.data(), 2), kErrorOk);
 }
 
 TEST_F(ImemWriteTest, SuccessWithOffset) {
@@ -91,7 +91,7 @@ TEST_F(ImemWriteTest, SuccessWithOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_IMEM_REG_OFFSET + 8, test_data[1]);
 
-  EXPECT_EQ(otbn_imem_write(4, test_data.data(), 2), kOtbnErrorOk);
+  EXPECT_EQ(otbn_imem_write(4, test_data.data(), 2), kErrorOk);
 }
 
 class DmemWriteTest : public OtbnTest {};
@@ -105,7 +105,7 @@ TEST_F(DmemWriteTest, SuccessWithoutOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[1]);
 
-  EXPECT_EQ(otbn_dmem_write(0, test_data.data(), 2), kOtbnErrorOk);
+  EXPECT_EQ(otbn_dmem_write(0, test_data.data(), 2), kErrorOk);
 }
 
 TEST_F(DmemWriteTest, SuccessWithOffset) {
@@ -117,7 +117,7 @@ TEST_F(DmemWriteTest, SuccessWithOffset) {
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 4, test_data[0]);
   EXPECT_ABS_WRITE32(base_ + OTBN_DMEM_REG_OFFSET + 8, test_data[1]);
 
-  EXPECT_EQ(otbn_dmem_write(4, test_data.data(), 2), kOtbnErrorOk);
+  EXPECT_EQ(otbn_dmem_write(4, test_data.data(), 2), kErrorOk);
 }
 
 class DmemReadTest : public OtbnTest {};
@@ -132,7 +132,7 @@ TEST_F(DmemReadTest, SuccessWithoutOffset) {
 
   std::array<uint32_t, 2> test_data = {0};
 
-  EXPECT_EQ(otbn_dmem_read(0, test_data.data(), 2), kOtbnErrorOk);
+  EXPECT_EQ(otbn_dmem_read(0, test_data.data(), 2), kErrorOk);
   EXPECT_THAT(test_data, ElementsAre(0x12345678, 0xabcdef01));
 }
 
@@ -145,7 +145,7 @@ TEST_F(DmemReadTest, SuccessWithOffset) {
 
   std::array<uint32_t, 2> test_data = {0};
 
-  EXPECT_EQ(otbn_dmem_read(4, test_data.data(), 2), kOtbnErrorOk);
+  EXPECT_EQ(otbn_dmem_read(4, test_data.data(), 2), kErrorOk);
   EXPECT_THAT(test_data, ElementsAre(0x12345678, 0xabcdef01));
 }
 
@@ -155,14 +155,14 @@ TEST_F(ControlSoftwareErrorsFatalTest, Success) {
   EXPECT_ABS_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
   EXPECT_ABS_READ32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
 
-  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(true), kOtbnErrorOk);
+  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(true), kErrorOk);
 }  // namespace
 
 TEST_F(ControlSoftwareErrorsFatalTest, Failure) {
   EXPECT_ABS_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x0);
   EXPECT_ABS_READ32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
 
-  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(false), kOtbnErrorUnavailable);
+  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(false), kErrorOtbnUnavailable);
 }
 
 }  // namespace

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -92,7 +92,10 @@ enum module_ {
   X(kErrorInterrupt,                  ERROR_(0, kModuleInterrupt, kUnknown)), \
   X(kErrorEpmpBadCheck,               ERROR_(1, kModuleEpmp, kInternal)), \
   X(kErrorOtpBadAlignment,            ERROR_(1, kModuleOtp, kInvalidArgument)), \
-  X(kErrorOtbnInternal,               ERROR_(1, kModuleOtbn, kInternal)), \
+  X(kErrorOtbnInvalidArgument,        ERROR_(1, kModuleOtbn, kInvalidArgument)), \
+  X(kErrorOtbnBadOffsetLen,           ERROR_(2, kModuleOtbn, kInvalidArgument)), \
+  X(kErrorOtbnExecutionFailed,        ERROR_(3, kModuleOtbn, kInternal)), \
+  X(kErrorOtbnUnavailable,            ERROR_(4, kModuleOtbn, kInternal)), \
   X(kErrorFlashCtrlDataRead,          ERROR_(1, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoRead,          ERROR_(2, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataWrite,         ERROR_(3, kModuleFlashCtrl, kInternal)), \

--- a/sw/device/silicon_creator/lib/otbn_util.c
+++ b/sw/device/silicon_creator/lib/otbn_util.c
@@ -22,7 +22,7 @@ void otbn_init(otbn_t *ctx) {
   };
 }
 
-otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
+rom_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
   while (otbn_is_busy()) {
   }
 
@@ -30,9 +30,9 @@ otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx) {
   otbn_get_err_bits(&err_bits);
   if (err_bits != kOtbnErrBitsNoError) {
     ctx->error_bits = err_bits;
-    return kOtbnErrorExecutionFailed;
+    return kErrorOtbnExecutionFailed;
   }
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
 /**
@@ -58,9 +58,9 @@ bool check_app_address_ranges(const otbn_app_t *app) {
   return true;
 }
 
-otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
+rom_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
   if (!check_app_address_ranges(&app)) {
-    return kOtbnErrorInvalidArgument;
+    return kErrorOtbnInvalidArgument;
   }
 
   const size_t imem_num_words = app.imem_end - app.imem_start;
@@ -68,38 +68,37 @@ otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app) {
 
   ctx->app_is_loaded = false;
 
-  OTBN_RETURN_IF_ERROR(otbn_imem_write(0, app.imem_start, imem_num_words));
+  RETURN_IF_ERROR(otbn_imem_write(0, app.imem_start, imem_num_words));
 
   otbn_zero_dmem();
   if (data_num_words > 0) {
-    OTBN_RETURN_IF_ERROR(
-        otbn_dmem_write(0, app.dmem_data_start, data_num_words));
+    RETURN_IF_ERROR(otbn_dmem_write(0, app.dmem_data_start, data_num_words));
   }
 
   ctx->app = app;
   ctx->app_is_loaded = true;
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
-otbn_error_t otbn_execute_app(otbn_t *ctx) {
+rom_error_t otbn_execute_app(otbn_t *ctx) {
   if (!ctx->app_is_loaded) {
-    return kOtbnErrorInvalidArgument;
+    return kErrorOtbnInvalidArgument;
   }
 
   otbn_execute();
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
-otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
-                                    const uint32_t *src, otbn_addr_t dest) {
-  OTBN_RETURN_IF_ERROR(otbn_dmem_write(dest, src, len));
+rom_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len, const uint32_t *src,
+                                   otbn_addr_t dest) {
+  RETURN_IF_ERROR(otbn_dmem_write(dest, src, len));
 
-  return kOtbnErrorOk;
+  return kErrorOk;
 }
 
-otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
-                                      otbn_addr_t src, uint32_t *dest) {
-  OTBN_RETURN_IF_ERROR(otbn_dmem_read(src, dest, len_bytes));
+rom_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len_bytes,
+                                     otbn_addr_t src, uint32_t *dest) {
+  RETURN_IF_ERROR(otbn_dmem_read(src, dest, len_bytes));
 
-  return kOtbnErrorOk;
+  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/otbn_util.h
+++ b/sw/device/silicon_creator/lib/otbn_util.h
@@ -195,7 +195,7 @@ void otbn_init(otbn_t *ctx);
  * @param app The application to load into OTBN.
  * @return The result of the operation.
  */
-otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
+rom_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
 
 /**
  * Start the OTBN application.
@@ -205,7 +205,7 @@ otbn_error_t otbn_load_app(otbn_t *ctx, const otbn_app_t app);
  * @param ctx The context object.
  * @return The result of the operation.
  */
-otbn_error_t otbn_execute_app(otbn_t *ctx);
+rom_error_t otbn_execute_app(otbn_t *ctx);
 
 /**
  * Busy waits for OTBN to be done with its operation.
@@ -213,7 +213,7 @@ otbn_error_t otbn_execute_app(otbn_t *ctx);
  * @param ctx The context object.
  * @return The result of the operation.
  */
-otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx);
+rom_error_t otbn_busy_wait_for_done(otbn_t *ctx);
 
 /**
  * Copies data from the CPU memory to OTBN data memory.
@@ -224,8 +224,8 @@ otbn_error_t otbn_busy_wait_for_done(otbn_t *ctx);
  * @param src Source of the data to copy.
  * @return The result of the operation.
  */
-otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
-                                    const uint32_t *src, otbn_addr_t dest);
+rom_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len, const uint32_t *src,
+                                   otbn_addr_t dest);
 
 /**
  * Copies data from OTBN's data memory to CPU memory.
@@ -237,22 +237,8 @@ otbn_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len,
  *                  (preallocated).
  * @return The result of the operation.
  */
-otbn_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len,
-                                      const otbn_addr_t src, uint32_t *dest);
-
-/**
- * Evaluate an expression and return a mask ROM error if the result is an
- * OTBN error.
- *
- * @param expr_ An expression which results in an otbn_error_t.
- */
-#define FOLD_OTBN_ERROR(expr_)          \
-  do {                                  \
-    otbn_error_t local_error_ = expr_;  \
-    if (local_error_ != kOtbnErrorOk) { \
-      return kErrorOtbnInternal;        \
-    }                                   \
-  } while (0)
+rom_error_t otbn_copy_data_from_otbn(otbn_t *ctx, size_t len,
+                                     const otbn_addr_t src, uint32_t *dest);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Replace `otbn_error_t` with a few new cases in `rom_error_t`. Originally the separate OTBN error type existed because we were planning to use the generic cryptolib RSA implementation in sigverify, but that plan has since changed, and a dedicated OTBN error type in mask ROM no longer makes sense. Related to #10190; this change hardens the OTBN error codes by folding them into `rom_error_t`.