### PR TITLE
[sw,tests] Test flash partition access based on LC_STATE

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2380,7 +2380,7 @@
               accessibility of the corresponding partition depending on the signal value.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
       name: chip_sw_flash_creator_seed_wipe_on_rma
@@ -2399,7 +2399,7 @@
               accessibility of the corresponding partition depending on the signal value.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
       name: chip_sw_flash_lc_iso_part_sw_rd_en
@@ -2410,7 +2410,7 @@
               accessibility of the corresponding partition depending on the signal value.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
       name: chip_sw_flash_lc_iso_part_sw_wr_en
@@ -2421,7 +2421,7 @@
               accessibility of the corresponding partition depending on the signal value.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
       name: chip_sw_flash_lc_seed_hw_rd_en
@@ -2433,7 +2433,7 @@
               keymgr.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_ctrl_lc_rw_en"]
     }
     {
       name: chip_sw_flash_lc_escalate_en

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -267,6 +267,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_flash_ctrl_lc_rw_en
+      uvm_test_seq: chip_sw_flash_ctrl_lc_rw_en_vseq
+      sw_images: ["sw/device/tests/flash_ctrl_lc_rw_en_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_flash_ctrl_access
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/flash_ctrl_test:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -42,6 +42,7 @@ filesets:
       - seq_lib/chip_sw_uart_rand_baudrate_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_flash_ctrl_lc_rw_en_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_flash_ctrl_lc_rw_en_vseq)
+
+  `uvm_object_new
+
+  localparam string FLASH_CTRL_HDL_PATH = "tb.dut.top_earlgrey.u_flash_ctrl";
+  localparam string RW_EN_PATHS[5] = '{
+      {FLASH_CTRL_HDL_PATH, ".lc_creator_seed_sw_rw_en_i"},
+      {FLASH_CTRL_HDL_PATH, ".lc_owner_seed_sw_rw_en_i"},
+      {FLASH_CTRL_HDL_PATH, ".lc_iso_part_sw_wr_en_i"},
+      {FLASH_CTRL_HDL_PATH, ".lc_iso_part_sw_rd_en_i"},
+      {FLASH_CTRL_HDL_PATH, ".lc_seed_hw_rd_en_i"}
+  };
+
+  virtual task dut_init(string reset_kind = "HARD");
+    super.dut_init(reset_kind);
+    // Override the LC partition to TestLocked state.
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStTestLocked2);
+  endtask
+
+  virtual function lc_ctrl_pkg::lc_tx_t get_rw_en_signals(int rw_en_index);
+    lc_ctrl_pkg::lc_tx_t read_value;
+    `DV_CHECK_EQ_FATAL(uvm_hdl_check_path(RW_EN_PATHS[rw_en_index]), 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", RW_EN_PATHS[rw_en_index]))
+    `DV_CHECK_EQ_FATAL(uvm_hdl_read(RW_EN_PATHS[rw_en_index], read_value), 1, $sformatf(
+                       "uvm_hdl_read failed for %0s", RW_EN_PATHS[rw_en_index]))
+    return read_value;
+  endfunction
+
+  virtual task body();
+
+    super.body();
+
+    // Starting LC state is TestLocked2. This state disables
+    // CPU execution so we check the values by directly reading
+    // the signals from the flash_ctrl inputs.
+
+    for (int i = 0; i < 5; i++) begin
+      `DV_CHECK_EQ_FATAL(get_rw_en_signals(i), lc_ctrl_pkg::Off,
+                         "Mismatch for expected rw_en value [%0d] in TestLocked2 LC state", i)
+    end
+
+    // LC state changed to Dev. and reset, CPU will now be enabled.
+
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStDev);
+    apply_reset();
+
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+
+    // LC state changed to Prod.
+
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStProd);
+    apply_reset();
+
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+
+    // LC state changed to Scrap. CPU not enabled so do the checks directly.
+
+    cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStScrap);
+    apply_reset();
+
+    for (int i = 0; i < 5; i++) begin
+      `DV_CHECK_EQ_FATAL(get_rw_en_signals(i), lc_ctrl_pkg::Off,
+                         "Mismatch for exepcted rw_en value [%0d] in Scrap LC state", i)
+    end
+
+    cfg.sw_test_status_vif.sw_test_status = SwTestStatusPassed;
+    cfg.sw_test_status_vif.sw_test_done   = 1'b1;
+
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -14,6 +14,7 @@
 `include "chip_sw_uart_rand_baudrate_vseq.sv"
 `include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"
+`include "chip_sw_flash_ctrl_lc_rw_en_vseq.sv"
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
 `include "chip_sw_spi_tx_rx_vseq.sv"
 `include "chip_sw_rom_ctrl_integrity_check_vseq.sv"

