### PR TITLE
[flash_ctrl] Secret Seeds and OTP Keys

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -220,17 +220,19 @@
     {
       name: secret_partition
       desc: '''
-            Verify values of secret information partitions. Enabling by life cycle and otp is
-            required. Pages are read upon flash controller initialization.
+            Verify the secret information partitions. Accessibility is controlled by the Life Cycle Controller
+            Seeds are read upon flash controller initialization and sent to the Key Manager, additionally verify
+            that scramble Keys are Read from the OTP and sent into the Flash Ctlr.  Also erify that programmed
+            Secret Partitions retain their values through a Reset Cycle.
             '''
       milestone: V2
-      tests: []
+      tests: ["flash_ctrl_hw_sec_otp"]
     }
     {
       name: isolation_partition
       desc: '''
-            Verify values of isolated information partitions. Accessablity is controlled by life
-            cycle and otp.
+            Verify the isolated information partitions. Accessiblity is controlled by the Life Cycle Controller
+            
             '''
       milestone: V2
       tests: []

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -38,6 +38,7 @@ filesets:
       - seq_lib/flash_ctrl_host_dir_rd_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_rd_buff_evict_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_phy_arb_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_hw_sec_otp_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -70,6 +70,19 @@ package flash_ctrl_env_pkg;
   // Need to create a design parameter for this
   parameter uint FlashFullDataWidth = flash_ctrl_pkg::DataWidth + 4;
 
+  parameter otp_ctrl_pkg::flash_otp_key_rsp_t FLASH_OTP_RSP_DEFAULT = '{
+      data_ack: 1'b0,
+      addr_ack: 1'b0,
+      key: '0,
+      rand_key: '0,
+      seed_valid: 1'b0
+  };
+
+  // For Secret Partitions
+  parameter uint FlashSecretPartWords = 8;  // Size Of Secret Part - (8x32=256 Bits)
+  parameter uint FlashCreatorPartStartAddr = 32'h00000800;  // Info Partition Page 1
+  parameter uint FlashOwnerPartStartAddr = 32'h00001000;  // Info Partition Page 2
+
   // types
   typedef enum int {
     FlashCtrlIntrProgEmpty = 0,
@@ -96,6 +109,13 @@ package flash_ctrl_env_pkg;
     FlashPartInfo1      = 2,
     FlashPartRedundancy = 4
   } flash_dv_part_e;
+
+  // Special Partitions
+  typedef enum logic [1:0] {
+    FlashCreatorPart = 0,
+    FlashOwnerPart   = 1,
+    FlashIsolPart    = 2
+  } flash_sec_part_e;
 
   typedef struct packed {
     bit  en;           // enable this region

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 // interface for OTP, Life cycle, RMA, PWRMGR and KEYMGR
-interface flash_ctrl_if();
+interface flash_ctrl_if ();
 
   import lc_ctrl_pkg::*;
   import pwrmgr_pkg::*;
@@ -11,30 +11,35 @@ interface flash_ctrl_if();
   import otp_ctrl_pkg::*;
   import ast_pkg::*;
 
-  lc_tx_t        lc_creator_seed_sw_rw_en = lc_ctrl_pkg::Off;
-  lc_tx_t        lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
-  lc_tx_t        lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
-  lc_tx_t        lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
-  lc_tx_t        lc_seed_hw_rd_en         = lc_ctrl_pkg::On;
-  lc_tx_t        lc_nvm_debug_en          = lc_ctrl_pkg::Off;
-  lc_tx_t        lc_escalate_en           = lc_ctrl_pkg::Off;
+  lc_tx_t                           lc_creator_seed_sw_rw_en = lc_ctrl_pkg::Off;
+  lc_tx_t                           lc_owner_seed_sw_rw_en = lc_ctrl_pkg::Off;
+  lc_tx_t                           lc_seed_hw_rd_en = lc_ctrl_pkg::On;
 
-  pwr_flash_t    pwrmgr;
+  lc_tx_t                           lc_iso_part_sw_rd_en = lc_ctrl_pkg::On;
+  lc_tx_t                           lc_iso_part_sw_wr_en = lc_ctrl_pkg::On;
 
-  keymgr_flash_t keymgr;
+  lc_tx_t                           lc_nvm_debug_en = lc_ctrl_pkg::Off;
+  lc_tx_t                           lc_escalate_en = lc_ctrl_pkg::Off;
 
-  lc_tx_t             rma_req  = lc_ctrl_pkg::Off;
-  lc_flash_rma_seed_t rma_seed = LC_FLASH_RMA_SEED_DEFAULT;
-  lc_tx_t             rma_ack;
+  pwr_flash_t                       pwrmgr;
+
+  keymgr_flash_t                    keymgr;
+
+  lc_tx_t                           rma_req = lc_ctrl_pkg::Off;
+  lc_flash_rma_seed_t               rma_seed = LC_FLASH_RMA_SEED_DEFAULT;
+  lc_tx_t                           rma_ack;
+
+  otp_ctrl_pkg::flash_otp_key_req_t otp_req;
+  otp_ctrl_pkg::flash_otp_key_rsp_t otp_rsp = flash_ctrl_env_pkg::FLASH_OTP_RSP_DEFAULT;
 
   //JTAG
-  logic cio_tck;
-  logic cio_tms;
-  logic cio_tdi;
-  logic cio_tdo_en;
-  logic cio_tdo;
+  logic                             cio_tck;
+  logic                             cio_tms;
+  logic                             cio_tdi;
+  logic                             cio_tdo_en;
+  logic                             cio_tdo;
 
   // alert
-  ast_dif_t flash_alert;
+  ast_dif_t                         flash_alert;
 
 endinterface

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -69,7 +69,6 @@ class flash_ctrl_seq_cfg extends uvm_object;
   bit op_readonly_on_info_partition;  // Make info partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
 
-
   uint op_erase_type_bank_pc;
   uint op_max_words;
   bit op_allow_invalid;
@@ -95,6 +94,12 @@ class flash_ctrl_seq_cfg extends uvm_object;
 
   // Timeout for erase transaction
   uint erase_timeout_ns;
+
+  // Enable/Disable the Secret Seeds and Keys during Initialisation
+  bit en_init_keys_seeds;
+
+  // Enable/Disable the Random Flash Inititlisation After Reset
+  bit disable_flash_init;
 
   `uvm_object_new
 
@@ -124,7 +129,6 @@ class flash_ctrl_seq_cfg extends uvm_object;
     op_on_redundancy_partition_pc = sel_redundancy_part_pc;
 
   endfunction : set_partition_pc
-
 
   virtual function void configure();
     max_num_trans                 = 20;
@@ -183,6 +187,10 @@ class flash_ctrl_seq_cfg extends uvm_object;
     prog_timeout_ns = 10_000_000;  // 10ms
 
     erase_timeout_ns = 120_000_000;  // 120ms
+
+    en_init_keys_seeds = 1'b0;  // Off
+
+    disable_flash_init = 1'b0;  // Off
 
     set_partition_pc();
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -10,6 +10,12 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 );
   `uvm_object_utils(flash_ctrl_base_vseq)
 
+  // OTP Scramble Keys, Used In OTP MODEL
+  logic [KeyWidth-1:0] otp_addr_key;
+  logic [KeyWidth-1:0] otp_addr_rand_key;
+  logic [KeyWidth-1:0] otp_data_key;
+  logic [KeyWidth-1:0] otp_data_rand_key;
+
   // flash ctrl configuration settings.
 
   constraint num_trans_c {num_trans inside {[1 : cfg.seq_cfg.max_num_trans]};}
@@ -20,12 +26,22 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   rand flash_mem_init_e flash_init;
 
   // default region cfg
-  flash_mp_region_cfg_t default_region_cfg = '{default:1, scramble_en:0, ecc_en:0, he_en:0,
-                                               num_pages:1, start_page:0};
+  flash_mp_region_cfg_t default_region_cfg = '{
+      default: 1,
+      scramble_en: 0,
+      ecc_en: 0,
+      he_en: 0,
+      num_pages: 1,
+      start_page: 0
+  };
 
   // default info cfg
