### PR TITLE
[otbn,dv] Fix typo in DPI call error detection

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -208,7 +208,7 @@ module otbn_core_model
       stop_pc_q <= 0;
     end else begin
       if (new_escalation) begin
-        failed_lc_escalate <= (otbn_model_send_lc_escalation(model_handle) == 0);
+        failed_lc_escalate <= (otbn_model_send_lc_escalation(model_handle) != 0);
       end
       if (!$stable(keymgr_key_i) || $rose(rst_ni)) begin
         otbn_model_set_keymgr_value(model_handle, keymgr_key_i.key[0], keymgr_key_i.key[1],

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -103,7 +103,8 @@ void otbn_model_reset(OtbnModel *model);
 // Take loop warps from an OtbnMemUtil
 void otbn_take_loop_warps(OtbnModel *model, OtbnMemUtil *memutil);
 
-// React to a lifecycle controller escalation signal
+// React to a lifecycle controller escalation signal. Returns 0 on success or
+// -1 on failure.
 int otbn_model_send_lc_escalation(OtbnModel *model);
 }
 


### PR DESCRIPTION
Like other similar functions, this DPI call returns 0 on success; -1
on failure.
