### PR TITLE
[aes] Rework hardened round counter, forward fatal alert to cipher core

### DIFF
--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -41,6 +41,7 @@ module aes_cipher_control import aes_pkg::*;
   input  logic                    mux_sel_err_i,
   input  logic                    sp_enc_err_i,
   input  logic                    op_err_i,
+  input  logic                    alert_fatal_i,
   output logic                    alert_o,
 
   // Control signals for masking PRNG
@@ -172,6 +173,7 @@ module aes_cipher_control import aes_pkg::*;
         .sp_enc_err_i          ( sp_enc_err               ),
         .rnd_ctr_err_i         ( rnd_ctr_err              ),
         .op_err_i              ( op_err_i                 ),
+        .alert_fatal_i         ( alert_fatal_i            ),
         .alert_o               ( mr_alert[i]              ), // OR-combine
 
         .prng_update_o         ( mr_prng_update[i]        ), // OR-combine
@@ -234,6 +236,7 @@ module aes_cipher_control import aes_pkg::*;
         .sp_enc_err_i          ( sp_enc_err               ),
         .rnd_ctr_err_i         ( rnd_ctr_err              ),
         .op_err_i              ( op_err_i                 ),
+        .alert_fatal_i         ( alert_fatal_i            ),
         .alert_o               ( mr_alert[i]              ), // OR-combine
 
         .prng_update_o         ( mr_prng_update[i]        ), // OR-combine

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
@@ -37,6 +37,7 @@ module aes_cipher_control_fsm import aes_pkg::*;
   input  logic             sp_enc_err_i,
   input  logic             rnd_ctr_err_i,
   input  logic             op_err_i,
+  input  logic             alert_fatal_i,
   output logic             alert_o,
 
   // Control signals for masking PRNG
@@ -460,8 +461,9 @@ module aes_cipher_control_fsm import aes_pkg::*;
     endcase
 
     // Unconditionally jump into the terminal error state in case a mux selector or a sparsely
-    // encoded signal becomes invalid, or in case we have detected a fault in the round counter.
-    if (mux_sel_err_i || sp_enc_err_i || rnd_ctr_err_i || op_err_i) begin
+    // encoded signal becomes invalid, in case we have detected a fault in the round counter,
+    // or if a fatal alert has been triggered.
+    if (mux_sel_err_i || sp_enc_err_i || rnd_ctr_err_i || op_err_i || alert_fatal_i) begin
       aes_cipher_ctrl_ns = ERROR;
     end
   end

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
@@ -64,16 +64,11 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
   input  logic             key_expand_out_req_ni, // Sparsify using multi-rail.
   output logic             key_expand_out_ack_no, // Sparsify using multi-rail.
   output logic             key_expand_clear_o,
+  output logic [3:0]       rnd_ctr_o,
   output key_words_sel_e   key_words_sel_o,
   output round_key_sel_e   round_key_sel_o,
 
   // Register signals
-  input  logic [3:0]       rnd_ctr_q_i,
-  output logic [3:0]       rnd_ctr_d_o,
-  input  logic [3:0]       rnd_ctr_rem_q_i,
-  output logic [3:0]       rnd_ctr_rem_d_o,
-  input  logic [3:0]       num_rounds_q_i,
-  output logic [3:0]       num_rounds_d_o,
   input  logic             crypt_q_ni,            // Sparsify using multi-rail.
   output logic             crypt_d_no,            // Sparsify using multi-rail.
   input  logic             dec_key_gen_q_ni,      // Sparsify using multi-rail.
@@ -108,9 +103,6 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     prng_reseed_ack_i,
     sub_bytes_out_req_ni,
     key_expand_out_req_ni,
-    rnd_ctr_q_i,
-    rnd_ctr_rem_q_i,
-    num_rounds_q_i,
     crypt_q_ni,
     dec_key_gen_q_ni,
     prng_reseed_q_i,
@@ -138,9 +130,6 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     prng_reseed_ack_i,
     sub_bytes_out_req_ni,
     key_expand_out_req_ni,
-    rnd_ctr_q_i,
-    rnd_ctr_rem_q_i,
-    num_rounds_q_i,
     crypt_q_ni,
     dec_key_gen_q_ni,
     prng_reseed_q_i,
@@ -175,9 +164,6 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
   logic                 prng_reseed_ack;
   logic                 sub_bytes_out_req_n;
   logic                 key_expand_out_req_n;
-  logic [3:0]           rnd_ctr_q;
-  logic [3:0]           rnd_ctr_rem_q;
-  logic [3:0]           num_rounds_q;
   logic                 crypt_q_n;
   logic                 dec_key_gen_q_n;
   logic                 prng_reseed_q;
