### PR TITLE
[dv/reggen] Adjust hier_path input for close source OTP tb

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -17,7 +17,7 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     { protocol: "tlul", direction: "device" }
   ],
   regwidth: "32",
-  hier_path: "u_reg_wrap"
+  hier_path: "u_reg_wrap.u_reg"
 ##############################################################################
   param_list: [
     // Random netlist constants

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -14,7 +14,7 @@
     { protocol: "tlul", direction: "device" }
   ],
   regwidth: "32",
-  hier_path: "u_reg_wrap"
+  hier_path: "u_reg_wrap.u_reg"
   param_list: [
     // Random netlist constants
     { name:      "RndCnstLfsrSeed",

--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -157,10 +157,10 @@ def gen_dv(block: IpBlock, dv_base_names: List[str], outdir: str) -> int:
     block_dv_base_names = get_block_base_name(dv_base_names_map, lblock)
 
     for if_name, rb in block.reg_blocks.items():
-        hier_path = '' if block.hier_path is None else block.hier_path + '.'
+        hier_path = '.u_reg' if block.hier_path is None else block.hier_path
         if_suffix = '' if if_name is None else '_' + if_name.lower()
         mod_base = lblock + if_suffix
-        reg_block_path = hier_path + 'u_reg' + if_suffix
+        reg_block_path = hier_path + if_suffix
 
         file_name = mod_base + '_ral_pkg.sv'
         generated.append(file_name)

--- a/util/topgen/top_uvm_reg.sv.tpl
+++ b/util/topgen/top_uvm_reg.sv.tpl
@@ -37,8 +37,8 @@
       if_suffix = '' if if_name is None else '_' + if_name
       esc_if_name = block_name.lower() + if_suffix
       if_desc = '' if if_name is None else '; interface {}'.format(if_name)
-      reg_block_path = 'u_reg' + if_suffix
-      reg_block_path = reg_block_path if block.hier_path is None else block.hier_path + "." + reg_block_path
+      reg_block_path = 'u_reg' + if_suffix if block.hier_path is None else if_suffix
+      reg_block_path = 'u_reg' + if_suffix if block.hier_path is None else if_suffix + block.hier_path
 %>\
 // Block: ${block_name.lower()}${if_desc}
 <%


### PR DESCRIPTION
This PR slightly adjust optional input `hier_path` for ip_blocks,
by removing the default `u_reg` path, close source OTP will have
the correct hier_path.
To accommodate the change, this PR also updates alert_handler's
hier_path value in hjson.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>