### PR TITLE
[sw/silicon_creator] Update `lifecycle_state_t`

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -472,14 +472,7 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
                                          boot_data_t *boot_data) {
   // TODO(#8778): Default boot data.
   switch (lc_state) {
-    case kLcStateTestUnlocked0:
-    case kLcStateTestUnlocked1:
-    case kLcStateTestUnlocked2:
-    case kLcStateTestUnlocked3:
-    case kLcStateTestUnlocked4:
-    case kLcStateTestUnlocked5:
-    case kLcStateTestUnlocked6:
-    case kLcStateTestUnlocked7:
+    case kLcStateTest:
     case kLcStateDev:
     case kLcStateRma:
       *boot_data = kBootDataDefault;

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -190,7 +190,7 @@ rom_error_t read_empty_default_allowed_test(void) {
   erase_boot_data_pages();
 
   boot_data_t boot_data;
-  RETURN_IF_ERROR(boot_data_read(kLcStateTestUnlocked0, &boot_data));
+  RETURN_IF_ERROR(boot_data_read(kLcStateTest, &boot_data));
   RETURN_IF_ERROR(check_boot_data(&boot_data, 5));
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -223,6 +223,27 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "lifecycle_unittest",
+    srcs = [
+        "lifecycle.h",
+        "lifecycle.c",
+        "lifecycle_unittest.cc",
+    ],
+    defines = [
+        "OT_OFF_TARGET_TEST",
+    ],
+    deps = [
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)
+
 cc_library(
     name = "otbn",
     srcs = ["otbn.c"],

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -272,8 +272,7 @@ bool test_main(void) {
   rom_error_t result = kErrorOk;
 
   // This test is expected to run in DEV, PROD or PROD_END states.
-  lifecycle_state_t lc_state = lifecycle_state_get();
-  LOG_INFO("lifecycle state: %s", lifecycle_state_name_get(lc_state));
+  LOG_INFO("lifecycle state: 0x%x", lifecycle_raw_state_get());
 
   // Initialize pwrmgr
   dif_pwrmgr_t pwrmgr;

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -8,91 +8,67 @@
 #include <stdint.h>
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "lc_ctrl_regs.h"
 
-static const char *const kStateNames[] = {
-    // clang-format off
-    "RAW",
-    "TEST_UNLOCKED0",
-    "TEST_LOCKED0",
-    "TEST_UNLOCKED1",
-    "TEST_LOCKED1",
-    "TEST_UNLOCKED2",
-    "TEST_LOCKED2",
-    "TEST_UNLOCKED3",
-    "TEST_LOCKED3",
-    "TEST_UNLOCKED4",
-    "TEST_LOCKED4",
-    "TEST_UNLOCKED5",
-    "TEST_LOCKED5",
-    "TEST_UNLOCKED6",
-    "TEST_LOCKED6",
-    "TEST_UNLOCKED7",
-    "DEV",
-    "PROD",
-    "PROD_END",
-    "RMA",
-    "SCRAP",
-    "POST_TRANSITION",
-    "ESCALATE",
-    "INVALID",
-    // clang-format on
-};
-
-static_assert(ARRAYSIZE(kStateNames) == kLcStateNumStates,
-              "length of the kStateNames array doesn't match the "
-              "number of states.");
-
-#define LC_ASSERT(a, b) static_assert(a == b, "Bad value for " #a)
-LC_ASSERT(kLcStateRaw, LC_CTRL_LC_STATE_STATE_VALUE_RAW);
-LC_ASSERT(kLcStateTestUnlocked0, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0);
-LC_ASSERT(kLcStateTestLocked0, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED0);
-LC_ASSERT(kLcStateTestUnlocked1, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1);
-LC_ASSERT(kLcStateTestLocked1, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED1);
-LC_ASSERT(kLcStateTestUnlocked2, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED2);
-LC_ASSERT(kLcStateTestLocked2, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED2);
-LC_ASSERT(kLcStateTestUnlocked3, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED3);
-LC_ASSERT(kLcStateTestLocked3, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED3);
-LC_ASSERT(kLcStateTestUnlocked4, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED4);
-LC_ASSERT(kLcStateTestLocked4, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED4);
-LC_ASSERT(kLcStateTestUnlocked5, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED5);
-LC_ASSERT(kLcStateTestLocked5, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED5);
-LC_ASSERT(kLcStateTestUnlocked6, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED6);
-LC_ASSERT(kLcStateTestLocked6, LC_CTRL_LC_STATE_STATE_VALUE_TEST_LOCKED6);
-LC_ASSERT(kLcStateTestUnlocked7, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED7);
-LC_ASSERT(kLcStateDev, LC_CTRL_LC_STATE_STATE_VALUE_DEV);
-LC_ASSERT(kLcStateProd, LC_CTRL_LC_STATE_STATE_VALUE_PROD);
-LC_ASSERT(kLcStateProdEnd, LC_CTRL_LC_STATE_STATE_VALUE_PROD_END);
-LC_ASSERT(kLcStateRma, LC_CTRL_LC_STATE_STATE_VALUE_RMA);
-LC_ASSERT(kLcStateScrap, LC_CTRL_LC_STATE_STATE_VALUE_SCRAP);
-LC_ASSERT(kLcStatePostTransition, LC_CTRL_LC_STATE_STATE_VALUE_POST_TRANSITION);
-LC_ASSERT(kLcStateEscalate, LC_CTRL_LC_STATE_STATE_VALUE_ESCALATE);
-LC_ASSERT(kLcStateInvalid, LC_CTRL_LC_STATE_STATE_VALUE_INVALID);
-
 enum {
   kBase = TOP_EARLGREY_LC_CTRL_BASE_ADDR,
 };
 
 lifecycle_state_t lifecycle_state_get(void) {
+  uint32_t raw_state = lifecycle_raw_state_get();
+
+  switch (launder32(raw_state)) {
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED2:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED2);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED3:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED3);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED4:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED4);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED5:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED5);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED6:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED6);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED7:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED7);
+      return kLcStateTest;
+    case LC_CTRL_LC_STATE_STATE_VALUE_DEV:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_DEV);
+      return kLcStateDev;
+    case LC_CTRL_LC_STATE_STATE_VALUE_PROD:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_PROD);
+      return kLcStateProd;
+    case LC_CTRL_LC_STATE_STATE_VALUE_PROD_END:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_PROD_END);
+      return kLcStateProdEnd;
+    case LC_CTRL_LC_STATE_STATE_VALUE_RMA:
+      HARDENED_CHECK_EQ(raw_state, LC_CTRL_LC_STATE_STATE_VALUE_RMA);
+      return kLcStateRma;
+    default:
+      HARDENED_UNREACHABLE();
+  }
+}
+
+uint32_t lifecycle_raw_state_get(void) {
   uint32_t value = bitfield_field32_read(
       sec_mmio_read32(kBase + LC_CTRL_LC_STATE_REG_OFFSET),
       LC_CTRL_LC_STATE_STATE_FIELD);
-  return (lifecycle_state_t)value;
-}
-
-const char *lifecycle_state_name_get(lifecycle_state_t lc_state) {
-  // Life cycle state value (`lc_state`) is a 32-bit value that repeats the
-  // 5-bit life cycle state index 6 times.
-  enum { kStateIndexMask = 0x1f };
-  size_t state_index = (uint32_t)lc_state & kStateIndexMask;
-  if (state_index >= kLcStateNumStates) {
-    state_index = kLcStateInvalid & kStateIndexMask;
-  }
-  return kStateNames[state_index];
+  return value;
 }
 
 void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.h
