### PR TITLE
[sw/silicon_creator] Additional rollback protection in mask_rom_verify()

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.h
+++ b/sw/device/silicon_creator/lib/boot_data.h
@@ -148,6 +148,17 @@ rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data);
  */
 rom_error_t boot_data_write(const boot_data_t *boot_data);
 
+/**
+ * Checks whether a boot data entry is valid.
+ *
+ * This function checks the `identifier` and `digest` fields of the given
+ * `boot_data` entry.
+ *
+ * @param boot_data A buffer that holds a boot data entry.
+ * @return Whether the digest of the entry is valid.
+ */
+rom_error_t boot_data_check(const boot_data_t *boot_data);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_ERROR_H_
 
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
 
 #define USING_ABSL_STATUS
 #include "sw/device/silicon_creator/lib/absl_status.h"
@@ -138,7 +139,7 @@ typedef enum rom_error {
 /**
  * Evaluate an expression and return if the result is an error.
  *
- * @param expr_ An expression which results in an rom_error_t.
+ * @param expr_ An expression which results in a `rom_error_t`.
  */
 #define RETURN_IF_ERROR(expr_)        \
   do {                                \
@@ -146,7 +147,24 @@ typedef enum rom_error {
     if (local_error_ != kErrorOk) {   \
       return local_error_;            \
     }                                 \
-  } while (0)
+  } while (false)
+
+/**
+ * Hardened version of `RETURN_IF_ERROR()`.
+ *
+ * See `launder32()` and `HARDENED_CHECK_EQ()` in
+ * `sw/device/lib/base/hardened.h` for more details.
+ *
+ * @param expr_ An expression which results in a `rom_error_t`.
+ */
+#define HARDENED_RETURN_IF_ERROR(expr_)  \
+  do {                                   \
+    rom_error_t error_ = expr_;          \
+    if (launder32(error_) != kErrorOk) { \
+      return error_;                     \
+    }                                    \
+    HARDENED_CHECK_EQ(error_, kErrorOk); \
+  } while (false)
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -121,6 +121,7 @@ enum module_ {
   X(kErrorLogBadFormatSpecifier,      ERROR_(1, kModuleLog, kInternal)), \
   X(kErrorBootDataNotFound,           ERROR_(1, kModuleBootData, kInternal)), \
   X(kErrorBootDataWriteCheck,         ERROR_(2, kModuleBootData, kInternal)), \
+  X(kErrorBootDataInvalid,            ERROR_(3, kModuleBootData, kInternal)), \
   X(kErrorShutdownBadLcState,         ERROR_(1, kModuleShutdown, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on

--- a/sw/device/silicon_creator/lib/mock_boot_data.h
+++ b/sw/device/silicon_creator/lib/mock_boot_data.h
@@ -19,6 +19,7 @@ class MockBootData : public GlobalMock<MockBootData> {
   MOCK_METHOD(rom_error_t, Read,
               (lifecycle_state_t lc_state, boot_data_t *boot_data));
   MOCK_METHOD(rom_error_t, Write, (const boot_data_t *boot_data));
+  MOCK_METHOD(rom_error_t, Check, (const boot_data_t *boot_data));
 };
 
 }  // namespace internal
@@ -33,6 +34,10 @@ rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data) {
 
 rom_error_t boot_data_write(const boot_data_t *boot_data) {
   return MockBootData::Instance().Write(boot_data);
+}
+
+rom_error_t boot_data_digest_is_valid(const boot_data *boot_data) {
+  return MockBootData::Instance().Check(boot_data);
 }
 
 }  // extern "C"

--- a/sw/device/silicon_creator/mask_rom/boot_policy.c
+++ b/sw/device/silicon_creator/mask_rom/boot_policy.c
@@ -24,8 +24,8 @@ boot_policy_manifests_t boot_policy_manifests_get(void) {
   };
 }
 
-rom_error_t boot_policy_manifest_check(lifecycle_state_t lc_state,
-                                       const manifest_t *manifest) {
+rom_error_t boot_policy_manifest_check(const manifest_t *manifest,
+                                       const boot_data_t *boot_data) {
   if (manifest->identifier != MANIFEST_IDENTIFIER_ROM_EXT) {
     return kErrorBootPolicyBadIdentifier;
   }
@@ -34,13 +34,11 @@ rom_error_t boot_policy_manifest_check(lifecycle_state_t lc_state,
     return kErrorBootPolicyBadLength;
   }
   RETURN_IF_ERROR(manifest_check(manifest));
-  boot_data_t boot_data;
-  RETURN_IF_ERROR(boot_data_read(lc_state, &boot_data));
 
   if (launder32(manifest->security_version) >=
-      boot_data.min_security_version_rom_ext) {
-    HARDENED_CHECK_GE(launder32(manifest->security_version),
-                      boot_data.min_security_version_rom_ext);
+      boot_data->min_security_version_rom_ext) {
+    HARDENED_CHECK_GE(manifest->security_version,
+                      boot_data->min_security_version_rom_ext);
     return kErrorOk;
   }
   return kErrorBootPolicyRollback;

--- a/sw/device/silicon_creator/mask_rom/boot_policy.h
+++ b/sw/device/silicon_creator/mask_rom/boot_policy.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOT_POLICY_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOT_POLICY_H_
 
+#include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
@@ -52,12 +53,12 @@ boot_policy_manifests_t boot_policy_manifests_get(void);
  * that its `identifier` is correct, and its `security_version` is greater than
  * or equal to the minimum required security version.
  *
- * @param lc_state Life cycle state of the device.
  * @param manifest A ROM_EXT manifest.
+ * @param boot_data Boot data.
  * @return Result of the operation.
  */
-rom_error_t boot_policy_manifest_check(lifecycle_state_t lc_state,
-                                       const manifest_t *manifest);
+rom_error_t boot_policy_manifest_check(const manifest_t *manifest,
+                                       const boot_data_t *boot_data);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -117,7 +117,7 @@ static rom_error_t mask_rom_init(void) {
 static rom_error_t mask_rom_verify(const manifest_t *manifest,
                                    uint32_t *flash_exec) {
   *flash_exec = 0;
-  HARDENED_RETURN_IF_ERROR(boot_policy_manifest_check(lc_state, manifest));
+  HARDENED_RETURN_IF_ERROR(boot_policy_manifest_check(manifest, &boot_data));
 
   const sigverify_rsa_key_t *key;
   HARDENED_RETURN_IF_ERROR(sigverify_rsa_key_get(

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -124,6 +124,16 @@ static rom_error_t mask_rom_verify(const manifest_t *manifest,
       sigverify_rsa_key_id_get(&manifest->modulus), lc_state, &key));
 
   hmac_sha256_init();
+  // Invalidate the digest if the security version of the manifest is smaller
+  // than the minimum required security version.
+  if (launder32(manifest->security_version) <
+      boot_data.min_security_version_rom_ext) {
+    uint32_t extra_word = UINT32_MAX;
+    hmac_sha256_update(&extra_word, sizeof(extra_word));
+  }
+  HARDENED_CHECK_GE(manifest->security_version,
+                    boot_data.min_security_version_rom_ext);
+
   // Hash usage constraints.
   manifest_usage_constraints_t usage_constraints_from_hw;
   sigverify_usage_constraints_get(manifest->usage_constraints.selector_bits,


### PR DESCRIPTION
This PR adds an additional rollback protection in mask_rom_verify() that invalidates the digest computed for signature verification if the security version of the manifest is smaller than the minimum required security version.

Individual commits:
* Remove boot_data_buffer_t
* Add boot_data_check()
* Add HARDENED_RETURN_IF_ERROR() and use in mask_rom.c
* Read boot data in mask_rom_init()
* Add boot_data parameter to boot_policy_manifest_check()
* Additional rollback protection in mask_rom_verify()