### PR TITLE
[sw/silicon_creator] Harden boot_data_digest_is_valid using shares

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -73,24 +73,48 @@ static void boot_data_digest_compute(const void *boot_data,
 }
 
 /**
+ * Shares for producing the `is_valid` value in `boot_data_digest_check()`.
+ * First 7 shares are generated using the `sparse-fsm-encode` script while the
+ * last share is `kHardenedBoolTrue ^ kHardenedBoolFalse ^ kDigestShares[0] ^
+ * ... ^ kDigestShares[7]` so that xor'ing all shares with the initial value of
+ * `is_valid`, i.e. `kHardenedBoolFalse`, produces `kHardenedBoolTrue`.
+ *
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 7 -n 32 \
+ *     -s 266012770 --language=c
+ *
+ * Minimum hamming distance: 12
+ * Maximum hamming distance: 19
+ * Minimum hamming weight: 14
+ * Maximum hamming weight: 23
+ */
+static const uint32_t kDigestShares[kHmacDigestNumWords] = {
+    0x0d0b4d17, 0xcd73e3ff, 0x07a6f2f4, 0xcedfd599,
+    0x54eac5b2, 0x0723ff0a, 0x6e234ee1, 0x34ebfb31,
+};
+
+/**
  * Checks whether the digest of a boot data entry is valid.
  *
  * @param boot_data A buffer that holds a boot data entry.
- * @param[out] is_valid Whether the digest of the entry is valid.
- * @return The result of the operation.
+ * @return Whether the digest of the entry is valid.
  */