@@ -12,111 +12,81 @@ extern "C" {
 #endif
 
 /**
- * Lifecycle States.
+ * Lifecycle states.
+ *
+ * This is a condensed version of the 24 possible life cycle states where
+ * TEST_UNLOCKED_* states are mapped to `kLcStateTest` and invalid states where
+ * CPU execution is disabled are omitted.
+ *
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 5 -n 32 \
+ *     -s 2447090565 --language=c
+ *
+ * Hamming distance histogram:
+ *
+ *  0: --
+ *  1: --
+ *  2: --
+ *  3: --
+ *  4: --
+ *  5: --
+ *  6: --
+ *  7: --
+ *  8: --
+ *  9: --
+ * 10: --
+ * 11: --
+ * 12: --
+ * 13: ||||| (10.00%)
+ * 14: ||||| (10.00%)
+ * 15: --
+ * 16: |||||||||| (20.00%)
+ * 17: |||||||||||||||||||| (40.00%)
+ * 18: ||||| (10.00%)
+ * 19: ||||| (10.00%)
+ * 20: --
+ * 21: --
+ * 22: --
+ * 23: --
+ * 24: --
+ * 25: --
+ * 26: --
+ * 27: --
+ * 28: --
+ * 29: --
+ * 30: --
+ * 31: --
+ * 32: --
+ *
+ * Minimum Hamming distance: 13
+ * Maximum Hamming distance: 19
+ * Minimum Hamming weight: 15
+ * Maximum Hamming weight: 20
  */
-typedef enum LcState {
-  /**
-   * Raw life cycle state after fabrication where all functions are disabled.
-   */
-  kLcStateRaw = 0x0,
+typedef enum lifecycle_state {
   /**
    * Unlocked test state where debug functions are enabled.
+   *
+   * Corresponds to TEST_UNLOCKED_* life cycle states.
    */
-  kLcStateTestUnlocked0 = 1 * 0x2108421,
-  /**
-   * Locked test state where where all functions are disabled.
-   */
-  kLcStateTestLocked0 = 2 * 0x2108421,
-  /**
-   * Unlocked test state where debug functions are enabled.
-   */
-  kLcStateTestUnlocked1 = 3 * 0x2108421,
-  /**
-   * Locked test state where where all functions are disabled.
-   */
-  kLcStateTestLocked1 = 4 * 0x2108421,
-  /**
-   * Unlocked test state where debug functions are enabled.
-   */
-  kLcStateTestUnlocked2 = 5 * 0x2108421,
-  /**
-   * Locked test state where debug all functions are disabled.
-   */
-  kLcStateTestLocked2 = 6 * 0x2108421,
-  /**
-   * Unlocked test state where debug functions are enabled.
-   */
-  kLcStateTestUnlocked3 = 7 * 0x2108421,
-  /**
-   * Locked test state where debug all functions are disabled.
-   */
-  kLcStateTestLocked3 = 8 * 0x2108421,
-  /**
-   * Unlocked test state where debug functions are enabled.
-   */
-  kLcStateTestUnlocked4 = 9 * 0x2108421,
-  /**
-   * Locked test state where debug all functions are disabled.
-   */
-  kLcStateTestLocked4 = 10 * 0x2108421,
-  /**
-   * Unlocked test state where debug functions are enabled.
-   */
-  kLcStateTestUnlocked5 = 11 * 0x2108421,
-  /**
-   * Locked test state where debug all functions are disabled.
-   */
-  kLcStateTestLocked5 = 12 * 0x2108421,
-  /**
-   * Unlocked test state where debug functions are enabled.
-   */
-  kLcStateTestUnlocked6 = 13 * 0x2108421,
-  /**
-   * Locked test state where debug all functions are disabled.
-   */
-  kLcStateTestLocked6 = 14 * 0x2108421,
-  /**
-   * Unlocked test state where debug functions are enabled.
-   */
-  kLcStateTestUnlocked7 = 15 * 0x2108421,
+  kLcStateTest = 0xb2865fbb,
   /**
    * Development life cycle state where limited debug functionality is
    * available.
    */
-  kLcStateDev = 16 * 0x2108421,
+  kLcStateDev = 0x0b5a75e0,
   /**
    * Production life cycle state.
    */
-  kLcStateProd = 17 * 0x2108421,
+  kLcStateProd = 0x65f2520f,
   /**
    * Same as PROD, but transition into RMA is not possible from this state.
    */
-  kLcStateProdEnd = 18 * 0x2108421,
+  kLcStateProdEnd = 0x91b9b68a,
   /**
    * RMA life cycle state.
    */
-  kLcStateRma = 19 * 0x2108421,
-  /**
-   * SCRAP life cycle state where all functions are disabled.
-   */
-  kLcStateScrap = 20 * 0x2108421,
-  /**
-   * This state is temporary and behaves the same way as SCRAP.
-   */
-  kLcStatePostTransition = 21 * 0x2108421,
-  /**
-   * This state is temporary and behaves the same way as SCRAP.
-   */
-  kLcStateEscalate = 22 * 0x2108421,
-  /**
-   * This state is reported when the life cycle state encoding is invalid.
-   * This state is temporary and behaves the same way as SCRAP.
-   */
-  kLcStateInvalid = 23 * 0x2108421,
-  /**
-   * This is not a state - it is the total number of states.
-   */
-  kLcStateNumStates = 24,
+  kLcStateRma = 0xcf8cfaab,
 } lifecycle_state_t;
 
 enum {
@@ -136,17 +106,21 @@ typedef struct lifecycle_device_id {
 /**
  * Get the life cycle state.
  *
+ * This function checks the value read from the hardware and returns a
+ * `life_cycle_state_t`. See `life_cyle_state_t` for more details.
+ *
  * @return Life cycle state.
  */
 lifecycle_state_t lifecycle_state_get(void);
 
 /**
- * Get the human-readable name for a life cycle state.
+ * Get the unprocessed life cycle state value read from the hardware.
  *
- * @param lc_state Life cycle state.
- * @return Name of the given state.
+ * This function directly returns the `uint32_t` value read from the hardware.
+ *
+ * @return Life cycle state.
  */
-const char *lifecycle_state_name_get(lifecycle_state_t lc_state);
+uint32_t lifecycle_raw_state_get(void);
 
 /**
  * Get the device identifier.

--- a/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
@@ -1,0 +1,151 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+
+#include <array>
+
+#include "gtest/gtest.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "lc_ctrl_regs.h"
+
+namespace lifecycle_unittest {
+namespace {
+using ::testing::ElementsAreArray;
+
+class LifecycleTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_LC_CTRL_BASE_ADDR;
+  mask_rom_test::MockSecMmio mmio_;
+};
+
+TEST_F(LifecycleTest, RawState) {
+  EXPECT_SEC_READ32(base_ + LC_CTRL_LC_STATE_REG_OFFSET,
+                    LC_CTRL_LC_STATE_STATE_VALUE_SCRAP);
+  EXPECT_EQ(lifecycle_raw_state_get(), LC_CTRL_LC_STATE_STATE_VALUE_SCRAP);
+}
+
+TEST_F(LifecycleTest, DeviceId) {
+  constexpr std::array<uint32_t, kLifecycleDeviceIdNumWords> kDeviceId{
+      0x8d2aed99, 0xdc7724d7, 0x33e5f191, 0xa0787993,
+      0x0dd390c5, 0xc95fcd6d, 0x9103a182, 0xdf82998e,
+  };
+  for (size_t i = 0; i < kLifecycleDeviceIdNumWords; ++i) {
+    EXPECT_SEC_READ32(
+        base_ + LC_CTRL_DEVICE_ID_0_REG_OFFSET + i * sizeof(uint32_t),
+        kDeviceId[i]);
+  }
+
+  lifecycle_device_id_t device_id;
+  lifecycle_device_id_get(&device_id);
+  EXPECT_THAT(device_id.device_id, ElementsAreArray(kDeviceId));
+}
+
+struct ValidStateTestCase {
+  /**
+   * Value reported by hardware.
+   */
+  uint32_t hw_state;
+  /**
+   * Value returned by software.
+   */
+  lifecycle_state_t sw_state;
+};
+
+class LifecycleValidStates
+    : public LifecycleTest,
+      public testing::WithParamInterface<ValidStateTestCase> {};
+
+TEST_P(LifecycleValidStates, ValidState) {
+  EXPECT_SEC_READ32(base_ + LC_CTRL_LC_STATE_REG_OFFSET, GetParam().hw_state);
+  EXPECT_EQ(lifecycle_state_get(), GetParam().sw_state);
+}
+
+constexpr std::array<ValidStateTestCase, 12> kValidStateTestCases{{
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED2,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED3,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED4,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED5,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED6,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED7,
+        .sw_state = kLcStateTest,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_DEV,
+        .sw_state = kLcStateDev,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_PROD,
+        .sw_state = kLcStateProd,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_PROD_END,
+        .sw_state = kLcStateProdEnd,
+    },
+    {
+        .hw_state = LC_CTRL_LC_STATE_STATE_VALUE_RMA,
+        .sw_state = kLcStateRma,
+    },
+}};
+
+INSTANTIATE_TEST_SUITE_P(AllValidStates, LifecycleValidStates,
+                         testing::ValuesIn(kValidStateTestCases));
+
+class LifecycleDeathTest : public LifecycleTest,
+                           public testing::WithParamInterface<uint32_t> {};
+
+TEST_P(LifecycleDeathTest, InvalidState) {
+  ASSERT_DEATH(
+      {
+        EXPECT_SEC_READ32(base_ + LC_CTRL_LC_STATE_REG_OFFSET, GetParam());
+        lifecycle_state_get();
+      },
+      "");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllInvalidStates, LifecycleDeathTest,
+    testing::Values(LC_CTRL_TRANSITION_TARGET_STATE_VALUE_RAW,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_TEST_LOCKED0,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_TEST_LOCKED1,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_TEST_LOCKED2,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_TEST_LOCKED3,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_TEST_LOCKED4,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_TEST_LOCKED5,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_TEST_LOCKED6,
+                    LC_CTRL_TRANSITION_TARGET_STATE_VALUE_SCRAP,
+                    LC_CTRL_LC_STATE_STATE_VALUE_POST_TRANSITION,
+                    LC_CTRL_LC_STATE_STATE_VALUE_ESCALATE,
+                    LC_CTRL_LC_STATE_STATE_VALUE_INVALID));
+
+}  // namespace
+}  // namespace lifecycle_unittest

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -17,6 +17,25 @@ sw_silicon_creator_lib_driver_lifecycle = declare_dependency(
   ),
 )
 
