### PR TITLE
[otp_ctrl/alert_handler] Prim_count related fixes

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -938,10 +938,10 @@
       desc: "The srambling datapath counter employs a cross-counter implementation."
     }
     { name: "TIMER_INTEG.CTR.REDUN",
-      desc: "The background integrity check timer employs a cross-counter implementation."
+      desc: "The background integrity check timer employs a duplicated counter implementation."
     }
     { name: "TIMER_CNSTY.CTR.REDUN",
-      desc: "The background consistency check timer employs a cross-counter implementation."
+      desc: "The background consistency check timer employs a duplicated counter implementation."
     }
     { name: "TIMER.LFSR.REDUN",
       desc: "The background check LFSR is duplicated."

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -379,10 +379,10 @@
       desc: "The srambling datapath counter employs a cross-counter implementation."
     }
     { name: "TIMER_INTEG.CTR.REDUN",
-      desc: "The background integrity check timer employs a cross-counter implementation."
+      desc: "The background integrity check timer employs a duplicated counter implementation."
     }
     { name: "TIMER_CNSTY.CTR.REDUN",
-      desc: "The background consistency check timer employs a cross-counter implementation."
+      desc: "The background consistency check timer employs a duplicated counter implementation."
     }
     { name: "TIMER.LFSR.REDUN",
       desc: "The background check LFSR is duplicated."

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -146,8 +146,8 @@ module otp_ctrl_lfsr_timer
   // SEC_CM: TIMER_INTEG.CTR.REDUN
   prim_count #(
     .Width(LfsrWidth),
-    .OutSelDnCnt(1), // count down
-    .CntStyle(prim_count_pkg::CrossCnt)
+    .OutSelDnCnt(0),
+    .CntStyle(prim_count_pkg::DupCnt)
   ) u_prim_count_integ (
     .clk_i,
     .rst_ni,
@@ -155,7 +155,7 @@ module otp_ctrl_lfsr_timer
     .set_i(integ_cnt_set),
     .set_cnt_i(integ_cnt_set_val),
     .en_i(!integ_cnt_zero),
-    .step_i(LfsrWidth'(1)),
+    .step_i({LfsrWidth{1'b1}}), // 2's complement for -1 so that this counts down.
     .cnt_o(integ_cnt),
     .err_o(integ_cnt_err)
   );
@@ -163,8 +163,8 @@ module otp_ctrl_lfsr_timer
   // SEC_CM: TIMER_CNSTY.CTR.REDUN
   prim_count #(
     .Width(LfsrWidth),
-    .OutSelDnCnt(1), // count down
-    .CntStyle(prim_count_pkg::CrossCnt)
+    .OutSelDnCnt(0),
+    .CntStyle(prim_count_pkg::DupCnt)
   ) u_prim_count_cnsty (
     .clk_i,
     .rst_ni,
@@ -172,7 +172,7 @@ module otp_ctrl_lfsr_timer
     .set_i(cnsty_cnt_set),
     .set_cnt_i(cnsty_cnt_set_val),
     .en_i(!cnsty_cnt_zero && !cnsty_cnt_pause),
-    .step_i(LfsrWidth'(1)),
+    .step_i({LfsrWidth{1'b1}}), // 2's complement for -1 so that this counts down.
     .cnt_o(cnsty_cnt),
     .err_o(cnsty_cnt_err)
   );

--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -281,13 +281,13 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
             '''
     }
     { name: "ACCU.CTR.REDUN",
-      desc: "Accumulator counters are redundant."
+      desc: "Accumulator counters employ a cross-counter implementation."
     }
     { name: "ESC_TIMER.CTR.REDUN",
-      desc: "Escalation timer counters are redundant."
+      desc: "Escalation timer counters employ a duplicated counter implementation."
     }
     { name: "PING_TIMER.CTR.REDUN",
-      desc: "Ping timer counters are redundant."
+      desc: "Ping timer counters employ a duplicated counter implementation."
     }
     { name: "PING_TIMER.LFSR.REDUN",
       desc: "Ping timer LFSR is redundant."

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -201,8 +201,8 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   // SEC_CM: PING_TIMER.CTR.REDUN
   prim_count #(
     .Width(PING_CNT_DW),
-    .OutSelDnCnt(1), // count down
-    .CntStyle(prim_count_pkg::CrossCnt),
+    .OutSelDnCnt(0),
+    .CntStyle(prim_count_pkg::DupCnt),
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
     .EnableAlertTriggerSVA(0)
@@ -213,7 +213,7 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .set_i(cnt_set),
     .set_cnt_i(cnt_setval),
     .en_i(!timer_expired),
-    .step_i(PING_CNT_DW'(1)),
+    .step_i({PING_CNT_DW{1'b1}}), // 2's complement for -1, since we count down
     .cnt_o(cnt),
     .err_o(cnt_error)
   );

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -381,13 +381,13 @@
             '''
     }
     { name: "ACCU.CTR.REDUN",
-      desc: "Accumulator counters are redundant."
+      desc: "Accumulator counters employ a cross-counter implementation."
     }
     { name: "ESC_TIMER.CTR.REDUN",
-      desc: "Escalation timer counters are redundant."
+      desc: "Escalation timer counters employ a duplicated counter implementation."
     }
     { name: "PING_TIMER.CTR.REDUN",
-      desc: "Ping timer counters are redundant."
+      desc: "Ping timer counters employ a duplicated counter implementation."
     }
     { name: "PING_TIMER.LFSR.REDUN",
       desc: "Ping timer LFSR is redundant."

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -201,8 +201,8 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   // SEC_CM: PING_TIMER.CTR.REDUN
   prim_count #(
     .Width(PING_CNT_DW),
-    .OutSelDnCnt(1), // count down
-    .CntStyle(prim_count_pkg::CrossCnt),
+    .OutSelDnCnt(0),
+    .CntStyle(prim_count_pkg::DupCnt),
     // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
     // an alert signal, this condition is handled internally in the alert handler.
     .EnableAlertTriggerSVA(0)
@@ -213,7 +213,7 @@ module alert_handler_ping_timer import alert_pkg::*; #(
     .set_i(cnt_set),
     .set_cnt_i(cnt_setval),
     .en_i(!timer_expired),
-    .step_i(PING_CNT_DW'(1)),
+    .step_i({PING_CNT_DW{1'b1}}), // 2's complement for -1, since we count down
     .cnt_o(cnt),
     .err_o(cnt_error)
   );


### PR DESCRIPTION
Due to a recent change in `prim_count`, the reset value of the counter is
not zero anymore in cross-count mode.
Since the FSMs in the `otp_ctrl_lfsr_timer` and `alert_handler_ping_timer expects this to be zero after reset, the `prim_count` mode is changed back to `DupCnt` in order to fix this.

Addresses #10478