### PR TITLE
[sw/silicon_creator] Use `void *` for input and output buffers in flash_ctrl

### DIFF
--- a/sw/device/lib/base/testing/meson.build
+++ b/sw/device/lib/base/testing/meson.build
@@ -12,6 +12,17 @@ sw_lib_testing_bitfield = declare_dependency(
   )
 )
 
+sw_lib_testing_memory = declare_dependency(
+  link_with: static_library(
+    'memory',
+    sources: [
+      meson.source_root() / 'sw/device/lib/base/memory.c',
+    ],
+    c_args: ['-fno-builtin'],
+    native: true,
+  ),
+)
+
 sw_lib_testing_hardened = declare_dependency(
   link_with: static_library(
     'hardened',

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -450,7 +450,6 @@ test('dif_hmac_unittest', executable(
     sources: [
       #'dif_hmac_unittest.cc',
       'autogen/dif_hmac_autogen_unittest.cc',
-      meson.source_root() / 'sw/device/lib/base/memory.c',
       meson.source_root() / 'sw/device/lib/dif/dif_hmac.c',
       meson.source_root() / 'sw/device/lib/dif/autogen/dif_hmac_autogen.c',
       hw_ip_hmac_reg_h,
@@ -458,6 +457,7 @@ test('dif_hmac_unittest', executable(
     dependencies: [
       sw_vendor_gtest,
       sw_lib_base_testing_mock_mmio,
+      sw_lib_testing_memory,
     ],
     native: true,
     c_args: ['-DMOCK_MMIO'],
@@ -488,7 +488,6 @@ test('dif_kmac_unittest', executable(
     sources: [
       'dif_kmac_unittest.cc',
       'autogen/dif_kmac_autogen_unittest.cc',
-      meson.source_root() / 'sw/device/lib/base/memory.c',
       meson.source_root() / 'sw/device/lib/dif/dif_kmac.c',
       meson.source_root() / 'sw/device/lib/dif/autogen/dif_kmac_autogen.c',
       hw_ip_kmac_reg_h,
@@ -496,6 +495,7 @@ test('dif_kmac_unittest', executable(
     dependencies: [
       sw_vendor_gtest,
       sw_lib_base_testing_mock_mmio,
+      sw_lib_testing_memory,
     ],
     native: true,
     c_args: ['-DMOCK_MMIO'],

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -223,11 +223,11 @@ void flash_ctrl_status_get(flash_ctrl_status_t *status);
  *
  * @param addr Address to read from.
  * @param word_count Number of bus words to read.
- * @param[out] data Buffer to store the read data.
+ * @param[out] data Buffer to store the read data. Must be word aligned.
  * @return Result of the operation.
  */
 rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
-                                 uint32_t *data);
+                                 void *data);
 
 /**
  * Reads data from an information page.
@@ -239,12 +239,12 @@ rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
  * @param info_page Information page to read from.
  * @param offset Offset from the start of the page.
  * @param word_count Number of bus words to read.
- * @param[out] data Buffer to store the read data.
+ * @param[out] data Buffer to store the read data. Must be word aligned.
  * @return Result of the operation.
  */
 rom_error_t flash_ctrl_info_read(flash_ctrl_info_page_t info_page,
                                  uint32_t offset, uint32_t word_count,
-                                 uint32_t *data);
+                                 void *data);
 
 /**
  * Writes data to the data partition.
@@ -255,11 +255,11 @@ rom_error_t flash_ctrl_info_read(flash_ctrl_info_page_t info_page,
  *
  * @param addr Address to write to.
  * @param word_count Number of bus words to write.
- * @param data Data to write.
+ * @param data Data to write. Must be word aligned.
  * @return Result of the operation.
  */
 rom_error_t flash_ctrl_data_write(uint32_t addr, uint32_t word_count,
-                                  const uint32_t *data);
+                                  const void *data);
 
 /**
  * Writes data to an information page.
@@ -271,12 +271,12 @@ rom_error_t flash_ctrl_data_write(uint32_t addr, uint32_t word_count,
  * @param info_page Information page to write to.
  * @param offset Offset from the start of the page.
  * @param word_count Number of bus words to write.
- * @param data Data to write.
+ * @param data Data to write. Must be word aligned.
  * @return Result of the operation.
  */
 rom_error_t flash_ctrl_info_write(flash_ctrl_info_page_t info_page,
                                   uint32_t offset, uint32_t word_count,
-                                  const uint32_t *data);
+                                  const void *data);
 
 typedef enum flash_ctrl_erase_type {
   /**

--- a/sw/device/silicon_creator/lib/drivers/hmac.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac.c
@@ -49,8 +49,7 @@ rom_error_t hmac_sha256_update(const void *data, size_t len) {
   }
 
   for (; len >= sizeof(uint32_t); len -= sizeof(uint32_t)) {
-    // FIXME: read_32 does not work for unittests.
-    uint32_t data_aligned = *(const uint32_t *)data_sent;
+    uint32_t data_aligned = read_32(data_sent);
     abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
                      data_aligned);
     data_sent += sizeof(uint32_t);

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -46,6 +46,7 @@ sw_silicon_creator_lib_driver_hmac = declare_dependency(
     ],
     dependencies: [
       sw_lib_abs_mmio,
+      sw_lib_mem,
     ],
   ),
 )
@@ -60,6 +61,7 @@ test('sw_silicon_creator_lib_driver_hmac_unittest', executable(
     dependencies: [
       sw_vendor_gtest,
       sw_silicon_creator_lib_base_mock_abs_mmio,
+      sw_lib_testing_memory,
     ],
     native: true,
     c_args: ['-DMOCK_ABS_MMIO'],

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -543,6 +543,7 @@ sw_silicon_creator_lib_driver_flash_ctrl = declare_dependency(
       sw_silicon_creator_lib_base_sec_mmio,
       sw_silicon_creator_lib_driver_otp,
       sw_lib_hardened,
+      sw_lib_mem,
     ],
   ),
 )
@@ -560,6 +561,7 @@ test('sw_silicon_creator_lib_driver_flash_ctrl_unittest', executable(
       sw_silicon_creator_lib_base_mock_abs_mmio,
       sw_silicon_creator_lib_base_mock_sec_mmio,
       sw_lib_testing_hardened,
+      sw_lib_testing_memory,
     ],
     native: true,
     c_args: ['-DMOCK_ABS_MMIO', '-DMOCK_SEC_MMIO', '-DOT_OFF_TARGET_TEST'],


### PR DESCRIPTION
This change will make it possible to read and write word aligned types without temporary buffers, e.g. `boot_data_buffer_t` in `boot_data.c`.

This change also resolves a `FIXME` in `hmac.c` by replacing the cast with `read_32()`.

Since //sw/device/lib/base already includes memory.{c,h} this change should not affect bazel builds.