### PR TITLE
[dw/rstmgr] Add stress_all test

### DIFF
--- a/hw/ip/rstmgr/dv/env/rstmgr_env.core
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/rstmgr_por_stretcher_vseq.sv: {is_include_file: true}
       - seq_lib/rstmgr_reset_vseq.sv: {is_include_file: true}
       - seq_lib/rstmgr_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/rstmgr_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/rstmgr_sw_rst_vseq.sv: {is_include_file: true}
       - rstmgr_if.sv
     file_type: systemVerilogSource

--- a/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_scoreboard.sv
@@ -131,6 +131,10 @@ class rstmgr_scoreboard extends cip_base_scoreboard #(
         // TODO Check with bitwise enables from sw_rst_regwen.
         do_read_check = 1'b0;
       end
+      "err_code": begin
+        // Set by hardware.
+        do_read_check = 1'b0;
+      end
       default: begin
         `uvm_fatal(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_base_vseq.sv
@@ -104,6 +104,13 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     cfg.rstmgr_vif.cpu_i.rst_cpu_n = value;
   endfunction
 
+  function logic is_running_sequence(string seq_name);
+    string actual_sequence = "none";
+    // Okay to ignore return value since the default won't match.
+    void'($value$plusargs("UVM_TEST_SEQ=%0s", actual_sequence));
+    return actual_sequence.compare(seq_name) == 0;
+  endfunction
+
   task check_reset_info(logic [TL_DW-1:0] expected_value, string msg = "reset_info mismatch");
     csr_rd_check(.ptr(ral.reset_info), .compare_value(expected_value), .err_msg(msg));
   endtask
@@ -198,6 +205,12 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     check_cpu_info_after_reset(cpu_dump, enable);
   endtask
 
+  task clear_alert_and_cpu_info();
+    set_alert_and_cpu_info_for_capture('0, '0);
+    send_sw_reset();
+    check_alert_and_cpu_info_after_reset(.alert_dump('0), .cpu_dump('0), .enable(0));
+  endtask
+
   // Stimulate and check sw_rst_ctrl_n with a given sw_rst_regen setting.
   task check_sw_rst_ctrl_n(sw_rst_t sw_rst_ctrl_n, sw_rst_t sw_rst_regen, bit erase_ctrl_n);
     sw_rst_t exp_ctrl_n;
@@ -244,7 +257,6 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     reset_start(reset_cause);
     cfg.io_div4_clk_rst_vif.wait_clks(non_ndm_reset_cycles);
     // Cause the reset to drop.
-    `uvm_info(`gfn, $sformatf("Clearing %0s reset", reset_cause.name()), UVM_LOW)
     set_rstreqs(0);
     reset_done();
   endtask
@@ -261,6 +273,8 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     update_scanmode(prim_mubi_pkg::MuBi4False);
     update_scan_rst_n(1'b1);
     reset_done();
+    // This makes sure the clock has restarted before this returns.
+    cfg.io_div4_clk_rst_vif.wait_clks(1);
     `uvm_info(`gfn, "Done sending scan reset.", UVM_MEDIUM)
   endtask
 
@@ -271,7 +285,6 @@ class rstmgr_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, "Sending ndm reset", UVM_LOW)
     cfg.io_div4_clk_rst_vif.wait_clks(ndm_reset_cycles);
     set_ndmreset_req(1'b0);
-    `uvm_info(`gfn, $sformatf("Clearing ndm reset"), UVM_LOW)
   endtask
 
   // Requests a sw reset. It is cleared by hardware once the reset is taken.

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
@@ -60,9 +60,11 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
     alert_pkg::alert_crashdump_t prev_alert_dump = '0;
     ibex_pkg::crash_dump_t prev_cpu_dump = '0;
 
-    // Expect reset info to be POR.
-    check_reset_info(1, "expected reset_info to be POR");
-    check_alert_and_cpu_info_after_reset(.alert_dump('0), .cpu_dump('0), .enable(1'b0));
+    // Expect reset info to be POR when running the sequence standalone.
+    if (is_running_sequence("rstmgr_reset_vseq")) begin
+      check_reset_info(1, "expected reset_info to be POR");
+      check_alert_and_cpu_info_after_reset(.alert_dump('0), .cpu_dump('0), .enable(1'b0));
+    end
 
     // Clear reset_info register, and enable cpu and alert info capture.
     csr_wr(.ptr(ral.reset_info), .value('1));
@@ -133,8 +135,8 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
       end
     end
     csr_wr(.ptr(ral.reset_info), .value('1));
-    set_alert_info_for_capture(.alert_dump('0), .enable(1'b0));
-    set_cpu_info_for_capture(.cpu_dump('0), .enable(1'b0));
+    // This clears the info registers to cancel side-effects into other sequences with stress tests.
+    clear_alert_and_cpu_info();
   endtask
 
 endclass : rstmgr_reset_vseq

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_stress_all_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_stress_all_vseq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all rstmgr seqs (except below seqs) in one seq to run sequentially
+// 1. csr seq, which requires scb to be disabled
+class rstmgr_stress_all_vseq extends rstmgr_base_vseq;
+  `uvm_object_utils(rstmgr_stress_all_vseq)
+
+  `uvm_object_new
+
+  task body();
+    string seq_names[] = {"rstmgr_reset_vseq", "rstmgr_smoke_vseq", "rstmgr_sw_rst_vseq"};
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence     seq;
+      rstmgr_base_vseq rstmgr_vseq;
+      uint             seq_idx = $urandom_range(0, seq_names.size - 1);
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(rstmgr_vseq, seq)
+
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_apply_reset) rstmgr_vseq.do_apply_reset = $urandom_range(0, 1);
+      else rstmgr_vseq.do_apply_reset = 0;
+      rstmgr_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(rstmgr_vseq)
+      `uvm_info(`gfn, $sformatf("seq_idx = %0d, sequence is %0s", seq_idx, rstmgr_vseq.get_name()),
+                UVM_MEDIUM)
+
+      rstmgr_vseq.start(p_sequencer);
+      `uvm_info(`gfn, $sformatf(
+                "End of sequence %0s with seq_idx = %0d", rstmgr_vseq.get_name(), seq_idx),
+                UVM_MEDIUM)
+    end
+  endtask : body
+endclass

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_vseq_list.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_vseq_list.sv
@@ -6,5 +6,6 @@
 `include "rstmgr_por_stretcher_vseq.sv"
 `include "rstmgr_reset_vseq.sv"
 `include "rstmgr_smoke_vseq.sv"
+`include "rstmgr_stress_all_vseq.sv"
 `include "rstmgr_sw_rst_vseq.sv"
 `include "rstmgr_common_vseq.sv"

--- a/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -33,7 +33,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 // Disable until the stress_all sequence is created.
-                //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
                 ]
 
   // Overrides

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -12,6 +12,9 @@
 //
 // Some individual reset outputs will always be off. Allowing for this in general would
 // weaken the property that some resets MUST rise following other rise.
+//
+// Peripheral resets cascade from sys, and are checked in rstmgr_sw_rst_sva_if since they
+// require additional inputs.
 interface rstmgr_cascading_sva_if (
   input logic clk_i,
   input logic clk_aon_i,
@@ -167,24 +170,6 @@ interface rstmgr_cascading_sva_if (
   `CASCADED_ASSERTS(CascadeSysToSysShadowed, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
                     resets_o.rst_sys_shadowed_n[rstmgr_pkg::Domain0Sel], SysCycles, clk_main_i)
 
-  // Peripheral resets cascade from sys.
-  // We only care for power domain 1 for peripherals.
-  `CASCADED_ASSERTS(CascadeSysToSpiDevice, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_spi_device_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
-  `CASCADED_ASSERTS(CascadeSysToSpiHost0, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_spi_host0_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_i)
-  `CASCADED_ASSERTS(CascadeSysToSpiHost1, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_spi_host1_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div2_i)
-  `CASCADED_ASSERTS(CascadeSysToUsb, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_usb_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
-  `CASCADED_ASSERTS(CascadeSysToUsbIf, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_usbif_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_usb_i)
-  `CASCADED_ASSERTS(CascadeSysToI2C0, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_i2c0_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
-  `CASCADED_ASSERTS(CascadeSysToI2C1, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_i2c1_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
-  `CASCADED_ASSERTS(CascadeSysToI2C2, rst_sys_src_n[rstmgr_pkg::Domain0Sel],
-                    resets_o.rst_i2c2_n[rstmgr_pkg::Domain0Sel], PeriCycles, clk_io_div4_i)
   `undef FALL_ASSERT
   `undef RISE_ASSERTS
   `undef CASCADED_ASSERTS

--- a/hw/ip/rstmgr/dv/tb.sv
+++ b/hw/ip/rstmgr/dv/tb.sv
@@ -56,7 +56,7 @@ module tb;
   pins_if #(1) devmode_if (devmode);
   tl_if tl_if (
     .clk,
-    .rst_n
+    .rst_n(rstmgr_if.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel])
   );
 
   rstmgr_if rstmgr_if (
@@ -105,10 +105,10 @@ module tb;
     .ndmreset_req_i(rstmgr_if.cpu_i.ndmreset_req),
 
     .alert_dump_i(rstmgr_if.alert_dump_i),
-    .cpu_dump_i(rstmgr_if.cpu_dump_i),
+    .cpu_dump_i  (rstmgr_if.cpu_dump_i),
 
     .scan_rst_ni(rstmgr_if.scan_rst_ni),
-    .scanmode_i(rstmgr_if.scanmode_i),
+    .scanmode_i (rstmgr_if.scanmode_i),
 
     .rst_en_o(rstmgr_if.rst_en_o),
     .resets_o(rstmgr_if.resets_o)
@@ -135,6 +135,11 @@ module tb;
 
     $timeformat(-12, 0, " ps", 12);
     run_test();
+  end
+
+  initial begin
+    clk_rst_if.drive_rst_n = 1'b0;
+    force clk_rst_if.rst_n = rstmgr_if.resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel];
   end
 
 endmodule


### PR DESCRIPTION
Disable POR check on entry to some tests unless they run standalone.
Disable the portions of some tests that modify sw_rst_regwen, since
writes are irreversible.
Remove peripheral reset checks from rstmgr_cascading_sva_if since
they are checked in rstmgr_sw_rst_sva_if due to their additional
dependencies.

Signed-off-by: Guillermo Maturana <maturana@google.com>