### PR TITLE
[dv/hmac] Fix hmac fcov bin and a stress_all_with_rand_reset issue

### DIFF
--- a/hw/ip/hmac/dv/env/hmac_env_cfg.sv
+++ b/hw/ip/hmac/dv/env/hmac_env_cfg.sv
@@ -20,8 +20,8 @@ class hmac_env_cfg extends cip_base_env_cfg #(.RAL_T(hmac_reg_block));
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 
-    // only support 2 outstanding TL items in tlul_adapter
-    m_tl_agent_cfg.max_outstanding_req = 2;
+    // only support 1 outstanding TL items in tlul_adapter
+    m_tl_agent_cfg.max_outstanding_req = 1;
   endfunction
 
 endclass

--- a/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
+++ b/hw/ip/hmac/dv/env/seq_lib/hmac_common_vseq.sv
@@ -42,6 +42,7 @@ class hmac_common_vseq extends hmac_base_vseq;
     end else begin
       super.wait_to_issue_reset(reset_delay_bound);
     end
+    cfg.hash_process_triggered = 0;
   endtask : wait_to_issue_reset
 
 endclass


### PR DESCRIPTION
1). Fix max outstanding item from 2 to 1.
2). Stress_all_with_rand_reset does not use `apply_reset`, so added a
  line of logic to set back the cfg flag before issuing the concurrent
  reset.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>