--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -1,0 +1,154 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/testing/check.h"
+
+bool flash_ctrl_testutils_wait_transaction_end(
+    dif_flash_ctrl_state_t *flash_state) {
+  dif_flash_ctrl_output_t output;
+  while (true) {
+    dif_result_t dif_result = dif_flash_ctrl_end(flash_state, &output);
+    CHECK(dif_result != kDifBadArg);
+    CHECK(dif_result != kDifError);
+    if (dif_result == kDifOk) {
+      break;
+    }
+  }
+  if (output.operation_error) {
+    LOG_INFO("Transaction end error_codes = %0x", output.error_code.codes);
+  }
+  CHECK_DIF_OK(
+      dif_flash_ctrl_clear_error_codes(flash_state, output.error_code.codes));
+  return output.operation_error;
+}
+
+uint32_t flash_ctrl_testutils_data_region_setup(
+    dif_flash_ctrl_state_t *flash_state, uint32_t base_page_index,
+    uint32_t data_region, uint32_t region_size) {
+  dif_flash_ctrl_region_properties_t region_properties = {
+      .ecc_en = true,
+      .high_endurance_en = false,
+      .erase_en = true,
+      .prog_en = true,
+      .rd_en = true,
+      .scramble_en = false};
+
+  dif_flash_ctrl_data_region_properties_t data_region_properties = {
+      .base = base_page_index,
+      .properties = region_properties,
+      .size = region_size};
+
+  CHECK_DIF_OK(dif_flash_ctrl_set_data_region_properties(
+      flash_state, data_region, data_region_properties));
+  CHECK_DIF_OK(dif_flash_ctrl_set_data_region_enablement(
+      flash_state, data_region, kDifToggleEnabled));
+
+  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
+  return (base_page_index * device_info.bytes_per_page);
+}
+
+uint32_t flash_ctrl_testutils_info_region_setup(
+    dif_flash_ctrl_state_t *flash_state, uint32_t page_id, uint32_t bank,
+    uint32_t partition_id) {
+  dif_flash_ctrl_region_properties_t region_properties = {
+      .ecc_en = true,
+      .high_endurance_en = false,
+      .erase_en = true,
+      .prog_en = true,
+      .rd_en = true,
+      .scramble_en = false};
+
+  dif_flash_ctrl_info_region_t info_region = {
+      .bank = bank, .page = page_id, .partition_id = partition_id};
+
+  CHECK_DIF_OK(dif_flash_ctrl_set_info_region_properties(
+      flash_state, info_region, region_properties));
+  CHECK_DIF_OK(dif_flash_ctrl_set_info_region_enablement(
+      flash_state, info_region, kDifToggleEnabled));
+
+  dif_flash_ctrl_device_info_t device_info = dif_flash_ctrl_get_device_info();
+  return (page_id * device_info.bytes_per_page);
+}
+
+bool flash_ctrl_testutils_erase_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, dif_flash_ctrl_partition_type_t partition_type) {
+  dif_flash_ctrl_transaction_t transaction = {.byte_address = byte_address,
+                                              .op = kDifFlashCtrlOpPageErase,
+                                              .partition_type = partition_type,
+                                              .partition_id = partition_id,
+                                              .word_count = 0x0};
+  CHECK_DIF_OK(dif_flash_ctrl_start(flash_state, transaction));
+  return flash_ctrl_testutils_wait_transaction_end(flash_state);
+}
+
+bool flash_ctrl_testutils_write_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, const uint32_t *data,
+    dif_flash_ctrl_partition_type_t partition_type, uint32_t word_count) {
+  dif_flash_ctrl_transaction_t transaction = {.byte_address = byte_address,
+                                              .op = kDifFlashCtrlOpProgram,
+                                              .partition_type = partition_type,
+                                              .partition_id = partition_id,
+                                              .word_count = 0x0};
+  uint32_t words_written = 0;
+  bool retval = false;
+  // The flash will accept a maximum of MAX_BEATS_PER_BURST per write
+  // before the transaction must be ended and a new one started.
+  while (words_written < word_count) {
+    uint32_t words_to_write =
+        ((word_count - words_written) < MAX_BEATS_PER_BURST)
+            ? (word_count - words_written)
+            : MAX_BEATS_PER_BURST;
+    transaction.word_count = words_to_write;
+    transaction.byte_address =
+        byte_address + (sizeof(uint32_t) * words_written);
+    CHECK_DIF_OK(dif_flash_ctrl_start(flash_state, transaction));
+    CHECK_DIF_OK(dif_flash_ctrl_prog_fifo_push(flash_state, words_to_write,
+                                               data + words_written));
+    retval |= flash_ctrl_testutils_wait_transaction_end(flash_state);
+    words_written += words_to_write;
+  }
+
+  return retval;
+}
+
+bool flash_ctrl_testutils_erase_and_write_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, const uint32_t *data,
+    dif_flash_ctrl_partition_type_t partition_type, uint32_t word_count) {
+  bool retval = flash_ctrl_testutils_erase_page(flash_state, byte_address,
+                                                partition_id, partition_type);
+  retval |=
+      flash_ctrl_testutils_write_page(flash_state, byte_address, partition_id,
+                                      data, partition_type, word_count);
+  return retval;
+}
+
+bool flash_ctrl_testutils_read_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, uint32_t *data_out,
+    dif_flash_ctrl_partition_type_t partition_type, uint32_t word_count,
+    uint32_t delay) {
+  dif_flash_ctrl_transaction_t transaction = {.byte_address = byte_address,
+                                              .op = kDifFlashCtrlOpRead,
+                                              .partition_type = partition_type,
+                                              .partition_id = partition_id,
+                                              .word_count = word_count};
+
+  // Read Page.
+  CHECK_DIF_OK(dif_flash_ctrl_start(flash_state, transaction));
+  // Optional delay to allow for read fifo fill testing.
+  busy_spin_micros(delay);
+  CHECK_DIF_OK(dif_flash_ctrl_read_fifo_pop(flash_state, word_count, data_out));
+  return flash_ctrl_testutils_wait_transaction_end(flash_state);
+}

