### PR TITLE
[rom_ctrl] Slightly beef up internal consistency checks

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl.hjson
@@ -95,6 +95,23 @@
       '''
     },
     {
+      name: "CHECKER.CTRL_FLOW.CONSISTENCY",
+      desc: '''
+        The main checker FSM steps on internal 'done' signals, coming
+        from its address counter, the KMAC response and its comparison
+        counter. If any of these are asserted at times we don't
+        expect, the FSM jumps to an invalid state. This triggers an
+        alert and will not set the external 'done' signal for pwrmgr
+        to continue boot.
+      '''
+    },
+    {
+      name: "CHECKER.FSM.LOCAL_ESC",
+      desc: '''
+        The main checker FSM moves to an invalid state on local escalation.
+      '''
+    },
+    {
       name: "COMPARE.CTRL_FLOW.CONSISTENCY",
       desc: '''
         The hash comparison module triggers a fatal error if the checker FSM


### PR DESCRIPTION
This was triggered by noticing that if we glitch the `checker_done`
signal then, while we would trigger an alert, we could also jump to
the `Done` state early, possibly hiding a difference in the ROM
contents.

With this change, we will jump to an invalid state. The alert signal
will still come out, but we'll never get to `Done`.

@prajwalaputtappa: I'm afraid that this change probably implies a couple of extra V2S tests, sorry! For `CHECKER.CTRL_FLOW.CONSISTENCY`, I think you're already going to be triggering the early comparison counter change (which is what made me notice this) but I think we should also try to force the address counter and KMAC response at an unexpected time. I don't think we need an explicit check for `CHECKER.FSM.LOCAL_ESC`: this will actually be triggered by things like the automated sparse FSM tests.