### PR TITLE
[rom_ctrl] Squash ROM bus responses on an internal error

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -160,6 +160,14 @@
         integrity scheme).
       '''
     },
+    { name: "BUS.LOCAL_ESC",
+      desc: '''
+        To avoid responding to a request with erroneous data, even though an
+        alert went out, the bus_rom_rvalid signal used to signal a response to
+        the ROM-side TL bus can only be high if no internal consistency error
+        has been spotted.
+      '''
+    }
     {
       name: "MUX.MUBI",
       desc: '''

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_mux.sv
@@ -96,7 +96,19 @@ module rom_ctrl_mux
   logic sel_q_reverted;
   assign sel_q_reverted = mubi4_test_true_loose(sel_bus_qq) & mubi4_test_false_loose(sel_bus_q);
 
-  assign alert_o = sel_invalid | sel_reverted | sel_q_reverted;
+  logic alert_q, alert_d;
+
+  assign alert_d = sel_invalid | sel_reverted | sel_q_reverted;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      alert_q <= 0;
+    end else begin
+      alert_q <= alert_q | alert_d;
+    end
+  end
+
+  assign alert_o = alert_q;
 
   // The bus can have access every cycle, from when the select signal switches to the bus.
   assign bus_gnt_o    = mubi4_test_true_strict(sel_bus_i);


### PR DESCRIPTION
There are a few awkward corner cases surrounding the mux, where an
injected fault can cause a response to come out as well as triggering
an alert. We've got some extra layers of safety here (e.g. ensuring
that the response data will have malformed integrity), but it's not
hard to explicitly squash things as well.

The result will be that the bus transaction hangs (and the chip will
eventually watchdog).
