### PR TITLE
[keymgr] sparsify the data control fsm

### DIFF
--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -711,4 +711,5 @@ module keymgr
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ReseedCtrlCntAlertCheck_A, u_reseed_ctrl.u_reseed_cnt,
                                          alert_tx_o[0])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlMainFsmCheck_A, u_ctrl.u_state_regs, alert_tx_o[0])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlDataFsmCheck_A, u_ctrl.u_data_state_regs, alert_tx_o[0])
 endmodule // keymgr

--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -72,14 +72,18 @@ module prim_count import prim_count_pkg::*; #(
   logic [Width-1:0] max_val;
   logic err;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      max_val <= '{default: '1};
-    end else if (clr_i) begin
-      max_val <= '{default: '1};
-    end else if (set_i && (CntStyle == CrossCnt)) begin
-      max_val <= set_cnt_i;
+  if (CntStyle == CrossCnt) begin : gen_crosscnt_max_val
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        max_val <= '1;
+      end else if (clr_i) begin
+        max_val <= '1;
+      end else if (set_i) begin
+        max_val <= set_cnt_i;
+      end
     end
+  end else begin : gen_dupcnt_max_val
+     assign max_val = '1;
   end
 
   for (genvar i = 0; i < CntCopies; i++) begin : gen_cnts


### PR DESCRIPTION
This ensures the main fsm and the data fsm which load software and
sideload keys are both in sparse format.

Signed-off-by: Timothy Chen <timothytim@google.com>