### PR TITLE
[dv/reggen] Fix xcelium hdl backdoor path error

### DIFF
--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -157,7 +157,7 @@ def gen_dv(block: IpBlock, dv_base_names: List[str], outdir: str) -> int:
     block_dv_base_names = get_block_base_name(dv_base_names_map, lblock)
 
     for if_name, rb in block.reg_blocks.items():
-        hier_path = '.u_reg' if block.hier_path is None else block.hier_path
+        hier_path = 'u_reg' if block.hier_path is None else block.hier_path
         if_suffix = '' if if_name is None else '_' + if_name.lower()
         mod_base = lblock + if_suffix
         reg_block_path = hier_path + if_suffix


### PR DESCRIPTION
When reggen tool set the following entities:
1). set_hdl_path_root("tb.dut", "BkdrRegPathRtl");
2).       alert_test.add_hdl_path_slice(
          ".u_reg.u_alert_test_recov_ctrl_update_err.qs",
          0, 1, 0, "BkdrRegPathRtl");
Xcelium will add another `.` while forming the hdl path.
This PR removes the extra `.` in front of `u_reg` to avoid xcelilum
hdl path error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>