### PR TITLE
[dv/hmac] Hmac V2

### DIFF
--- a/hw/ip/hmac/data/hmac.prj.hjson
+++ b/hw/ip/hmac/data/hmac.prj.hjson
@@ -21,7 +21,7 @@
         version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2S",
-        verification_stage: "V1",
+        verification_stage: "V2",
         dif_stage:          "S0",
         notes:              "Rolled back to D2 in order to add the first alert",
       }


### PR DESCRIPTION
Re-declare V2 in HMAC with the following steps:
1). Add wipe secret support in PR:  #10363
2). Issue reset in specific FSM states to increase FSM cvoerage in PR #10417
3). Remove old exclusion file due to the design change: PR #10427

Signed-off-by: Cindy Chen <chencindy@opentitan.org>