### PR TITLE
[usbdev] Detect AON bus reset, sense lost events

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -151,6 +151,22 @@
       struct:  "logic",
       width:   "1"
     },
+    { name:    "usb_bus_reset",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1",
+      default: "1'b0"
+    },
+    { name:    "usb_sense_lost",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1",
+      default: "1'b0"
+    },
     { name:    "usb_state_debug",
       type:    "uni",
       act:     "req",

--- a/hw/ip/pinmux/rtl/pinmux.sv
+++ b/hw/ip/pinmux/rtl/pinmux.sv
@@ -50,6 +50,8 @@ module pinmux
   input                            usb_aon_wake_en_i,
   input                            usb_aon_wake_ack_i,
   input                            usb_suspend_i,
+  output                           usb_bus_reset_o,
+  output                           usb_sense_lost_o,
   output usbdev_pkg::awk_state_t   usb_state_debug_o,
   // Bus Interface (device)
   input  tlul_pkg::tl_h2d_t        tl_i,
@@ -245,6 +247,7 @@ module pinmux
     // input signals for resume detection
     .usb_dp_async_alw_i(dio_to_periph_o[TargetCfg.usb_dp_idx]),
     .usb_dn_async_alw_i(dio_to_periph_o[TargetCfg.usb_dn_idx]),
+    .usb_sense_async_alw_i(mio_to_periph_o[TargetCfg.usb_sense_idx]),
     .usb_dppullup_en_alw_i(dio_out_o[TargetCfg.usb_dp_pullup_idx]),
     .usb_dnpullup_en_alw_i(dio_out_o[TargetCfg.usb_dn_pullup_idx]),
 
@@ -256,6 +259,8 @@ module pinmux
 
     // wake/powerup request
     .wake_req_alw_o(usb_wkup_req_o),
+    .bus_reset_alw_o(usb_bus_reset_o),
+    .sense_lost_alw_o(usb_sense_lost_o),
     .state_debug_o(usb_state_debug_o)
   );
 

--- a/hw/ip/pinmux/rtl/pinmux_pkg.sv
+++ b/hw/ip/pinmux/rtl/pinmux_pkg.sv
@@ -29,6 +29,7 @@ package pinmux_pkg;
     integer                   usb_dn_idx;
     integer                   usb_dp_pullup_idx;
     integer                   usb_dn_pullup_idx;
+    integer                   usb_sense_idx;
     pad_type_e [NDioPads-1:0] dio_pad_type;
     pad_type_e [NMioPads-1:0] mio_pad_type;
   } target_cfg_t;
@@ -47,6 +48,7 @@ package pinmux_pkg;
     usb_dn_idx:        0,
     usb_dp_pullup_idx: 0,
     usb_dn_pullup_idx: 0,
+    usb_sense_idx:     0,
     dio_pad_type:      {NDioPads{BidirStd}},
     mio_pad_type:      {NMioPads{BidirStd}}
   };

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_in_pe.sv
@@ -17,7 +17,8 @@ module usb_fs_nb_in_pe #(
   parameter int unsigned MaxInPktSizeByte = 32,
   // Targeting 17 bit times for the timeout. The counter runs on the 48 MHz
   // clock, the SOP delay to rx_pkt_start_i is 3 bit times, and the EOP delay
-  // to tx_pkt_end_i is essentially 0.
+  // to tx_pkt_end_i is essentially 0. This timeout originates from Section
+  // 7.1.19.1 of the USB 2.0 specification.
   parameter int unsigned AckTimeoutCnt = (17 + 3) * 4,
   localparam int unsigned InEpW = $clog2(NumInEps), // derived parameter
   localparam int unsigned PktW = $clog2(MaxInPktSizeByte), // derived parameter

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_out_pe.sv
@@ -18,7 +18,8 @@ module usb_fs_nb_out_pe #(
   parameter int unsigned MaxOutPktSizeByte = 32,
   // Targeting 17 bit times for the timeout. The counter runs on the 48 MHz
   // clock. The SOP delay to rx_pkt_start_i is 3 bit times, but the two
