### PR TITLE
[flash_ctrl/dv] Make flash_ctrl_base_test to be extendable with params

### DIFF
--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -16,6 +16,21 @@ module tb;
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  // TB base test ENV_T & CFG_T specification
+  //
+  // Specify the parameters for the flash_ctrl_base_test
+  // This will invoke the UVM registry and link this test type to
+  // the name 'flash_ctrl_base_test' as a test name passed by UVM_TESTNAME
+  //
+  // This is done explicitly only for the prim_pkg::ImplGeneric implementation
+  // since partner base tests inherit from flash_ctrl_base_test#(CFG_T, ENV_T) and
+  // specify directly (CFG_T, ENV_T) via the class extension and use a different
+  // UVM_TESTNAME
+  if (`PRIM_DEFAULT_IMPL==prim_pkg::ImplGeneric) begin : gen_spec_base_test_params
+    typedef flash_ctrl_base_test #(.CFG_T(flash_ctrl_env_cfg),
+                                   .ENV_T(flash_ctrl_env)) flash_ctrl_base_test_t;
+  end
+
   wire clk, rst_n, rst_shadowed_n;
   wire devmode;
   wire intr_prog_empty;

--- a/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
+++ b/hw/ip/flash_ctrl/dv/tests/flash_ctrl_base_test.sv
@@ -2,12 +2,44 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class flash_ctrl_base_test extends cip_base_test #(
-    .CFG_T(flash_ctrl_env_cfg),
-    .ENV_T(flash_ctrl_env)
+class flash_ctrl_base_test #(
+    type CFG_T = flash_ctrl_env_cfg,
+    type ENV_T = flash_ctrl_env
+  ) extends cip_base_test #(
+    .CFG_T(CFG_T),
+    .ENV_T(ENV_T)
   );
 
-  `uvm_component_utils(flash_ctrl_base_test)
+  // A prototype for the registry to associate the parameterized base test
+  // with the name 'flash_ctrl_base_test'
+  //
+  // Register the name 'flash_ctrl_base_test' with the UVM factory to be associated
+  // with the template base test class parameterized with the default types (see
+  // declaration. We cannot invoke the standard UVM factory automation macro t
+  // (uvm_component_param_utils) to register a parameterized test class with the
+  // factory because the creation of the test by name (via the UVM_TESTNAME
+  // plusarg) does not work. We expand the contents of the automation macro
+  // here instead. See the following paper for details:
+  // https://verificationacademy-news.s3.amazonaws.com/DVCon2016/Papers/
+  // dvcon-2016_paramaters-uvm-coverage-and-emulation-take-two-and-call-me-in-the-morning_paper.pdf
+  typedef uvm_component_registry#(flash_ctrl_base_test#(CFG_T, ENV_T),
+                                  "flash_ctrl_base_test") type_id;
+
+  // functions to support the component registry above
+  static function type_id get_type();
+    return type_id::get();
+  endfunction : get_type
+
+  virtual function uvm_object_wrapper get_object_type();
+    return type_id::get();
+  endfunction : get_object_type
+
+  const static string type_name = "flash_ctrl_base_test";
+
+  virtual function string get_type_name();
+    return type_name;
+  endfunction : get_type_name
+
   `uvm_component_new
 
   // the base class dv_base_test creates the following instances:


### PR DESCRIPTION
Hi,
This PR is making flash_ctrl_base_test to be extendable with parameters.
This needed for the extending partner base test using parameters and to keep this test executable.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>