### PR TITLE
[sw,tests] Add the chip level test chip_sw_aon_timer_wdog_lc_escalate

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -676,11 +676,14 @@
       desc: '''Verify that the LC escalation signal disables the AON timer wdog.
 
             - Program the AON timer wdog to 'bark' after some time and enable the bark interrupt.
-            - Program the alert handler to escalate on alerts upto phase 1 (i.e. stop after wipe
-              secrets).
-            - Trigger an alert to cause an escalation condition before the wakeup signal asserts.
-            - Wait for sufficiently long time to ensure that the bark interrupt does not trigger,
-              to prove that the wdog was disabled.
+            - Stop the escalation process and fail the test in the interrupt handler in case the
+              bark interrupt is fired.
+            - Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but the
+              phase 1 (i.e. wipe secrets) should occur and last during the time the wdog is 
+              programed to bark and bite.
+            - Trigger an alert to cause an escalation condition before the bark signal asserts.
+            - After the reset ensure that the reset cause was due to the escalation to prove that
+              the wdog was disabled.
             '''
       milestone: V2
       tests: []

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -1,0 +1,244 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/freestanding/limits.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_alert_handler.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_rv_timer.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/alert_handler_testutils.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/FreeRTOSConfig.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+#include "sw/device/lib/testing/test_framework/test_status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig;
+
+/**
+ * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
+ * the phase 1 (i.e. wipe secrets) should occur and last during the time the
+ * wdog is programed to bark.
+ */
+enum {
+  kWdogBarkMicros = 4 * 1000,          // 4 ms
+  kWdogBiteMicros = 5 * 1000,          // 5 ms
+  kEscalationPhase0Micros = 3 * 1000,  // 3 ms
+  kEscalationPhase1Micros = 3 * 1000,  // 3 ms
+  kEscalationPhase2Micros = 500,       // 500 us
+};
+
+static_assert(
+    kWdogBarkMicros < kWdogBiteMicros &&
+        kWdogBarkMicros > kEscalationPhase0Micros &&
+        kWdogBarkMicros < (kEscalationPhase0Micros + kEscalationPhase1Micros) &&
+        kWdogBiteMicros < (kEscalationPhase0Micros + kEscalationPhase1Micros),
+    "The wdog bark and bite shall happens during the escalation phase 1");
+
+/**
+ * Objects to access the peripherals used in this test via dif API.
+ */
+static const uint32_t kPlicTarget = kTopEarlgreyPlicTargetIbex0;
+static dif_aon_timer_t aon_timer;
+static dif_rv_plic_t plic;
+static dif_pwrmgr_t pwrmgr;
+static dif_rstmgr_t rstmgr;
+static dif_alert_handler_t alert_handler;
+
+/**
+ * External ISR.
+ *
+ * Handles all peripheral interrupts on Ibex. PLIC asserts an external interrupt
+ * line to the CPU, which results in a call to this OTTF ISR. This ISR
+ * overrides the default OTTF implementation.
+ */
+void ottf_external_isr(void) {
+  top_earlgrey_plic_peripheral_t peripheral;
+  dif_rv_plic_irq_id_t irq_id;
+  uint32_t irq = 0;
+  uint32_t alert = 0;
+
+  CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kPlicTarget, &irq_id));
+
+  peripheral = (top_earlgrey_plic_peripheral_t)
+      top_earlgrey_plic_interrupt_for_peripheral[irq_id];
+
+  if (peripheral == kTopEarlgreyPlicPeripheralAonTimerAon) {
+    irq = (dif_aon_timer_irq_t)(
+        irq_id -
+        (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired);
+
+    // Stops escalation process.
+    CHECK_DIF_OK(dif_alert_handler_escalation_clear(&alert_handler,
+                                                    kDifAlertHandlerClassA));
+    CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(&aon_timer, irq));
+
+    CHECK(irq != kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark,
+          "AON Timer Wdog should not bark");
+
+  } else if (peripheral == kTopEarlgreyPlicPeripheralAlertHandler) {
+    irq = (irq_id -
+           (dif_rv_plic_irq_id_t)kTopEarlgreyPlicIrqIdAlertHandlerClassa);
+
+    CHECK_DIF_OK(dif_alert_handler_alert_acknowledge(&alert_handler, alert));
+
+    dif_alert_handler_class_state_t state;
+    CHECK_DIF_OK(dif_alert_handler_get_class_state(
+        &alert_handler, kDifAlertHandlerClassA, &state));
+
+    CHECK(state == kDifAlertHandlerClassStatePhase0, "Wrong phase %d", state);
+
+    CHECK_DIF_OK(dif_alert_handler_irq_acknowledge(&alert_handler, irq));
+  }
+
+  // Complete the IRQ by writing the IRQ source to the Ibex specific CC
+  // register.
+  CHECK_DIF_OK(dif_rv_plic_irq_complete(&plic, kPlicTarget, irq_id));
+}
+
+/**
+ * Initialize the peripherals used in this test.
+ */
+void init_peripherals(void) {
+  mmio_region_t base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_pwrmgr_init(base_addr, &pwrmgr));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_rstmgr_init(base_addr, &rstmgr));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_aon_timer_init(base_addr, &aon_timer));
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_plic_init(base_addr, &plic));
+
+  rv_plic_testutils_irq_range_enable(
+      &plic, kPlicTarget, kTopEarlgreyPlicIrqIdAonTimerAonWkupTimerExpired,
+      kTopEarlgreyPlicIrqIdAonTimerAonWdogTimerBark);
+
+  base_addr = mmio_region_from_addr(TOP_EARLGREY_ALERT_HANDLER_BASE_ADDR);
+  CHECK_DIF_OK(dif_alert_handler_init(base_addr, &alert_handler));
+}
+
+/**
+ * Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but
+ * the phase 1 (i.e. wipe secrets) should occur and last during the time the
+ * wdog is programed to bark.
+ */
+static void alert_handler_config(void) {
+  dif_alert_handler_alert_t alerts[] = {kTopEarlgreyAlertIdPwrmgrAonFatalFault};
+  dif_alert_handler_class_t alert_classes[] = {kDifAlertHandlerClassA};
+
+  dif_alert_handler_escalation_phase_t esc_phases[] = {
+      {.phase = kDifAlertHandlerClassStatePhase0,
+       .signal = 0,
+       .duration_cycles =
+           kEscalationPhase0Micros * kClockFreqPeripheralHz / 1000000},
+      {.phase = kDifAlertHandlerClassStatePhase1,
+       .signal = 1,
+       .duration_cycles =
+           kEscalationPhase1Micros * kClockFreqPeripheralHz / 1000000},
+      {.phase = kDifAlertHandlerClassStatePhase2,
+       .signal = 3,
+       .duration_cycles =
+           kEscalationPhase2Micros * kClockFreqPeripheralHz / 1000000}};
+
+  dif_alert_handler_class_config_t class_config[] = {{
+      .auto_lock_accumulation_counter = kDifToggleDisabled,
+      .accumulator_threshold = 0,
+      .irq_deadline_cycles = 10 * kClockFreqPeripheralHz / 1000000,
+      .escalation_phases = esc_phases,
+      .escalation_phases_len = ARRAYSIZE(esc_phases),
+      .crashdump_escalation_phase = kDifAlertHandlerClassStatePhase3,
+  }};
+
+  dif_alert_handler_class_t classes[] = {kDifAlertHandlerClassA};
+  dif_alert_handler_config_t config = {
+      .alerts = alerts,
+      .alert_classes = alert_classes,
+      .alerts_len = ARRAYSIZE(alerts),
+      .classes = classes,
+      .class_configs = class_config,
+      .classes_len = ARRAYSIZE(class_config),
+      .ping_timeout = 0,
+  };
+
+  alert_handler_testutils_configure_all(&alert_handler, config,
+                                        kDifToggleEnabled);
+  // Enables alert handler irq.
+  CHECK_DIF_OK(dif_alert_handler_irq_set_enabled(
+      &alert_handler, kDifAlertHandlerIrqClassa, kDifToggleEnabled));
+}
+
+/**
+ * Execute the aon timer interrupt test.
+ */
+static void execute_test(dif_aon_timer_t *aon_timer) {
+  uint64_t bark_cycles = (kWdogBarkMicros * kClockFreqAonHz / 1000000);
+  uint64_t bite_cycles = (kWdogBiteMicros * kClockFreqAonHz / 1000000);
+
+  CHECK(bite_cycles < UINT32_MAX,
+        "The value %u can't fit into the 32 bits timer counter.", bite_cycles);
+
+  LOG_INFO(
+      "Wdog will bark after %u/%u us/cycles and bite after %u/%u us/cycles",
+      (uint32_t)kWdogBarkMicros, (uint32_t)bark_cycles,
+      (uint32_t)kWdogBiteMicros, (uint32_t)bite_cycles);
+
+  // Setup the wdog bark and bite timeouts.
+  aon_timer_testutils_watchdog_config(aon_timer, bark_cycles, bite_cycles,
+                                      false);
+
+  // Trigger the alert handler to escalate.
+  dif_pwrmgr_alert_t alert = kDifPwrmgrAlertFatalFault;
+  CHECK_DIF_OK(dif_pwrmgr_alert_force(&pwrmgr, alert));
+  CHECK(false, "The alert handler failed to escalate");
+}
+
+bool test_main(void) {
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  init_peripherals();
+
+  // Enable all the AON interrupts used in this test.
+  rv_plic_testutils_irq_range_enable(&plic, kPlicTarget,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassa,
+                                     kTopEarlgreyPlicIrqIdAlertHandlerClassd);
+
+  alert_handler_config();
+
+  // Check if there was a HW reset caused by the escalation.
+  dif_rstmgr_reset_info_bitfield_t rst_info;
+  CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &rst_info));
+  CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
+
+  CHECK(rst_info == kDifRstmgrResetInfoPor ||
+            rst_info == kDifRstmgrResetInfoEscalation,
+        "Wrong reset reason %02X", rst_info);
+
+  LOG_INFO("rst=0x%x", rst_info);
+  if (rst_info == kDifRstmgrResetInfoPor) {
+    LOG_INFO("Booting for the first time, starting test");
+    execute_test(&aon_timer);
+  } else if (rst_info == kDifRstmgrResetInfoEscalation) {
+    LOG_INFO("Booting for the second time due to escalation reset");
+  }
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -853,6 +853,36 @@ sw_tests += {
   }
 }
 
+# AON Timer wdog lc escalate test.
+aon_timer_wdog_lc_escalate_test = declare_dependency(
+  link_with: static_library(
+    'aon_timer_wdog_lc_escalate_test',
+    sources: [
+      hw_ip_rstmgr_reg_h,
+      'aon_timer_wdog_lc_escalate_test.c',
+    ],
+    dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_dif_aon_timer,
+      sw_lib_dif_alert_handler,
+      sw_lib_dif_pwrmgr,
+      sw_lib_dif_rv_plic,
+      sw_lib_runtime_log,
+      sw_lib_runtime_ibex,
+      sw_lib_testing_aon_timer_testutils,
+      sw_lib_testing_alert_handler_testutils,
+      sw_lib_testing_rstmgr_testutils,
+      sw_lib_testing_rv_plic_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'aon_timer_wdog_lc_escalate_test': {
+    'library': aon_timer_wdog_lc_escalate_test,
+  }
+}
+
 ###############################################################################
 # Auto-generated tests
 ###############################################################################


### PR DESCRIPTION
The original test description was impossible to implement since the escalation phase 1 (wipe-secrets) is drastic enough to stop the execution of any instruction.
Therefore this PR changes the test description to use one extra escalation phase to reset the system and check whether the wdog was disabled.