--- a/sw/device/lib/testing/flash_ctrl_testutils.h
+++ b/sw/device/lib/testing/flash_ctrl_testutils.h
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+
+#define MAX_BEATS_PER_BURST 16
+
+/**
+ * Wait for a flash_ctrl operation to end.
+ *
+ * Calls dif_flash_ctrl_end in a loop and waits for a dif_result of Ok. If at
+ * any time the result is BadArg or Error this will fail.
+ * Clears any error codes and returns the value of operation_error.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @return The operation error flag.
+ */
+bool flash_ctrl_testutils_wait_transaction_end(
+    dif_flash_ctrl_state_t *flash_state);
+
+/**
+ * Setup and enable for a data region.
+ * Returns the address offset of the region.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param base_page_index The region base page index.
+ * @param data_region The region index.
+ * @param region_size The region size (in number of pages).
+ * @return The byte address offset of the region.
+ */
+uint32_t flash_ctrl_testutils_data_region_setup(
+    dif_flash_ctrl_state_t *flash_state, uint32_t base_page_index,
+    uint32_t data_region, uint32_t region_size);
+
+/**
+ * Setup and enable for an info region.
+ * Returns the address offset of the region.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param page_id Region page index.
+ * @param bank The required bank.
+ * @param paritiion_id The partition index.
+ * @return The byte address offset of the region.
+ */
+uint32_t flash_ctrl_testutils_info_region_setup(
+    dif_flash_ctrl_state_t *flash_state, uint32_t page_id, uint32_t bank,
+    uint32_t partition_id);
+
+/**
+ * Erases the page at byte_address.
+ * Returns the result of transaction_end.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param byte_address The byte address of the page to erase.
+ * @param paritiion_id The partition index.
+ * @param partition_type The partition type, data or info.
+ * @return The operation error flag.
+ */
+bool flash_ctrl_testutils_erase_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, dif_flash_ctrl_partition_type_t partition_type);
+
+/**
+ * Programs the page at byte_address. The write is broken into
+ * as many transactions as required for the supplied word_count such
+ * that MAX_BEATS_PER_BURST is not exceded in any transaction.
+ * Returns the result of transaction_end.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param byte_address The byte address of the page to program.
+ * @param paritiion_id The partition index.
+ * @param data The data to program.
+ * @param partition_type The partition type, data or info.
+ * @param word_count The number of words to program.
+ * @return The operation error flag.
+ */
+bool flash_ctrl_testutils_write_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, const uint32_t *data,
+    dif_flash_ctrl_partition_type_t partition_type, uint32_t word_count);
+
+/**
+ * Erases and Programs the page at byte_address.
+ * Calls the erase and write functions in turn.
+ * Returns the combined result of the transaction_ends.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param byte_address The byte address of the page to erase and program.
+ * @param paritiion_id The partition index.
+ * @param data The data to program.
+ * @param partition_type The partition type, data or info.
+ * @param word_count The number of words to program.
+ * @return The combined operation error flags from erase and program.
+ */
+bool flash_ctrl_testutils_erase_and_write_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, const uint32_t *data,
+    dif_flash_ctrl_partition_type_t partition_type, uint32_t word_count);
+
+/**
+ * Reads the page at byte_address.
+ * Returns the result of transaction_end.
+ *
+ * @param flash_state A flash_ctrl state handle.
+ * @param byte_address The byte address of the page to erase and program.
+ * @param paritiion_id The partition index.
+ * @param data_out The data read from the page.
+ * @param partition_type The partition type, data or info.
+ * @param word_count The number of words to read.
+ * @return The operation error flag.
+ */
+bool flash_ctrl_testutils_read_page(
+    dif_flash_ctrl_state_t *flash_state, uint32_t byte_address,
+    uint32_t partition_id, uint32_t *data_out,
+    dif_flash_ctrl_partition_type_t partition_type, uint32_t word_count,
+    uint32_t delay);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_FLASH_CTRL_TESTUTILS_H_

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -86,6 +86,21 @@ sw_lib_testing_entropy_testutils = declare_dependency(
   ),
 )
 
