### PR TITLE
[aes] Fix VCS warning

### DIFF
--- a/hw/ip/aes/rtl/aes_key_expand.sv
+++ b/hw/ip/aes/rtl/aes_key_expand.sv
@@ -215,8 +215,7 @@ module aes_key_expand import aes_pkg::*;
   for (genvar i = 0; i < 4; i++) begin : gen_sbox
     // Rotate the randomness produced by the S-Boxes. The LSBs are taken from the masking PRNG
     // (prd_i) whereas the MSBs are produced by the other S-Box instances.
-    assign in_prd[i] = (i == 0) ? {out_prd[3],   prd_i[WidthPRDSBox*i +: WidthPRDSBox]} :
-                                  {out_prd[i-1], prd_i[WidthPRDSBox*i +: WidthPRDSBox]};
+    assign in_prd[i] = {out_prd[aes_rot_int(i,4)], prd_i[WidthPRDSBox*i +: WidthPRDSBox]};
 
     aes_sbox #(
       .SBoxImpl ( SBoxImpl )

--- a/hw/ip/aes/rtl/aes_pkg.sv
+++ b/hw/ip/aes/rtl/aes_pkg.sv
@@ -441,6 +441,17 @@ function automatic logic [7:0] aes_mvm(
   return vec_c;
 endfunction
 
+// Rotate integer indices
+function automatic integer aes_rot_int(integer in, integer num);
+  integer out;
+  if (in == 0) begin
+    out = num - 1;
+  end else begin
+    out = in - 1;
+  end
+  return out;
+endfunction
+
 // Function for extracting LSBs of the per-S-Box pseudo-random data (PRD) from the output of the
 // masking PRNG.
 //

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -68,8 +68,7 @@ module aes_sub_bytes import aes_pkg::*;
       // Rotate the randomness produced by the S-Boxes over the columns but not across rows as
       // MixColumns will operate across rows. The LSBs are taken from the masking PRNG (prd_i)
       // whereas the MSBs are produced by the other S-Box instances.
-      assign in_prd[i][j] = (j == 0) ? {out_prd[i][3],   prd_i[i][j]}  :
-                                       {out_prd[i][j-1], prd_i[i][j]};
+      assign in_prd[i][j] = {out_prd[i][aes_rot_int(j,4)], prd_i[i][j]};
 
       aes_sbox #(
         .SBoxImpl ( SBoxImpl )


### PR DESCRIPTION
VCS erroneously thinks below statement would result in an out-of-bounds
index:
```sv
  for (genvar i = 0; i < 4; i++) begin : gen_out
    assign out[i] = (i == 0) ? {in[3],   in1[i]} :
                               {in[i-1], in1[i]};
  end
```
To avoid this, this PR introduces a function to compute the index
rotation and avoid the ternary expression.

This resolves lowRISC/OpenTitan#10379.