### PR TITLE
[flash_ctrl/dv] Tiny change in tb power_down driving

### DIFF
--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -149,7 +149,7 @@ module tb;
               end : deassert_init
             join_none
           end else begin
-            init = (rst_n === 1'b0) ? 1'b1 : 1'bx;
+            init = 1'b1;
           end
 
           // Wait for the rst_n to change.


### PR DESCRIPTION
Hi,
This PR only make sure the power_down signal driven by the TB will never be X.
This X in specific cases causes errors in the CS simulations.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>