+# flash_ctrl test utilities
+sw_lib_testing_flash_ctrl_testutils = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_flash_ctrl_testutils',
+    sources: [
+      'flash_ctrl_testutils.c'
+    ],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+      sw_lib_dif_flash_ctrl,
+    ],
+  ),
+)
+
 # pwrmgr test utilities
 sw_lib_testing_pwrmgr_testutils = declare_dependency(
   link_with: static_library(

--- a/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
+++ b/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
@@ -1,0 +1,176 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_keymgr.h"
+#include "sw/device/lib/dif/dif_kmac.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/dif/dif_otp_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+static dif_flash_ctrl_state_t flash;
+
+const test_config_t kTestConfig;
+
+enum {
+  kFlashInfoPageIdCreatorSecret = 1,
+  kFlashInfoPageIdOwnerSecret = 2,
+  kFlashInfoPageIdIsoPart = 3,
+  kPartSize = 16,
+  kBankId = 0,
+  kPartitionId = 0,
+};
+
+// Random data to read/write to flash partitions.
+
+const uint32_t kCreatorSecret[kPartSize] = {
+    0xb295d21b, 0xecdfbdcd, 0x67e7ab2d, 0x6f660b08, 0x273bf65c, 0xe80f1695,
+    0x586b80db, 0xc3dba27e, 0xdc124c5d, 0xb01ccd52, 0x815713e1, 0x31a141b2,
+    0x2124be3b, 0x299a6f2a, 0x1f2a4741, 0x1a073cc0,
+};
+
+const uint32_t kOwnerSecret[kPartSize] = {
+    0x69e705a0, 0x65c2ec6b, 0x04b0b634, 0x59313526, 0x1858aee1, 0xd49f3ba9,
+    0x230bcd38, 0xc1eb6b3e, 0x68c15e3b, 0x024d02a9, 0x0b062ae4, 0x334dd155,
+    0x53fdbf8a, 0x3792f1e2, 0xee317161, 0x33b19bf3,
+};
+
+const uint32_t kIsoPartData[kPartSize] = {
+    0x2b78dbf5, 0x3e6e5a00, 0xbf82c6d5, 0x68d8e33f, 0x9c524bbc, 0xac5beeef,
+    0x1287ca5a, 0x12b61419, 0x872e709f, 0xf91b7c0c, 0x18312a1f, 0x325cef9a,
+    0x19fefa95, 0x4ceb421b, 0xa57d74c4, 0xaf1d723d,
+};
+
+// For Dev LC state before personalization the
+// expected enabled values should be as follows :
+// 0 - seed hw read = 0
+// 1 - iso partition read = 0
+// 2 - iso partition write = 1
+// 3 - owner seed  = 1
+// 4 - creator seed = 1
+const bool kDevExpectedAccess[5] = {false, false, true, true, true};
+
+// For Prod LC state (after personalization) the
+// expected enabled values should be as follows :
+// 0 - seed hw read = 1
+// 1 - iso partition read = 1
+// 2 - iso partition write = 1
+// 3 - owner seed = 1
+// 4 - creator seed = 0
+const bool kProdExpectedAccess[5] = {true, true, true, true, false};
+
+static bool access_partitions(bool do_write, bool do_read, int page_id,
+                              const uint32_t *data, uint32_t size) {
+  uint32_t address = flash_ctrl_testutils_info_region_setup(
+      &flash, page_id, kBankId, kPartitionId);
+
+  bool retval = false;
+
+  if (do_write == true) {
+    // Erase and write page.
+    retval |= flash_ctrl_testutils_erase_and_write_page(
+        &flash, address, kPartitionId, data, kDifFlashCtrlPartitionTypeInfo,
+        size);
+  }
+
+  if (do_read == true) {
+    // Read page.
+    uint32_t readback_data[size];
+    retval |= flash_ctrl_testutils_read_page(
+        &flash, address, kPartitionId, readback_data,
+        kDifFlashCtrlPartitionTypeInfo, size, 0);
+    if (retval == false) {
+      CHECK_BUFFER(data, readback_data, size);
+    }
+  }
+  return (!retval);
+}
+
+static bool keymgr_advance_state(dif_keymgr_t *keymgr,
+                                 dif_keymgr_state_params_t *params,
+                                 dif_keymgr_state_t expected_state) {
+  CHECK_DIF_OK(dif_keymgr_advance_state(keymgr, params));
+  dif_keymgr_status_codes_t keymgr_status_codes;
+  do {
+    CHECK_DIF_OK(dif_keymgr_get_status_codes(keymgr, &keymgr_status_codes));
+  } while (!(keymgr_status_codes & kDifKeymgrStatusCodeIdle));
+
+  dif_keymgr_state_t keymgr_state;
+  CHECK_DIF_OK(dif_keymgr_get_state(keymgr, &keymgr_state));
+  return (keymgr_state == expected_state);
+}
+
+bool test_main(void) {
+  dif_otp_ctrl_t otp;
+  dif_kmac_t kmac;
+  dif_lc_ctrl_t lc;
+  dif_keymgr_t keymgr;
+
+  CHECK_DIF_OK(dif_keymgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_KEYMGR_BASE_ADDR), &keymgr));
+  CHECK_DIF_OK(dif_otp_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR), &otp));
+  CHECK_DIF_OK(
+      dif_kmac_init(mmio_region_from_addr(TOP_EARLGREY_KMAC_BASE_ADDR), &kmac));
+  CHECK_DIF_OK(dif_lc_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR), &lc));
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash, mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  dif_lc_ctrl_state_t curr_state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc, &curr_state));
+
+  dif_keymgr_config_t keymgr_config = {.entropy_reseed_interval = 0xFFFF};
+  CHECK_DIF_OK(dif_keymgr_configure(&keymgr, keymgr_config));
+
+  dif_keymgr_state_params_t keymgr_params = {
+      .binding_value = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF},
+      .max_key_version = 0xFFFFFFFF};
+
+  dif_kmac_config_t kmac_config = (dif_kmac_config_t){
+      .sideload = true,
+      .entropy_mode = kDifKmacEntropyModeSoftware,
+  };
+  CHECK_DIF_OK(dif_kmac_configure(&kmac, kmac_config));
+
+  bool access_checks[5];
+
+  access_checks[4] = access_partitions(
+      true, true, kFlashInfoPageIdCreatorSecret, kCreatorSecret, kPartSize);
+  access_checks[3] = access_partitions(true, true, kFlashInfoPageIdOwnerSecret,
+                                       kOwnerSecret, kPartSize);
+  access_checks[2] = access_partitions(true, false, kFlashInfoPageIdIsoPart,
+                                       kIsoPartData, kPartSize);
+  access_checks[1] = access_partitions(false, true, kFlashInfoPageIdIsoPart,
+                                       kIsoPartData, kPartSize);
+  access_checks[0] =
+      keymgr_advance_state(&keymgr, NULL, kDifKeymgrStateInitialized);
+  access_checks[0] &= keymgr_advance_state(&keymgr, &keymgr_params,
+                                           kDifKeymgrStateCreatorRootKey);
+
+  if (curr_state == kDifLcCtrlStateDev) {
+    CHECK_BUFFER(access_checks, kDevExpectedAccess, ARRAYSIZE(access_checks));
+
+    CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret2, 0));
+    dif_otp_ctrl_status_t otp_status;
+    do {
+      CHECK_DIF_OK(dif_otp_ctrl_get_status(&otp, &otp_status));
+    } while (
+        !(bitfield_bit32_read(otp_status.codes, kDifOtpCtrlStatusCodeDaiIdle)));
+  } else if (curr_state == kDifLcCtrlStateProd) {
+    CHECK_BUFFER(access_checks, kProdExpectedAccess, ARRAYSIZE(access_checks));
+  }
+
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+
+  return true;
+}

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -142,6 +142,28 @@ sw_tests += {
   }
 }
 
