### PR TITLE
[rom_ctrl,rtl] Fix a bug in the mux with invalid signals

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -107,8 +107,20 @@ module rom_ctrl_mux
 
   assign chk_rdata_o = rom_scr_rdata_i;
 
-  assign rom_req_o         = mubi4_test_true_strict(sel_bus_i) ? bus_req_i         : chk_req_i;
-  assign rom_rom_addr_o    = mubi4_test_true_strict(sel_bus_i) ? bus_rom_addr_i    : chk_addr_i;
-  assign rom_prince_addr_o = mubi4_test_true_strict(sel_bus_i) ? bus_prince_addr_i : chk_addr_i;
+  always_comb begin
+    unique if (mubi4_test_true_strict(sel_bus_i)) begin
+      rom_req_o         = bus_req_i;
+      rom_rom_addr_o    = bus_rom_addr_i;
+      rom_prince_addr_o = bus_prince_addr_i;
+    end else if (mubi4_test_false_strict(sel_bus_i)) begin
+      rom_req_o         = chk_req_i;
+      rom_rom_addr_o    = chk_addr_i;
+      rom_prince_addr_o = chk_addr_i;
+    end else begin
+      rom_req_o         = '0;
+      rom_rom_addr_o    = '0;
+      rom_prince_addr_o = '0;
+    end
+  end
 
 endmodule


### PR DESCRIPTION
This fixes a bug discovered by @prajwalaputtappa with her signal corruption
tests. Suppose you corrupt the `mubi4_t` that appears here as `sel_bus_i`
some time after the ROM check has completed.

With the previous code, we sent `chk_req_i` (constant 1) to the ROM and
then reflected it back as `bus_rvalid_o` on the cycle after the glitch
went away. This, in turn, caused an assertion to go off in the TL
converter. In the real design, we might have even manufactured a stray
bus response. Oops!

This commit makes sure that we only make a request if `sel_q` is one of
the allowed `mubi4_t` values.
