### PR TITLE
[dv/stress_all_with_rand_reset] Add back missing ongoing_reset logic

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -674,6 +674,7 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
             end
             begin : issue_rand_reset
               wait_to_issue_reset(reset_delay_bound);
+              ongoing_reset = 1'b1;
               `uvm_info(`gfn, $sformatf("\nReset is issued for run %0d/%0d", i, num_times), UVM_LOW)
               apply_resets_concurrently();
               ongoing_reset = 1'b0;


### PR DESCRIPTION
In my previous commit: PR #10417, I modify the wait for reset timing but
missed the logic to assign `ongoing_reset` to 1.
This PR adds back this logic to ensure when sequence ended, it won't
kill the `apply_resets_concurrently` process.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>