-  flash_bank_mp_info_page_cfg_t default_info_page_cfg = '{default:1, scramble_en:0, ecc_en:0,
-                                                          he_en:0};
+  flash_bank_mp_info_page_cfg_t default_info_page_cfg = '{
+      default: 1,
+      scramble_en: 0,
+      ecc_en: 0,
+      he_en: 0
+  };
 
   // By default, in 30% of the times initialize flash as in initial state (all 1s),
   //  while in 70% of the times the initialization will be randomized (simulating working flash).
@@ -41,8 +57,9 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   virtual task pre_start();
     `uvm_create_on(callback_vseq, p_sequencer);
+    otp_model();  // Start OTP Model
     super.pre_start();
-  endtask
+  endtask : pre_start
 
   // After finishing basic dut_init do some additional required actions with callback_vseq
   virtual task dut_init(string reset_kind = "HARD");
@@ -53,9 +70,11 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   virtual task dut_shutdown();
     // check for pending flash_ctrl operations and wait for them to complete
     // TODO
-  endtask
+  endtask : dut_shutdown
 
+  // Reset the Flash Device
   virtual task reset_flash();
+
     // Set all flash partitions to 1s.
     flash_dv_part_e part = part.first();
     do begin
@@ -67,68 +86,78 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     csr_spinwait(.ptr(ral.status.init_wip), .exp_data(1'b0));
   endtask : reset_flash
 
+  // Apply a Reset to the DUT
   virtual task apply_reset(string kind = "HARD");
     uvm_reg_data_t data;
+
     bit init_busy;
     super.apply_reset(kind);
     if (kind == "HARD") begin
       cfg.clk_rst_vif.wait_clks(cfg.post_reset_delay_clks);
     end
-    reset_flash();
 
-  endtask  // apply_reset
+    if (cfg.seq_cfg.disable_flash_init == 0) begin
+      reset_flash();  // Randomly Inititalise Flash After Reset
+    end
+
+    if (cfg.seq_cfg.en_init_keys_seeds == 1) begin
+      csr_wr(.ptr(ral.init), .value(1));  // Enable Secret Seed Output during INIT
+    end
+
+  endtask : apply_reset
 
   // Configure the memory protection regions.
-  virtual task flash_ctrl_mp_region_cfg(uint index, flash_mp_region_cfg_t region_cfg =
-                                        default_region_cfg);
+  virtual task flash_ctrl_mp_region_cfg(uint index,
+                                        flash_mp_region_cfg_t region_cfg = default_region_cfg);
     uvm_reg_data_t data;
     uvm_reg csr;
-    //verilog_format: off
     data =
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].en, data,
-                                       region_cfg.en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].rd_en, data,
-                                       region_cfg.read_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].prog_en, data,
-                                       region_cfg.program_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].erase_en, data,
-                                       region_cfg.erase_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].scramble_en, data,
-                                       region_cfg.scramble_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].ecc_en, data,
-                                       region_cfg.ecc_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].he_en, data,
-                                       region_cfg.he_en) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].base, data,
-                                       region_cfg.start_page) |
-        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].size, data,
-                                       region_cfg.num_pages);
-    //verilog_format: on
+        get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].en, data, region_cfg.en);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].rd_en, data,
+                                                 region_cfg.read_en);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].prog_en, data,
+                                                 region_cfg.program_en);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].erase_en, data,
+                                                 region_cfg.erase_en);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].scramble_en,
+                                                 data, region_cfg.scramble_en);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].ecc_en, data,
+                                                 region_cfg.ecc_en);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].he_en, data,
+                                                 region_cfg.he_en);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].base, data,
+                                                 region_cfg.start_page);
+    data = data | get_csr_val_with_updated_field(ral.mp_region_cfg_shadowed[index].size, data,
+                                                 region_cfg.num_pages);
     csr_wr(.ptr(ral.mp_region_cfg_shadowed[index]), .value(data));
-  endtask
+  endtask : flash_ctrl_mp_region_cfg
 
   // Configure the protection for the "default" region (all pages that do not fall into one
   // of the memory protection regions).
   virtual task flash_ctrl_default_region_cfg(bit read_en = 1, bit program_en = 1, bit erase_en = 1,
                                              bit scramble_en = 0, bit ecc_en = 0, bit he_en = 0);
     uvm_reg_data_t data;
-
-    data = get_csr_val_with_updated_field(ral.default_region_shadowed.rd_en, data, read_en) |
-        get_csr_val_with_updated_field(ral.default_region_shadowed.prog_en, data, program_en) |
-        get_csr_val_with_updated_field(ral.default_region_shadowed.erase_en, data, erase_en) |
-        get_csr_val_with_updated_field(ral.default_region_shadowed.scramble_en, data,
-                                       scramble_en) |
-        get_csr_val_with_updated_field(ral.default_region_shadowed.ecc_en, data, ecc_en) |
-        get_csr_val_with_updated_field(ral.default_region_shadowed.he_en, data, he_en);
+    data = get_csr_val_with_updated_field(ral.default_region_shadowed.rd_en, data, read_en);
+    data = data |
+        get_csr_val_with_updated_field(ral.default_region_shadowed.prog_en, data, program_en);
+    data = data |
+        get_csr_val_with_updated_field(ral.default_region_shadowed.erase_en, data, erase_en);
+    data = data |
+        get_csr_val_with_updated_field(ral.default_region_shadowed.scramble_en, data, scramble_en);
+    data = data | get_csr_val_with_updated_field(ral.default_region_shadowed.ecc_en, data, ecc_en);
+    data = data | get_csr_val_with_updated_field(ral.default_region_shadowed.he_en, data, he_en);
     csr_wr(.ptr(ral.default_region_shadowed), .value(data));
-  endtask
+  endtask : flash_ctrl_default_region_cfg
 
   // Configure the memory protection of some selected page in one of the information partitions in
   //  one of the banks.
-  virtual task flash_ctrl_mp_info_page_cfg(uint bank, uint info_part, uint page,
-                                  flash_bank_mp_info_page_cfg_t page_cfg = default_info_page_cfg);
+  virtual task flash_ctrl_mp_info_page_cfg(
+      uint bank, uint info_part, uint page,
+      flash_bank_mp_info_page_cfg_t page_cfg = default_info_page_cfg);
+
     uvm_reg_data_t data;
     uvm_reg csr;
+
     string csr_name = $sformatf("bank%0d_info%0d_page_cfg_shadowed", bank, info_part);
     // If the selected information partition has only 1 page, no suffix needed to the register
     //  name, if there is more than one page, the page index should be added to the register name.
@@ -136,40 +165,40 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       csr_name = $sformatf({csr_name, "_%0d"}, page);
     end
     csr = ral.get_reg_by_name(csr_name);
-    data = get_csr_val_with_updated_field(csr.get_field_by_name("en"), data, page_cfg.en) |
-        get_csr_val_with_updated_field(csr.get_field_by_name("rd_en"), data, page_cfg.read_en) |
-        get_csr_val_with_updated_field(csr.get_field_by_name("prog_en"), data,
-                                       page_cfg.program_en) |
-        get_csr_val_with_updated_field(csr.get_field_by_name("erase_en"), data,
-                                       page_cfg.erase_en) |
-        get_csr_val_with_updated_field(csr.get_field_by_name("scramble_en"), data,
-                                       page_cfg.scramble_en) |
-        get_csr_val_with_updated_field(csr.get_field_by_name("ecc_en"), data,
-                                       page_cfg.ecc_en) |
-        get_csr_val_with_updated_field(csr.get_field_by_name("he_en"), data,
-                                       page_cfg.he_en);
+    data = get_csr_val_with_updated_field(csr.get_field_by_name("en"), data, page_cfg.en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("rd_en"), data, page_cfg.read_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("prog_en"), data, page_cfg.program_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("erase_en"), data, page_cfg.erase_en);
+    data = data | get_csr_val_with_updated_field(csr.get_field_by_name("scramble_en"), data,
+                                                 page_cfg.scramble_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("ecc_en"), data, page_cfg.ecc_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("he_en"), data, page_cfg.he_en);
     csr_wr(.ptr(csr), .value(data));
-  endtask
+  endtask : flash_ctrl_mp_info_page_cfg
 
   // Configure bank erasability.
   virtual task flash_ctrl_bank_erase_cfg(bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en);
     csr_wr(.ptr(ral.mp_bank_cfg_shadowed[0]), .value(bank_erase_en));
-  endtask
+  endtask : flash_ctrl_bank_erase_cfg
 
   // Configure read and program fifo levels for interrupt.
   virtual task flash_ctrl_fifo_levels_cfg_intr(uint read_fifo_intr_level,
                                                uint program_fifo_intr_level);
     uvm_reg_data_t data;
-
     data = get_csr_val_with_updated_field(ral.fifo_lvl.prog, data, program_fifo_intr_level) |
         get_csr_val_with_updated_field(ral.fifo_lvl.rd, data, read_fifo_intr_level);
     csr_wr(.ptr(ral.fifo_lvl), .value(data));
-  endtask
+  endtask : flash_ctrl_fifo_levels_cfg_intr
 
   // Reset the program and read fifos.
   virtual task flash_ctrl_fifo_reset(bit reset = 1'b1);
     csr_wr(.ptr(ral.fifo_rst), .value(reset));
-  endtask
+  endtask : flash_ctrl_fifo_reset
 
   // Wait for flash_ctrl op to finish.
   virtual task wait_flash_op_done(
@@ -185,7 +214,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       data = get_csr_val_with_updated_field(ral.op_status.done, data, 0);
       csr_wr(.ptr(ral.op_status), .value(data));
     end
-  endtask
+  endtask : wait_flash_op_done
 
   // Wait for flash_ctrl op to finish with error.
   virtual task wait_flash_op_err(bit clear_op_status = 1'b1);
@@ -199,7 +228,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       data = get_csr_val_with_updated_field(ral.op_status.err, data, 0);
       csr_wr(.ptr(ral.op_status), .value(data));
     end
-  endtask
+  endtask : wait_flash_op_err
 
   // Wait for prog fifo to not be full.
   virtual task wait_flash_ctrl_prog_fifo_not_full();
@@ -208,7 +237,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     `DV_SPINWAIT(do begin
         csr_rd(.ptr(ral.status.prog_full), .value(prog_full));
       end while (prog_full);, "wait_flash_ctrl_prog_fifo_not_full timeout occurred!")