+test('sw_silicon_creator_lib_driver_lifecycle_unittest', executable(
+    'sw_silicon_creator_lib_driver_lifecycle_unittest',
+    sources: [
+      'lifecycle_unittest.cc',
+      hw_ip_lc_ctrl_reg_h,
+      'lifecycle.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_silicon_creator_lib_base_mock_sec_mmio,
+      sw_lib_testing_hardened,
+    ],
+    native: true,
+    c_args: ['-DOT_OFF_TARGET_TEST'],
+    cpp_args: ['-DOT_OFF_TARGET_TEST'],
+  ),
+  suite: 'mask_rom',
+)
+
 # Mask ROM hmac driver
 sw_silicon_creator_lib_driver_hmac = declare_dependency(
   link_with: static_library(

--- a/sw/device/silicon_creator/lib/drivers/mock_lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_lifecycle.h
@@ -17,6 +17,7 @@ namespace internal {
 class MockLifecycle : public GlobalMock<MockLifecycle> {
  public:
   MOCK_METHOD(lifecycle_state_t, State, ());
+  MOCK_METHOD(uint32_t, RawState, ());
   MOCK_METHOD(void, DeviceId, (lifecycle_device_id_t * device_id));
 };
 
@@ -28,6 +29,10 @@ extern "C" {
 
 lifecycle_state_t lifecycle_state_get(void) {
   return MockLifecycle::Instance().State();
+}
+
+uint32_t lifecycle_raw_state_get(void) {
+  return MockLifecycle::Instance().RawState();
 }
 
 void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -71,14 +71,7 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
   // Are we in a lifecycle state which needs alert configuration?
   uint32_t lc_shift;
   switch (lc_state) {
-    case kLcStateTestUnlocked0:
-    case kLcStateTestUnlocked1:
-    case kLcStateTestUnlocked2:
-    case kLcStateTestUnlocked3:
-    case kLcStateTestUnlocked4:
-    case kLcStateTestUnlocked5:
-    case kLcStateTestUnlocked6:
-    case kLcStateTestUnlocked7:
+    case kLcStateTest:
       // Don't configure alerts during manufacturing as OTP may not have been
       // programmed yet.
       return kErrorOk;
@@ -226,25 +219,25 @@ shutdown_redact_policy_inline(void) {
   //
   // Note that we cannot use the lifecycle or OTP libraries since an error
   // may trigger a call to `shutdown_finalize`.
-  lifecycle_state_t lc_state = (lifecycle_state_t)bitfield_field32_read(
-      abs_mmio_read32(TOP_EARLGREY_LC_CTRL_BASE_ADDR +
-                      LC_CTRL_LC_STATE_REG_OFFSET),
-      LC_CTRL_LC_STATE_STATE_FIELD);
-  switch (lc_state) {
-    case kLcStateTestUnlocked0:
-    case kLcStateTestUnlocked1:
-    case kLcStateTestUnlocked2:
-    case kLcStateTestUnlocked3:
-    case kLcStateTestUnlocked4:
-    case kLcStateTestUnlocked5:
-    case kLcStateTestUnlocked6:
-    case kLcStateTestUnlocked7:
-    case kLcStateRma:
+  uint32_t raw_state =
+      bitfield_field32_read(abs_mmio_read32(TOP_EARLGREY_LC_CTRL_BASE_ADDR +
+                                            LC_CTRL_LC_STATE_REG_OFFSET),
+                            LC_CTRL_LC_STATE_STATE_FIELD);
+  switch (raw_state) {
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0:
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1:
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED2:
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED3:
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED4:
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED5:
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED6:
+    case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED7:
+    case LC_CTRL_LC_STATE_STATE_VALUE_RMA:
       // No error redaction in TEST_UNLOCKED and RMA states.
       return kShutdownErrorRedactNone;
-    case kLcStateProd:
-    case kLcStateProdEnd:
-    case kLcStateDev:
+    case LC_CTRL_LC_STATE_STATE_VALUE_DEV:
+    case LC_CTRL_LC_STATE_STATE_VALUE_PROD:
+    case LC_CTRL_LC_STATE_STATE_VALUE_PROD_END:
       // In production states use the redaction level specified in OTP.
       return (shutdown_error_redact_t)abs_mmio_read32(
           TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR +

--- a/sw/device/silicon_creator/lib/sigverify.c
+++ b/sw/device/silicon_creator/lib/sigverify.c
@@ -207,14 +207,7 @@ static rom_error_t sigverify_encoded_message_check(
 static rom_error_t sigverify_use_sw_rsa_verify(lifecycle_state_t lc_state,
                                                hardened_bool_t *use_sw) {
   switch (lc_state) {
-    case kLcStateTestUnlocked0:
-    case kLcStateTestUnlocked1:
-    case kLcStateTestUnlocked2:
-    case kLcStateTestUnlocked3:
-    case kLcStateTestUnlocked4:
-    case kLcStateTestUnlocked5:
-    case kLcStateTestUnlocked6:
-    case kLcStateTestUnlocked7:
+    case kLcStateTest:
       // Don't read from OTP during manufacturing. Use software
       // implementation by default.
       *use_sw = kHardenedBoolTrue;

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -199,7 +199,7 @@ void mask_rom_main(void) {
   // TODO(lowrisc/opentitan#7894): What (if anything) should we print at
   // startup?
   log_printf("OpenTitan: \"version-tag\"\r\n");
-  log_printf("lc_state: %s\r\n", lifecycle_state_name_get(lc_state));
+  log_printf("lc_state: 0x%x\r\n", (unsigned int)lifecycle_raw_state_get());
 
   // TODO(lowrisc/opentitan#1513): Switch to EEPROM SPI device bootstrap
   // protocol.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -42,7 +42,7 @@ volatile sec_mmio_ctx_t sec_mmio_ctx;
 // In-memory copy of the ePMP register configuration.
 epmp_state_t epmp;
 // Life cycle state of the chip.
-lifecycle_state_t lc_state = kLcStateProd;
+lifecycle_state_t lc_state = (lifecycle_state_t)0;
 
 static inline rom_error_t mask_rom_irq_error(void) {
   uint32_t mcause;
@@ -153,6 +153,9 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
 
   // Enable execution of code from flash if signature is verified.
   flash_ctrl_exec_set(flash_exec);
+
+  // Check cached lc_state value aginst the value reported by hardware.
+  HARDENED_CHECK_EQ(lc_state, lifecycle_state_get());
 
   sec_mmio_check_values(rnd_uint32());
   sec_mmio_check_counters(/*expected_check_count=*/3);

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys.c
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys.c
@@ -185,29 +185,8 @@ static rom_error_t key_is_valid_in_lc_state_test(
 static rom_error_t key_is_valid(sigverify_key_type_t key_type,
                                 lifecycle_state_t lc_state, size_t key_index) {
   switch (launder32(lc_state)) {
-    case kLcStateTestUnlocked0:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked0);
-      return key_is_valid_in_lc_state_test(key_type);
-    case kLcStateTestUnlocked1:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked1);
-      return key_is_valid_in_lc_state_test(key_type);
-    case kLcStateTestUnlocked2:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked2);
-      return key_is_valid_in_lc_state_test(key_type);
-    case kLcStateTestUnlocked3:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked3);
-      return key_is_valid_in_lc_state_test(key_type);
-    case kLcStateTestUnlocked4:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked4);
-      return key_is_valid_in_lc_state_test(key_type);
-    case kLcStateTestUnlocked5:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked5);
-      return key_is_valid_in_lc_state_test(key_type);
-    case kLcStateTestUnlocked6:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked6);
-      return key_is_valid_in_lc_state_test(key_type);
-    case kLcStateTestUnlocked7:
-      HARDENED_CHECK_EQ(lc_state, kLcStateTestUnlocked7);
+    case kLcStateTest:
+      HARDENED_CHECK_EQ(lc_state, kLcStateTest);
       return key_is_valid_in_lc_state_test(key_type);
     case kLcStateProd:
       HARDENED_CHECK_EQ(lc_state, kLcStateProd);


### PR DESCRIPTION
This change
* Reduces the number of `lifecycle_state_t` variants to 5, i.e. to the ones that we use in mask rom,
* Adds `lifecycle_raw_state_get()` to get the unprocessed life cycle state from hardware (mostly for debug purposes),
* Removes `lifecycle_state_name_get()`, 
* Updates call sites and tests,
* Adds unit tests for the lifecycle driver, and
* Adds an additional check to `mask_rom_boot()` before jumping to ROM_EXT.

I'll create another PR for hardening life cycle switch statements in mask rom.