### PR TITLE
[aes] Use one-hot encoding for OPERATION field in main control register

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -372,15 +372,31 @@
     update_err_alert: "recov_ctrl_update_err",
     storage_err_alert: "fatal_fault",
     fields: [
-      { bits: "0",
+      { bits: "1:0",
         name: "OPERATION",
-        resval: "0",
+        resval: "0x1",
+        hwaccess: "hrw",
         desc:  '''
-          Select encryption(0) or decryption(1) operation of AES unit.
+          2-bit one-hot field to select the operation of AES unit.
+          Invalid input values, i.e., values with multiple bits set and value 2'b00, are mapped to AES_ENCRYPTION (2'b01).
         '''
+        enum: [
+          { value: "1",
+            name: "AES_ENC",
+            desc: '''
+              2'b01: Encryption.
+            '''
+          },
+          { value: "2",
+            name: "AES_DEC",
+            desc: '''
+              2'b10: Decryption.
+            '''
+          },
+        ]
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_operation"]
       }
-      { bits: "6:1",
+      { bits: "7:2",
         name: "MODE",
         resval: "0x20",
         hwaccess: "hrw",
@@ -428,7 +444,7 @@
         ]
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_mode"]
       }
-      { bits: "9:7",
+      { bits: "10:8",
         name: "KEY_LEN",
         resval: "1",
         hwaccess: "hrw",
@@ -460,7 +476,7 @@
         ]
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_key_len"]
       }
-      { bits: "10",
+      { bits: "11",
         name: "SIDELOAD",
         resval: "0",
         desc: '''
@@ -468,7 +484,7 @@
         '''
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_sideload"]
       }
-      { bits: "13:11",
+      { bits: "14:12",
         name: "PRNG_RESEED_RATE",
         resval: "1",
         hwaccess: "hrw",
@@ -499,7 +515,7 @@
         ]
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_prng_reseed_rate"]
       }
-      { bits: "14",
+      { bits: "15",
         name: "MANUAL_OPERATION",
         resval: "0"
         desc:  '''
@@ -512,7 +528,7 @@
         '''
         tags: ["shadowed_reg_path:u_aes_core.u_ctrl_reg_shadowed.u_ctrl_reg_shadowed_manual_operation"]
       }
-      { bits: "15",
+      { bits: "16",
         name: "FORCE_ZERO_MASKS",
         resval: "0"
         desc:  '''

--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -529,6 +529,7 @@ virtual task rebuild_message();
     bit [3:0][31:0] tmp_output;
 
     forever begin
+      bit operation;
       aes_message_item msg;
       msg_fifo.get(msg);
       `uvm_info(`gfn, $sformatf("model %b, operation: %b, mode %06b, IV %h, key_len %03b, key share0 %h, key share1 %h ",
@@ -540,7 +541,9 @@ virtual task rebuild_message();
         msg.alloc_predicted_msg();
 
         //ref-model      / opration     / chipher mode /    IV   / key_len    / key /data i /data o //
-        c_dpi_aes_crypt_message(cfg.ref_model, msg.aes_operation, msg.aes_mode, msg.aes_iv,
+        operation = msg.aes_operation == AES_ENC ? 1'b0 :
+                    msg.aes_operation == AES_DEC ? 1'b1 : 1'b0;
+        c_dpi_aes_crypt_message(cfg.ref_model, operation, msg.aes_mode, msg.aes_iv,
                                 msg.aes_keylen, msg.aes_key[0] ^ msg.aes_key[1],
                                 msg.input_msg, msg.predicted_msg);
 

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -56,9 +56,9 @@ class aes_base_vseq extends cip_base_vseq #(
      // Wait for DUT ready
     csr_spinwait(.ptr(ral.status.idle) , .exp_data(1'b1));
     // initialize control register
-    aes_ctrl[0]    = 0;                  // set to encryption
-    aes_ctrl[6:1]  = aes_pkg::AES_ECB;   // 6'b00_0001
-    aes_ctrl[9:7]  = aes_pkg::AES_128;   // set to 128b key
+    aes_ctrl[1:0]  = aes_pkg::AES_ENC;   // 2'b01
+    aes_ctrl[7:2]  = aes_pkg::AES_ECB;   // 6'b00_0001
+    aes_ctrl[10:8] = aes_pkg::AES_128;   // 3'b001
     csr_wr(.ptr(ral.ctrl_shadowed), .value(aes_ctrl), .en_shadow_wr(1'b1), .blocking(1));
     // initialize aux control register and lock it
     // This is a temporary workaround until the aux control register is properly supported.
@@ -94,7 +94,7 @@ class aes_base_vseq extends cip_base_vseq #(
   endtask // prng_reseed
 
 
-  virtual task set_operation(bit operation);
+  virtual task set_operation(bit [1:0] operation);
       ral.ctrl_shadowed.operation.set(operation);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
   endtask // set_operation

--- a/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_wake_up_vseq.sv
@@ -10,9 +10,6 @@ class aes_wake_up_vseq extends aes_base_vseq;
   `uvm_object_new
 
 
-  parameter bit       ENCRYPT = 1'b0;
-  parameter bit       DECRYPT = 1'b1;
-
   bit [3:0] [31:0]    plain_text       = 128'hDEADBEEFEEDDBBAABAADBEEFDEAFBEAD;
   logic [255:0]       init_key [2]     = '{256'h0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF, 256'h0};
   bit [3:0] [31:0]    cypher_text;
@@ -31,7 +28,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
 
     `uvm_info(`gfn, $sformatf(" \n\t ---|setting operation to encrypt"), UVM_HIGH)
     // set operation to encrypt
-    set_operation(ENCRYPT);
+    set_operation(AES_ENC);
 
     `uvm_info(`gfn, $sformatf(" \n\t ---| WRITING INIT KEY \n\t ----| SHARE0 %02h \n\t ---| SHARE1 %02h ", init_key[0], init_key[1]), UVM_HIGH)
     write_key(init_key, do_b2b);
@@ -54,7 +51,7 @@ class aes_wake_up_vseq extends aes_base_vseq;
     cfg.clk_rst_vif.wait_clks(20);
 
     // set aes to decrypt
-    set_operation(DECRYPT);
+    set_operation(AES_DEC);
     cfg.clk_rst_vif.wait_clks(20);
     `uvm_info(`gfn, $sformatf("\n\t ---| WRITING INIT KEY \n\t ----| SHARE0 %02h \n\t ---| SHARE1 %02h ", init_key[0], init_key[1]), UVM_HIGH)
     write_key(init_key, do_b2b);

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -40,6 +40,7 @@ module aes_cipher_control import aes_pkg::*;
   output logic                    data_out_clear_o,
   input  logic                    mux_sel_err_i,
   input  logic                    sp_enc_err_i,
+  input  logic                    op_err_i,
   output logic                    alert_o,
 
   // Control signals for masking PRNG
@@ -176,6 +177,7 @@ module aes_cipher_control import aes_pkg::*;
         .mux_sel_err_i         ( mux_sel_err              ),
         .sp_enc_err_i          ( sp_enc_err               ),
         .rnd_ctr_err_i         ( rnd_ctr_err              ),
+        .op_err_i              ( op_err_i                 ),
         .alert_o               ( mr_alert[i]              ), // OR-combine
 
         .prng_update_o         ( mr_prng_update[i]        ), // OR-combine
@@ -242,6 +244,7 @@ module aes_cipher_control import aes_pkg::*;
         .mux_sel_err_i         ( mux_sel_err              ),
         .sp_enc_err_i          ( sp_enc_err               ),
         .rnd_ctr_err_i         ( rnd_ctr_err              ),
+        .op_err_i              ( op_err_i                 ),
         .alert_o               ( mr_alert[i]              ), // OR-combine
 
         .prng_update_o         ( mr_prng_update[i]        ), // OR-combine
@@ -538,6 +541,9 @@ module aes_cipher_control import aes_pkg::*;
   ////////////////
 
   // Selectors must be known/valid
-  `ASSERT_KNOWN(AesCiphOpKnown, op_i)
+  `ASSERT(AesCiphOpValid, cfg_valid_i |-> op_i inside {
+      CIPH_FWD,
+      CIPH_INV
+      })
 
 endmodule

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
@@ -39,6 +39,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
   input  logic             mux_sel_err_i,
   input  logic             sp_enc_err_i,
   input  logic             rnd_ctr_err_i,
+  input  logic             op_err_i,
   output logic             alert_o,
 
   // Control signals for masking PRNG
@@ -103,6 +104,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     mux_sel_err_i,
     sp_enc_err_i,
     rnd_ctr_err_i,
+    op_err_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_ni,
     key_expand_out_req_ni,
@@ -132,6 +134,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     mux_sel_err_i,
     sp_enc_err_i,
     rnd_ctr_err_i,
+    op_err_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_ni,
     key_expand_out_req_ni,
@@ -154,31 +157,32 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     .out_o(in_buf)
   );
 
-  logic             in_valid_n;
-  logic             out_ready_n;
-  logic             cfg_valid;
-  logic             op_raw;
-  ciph_op_e         op;
-  key_len_e         key_len;
-  logic             crypt_n;
-  logic             dec_key_gen_n;
-  logic             prng_reseed;
-  logic             key_clear;
-  logic             data_out_clear;
-  logic             mux_sel_err;
-  logic             sp_enc_err;
-  logic             rnd_ctr_err;
-  logic             prng_reseed_ack;
-  logic             sub_bytes_out_req_n;
-  logic             key_expand_out_req_n;
-  logic [3:0]       rnd_ctr_q;
-  logic [3:0]       rnd_ctr_rem_q;
-  logic [3:0]       num_rounds_q;
-  logic             crypt_q_n;
-  logic             dec_key_gen_q_n;
-  logic             prng_reseed_q;
-  logic             key_clear_q;
-  logic             data_out_clear_q;
+  logic                 in_valid_n;
+  logic                 out_ready_n;
+  logic                 cfg_valid;
+  ciph_op_e             op;
+  logic [$bits(op)-1:0] op_raw;
+  key_len_e             key_len;
+  logic                 crypt_n;
+  logic                 dec_key_gen_n;
+  logic                 prng_reseed;
+  logic                 key_clear;
+  logic                 data_out_clear;
+  logic                 mux_sel_err;
+  logic                 sp_enc_err;
+  logic                 rnd_ctr_err;
+  logic                 op_err;
+  logic                 prng_reseed_ack;
+  logic                 sub_bytes_out_req_n;
+  logic                 key_expand_out_req_n;
+  logic [3:0]           rnd_ctr_q;
+  logic [3:0]           rnd_ctr_rem_q;
+  logic [3:0]           num_rounds_q;
+  logic                 crypt_q_n;
+  logic                 dec_key_gen_q_n;
+  logic                 prng_reseed_q;
+  logic                 key_clear_q;
+  logic                 data_out_clear_q;
 
   assign {in_valid_n,
           out_ready_n,
@@ -193,6 +197,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
           mux_sel_err,
           sp_enc_err,
           rnd_ctr_err,
+          op_err,
           prng_reseed_ack,
           sub_bytes_out_req_n,
           key_expand_out_req_n,
@@ -268,6 +273,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     .mux_sel_err_i         ( mux_sel_err           ),
     .sp_enc_err_i          ( sp_enc_err            ),
     .rnd_ctr_err_i         ( rnd_ctr_err           ),
+    .op_err_i              ( op_err                ),
     .alert_o               ( alert                 ),
 
     .prng_update_o         ( prng_update           ),

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
@@ -35,6 +35,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
   input  logic             mux_sel_err_i,
   input  logic             sp_enc_err_i,
   input  logic             rnd_ctr_err_i,
+  input  logic             op_err_i,
   output logic             alert_o,
 
   // Control signals for masking PRNG
@@ -99,6 +100,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     mux_sel_err_i,
     sp_enc_err_i,
     rnd_ctr_err_i,
+    op_err_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_i,
     key_expand_out_req_i,
@@ -128,6 +130,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     mux_sel_err_i,
     sp_enc_err_i,
     rnd_ctr_err_i,
+    op_err_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_i,
     key_expand_out_req_i,
@@ -150,31 +153,32 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     .out_o(in_buf)
   );
 
-  logic             in_valid;
-  logic             out_ready;
-  logic             cfg_valid;
-  logic             op_raw;
-  ciph_op_e         op;
-  key_len_e         key_len;
-  logic             crypt;
-  logic             dec_key_gen;
-  logic             prng_reseed;
-  logic             key_clear;
-  logic             data_out_clear;
-  logic             mux_sel_err;
-  logic             sp_enc_err;
-  logic             rnd_ctr_err;
-  logic             prng_reseed_ack;
-  logic             sub_bytes_out_req;
-  logic             key_expand_out_req;
-  logic [3:0]       rnd_ctr_q;
-  logic [3:0]       rnd_ctr_rem_q;
-  logic [3:0]       num_rounds_q;
-  logic             crypt_q;
-  logic             dec_key_gen_q;
-  logic             prng_reseed_q;
-  logic             key_clear_q;
-  logic             data_out_clear_q;
+  logic                 in_valid;
+  logic                 out_ready;
+  logic                 cfg_valid;
+  ciph_op_e             op;
+  logic [$bits(op)-1:0] op_raw;
+  key_len_e             key_len;
+  logic                 crypt;
+  logic                 dec_key_gen;
+  logic                 prng_reseed;
+  logic                 key_clear;
+  logic                 data_out_clear;
+  logic                 mux_sel_err;
+  logic                 sp_enc_err;
+  logic                 rnd_ctr_err;
+  logic                 op_err;
+  logic                 prng_reseed_ack;
+  logic                 sub_bytes_out_req;
+  logic                 key_expand_out_req;
+  logic [3:0]           rnd_ctr_q;
+  logic [3:0]           rnd_ctr_rem_q;
+  logic [3:0]           num_rounds_q;
+  logic                 crypt_q;
+  logic                 dec_key_gen_q;
+  logic                 prng_reseed_q;
+  logic                 key_clear_q;
+  logic                 data_out_clear_q;
 
   assign {in_valid,
           out_ready,
@@ -189,6 +193,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
           mux_sel_err,
           sp_enc_err,
           rnd_ctr_err,
+          op_err,
           prng_reseed_ack,
           sub_bytes_out_req,
           key_expand_out_req,
@@ -260,6 +265,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     .mux_sel_err_i         ( mux_sel_err            ),
     .sp_enc_err_i          ( sp_enc_err             ),
     .rnd_ctr_err_i         ( rnd_ctr_err            ),
+    .op_err_i              ( op_err                 ),
     .alert_o               ( alert                  ),
 
     .prng_update_o         ( prng_update            ),

--- a/hw/ip/aes/rtl/aes_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_n.sv
@@ -211,8 +211,8 @@ module aes_control_fsm_n
   logic                                    ctrl_err_storage;
   aes_op_e                                 op;
   aes_mode_e                               mode;
-  logic                                    cipher_op_raw;
   ciph_op_e                                cipher_op;
+  logic             [$bits(cipher_op)-1:0] cipher_op_raw;
   logic                                    sideload;
   prs_rate_e                               prng_reseed_rate;
   logic                                    manual_operation;

--- a/hw/ip/aes/rtl/aes_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_p.sv
@@ -207,8 +207,8 @@ module aes_control_fsm_p
   logic                                    ctrl_err_storage;
   aes_op_e                                 op;
   aes_mode_e                               mode;
-  logic                                    cipher_op_raw;
   ciph_op_e                                cipher_op;
+  logic             [$bits(cipher_op)-1:0] cipher_op_raw;
   logic                                    sideload;
   prs_rate_e                               prng_reseed_rate;
   logic                                    manual_operation;

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -872,7 +872,10 @@ module aes_core
       AES_CTR,
       AES_NONE
       })
-  `ASSERT_KNOWN(AesOpKnown, aes_op_q)
+  `ASSERT(AesOpValid, !ctrl_err_storage |-> aes_op_q inside {
+      AES_ENC,
+      AES_DEC
+      })
 
   // Check parameters
   `ASSERT_INIT(AesNumSlicesCtr, NumSlicesCtr == 8)

--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -45,6 +45,7 @@ module aes_ctrl_reg_shadowed
 
   // Signals
   ctrl_reg_t ctrl_wd;
+  aes_op_e   op;
   aes_mode_e mode;
   key_len_e  key_len;
   prs_rate_e prng_reseed_rate;
@@ -73,7 +74,14 @@ module aes_ctrl_reg_shadowed
       reg2hw_ctrl_i.force_zero_masks.qe;
 
   // Get and resolve values from register interface.
-  assign ctrl_wd.operation = aes_op_e'(reg2hw_ctrl_i.operation.q);
+  assign op = aes_op_e'(reg2hw_ctrl_i.operation.q);
+  always_comb begin : op_get
+    unique case (op)
+      AES_ENC: ctrl_wd.operation = AES_ENC;
+      AES_DEC: ctrl_wd.operation = AES_DEC;
+      default: ctrl_wd.operation = AES_ENC; // unsupported values are mapped to AES_ENC
+    endcase
+  end
 
   assign mode = aes_mode_e'(reg2hw_ctrl_i.mode.q);
   always_comb begin : mode_get
@@ -128,7 +136,7 @@ module aes_ctrl_reg_shadowed
     .rst_shadowed_ni,
     .re         (reg2hw_ctrl_i.operation.re),
     .we         (we_i),
-    .wd         (ctrl_wd.operation),
+    .wd         ({ctrl_wd.operation}),
     .de         (1'b0),
     .d          ('0),
     .qe         (),

--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -447,7 +447,10 @@ module aes_key_expand import aes_pkg::*;
        SBoxImpl == SBoxImplCanright)))
 
   // Selectors must be known/valid
-  `ASSERT_KNOWN(AesCiphOpKnown, op_i)
+  `ASSERT(AesCiphOpValid, cfg_valid_i |-> op_i inside {
+      CIPH_FWD,
+      CIPH_INV
+      })
   `ASSERT(AesKeyLenValid, cfg_valid_i |-> key_len_i inside {
       AES_128,
       AES_192,

--- a/hw/ip/aes/rtl/aes_mix_single_column.sv
+++ b/hw/ip/aes/rtl/aes_mix_single_column.sv
@@ -56,8 +56,10 @@ module aes_mix_single_column (
   assign z[1] = y2 ^ y[1];
 
   // Mux z
-  assign z_muxed[0] = (op_i == CIPH_FWD) ? 8'b0 : z[0];
-  assign z_muxed[1] = (op_i == CIPH_FWD) ? 8'b0 : z[1];
+  assign z_muxed[0] = (op_i == CIPH_FWD) ? 8'b0 :
+                      (op_i == CIPH_INV) ? z[0] : 8'b0;
+  assign z_muxed[1] = (op_i == CIPH_FWD) ? 8'b0 :
+                      (op_i == CIPH_INV) ? z[1] : 8'b0;
 
   // Drive outputs
   assign data_o[0] = data_i[1] ^ x_mul2[3] ^ x[1] ^ z_muxed[1];

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -77,13 +77,14 @@ typedef enum integer {
 
 
 // Parameters used for controlgroups in the coverage
+parameter int AES_OP_WIDTH             = 2;
 parameter int AES_MODE_WIDTH           = 6;
 parameter int AES_KEYLEN_WIDTH         = 3;
 parameter int AES_PRNGRESEEDRATE_WIDTH = 3;
 
-typedef enum logic {
-  AES_ENC = 1'b0,
-  AES_DEC = 1'b1
+typedef enum logic [AES_OP_WIDTH-1:0] {
+  AES_ENC = 2'b01,
+  AES_DEC = 2'b10
 } aes_op_e;
 
 typedef enum logic [AES_MODE_WIDTH-1:0] {
@@ -95,9 +96,9 @@ typedef enum logic [AES_MODE_WIDTH-1:0] {
   AES_NONE = 6'b10_0000
 } aes_mode_e;
 
-typedef enum logic {
-  CIPH_FWD = 1'b0,
-  CIPH_INV = 1'b1
+typedef enum logic [AES_OP_WIDTH-1:0] {
+  CIPH_FWD = 2'b01,
+  CIPH_INV = 2'b10
 } ciph_op_e;
 
 typedef enum logic [AES_KEYLEN_WIDTH-1:0] {

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -57,7 +57,7 @@ package aes_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        q;
+      logic [1:0]  q;
       logic        qe;
       logic        re;
     } operation;
@@ -143,7 +143,7 @@ package aes_reg_pkg;
 
   typedef struct packed {
     struct packed {
-      logic        d;
+      logic [1:0]  d;
     } operation;
     struct packed {
       logic [5:0]  d;
@@ -217,13 +217,13 @@ package aes_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    aes_reg2hw_alert_test_reg_t alert_test; // [956:953]
-    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [952:689]
-    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [688:425]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [424:293]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [292:161]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [160:29]
-    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [28:6]
+    aes_reg2hw_alert_test_reg_t alert_test; // [957:954]
+    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [953:690]
+    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [689:426]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [425:294]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [293:162]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [161:30]
+    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [29:6]
     aes_reg2hw_ctrl_aux_shadowed_reg_t ctrl_aux_shadowed; // [5:5]
     aes_reg2hw_trigger_reg_t trigger; // [4:1]
     aes_reg2hw_status_reg_t status; // [0:0]
@@ -231,12 +231,12 @@ package aes_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    aes_hw2reg_key_share0_mreg_t [7:0] key_share0; // [937:682]
-    aes_hw2reg_key_share1_mreg_t [7:0] key_share1; // [681:426]
-    aes_hw2reg_iv_mreg_t [3:0] iv; // [425:298]
-    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [297:166]
-    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [165:38]
-    aes_hw2reg_ctrl_shadowed_reg_t ctrl_shadowed; // [37:22]
+    aes_hw2reg_key_share0_mreg_t [7:0] key_share0; // [938:683]
+    aes_hw2reg_key_share1_mreg_t [7:0] key_share1; // [682:427]
+    aes_hw2reg_iv_mreg_t [3:0] iv; // [426:299]
+    aes_hw2reg_data_in_mreg_t [3:0] data_in; // [298:167]
+    aes_hw2reg_data_out_mreg_t [3:0] data_out; // [166:39]
+    aes_hw2reg_ctrl_shadowed_reg_t ctrl_shadowed; // [38:22]
     aes_hw2reg_trigger_reg_t trigger; // [21:14]
     aes_hw2reg_status_reg_t status; // [13:0]
   } aes_hw2reg_t;
@@ -329,8 +329,8 @@ package aes_reg_pkg;
   parameter logic [31:0] AES_DATA_OUT_2_DATA_OUT_2_RESVAL = 32'h 0;
   parameter logic [31:0] AES_DATA_OUT_3_RESVAL = 32'h 0;
   parameter logic [31:0] AES_DATA_OUT_3_DATA_OUT_3_RESVAL = 32'h 0;
-  parameter logic [15:0] AES_CTRL_SHADOWED_RESVAL = 16'h 8c0;
-  parameter logic [0:0] AES_CTRL_SHADOWED_OPERATION_RESVAL = 1'h 0;
+  parameter logic [16:0] AES_CTRL_SHADOWED_RESVAL = 17'h 1181;
+  parameter logic [1:0] AES_CTRL_SHADOWED_OPERATION_RESVAL = 2'h 1;
   parameter logic [5:0] AES_CTRL_SHADOWED_MODE_RESVAL = 6'h 20;
   parameter logic [2:0] AES_CTRL_SHADOWED_KEY_LEN_RESVAL = 3'h 1;
   parameter logic [0:0] AES_CTRL_SHADOWED_SIDELOAD_RESVAL = 1'h 0;
@@ -407,7 +407,7 @@ package aes_reg_pkg;
     4'b 1111, // index[26] AES_DATA_OUT_1
     4'b 1111, // index[27] AES_DATA_OUT_2
     4'b 1111, // index[28] AES_DATA_OUT_3
-    4'b 0011, // index[29] AES_CTRL_SHADOWED
+    4'b 0111, // index[29] AES_CTRL_SHADOWED
     4'b 0001, // index[30] AES_CTRL_AUX_SHADOWED
     4'b 0001, // index[31] AES_CTRL_AUX_REGWEN
     4'b 0001, // index[32] AES_TRIGGER

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -170,8 +170,8 @@ module aes_reg_top (
   logic [31:0] data_out_3_qs;
   logic ctrl_shadowed_re;
   logic ctrl_shadowed_we;
-  logic ctrl_shadowed_operation_qs;
-  logic ctrl_shadowed_operation_wd;
+  logic [1:0] ctrl_shadowed_operation_qs;
+  logic [1:0] ctrl_shadowed_operation_wd;
   logic [5:0] ctrl_shadowed_mode_qs;
   logic [5:0] ctrl_shadowed_mode_wd;
   logic [2:0] ctrl_shadowed_key_len_qs;
@@ -728,9 +728,9 @@ module aes_reg_top (
 
 
   // R[ctrl_shadowed]: V(True)
-  //   F[operation]: 0:0
+  //   F[operation]: 1:0
   prim_subreg_ext #(
-    .DW    (1)
+    .DW    (2)
   ) u_ctrl_shadowed_operation (
     .re     (ctrl_shadowed_re),
     .we     (ctrl_shadowed_we),
@@ -742,7 +742,7 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_operation_qs)
   );
 
-  //   F[mode]: 6:1
+  //   F[mode]: 7:2
   prim_subreg_ext #(
     .DW    (6)
   ) u_ctrl_shadowed_mode (
@@ -756,7 +756,7 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_mode_qs)
   );
 
-  //   F[key_len]: 9:7
+  //   F[key_len]: 10:8
   prim_subreg_ext #(
     .DW    (3)
   ) u_ctrl_shadowed_key_len (
@@ -770,7 +770,7 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_key_len_qs)
   );
 
-  //   F[sideload]: 10:10
+  //   F[sideload]: 11:11
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_sideload (
@@ -784,7 +784,7 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_sideload_qs)
   );
 
-  //   F[prng_reseed_rate]: 13:11
+  //   F[prng_reseed_rate]: 14:12
   prim_subreg_ext #(
     .DW    (3)
   ) u_ctrl_shadowed_prng_reseed_rate (
@@ -798,7 +798,7 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_prng_reseed_rate_qs)
   );
 
-  //   F[manual_operation]: 14:14
+  //   F[manual_operation]: 15:15
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_manual_operation (
@@ -812,7 +812,7 @@ module aes_reg_top (
     .qs     (ctrl_shadowed_manual_operation_qs)
   );
 
-  //   F[force_zero_masks]: 15:15
+  //   F[force_zero_masks]: 16:16
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl_shadowed_force_zero_masks (
@@ -1328,19 +1328,19 @@ module aes_reg_top (
   assign ctrl_shadowed_re = addr_hit[29] & reg_re & !reg_error;
   assign ctrl_shadowed_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign ctrl_shadowed_operation_wd = reg_wdata[0];
+  assign ctrl_shadowed_operation_wd = reg_wdata[1:0];
 
-  assign ctrl_shadowed_mode_wd = reg_wdata[6:1];
+  assign ctrl_shadowed_mode_wd = reg_wdata[7:2];
 
-  assign ctrl_shadowed_key_len_wd = reg_wdata[9:7];
+  assign ctrl_shadowed_key_len_wd = reg_wdata[10:8];
 
-  assign ctrl_shadowed_sideload_wd = reg_wdata[10];
+  assign ctrl_shadowed_sideload_wd = reg_wdata[11];
 
-  assign ctrl_shadowed_prng_reseed_rate_wd = reg_wdata[13:11];
+  assign ctrl_shadowed_prng_reseed_rate_wd = reg_wdata[14:12];
 
-  assign ctrl_shadowed_manual_operation_wd = reg_wdata[14];
+  assign ctrl_shadowed_manual_operation_wd = reg_wdata[15];
 
-  assign ctrl_shadowed_force_zero_masks_wd = reg_wdata[15];
+  assign ctrl_shadowed_force_zero_masks_wd = reg_wdata[16];
   assign ctrl_aux_shadowed_re = addr_hit[30] & reg_re & !reg_error;
   assign ctrl_aux_shadowed_we = addr_hit[30] & reg_we & !reg_error;
 
@@ -1480,13 +1480,13 @@ module aes_reg_top (
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[0] = ctrl_shadowed_operation_qs;
-        reg_rdata_next[6:1] = ctrl_shadowed_mode_qs;
-        reg_rdata_next[9:7] = ctrl_shadowed_key_len_qs;
-        reg_rdata_next[10] = ctrl_shadowed_sideload_qs;
-        reg_rdata_next[13:11] = ctrl_shadowed_prng_reseed_rate_qs;
-        reg_rdata_next[14] = ctrl_shadowed_manual_operation_qs;
-        reg_rdata_next[15] = ctrl_shadowed_force_zero_masks_qs;
+        reg_rdata_next[1:0] = ctrl_shadowed_operation_qs;
+        reg_rdata_next[7:2] = ctrl_shadowed_mode_qs;
+        reg_rdata_next[10:8] = ctrl_shadowed_key_len_qs;
+        reg_rdata_next[11] = ctrl_shadowed_sideload_qs;
+        reg_rdata_next[14:12] = ctrl_shadowed_prng_reseed_rate_qs;
+        reg_rdata_next[15] = ctrl_shadowed_manual_operation_qs;
+        reg_rdata_next[16] = ctrl_shadowed_force_zero_masks_qs;
       end
 
       addr_hit[30]: begin

--- a/hw/ip/aes/rtl/aes_sbox_canright.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright.sv
@@ -55,14 +55,16 @@ module aes_sbox_canright (
   logic [7:0] data_basis_x, data_inverse;
 
   // Convert to normal basis X.
-  assign data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X) :
-                                             aes_mvm(data_i ^ 8'h63, S2X);
+  assign data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X)         :
+                        (op_i == CIPH_INV) ? aes_mvm(data_i ^ 8'h63, S2X) :
+                                             aes_mvm(data_i, A2X);
 
   // Do the inversion in normal basis X.
   assign data_inverse = aes_inverse_gf2p8(data_basis_x);
 
   // Convert to basis S or A.
   assign data_o       = (op_i == CIPH_FWD) ? aes_mvm(data_inverse, X2S) ^ 8'h63 :
-                                             aes_mvm(data_inverse, X2A);
+                        (op_i == CIPH_INV) ? aes_mvm(data_inverse, X2A) :
+                                             aes_mvm(data_inverse, X2S) ^ 8'h63;
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked.sv
@@ -450,8 +450,9 @@ module aes_sbox_canright_masked (
   logic [7:0] in_mask_basis_x, out_mask_basis_x;
 
   // Convert data to normal basis X.
-  assign in_data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X) :
-                                                aes_mvm(data_i ^ 8'h63, S2X);
+  assign in_data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X)         :
+                           (op_i == CIPH_INV) ? aes_mvm(data_i ^ 8'h63, S2X) :
+                                                aes_mvm(data_i, A2X);
 
   // For the masked Canright SBox, the output mask directly corresponds to the pseduo-random data
   // provided as input.
@@ -460,10 +461,12 @@ module aes_sbox_canright_masked (
   // Convert masks to normal basis X.
   // The addition of constant 8'h63 following the affine transformation is skipped.
   assign in_mask_basis_x  = (op_i == CIPH_FWD) ? aes_mvm(mask_i, A2X) :
-                                                 aes_mvm(mask_i, S2X);
+                            (op_i == CIPH_INV) ? aes_mvm(mask_i, S2X) :
+                                                 aes_mvm(mask_i, A2X);
 
   // The output mask is converted in the opposite direction.
   assign out_mask_basis_x = (op_i == CIPH_INV) ? aes_mvm(mask_o, A2X) :
+                            (op_i == CIPH_FWD) ? aes_mvm(mask_o, S2X) :
                                                  aes_mvm(mask_o, S2X);
 
   // Do the inversion in normal basis X.
@@ -476,6 +479,7 @@ module aes_sbox_canright_masked (
 
   // Convert to basis S or A.
   assign data_o = (op_i == CIPH_FWD) ? (aes_mvm(out_data_basis_x, X2S) ^ 8'h63) :
-                                       (aes_mvm(out_data_basis_x, X2A));
+                  (op_i == CIPH_INV) ? (aes_mvm(out_data_basis_x, X2A))         :
+                                       (aes_mvm(out_data_basis_x, X2S) ^ 8'h63);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
+++ b/hw/ip/aes/rtl/aes_sbox_canright_masked_noreuse.sv
@@ -409,8 +409,9 @@ module aes_sbox_canright_masked_noreuse (
   logic [7:0] in_mask_basis_x, out_mask_basis_x;
 
   // Convert data to normal basis X.
-  assign in_data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X) :
-                                                aes_mvm(data_i ^ 8'h63, S2X);
+  assign in_data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X)         :
+                           (op_i == CIPH_INV) ? aes_mvm(data_i ^ 8'h63, S2X) :
+                                                aes_mvm(data_i, A2X);
 
   // For the masked Canright SBox with no re-use, the output mask directly corresponds to the
   // LSBs of the pseduo-random data provided as input.
@@ -423,10 +424,12 @@ module aes_sbox_canright_masked_noreuse (
   // Convert masks to normal basis X.
   // The addition of constant 8'h63 following the affine transformation is skipped.
   assign in_mask_basis_x  = (op_i == CIPH_FWD) ? aes_mvm(mask_i, A2X) :
-                                                 aes_mvm(mask_i, S2X);
+                            (op_i == CIPH_INV) ? aes_mvm(mask_i, S2X) :
+                                                 aes_mvm(mask_i, A2X);
 
   // The output mask is converted in the opposite direction.
   assign out_mask_basis_x = (op_i == CIPH_INV) ? aes_mvm(mask_o, A2X) :
+                            (op_i == CIPH_FWD) ? aes_mvm(mask_o, S2X) :
                                                  aes_mvm(mask_o, S2X);
 
   // Do the inversion in normal basis X.
@@ -440,6 +443,7 @@ module aes_sbox_canright_masked_noreuse (
 
   // Convert to basis S or A.
   assign data_o = (op_i == CIPH_FWD) ? (aes_mvm(out_data_basis_x, X2S) ^ 8'h63) :
-                                       (aes_mvm(out_data_basis_x, X2A));
+                  (op_i == CIPH_INV) ? (aes_mvm(out_data_basis_x, X2A))         :
+                                       (aes_mvm(out_data_basis_x, X2S) ^ 8'h63);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_sbox_dom.sv
+++ b/hw/ip/aes/rtl/aes_sbox_dom.sv
@@ -1010,13 +1010,15 @@ module aes_sbox_dom
   prd_out_t   out_prd;
 
   // Convert data to normal basis X.
-  assign in_data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X) :
-                                                aes_mvm(data_i ^ 8'h63, S2X);
+  assign in_data_basis_x = (op_i == CIPH_FWD) ? aes_mvm(data_i, A2X)         :
+                           (op_i == CIPH_INV) ? aes_mvm(data_i ^ 8'h63, S2X) :
+                                                aes_mvm(data_i, A2X);
 
   // Convert mask to normal basis X.
   // The addition of constant 8'h63 prior to the affine transformation is skipped.
-  assign in_mask_basis_x  = (op_i == CIPH_FWD) ? aes_mvm(mask_i, A2X) :
-                                                 aes_mvm(mask_i, S2X);
+  assign in_mask_basis_x = (op_i == CIPH_FWD) ? aes_mvm(mask_i, A2X) :
+                           (op_i == CIPH_INV) ? aes_mvm(mask_i, S2X) :
+                                                aes_mvm(mask_i, A2X);
 
   // Do the inversion in normal basis X.
   aes_dom_inverse_gf2p8 #(
@@ -1035,12 +1037,14 @@ module aes_sbox_dom
 
   // Convert data to basis S or A.
   assign data_o = (op_i == CIPH_FWD) ? (aes_mvm(out_data_basis_x, X2S) ^ 8'h63) :
-                                       (aes_mvm(out_data_basis_x, X2A));
+                  (op_i == CIPH_INV) ? (aes_mvm(out_data_basis_x, X2A))         :
+                                       (aes_mvm(out_data_basis_x, X2S) ^ 8'h63);
 
   // Convert mask to basis S or A.
   // The addition of constant 8'h63 following the affine transformation is skipped.
   assign mask_o = (op_i == CIPH_FWD) ? aes_mvm(out_mask_basis_x, X2S) :
-                                       aes_mvm(out_mask_basis_x, X2A);
+                  (op_i == CIPH_INV) ? aes_mvm(out_mask_basis_x, X2A) :
+                                       aes_mvm(out_mask_basis_x, X2S);
 
   // Counter register
   logic [2:0] count_d, count_q;

--- a/hw/ip/aes/rtl/aes_sbox_lut.sv
+++ b/hw/ip/aes/rtl/aes_sbox_lut.sv
@@ -114,6 +114,7 @@ module aes_sbox_lut (
   };
 
   // Drive output
-  assign data_o = (op_i == CIPH_FWD) ? SBOX_FWD[data_i] : SBOX_INV[data_i];
+  assign data_o = (op_i == CIPH_FWD) ? SBOX_FWD[data_i] :
+                  (op_i == CIPH_INV) ? SBOX_INV[data_i] : SBOX_FWD[data_i];
 
 endmodule

--- a/hw/ip/aes/rtl/aes_shift_rows.sv
+++ b/hw/ip/aes/rtl/aes_shift_rows.sv
@@ -19,11 +19,13 @@ module aes_shift_rows (
   assign data_o[2] = aes_circ_byte_shift(data_i[2], 2'h2);
 
   // Row 1
-  assign data_o[1] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[1], 2'h3)
-                                        : aes_circ_byte_shift(data_i[1], 2'h1);
+  assign data_o[1] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[1], 2'h3) :
+                     (op_i == CIPH_INV) ? aes_circ_byte_shift(data_i[1], 2'h1) :
+                                          aes_circ_byte_shift(data_i[1], 2'h3);
 
   // Row 3
-  assign data_o[3] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[3], 2'h1)
-                                        : aes_circ_byte_shift(data_i[3], 2'h3);
+  assign data_o[3] = (op_i == CIPH_FWD) ? aes_circ_byte_shift(data_i[3], 2'h1) :
+                     (op_i == CIPH_INV) ? aes_circ_byte_shift(data_i[3], 2'h3) :
+                                          aes_circ_byte_shift(data_i[3], 2'h1);
 
 endmodule

--- a/hw/ip/aes/rtl/aes_wrap.sv
+++ b/hw/ip/aes/rtl/aes_wrap.sv
@@ -194,7 +194,7 @@ module aes_wrap
         h2d.a_valid   = 1'b1;
         h2d.a_opcode  = PutFullData;
         h2d.a_address = {{{32-BlockAw}{1'b0}}, AES_CTRL_SHADOWED_OFFSET};
-        h2d.a_data    = {19'h0, 1'b0 ,1'b0, SIDELOAD, AES_128, AES_MODE, AES_ENC};
+        h2d.a_data    = {18'h0, 1'b0 ,1'b0, SIDELOAD, AES_128, AES_MODE, AES_ENC};
 
         // We can't do back to back transactions. De-assert valid while receiving response.
         if (d2h.d_valid) begin

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -82,6 +82,46 @@ typedef struct dif_aes_data {
 } dif_aes_data_t;
 
 /**
+ * AES operation.
+ */
+typedef enum dif_aes_operation {
+  /**
+   * AES encryption.
+   */
+  kDifAesOperationEncrypt = 0,
+  /**
+   * AES decryption.
+   */
+  kDifAesOperationDecrypt,
+} dif_aes_operation_t;
+
+/**
+ * AES block cipher mode of operation.
+ */
+typedef enum dif_aes_mode {
+  /**
+   * The Electronic Codebook Mode.
+   */
+  kDifAesModeEcb = 0,
+  /**
+   * The Cipher Block Chaining Mode.
+   */
+  kDifAesModeCbc,
+  /**
+   * The Cipher Feedback Mode.
+   */
+  kDifAesModeCfb,
+  /**
+   * The Output Feedback Mode.
+   */
+  kDifAesModeOfb,
+  /**
+   * The Counter Mode.
+   */
+  kDifAesModeCtr,
+} dif_aes_mode_t;
+
+/**
  * AES key length in bits.
  */
 typedef enum dif_aes_key_length {
@@ -100,34 +140,20 @@ typedef enum dif_aes_key_length {
 } dif_aes_key_length_t;
 
 /**
- * AES mode.
+ * AES manual operation.
  */
-typedef enum dif_aes_mode {
-  /**
-   * AES encryption mode.
-   */
-  kDifAesModeEncrypt = 0,
-  /**
-   * AES decryption mode.
-   */
-  kDifAesModeDecrypt,
-} dif_aes_mode_t;
-
-/**
- * AES operation.
- */
-typedef enum dif_aes_operation {
+typedef enum dif_aes_manual_operation {
   /**
    * AES operates in automatic mode - which means that the encryption/decryption
    * is automatically triggered on every successful `dif_aes_*_load_data()`.
    */
-  kDifAesOperationAuto = 0,
+  kDifAesManualOperationAuto = 0,
   /**
    * AES operates in manual mode - which means that the encryption/decryption
    * is manually triggered by `dif_aes_trigger(kDifAesTriggerStart)`.
    */
-  kDifAesOperationManual,
-} dif_aes_operation_t;
+  kDifAesManualOperationManual,
+} dif_aes_manual_operation_t;
 
 /**
  * AES masking.
@@ -151,9 +177,10 @@ typedef enum dif_aes_masking {
  * Parameters for an AES transaction.
  */
 typedef struct dif_aes_transaction {
-  dif_aes_key_length_t key_len;
-  dif_aes_mode_t mode;
   dif_aes_operation_t operation;
+  dif_aes_mode_t mode;
+  dif_aes_key_length_t key_len;
+  dif_aes_manual_operation_t manual_operation;
   dif_aes_masking_t masking;
 } dif_aes_transaction_t;
 

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -60,9 +60,10 @@ class AesTestInitialized : public AesTest {
   dif_aes_t aes_;
 
   const dif_aes_transaction_t kTransaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeEcb,
       .key_len = kDifAesKey128,
-      .mode = kDifAesModeEncrypt,
-      .operation = kDifAesOperationAuto,
+      .manual_operation = kDifAesManualOperationAuto,
       .masking = kDifAesMaskingInternalPrng,
   };
 
@@ -86,7 +87,7 @@ TEST_F(EcbTest, start) {
     EXPECT_WRITE32(AES_CTRL_SHADOWED_REG_OFFSET,
                    {{AES_CTRL_SHADOWED_KEY_LEN_OFFSET, 0x01},
                     {AES_CTRL_SHADOWED_MODE_OFFSET, 0x01},
-                    {AES_CTRL_SHADOWED_OPERATION_BIT, false},
+                    {AES_CTRL_SHADOWED_OPERATION_OFFSET, 0x1},
                     {AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false},
                     {AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT, false}});
   }
@@ -105,7 +106,7 @@ TEST_F(CbcTest, start) {
     EXPECT_WRITE32(AES_CTRL_SHADOWED_REG_OFFSET,
                    {{AES_CTRL_SHADOWED_KEY_LEN_OFFSET, 0x01},
                     {AES_CTRL_SHADOWED_MODE_OFFSET, 0x02},
-                    {AES_CTRL_SHADOWED_OPERATION_BIT, false},
+                    {AES_CTRL_SHADOWED_OPERATION_OFFSET, 0x1},
                     {AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false},
                     {AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT, false}});
   }
@@ -125,7 +126,7 @@ TEST_F(CFBTest, start) {
     EXPECT_WRITE32(AES_CTRL_SHADOWED_REG_OFFSET,
                    {{AES_CTRL_SHADOWED_KEY_LEN_OFFSET, 0x01},
                     {AES_CTRL_SHADOWED_MODE_OFFSET, 0x04},
-                    {AES_CTRL_SHADOWED_OPERATION_BIT, false},
+                    {AES_CTRL_SHADOWED_OPERATION_OFFSET, 0x1},
                     {AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false},
                     {AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT, false}});
   }
@@ -145,7 +146,7 @@ TEST_F(OFBTest, start) {
     EXPECT_WRITE32(AES_CTRL_SHADOWED_REG_OFFSET,
                    {{AES_CTRL_SHADOWED_KEY_LEN_OFFSET, 0x01},
                     {AES_CTRL_SHADOWED_MODE_OFFSET, 0x08},
-                    {AES_CTRL_SHADOWED_OPERATION_BIT, false},
+                    {AES_CTRL_SHADOWED_OPERATION_OFFSET, 0x1},
                     {AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false},
                     {AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT, false}});
   }
@@ -165,7 +166,7 @@ TEST_F(CTRTest, start) {
     EXPECT_WRITE32(AES_CTRL_SHADOWED_REG_OFFSET,
                    {{AES_CTRL_SHADOWED_KEY_LEN_OFFSET, 0x01},
                     {AES_CTRL_SHADOWED_MODE_OFFSET, 0x10},
-                    {AES_CTRL_SHADOWED_OPERATION_BIT, false},
+                    {AES_CTRL_SHADOWED_OPERATION_OFFSET, 0x1},
                     {AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, false},
                     {AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT, false}});
   }

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -54,10 +54,11 @@ static dif_aes_t aes;
 static void aes_serial_set_key(const uint8_t *key, size_t key_len) {
   SS_CHECK(key_len == kAesKeyLength);
   dif_aes_transaction_t transaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeEcb,
       .key_len = kDifAesKey128,
       .masking = kDifAesMaskingInternalPrng,
-      .mode = kDifAesModeEncrypt,
-      .operation = kDifAesOperationManual,
+      .manual_operation = kDifAesManualOperationManual,
   };
   dif_aes_key_share_t key_shares;
   memcpy(key_shares.share0, key, sizeof(key_shares.share0));

--- a/sw/device/tests/aes_smoketest.c
+++ b/sw/device/tests/aes_smoketest.c
@@ -88,9 +88,10 @@ bool test_main(void) {
 
   // Setup ECB encryption transaction.
   dif_aes_transaction_t transaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeEcb,
       .key_len = kDifAesKey256,
-      .mode = kDifAesModeEncrypt,
-      .operation = kDifAesOperationAuto,
+      .manual_operation = kDifAesManualOperationAuto,
   };
   CHECK_DIF_OK(dif_aes_start_ecb(&aes, &transaction, key));
 
@@ -122,7 +123,7 @@ bool test_main(void) {
   }
 
   // Setup ECB decryption transaction.
-  transaction.mode = kDifAesModeDecrypt;
+  transaction.operation = kDifAesOperationDecrypt;
   CHECK_DIF_OK(dif_aes_start_ecb(&aes, &transaction, key));
 
   // Load the previously produced cipher text to start the decryption operation.


### PR DESCRIPTION
Sorry, it got a bit more involved than anticipated as invalid encodings need to be catched inside the cipher core.

@msfschaffner, @tjaychen, @cdgori can you please take a look? We should get this in as it's not transparent DV and therefore blocks other DV tasks.

This is related to lowRISC/OpenTitan#10422.

