### PR TITLE
[COMMITTERS] Add Timothy Trippel to COMMITTERS list

### DIFF
--- a/COMMITTERS
+++ b/COMMITTERS
@@ -25,6 +25,7 @@ Committer list:
 * Michael Schaffner (msfschaffner)
 * Rupert Swarbrick (rswarbrick)
 * Silvestrs Timofejevs (silvestrst)
+* Timothy Trippel (timothytrippel)
 * Alphan Ulusoy (alphan)
 * Pirmin Vogel (vogelpi)
 * Weicai Yang (weicaiyang)


### PR DESCRIPTION
The Technical Committee has agreed to make Timothy a committer in the
OpenTitan project.

Congratulations! Thanks for all your hard work on OpenTitan so far.
We're really excited to see your future contributions to the project.