### PR TITLE
[sw,tests] SRAM scrambled access tests DV integration

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2042,7 +2042,8 @@
               anymore.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_sram_ctrl_ret_scrambled_access",
+              "chip_sw_sram_ctrl_main_scrambled_access"]
     }
     {
       name: chip_sw_sleep_sram_ret_contents

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -496,6 +496,21 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_sram_ctrl_ret_scrambled_access
+      uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
+      sw_images: ["sw/device/tests/sram_ctrl_ret_scrambled_access_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+mem_sel=ret"]
+    }
+    {
+      name: chip_sw_sram_ctrl_main_scrambled_access
+      uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
+      sw_images: ["sw/device/tests/sram_ctrl_main_scrambled_access_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+mem_sel=main",
+                 "+sw_test_timeout_ns=7000000"]
+    }
+    {
       name: chip_sw_sram_ctrl_execution_main
       uvm_test_seq: chip_sw_sram_ctrl_execution_main_vseq
       sw_images: ["sw/device/tests/sram_ctrl_execution_test_main:1"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -52,6 +52,7 @@ filesets:
       - seq_lib/chip_sw_spi_tx_rx_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_rom_ctrl_integrity_check_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_keymgr_key_derivation_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv
@@ -1,0 +1,220 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_sram_ctrl_scrambled_access_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_sram_ctrl_scrambled_access_vseq)
+
+  `uvm_object_new
+
+  // Number of words to write.
+  localparam uint BACKDOOR_DATA_WORDS = 16;
+
+  // Offsets in number of words for the locations in SRAM where we will write backdoor data.
+  // For retention RAM this can be anywhere except at the base address which is
+  // already used in the test for the scramble check.
+  // For main SRAM after scrambling the runtime environment will have been trashed so we only need
+  // to avoid the location of the scramble buffer. This will have been allocated by the
+  // compiler close to the start of the RAM.
+  // For both, an offset that is at the midpoint of the SRAM should suffice.
+  localparam uint BACKDOOR_RET_OFFSET = (top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_SIZE_BYTES / 8);
+  localparam uint BACKDOOR_MAIN_OFFSET = (top_earlgrey_pkg::TOP_EARLGREY_SRAM_CTRL_MAIN_RAM_SIZE_BYTES / 8);
+
+  localparam string MAIN_INDEX = "0";
+  localparam string MAIN_REQ_INDEX = "3";
+  localparam string RET_INDEX = "1";
+  localparam string RET_REQ_INDEX = "4";
+
+  localparam string SRAM_CTRL_RET_HDL_PATH = "tb.dut.top_earlgrey.u_sram_ctrl_ret_aon";
+  localparam string SRAM_CTRL_MAIN_HDL_PATH = "tb.dut.top_earlgrey.u_sram_ctrl_main";
+  localparam string OTP_CTRL_KDI_HDL_PATH = "tb.dut.top_earlgrey.u_otp_ctrl.u_otp_ctrl_kdi";
+
+  localparam string KEY_VALID_PATH = ".u_reg_regs.u_status_scr_key_valid.qs[0]";
+
+  localparam string RET_NONCE_PATH = {
+    OTP_CTRL_KDI_HDL_PATH, ".sram_otp_key_o[", RET_INDEX, "].nonce"
+  };
+  localparam string RET_KEY_PATH = {OTP_CTRL_KDI_HDL_PATH, ".sram_otp_key_o[", RET_INDEX, "].key"};
+  localparam string RET_ACK_PATH = {OTP_CTRL_KDI_HDL_PATH, ".sram_otp_key_o[", RET_INDEX, "].ack"};
+  localparam string RET_REQ_PATH = {OTP_CTRL_KDI_HDL_PATH, ".req[", RET_REQ_INDEX, "]"};
+
+  localparam string MAIN_NONCE_PATH = {
+    OTP_CTRL_KDI_HDL_PATH, ".sram_otp_key_o[", MAIN_INDEX, "].nonce"
+  };
+  localparam string MAIN_KEY_PATH = {
+    OTP_CTRL_KDI_HDL_PATH, ".sram_otp_key_o[", MAIN_INDEX, "].key"
+  };
+  localparam string MAIN_ACK_PATH = {
+    OTP_CTRL_KDI_HDL_PATH, ".sram_otp_key_o[", MAIN_INDEX, "].ack"
+  };
+  localparam string MAIN_REQ_PATH = {OTP_CTRL_KDI_HDL_PATH, ".req[", MAIN_REQ_INDEX, "]"};
+
+  localparam string SRAM_CTRL_RET_SCR_KEY_VALID_PATH = {SRAM_CTRL_RET_HDL_PATH, KEY_VALID_PATH};
+  localparam string SRAM_CTRL_MAIN_SCR_KEY_VALID_PATH = {SRAM_CTRL_MAIN_HDL_PATH, KEY_VALID_PATH};
+
+  rand bit [7:0] backdoor_data[];
+  constraint backdoor_data_c {backdoor_data.size() == (BACKDOOR_DATA_WORDS * 4);}
+
+  bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0] sram_ret_nonce;
+  bit [  sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0] sram_ret_key;
+  bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0] sram_main_nonce;
+  bit [  sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0] sram_main_key;
+
+  virtual task check_hdl_paths();
+    int retval;
+    retval = uvm_hdl_check_path(RET_NONCE_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", RET_NONCE_PATH))
+    retval = uvm_hdl_check_path(RET_KEY_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", RET_KEY_PATH))
+    retval = uvm_hdl_check_path(RET_ACK_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", RET_ACK_PATH))
+    retval = uvm_hdl_check_path(RET_REQ_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", RET_REQ_PATH))
+    retval = uvm_hdl_check_path(MAIN_NONCE_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", MAIN_NONCE_PATH))
+    retval = uvm_hdl_check_path(MAIN_KEY_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", MAIN_KEY_PATH))
+    retval = uvm_hdl_check_path(MAIN_ACK_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", MAIN_ACK_PATH))
+    retval = uvm_hdl_check_path(MAIN_REQ_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", MAIN_REQ_PATH))
+    retval = uvm_hdl_check_path(SRAM_CTRL_RET_SCR_KEY_VALID_PATH);
+    `DV_CHECK_EQ_FATAL(
+        retval, 1, $sformatf(
+        "Hierarchical path %0s appears to be invalid.", SRAM_CTRL_RET_SCR_KEY_VALID_PATH))
+    retval = uvm_hdl_check_path(SRAM_CTRL_MAIN_SCR_KEY_VALID_PATH);
+    `DV_CHECK_EQ_FATAL(
+        retval, 1, $sformatf(
+        "Hierarchical path %0s appears to be invalid.", SRAM_CTRL_MAIN_SCR_KEY_VALID_PATH))
+  endtask
+
+  virtual task get_ret_keys();
+    int retval;
+    int req;
+    int ack;
+    forever begin
+      retval = uvm_hdl_read(RET_REQ_PATH, req);
+      `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", RET_REQ_PATH))
+      retval = uvm_hdl_read(RET_ACK_PATH, ack);
+      `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", RET_ACK_PATH))
+      if (req == 1 && ack == 1) begin
+        retval = uvm_hdl_read(RET_NONCE_PATH, sram_ret_nonce);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", RET_NONCE_PATH))
+        retval = uvm_hdl_read(RET_KEY_PATH, sram_ret_key);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", RET_KEY_PATH))
+      end
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task get_main_keys();
+    int retval;
+    int req;
+    int ack;
+    forever begin
+      retval = uvm_hdl_read(MAIN_REQ_PATH, req);
+      `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", MAIN_REQ_PATH))
+      retval = uvm_hdl_read(MAIN_ACK_PATH, ack);
+      `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", MAIN_ACK_PATH))
+      if (req == 1 && ack == 1) begin
+        retval = uvm_hdl_read(MAIN_NONCE_PATH, sram_main_nonce);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", MAIN_NONCE_PATH))
+        retval = uvm_hdl_read(MAIN_KEY_PATH, sram_main_key);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", MAIN_KEY_PATH))
+      end
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task ret_backdoor_write();
+    int retval;
+    bit scr_key_valid;
+    forever begin
+      retval = uvm_hdl_read(SRAM_CTRL_RET_SCR_KEY_VALID_PATH, scr_key_valid);
+      `DV_CHECK_EQ(retval, 1, $sformatf(
+                   "uvm_hdl_read failed for %0s", SRAM_CTRL_RET_SCR_KEY_VALID_PATH))
+      // Wait for sram_ctrl.STATUS.SCR_KEY_VALID.
+      if (scr_key_valid == 1) begin
+        // Write the data to a known offset in the SRAM. The random byte data
+        // is used little-endian.
+        for (int i = 0; i < BACKDOOR_DATA_WORDS; i++) begin
+          ret_sram_bkdr_write32((BACKDOOR_RET_OFFSET + i) * 4, {
+                                backdoor_data[(i*4)+3],
+                                backdoor_data[(i*4)+2],
+                                backdoor_data[(i*4)+1],
+                                backdoor_data[(i*4)+0]
+                                }, sram_ret_key, sram_ret_nonce);
+        end
+        break;
+      end
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task main_backdoor_write();
+    int retval;
+    bit scr_key_valid;
+    forever begin
+      retval = uvm_hdl_read(SRAM_CTRL_MAIN_SCR_KEY_VALID_PATH, scr_key_valid);
+      `DV_CHECK_EQ(retval, 1, $sformatf(
+                   "uvm_hdl_read failed for %0s", SRAM_CTRL_MAIN_SCR_KEY_VALID_PATH))
+      // Wait for sram_ctrl.STATUS.SCR_KEY_VALID.
+      if (scr_key_valid == 1) begin
+        // Write the data to a known offset in the SRAM. The random byte data
+        // is used little-endian.
+        for (int i = 0; i < BACKDOOR_DATA_WORDS; i++) begin
+          main_sram_bkdr_write32((BACKDOOR_MAIN_OFFSET + i) * 4, {
+                                 backdoor_data[(i*4)+3],
+                                 backdoor_data[(i*4)+2],
+                                 backdoor_data[(i*4)+1],
+                                 backdoor_data[(i*4)+0]
+                                 }, sram_main_key, sram_main_nonce);
+        end
+        break;
+      end
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task body();
+    string mem_sel;
+    super.body();
+
+    // Disable SRAM data integrity checks.
+    cfg.disable_d_user_data_intg_check_for_passthru_mem = 1;
+    cfg.en_scb_mem_chk = 0;
+
+    check_hdl_paths();
+
+    sw_symbol_backdoor_overwrite("kBackdoorExpectedBytes", backdoor_data);
+
+    // This sequence can test main or retention SRAM by setting
+    // plusarg +mem_sel to "ret" for retention SRAM. Any other value
+    // will test main SRAM. The relevant tasks are forked based
+    // on this choice.
+    if ($value$plusargs("mem_sel=%s", mem_sel)) begin
+      if (mem_sel == "ret") begin
+        fork
+          get_ret_keys();
+          ret_backdoor_write();
+        join_none
+      end else begin
+        fork
+          get_main_keys();
+          main_backdoor_write();
+        join_none
+      end
+    end else begin
+      `uvm_error(`gfn, "mem_sel plusarg not found.")
+    end
+  endtask
+
+endclass : chip_sw_sram_ctrl_scrambled_access_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -20,5 +20,6 @@
 `include "chip_sw_spi_tx_rx_vseq.sv"
 `include "chip_sw_rom_ctrl_integrity_check_vseq.sv"
 `include "chip_sw_sram_ctrl_execution_main_vseq.sv"
+`include "chip_sw_sram_ctrl_scrambled_access_vseq.sv"
 `include "chip_sw_pwm_pulses_vseq.sv"
 `include "chip_sw_keymgr_key_derivation_vseq.sv"

--- a/sw/device/lib/dif/dif_sram_ctrl.c
+++ b/sw/device/lib/dif/dif_sram_ctrl.c
@@ -113,6 +113,21 @@ dif_result_t dif_sram_ctrl_request_new_key(const dif_sram_ctrl_t *sram_ctrl) {
   return kDifOk;
 }
 
+dif_result_t dif_sram_ctrl_wipe(const dif_sram_ctrl_t *sram_ctrl) {
+  if (sram_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  if (sram_ctrl_locked_ctrl(sram_ctrl)) {
+    return kDifLocked;
+  }
+
+  uint32_t reg = bitfield_bit32_write(0, SRAM_CTRL_CTRL_INIT_BIT, true);
+  mmio_region_write32(sram_ctrl->base_addr, SRAM_CTRL_CTRL_REG_OFFSET, reg);
+
+  return kDifOk;
+}
+
 dif_result_t dif_sram_ctrl_get_status(const dif_sram_ctrl_t *sram_ctrl,
                                       dif_sram_ctrl_status_bitfield_t *status) {
   if (sram_ctrl == NULL) {

--- a/sw/device/lib/dif/dif_sram_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sram_ctrl_unittest.cc
@@ -97,6 +97,25 @@ TEST_F(RequestNewKeyTest, Success) {
   EXPECT_DIF_OK(dif_sram_ctrl_request_new_key(&sram_ctrl_));
 }
 
+class WipeTest : public SramCtrlTest {};
+
+TEST_F(WipeTest, NullArgs) {
+  EXPECT_EQ(dif_sram_ctrl_wipe(nullptr), kDifBadArg);
+}
+
+TEST_F(WipeTest, Locked) {
+  EXPECT_READ32(SRAM_CTRL_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_sram_ctrl_wipe(&sram_ctrl_), kDifLocked);
+}
+
+TEST_F(WipeTest, Success) {
+  EXPECT_READ32(SRAM_CTRL_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(SRAM_CTRL_CTRL_REG_OFFSET,
+                 {{SRAM_CTRL_CTRL_RENEW_SCR_KEY_BIT, false},
+                  {SRAM_CTRL_CTRL_INIT_BIT, true}});
+  EXPECT_EQ(dif_sram_ctrl_wipe(&sram_ctrl_), kDifOk);
+}
+
 class GetStatusTest : public SramCtrlTest {};
 
 TEST_F(GetStatusTest, NullArgs) {

--- a/sw/device/lib/testing/sram_ctrl_testutils.h
+++ b/sw/device/lib/testing/sram_ctrl_testutils.h
@@ -56,4 +56,20 @@ bool sram_ctrl_testutils_read_check_neq(
  */
 void sram_ctrl_testutils_scramble(const dif_sram_ctrl_t *sram_ctrl);
 
+/**
+ * Triggers the SRAM wipe operation and waits for it to finish.
+ */
+void sram_ctrl_testutils_wipe(const dif_sram_ctrl_t *sram_ctrl);
+
+/**
+ * Reads data from `backdoor_addr` in SRAM (retention or main) and
+ * compares against `expected_bytes`.
+ *
+ * The data is checked for equality.
+ */
+void sram_ctrl_testutils_check_backdoor_write(uintptr_t backdoor_addr,
+                                              uint32_t num_words,
+                                              uint32_t offset_addr,
+                                              const uint8_t *expected_bytes);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_SRAM_CTRL_TESTUTILS_H_

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -826,51 +826,6 @@ sw_tests += {
   }
 }
 
-
-# SRAM Controller scrambled access test.
-sram_ctrl_scrambled_access_test_lib = declare_dependency(
-  link_with: static_library(
-    'sram_ctrl_scrambled_access_test_lib',
-    sources: ['sram_ctrl_scrambled_access_test.c'],
-    dependencies: [
-      sw_lib_dif_sram_ctrl,
-      sw_lib_runtime_log,
-      sw_lib_testing_sram_ctrl_testutils,
-      top_earlgrey,
-    ],
-  ),
-)
-sw_tests += {
-  'sram_ctrl_scrambled_access_test': {
-    'library': sram_ctrl_scrambled_access_test_lib,
-  }
-}
-
-# SRAM Controller main scrambled access test.
-sram_ctrl_main_scrambled_access_test_lib = declare_dependency(
-  link_with: static_library(
-    'sram_ctrl_main_scrambled_access_test_lib',
-    sources: [
-      hw_ip_rstmgr_reg_h,
-      hw_ip_sram_ctrl_reg_h,
-      'sram_ctrl_main_scrambled_access_test.c',
-    ],
-    dependencies: [
-      sw_lib_dif_rstmgr,
-      sw_lib_dif_sram_ctrl,
-      sw_lib_runtime_log,
-      sw_lib_testing_rstmgr_testutils,
-      sw_lib_testing_sram_ctrl_testutils,
-      top_earlgrey,
-    ],
-  ),
-)
-sw_tests += {
-  'sram_ctrl_main_scrambled_access_test': {
-    'library': sram_ctrl_main_scrambled_access_test_lib,
-  }
-}
-
 # SRAM Controller execution from Ret SRAM test.
 sram_ctrl_execution_test_ret_lib = declare_dependency(
   link_with: static_library(

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -238,3 +238,49 @@ sw_tests += {
     'library': sram_ctrl_execution_test_main_lib,
   }
 }
+
+# SRAM Controller retention scrambled access test.
+sram_ctrl_ret_scrambled_access_test_lib = declare_dependency(
+  link_with: static_library(
+    'sram_ctrl_ret_scrambled_access_test_lib',
+    sources: ['sram_ctrl_ret_scrambled_access_test.c'],
+    dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_dif_sram_ctrl,
+      sw_lib_runtime_log,
+      sw_lib_testing_sram_ctrl_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'sram_ctrl_ret_scrambled_access_test': {
+    'library': sram_ctrl_ret_scrambled_access_test_lib,
+  }
+}
+
+# SRAM Controller main scrambled access test.
+sram_ctrl_main_scrambled_access_test_lib = declare_dependency(
+  link_with: static_library(
+    'sram_ctrl_main_scrambled_access_test_lib',
+    sources: [
+      hw_ip_rstmgr_reg_h,
+      hw_ip_sram_ctrl_reg_h,
+      'sram_ctrl_main_scrambled_access_test.c',
+    ],
+    dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_dif_sram_ctrl,
+      sw_lib_runtime_log,
+      sw_lib_testing_rstmgr_testutils,
+      sw_lib_testing_sram_ctrl_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'sram_ctrl_main_scrambled_access_test': {
+    'library': sram_ctrl_main_scrambled_access_test_lib,
+  }
+}
+


### PR DESCRIPTION
Checks that known data written to main and retention SRAMs is unreadable once the memories have been scrambled.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>