### PR TITLE
[dv/mubi] Fix mubi constraints for xcelium

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -79,15 +79,14 @@ package cip_base_pkg;
   // t_weight: randomization weight of the value True
   // f_weight: randomization weight of the value False
   // other_weight: collective randomization weight of all values other than True or False
-  `define _DV_MUBI_RAND_VAL(WIDTH_) \
-    function automatic mubi``WIDTH_``_t get_rand_mubi``WIDTH_``_val( \
-        int t_weight = 2, int f_weight = 2, int other_weight = 1); \
-      bit[WIDTH_-1:0] val; \
-      int             scaling = (1 << WIDTH_) - 2; \
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val, \
-          `DV_MUBI``WIDTH_``_DIST(val, t_weight * scaling, f_weight * scaling, other_weight), , \
-                                         msg_id) \
-      return mubi``WIDTH_``_t'(val); \
+  `define _DV_MUBI_RAND_VAL(WIDTH_)                                         \
+    function automatic mubi``WIDTH_``_t get_rand_mubi``WIDTH_``_val(        \
+        int t_weight = 2, int f_weight = 2, int other_weight = 1);          \
+      bit[WIDTH_-1:0] val;                                                  \
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(val,                               \
+          `DV_MUBI``WIDTH_``_DIST(val, t_weight, f_weight, other_weight), , \
+                                         msg_id)                            \
+      return mubi``WIDTH_``_t'(val);                                        \
     endfunction
 
   // Create function - get_rand_mubi4_val

--- a/hw/dv/sv/cip_lib/cip_macros.svh
+++ b/hw/dv/sv/cip_lib/cip_macros.svh
@@ -48,21 +48,26 @@
 `endif
 
 // A macro to simplify the distribution constraint of mubi type variable
-// Don't use this macro directly, use DV_MUBI4|8|16_DIST
+// Don't use this macro directly, use DV_MUBI4|8|16_DIST.
+// The weights of both TRUE and FALSE are scaled by the number of other
+// values, and this uses ":=" for the distribution of other values, so they
+// are truly uniform.
+// The MAX_ argument is the maximum value that VAR_ can take, which means
+// (MAX_ - 1) is the scaling factor.
 `ifndef _DV_MUBI_DIST
-`define _DV_MUBI_DIST(VAR_, TRUE_, FALSE_, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_) \
+`define _DV_MUBI_DIST(VAR_, TRUE_, FALSE_, MAX_, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_) \
   if (TRUE_ > FALSE_) { \
-    VAR_ dist {TRUE_                         := T_WEIGHT_,      \
-               FALSE_                        := F_WEIGHT_,      \
-               [0 : FALSE_ - 1]              := OTHER_WEIGHT_,  \
-               [FALSE_ + 1 : TRUE_ - 1]      := OTHER_WEIGHT_,  \
-               [TRUE_ + 1 : type(VAR_)'('1)] := OTHER_WEIGHT_}; \
-  } else {                                                      \
-    VAR_ dist {TRUE_                         := T_WEIGHT_,      \
-               FALSE_                        := F_WEIGHT_,      \
-               [0 : TRUE_ - 1]               := OTHER_WEIGHT_,  \
-               [TRUE_ + 1 : FALSE_ - 1]      := OTHER_WEIGHT_,  \
-               [FALSE_+ 1 : type(VAR_)'('1)] := OTHER_WEIGHT_}; \
+    VAR_ dist {TRUE_                         := T_WEIGHT_ * (MAX_ - 1), \
+               FALSE_                        := F_WEIGHT_ * (MAX_ - 1), \
+               [0 : FALSE_ - 1]              := OTHER_WEIGHT_,          \
+               [FALSE_ + 1 : TRUE_ - 1]      := OTHER_WEIGHT_,          \
+               [TRUE_ + 1 : MAX_]            := OTHER_WEIGHT_};         \
+  } else {                                                              \
+    VAR_ dist {TRUE_                         := T_WEIGHT_ * (MAX_ - 1), \
+               FALSE_                        := F_WEIGHT_ * (MAX_ - 1), \
+               [0 : TRUE_ - 1]               := OTHER_WEIGHT_,          \
+               [TRUE_ + 1 : FALSE_ - 1]      := OTHER_WEIGHT_,          \
+               [FALSE_+ 1 : MAX_]            := OTHER_WEIGHT_};         \
   }
 `endif
 
@@ -73,22 +78,22 @@
 // OTHER_WEIGHT_: randomization weight of values other than True or False
 `ifndef DV_MUBI4_DIST
 `define DV_MUBI4_DIST(VAR_, T_WEIGHT_ = 2, F_WEIGHT_ = 2, OTHER_WEIGHT_ = 1) \
-  `_DV_MUBI_DIST(VAR_, MuBi4True, MuBi4False, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
+  `_DV_MUBI_DIST(VAR_, MuBi4True, MuBi4False, (1 << 4) - 1, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
 `endif
 
 `ifndef DV_MUBI8_DIST
 `define DV_MUBI8_DIST(VAR_, T_WEIGHT_ = 2, F_WEIGHT_ = 2, OTHER_WEIGHT_ = 1) \
-  `_DV_MUBI_DIST(VAR_, MuBi8True, MuBi8False, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
+  `_DV_MUBI_DIST(VAR_, MuBi8True, MuBi8False, (1 << 8) - 1, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
 `endif
 
 `ifndef DV_MUBI12_DIST
 `define DV_MUBI12_DIST(VAR_, T_WEIGHT_ = 2, F_WEIGHT_ = 2, OTHER_WEIGHT_ = 1) \
-  `_DV_MUBI_DIST(VAR_, MuBi12True, MuBi12False, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
+  `_DV_MUBI_DIST(VAR_, MuBi12True, MuBi12False, (1 << 12) - 1,T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
 `endif
 
 `ifndef DV_MUBI16_DIST
 `define DV_MUBI16_DIST(VAR_, T_WEIGHT_ = 2, F_WEIGHT_ = 2, OTHER_WEIGHT_ = 1) \
-  `_DV_MUBI_DIST(VAR_, MuBi16True, MuBi16False, T_WEIGHT_, F_WEIGHT_, OTHER_WEIGHT_)
+  `_DV_MUBI_DIST(VAR_, MuBi16True, MuBi16False, T_WEIGHT_, (1 << 16) - 1, F_WEIGHT_, OTHER_WEIGHT_)
 `endif
 
 `endif  // __CIP_MACROS_SVH__


### PR DESCRIPTION
Apparently xcelium cannot read with the type casts here, so use a
simpler scheme to find the maximum value in the range.

Signed-off-by: Guillermo Maturana <maturana@google.com>