### PR TITLE
[edn/rtl] Fix for auto-mode

### DIFF
--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -521,7 +521,7 @@ module edn_core import edn_pkg::*;
     .rst_ni(rst_ni),
     .boot_req_mode_i(boot_auto_req_dly_q),
     .auto_req_mode_i(auto_req_mode),
-    .sw_cmd_req_load_i(sw_cmd_req_load),
+    .sw_cmd_req_load_i(cs_cmd_req_out_q),
     .seq_auto_req_mode_o(seq_auto_req_mode),
     .auto_req_mode_end_o(auto_req_mode_end),
     .csrng_cmd_ack_i(csrng_cmd_ack),


### PR DESCRIPTION
A timing delay fix is needed to make both auto_req and boot_req
modes work together.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>