### PR TITLE
[dv/hmac] Enhance stress_all_with_rand_reset to reset at target timing

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -7,6 +7,10 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
   // A flag to nofity scoreboard if digest is corrupted by wipe_secret command.
   bit wipe_secret_triggered;
 
+  // Flag to notify stress_all_with_rand_reset task that hash_process command is triggered.
+  // This would help trying to issue reset at specific timing during hmac hashing.
+  bit hash_process_triggered;
+
   `uvm_object_utils(hmac_env_cfg)
   `uvm_object_new
 

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_base_vseq.sv
@@ -36,6 +36,11 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
     if (do_hmac_init) hmac_init();
   endtask
 
+  virtual task apply_reset(string kind = "HARD");
+    super.apply_reset(kind);
+    cfg.hash_process_triggered = 0;
+  endtask
+
   virtual task dut_shutdown();
     super.dut_shutdown();
     // TODO: nothing extra to do yet
@@ -97,6 +102,7 @@ class hmac_base_vseq extends cip_base_vseq #(.CFG_T               (hmac_env_cfg)
 
   virtual task trigger_process();
     csr_wr(.ptr(ral.cmd), .value(1'b1 << HashProcess));
+    cfg.hash_process_triggered = 1;
   endtask
 
   virtual task trigger_hash_when_active();

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
@@ -6,6 +6,15 @@ class hmac_common_vseq extends hmac_base_vseq;
   `uvm_object_utils(hmac_common_vseq)
   `uvm_object_new
 
+  rand bit trigger_reset_during_hash_process;
+
+  constraint trigger_reset_during_hash_process_c {
+    trigger_reset_during_hash_process dist {
+      1 :/ 1,
+      0 :/ 9
+    };
+  }
+
   constraint num_trans_c {
     num_trans inside {[1:3]};
   }
@@ -18,5 +27,21 @@ class hmac_common_vseq extends hmac_base_vseq;
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body
+
+  virtual task wait_to_issue_reset(uint reset_delay_bound = 10_000_000);
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(trigger_reset_during_hash_process)
+
+    if (trigger_reset_during_hash_process) begin
+      // In hmac_core, the FSM `StPushToMsgFifo` only spans around 20 clock cycles in the entire
+      // hashing process. So to ensure hmac won't corrupt if reset is issued during
+      // `StPushToMsgFifo` state, this task try to issue reset (with a large possibility) during
+      // `StPushToMsgFifo` state.
+      wait (cfg.hash_process_triggered == 1);
+      cfg.clk_rst_vif.wait_clks($urandom_range(100, 150));
+      #($urandom_range(0, cfg.clk_rst_vif.clk_period_ps) * 1ps);
+    end else begin
+      super.wait_to_issue_reset(reset_delay_bound);
+    end
+  endtask : wait_to_issue_reset
 
 endclass


### PR DESCRIPTION
Follow the suggestion from PR #10397, thanks Rupert for the feedback.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>