### PR TITLE
Revert "[dv/mubi] Fix randomization"

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -73,20 +73,18 @@ package cip_base_pkg;
   endfunction
 
   // Create functions that return a random value for the mubi type variable, based on weight
-  // settings.
+  // settings
   //
   // The function is `get_rand_mubi4|8|16_val(t_weight, f_weight, other_weight)`
   // t_weight: randomization weight of the value True
   // f_weight: randomization weight of the value False
-  // other_weight: collective randomization weight of all values other than True or False
+  // other_weight: randomization weight of values other than True or False
   `define _DV_MUBI_RAND_VAL(WIDTH_) \
     function automatic mubi``WIDTH_``_t get_rand_mubi``WIDTH_``_val( \
         int t_weight = 2, int f_weight = 2, int other_weight = 1); \
       bit[WIDTH_-1:0] val; \
-      int             scaling = (1 << WIDTH_) - 2; \
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val, \
-          `DV_MUBI``WIDTH_``_DIST(val, t_weight * scaling, f_weight * scaling, other_weight), , \
-                                         msg_id) \
+          `DV_MUBI``WIDTH_``_DIST(val, t_weight, f_weight, other_weight), , msg_id) \
       return mubi``WIDTH_``_t'(val); \
     endfunction
 

--- a/hw/dv/sv/cip_lib/cip_macros.svh
+++ b/hw/dv/sv/cip_lib/cip_macros.svh
@@ -52,17 +52,17 @@
 `ifndef _DV_MUBI_DIST
 `define _DV_MUBI_DIST(VAR_, TRUE_, FALSE_, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_) \
   if (TRUE_ > FALSE_) { \
-    VAR_ dist {TRUE_                         := T_WEIGHT_,      \
-               FALSE_                        := F_WEIGHT_,      \
-               [0 : FALSE_ - 1]              := OTHER_WEIGHT_,  \
-               [FALSE_ + 1 : TRUE_ - 1]      := OTHER_WEIGHT_,  \
-               [TRUE_ + 1 : type(VAR_)'('1)] := OTHER_WEIGHT_}; \
-  } else {                                                      \
-    VAR_ dist {TRUE_                         := T_WEIGHT_,      \
-               FALSE_                        := F_WEIGHT_,      \
-               [0 : TRUE_ - 1]               := OTHER_WEIGHT_,  \
-               [TRUE_ + 1 : FALSE_ - 1]      := OTHER_WEIGHT_,  \
-               [FALSE_+ 1 : type(VAR_)'('1)] := OTHER_WEIGHT_}; \
+    VAR_ dist {TRUE_  :/ T_WEIGHT_ * 3, \
+               FALSE_ :/ F_WEIGHT_ * 3, \
+               [0 : FALSE_ - 1]         :/ OTHER_WEIGHT_, \
+               [FALSE_ + 1 : TRUE_ - 1] :/ OTHER_WEIGHT_, \
+               [TRUE_ + 1 : $]          :/ OTHER_WEIGHT_}; \
+  } else { \
+    VAR_ dist {TRUE_  :/ T_WEIGHT_ * 3, \
+               FALSE_ :/ F_WEIGHT_ * 3, \
+               [0 : TRUE_ - 1]          :/ OTHER_WEIGHT_, \
+               [TRUE_ + 1 : FALSE_ - 1] :/ OTHER_WEIGHT_, \
+               [FALSE_+ 1 : $]          :/ OTHER_WEIGHT_}; \
   }
 `endif
 
@@ -91,4 +91,4 @@
   `_DV_MUBI_DIST(VAR_, MuBi16True, MuBi16False, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
 `endif
 
-`endif  // __CIP_MACROS_SVH__
+`endif // __CIP_MACROS_SVH__


### PR DESCRIPTION
#10455 
breaks compile for xcelium, this is blocking for WD
reverting commit until this is fixed

This reverts commit ef5bc57ef8f9c06db162afd4fe79129b3eefae4f.