@@ -201,9 +187,6 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
           prng_reseed_ack,
           sub_bytes_out_req_n,
           key_expand_out_req_n,
-          rnd_ctr_q,
-          rnd_ctr_rem_q,
-          num_rounds_q,
           crypt_q_n,
           dec_key_gen_q_n,
           prng_reseed_q,
@@ -232,9 +215,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
   logic             key_expand_clear;
   key_words_sel_e   key_words_sel;
   round_key_sel_e   round_key_sel;
-  logic [3:0]       rnd_ctr_d;
-  logic [3:0]       rnd_ctr_rem_d;
-  logic [3:0]       num_rounds_d;
+  logic [3:0]       rnd_ctr;
   logic             crypt_d;
   logic             dec_key_gen_d;
   logic             prng_reseed_d;
@@ -295,15 +276,10 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     .key_expand_out_req_i  ( ~key_expand_out_req_n ), // Invert for regular FSM.
     .key_expand_out_ack_o  ( key_expand_out_ack    ), // Invert below for negated output.
     .key_expand_clear_o    ( key_expand_clear      ),
+    .rnd_ctr_o             ( rnd_ctr               ),
     .key_words_sel_o       ( key_words_sel         ),
     .round_key_sel_o       ( round_key_sel         ),
 
-    .rnd_ctr_q_i           ( rnd_ctr_q             ),
-    .rnd_ctr_d_o           ( rnd_ctr_d             ),
-    .rnd_ctr_rem_q_i       ( rnd_ctr_rem_q         ),
-    .rnd_ctr_rem_d_o       ( rnd_ctr_rem_d         ),
-    .num_rounds_q_i        ( num_rounds_q          ),
-    .num_rounds_d_o        ( num_rounds_d          ),
     .crypt_q_i             ( ~crypt_q_n            ), // Invert for regular FSM.
     .crypt_d_o             ( crypt_d               ), // Invert below for negated output.
     .dec_key_gen_q_i       ( ~dec_key_gen_q_n      ), // Invert for regular FSM.
@@ -338,11 +314,9 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     key_expand_en_no,
     key_expand_out_ack_no,
     key_expand_clear_o,
+    rnd_ctr_o,
     key_words_sel_o,
     round_key_sel_o,
-    rnd_ctr_d_o,
-    rnd_ctr_rem_d_o,
-    num_rounds_d_o,
     crypt_d_no,
     dec_key_gen_d_no,
     key_clear_d_o,
@@ -372,11 +346,9 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     ~key_expand_en,
     ~key_expand_out_ack,
     key_expand_clear,
+    rnd_ctr,
     key_words_sel,
     round_key_sel,
-    rnd_ctr_d,
-    rnd_ctr_rem_d,
-    num_rounds_d,
     ~crypt_d,
     ~dec_key_gen_d,
     key_clear_d,
@@ -410,11 +382,9 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
           key_expand_en_no,
           key_expand_out_ack_no,
           key_expand_clear_o,
+          rnd_ctr_o,
           key_words_sel_o,
           round_key_sel_o,
-          rnd_ctr_d_o,
-          rnd_ctr_rem_d_o,
-          num_rounds_d_o,
           crypt_d_no,
           dec_key_gen_d_no,
           key_clear_d_o,

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
@@ -40,6 +40,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
   input  logic             sp_enc_err_i,
   input  logic             rnd_ctr_err_i,
   input  logic             op_err_i,
+  input  logic             alert_fatal_i,
   output logic             alert_o,
 
   // Control signals for masking PRNG
@@ -100,6 +101,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     sp_enc_err_i,
     rnd_ctr_err_i,
     op_err_i,
+    alert_fatal_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_ni,
     key_expand_out_req_ni,
@@ -127,6 +129,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     sp_enc_err_i,
     rnd_ctr_err_i,
     op_err_i,
+    alert_fatal_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_ni,
     key_expand_out_req_ni,
@@ -161,6 +164,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
   logic                 sp_enc_err;
   logic                 rnd_ctr_err;
   logic                 op_err;
+  logic                 alert_fatal;
   logic                 prng_reseed_ack;
   logic                 sub_bytes_out_req_n;
   logic                 key_expand_out_req_n;
@@ -184,6 +188,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
           sp_enc_err,
           rnd_ctr_err,
           op_err,
+          alert_fatal,
           prng_reseed_ack,
           sub_bytes_out_req_n,
           key_expand_out_req_n,
@@ -255,6 +260,7 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
     .sp_enc_err_i          ( sp_enc_err            ),
     .rnd_ctr_err_i         ( rnd_ctr_err           ),
     .op_err_i              ( op_err                ),