-static rom_error_t boot_data_digest_is_valid(
-    const boot_data_buffer_t *boot_data, hardened_bool_t *is_valid) {
+static hardened_bool_t boot_data_digest_is_valid(
+    const boot_data_buffer_t *boot_data) {
   static_assert(offsetof(boot_data_t, digest) == 0,
                 "`digest` must be the first field of `boot_data_t`.");
 
-  *is_valid = kHardenedBoolFalse;
+  hardened_bool_t is_valid = kHardenedBoolFalse;
   hmac_digest_t act_digest;
   boot_data_digest_compute(boot_data, &act_digest);
-  if (memcmp(&act_digest, boot_data, sizeof(act_digest.digest)) == 0) {
-    *is_valid = kHardenedBoolTrue;
+
+  size_t i = 0;
+  for (; launder32(i) < kHmacDigestNumWords; ++i) {
+    is_valid ^= boot_data->data[i] ^ act_digest.digest[i] ^ kDigestShares[i];
   }
-  return kErrorOk;
+  HARDENED_CHECK_EQ(i, kHmacDigestNumWords);
+
+  return is_valid;
 }
 
 /**
@@ -362,10 +386,8 @@ static rom_error_t boot_data_page_info_get_impl(
   for (size_t i = start_index; i < kBootDataEntriesPerPage; --i) {
     // Check the digest only if this entry can be valid.
     if (sniff_results[i] == kBootDataIdentifier) {
-      hardened_bool_t is_valid;
       RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
-      RETURN_IF_ERROR(boot_data_digest_is_valid(&buf, &is_valid));
-      if (is_valid == kHardenedBoolTrue) {
+      if (boot_data_digest_is_valid(&buf) == kHardenedBoolTrue) {
         memcpy(&page_info->last_valid_entry, &buf, sizeof(boot_data_t));
         page_info->last_valid_index = i;
         page_info->has_valid_entry = kHardenedBoolTrue;

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -172,9 +172,9 @@ static rom_error_t check_boot_data(const boot_data_t *boot_data,
 
   hmac_digest_t act_digest;
   hmac_sha256_init();
-  RETURN_IF_ERROR(hmac_sha256_update(
-      (const char *)boot_data + kDigestRegionOffset, kDigestRegionSize));
-  RETURN_IF_ERROR(hmac_sha256_final(&act_digest));
+  hmac_sha256_update((const char *)boot_data + kDigestRegionOffset,
+                     kDigestRegionSize);
+  hmac_sha256_final(&act_digest);
   if (memcmp(&act_digest, &boot_data->digest, sizeof(act_digest)) != 0) {
     return kErrorUnknown;
   }

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -36,10 +36,7 @@ void hmac_sha256_init(void) {
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
 }
 
-rom_error_t hmac_sha256_update(const void *data, size_t len) {
-  if (data == NULL) {
-    return kErrorHmacInvalidArgument;
-  }
+void hmac_sha256_update(const void *data, size_t len) {
   const uint8_t *data_sent = (const uint8_t *)data;
 
   // Individual byte writes are needed if the buffer isn't word aligned.
@@ -61,14 +58,9 @@ rom_error_t hmac_sha256_update(const void *data, size_t len) {
     abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
                     *data_sent++);
   }
-  return kErrorOk;
 }
 
-rom_error_t hmac_sha256_final(hmac_digest_t *digest) {
-  if (digest == NULL) {
-    return kErrorHmacInvalidArgument;
-  }
-
+void hmac_sha256_final(hmac_digest_t *digest) {
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_PROCESS_BIT, true);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
@@ -87,5 +79,4 @@ rom_error_t hmac_sha256_final(hmac_digest_t *digest) {
         abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_7_REG_OFFSET -
                         (i * sizeof(uint32_t)));
   }
-  return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/hmac.h
@@ -47,19 +47,15 @@ void hmac_sha256_init(void);
  *
  * @param data Buffer to copy data from.
  * @param len size of the `data` buffer.
- * @return The result of the operation.
  */
-HMAC_WARN_UNUSED_RESULT
-rom_error_t hmac_sha256_update(const void *data, size_t len);
+void hmac_sha256_update(const void *data, size_t len);
 
 /**
  * Finalizes SHA256 operation and writes `digest` buffer.
  *
  * @param[out] digest Buffer to copy digest to.
- * @return The result of the operation.
  */
-HMAC_WARN_UNUSED_RESULT
-rom_error_t hmac_sha256_final(hmac_digest_t *digest);
+void hmac_sha256_final(hmac_digest_t *digest);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -37,11 +37,10 @@ static const uint32_t kGettysburgDigest[] = {
 
 rom_error_t hmac_test(void) {
   hmac_sha256_init();
-  RETURN_IF_ERROR(
-      hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1));
+  hmac_sha256_update(kGettysburgPrelude, sizeof(kGettysburgPrelude) - 1);
 
   hmac_digest_t digest;
-  RETURN_IF_ERROR(hmac_sha256_final(&digest));
+  hmac_sha256_final(&digest);
 
   const size_t len = ARRAYSIZE(digest.digest);
   for (int i = 0; i < len; ++i) {

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -46,10 +46,6 @@ TEST_F(Sha256InitTest, Initialize) {
 
 class Sha256UpdateTest : public HmacTest {};
 
-TEST_F(Sha256UpdateTest, NullArgs) {
-  EXPECT_EQ(hmac_sha256_update(nullptr, 0), kErrorHmacInvalidArgument);
-}
-
 TEST_F(Sha256UpdateTest, SendData) {
   constexpr std::array<uint8_t, 16> kData = {
       0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -59,11 +55,11 @@ TEST_F(Sha256UpdateTest, SendData) {
   // Trigger 8bit aligned writes.
   EXPECT_ABS_WRITE8(base_ + HMAC_MSG_FIFO_REG_OFFSET, 0x01);
   EXPECT_ABS_WRITE8(base_ + HMAC_MSG_FIFO_REG_OFFSET, 0x02);
-  EXPECT_EQ(hmac_sha256_update(&kData[1], 2), kErrorOk);
+  hmac_sha256_update(&kData[1], 2);
 
   // Trigger a single 32bit aligned write.
   EXPECT_ABS_WRITE32(base_ + HMAC_MSG_FIFO_REG_OFFSET, 0x03020100);
-  EXPECT_EQ(hmac_sha256_update(&kData[0], 4), kErrorOk);
+  hmac_sha256_update(&kData[0], 4);
 
   // Trigger 8bit/32bit/8bit sequence.
   EXPECT_ABS_WRITE8(base_ + HMAC_MSG_FIFO_REG_OFFSET, 0x02);
@@ -71,14 +67,10 @@ TEST_F(Sha256UpdateTest, SendData) {
   EXPECT_ABS_WRITE32(base_ + HMAC_MSG_FIFO_REG_OFFSET, 0x07060504);
   EXPECT_ABS_WRITE8(base_ + HMAC_MSG_FIFO_REG_OFFSET, 0x08);
   EXPECT_ABS_WRITE8(base_ + HMAC_MSG_FIFO_REG_OFFSET, 0x09);
-  EXPECT_EQ(hmac_sha256_update(&kData[2], 8), kErrorOk);
+  hmac_sha256_update(&kData[2], 8);
 }
 
 class Sha256FinalTest : public HmacTest {};
-
-TEST_F(Sha256FinalTest, NullArgs) {
-  EXPECT_EQ(hmac_sha256_final(nullptr), kErrorHmacInvalidArgument);
-}
 
 TEST_F(Sha256FinalTest, GetDigest) {
   constexpr std::array<uint32_t, 8> kExpectedDigest = {
@@ -116,7 +108,7 @@ TEST_F(Sha256FinalTest, GetDigest) {
   EXPECT_ABS_READ32(base_ + HMAC_DIGEST_0_REG_OFFSET, kExpectedDigest[7]);
 
   hmac_digest_t got_digest;
-  EXPECT_EQ(hmac_sha256_final(&got_digest), kErrorOk);
+  hmac_sha256_final(&got_digest);
   EXPECT_THAT(got_digest.digest, ElementsAreArray(kExpectedDigest));
 }
 

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -27,7 +27,6 @@ enum module_ {
   kModuleUnknown = 0,
   kModuleAlertHandler = MODULE_CODE('A', 'H'),
   kModuleUart =         MODULE_CODE('U', 'A'),
-  kModuleHmac =         MODULE_CODE('H', 'M'),
   kModuleSigverify =    MODULE_CODE('S', 'V'),
   kModuleKeymgr =       MODULE_CODE('K', 'M'),
   kModuleManifest =     MODULE_CODE('M', 'A'),
@@ -74,7 +73,6 @@ enum module_ {
   X(kErrorOk, 0x739), \
   X(kErrorUartInvalidArgument,        ERROR_(1, kModuleUart, kInvalidArgument)), \
   X(kErrorUartBadBaudRate,            ERROR_(2, kModuleUart, kInvalidArgument)), \
-  X(kErrorHmacInvalidArgument,        ERROR_(1, kModuleHmac, kInvalidArgument)), \
   X(kErrorSigverifyBadEncodedMessage, ERROR_(1, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadKey,            ERROR_(2, kModuleSigverify, kInvalidArgument)), \
   X(kErrorSigverifyBadOtpValue,       ERROR_(3, kModuleSigverify, kInternal)), \

--- a/sw/device/silicon_creator/lib/sigverify.c
+++ b/sw/device/silicon_creator/lib/sigverify.c
@@ -244,10 +244,7 @@ rom_error_t sigverify_rsa_verify(const sigverify_rsa_buffer_t *signature,
     default:
       HARDENED_UNREACHABLE();
   }
-  RETURN_IF_ERROR(
-      sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec));
-
-  return kErrorOk;
+  return sigverify_encoded_message_check(&enc_msg, act_digest, flash_exec);
 }
 
 void sigverify_usage_constraints_get(

--- a/sw/device/silicon_creator/lib/sigverify_functest.c
+++ b/sw/device/silicon_creator/lib/sigverify_functest.c
@@ -120,11 +120,10 @@ static const sigverify_rsa_key_t kKeyExp3 = {
         },
 };
 
-rom_error_t compute_digest(void) {
+void compute_digest(void) {
   hmac_sha256_init();
-  RETURN_IF_ERROR(hmac_sha256_update(&kMessage, sizeof(kMessage) - 1));
-  RETURN_IF_ERROR(hmac_sha256_final(&act_digest));
-  return kErrorOk;
+  hmac_sha256_update(&kMessage, sizeof(kMessage) - 1);
+  hmac_sha256_final(&act_digest);
 }
 
 rom_error_t sigverify_test_exp_3(void) {
@@ -163,7 +162,7 @@ const test_config_t kTestConfig;
 bool test_main(void) {
   rom_error_t result = kErrorOk;
 
-  CHECK(compute_digest() == kErrorOk);
+  compute_digest();
 
   EXECUTE_TEST(result, sigverify_test_exp_3);
   EXECUTE_TEST(result, sigverify_test_exp_65537);

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -122,15 +122,15 @@ static rom_error_t mask_rom_verify(const manifest_t *manifest,
   manifest_usage_constraints_t usage_constraints_from_hw;
   sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits,
                                   &usage_constraints_from_hw);
-  RETURN_IF_ERROR(hmac_sha256_update(&usage_constraints_from_hw,
-                                     sizeof(usage_constraints_from_hw)));
+  hmac_sha256_update(&usage_constraints_from_hw,
+                     sizeof(usage_constraints_from_hw));
   // Hash the remaining part of the image.
   manifest_digest_region_t digest_region = manifest_digest_region_get(manifest);
-  RETURN_IF_ERROR(
-      hmac_sha256_update(digest_region.start, digest_region.length));
+
+  hmac_sha256_update(digest_region.start, digest_region.length);
   // Verify signature
   hmac_digest_t act_digest;
-  RETURN_IF_ERROR(hmac_sha256_final(&act_digest));
+  hmac_sha256_final(&act_digest);
   return sigverify_rsa_verify(&manifest->signature, key, &act_digest, lc_state,
                               flash_exec);
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -78,19 +78,17 @@ static rom_error_t rom_ext_verify(const manifest_t *manifest) {
   manifest_usage_constraints_t usage_constraints_from_hw;
   sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits,
                                   &usage_constraints_from_hw);
-  RETURN_IF_ERROR(hmac_sha256_update(&usage_constraints_from_hw,
-                                     sizeof(usage_constraints_from_hw)));
+  hmac_sha256_update(&usage_constraints_from_hw,
+                     sizeof(usage_constraints_from_hw));
   // Hash the remaining part of the image.
   manifest_digest_region_t digest_region = manifest_digest_region_get(manifest);
-  RETURN_IF_ERROR(
-      hmac_sha256_update(digest_region.start, digest_region.length));
+  hmac_sha256_update(digest_region.start, digest_region.length);
   // Verify signature
   hmac_digest_t act_digest;
-  RETURN_IF_ERROR(hmac_sha256_final(&act_digest));
+  hmac_sha256_final(&act_digest);
   uint32_t flash_exec = 0;
-  RETURN_IF_ERROR(sigverify_rsa_verify(&manifest->signature, key, &act_digest,
-                                       lc_state, &flash_exec));
-  return kErrorOk;
+  return sigverify_rsa_verify(&manifest->signature, key, &act_digest, lc_state,
+                              &flash_exec);
 }
 
 static rom_error_t rom_ext_boot(const manifest_t *manifest) {


### PR DESCRIPTION
This PR
* Removes NULL checks from hmac driver functions, and
* Hardens `boot_data_digest_is_valid` using shares.

I will create additional PRs for hardening the rest of `boot_data`.