### PR TITLE
[dv/otp_ctrl] Add back ECC correctable coverage bin

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -17,8 +17,7 @@ class otp_ctrl_unbuf_err_code_cg_wrap;
     err_code_vals: coverpoint val {
       bins no_err              = {OtpNoError};
       bins macro_err           = {OtpMacroError};
-      // TODO: will cover with the latest mem_bkdr_if method
-      // bins ecc_corr_err     = {'b010};
+      bins ecc_corr_err        = {OtpMacroEccCorrError};
       bins ecc_uncorr_err      = {OtpMacroEccUncorrError};
       bins access_err          = {OtpAccessError};
       bins check_fail          = {OtpCheckFailError};


### PR DESCRIPTION
This PR fixes a previous TODO by adding back the ECC correctable
coverbin.
The actual implementation is done is PR: https://github.com/lowRISC/opentitan/pull/10389
This PR just re-enable the coverpoint.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>