### PR TITLE
[otbn,dv] Sort out timing so that we can pass the smoke test with secure wipe enabled

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -21,15 +21,27 @@ struct TmpDir;
 class MirroredRegs {
  public:
   MirroredRegs()
-      : status(0), insn_cnt(0), err_bits(0), rnd_req(0), stop_pc(0) {}
+      : status(0),
+        insn_cnt(0),
+        err_bits(0),
+        stop_pc(0),
+        rnd_req(false),
+        wipe_start(false) {}
 
   uint32_t status;
   uint32_t insn_cnt;
   uint32_t err_bits;
-  uint32_t rnd_req;
 
   // The final PC from the most recent run
   uint32_t stop_pc;
+
+  // We are issuing an EDN request for RND
+  bool rnd_req;
+
+  // This goes high for a single cycle when we start the internal secure wipe
+  // (and can be used as a trigger to check internal state before it gets
+  // trashed)
+  bool wipe_start;
 
   // Execution is stopped if status is either 0 (IDLE) or 0xff (LOCKED)
   bool stopped() const { return status == 0 || status == 0xff; }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -94,6 +94,10 @@ class OtbnModel {
   // success; -1 on failure.
   int send_lc_escalation();
 
+  // Returns true if we have an ISS wrapper and it has the START_WIPE flag
+  // asserted
+  bool is_at_start_of_wipe() const;
+
  private:
   // Constructs an ISS wrapper if necessary. If something goes wrong, this
   // function prints a message and then returns null. If ensure is true, it

--- a/hw/ip/otbn/dv/model/otbn_model_pkg.sv
+++ b/hw/ip/otbn/dv/model/otbn_model_pkg.sv
@@ -43,6 +43,8 @@ package otbn_model_pkg;
                                  inout bit [31:0] err_bits,
                                  inout bit [31:0] stop_pc);
 
+  import "DPI-C" context function int otbn_model_check(chandle model, inout bit mismatch);
+
   import "DPI-C" function int otbn_model_invalidate_imem(chandle model);
 
   import "DPI-C" function int otbn_model_step_crc(chandle          model,

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -185,6 +185,10 @@ class RGReg:
         return self._trace
 
 
+def make_flag_reg(name: str, double_flopped: bool) -> RGReg:
+    return RGReg([RGField(name, 32, 0, 0, 'ro')], double_flopped)
+
+
 class OTBNExtRegs:
     '''A class representing OTBN's externally visible CSRs
 
@@ -217,13 +221,16 @@ class OTBNExtRegs:
         # the future (see issue #4327) but, for now, it's just used in
         # simulation to help track whether RIG-generated binaries finished
         # where they expected to finish.
-        self.regs['STOP_PC'] = RGReg([RGField('STOP_PC', 32, 0, 0, 'ro')],
-                                     True)
+        self.regs['STOP_PC'] = make_flag_reg('STOP_PC', True)
 
         # Add a fake "RND_REQ" register to pass it through otbn_core_model
         # when OTBN_USE_MODEL parameter is enabled in system level tests.
-        self.regs['RND_REQ'] = RGReg([RGField('RND_REQ', 32, 0, 0, 'ro')],
-                                     True)
+        self.regs['RND_REQ'] = make_flag_reg('RND_REQ', True)
+
+        # Add a fake "WIPE_START" register. We set this for a single cycle when
+        # starting secure wipe and the C++ model can use this to trigger a dump
+        # of internal state before it gets zeroed out.
+        self.regs['WIPE_START'] = make_flag_reg('WIPE_START', False)
 
     def _get_reg(self, reg_name: str) -> RGReg:
         reg = self.regs.get(reg_name)

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -161,6 +161,11 @@ class OTBNSim:
         if self.state.fsm_state in [FsmState.WIPING_GOOD, FsmState.WIPING_BAD]:
             assert self.state.wipe_cycles > 0
             self.state.wipe_cycles -= 1
+
+            # Clear the WIPE_START register if it was set
+            if self.state.ext_regs.read('WIPE_START', True):
+                self.state.ext_regs.write('WIPE_START', 0, True)
+
             # Wipe all registers and set STATUS on the penultimate cycle.
             if self.state.wipe_cycles == 1:
                 next_status = (Status.IDLE

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -87,7 +87,7 @@ class OTBNSim:
         self.state.commit(sim_stalled=True)
         if fetch_next:
             self._next_insn = self._fetch(self.state.pc)
-        if self.stats is not None:
+        if self.stats is not None and not self.state.wiping():
             self.stats.record_stall()
         if verbose:
             self._print_trace(self.state.pc, '(stall)', changes)

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -456,6 +456,10 @@ class OTBNState:
         # expected to stop.
         self.ext_regs.write('STOP_PC', self.pc, True)
 
+        # Set the WIPE_START flag. This will be cleared again on the
+        # next cycle.
+        self.ext_regs.write('WIPE_START', 1, True)
+
     def set_flags(self, fg: int, flags: FlagReg) -> None:
         '''Update flags for a flag group'''
         self.csrs.flags[fg] = flags

--- a/hw/ip/otbn/dv/otbnsim/standalone.py
+++ b/hw/ip/otbn/dv/otbnsim/standalone.py
@@ -50,7 +50,7 @@ def main() -> int:
     sim.state.ext_regs.commit()
 
     sim.start(collect_stats)
-    sim.run(verbose=args.verbose)
+    sim.run(verbose=args.verbose, dump_file=args.dump_regs)
 
     if exp_end_addr is not None:
         if sim.state.pc != exp_end_addr:
@@ -61,12 +61,6 @@ def main() -> int:
 
     if args.dump_dmem is not None:
         args.dump_dmem.write(sim.dump_data())
-
-    if args.dump_regs is not None:
-        for idx, value in enumerate(sim.state.gprs.peek_unsigned_values()):
-            args.dump_regs.write(' x{:<2} = 0x{:08x}\n'.format(idx, value))
-        for idx, value in enumerate(sim.state.wdrs.peek_unsigned_values()):
-            args.dump_regs.write(' w{:<2} = 0x{:064x}\n'.format(idx, value))
 
     if collect_stats:
         assert sim.stats is not None

--- a/hw/ip/otbn/dv/otbnsim/test/state_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/state_test.py
@@ -19,7 +19,7 @@ def test_ext_regs_success(tmpdir: py.path.local) -> None:
     """
 
     sim = prepare_sim_for_asm_str(simple_asm, tmpdir, False)
-    sim.run(verbose=False)
+    sim.run(verbose=False, dump_file=None)
 
     assert sim.state.ext_regs.read('ERR_BITS', False) == 0
     assert sim.state.ext_regs.read('FATAL_ALERT_CAUSE', False) == 0
@@ -43,7 +43,7 @@ def test_ext_regs_err_bits_bad(tmpdir: py.path.local) -> None:
     """
 
     sim = prepare_sim_for_asm_str(invalid_jump_asm, tmpdir, False)
-    sim.run(verbose=False)
+    sim.run(verbose=False, dump_file=None)
 
     assert sim.state.ext_regs.read('ERR_BITS', False) == ErrBits.BAD_INSN_ADDR
 

--- a/hw/ip/otbn/dv/otbnsim/test/stats_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/stats_test.py
@@ -11,7 +11,7 @@ import testutil
 
 
 def _run_sim_for_stats(sim: StandaloneSim) -> ExecutionStats:
-    sim.run(verbose=False)
+    sim.run(verbose=False, dump_file=None)
 
     # Ensure that the execution was successful.
     assert sim.state.ext_regs.read('ERR_BITS', False) == 0

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -134,63 +134,6 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  std::cout << "Call Stack:" << std::endl;
-  std::cout << "-----------" << std::endl;
-  for (int i = 0; i < otbn_base_call_stack_get_size(); ++i) {
-    std::cout << std::setfill(' ') << "0x" << std::hex << std::setw(8)
-              << std::setfill('0') << std::right
-              << otbn_base_call_stack_get_element(i) << std::endl;
-  }
-
-  std::cout << std::endl;
-
-  std::cout << "Final Base Register Values:" << std::endl;
-  std::cout << "Reg | Value" << std::endl;
-  std::cout << "----------------" << std::endl;
-  for (int i = 2; i < 32; ++i) {
-    std::cout << "x" << std::left << std::dec << std::setw(2)
-              << std::setfill(' ') << i << " | 0x" << std::hex << std::setw(8)
-              << std::setfill('0') << std::right << otbn_base_reg_get(i)
-              << std::endl;
-  }
-
-  std::cout << std::endl;
-
-  std::cout << "Final Bignum Register Values:" << std::endl;
-  std::cout << "Reg | Value" << std::endl;
-  std::cout << "---------------------------------------------------------------"
-               "----------------"
-            << std::endl;
-
-  for (int i = 0; i < 32; ++i) {
-    std::cout << "w" << std::left << std::dec << std::setw(2)
-              << std::setfill(' ') << i << " | 0x" << std::hex;
-
-    std::cout << std::setw(8) << std::setfill('0') << std::right
-              << otbn_bignum_reg_get(i, 7) << "_";
-
-    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 6)
-              << "_";
-
-    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 5)
-              << "_";
-
-    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 4)
-              << "_";
-
-    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 3)
-              << "_";
-
-    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 2)
-              << "_";
-
-    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 1)
-              << "_";
-
-    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 0)
-              << std::endl;
-  }
-
   int exp_stop_pc = otbn_memutil.GetExpEndAddr();
   if (exp_stop_pc >= 0) {
     SVScoped core_scope("TOP.otbn_top_sim.u_otbn_core_model");
@@ -299,5 +242,67 @@ extern "C" void OtbnTopApplyLoopWarp() {
       loop_controller->current_loop_d =
           ((loop_controller->current_loop_d >> 32) << 32) | new_iters_d;
     }
+  }
+}
+
+// This is executed over DPI when the model says that execution has just
+// finished. We use it to dump out the current RTL state before secure wipe
+// zeroes everything out.
+extern "C" void OtbnTopDumpState() {
+  std::cout << "Call Stack:" << std::endl;
+  std::cout << "-----------" << std::endl;
+  for (int i = 0; i < otbn_base_call_stack_get_size(); ++i) {
+    std::cout << std::setfill(' ') << "0x" << std::hex << std::setw(8)
+              << std::setfill('0') << std::right
+              << otbn_base_call_stack_get_element(i) << std::endl;
+  }
+
+  std::cout << std::endl;
+
+  std::cout << "Final Base Register Values:" << std::endl;
+  std::cout << "Reg | Value" << std::endl;
+  std::cout << "----------------" << std::endl;
+  for (int i = 2; i < 32; ++i) {
+    std::cout << "x" << std::left << std::dec << std::setw(2)
+              << std::setfill(' ') << i << " | 0x" << std::hex << std::setw(8)
+              << std::setfill('0') << std::right << otbn_base_reg_get(i)
+              << std::endl;
+  }
+
+  std::cout << std::endl;
+
+  std::cout << "Final Bignum Register Values:" << std::endl;
+  std::cout << "Reg | Value" << std::endl;
+  std::cout << "---------------------------------------------------------------"
+               "----------------"
+            << std::endl;
+
+  for (int i = 0; i < 32; ++i) {
+    std::cout << "w" << std::left << std::dec << std::setw(2)
+              << std::setfill(' ') << i << " | 0x" << std::hex;
+
+    std::cout << std::setw(8) << std::setfill('0') << std::right
+              << otbn_bignum_reg_get(i, 7) << "_";
+
+    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 6)
+              << "_";
+
+    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 5)
+              << "_";
+
+    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 4)
+              << "_";
+
+    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 3)
+              << "_";
+
+    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 2)
+              << "_";
+
+    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 1)
+              << "_";
+
+    std::cout << std::setw(8) << std::setfill('0') << otbn_bignum_reg_get(i, 0)
+              << std::endl;
   }
 }

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -394,6 +394,7 @@ module otbn_top_sim (
   // Defined in otbn_top_sim.cc
   import "DPI-C" context function int OtbnTopInstallLoopWarps();
   import "DPI-C" context function void OtbnTopApplyLoopWarp();
+  import "DPI-C" context function void OtbnTopDumpState();
   bit warps_installed;
 
   always_ff @(negedge IO_CLK or negedge IO_RST_N) begin
@@ -412,6 +413,11 @@ module otbn_top_sim (
   always_ff @(posedge IO_CLK or negedge IO_RST_N) begin
     if (IO_RST_N) begin
       OtbnTopApplyLoopWarp();
+    end
+  end
+  always_ff @(negedge IO_CLK or negedge IO_RST_N) begin
+    if (IO_RST_N && u_otbn_core_model.check_due && u_otbn_core_model.running) begin
+      OtbnTopDumpState();
     end
   end
 


### PR DESCRIPTION
This PR follows on from #10374. There, we taught the ISS enough that the trace entries and final state would match when secure wipe was enabled. Unfortunately, that final state isn't very informative: everything is zero! So we need to install a "hook" to check and/or dump state just before the secure wipe runs. This PR does that. It has the following commits:

- [otbn,dv] Dump regs before secure wipe in standalone ISS
- [otbn,dv] Tweak stats collection not to record stalls when wiping
- [otbn,dv] Expose a single-cycle 'WIPE_START' pulse from ISS
- [otbn,dv] Run a check at start of wipe
- [otbn,dv] Dump state in otbn_top_sim before secure wipe

The first two commits are for when we're not using the RTL at all, but they restore the values that we were seeing with secure wipe disabled. (For now, they'll make no difference; hack the initialisation of `OTBNState.secure_wipe_enabled` in `state.py` to see something!)

The remaining three commits are to do with integration with the RTL. The first wires out a single-cycle pulse from the ISS up to the C++ wrapper. The idea is that this signal is high at the end of the cycle where we've finished execution but haven't yet started wiping things. The second commit of the group moves around where we compare RTL and ISS state. Now we have a check at the end of the operation (as before), but have another check that runs a bit earlier, before the internal wipe. The final commit is in a similar vein but controls when we dump state when running Verilator simulations. This is needed because we have a smoke test that runs one of these sims and expects to see particular register values, so we need to make sure they are printed out before they get zeroed.

This PR still doesn't enable the secure wipe behaviour (you have to hack the testbenches to do that!) but, modulo nitty bugs, it should be most of the engineering work needed to let us remove the flag and enable it.