+    .alert_fatal_i         ( alert_fatal           ),
     .alert_o               ( alert                 ),
 
     .prng_update_o         ( prng_update           ),

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
@@ -36,6 +36,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
   input  logic             sp_enc_err_i,
   input  logic             rnd_ctr_err_i,
   input  logic             op_err_i,
+  input  logic             alert_fatal_i,
   output logic             alert_o,
 
   // Control signals for masking PRNG
@@ -96,6 +97,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     sp_enc_err_i,
     rnd_ctr_err_i,
     op_err_i,
+    alert_fatal_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_i,
     key_expand_out_req_i,
@@ -123,6 +125,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     sp_enc_err_i,
     rnd_ctr_err_i,
     op_err_i,
+    alert_fatal_i,
     prng_reseed_ack_i,
     sub_bytes_out_req_i,
     key_expand_out_req_i,
@@ -157,6 +160,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
   logic                 sp_enc_err;
   logic                 rnd_ctr_err;
   logic                 op_err;
+  logic                 alert_fatal;
   logic                 prng_reseed_ack;
   logic                 sub_bytes_out_req;
   logic                 key_expand_out_req;
@@ -180,6 +184,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
           sp_enc_err,
           rnd_ctr_err,
           op_err,
+          alert_fatal,
           prng_reseed_ack,
           sub_bytes_out_req,
           key_expand_out_req,
@@ -247,6 +252,7 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     .sp_enc_err_i          ( sp_enc_err             ),
     .rnd_ctr_err_i         ( rnd_ctr_err            ),
     .op_err_i              ( op_err                 ),
+    .alert_fatal_i         ( alert_fatal            ),
     .alert_o               ( alert                  ),
 
     .prng_update_o         ( prng_update            ),

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
@@ -60,16 +60,11 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
   input  logic             key_expand_out_req_i,  // Sparsify using multi-rail.
   output logic             key_expand_out_ack_o,  // Sparsify using multi-rail.
   output logic             key_expand_clear_o,
+  output logic [3:0]       rnd_ctr_o,
   output key_words_sel_e   key_words_sel_o,
   output round_key_sel_e   round_key_sel_o,
 
   // Register signals
-  input  logic [3:0]       rnd_ctr_q_i,
-  output logic [3:0]       rnd_ctr_d_o,
-  input  logic [3:0]       rnd_ctr_rem_q_i,
-  output logic [3:0]       rnd_ctr_rem_d_o,
-  input  logic [3:0]       num_rounds_q_i,
-  output logic [3:0]       num_rounds_d_o,
   input  logic             crypt_q_i,             // Sparsify using multi-rail.
   output logic             crypt_d_o,             // Sparsify using multi-rail.
   input  logic             dec_key_gen_q_i,       // Sparsify using multi-rail.
@@ -104,9 +99,6 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     prng_reseed_ack_i,
     sub_bytes_out_req_i,
     key_expand_out_req_i,
-    rnd_ctr_q_i,
-    rnd_ctr_rem_q_i,
-    num_rounds_q_i,
     crypt_q_i,
     dec_key_gen_q_i,
     prng_reseed_q_i,
@@ -134,9 +126,6 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     prng_reseed_ack_i,
     sub_bytes_out_req_i,
     key_expand_out_req_i,
-    rnd_ctr_q_i,
-    rnd_ctr_rem_q_i,
-    num_rounds_q_i,
     crypt_q_i,
     dec_key_gen_q_i,
     prng_reseed_q_i,
@@ -171,9 +160,6 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
   logic                 prng_reseed_ack;
   logic                 sub_bytes_out_req;
   logic                 key_expand_out_req;
-  logic [3:0]           rnd_ctr_q;
-  logic [3:0]           rnd_ctr_rem_q;
-  logic [3:0]           num_rounds_q;
   logic                 crypt_q;
   logic                 dec_key_gen_q;
   logic                 prng_reseed_q;
@@ -197,9 +183,6 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
           prng_reseed_ack,
           sub_bytes_out_req,
           key_expand_out_req,
-          rnd_ctr_q,
-          rnd_ctr_rem_q,
-          num_rounds_q,
           crypt_q,
           dec_key_gen_q,
           prng_reseed_q,
@@ -226,11 +209,9 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
   logic             key_expand_en;
   logic             key_expand_out_ack;
   logic             key_expand_clear;
+  logic [3:0]       rnd_ctr;
   key_words_sel_e   key_words_sel;
   round_key_sel_e   round_key_sel;
-  logic [3:0]       rnd_ctr_d;
-  logic [3:0]       rnd_ctr_rem_d;
-  logic [3:0]       num_rounds_d;
   logic             crypt_d;
   logic             dec_key_gen_d;
   logic             prng_reseed_d;
