### PR TITLE
[entropy_src/rtl] Add full REGWEN solution

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -121,8 +121,8 @@
 
   regwidth: "32",
   registers: [
-    { name: "REGWEN_ME",
-      desc: "Register write enable for module enable control register",
+    { name: "ME_REGWEN",
+      desc: "Register write enable for module enable register",
       swaccess: "rw0c",
       hwaccess: "none",
       fields: [
@@ -135,15 +135,38 @@
         }
       ]
     },
-    { name: "REGWEN",
-      desc: "Register write enable for all control registers",
+    { name: "SW_REGUPD",
+      desc: "Register write enable for control and threshold registers",
       swaccess: "rw0c",
-      hwaccess: "none",
+      hwaccess: "hro",
+      tags: [// Exclude from writes to these field because they cause side affects.
+             "excl:CsrAllTests:CsrExclAll"]
       fields: [
         {
             bits: "0",
-            desc: ''' When true, all writeable registers can be modified.
-            When false, they become read-only.
+            desc: ''' When this bit true and the MODULE_ENABLE field is false,
+            the REGWEN write enable bit read as true, and is distributed to
+            all associated control and threshold registers.
+            When false, these registers become read-only.
+            '''
+            resval: 1
+        }
+      ]
+    },
+    { name: "REGWEN",
+      desc: "Register write enable for all control registers",
+      swaccess: "ro",  // this particular enable bit is meant to be fully HW managed
+      hwaccess: "hwo",
+      tags: [// Internal HW can modify status register
+             "excl:CsrAllTests:CsrExclCheck"]
+      fields: [
+        {
+            bits: "0",
+            desc: ''' This read-only write enable bit will allow write access
+            to control and theshold registers that are associated with this bit,
+            but only when the MODULE_ENABLE field is set to kMuBi4False and the
+            SW_REGUPD write enable bit is set to true.
+            When read as false, these registers become read-only.
             '''
             resval: 1
         }
@@ -175,7 +198,7 @@
       desc: "Module enable register",
       swaccess: "rw",
       hwaccess: "hro",
-      regwen:   "REGWEN_ME",
+      regwen:   "ME_REGWEN",
       tags: [// Exclude from writes to these field because they cause side affects.
              "excl:CsrAllTests:CsrExclAll"]
       fields: [

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -77,6 +77,10 @@ package entropy_src_reg_pkg;
   } entropy_src_reg2hw_alert_test_reg_t;
 
   typedef struct packed {
+    logic        q;
+  } entropy_src_reg2hw_sw_regupd_reg_t;
+
+  typedef struct packed {
     logic [3:0]  q;
   } entropy_src_reg2hw_module_enable_reg_t;
 
@@ -278,6 +282,11 @@ package entropy_src_reg_pkg;
       logic        de;
     } es_fatal_err;
   } entropy_src_hw2reg_intr_state_reg_t;
+
+  typedef struct packed {
+    logic        d;
+    logic        de;
+  } entropy_src_hw2reg_regwen_reg_t;
 
   typedef struct packed {
     logic [31:0] d;
@@ -645,10 +654,11 @@ package entropy_src_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    entropy_src_reg2hw_intr_state_reg_t intr_state; // [543:540]
-    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [539:536]
-    entropy_src_reg2hw_intr_test_reg_t intr_test; // [535:528]
-    entropy_src_reg2hw_alert_test_reg_t alert_test; // [527:524]
+    entropy_src_reg2hw_intr_state_reg_t intr_state; // [544:541]
+    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [540:537]
+    entropy_src_reg2hw_intr_test_reg_t intr_test; // [536:529]
+    entropy_src_reg2hw_alert_test_reg_t alert_test; // [528:525]
+    entropy_src_reg2hw_sw_regupd_reg_t sw_regupd; // [524:524]
     entropy_src_reg2hw_module_enable_reg_t module_enable; // [523:520]
     entropy_src_reg2hw_conf_reg_t conf; // [519:498]
     entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [497:490]
@@ -673,7 +683,8 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1050:1043]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1052:1045]
+    entropy_src_hw2reg_regwen_reg_t regwen; // [1044:1043]
     entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1042:1011]
     entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1010:979]
     entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [978:947]
@@ -716,53 +727,54 @@ package entropy_src_reg_pkg;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_INTR_ENABLE_OFFSET = 8'h 4;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_INTR_TEST_OFFSET = 8'h 8;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_TEST_OFFSET = 8'h c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_ME_OFFSET = 8'h 10;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_OFFSET = 8'h 14;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REV_OFFSET = 8'h 18;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MODULE_ENABLE_OFFSET = 8'h 1c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_CONF_OFFSET = 8'h 20;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_CONTROL_OFFSET = 8'h 24;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_DATA_OFFSET = 8'h 28;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET = 8'h 2c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET = 8'h 30;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET = 8'h 34;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET = 8'h 38;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET = 8'h 3c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET = 8'h 40;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET = 8'h 44;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET = 8'h 48;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET = 8'h 4c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET = 8'h 50;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET = 8'h 54;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET = 8'h 58;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET = 8'h 5c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET = 8'h 60;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET = 8'h 64;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET = 8'h 68;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET = 8'h 6c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET = 8'h 70;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET = 8'h 74;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET = 8'h 78;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET = 8'h 7c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET = 8'h 80;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET = 8'h 84;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET = 8'h 88;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET = 8'h 8c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET = 8'h 90;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET = 8'h 94;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET = 8'h 98;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_THRESHOLD_OFFSET = 8'h 9c;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET = 8'h a0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET = 8'h a4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET = 8'h a8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h ac;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h b0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h b4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h b8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h bc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h c0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h c4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h c8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ME_REGWEN_OFFSET = 8'h 10;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_SW_REGUPD_OFFSET = 8'h 14;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REGWEN_OFFSET = 8'h 18;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REV_OFFSET = 8'h 1c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MODULE_ENABLE_OFFSET = 8'h 20;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_CONF_OFFSET = 8'h 24;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_CONTROL_OFFSET = 8'h 28;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ENTROPY_DATA_OFFSET = 8'h 2c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_HEALTH_TEST_WINDOWS_OFFSET = 8'h 30;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_THRESHOLDS_OFFSET = 8'h 34;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_THRESHOLDS_OFFSET = 8'h 38;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS_OFFSET = 8'h 3c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS_OFFSET = 8'h 40;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_THRESHOLDS_OFFSET = 8'h 44;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_THRESHOLDS_OFFSET = 8'h 48;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_THRESHOLDS_OFFSET = 8'h 4c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_THRESHOLDS_OFFSET = 8'h 50;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_THRESHOLDS_OFFSET = 8'h 54;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_HI_WATERMARKS_OFFSET = 8'h 58;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_HI_WATERMARKS_OFFSET = 8'h 5c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_WATERMARKS_OFFSET = 8'h 60;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_WATERMARKS_OFFSET = 8'h 64;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_WATERMARKS_OFFSET = 8'h 68;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_WATERMARKS_OFFSET = 8'h 6c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_HI_WATERMARKS_OFFSET = 8'h 70;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_WATERMARKS_OFFSET = 8'h 74;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_WATERMARKS_OFFSET = 8'h 78;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNT_TOTAL_FAILS_OFFSET = 8'h 7c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_REPCNTS_TOTAL_FAILS_OFFSET = 8'h 80;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS_OFFSET = 8'h 84;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS_OFFSET = 8'h 88;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_BUCKET_TOTAL_FAILS_OFFSET = 8'h 8c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS_OFFSET = 8'h 90;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS_OFFSET = 8'h 94;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS_OFFSET = 8'h 98;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS_OFFSET = 8'h 9c;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_THRESHOLD_OFFSET = 8'h a0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_OFFSET = 8'h a4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET = 8'h a8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET = 8'h ac;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h b0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h b4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h b8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h bc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h c0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h c4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h c8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h cc;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] ENTROPY_SRC_INTR_TEST_RESVAL = 4'h 0;
@@ -838,7 +850,8 @@ package entropy_src_reg_pkg;
     ENTROPY_SRC_INTR_ENABLE,
     ENTROPY_SRC_INTR_TEST,
     ENTROPY_SRC_ALERT_TEST,
-    ENTROPY_SRC_REGWEN_ME,
+    ENTROPY_SRC_ME_REGWEN,
+    ENTROPY_SRC_SW_REGUPD,
     ENTROPY_SRC_REGWEN,
     ENTROPY_SRC_REV,
     ENTROPY_SRC_MODULE_ENABLE,
@@ -888,58 +901,59 @@ package entropy_src_reg_pkg;
   } entropy_src_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] ENTROPY_SRC_PERMIT [51] = '{
+  parameter logic [3:0] ENTROPY_SRC_PERMIT [52] = '{
     4'b 0001, // index[ 0] ENTROPY_SRC_INTR_STATE
     4'b 0001, // index[ 1] ENTROPY_SRC_INTR_ENABLE
     4'b 0001, // index[ 2] ENTROPY_SRC_INTR_TEST
     4'b 0001, // index[ 3] ENTROPY_SRC_ALERT_TEST
-    4'b 0001, // index[ 4] ENTROPY_SRC_REGWEN_ME
-    4'b 0001, // index[ 5] ENTROPY_SRC_REGWEN
-    4'b 0111, // index[ 6] ENTROPY_SRC_REV
-    4'b 0001, // index[ 7] ENTROPY_SRC_MODULE_ENABLE
-    4'b 1111, // index[ 8] ENTROPY_SRC_CONF
-    4'b 0001, // index[ 9] ENTROPY_SRC_ENTROPY_CONTROL
-    4'b 1111, // index[10] ENTROPY_SRC_ENTROPY_DATA
-    4'b 1111, // index[11] ENTROPY_SRC_HEALTH_TEST_WINDOWS
-    4'b 1111, // index[12] ENTROPY_SRC_REPCNT_THRESHOLDS
-    4'b 1111, // index[13] ENTROPY_SRC_REPCNTS_THRESHOLDS
-    4'b 1111, // index[14] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS
-    4'b 1111, // index[15] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS
-    4'b 1111, // index[16] ENTROPY_SRC_BUCKET_THRESHOLDS
-    4'b 1111, // index[17] ENTROPY_SRC_MARKOV_HI_THRESHOLDS
-    4'b 1111, // index[18] ENTROPY_SRC_MARKOV_LO_THRESHOLDS
-    4'b 1111, // index[19] ENTROPY_SRC_EXTHT_HI_THRESHOLDS
-    4'b 1111, // index[20] ENTROPY_SRC_EXTHT_LO_THRESHOLDS
-    4'b 1111, // index[21] ENTROPY_SRC_REPCNT_HI_WATERMARKS
-    4'b 1111, // index[22] ENTROPY_SRC_REPCNTS_HI_WATERMARKS
-    4'b 1111, // index[23] ENTROPY_SRC_ADAPTP_HI_WATERMARKS
-    4'b 1111, // index[24] ENTROPY_SRC_ADAPTP_LO_WATERMARKS
-    4'b 1111, // index[25] ENTROPY_SRC_EXTHT_HI_WATERMARKS
-    4'b 1111, // index[26] ENTROPY_SRC_EXTHT_LO_WATERMARKS
-    4'b 1111, // index[27] ENTROPY_SRC_BUCKET_HI_WATERMARKS
-    4'b 1111, // index[28] ENTROPY_SRC_MARKOV_HI_WATERMARKS
-    4'b 1111, // index[29] ENTROPY_SRC_MARKOV_LO_WATERMARKS
-    4'b 1111, // index[30] ENTROPY_SRC_REPCNT_TOTAL_FAILS
-    4'b 1111, // index[31] ENTROPY_SRC_REPCNTS_TOTAL_FAILS
-    4'b 1111, // index[32] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS
-    4'b 1111, // index[33] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS
-    4'b 1111, // index[34] ENTROPY_SRC_BUCKET_TOTAL_FAILS
-    4'b 1111, // index[35] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS
-    4'b 1111, // index[36] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS
-    4'b 1111, // index[37] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS
-    4'b 1111, // index[38] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS
-    4'b 1111, // index[39] ENTROPY_SRC_ALERT_THRESHOLD
-    4'b 0011, // index[40] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS
-    4'b 1111, // index[41] ENTROPY_SRC_ALERT_FAIL_COUNTS
-    4'b 0001, // index[42] ENTROPY_SRC_EXTHT_FAIL_COUNTS
-    4'b 0001, // index[43] ENTROPY_SRC_FW_OV_CONTROL
-    4'b 1111, // index[44] ENTROPY_SRC_FW_OV_RD_DATA
-    4'b 1111, // index[45] ENTROPY_SRC_FW_OV_WR_DATA
-    4'b 0001, // index[46] ENTROPY_SRC_OBSERVE_FIFO_THRESH
-    4'b 1111, // index[47] ENTROPY_SRC_DEBUG_STATUS
-    4'b 0011, // index[48] ENTROPY_SRC_RECOV_ALERT_STS
-    4'b 1111, // index[49] ENTROPY_SRC_ERR_CODE
-    4'b 0001  // index[50] ENTROPY_SRC_ERR_CODE_TEST
+    4'b 0001, // index[ 4] ENTROPY_SRC_ME_REGWEN
+    4'b 0001, // index[ 5] ENTROPY_SRC_SW_REGUPD
+    4'b 0001, // index[ 6] ENTROPY_SRC_REGWEN
+    4'b 0111, // index[ 7] ENTROPY_SRC_REV
+    4'b 0001, // index[ 8] ENTROPY_SRC_MODULE_ENABLE
+    4'b 1111, // index[ 9] ENTROPY_SRC_CONF
+    4'b 0001, // index[10] ENTROPY_SRC_ENTROPY_CONTROL
+    4'b 1111, // index[11] ENTROPY_SRC_ENTROPY_DATA
+    4'b 1111, // index[12] ENTROPY_SRC_HEALTH_TEST_WINDOWS
+    4'b 1111, // index[13] ENTROPY_SRC_REPCNT_THRESHOLDS
+    4'b 1111, // index[14] ENTROPY_SRC_REPCNTS_THRESHOLDS
+    4'b 1111, // index[15] ENTROPY_SRC_ADAPTP_HI_THRESHOLDS
+    4'b 1111, // index[16] ENTROPY_SRC_ADAPTP_LO_THRESHOLDS
+    4'b 1111, // index[17] ENTROPY_SRC_BUCKET_THRESHOLDS
+    4'b 1111, // index[18] ENTROPY_SRC_MARKOV_HI_THRESHOLDS
+    4'b 1111, // index[19] ENTROPY_SRC_MARKOV_LO_THRESHOLDS
+    4'b 1111, // index[20] ENTROPY_SRC_EXTHT_HI_THRESHOLDS
+    4'b 1111, // index[21] ENTROPY_SRC_EXTHT_LO_THRESHOLDS
+    4'b 1111, // index[22] ENTROPY_SRC_REPCNT_HI_WATERMARKS
+    4'b 1111, // index[23] ENTROPY_SRC_REPCNTS_HI_WATERMARKS
+    4'b 1111, // index[24] ENTROPY_SRC_ADAPTP_HI_WATERMARKS
+    4'b 1111, // index[25] ENTROPY_SRC_ADAPTP_LO_WATERMARKS
+    4'b 1111, // index[26] ENTROPY_SRC_EXTHT_HI_WATERMARKS
+    4'b 1111, // index[27] ENTROPY_SRC_EXTHT_LO_WATERMARKS
+    4'b 1111, // index[28] ENTROPY_SRC_BUCKET_HI_WATERMARKS
+    4'b 1111, // index[29] ENTROPY_SRC_MARKOV_HI_WATERMARKS
+    4'b 1111, // index[30] ENTROPY_SRC_MARKOV_LO_WATERMARKS
+    4'b 1111, // index[31] ENTROPY_SRC_REPCNT_TOTAL_FAILS
+    4'b 1111, // index[32] ENTROPY_SRC_REPCNTS_TOTAL_FAILS
+    4'b 1111, // index[33] ENTROPY_SRC_ADAPTP_HI_TOTAL_FAILS
+    4'b 1111, // index[34] ENTROPY_SRC_ADAPTP_LO_TOTAL_FAILS
+    4'b 1111, // index[35] ENTROPY_SRC_BUCKET_TOTAL_FAILS
+    4'b 1111, // index[36] ENTROPY_SRC_MARKOV_HI_TOTAL_FAILS
+    4'b 1111, // index[37] ENTROPY_SRC_MARKOV_LO_TOTAL_FAILS
+    4'b 1111, // index[38] ENTROPY_SRC_EXTHT_HI_TOTAL_FAILS
+    4'b 1111, // index[39] ENTROPY_SRC_EXTHT_LO_TOTAL_FAILS
+    4'b 1111, // index[40] ENTROPY_SRC_ALERT_THRESHOLD
+    4'b 0011, // index[41] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS
+    4'b 1111, // index[42] ENTROPY_SRC_ALERT_FAIL_COUNTS
+    4'b 0001, // index[43] ENTROPY_SRC_EXTHT_FAIL_COUNTS
+    4'b 0001, // index[44] ENTROPY_SRC_FW_OV_CONTROL
+    4'b 1111, // index[45] ENTROPY_SRC_FW_OV_RD_DATA
+    4'b 1111, // index[46] ENTROPY_SRC_FW_OV_WR_DATA
+    4'b 0001, // index[47] ENTROPY_SRC_OBSERVE_FIFO_THRESH
+    4'b 1111, // index[48] ENTROPY_SRC_DEBUG_STATUS
+    4'b 0011, // index[49] ENTROPY_SRC_RECOV_ALERT_STS
+    4'b 1111, // index[50] ENTROPY_SRC_ERR_CODE
+    4'b 0001  // index[51] ENTROPY_SRC_ERR_CODE_TEST
   };
 
 endpackage

--- a/sw/device/lib/dif/dif_entropy_src.c
+++ b/sw/device/lib/dif/dif_entropy_src.c
@@ -234,7 +234,9 @@ dif_result_t dif_entropy_src_disable(const dif_entropy_src_t *entropy_src) {
     return kDifBadArg;
   }
   // TODO: should first check if entropy is locked and return error if it is.
-  mmio_region_write32(entropy_src->base_addr, ENTROPY_SRC_CONF_REG_OFFSET, 0);
+  mmio_region_write32(entropy_src->base_addr,
+                      ENTROPY_SRC_MODULE_ENABLE_REG_OFFSET,
+                      kMultiBitBool4False);
 
   const dif_entropy_src_fw_override_config_t kDefaultFwOverrideConfig = {
       .enable = false,

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -22,9 +22,8 @@ const size_t kEntropyDataNumWords = 12;
 // Issue #10092 has been opened to discuss this.
 
 const uint32_t kExpectedEntropyData[] = {
-    0x7c7baa24, 0x4e3f30f8, 0xcae3aefe, 0x80197526, 0xbb8761a4, 0x18b5b15f,
-    0xe8126c66, 0x69efaf13, 0x8cc59ac2, 0xb7f3bcad, 0x06dc9089, 0x1f4c6ef2,
-};
+    0xdaf90306, 0x466d674,  0x9691df54, 0xd2e3c93f, 0xdcbc993e, 0x64bfd173,
+    0xaba04e99, 0xf8ae1105, 0xd01dc17a, 0x608c5480, 0x373c5dcc, 0xc4e6cd55};
 
 bool test_main() {
   dif_entropy_src_t entropy_src;


### PR DESCRIPTION
Three REGWEN register will now control register access.
A HW_REGWEN, SW_REGWEN_SW, and ME_REGWEN bit allow different register
access at different points in the boot process.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>