-  endtask
+  endtask : wait_flash_ctrl_prog_fifo_not_full
 
   // Wait for rd fifo to not be empty.
   virtual task wait_flash_ctrl_rd_fifo_not_empty();
@@ -217,13 +246,13 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     `DV_SPINWAIT(do begin
         csr_rd(.ptr(ral.status.rd_empty), .value(read_empty));
       end while (read_empty);, "wait_flash_ctrl_rd_fifo_not_empty timeout occurred!")
-  endtask
+  endtask : wait_flash_ctrl_rd_fifo_not_empty
 
+  // Starts an Operation on the Flash Controller
   virtual task flash_ctrl_start_op(flash_op_t flash_op);
     uvm_reg_data_t data;
     flash_part_e partition_sel;
     bit [InfoTypesWidth-1:0] info_sel;
-
 
     csr_wr(.ptr(ral.addr), .value(flash_op.addr));
 
@@ -234,17 +263,17 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     //  FlashPartInfo        = 1 | FlashPartInfo=1 |         0           |
     //  FlashPartInfo1       = 2 | FlashPartInfo=1 |         1           |
     //  FlashPartRedundancy  = 4 | FlashPartInfo=1 |         2           |
+
     partition_sel = |flash_op.partition;
     info_sel = flash_op.partition >> 1;
-
-    data = get_csr_val_with_updated_field(ral.control.start, data, 1'b1) |
-        get_csr_val_with_updated_field(ral.control.op, data, flash_op.op) |
-        get_csr_val_with_updated_field(ral.control.erase_sel, data, flash_op.erase_type) |
-        get_csr_val_with_updated_field(ral.control.partition_sel, data, partition_sel) |
-        get_csr_val_with_updated_field(ral.control.info_sel, data, info_sel) |
-        get_csr_val_with_updated_field(ral.control.num, data, flash_op.num_words - 1);
+    data = get_csr_val_with_updated_field(ral.control.start, data, 1'b1);
+    data = data | get_csr_val_with_updated_field(ral.control.op, data, flash_op.op);
+    data = data | get_csr_val_with_updated_field(ral.control.erase_sel, data, flash_op.erase_type);
+    data = data | get_csr_val_with_updated_field(ral.control.partition_sel, data, partition_sel);
+    data = data | get_csr_val_with_updated_field(ral.control.info_sel, data, info_sel);
+    data = data | get_csr_val_with_updated_field(ral.control.num, data, flash_op.num_words - 1);
     csr_wr(.ptr(ral.control), .value(data));
-  endtask
+  endtask : flash_ctrl_start_op
 
   // Program data into flash, stopping whenever full.
   // The flash op is assumed to have already commenced.
@@ -258,7 +287,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       mem_wr(.ptr(ral.prog_fifo), .offset(0), .data(data[i]));
       `uvm_info(`gfn, $sformatf("flash_ctrl_write: 0x%0h", data[i]), UVM_MEDIUM)
     end
-  endtask
+  endtask : flash_ctrl_write
 
   // Read data from flash, stopping whenever empty.
   // The flash op is assumed to have already commenced.
@@ -272,7 +301,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       mem_rd(.ptr(ral.rd_fifo), .offset(0), .data(data[i]));
       `uvm_info(`gfn, $sformatf("flash_ctrl_read: 0x%0h", data[i]), UVM_MEDIUM)
     end
-  endtask
+  endtask : flash_ctrl_read
 
   // Task to perform a direct Flash read at the specified location
   virtual task do_direct_read(
@@ -284,6 +313,184 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
               .check_exp_data(check_rdata), .exp_data(exp_rdata), .compare_mask(mask),
               .instr_type(instr_type),
               .tl_sequencer_h(p_sequencer.tl_sequencer_hs[cfg.flash_ral_name]));
-  endtask
+  endtask : do_direct_read
+
+  // Task to Read/Erase/Program the Two Secret Seed Partitions (Creator and Owner)
+  virtual task do_flash_op_secret_part(input flash_sec_part_e secret_part, input flash_op_e op,
+                                       output data_q_t flash_op_data);
+
+    // Note:
+    // Secret partition 0 (used for creator): Bank 0, information partition 0, page 1
+    // Secret partition 1 (used for owner):   Bank 0, information partition 0, page 2
+
+    // Local Signals
+    bit                    poll_fifo_status;
+    logic      [TL_DW-1:0] exp_data         [$];
+    flash_op_t             flash_op;
+
+    // Flash Operation Assignments
+    flash_op.op                         = op;
+    flash_op.partition                  = FlashPartInfo;
+    flash_op.erase_type                 = FlashErasePage;
+    flash_op.num_words                  = FlashSecretPartWords;
+    poll_fifo_status                    = 1;
+
+    // Enable Secret Partition from Life Cycle Controller Interface (Write/Read/Erase)
+    cfg.flash_ctrl_vif.lc_seed_hw_rd_en = lc_ctrl_pkg::Off;  // Disable Secret Partition HW Access
+
+    unique case (secret_part)
+      FlashCreatorPart: begin
+        flash_op.addr = FlashCreatorPartStartAddr;
+        cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
+      end
+      FlashOwnerPart: begin
+        flash_op.addr = FlashOwnerPartStartAddr;
+        cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en = lc_ctrl_pkg::On;
+      end
+      default: `uvm_error(`gfn, "Secret Partition Unrecognised, FAIL")
+    endcase
+
+    // Perform Flash Opeation via Host Interface
+    unique case (flash_op.op)
+      flash_ctrl_pkg::FlashOpErase: begin
+        flash_ctrl_start_op(flash_op);
+        wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
+        if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_erase_check(flash_op, exp_data);
+      end
+      flash_ctrl_pkg::FlashOpProgram: begin
+        // Write Frontdoor, Read Backdoor
+        // Generate Random Key
+        for (int i = 0; i < flash_op.num_words; i++) begin
+          flash_op_data[i] = $urandom_range(0, 2 ** (TL_DW) - 1);
+        end
+        // Calculate expected data for post-transaction checks
+        exp_data = cfg.calculate_expected_data(flash_op, flash_op_data);
+        flash_ctrl_start_op(flash_op);
+        flash_ctrl_write(flash_op_data, poll_fifo_status);
+        wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
+        if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_read_check(flash_op, exp_data);
+      end
+      flash_ctrl_pkg::FlashOpRead: begin
+        // Read Frontdoor, Compare Backdoor
+        flash_ctrl_start_op(flash_op);
+        flash_ctrl_read(flash_op.num_words, flash_op_data, poll_fifo_status);
+        wait_flash_op_done();
+        if (cfg.seq_cfg.check_mem_post_tran) cfg.flash_mem_bkdr_read_check(flash_op, flash_op_data);
+      end
+      default: `uvm_error(`gfn, "Flash Operation Unrecognised, FAIL")
+    endcase
+
+    // Disable Secret Partitions from Life Cycle Contoller Interface (Write/Read/Erase)
+    unique case (secret_part)
+      FlashCreatorPart: begin
+        cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::Off;
+      end
+      FlashOwnerPart: begin
+        cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en = lc_ctrl_pkg::Off;
+      end
+      default: `uvm_error(`gfn, "Secret Partition Unrecognised, FAIL")
+    endcase
+
+  endtask : do_flash_op_secret_part
+
+  // Task to compare a Secret Seed sent to the Key Manager with the Value in the FLASH
+  virtual task compare_secret_seed(input flash_sec_part_e secret_part,
+                                   input data_q_t flash_op_data);
+
+    // Local Variables
+    data_q_t key_data;
+
+    // Check for the Key being 'x
+    foreach (cfg.flash_ctrl_vif.keymgr.seeds[bit'(secret_part)][i]) begin
+      if (cfg.flash_ctrl_vif.keymgr.seeds[bit'(secret_part)][i] === 'x) begin
+        `uvm_error(`gfn, "Key Manager Keys Sampled : 'x', FAIL")
+      end
+    end
+
+    // Read Key Manager Interface
+    foreach (flash_op_data[i]) begin
+      key_data[i] = cfg.flash_ctrl_vif.keymgr.seeds[bit'(secret_part)][i*32+:32];
+    end
+
+    // Display Keys
+    `uvm_info(`gfn, $sformatf("Secret Partition : %s", secret_part.name()), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("Data   Read      : %p", flash_op_data), UVM_LOW)
+    `uvm_info(`gfn, $sformatf("KeyMgr Read      : %p", key_data), UVM_LOW)
+
+    // Compare Seeds
+    foreach (key_data[i]) begin
+      `DV_CHECK_EQ(key_data[i], flash_op_data[i], $sformatf(
+                   "(Read) Secret Partition : %s : Keys Mismatch, FAIL", secret_part.name()))
+    end
+
+  endtask : compare_secret_seed
+
+  // Task to restore the stimulus from the Life Cycle Controller to its Reset State
+  virtual task lc_ctrl_if_rst();
+
+    cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.lc_seed_hw_rd_en         = lc_ctrl_pkg::On;
+
+    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
+
+    cfg.flash_ctrl_vif.lc_nvm_debug_en          = lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.lc_escalate_en           = lc_ctrl_pkg::Off;
+
+    cfg.flash_ctrl_vif.rma_req                  = lc_ctrl_pkg::Off;
+    cfg.flash_ctrl_vif.rma_seed                 = '0;
+
+  endtask : lc_ctrl_if_rst
+
+  // ----------------------
+  // -- Task : otp_model --
+  // ----------------------
+
+  // Simple Model Of The OTP Key Seeds
+  virtual task otp_model();
+
+    `uvm_info(`gfn, "Starting OTP Model", UVM_LOW)
+
+    fork
+      forever begin
+        @(posedge cfg.clk_rst_vif.rst_n);
+        @(posedge cfg.flash_ctrl_vif.otp_req.addr_req);
+        otp_addr_key                          = {$urandom, $urandom, $urandom, $urandom};
+        otp_addr_rand_key                     = {$urandom, $urandom, $urandom, $urandom};
+        cfg.flash_ctrl_vif.otp_rsp.key        = otp_addr_key;
+        cfg.flash_ctrl_vif.otp_rsp.rand_key   = otp_addr_rand_key;
+        cfg.flash_ctrl_vif.otp_rsp.seed_valid = 1'b1;
+        #1ns;
+        cfg.flash_ctrl_vif.otp_rsp.addr_ack = 1'b1;
+        @(negedge cfg.flash_ctrl_vif.otp_req.addr_req);
+        #1ns;
+        cfg.flash_ctrl_vif.otp_rsp.addr_ack = 1'b0;
+      end
+      forever begin
+        @(posedge cfg.clk_rst_vif.rst_n);
+        @(posedge cfg.flash_ctrl_vif.otp_req.data_req);
+        otp_data_key                          = {$urandom, $urandom, $urandom, $urandom};
+        otp_data_rand_key                     = {$urandom, $urandom, $urandom, $urandom};
+        cfg.flash_ctrl_vif.otp_rsp.key        = otp_data_key;
+        cfg.flash_ctrl_vif.otp_rsp.rand_key   = otp_data_rand_key;
+        cfg.flash_ctrl_vif.otp_rsp.seed_valid = 1'b1;
+        #1ns;
+        cfg.flash_ctrl_vif.otp_rsp.data_ack = 1'b1;
+        @(negedge cfg.flash_ctrl_vif.otp_req.data_req);
+        #1ns;
+        cfg.flash_ctrl_vif.otp_rsp.data_ack = 1'b0;
+      end
+    join_none
+
+  endtask : otp_model
+
+  // Compares Two Queues Of Data
+  virtual function void check_data_match(ref data_q_t data, ref data_q_t exp_data);
+    foreach (exp_data[i]) begin
+      `DV_CHECK_EQ(data[i], exp_data[i], $sformatf(
+                   "Expected : 0x%0x, Read : 0x%0x, FAIL", exp_data[i], data[i]))
+    end
+  endfunction : check_data_match
 
 endclass : flash_ctrl_base_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_sec_otp_vseq.sv
@@ -1,0 +1,317 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//  name: secret_partition
+//  desc: '''
+//        Verify the secret information partitions. Accessibility is controlled by the Life Cycle Controller
+//        Seeds are read upon flash controller initialization and sent to the Key Manager, additionally verify
+//        that scramble Keys are Read from the OTP and sent into the Flash Ctlr.  Also erify that programmed
+//        Secret Partitions retain their values through a Reset Cycle.
+//        '''
+//  milestone: V2
+//  tests: ["flash_ctrl_hw_sec_otp"]
+
+//  Pseudo Code:
+//  Randomize Flash Content (Backdoor)
+//  Power Up Initialisation (With Secret Seeds and Keys Enabled)
+//  Loop {
+//    Randomize OTP Keys, Grab During INIT
+//    Initialise Data and Info Partitions
+//    FLASH READ    : Creator and Owner Partition and Compare Seeds Read with Key Manager.
+//                    Additionally check Partitions with the previous data programmed
+//                    after initial power (if programmed)
+//    FLASH ERASE   : Creator and Owner Partitions (Backdoor Check)
+//    FLASH PROGRAM : Creator and Owner Partitions (Backdoor Check)
+//    FLASH READ    : Creator/Owner Partition (Save Programmed Data)
+//    Check OTP Keys At Destination in Flash Ctrl Module
+//    Reset DUT - Enable Secret Key INIT
+//    Do Not Randomly Initialise Flash Content
+//  Repeat
+//  }
+
+// flash_ctrl_secret_partition Test
+
+class flash_ctrl_hw_sec_otp_vseq extends flash_ctrl_base_vseq;
+  `uvm_object_utils(flash_ctrl_hw_sec_otp_vseq)
+
+  `uvm_object_new
+
+  // Configure sequence knobs to tailor it to this seq
+  virtual function void configure_vseq();
+
+    // Max Num Iterations
+    cfg.seq_cfg.max_num_trans = 64;
+
+    // Enable NO memory protection regions
+    cfg.seq_cfg.num_en_mp_regions = 0;
+
+    // Enable Checks Post Transaction
+    cfg.seq_cfg.check_mem_post_tran = 1;
+
+    // Enable Initial Secret Seed Readout
+    cfg.seq_cfg.en_init_keys_seeds = 1;
+
+  endfunction : configure_vseq
+
+  task body();
+
+    // Local Variables
+    data_q_t flash_op_data;
+    data_q_t exp_creator_data;
+    data_q_t exp_owner_data;
+    data_q_t dummy_data;  // Not Used (But Passed to Task)
+    uint     case_sel;
+    bit      creator_prog_flag;
+    bit      owner_prog_flag;  // Indicates When Secret Partition Has Been Written
+
+    `uvm_info(`gfn, "FLASH CTRL SECRET PARTITION & OTP KEY TESTS", UVM_LOW)
+
+    // Initialise Partion Flags to Indicate Unwritten (from Frontdoor)
+    creator_prog_flag = 1'b0;
+    owner_prog_flag   = 1'b0;
+
+    // Test over a number of RESET Cycles
+    for (int iter = 0; iter < num_trans; iter++) begin
+
+      // Configure the FLASH Controller
+
+      // INITIALIZE FLASH REGIONS
+      init_data_part();
+      init_info_part();
+
+      // READ and COMPARE CREATOR AND OWNER SEEDS
+
+      `uvm_info(`gfn, "READ and COMPARE", UVM_LOW)
+
+      // Read back Creator and Owner seeds via Host, and compare with the data presented to the Key Manager Interface.
+      randcase
+        1: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
+          compare_secret_seed(FlashCreatorPart, flash_op_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
+          compare_secret_seed(FlashOwnerPart, flash_op_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
+          compare_secret_seed(FlashCreatorPart, flash_op_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
+          compare_secret_seed(FlashOwnerPart, flash_op_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          if (owner_prog_flag) check_data_match(flash_op_data, exp_owner_data);
+          compare_secret_seed(FlashOwnerPart, flash_op_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, flash_op_data);
+          if (creator_prog_flag) check_data_match(flash_op_data, exp_creator_data);
+          compare_secret_seed(FlashCreatorPart, flash_op_data);
+        end
+      endcase
+
+      // ERASE CREATOR AND OWNER PARTITIONS
+
+      // Choose an Erase/Program Test Order
+      case_sel = $urandom_range(0, 3);
+
+      `uvm_info(`gfn, "ERASE", UVM_LOW)
+
+      // Choose Erase/Program Combination to perform this iteration
+      unique case (case_sel)
+        0: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+        end
+        2: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+        end
+        3: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpErase, dummy_data);
+        end
+        default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
+      endcase
+
+      // PROGRAM CREATOR AND OWNER PARTITIONS
+
+      `uvm_info(`gfn, "PROGRAM", UVM_LOW)
+
+      // Note: Uses case_sel value from above
+      unique case (case_sel)
+        0: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+        end
+        2: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+        end
+        3: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpProgram, dummy_data);
+        end
+        default: `uvm_error(`gfn, $sformatf("No case item match, FAIL"))
+      endcase
+
+      // READ CREATOR AND OWNER SEED PARTITIONS
+
+      `uvm_info(`gfn, "READ", UVM_LOW)
+
+      randcase
+        1: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+        end
+        1: begin
+          do_flash_op_secret_part(FlashOwnerPart, flash_ctrl_pkg::FlashOpRead, exp_owner_data);
+          do_flash_op_secret_part(FlashCreatorPart, flash_ctrl_pkg::FlashOpRead, exp_creator_data);
+        end
+      endcase
+
+      // OTP SCRAMBLE SEED TESTS - CONNECTIVITY TEST ONLY
+      otp_scramble_key_test_connect();
+
+      // RESET DUT
+
+      `uvm_info(`gfn, "RESET DUT", UVM_LOW)
+
+      lc_ctrl_if_rst();  // Restore lc_ctrl_if to Reset Values
+      cfg.seq_cfg.disable_flash_init = 1;  // Disable Flash Random Initialisation
+      apply_reset();
+
+      // Delay
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+    end
+
+  endtask : body
+
+  virtual task init_data_part();
+
+    // DATA PARTITION
+
+    flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+    bit default_region_read_en;
+    bit default_region_program_en;
+    bit default_region_erase_en;
+
+    // MEMORY PROTECTION REGIONS
+
+    // No Protection Regions
+    foreach (mp_regions[i]) begin
+      mp_regions[i].en = 0;
+    end
+
+    // Configure the flash based on the given settings
+    foreach (mp_regions[i]) begin
+      flash_ctrl_mp_region_cfg(i, mp_regions[i]);
+    end
+
+    // DEFAULT REGIONS
+
+    default_region_read_en    = 1'b1;
+    default_region_program_en = 1'b1;
+    default_region_erase_en   = 1'b1;
+
+    // Memory Default Regions
+    flash_ctrl_default_region_cfg(.read_en(default_region_read_en),
+                                  .program_en(default_region_program_en),
+                                  .erase_en(default_region_erase_en));
+
+  endtask : init_data_part
+
+  virtual task init_info_part();
+
+    // INFO REGION
+
+    flash_bank_mp_info_page_cfg_t info_regions[flash_ctrl_reg_pkg::NumInfos0];
+
+    foreach (info_regions[i]) begin
+      info_regions[i].en         = 1;
+      info_regions[i].read_en    = 1;
+      info_regions[i].program_en = 1;
+      info_regions[i].erase_en   = 1;
+    end
+
+    foreach (info_regions[i]) begin
+      flash_ctrl_mp_info_page_cfg(.bank(0), .info_part(0), .page(i), .page_cfg(info_regions[i]));
+    end
+
+  endtask : init_info_part
+
+  // Tests the connections between the Flash OTP and the Scramble Block in the Flash Ctrl
+  virtual task otp_scramble_key_test_connect();
+
+    logic [KeyWidth-1:0] prb_otp_addr_key     [flash_ctrl_pkg::NumBanks];
+    logic [KeyWidth-1:0] prb_otp_data_key     [flash_ctrl_pkg::NumBanks];
+    logic [KeyWidth-1:0] prb_otp_addr_rand_key[flash_ctrl_pkg::NumBanks];
+    logic [KeyWidth-1:0] prb_otp_data_rand_key[flash_ctrl_pkg::NumBanks];
+
+    // OTP SCRAMBLE KEY TESTS - CONNECTIVITY TEST ONLY
+    // OTP Acknowledge and Random Scramble Seeds are Provided by the TestBench (tb.sv)
+
+    `uvm_info(`gfn, "FLASH OTP KEY - Scramble Connectivity Check", UVM_LOW)
+
+    // Probe Internal Scramble Signals
+    for (int i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin
+      prb_otp_addr_key[i] = read_key_probe(
+          $sformatf("tb.dut.u_eflash.gen_flash_cores[%0d].u_core.u_scramble.addr_key_i", i));
+      prb_otp_addr_rand_key[i] = read_key_probe(
+          $sformatf("tb.dut.u_eflash.gen_flash_cores[%0d].u_core.u_scramble.rand_addr_key_i", i));
+      prb_otp_data_key[i] = read_key_probe(
+          $sformatf("tb.dut.u_eflash.gen_flash_cores[%0d].u_core.u_scramble.data_key_i", i));
+      prb_otp_data_rand_key[i] = read_key_probe(
+          $sformatf("tb.dut.u_eflash.gen_flash_cores[%0d].u_core.u_scramble.rand_data_key_i", i));
+    end
+
+    // Compare OTP Keys - Probed vs Expected (For This Test Scenario)                                                                                                                        
+    for (int i = 0; i < flash_ctrl_pkg::NumBanks; i++) begin
+      compare_key_probe(i, "otp_addr_key", prb_otp_addr_key[i], otp_addr_key);
+      compare_key_probe(i, "otp_addr_rand_key", prb_otp_addr_rand_key[i], otp_addr_rand_key);
+      compare_key_probe(i, "otp_data_key", prb_otp_data_key[i], otp_data_key);
+      compare_key_probe(i, "otp_data_rand_key", prb_otp_data_rand_key[i], otp_data_rand_key);
+    end
+
+  endtask : otp_scramble_key_test_connect
+
+  // Function Reads the OTP Key values within the Flash Ctrl, at the Scrambing Module
+  virtual function logic [KeyWidth-1:0] read_key_probe(input string dut_prb);
+    if (!uvm_hdl_read(dut_prb, read_key_probe))
+      `uvm_error(`gfn, $sformatf("Unable to Read from DUT Probe : %s, FAIL", dut_prb))
+  endfunction : read_key_probe
+
+  // Task that compares an expected Key with a given key
+  virtual task compare_key_probe(input uint i, input string dut_prb,
+                                 input logic [KeyWidth-1:0] key,
+                                 input logic [KeyWidth-1:0] expected_key);
+
+    `uvm_info(`gfn, $sformatf("Compare OTP Key, Read : 0x%0x, Expected : 0x%0x", key, expected_key),
+              UVM_LOW)
+
+    `DV_CHECK_EQ(key, expected_key, $sformatf(
+                 "Flash OTP Scramble Key Mismatch, Key : %s[%0d], Read : 0x%0x, Expected : 0x%0x, FAIL",
+                 dut_prb,
+                 i,
+                 key,
+                 expected_key
+                 ))
+
+  endtask : compare_key_probe
+
+endclass : flash_ctrl_hw_sec_otp_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -13,3 +13,4 @@
 `include "flash_ctrl_host_dir_rd_vseq.sv"
 `include "flash_ctrl_rd_buff_evict_vseq.sv"
 `include "flash_ctrl_phy_arb_vseq.sv"
+`include "flash_ctrl_hw_sec_otp_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -92,6 +92,12 @@
       run_opts: ["+zero_delays=1"]
       reseed: 20
     }
+    {
+      name: flash_ctrl_hw_sec_otp
+      uvm_test_seq: flash_ctrl_hw_sec_otp_vseq
+      reseed: 5
+    }
+  
   ]
 
   // List of regressions.

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -64,14 +64,19 @@ module tb;
 
   `DV_ALERT_IF_CONNECT
 
+  // SIMPLE OTP KEY INTERFACE (Access via VIF)
+
   otp_ctrl_pkg::flash_otp_key_req_t otp_req;
   otp_ctrl_pkg::flash_otp_key_rsp_t otp_rsp;
 
-  always_comb begin
-    otp_rsp = otp_ctrl_pkg::FLASH_OTP_KEY_RSP_DEFAULT;
-    otp_rsp.data_ack = otp_req.data_req;
-    otp_rsp.addr_ack = otp_req.addr_req;
-  end
+  assign flash_ctrl_if.otp_req.addr_req = otp_req.addr_req;
+  assign flash_ctrl_if.otp_req.data_req = otp_req.data_req;
+
+  assign otp_rsp.addr_ack               = flash_ctrl_if.otp_rsp.addr_ack;
+  assign otp_rsp.data_ack               = flash_ctrl_if.otp_rsp.data_ack;
+  assign otp_rsp.key                    = flash_ctrl_if.otp_rsp.key;
+  assign otp_rsp.rand_key               = flash_ctrl_if.otp_rsp.rand_key;
+  assign otp_rsp.seed_valid             = flash_ctrl_if.otp_rsp.seed_valid;
 
   wire flash_test_v;
   assign (pull1, pull0) flash_test_v = 1'b1;
@@ -147,7 +152,6 @@ module tb;
     .flash_alert_o    (flash_ctrl_if.flash_alert)
   );
 
-  // -----------------------------------
   // Create edge in flash_power_down_h_i, whenever reset is asserted
   logic init;
   assign flash_power_down_h = (init ? 1'b1 : 1'b0);


### PR DESCRIPTION
New test that verifies the secret seed/secret partition functionality, keys are output from Flash Ctrl and sent to key manager.
Additionally the test verifies that OTP keys are collected from the otp and sent to the scramble function in the Flash Ctrl (connection test, not full scramble test, which will follow)