### PR TITLE
[fpga] Make divided clock constraint more precise

### DIFF
--- a/hw/top_earlgrey/data/clocks.xdc
+++ b/hw/top_earlgrey/data/clocks.xdc
@@ -21,6 +21,12 @@ create_generated_clock -name clk_io_div2 -source [get_pin ${u_pll}/CLKOUT0] -div
 set u_div4 top_*/u_clkmgr_aon/u_no_scan_io_div4_div
 create_generated_clock -name clk_io_div4 -source [get_pin ${u_pll}/CLKOUT0] -divide_by 4 [get_pin ${u_div4}/u_clk_div_buf/gen_xilinx.u_impl_xilinx/gen_fpga_buf.bufg_i/O]
 
+# the step-down mux is implemented with a LUT right now and the mux switches on the falling edge. 
+# therefore, Vivado propagates both clock edges down the clock network.
+# this implementation is not ideal - but we can at least tell Vivado to only honour the rising edge for 
+# timing analysis.
+set_clock_sense -positive top_*/u_clkmgr_aon/u_no_scan_io_div2_div/gen_div2.u_div2/gen_fpga_buf.bufg_i_i_1__0/O
+
 ## JTAG and SPI clocks
 create_clock -add -name lc_jtag_tck -period 100.00 -waveform {0 5} [get_pin top_*/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_lc/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.bufg_i/O]
 create_clock -add -name rv_jtag_tck -period 100.00 -waveform {0 5} [get_pin top_*/u_pinmux_aon/u_pinmux_strap_sampling/u_pinmux_jtag_buf_rv/prim_clock_buf_tck/gen_xilinx.u_impl_xilinx/gen_fpga_buf.bufg_i/O]


### PR DESCRIPTION
This gets rid of a timing analyzer warning that complains about both clock edges being propagated down the clock tree of the DIV2 divided clock.

Signed-off-by: Michael Schaffner <msf@google.com>