-  // packets go in the same direction, so this is negated.
+  // packets go in the same direction, so this is negated. This timeout
+  // originates from Section 7.1.19.1 of the USB 2.0 specification.
   parameter int unsigned AckTimeoutCnt = 17 * 4,
   localparam int unsigned OutEpW = $clog2(NumOutEps), // derived parameter
   localparam int unsigned PktW = $clog2(MaxOutPktSizeByte), // derived parameter

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -69,6 +69,20 @@
       struct:  "logic",
       width:   "1"
     },
+    { name:    "usb_aon_bus_reset",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
+    { name:    "usb_aon_sense_lost",
+      type:    "uni",
+      act:     "rcv",
+      package: "",
+      struct:  "logic",
+      width:   "1"
+    },
     { name:    "usb_state_debug",
       type:    "uni",
       act:     "rcv",
@@ -859,17 +873,34 @@
       ]
     }
 
-    { name: "wake_debug",
-      desc: "USB wake module debug",
+    { name: "wake_events",
+      desc: "USB wake module events and debug",
       swaccess: "ro",
       hwaccess: "hwo",
+      async: "clk_aon_i",
       fields: [
         {
           bits: "2:0",
           resval: "0",
           name: "state",
           desc: '''
-                  USB aon wake module state read back
+                USB aon wake module state read back
+                '''
+        }
+        {
+          bits: "8",
+          resval: "0",
+          name: "disconnected",
+          desc: '''
+                USB aon wake module detected VBUS was interrupted while monitoring events.
+                '''
+        }
+        {
+          bits: "9",
+          resval: "0",
+          name: "bus_reset",
+          desc: '''
+                USB aon wake module detected a bus reset while monitoring events.
                 '''
         }
       ]

--- a/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
+++ b/hw/ip/usbdev/dv/env/usbdev_env_pkg.sv
@@ -43,6 +43,7 @@ package usbdev_env_pkg;
     IntrRxBitstuffErr = 13,
     IntrFrame = 14,
     IntrConnected = 15,
+    IntrLinkOutErr = 16,
     NumUsbdevInterrupts
   } usbdev_intr_e;
 

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -28,6 +28,7 @@ module tb;
   wire intr_rx_full;
   wire intr_av_overflow;
   wire intr_link_in_err;
+  wire intr_link_out_err;
   wire intr_rx_crc_err;
   wire intr_rx_pid_err;
   wire intr_rx_bitstuff_err;
@@ -60,16 +61,19 @@ module tb;
     .alert_rx_i           (alert_rx   ),
     .alert_tx_o           (alert_tx   ),
 
-    // pinmux wakeup interface
-    .usb_state_debug_i    ('0),
-
     // USB Interface
     // TOOD: need to hook up an interface
-    .cio_sense_i          (1'b0),
     .cio_d_i              (1'b0),
     .cio_dp_i             (1'b1),
     .cio_dn_i             (1'b0),
+    .cio_d_o              (),
+    .cio_d_en_o           (),
+    .cio_dp_o             (),
+    .cio_dp_en_o          (),
+    .cio_dn_o             (),
+    .cio_dn_en_o          (),
 
+    .cio_sense_i          (1'b0),
     .cio_se0_o            (),
     .cio_se0_en_o         (),
     .cio_dp_pullup_o      (),
@@ -80,12 +84,26 @@ module tb;
     .cio_tx_mode_se_en_o  (),
     .cio_suspend_o        (),
     .cio_suspend_en_o     (),
-    .cio_d_o              (),
-    .cio_d_en_o           (),
-    .cio_dp_o             (),
-    .cio_dp_en_o          (),
-    .cio_dn_o             (),
-    .cio_dn_en_o          (),
+    .cio_rx_enable_o      (),
+    .cio_rx_enable_en_o   (),
+
+    // Direct pinmux aon detect connections
+    .usb_out_of_rst_o     (),
+    .usb_aon_wake_en_o    (),
+    .usb_aon_wake_ack_o   (),
+    .usb_suspend_o        (),
+
+    // Events and debug info from wakeup module
+    .usb_aon_bus_reset_i  ('0),
+    .usb_aon_sense_lost_i ('0),
+    .usb_state_debug_i    ('0),
+
+    // SOF reference for clock calibration
+    .usb_ref_val_o        (),
+    .usb_ref_pulse_o      (),
+
+    // memory configuration
+    .ram_cfg_i            ('0),
 
     // Interrupts
     .intr_pkt_received_o    (intr_pkt_received    ),
@@ -100,6 +118,7 @@ module tb;
     .intr_rx_full_o         (intr_rx_full         ),
     .intr_av_overflow_o     (intr_av_overflow     ),
     .intr_link_in_err_o     (intr_link_in_err     ),
+    .intr_link_out_err_o    (intr_link_out_err    ),
     .intr_rx_crc_err_o      (intr_rx_crc_err      ),
     .intr_rx_pid_err_o      (intr_rx_pid_err      ),
     .intr_rx_bitstuff_err_o (intr_rx_bitstuff_err ),
@@ -119,6 +138,7 @@ module tb;
   assign interrupts[IntrRxFull]         = intr_rx_full;
   assign interrupts[IntrAvOverflow]     = intr_av_overflow;
   assign interrupts[IntrLinkInErr]      = intr_link_in_err;
+  assign interrupts[IntrLinkOutErr]     = intr_link_out_err;
   assign interrupts[IntrRxCrcErr]       = intr_rx_crc_err;
   assign interrupts[IntrRxPidErr]       = intr_rx_pid_err;
   assign interrupts[IntrRxBitstuffErr]  = intr_rx_bitstuff_err;

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -15,6 +15,7 @@ module usbdev_linkstate (
   input  logic usb_oe_i,
   input  logic rx_jjj_det_i,
   input  logic sof_valid_i,
+
   output logic link_disconnect_o,  // level
   output logic link_connect_o,     // level
   output logic link_reset_o,       // level
@@ -26,8 +27,12 @@ module usbdev_linkstate (
   output logic [2:0] link_state_o
 );
 
-  localparam logic [11:0] SUSPEND_TIMEOUT = 12'd3000; // 3ms by spec
-  localparam logic [2:0]  RESET_TIMEOUT   = 3'd3;     // 3us. Can be 2.5us - 10ms by spec
+  // Suspend signaling is 3ms of J by spec.
+  localparam logic [11:0] SUSPEND_TIMEOUT = 12'd3000;
+  // Reset is 2.5us - 10ms of SE0 by spec, though care should be taken to not
+  // confuse the 2 *low-speed* bit times (1.33us) of SE0 that terminate resume
+  // signaling. Use 3us here.
+  localparam logic [2:0]  RESET_TIMEOUT   = 3'd3;
 
   typedef enum logic [2:0] {
     // Unpowered state
@@ -267,7 +272,7 @@ module usbdev_linkstate (
   ////////////////////
   // Idle detection //
   ////////////////////
-  //  Here we clean up the idle signal and generate a signle ev_bus_inactive
+  //  Here we clean up the idle signal and generate a single ev_bus_inactive
   //  after the timer expires
   always_comb begin : proc_idle_det
     link_inac_state_d = link_inac_state_q;

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -525,9 +525,19 @@ package usbdev_reg_pkg;
   } usbdev_hw2reg_phy_pins_sense_reg_t;
 
   typedef struct packed {
-    logic [2:0]  d;
-    logic        de;
-  } usbdev_hw2reg_wake_debug_reg_t;
+    struct packed {
+      logic [2:0]  d;
+      logic        de;
+    } state;
+    struct packed {
+      logic        d;
+      logic        de;
+    } disconnected;
+    struct packed {
+      logic        d;
+      logic        de;
+    } bus_reset;
+  } usbdev_hw2reg_wake_events_reg_t;
 
   // Register -> HW type
   typedef struct packed {
@@ -554,16 +564,16 @@ package usbdev_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    usbdev_hw2reg_intr_state_reg_t intr_state; // [216:183]
-    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [182:175]
-    usbdev_hw2reg_usbstat_reg_t usbstat; // [174:151]
-    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [150:134]
-    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [133:110]
-    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [109:86]
-    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [85:62]
-    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [61:14]
-    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [13:4]
-    usbdev_hw2reg_wake_debug_reg_t wake_debug; // [3:0]
+    usbdev_hw2reg_intr_state_reg_t intr_state; // [220:187]
+    usbdev_hw2reg_usbctrl_reg_t usbctrl; // [186:179]
+    usbdev_hw2reg_usbstat_reg_t usbstat; // [178:155]
+    usbdev_hw2reg_rxfifo_reg_t rxfifo; // [154:138]
+    usbdev_hw2reg_in_sent_mreg_t [11:0] in_sent; // [137:114]
+    usbdev_hw2reg_out_stall_mreg_t [11:0] out_stall; // [113:90]
+    usbdev_hw2reg_in_stall_mreg_t [11:0] in_stall; // [89:66]
+    usbdev_hw2reg_configin_mreg_t [11:0] configin; // [65:18]
+    usbdev_hw2reg_phy_pins_sense_reg_t phy_pins_sense; // [17:8]
+    usbdev_hw2reg_wake_events_reg_t wake_events; // [7:0]
   } usbdev_hw2reg_t;
 
   // Register offsets
@@ -600,7 +610,7 @@ package usbdev_reg_pkg;
   parameter logic [BlockAw-1:0] USBDEV_PHY_PINS_DRIVE_OFFSET = 12'h 78;
   parameter logic [BlockAw-1:0] USBDEV_PHY_CONFIG_OFFSET = 12'h 7c;
   parameter logic [BlockAw-1:0] USBDEV_WAKE_CONFIG_OFFSET = 12'h 80;
-  parameter logic [BlockAw-1:0] USBDEV_WAKE_DEBUG_OFFSET = 12'h 84;
+  parameter logic [BlockAw-1:0] USBDEV_WAKE_EVENTS_OFFSET = 12'h 84;
 
   // Reset values for hwext registers and their fields
   parameter logic [16:0] USBDEV_INTR_TEST_RESVAL = 17'h 0;
@@ -667,7 +677,7 @@ package usbdev_reg_pkg;
     USBDEV_PHY_PINS_DRIVE,
     USBDEV_PHY_CONFIG,
     USBDEV_WAKE_CONFIG,
-    USBDEV_WAKE_DEBUG
+    USBDEV_WAKE_EVENTS
   } usbdev_id_e;
 
   // Register width information to check illegal writes
@@ -705,7 +715,7 @@ package usbdev_reg_pkg;
     4'b 0111, // index[30] USBDEV_PHY_PINS_DRIVE
     4'b 0001, // index[31] USBDEV_PHY_CONFIG
     4'b 0001, // index[32] USBDEV_WAKE_CONFIG
-    4'b 0001  // index[33] USBDEV_WAKE_DEBUG
+    4'b 0011  // index[33] USBDEV_WAKE_EVENTS
   };
 
 endpackage

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -97,7 +97,8 @@ module usbdev_usbif  #(
   output logic                     rx_bitstuff_err_o
 );
 
-  assign usb_pullup_en_o = enable_i;
+  // Enable pull-up resistor only if VBUS is active
+  assign usb_pullup_en_o = enable_i & usb_sense_i;
 
   // OUT or SETUP direction
   logic [PktW:0]                     out_max_used_d, out_max_used_q;

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1198,6 +1198,34 @@
           index: -1
         }
         {
+          name: usb_aon_bus_reset
+          struct: logic
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: usbdev
+          default: ""
+          package: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: usbdev_usb_aon_bus_reset
+          index: -1
+        }
+        {
+          name: usb_aon_sense_lost
+          struct: logic
+          type: uni
+          act: rcv
+          width: 1
+          inst_name: usbdev
+          default: ""
+          package: ""
+          end_idx: -1
+          top_type: broadcast
+          top_signame: usbdev_usb_aon_sense_lost
+          index: -1
+        }
+        {
           name: usb_state_debug
           struct: awk_state
           package: usbdev_pkg
@@ -3512,6 +3540,30 @@
           default: ""
           package: ""
           top_signame: usbdev_usb_suspend
+          index: -1
+        }
+        {
+          name: usb_bus_reset
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          default: 1'b0
+          inst_name: pinmux_aon
+          package: ""
+          top_signame: usbdev_usb_aon_bus_reset
+          index: -1
+        }
+        {
+          name: usb_sense_lost
+          struct: logic
+          type: uni
+          act: req
+          width: 1
+          default: 1'b0
+          inst_name: pinmux_aon
+          package: ""
+          top_signame: usbdev_usb_aon_sense_lost
           index: -1
         }
         {
@@ -7220,6 +7272,14 @@
       usbdev.usb_suspend:
       [
         pinmux_aon.usb_suspend
+      ]
+      usbdev.usb_aon_bus_reset:
+      [
+        pinmux_aon.usb_bus_reset
+      ]
+      usbdev.usb_aon_sense_lost:
+      [
+        pinmux_aon.usb_sense_lost
       ]
       pinmux_aon.usb_state_debug:
       [
@@ -14290,6 +14350,34 @@
         index: -1
       }
       {
+        name: usb_aon_bus_reset
+        struct: logic
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: usbdev
+        default: ""
+        package: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: usbdev_usb_aon_bus_reset
+        index: -1
+      }
+      {
+        name: usb_aon_sense_lost
+        struct: logic
+        type: uni
+        act: rcv
+        width: 1
+        inst_name: usbdev
+        default: ""
+        package: ""
+        end_idx: -1
+        top_type: broadcast
+        top_signame: usbdev_usb_aon_sense_lost
+        index: -1
+      }
+      {
         name: usb_state_debug
         struct: awk_state
         package: usbdev_pkg
@@ -15928,6 +16016,30 @@
         default: ""
         package: ""
         top_signame: usbdev_usb_suspend
+        index: -1
+      }
+      {
+        name: usb_bus_reset
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        default: 1'b0
+        inst_name: pinmux_aon
+        package: ""
+        top_signame: usbdev_usb_aon_bus_reset
+        index: -1
+      }
+      {
+        name: usb_sense_lost
+        struct: logic
+        type: uni
+        act: req
+        width: 1
+        default: 1'b0
+        inst_name: pinmux_aon
+        package: ""
+        top_signame: usbdev_usb_aon_sense_lost
         index: -1
       }
       {
@@ -19421,6 +19533,28 @@
         type: uni
         end_idx: -1
         act: req
+        suffix: ""
+        default: "'0"
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_aon_bus_reset
+        width: 1
+        type: uni
+        end_idx: -1
+        act: rcv
+        suffix: ""
+        default: "'0"
+      }
+      {
+        package: ""
+        struct: logic
+        signame: usbdev_usb_aon_sense_lost
+        width: 1
+        type: uni
+        end_idx: -1
+        act: rcv
         suffix: ""
         default: "'0"
       }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -820,10 +820,12 @@
       'csrng.entropy_src_hw_if' : ['entropy_src.entropy_src_hw_if'],
 
       // usbdev connection to pinmux
-      'usbdev.usb_out_of_rst'   : ['pinmux_aon.usb_out_of_rst'],
-      'usbdev.usb_aon_wake_en'  : ['pinmux_aon.usb_aon_wake_en'],
-      'usbdev.usb_aon_wake_ack' : ['pinmux_aon.usb_aon_wake_ack'],
-      'usbdev.usb_suspend'      : ['pinmux_aon.usb_suspend'],
+      'usbdev.usb_out_of_rst'     : ['pinmux_aon.usb_out_of_rst'],
+      'usbdev.usb_aon_wake_en'    : ['pinmux_aon.usb_aon_wake_en'],
+      'usbdev.usb_aon_wake_ack'   : ['pinmux_aon.usb_aon_wake_ack'],
+      'usbdev.usb_suspend'        : ['pinmux_aon.usb_suspend'],
+      'usbdev.usb_aon_bus_reset'  : ['pinmux_aon.usb_bus_reset'],
+      'usbdev.usb_aon_sense_lost' : ['pinmux_aon.usb_sense_lost'],
       'pinmux_aon.usb_state_debug' : ['usbdev.usb_state_debug'],
 
       // Edn connections

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -147,6 +147,22 @@
       struct:  "logic",
       width:   "1"
     },
+    { name:    "usb_bus_reset",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1",
+      default: "1'b0"
+    },
+    { name:    "usb_sense_lost",
+      type:    "uni",
+      act:     "req",
+      package: "",
+      struct:  "logic",
+      width:   "1",
+      default: "1'b0"
+    },
     { name:    "usb_state_debug",
       type:    "uni",
       act:     "req",

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -119,6 +119,7 @@ module chip_earlgrey_asic (
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
     usb_dn_pullup_idx: DioUsbdevDnPullup,
+    usb_sense_idx:     MioInUsbdevSense,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
       BidirOd, // DIO sysrst_ctrl_aon_flash_wp_l

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -114,6 +114,7 @@ module chip_earlgrey_cw310 #(
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
     usb_dn_pullup_idx: DioUsbdevDnPullup,
+    usb_sense_idx:     MioInUsbdevSense,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
       BidirOd, // DIO sysrst_ctrl_aon_flash_wp_l

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -104,6 +104,7 @@ module chip_earlgrey_nexysvideo #(
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
     usb_dn_pullup_idx: DioUsbdevDnPullup,
+    usb_sense_idx:     MioInUsbdevSense,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
       BidirOd, // DIO sysrst_ctrl_aon_flash_wp_l

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -562,6 +562,8 @@ module top_earlgrey #(
   logic       usbdev_usb_aon_wake_en;
   logic       usbdev_usb_aon_wake_ack;
   logic       usbdev_usb_suspend;
+  logic       usbdev_usb_aon_bus_reset;
+  logic       usbdev_usb_aon_sense_lost;
   usbdev_pkg::awk_state_t       pinmux_aon_usb_state_debug;
   edn_pkg::edn_req_t [7:0] edn0_edn_req;
   edn_pkg::edn_rsp_t [7:0] edn0_edn_rsp;
@@ -1419,6 +1421,8 @@ module top_earlgrey #(
       .usb_aon_wake_en_o(usbdev_usb_aon_wake_en),
       .usb_aon_wake_ack_o(usbdev_usb_aon_wake_ack),
       .usb_suspend_o(usbdev_usb_suspend),
+      .usb_aon_bus_reset_i(usbdev_usb_aon_bus_reset),
+      .usb_aon_sense_lost_i(usbdev_usb_aon_sense_lost),
       .usb_state_debug_i(pinmux_aon_usb_state_debug),
       .ram_cfg_i(ast_ram_2p_cfg),
       .tl_i(usbdev_tl_req),
@@ -1892,6 +1896,8 @@ module top_earlgrey #(
       .usb_aon_wake_en_i(usbdev_usb_aon_wake_en),
       .usb_aon_wake_ack_i(usbdev_usb_aon_wake_ack),
       .usb_suspend_i(usbdev_usb_suspend),
+      .usb_bus_reset_o(usbdev_usb_aon_bus_reset),
+      .usb_sense_lost_o(usbdev_usb_aon_sense_lost),
       .usb_state_debug_o(pinmux_aon_usb_state_debug),
       .tl_i(pinmux_aon_tl_req),
       .tl_o(pinmux_aon_tl_rsp),

--- a/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
+++ b/hw/top_earlgrey/rtl/chip_earlgrey_verilator.sv
@@ -399,6 +399,7 @@ module chip_earlgrey_verilator (
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
     usb_dn_pullup_idx: DioUsbdevDnPullup,
+    usb_sense_idx:     MioInUsbdevSense,
     // TODO: connect these once the verilator chip-level has been merged with the chiplevel.sv.tpl
     dio_pad_type: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::BidirStd}},
     mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}}

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -558,10 +558,12 @@
       'pwrmgr_aon.fetch_en'     : ['rv_core_ibex.pwrmgr_cpu_en'],
 
       // usbdev connection to pinmux
-      'usbdev.usb_out_of_rst'   : ['pinmux_aon.usb_out_of_rst'],
-      'usbdev.usb_aon_wake_en'  : ['pinmux_aon.usb_aon_wake_en'],
-      'usbdev.usb_aon_wake_ack' : ['pinmux_aon.usb_aon_wake_ack'],
-      'usbdev.usb_suspend'      : ['pinmux_aon.usb_suspend'],
+      'usbdev.usb_out_of_rst'      : ['pinmux_aon.usb_out_of_rst'],
+      'usbdev.usb_aon_wake_en'     : ['pinmux_aon.usb_aon_wake_en'],
+      'usbdev.usb_aon_wake_ack'    : ['pinmux_aon.usb_aon_wake_ack'],
+      'usbdev.usb_suspend'         : ['pinmux_aon.usb_suspend'],
+      'usbdev.usb_aon_bus_reset'   : ['pinmux_aon.usb_bus_reset'],
+      'usbdev.usb_aon_sense_lost'  : ['pinmux_aon.usb_sense_lost'],
       'pinmux_aon.usb_state_debug' : ['usbdev.usb_state_debug'],
 
       // The idle connection is automatically connected through topgen.
@@ -861,6 +863,7 @@
       { instance: "gpio",            port: '',      connection: 'muxed' , pad: ''             , desc: ''},
       { instance: "uart0",           port: '',      connection: 'muxed' , pad: ''             , desc: ''},
       { instance: "flash_ctrl",      port: '',      connection: 'muxed' , pad: ''             , desc: ''},
+      { instance: 'usbdev',          port: 'sense', connection: 'muxed' , pad: ''             , desc: ''},
     ],
 
     // Number of wakeup detectors to instantiate, and bitwidth for the wakeup counters.

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -146,6 +146,7 @@ module chip_englishbreakfast_verilator (
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
     usb_dn_pullup_idx: DioUsbdevDnPullup,
+    usb_sense_idx:     MioInUsbdevSense,
     // TODO: connect these once the verilator chip-level has been merged with the chiplevel.sv.tpl
     dio_pad_type: {pinmux_reg_pkg::NDioPads{prim_pad_wrapper_pkg::BidirStd}},
     mio_pad_type: {pinmux_reg_pkg::NMioPads{prim_pad_wrapper_pkg::BidirStd}}

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -144,6 +144,7 @@ module chip_${top["name"]}_${target["name"]} (
     usb_dn_idx:        DioUsbdevDn,
     usb_dp_pullup_idx: DioUsbdevDpPullup,
     usb_dn_pullup_idx: DioUsbdevDnPullup,
+    usb_sense_idx:     MioInUsbdevSense,
     // Pad types for attribute WARL behavior
     dio_pad_type: {
 <%


### PR DESCRIPTION
Detect bus reset and VBUS lost events in the AON module while usbdev is
suspended. Monitor and report the events to the usbdev's software
interface until given wake_ack.

Prevent the pull-up from enabling unless VBUS is present.

Update the top level and pinmux to connect the new signals.