+flash_ctrl_lc_rw_en_test_lib = declare_dependency(
+  link_with: static_library(
+    'flash_ctrl_lc_rw_en_test_lib',
+    sources: ['flash_ctrl_lc_rw_en_test.c'],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_flash_ctrl,
+      sw_lib_dif_lc_ctrl,
+      sw_lib_dif_otp_ctrl,
+      sw_lib_dif_kmac,
+      sw_lib_dif_keymgr,
+      sw_lib_testing_flash_ctrl_testutils,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'flash_ctrl_lc_rw_en_test': {
+    'library': flash_ctrl_lc_rw_en_test_lib,
+  }
+}
+
 rom_ctrl_integrity_check_test_lib = declare_dependency(
   link_with: static_library(
     'rom_ctrl_integrity_check_test_lib',


### PR DESCRIPTION
This will check if software can read/write to various flash partitions based
on the LC enable signals which depend on the LC_STATE.

Checks for the following tests:
chip_sw_flash_lc_creator_seed_sw_rw_en
chip_sw_flash_lc_owner_seed_sw_rw_en
chip_sw_flash_lc_iso_part_sw_wr_en
chip_sw_flash_lc_iso_part_sw_rd_en
chip_sw_flash_lc_seed_hw_rd_en

Signed-off-by: Dave Williams <dave.williams@ensilica.com>