### PR TITLE
[lc_ctrl] Beef up security of the token mux and transition matrix LUT

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -390,6 +390,14 @@
             24 state transitions in order to guard against bruteforcing.
             '''
     }
+    { name: "STATE.CONFIG.SPARSE",
+      desc: '''
+            The decoded manufacturing state uses a replicated enum encoding to fill the 32bit
+            value exposed in the CSRs (both the LC_STATE and TRANSITION_TARGET registers).
+            This is done to 1) ease hardening of firmware code, and 2) to ensure that even the decoded
+            life cycle state vector inside the life cycle controller still has a redundant encoding.
+            '''
+    }
     { name: "MAIN.FSM.SPARSE",
       desc: "The main state FSM is sparsely encoded."
     }

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -54,22 +54,10 @@
       randcount: "128",
       randtype:  "data",
     }
-    { name:      "RndCnstRmaTokenInvalid",
-      desc:      "Compile-time random bits used as token value if the token is not valid",
-      type:      "lc_ctrl_state_pkg::lc_token_t",
-      randcount: "128",
-      randtype:  "data",
-    }
-    { name:      "RndCnstTestUnlockTokenInvalid",
-      desc:      "Compile-time random bits used as token value if the token is not valid",
-      type:      "lc_ctrl_state_pkg::lc_token_t",
-      randcount: "128",
-      randtype:  "data",
-    }
-    { name:      "RndCnstTestExitTokenInvalid",
-      desc:      "Compile-time random bits used as token value if the token is not valid",
-      type:      "lc_ctrl_state_pkg::lc_token_t",
-      randcount: "128",
+    { name:      "RndCnstInvalidTokens",
+      desc:      "Compile-time random bits used for invalid tokens in the token mux",
+      type:      "lc_ctrl_pkg::lc_token_mux_t",
+      randcount: "1024",
       randtype:  "data",
     }
     // Regular parameters
@@ -430,9 +418,27 @@
     { name: "INTERSIG.MUBI",
       desc: "Life cycle control signals are multibit encoded."
     }
+    { name: "TOKEN_VALID.CTRL.MUBI",
+      desc: "The token valid signals coming from OTP are MUBI encoded."
+    }
     { name: "TOKEN.DIGEST",
       desc: "Life cycle transition tokens are hashed with cSHAKE128, using a custom 'LC_CTRL' prefix."
     }
+    { name: "TOKEN_MUX.CTRL.REDUN",
+      desc: '''
+            The life cycle transition token mux is broken into two halves that are steered with
+            separately decoded and buffered MUBI valid signals (see also TOKEN_VALID.CTRL.MUBI).
+            '''
+    }
+    { name: "TOKEN_VALID.MUX.REDUN",
+      desc: '''
+            The life cycle transition token valid mux is replicated twice.
+            If a transition is initiated and the two mux index signals are inconsistent
+            or if any of the two valid mux outputs is not set to valid, the transition will
+            fail with a TRANSITION_ERROR.
+            '''
+    }
+
   ]
 
   registers: [

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -122,7 +122,7 @@ module lc_ctrl
   lc_ctrl_reg_pkg::lc_ctrl_reg2hw_t reg2hw;
   lc_ctrl_reg_pkg::lc_ctrl_hw2reg_t hw2reg;
 
-  // SEC_CM: TRANSITION.CONFIG.REGWEN
+  // SEC_CM: TRANSITION.CONFIG.REGWEN, STATE.CONFIG.SPARSE
   logic fatal_bus_integ_error_q, fatal_bus_integ_error_d;
   lc_ctrl_reg_top u_reg (
     .clk_i,
@@ -278,9 +278,9 @@ module lc_ctrl
   lc_token_t     transition_token_d, transition_token_q;
   ext_dec_lc_state_t transition_target_d, transition_target_q;
   // No need to register these.
-  dec_lc_state_e    dec_lc_state;
-  dec_lc_cnt_t      dec_lc_cnt;
-  dec_lc_id_state_e dec_lc_id_state;
+  ext_dec_lc_state_t dec_lc_state;
+  dec_lc_cnt_t       dec_lc_cnt;
+  dec_lc_id_state_e  dec_lc_id_state;
 
   logic lc_idle_d;
 
@@ -301,7 +301,7 @@ module lc_ctrl
     hw2reg.status.state_error            = fatal_state_error_q;
     hw2reg.status.otp_partition_error    = otp_part_error_q;
     hw2reg.status.bus_integ_error        = fatal_bus_integ_error_q;
-    hw2reg.lc_state                      = {DecLcStateNumRep{dec_lc_state}};
+    hw2reg.lc_state                      = dec_lc_state;
     hw2reg.lc_transition_cnt             = dec_lc_cnt;
     hw2reg.lc_id_state                   = {DecLcIdStateNumRep{dec_lc_id_state}};
     hw2reg.device_id                     = otp_device_id_i;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -20,9 +20,7 @@ module lc_ctrl
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivInvalid    = LcKeymgrDivWidth'(0),
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivTestDevRma = LcKeymgrDivWidth'(1),
   parameter lc_keymgr_div_t RndCnstLcKeymgrDivProduction = LcKeymgrDivWidth'(2),
-  parameter lc_token_t RndCnstRmaTokenInvalid        = LcTokenWidth'(8'hAA),
-  parameter lc_token_t RndCnstTestUnlockTokenInvalid = LcTokenWidth'(8'hBB),
-  parameter lc_token_t RndCnstTestExitTokenInvalid   = LcTokenWidth'(8'hCC)
+  parameter lc_token_mux_t  RndCnstInvalidTokens         = {TokenMuxBits{1'b1}}
 ) (
   // Life cycle controller clock
   input                                              clk_i,
@@ -66,6 +64,7 @@ module lc_ctrl
   output kmac_pkg::app_req_t                         kmac_data_o,
   // OTP broadcast outputs
   // No sync required since LC and OTP are in the same clock domain.
+  // SEC_CM: TOKEN_VALID.CTRL.MUBI
   input  otp_ctrl_pkg::otp_lc_data_t                 otp_lc_data_i,
   // Life cycle broadcast outputs (all of them are registered).
   // SEC_CM: INTERSIG.MUBI
@@ -621,9 +620,7 @@ module lc_ctrl
     .RndCnstLcKeymgrDivInvalid     ( RndCnstLcKeymgrDivInvalid     ),
     .RndCnstLcKeymgrDivTestDevRma  ( RndCnstLcKeymgrDivTestDevRma  ),
     .RndCnstLcKeymgrDivProduction  ( RndCnstLcKeymgrDivProduction  ),
-    .RndCnstRmaTokenInvalid        ( RndCnstRmaTokenInvalid        ),
-    .RndCnstTestUnlockTokenInvalid ( RndCnstTestUnlockTokenInvalid ),
-    .RndCnstTestExitTokenInvalid   ( RndCnstTestExitTokenInvalid   )
+    .RndCnstInvalidTokens          ( RndCnstInvalidTokens          )
   ) u_lc_ctrl_fsm (
     .clk_i,
     .rst_ni,

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -27,6 +27,9 @@ package lc_ctrl_pkg;
     InvalidTokenIdx    = 3'h5
   } token_idx_e;
 
+  parameter int TokenMuxBits = 2**TokenIdxWidth*LcTokenWidth;
+  typedef logic [TokenMuxBits-1:0] lc_token_mux_t;
+
   ////////////////////////////////
   // Typedefs for LC Interfaces //
   ////////////////////////////////

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_state_decode.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_state_decode.sv
@@ -16,7 +16,7 @@ module lc_ctrl_state_decode
   // Main FSM state.
   input  fsm_state_e        fsm_state_i,
   // Decoded state vector.
-  output dec_lc_state_e     dec_lc_state_o,
+  output ext_dec_lc_state_t dec_lc_state_o,
   output dec_lc_id_state_e  dec_lc_id_state_o,
   output dec_lc_cnt_t       dec_lc_cnt_o,
   output logic [5:0]        state_invalid_error_o
@@ -26,13 +26,24 @@ module lc_ctrl_state_decode
   // Signal Decoder Logic //
   //////////////////////////
 
+  // SEC_CM: STATE.CONFIG.SPARSE
+  // The decoded life cycle state uses a redundant representation that is used internally
+  // and in the CSR node.
+  ext_dec_lc_state_t dec_lc_state;
+  prim_sec_anchor_buf #(
+    .Width($bits(ext_dec_lc_state_t))
+  ) u_prim_sec_anchor_buf (
+    .in_i(dec_lc_state),
+    .out_o(dec_lc_state_o)
+  );
+
   // The decoder logic below decodes the life cycle state vector and counter
   // into a format that can be exposed in the CSRs. If the state is invalid,
   // this will be flagged as well.
 
   always_comb begin : p_lc_state_decode
     // Decoded state defaults
-    dec_lc_state_o        = DecLcStInvalid;
+    dec_lc_state        = {DecLcStateNumRep{DecLcStInvalid}};
     dec_lc_cnt_o          = {DecLcCountWidth{1'b1}};
     dec_lc_id_state_o     = DecLcIdInvalid;
     state_invalid_error_o = '0;
@@ -42,9 +53,9 @@ module lc_ctrl_state_decode
       ResetSt: ;
       // These are temporary, terminal states that are not encoded
       // in the persistent LC state vector from OTP, hence we decode them first.
-      EscalateSt:  dec_lc_state_o = DecLcStEscalate;
-      PostTransSt: dec_lc_state_o = DecLcStPostTrans;
-      InvalidSt:   dec_lc_state_o = DecLcStInvalid;
+      EscalateSt:  dec_lc_state = {DecLcStateNumRep{DecLcStEscalate}};
+      PostTransSt: dec_lc_state = {DecLcStateNumRep{DecLcStPostTrans}};
+      InvalidSt:   dec_lc_state = {DecLcStateNumRep{DecLcStInvalid}};
       // Otherwise check and decode the life cycle state continously.
       default: begin
         // Note that we require that the valid signal from OTP is
@@ -55,27 +66,27 @@ module lc_ctrl_state_decode
         state_invalid_error_o[0] = ~lc_state_valid_i;
 
         unique case (lc_state_i)
-          LcStRaw:           dec_lc_state_o = DecLcStRaw;
-          LcStTestUnlocked0: dec_lc_state_o = DecLcStTestUnlocked0;
-          LcStTestLocked0:   dec_lc_state_o = DecLcStTestLocked0;
-          LcStTestUnlocked1: dec_lc_state_o = DecLcStTestUnlocked1;
-          LcStTestLocked1:   dec_lc_state_o = DecLcStTestLocked1;
-          LcStTestUnlocked2: dec_lc_state_o = DecLcStTestUnlocked2;
-          LcStTestLocked2:   dec_lc_state_o = DecLcStTestLocked2;
-          LcStTestUnlocked3: dec_lc_state_o = DecLcStTestUnlocked3;
-          LcStTestLocked3:   dec_lc_state_o = DecLcStTestLocked3;
-          LcStTestUnlocked4: dec_lc_state_o = DecLcStTestUnlocked4;
-          LcStTestLocked4:   dec_lc_state_o = DecLcStTestLocked4;
-          LcStTestUnlocked5: dec_lc_state_o = DecLcStTestUnlocked5;
-          LcStTestLocked5:   dec_lc_state_o = DecLcStTestLocked5;
-          LcStTestUnlocked6: dec_lc_state_o = DecLcStTestUnlocked6;
-          LcStTestLocked6:   dec_lc_state_o = DecLcStTestLocked6;
-          LcStTestUnlocked7: dec_lc_state_o = DecLcStTestUnlocked7;
-          LcStDev:           dec_lc_state_o = DecLcStDev;
-          LcStProd:          dec_lc_state_o = DecLcStProd;
-          LcStProdEnd:       dec_lc_state_o = DecLcStProdEnd;
-          LcStRma:           dec_lc_state_o = DecLcStRma;
-          LcStScrap:         dec_lc_state_o = DecLcStScrap;
+          LcStRaw:           dec_lc_state = {DecLcStateNumRep{DecLcStRaw}};
+          LcStTestUnlocked0: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked0}};
+          LcStTestLocked0:   dec_lc_state = {DecLcStateNumRep{DecLcStTestLocked0}};
+          LcStTestUnlocked1: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked1}};
+          LcStTestLocked1:   dec_lc_state = {DecLcStateNumRep{DecLcStTestLocked1}};
+          LcStTestUnlocked2: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked2}};
+          LcStTestLocked2:   dec_lc_state = {DecLcStateNumRep{DecLcStTestLocked2}};
+          LcStTestUnlocked3: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked3}};
+          LcStTestLocked3:   dec_lc_state = {DecLcStateNumRep{DecLcStTestLocked3}};
+          LcStTestUnlocked4: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked4}};
+          LcStTestLocked4:   dec_lc_state = {DecLcStateNumRep{DecLcStTestLocked4}};
+          LcStTestUnlocked5: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked5}};
+          LcStTestLocked5:   dec_lc_state = {DecLcStateNumRep{DecLcStTestLocked5}};
+          LcStTestUnlocked6: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked6}};
+          LcStTestLocked6:   dec_lc_state = {DecLcStateNumRep{DecLcStTestLocked6}};
+          LcStTestUnlocked7: dec_lc_state = {DecLcStateNumRep{DecLcStTestUnlocked7}};
+          LcStDev:           dec_lc_state = {DecLcStateNumRep{DecLcStDev}};
+          LcStProd:          dec_lc_state = {DecLcStateNumRep{DecLcStProd}};
+          LcStProdEnd:       dec_lc_state = {DecLcStateNumRep{DecLcStProdEnd}};
+          LcStRma:           dec_lc_state = {DecLcStateNumRep{DecLcStRma}};
+          LcStScrap:         dec_lc_state = {DecLcStateNumRep{DecLcStScrap}};
           // SEC_CM: MANUF.STATE.BKGN_CHK
           default:           state_invalid_error_o[1] = 1'b1;
         endcase // lc_state_i

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1644,34 +1644,14 @@
           randwidth: 128
         }
         {
-          name: RndCnstRmaTokenInvalid
-          desc: Compile-time random bits used as token value if the token is not valid
-          type: lc_ctrl_state_pkg::lc_token_t
-          randcount: 128
+          name: RndCnstInvalidTokens
+          desc: Compile-time random bits used for invalid tokens in the token mux
+          type: lc_ctrl_pkg::lc_token_mux_t
+          randcount: 1024
           randtype: data
-          name_top: RndCnstLcCtrlRmaTokenInvalid
-          default: 0x3a0b091dc41d062dd10ca2d7b93136f
-          randwidth: 128
-        }
-        {
-          name: RndCnstTestUnlockTokenInvalid
-          desc: Compile-time random bits used as token value if the token is not valid
-          type: lc_ctrl_state_pkg::lc_token_t
-          randcount: 128
-          randtype: data
-          name_top: RndCnstLcCtrlTestUnlockTokenInvalid
-          default: 0xee2a465fd4dabcbd877afb6bcfeed7e
-          randwidth: 128
-        }
-        {
-          name: RndCnstTestExitTokenInvalid
-          desc: Compile-time random bits used as token value if the token is not valid
-          type: lc_ctrl_state_pkg::lc_token_t
-          randcount: 128
-          randtype: data
-          name_top: RndCnstLcCtrlTestExitTokenInvalid
-          default: 0x3c91917516d51a2fa4400adc2669e253
-          randwidth: 128
+          name_top: RndCnstLcCtrlInvalidTokens
+          default: 0xe0f7489a309cbe57b77f07ff3d7297200d5ab25561af49c696466a983e5346826a43628219e5a91389b9fe0d3b818e46ce7d846469a3b8e35a6bd38295bd2fb366b3d62126c75eeaeb93d32f5cbc77463c91917516d51a2fa4400adc2669e2530ee2a465fd4dabcbd877afb6bcfeed7e03a0b091dc41d062dd10ca2d7b93136f
+          randwidth: 1024
         }
       ]
       inter_signal_list:
@@ -2130,7 +2110,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0x5cbc7746
+          default: 0xf1435f85
           randwidth: 32
         }
         {
@@ -2140,7 +2120,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0xb9702781ca9da90e7c883543eeeb6389f2d5c989
+          default: 0x8a9e933b2126cbfc2e87af8121b39db89bab4d10
           randwidth: 160
         }
       ]
@@ -3944,7 +3924,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0xe21ffdf7075a864cb4daab803225b91e
+          default: 0x3af5fa0aaf8c6a6b90f868a3f2590e4a
           randwidth: 128
         }
         {
@@ -3954,7 +3934,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0x47e71b5c0205ae5e5feed81e0cb15451
+          default: 0x67eb674bbdf38d62d362249384b1a5a6
           randwidth: 128
         }
         {
@@ -3964,7 +3944,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstSramCtrlRetAonLfsrSeed
-          default: 0x1702ef71
+          default: 0x89ecd94b
           randwidth: 32
         }
         {
@@ -3974,7 +3954,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlRetAonLfsrPerm
-          default: 0xa593f517835ddcd09006f47b03ea5960ab846df3
+          default: 0x3d96ced1f5b89d2e422a2b71b9fb440a723400df
           randwidth: 160
         }
         {
@@ -4151,7 +4131,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0xd417df2f55255e182efed724cf837046
+          default: 0x8440934dcb834f93689fe9e88ebd5340
           randwidth: 128
         }
         {
@@ -4161,7 +4141,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0xf70a5b088fefbc18548dfcb2fd145395
+          default: 0x192aadbb7c918acb0af06b42350bb6b6
           randwidth: 128
         }
         {
@@ -4171,7 +4151,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0x102f4c28
+          default: 0x871cb178
           randwidth: 32
         }
         {
@@ -4181,7 +4161,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0xeba451575157868b9f266eff382c017d989c7094
+          default: 0x3580d1897f7cb7dc51419f8b7d5630e65c441d2c
           randwidth: 160
         }
       ]
@@ -4823,7 +4803,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstAesClearingLfsrSeed
-          default: 0x4ad181a3be2d2767
+          default: 0x8e18edeb46b20763
           randwidth: 64
         }
         {
@@ -4833,7 +4813,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingLfsrPerm
-          default: 0x9d7e68ebc6ed5b034b3e40ae040ce5d9ad18acccb12667a213e1d3bf5577778f438d12a0219b1f40efc5512721ee9a86
+          default: 0x5cf6536a2ee3e49d22a36fa59ea2c4620d062f69f5f3209dc203ee4c87ff199b2af013b1ed4e0395175c5dd94e29d06
           randwidth: 384
         }
         {
@@ -4843,7 +4823,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstAesClearingSharePerm
-          default: 0x2837d9dfcb60e8bc7431a89c6c136576c254780feb5bdf8eba84b092f239cb51d1a671a3857e0fa85cc44f699054263b
+          default: 0x57ec2e416728b1fd9d00a60c08d538de2c75cc325a65e95b98bac182f10eeb4e52f2a93d22d3f24c51d1a7f1a387b5e7
           randwidth: 384
         }
         {
@@ -4853,7 +4833,7 @@
           randcount: 160
           randtype: data
           name_top: RndCnstAesMaskingLfsrSeed
-          default: 0xb978c925193f36d89ece5f177e58b7ba1ba4dca2
+          default: 0x5147f1ef84f4b3a9d281437d77f970022c91c1a2
           randwidth: 160
         }
         {
@@ -4863,7 +4843,7 @@
           randcount: 160
           randtype: perm
           name_top: RndCnstAesMaskingLfsrPerm
-          default: 0xb537b3a742586214d711055987e642841830732425b233624271a3b884b115a7c3d91379d44897a298f139e5c39676d8e62471243690a755d787f339b6a5240149a031c724a6b48093e0e2f1d150d1f93951787044e3f941b73822b8d660c269f450f354f761e684c57188b798c96706c978000018a58469c2250996e605f2a65597d8119023c163063902d3120923405085485385184772c2e49565e06616f
+          default: 0x8a88993a824011121a5e9a4936802793375f2e640110219e6607524d796847435a3b257f67298e72469c239506756b614869422c91506a7b76733d60327141132439704a0b908b28977c4b1455841c89569653095d3e0e2f1d150d1f8f511792048d4e3f9f1b83742b6298770c26226e450f6d356f4f581e7e784c6c57187a5b86943300030a445c2a65597d818719023c8c1630639b2d31209d340508548538
           randwidth: 1280
         }
       ]
@@ -5097,7 +5077,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacLfsrPerm
-          default: 0xad9885b9785b3fc6b67f29c1411837cdc7b958d6130152a3f6a1cce0352cee89b022fd1db46fc92f14a53b50bafa9904
+          default: 0x58560fbde2b6ca5ec0360ab98e1f13c1cd1ff9b890459ffdb129d5a5ad41aeecf11e430e0d4dc2a26e08e8b76d184257
           randwidth: 384
         }
       ]
@@ -5251,7 +5231,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndPrngSeed
-          default: 0x15891b60c560a7fb75457e09e258c252c3083125be14e22d044c7bd9e98eb284
+          default: 0x93bf7d52c8a744ad83d2630b2af4ec91410d0bd90b447e3291b8e6cb502bf90b
           randwidth: 256
         }
         {
@@ -5261,7 +5241,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0xdda4c0a399420265983d914e80a925bc
+          default: 0xd4cd7f1bdce673b937a6d75202fedbf8
           randwidth: 128
         }
         {
@@ -5271,7 +5251,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0xd95cd1c662bdae87
+          default: 0xe3e8d3f817a9838d
           randwidth: 64
         }
       ]
@@ -5442,7 +5422,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0x562ce22f82424801
+          default: 0x8aaa4783f2b5e094
           randwidth: 64
         }
         {
@@ -5452,7 +5432,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKeymgrLfsrPerm
-          default: 0x6bc39971578c9add918eb1d75b40fa12fa3dfc195f9f8a6a74be6e609b1b206c3eee214d037ca02900a4513cf1852d4f
+          default: 0x3ff5949ae5ec2a7733679af7d4d134be31def65b50383855f22eda45f09207833e74b4f617aa98a09ca4a5bc481b0020
           randwidth: 384
         }
         {
@@ -5462,7 +5442,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstKeymgrRandPerm
-          default: 0x640df7e2b41b9496c742974b925ce0e23cbb4c3b
+          default: 0x3bdbc56fe25e188ab805b8532366daed27088fc4
           randwidth: 160
         }
         {
@@ -5472,7 +5452,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrRevisionSeed
-          default: 0x80a8d540ce8fd0cd3d3bc1416c0834af84dc448f6a9887a8e3ed3cd5ea91a34a
+          default: 0x40d7d8470e011cf1b1987a780af5815cf779ee523615334390cf654ec6352adf
           randwidth: 256
         }
         {
@@ -5482,7 +5462,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrCreatorIdentitySeed
-          default: 0x95ec8aa1ba59ceee7530a14494e10193220b62d997f24a95f0c5e668a34ce097
+          default: 0xe8f6679035da35061952cd5387f9fb727236a121e1e0ff0a4fd70234bb32ea72
           randwidth: 256
         }
         {
@@ -5492,7 +5472,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIntIdentitySeed
-          default: 0xf779ee523615334390cf654ec6352adf5010157d1342bd7b2ee4c310defc471b
+          default: 0x9e8e5600260058176d17f3660ebad9424ae5e2cf5e723b547cb4949b21b3decf
           randwidth: 256
         }
         {
@@ -5502,7 +5482,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOwnerIdentitySeed
-          default: 0x7236a121e1e0ff0a4fd70234bb32ea7240d7d8470e011cf1b1987a780af5815c
+          default: 0x7d8490dc838e24fafe4257bcd0d4af885661e47d54c36f827b99dcc91893c0ce
           randwidth: 256
         }
         {
@@ -5512,7 +5492,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrSoftOutputSeed
-          default: 0x4ae5e2cf5e723b547cb4949b21b3decfe8f6679035da35061952cd5387f9fb72
+          default: 0x62ca8d4d838b3501e1cbebb834986e64be66e95792c3d8eafd0bc4de80468fd
           randwidth: 256
         }
         {
@@ -5522,7 +5502,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrHardOutputSeed
-          default: 0x5661e47d54c36f827b99dcc91893c0ce9e8e5600260058176d17f3660ebad942
+          default: 0x56cbeefc913b5ff592bbc26408e95bdbe8bc8757cc921f3c920c664026717440
           randwidth: 256
         }
         {
@@ -5532,7 +5512,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrAesSeed
-          default: 0x4be66e95792c3d8eafd0bc4de80468fd7d8490dc838e24fafe4257bcd0d4af88
+          default: 0x740aabd84d6481d22fe896642a15985eb9ecde94c6064c512f50996293612ad0
           randwidth: 256
         }
         {
@@ -5542,7 +5522,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrKmacSeed
-          default: 0xe8bc8757cc921f3c920c664026717440062ca8d4d838b3501e1cbebb834986e6
+          default: 0xbfafcbebd7c3361357bee83e46164c82a0c86b9c1ef6117215c2e6fcb683d3a9
           randwidth: 256
         }
         {
@@ -5552,7 +5532,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrOtbnSeed
-          default: 0xb9ecde94c6064c512f50996293612ad056cbeefc913b5ff592bbc26408e95bdb
+          default: 0xdf2a87abf7c57a6d06f2e1721e3a5f3b217d62acf1c966c712691421cef76350
           randwidth: 256
         }
         {
@@ -5562,7 +5542,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstKeymgrNoneSeed
-          default: 0xa0c86b9c1ef6117215c2e6fcb683d3a9740aabd84d6481d22fe896642a15985e
+          default: 0x5910642e0f9946cb60f5f7d233a13b89bfc3162d205b4d60c9b16a8eb0aa75fa
           randwidth: 256
         }
       ]
@@ -5772,7 +5752,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivNonProduction
-          default: 0xdf2a87abf7c57a6d06f2e1721e3a5f3b217d62acf1c966c712691421cef76350bfafcbebd7c3361357bee83e46164c82
+          default: 0x2e53c3844212490ced20e7e16f71067e30ac79eec48e320bdcfa32f724f82840fdaced02da0253d803d1cdf325afff8b
           randwidth: 384
         }
         {
@@ -5782,7 +5762,7 @@
           randcount: 384
           randtype: data
           name_top: RndCnstCsrngCsKeymgrDivProduction
-          default: 0xfdaced02da0253d803d1cdf325afff8b5910642e0f9946cb60f5f7d233a13b89bfc3162d205b4d60c9b16a8eb0aa75fa
+          default: 0xb00fe9a3a2be362bc57ce4588424f90946b441fa5e08b2317fb3e9032db9eddf8db302ed56b78538c92ba96fe7ba5d88
           randwidth: 384
         }
         {
@@ -6246,7 +6226,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramKey
-          default: 0x30ac79eec48e320bdcfa32f724f82840
+          default: 0xd52654489a981b7bdc91865141701fd5
           randwidth: 128
         }
         {
@@ -6256,7 +6236,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlMainSramNonce
-          default: 0x2e53c3844212490ced20e7e16f71067e
+          default: 0xd05781d31c4b4dab379c12b6681950e6
           randwidth: 128
         }
         {
@@ -6266,7 +6246,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstSramCtrlMainLfsrSeed
-          default: 0xe7ba5d88
+          default: 0xe179c299
           randwidth: 32
         }
         {
@@ -6276,7 +6256,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlMainLfsrPerm
-          default: 0x26fce91ccccbe2d84fe50ccd9ead4c410b79635
+          default: 0xb70c2fade19b3353836a4ea5e4162d812fd70f14
           randwidth: 160
         }
         {
@@ -6447,7 +6427,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstRomCtrlScrNonce
-          default: 0xeb63a613068d71d
+          default: 0x19a51f55617306d3
           randwidth: 64
         }
         {
@@ -6457,7 +6437,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstRomCtrlScrKey
-          default: 0xc967eaa9fc47e9e7507d72b87001fa7b
+          default: 0xacebe93343ed6321c82c19be70b04c05
           randwidth: 128
         }
         {
@@ -6631,7 +6611,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstRvCoreIbexLfsrSeed
-          default: 0x406d9d57
+          default: 0x4fedb1e5
           randwidth: 32
         }
         {
@@ -6641,7 +6621,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstRvCoreIbexLfsrPerm
-          default: 0xdc03cc122d518f3c805643b555b125a7c7e7cafd
+          default: 0xc74d7925041c0ba9aea26d1f6f823963b9b387ca
           randwidth: 160
         }
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1498,9 +1498,7 @@ module top_earlgrey #(
     .RndCnstLcKeymgrDivInvalid(RndCnstLcCtrlLcKeymgrDivInvalid),
     .RndCnstLcKeymgrDivTestDevRma(RndCnstLcCtrlLcKeymgrDivTestDevRma),
     .RndCnstLcKeymgrDivProduction(RndCnstLcCtrlLcKeymgrDivProduction),
-    .RndCnstRmaTokenInvalid(RndCnstLcCtrlRmaTokenInvalid),
-    .RndCnstTestUnlockTokenInvalid(RndCnstLcCtrlTestUnlockTokenInvalid),
-    .RndCnstTestExitTokenInvalid(RndCnstLcCtrlTestExitTokenInvalid)
+    .RndCnstInvalidTokens(RndCnstLcCtrlInvalidTokens)
   ) u_lc_ctrl (
       // [15]: fatal_prog_error
       // [16]: fatal_state_error

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -43,19 +43,12 @@ package top_earlgrey_rnd_cnst_pkg;
     128'h79EE911CE801484BA8373086F9DD4EEE
   };
 
-  // Compile-time random bits used as token value if the token is not valid
-  parameter lc_ctrl_state_pkg::lc_token_t RndCnstLcCtrlRmaTokenInvalid = {
-    128'h03A0B091DC41D062DD10CA2D7B93136F
-  };
-
-  // Compile-time random bits used as token value if the token is not valid
-  parameter lc_ctrl_state_pkg::lc_token_t RndCnstLcCtrlTestUnlockTokenInvalid = {
-    128'h0EE2A465FD4DABCBD877AFB6BCFEED7E
-  };
-
-  // Compile-time random bits used as token value if the token is not valid
-  parameter lc_ctrl_state_pkg::lc_token_t RndCnstLcCtrlTestExitTokenInvalid = {
-    128'h3C91917516D51A2FA4400ADC2669E253
+  // Compile-time random bits used for invalid tokens in the token mux
+  parameter lc_ctrl_pkg::lc_token_mux_t RndCnstLcCtrlInvalidTokens = {
+    256'hE0F7489A309CBE57B77F07FF3D7297200D5AB25561AF49C696466A983E534682,
+    256'h6A43628219E5A91389B9FE0D3B818E46CE7D846469A3B8E35A6BD38295BD2FB3,
+    256'h66B3D62126C75EEAEB93D32F5CBC77463C91917516D51A2FA4400ADC2669E253,
+    256'h0EE2A465FD4DABCBD877AFB6BCFEED7E03A0B091DC41D062DD10CA2D7B93136F
   };
 
   ////////////////////////////////////////////
@@ -63,12 +56,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'h5CBC7746
+    32'hF1435F85
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'hB9702781CA9DA90E7C883543EEEB6389F2D5C989
+    160'h8A9E933B2126CBFC2E87AF8121B39DB89BAB4D10
   };
 
   ////////////////////////////////////////////
@@ -76,22 +69,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'hE21FFDF7075A864CB4DAAB803225B91E
+    128'h3AF5FA0AAF8C6A6B90F868A3F2590E4A
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'h47E71B5C0205AE5E5FEED81E0CB15451
+    128'h67EB674BBDF38D62D362249384B1A5A6
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlRetAonLfsrSeed = {
-    32'h1702EF71
+    32'h89ECD94B
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonLfsrPerm = {
-    160'hA593F517835DDCD09006F47B03EA5960AB846DF3
+    160'h3D96CED1F5B89D2E422A2B71B9FB440A723400DF
   };
 
   ////////////////////////////////////////////
@@ -99,22 +92,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'hD417DF2F55255E182EFED724CF837046
+    128'h8440934DCB834F93689FE9E88EBD5340
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'hF70A5B088FEFBC18548DFCB2FD145395
+    128'h192AADBB7C918ACB0AF06B42350BB6B6
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h102F4C28
+    32'h871CB178
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'hEBA451575157868B9F266EFF382C017D989C7094
+    160'h3580D1897F7CB7DC51419F8B7D5630E65C441D2C
   };
 
   ////////////////////////////////////////////
@@ -122,33 +115,33 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for register clearing.
   parameter aes_pkg::clearing_lfsr_seed_t RndCnstAesClearingLfsrSeed = {
-    64'h4AD181A3BE2D2767
+    64'h8E18EDEB46B20763
   };
 
   // Permutation applied to the LFSR of the PRNG used for clearing.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingLfsrPerm = {
-    128'h9D7E68EBC6ED5B034B3E40AE040CE5D9,
-    256'hAD18ACCCB12667A213E1D3BF5577778F438D12A0219B1F40EFC5512721EE9A86
+    128'h05CF6536A2EE3E49D22A36FA59EA2C46,
+    256'h20D062F69F5F3209DC203EE4C87FF199B2AF013B1ED4E0395175C5DD94E29D06
   };
 
   // Permutation applied to the clearing PRNG output for clearing the second share of registers.
   parameter aes_pkg::clearing_lfsr_perm_t RndCnstAesClearingSharePerm = {
-    128'h2837D9DFCB60E8BC7431A89C6C136576,
-    256'hC254780FEB5BDF8EBA84B092F239CB51D1A671A3857E0FA85CC44F699054263B
+    128'h57EC2E416728B1FD9D00A60C08D538DE,
+    256'h2C75CC325A65E95B98BAC182F10EEB4E52F2A93D22D3F24C51D1A7F1A387B5E7
   };
 
   // Default seed of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_seed_t RndCnstAesMaskingLfsrSeed = {
-    160'hB978C925193F36D89ECE5F177E58B7BA1BA4DCA2
+    160'h5147F1EF84F4B3A9D281437D77F970022C91C1A2
   };
 
   // Permutation applied to the concatenated LFSRs of the PRNG used for masking.
   parameter aes_pkg::masking_lfsr_perm_t RndCnstAesMaskingLfsrPerm = {
-    256'h0B537B3A742586214D711055987E642841830732425B233624271A3B884B115A,
-    256'h7C3D91379D44897A298F139E5C39676D8E62471243690A755D787F339B6A5240,
-    256'h149A031C724A6B48093E0E2F1D150D1F93951787044E3F941B73822B8D660C26,
-    256'h9F450F354F761E684C57188B798C96706C978000018A58469C2250996E605F2A,
-    256'h65597D8119023C163063902D3120923405085485385184772C2E49565E06616F
+    256'h8A88993A824011121A5E9A4936802793375F2E640110219E6607524D79684743,
+    256'h5A3B257F67298E72469C239506756B614869422C91506A7B76733D6032714113,
+    256'h2439704A0B908B28977C4B1455841C89569653095D3E0E2F1D150D1F8F511792,
+    256'h048D4E3F9F1B83742B6298770C26226E450F6D356F4F581E7E784C6C57187A5B,
+    256'h86943300030A445C2A65597D818719023C8C1630639B2D31209D340508548538
   };
 
   ////////////////////////////////////////////
@@ -156,8 +149,8 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random permutation for LFSR output
   parameter kmac_pkg::lfsr_perm_t RndCnstKmacLfsrPerm = {
-    128'hAD9885B9785B3FC6B67F29C1411837CD,
-    256'hC7B958D6130152A3F6A1CCE0352CEE89B022FD1DB46FC92F14A53B50BAFA9904
+    128'h58560FBDE2B6CA5EC0360AB98E1F13C1,
+    256'hCD1FF9B890459FFDB129D5A5AD41AEECF11E430E0D4DC2A26E08E8B76D184257
   };
 
   ////////////////////////////////////////////
@@ -165,17 +158,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
-    256'h15891B60C560A7FB75457E09E258C252C3083125BE14E22D044C7BD9E98EB284
+    256'h93BF7D52C8A744AD83D2630B2AF4EC91410D0BD90B447E3291B8E6CB502BF90B
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'hDDA4C0A399420265983D914E80A925BC
+    128'hD4CD7F1BDCE673B937A6D75202FEDBF8
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'hD95CD1C662BDAE87
+    64'hE3E8D3F817A9838D
   };
 
   ////////////////////////////////////////////
@@ -183,68 +176,68 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'h562CE22F82424801
+    64'h8AAA4783F2B5E094
   };
 
   // Compile-time random permutation for LFSR output
   parameter keymgr_pkg::lfsr_perm_t RndCnstKeymgrLfsrPerm = {
-    128'h6BC39971578C9ADD918EB1D75B40FA12,
-    256'hFA3DFC195F9F8A6A74BE6E609B1B206C3EEE214D037CA02900A4513CF1852D4F
+    128'h3FF5949AE5EC2A7733679AF7D4D134BE,
+    256'h31DEF65B50383855F22EDA45F09207833E74B4F617AA98A09CA4A5BC481B0020
   };
 
   // Compile-time random permutation for entropy used in share overriding
   parameter keymgr_pkg::rand_perm_t RndCnstKeymgrRandPerm = {
-    160'h640DF7E2B41B9496C742974B925CE0E23CBB4C3B
+    160'h3BDBC56FE25E188AB805B8532366DAED27088FC4
   };
 
   // Compile-time random bits for revision seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrRevisionSeed = {
-    256'h80A8D540CE8FD0CD3D3BC1416C0834AF84DC448F6A9887A8E3ED3CD5EA91A34A
+    256'h40D7D8470E011CF1B1987A780AF5815CF779EE523615334390CF654EC6352ADF
   };
 
   // Compile-time random bits for creator identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrCreatorIdentitySeed = {
-    256'h95EC8AA1BA59CEEE7530A14494E10193220B62D997F24A95F0C5E668A34CE097
+    256'hE8F6679035DA35061952CD5387F9FB727236A121E1E0FF0A4FD70234BB32EA72
   };
 
   // Compile-time random bits for owner intermediate identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIntIdentitySeed = {
-    256'hF779EE523615334390CF654EC6352ADF5010157D1342BD7B2EE4C310DEFC471B
+    256'h9E8E5600260058176D17F3660EBAD9424AE5E2CF5E723B547CB4949B21B3DECF
   };
 
   // Compile-time random bits for owner identity seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrOwnerIdentitySeed = {
-    256'h7236A121E1E0FF0A4FD70234BB32EA7240D7D8470E011CF1B1987A780AF5815C
+    256'h7D8490DC838E24FAFE4257BCD0D4AF885661E47D54C36F827B99DCC91893C0CE
   };
 
   // Compile-time random bits for software generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrSoftOutputSeed = {
-    256'h4AE5E2CF5E723B547CB4949B21B3DECFE8F6679035DA35061952CD5387F9FB72
+    256'h062CA8D4D838B3501E1CBEBB834986E64BE66E95792C3D8EAFD0BC4DE80468FD
   };
 
   // Compile-time random bits for hardware generation seed
   parameter keymgr_pkg::seed_t RndCnstKeymgrHardOutputSeed = {
-    256'h5661E47D54C36F827B99DCC91893C0CE9E8E5600260058176D17F3660EBAD942
+    256'h56CBEEFC913B5FF592BBC26408E95BDBE8BC8757CC921F3C920C664026717440
   };
 
   // Compile-time random bits for generation seed when aes destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrAesSeed = {
-    256'h4BE66E95792C3D8EAFD0BC4DE80468FD7D8490DC838E24FAFE4257BCD0D4AF88
+    256'h740AABD84D6481D22FE896642A15985EB9ECDE94C6064C512F50996293612AD0
   };
 
   // Compile-time random bits for generation seed when kmac destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrKmacSeed = {
-    256'hE8BC8757CC921F3C920C664026717440062CA8D4D838B3501E1CBEBB834986E6
+    256'hBFAFCBEBD7C3361357BEE83E46164C82A0C86B9C1EF6117215C2E6FCB683D3A9
   };
 
   // Compile-time random bits for generation seed when otbn destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrOtbnSeed = {
-    256'hB9ECDE94C6064C512F50996293612AD056CBEEFC913B5FF592BBC26408E95BDB
+    256'hDF2A87ABF7C57A6D06F2E1721E3A5F3B217D62ACF1C966C712691421CEF76350
   };
 
   // Compile-time random bits for generation seed when no destination selected
   parameter keymgr_pkg::seed_t RndCnstKeymgrNoneSeed = {
-    256'hA0C86B9C1EF6117215C2E6FCB683D3A9740AABD84D6481D22FE896642A15985E
+    256'h5910642E0F9946CB60F5F7D233A13B89BFC3162D205B4D60C9B16A8EB0AA75FA
   };
 
   ////////////////////////////////////////////
@@ -252,14 +245,14 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivNonProduction = {
-    128'hDF2A87ABF7C57A6D06F2E1721E3A5F3B,
-    256'h217D62ACF1C966C712691421CEF76350BFAFCBEBD7C3361357BEE83E46164C82
+    128'h2E53C3844212490CED20E7E16F71067E,
+    256'h30AC79EEC48E320BDCFA32F724F82840FDACED02DA0253D803D1CDF325AFFF8B
   };
 
   // Compile-time random bits for csrng state group diversification value
   parameter csrng_pkg::cs_keymgr_div_t RndCnstCsrngCsKeymgrDivProduction = {
-    128'hFDACED02DA0253D803D1CDF325AFFF8B,
-    256'h5910642E0F9946CB60F5F7D233A13B89BFC3162D205B4D60C9B16A8EB0AA75FA
+    128'hB00FE9A3A2BE362BC57CE4588424F909,
+    256'h46B441FA5E08B2317FB3E9032DB9EDDF8DB302ED56B78538C92BA96FE7BA5D88
   };
 
   ////////////////////////////////////////////
@@ -267,22 +260,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlMainSramKey = {
-    128'h30AC79EEC48E320BDCFA32F724F82840
+    128'hD52654489A981B7BDC91865141701FD5
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlMainSramNonce = {
-    128'h2E53C3844212490CED20E7E16F71067E
+    128'hD05781D31C4B4DAB379C12B6681950E6
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlMainLfsrSeed = {
-    32'hE7BA5D88
+    32'hE179C299
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlMainLfsrPerm = {
-    160'h026FCE91CCCCBE2D84FE50CCD9EAD4C410B79635
+    160'hB70C2FADE19B3353836A4EA5E4162D812FD70F14
   };
 
   ////////////////////////////////////////////
@@ -290,12 +283,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Fixed nonce used for address / data scrambling
   parameter bit [63:0] RndCnstRomCtrlScrNonce = {
-    64'h0EB63A613068D71D
+    64'h19A51F55617306D3
   };
 
   // Randomised constant used as a scrambling key for ROM data
   parameter bit [127:0] RndCnstRomCtrlScrKey = {
-    128'hC967EAA9FC47E9E7507D72B87001FA7B
+    128'hACEBE93343ED6321C82C19BE70B04C05
   };
 
   ////////////////////////////////////////////
@@ -303,12 +296,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_seed_t RndCnstRvCoreIbexLfsrSeed = {
-    32'h406D9D57
+    32'h4FEDB1E5
   };
 
   // Permutation applied to the LFSR of the PRNG used for random instructions.
   parameter ibex_pkg::lfsr_perm_t RndCnstRvCoreIbexLfsrPerm = {
-    160'hDC03CC122D518F3C805643B555B125A7C7E7CAFD
+    160'hC74D7925041C0BA9AEA26D1F6F823963B9B387CA
   };
 
 endpackage : top_earlgrey_rnd_cnst_pkg


### PR DESCRIPTION
This patch does 2 things:
1) the first commit beefs up the security of the transition token mux. in particular, it splits both the token mux into two halves that are both steered with separately computed and buffered valid signals. in a similar vein, the valid bit mux is duplicated. the out of bound mux indices are all set to a random netlist constant instead of tying them to a known all-zero constant. this basically addresses https://github.com/lowRISC/opentitan/issues/10445.
2) the second commit recognizes the replicated enum encoding that was added to ease firmware hardening as a separate countermeasure. it also extends the internal usage of this encoding as it aligns nicely with the two independent mux halves that have been added in 1). I.e., the use of a replicated enum encoding can now be leveraged to duplicate the state transition matrix lookup, which in turn can be used to create two separate mux indices that feed into the two mux halves of the token mux.