@@ -287,15 +268,10 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     .key_expand_out_req_i  ( key_expand_out_req     ),
     .key_expand_out_ack_o  ( key_expand_out_ack     ),
     .key_expand_clear_o    ( key_expand_clear       ),
+    .rnd_ctr_o             ( rnd_ctr                ),
     .key_words_sel_o       ( key_words_sel          ),
     .round_key_sel_o       ( round_key_sel          ),
 
-    .rnd_ctr_q_i           ( rnd_ctr_q              ),
-    .rnd_ctr_d_o           ( rnd_ctr_d              ),
-    .rnd_ctr_rem_q_i       ( rnd_ctr_rem_q          ),
-    .rnd_ctr_rem_d_o       ( rnd_ctr_rem_d          ),
-    .num_rounds_q_i        ( num_rounds_q           ),
-    .num_rounds_d_o        ( num_rounds_d           ),
     .crypt_q_i             ( crypt_q                ),
     .crypt_d_o             ( crypt_d                ),
     .dec_key_gen_q_i       ( dec_key_gen_q          ),
@@ -330,11 +306,9 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     key_expand_en_o,
     key_expand_out_ack_o,
     key_expand_clear_o,
+    rnd_ctr_o,
     key_words_sel_o,
     round_key_sel_o,
-    rnd_ctr_d_o,
-    rnd_ctr_rem_d_o,
-    num_rounds_d_o,
     crypt_d_o,
     dec_key_gen_d_o,
     key_clear_d_o,
@@ -362,11 +336,9 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
     key_expand_en,
     key_expand_out_ack,
     key_expand_clear,
+    rnd_ctr,
     key_words_sel,
     round_key_sel,
-    rnd_ctr_d,
-    rnd_ctr_rem_d,
-    num_rounds_d,
     crypt_d,
     dec_key_gen_d,
     key_clear_d,
@@ -400,11 +372,9 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
           key_expand_en_o,
           key_expand_out_ack_o,
           key_expand_clear_o,
+          rnd_ctr_o,
           key_words_sel_o,
           round_key_sel_o,
-          rnd_ctr_d_o,
-          rnd_ctr_rem_d_o,
-          num_rounds_d_o,
           crypt_d_o,
           dec_key_gen_d_o,
           key_clear_d_o,

--- a/hw/ip/aes/rtl/aes_cipher_core.sv
+++ b/hw/ip/aes/rtl/aes_cipher_core.sv
@@ -131,6 +131,7 @@ module aes_cipher_core import aes_pkg::*;
   output logic                        key_clear_o,
   input  logic                        data_out_clear_i, // Re-use the cipher core muxes.
   output logic                        data_out_clear_o,
+  input  logic                        alert_fatal_i,
   output logic                        alert_o,
 
   // Pseudo-random data for register clearing
@@ -543,6 +544,7 @@ module aes_cipher_core import aes_pkg::*;
     .mux_sel_err_i        ( mux_sel_err         ),
     .sp_enc_err_i         ( sp_enc_err_q        ),
     .op_err_i             ( op_err              ),
+    .alert_fatal_i        ( alert_fatal_i       ),
     .alert_o              ( alert_o             ),
 
     .prng_update_o        ( prd_masking_upd     ),

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -432,6 +432,7 @@ module aes_core
     .key_clear_o        ( cipher_key_clear_busy      ),
     .data_out_clear_i   ( cipher_data_out_clear      ),
     .data_out_clear_o   ( cipher_data_out_clear_busy ),
+    .alert_fatal_i      ( alert_fatal_o              ),
     .alert_o            ( cipher_alert               ),
 
     .prd_clearing_i     ( cipher_prd_clearing        ),

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -104,6 +104,7 @@ module csrng_block_encrypt import csrng_pkg::*; #(
     .key_len_i          ( aes_pkg::AES_256           ),
     .crypt_i            ( aes_pkg::SP2V_HIGH         ), // Enable
     .crypt_o            ( cipher_crypt_busy          ),
+    .alert_fatal_i      ( 1'b0                       ),
     .alert_o            ( block_encrypt_aes_cipher_sm_err_o),
     .dec_key_gen_i      ( aes_pkg::SP2V_LOW          ), // Disable
     .dec_key_gen_o      (                            ),


### PR DESCRIPTION
Based on the D2S review (See #10422) this PR implements the following two changes:
1. The hardened round counter is reworked to move the counter flops back into the multi-rail FSMs.
2. The fatal alert is forwarded from the main FSM to the cipher core.

I will update the documentation accordingly in a separate PR (together with other doc-related AIs of the D2S review). 
