### PR TITLE
[keymgr/dv] Several DV updates for recent design changes

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cov.sv
@@ -200,6 +200,7 @@ class keymgr_env_cov extends cip_base_env_cov #(.CFG_T(keymgr_env_cfg));
     create_sw_input_cg_obj(cfg.ral.max_creator_key_ver_shadowed.get_name());
     create_sw_input_cg_obj(cfg.ral.max_owner_int_key_ver_shadowed.get_name());
     create_sw_input_cg_obj(cfg.ral.max_owner_key_ver_shadowed.get_name());
+    create_sw_input_cg_obj(cfg.ral.start.get_name());
   endfunction
 
   virtual function void create_sw_input_cg_obj(string name);

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -615,8 +615,6 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
                 end
               end
             endcase
-            // start will be clear after OP is done
-            void'(ral.start.en.predict(.value(0), .kind(UVM_PREDICT_WRITE)));
           end // start
         end // addr_phase_write
       end

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -218,12 +218,13 @@ class keymgr_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("Advance key manager state from %0s", current_state.name), UVM_MEDIUM)
     ral.control_shadowed.operation.set(keymgr_pkg::OpAdvance);
     csr_update(.csr(ral.control_shadowed));
-    ral.start.en.set(1'b1);
-    csr_update(.csr(ral.start));
+    csr_wr(.ptr(ral.start), .value(1));
 
     if (wait_done) begin
       wait_op_done();
       if (get_check_en()) `DV_CHECK_EQ(current_state, exp_next_state)
+      // randomly program to 0, which should not affect anything
+      if ($urandom_range(0, 1)) csr_wr(.ptr(ral.start), .value(0));
     end
   endtask : keymgr_advance
 
@@ -237,9 +238,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
     `DV_CHECK_RANDOMIZE_FATAL(ral.control_shadowed.cdi_sel)
     ral.control_shadowed.dest_sel.set(int'(key_dest));
     csr_update(.csr(ral.control_shadowed));
-    ral.start.en.set(1'b1);
-    csr_update(.csr(ral.start));
-    ral.start.en.set(1'b0);
+    csr_wr(.ptr(ral.start), .value(1));
 
     if (wait_done) wait_op_done();
   endtask : keymgr_generate

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv
@@ -60,7 +60,10 @@ class keymgr_common_vseq extends keymgr_base_vseq;
 
     // Don't do additional operation in shadow_reg_errors_with_csr_rw, as the csr_rw_seq runs in
     // parallel and issueing an operation affects CSR access.
-    if (`gmv(ral.fault_status.shadow) && common_seq_type != "shadow_reg_errors_with_csr_rw") begin
+    // If control_shadowed has a storage error, this reg is locked. We can't update its value to do
+    // an advance operation.
+    if (`gmv(ral.fault_status.shadow) && common_seq_type != "shadow_reg_errors_with_csr_rw" &&
+      !ral.control_shadowed.get_shadow_storage_err()) begin
       check_state_after_non_operation_fault();
     end
   endtask

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_direct_to_disabled_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_direct_to_disabled_vseq.sv
@@ -16,14 +16,14 @@ class keymgr_direct_to_disabled_vseq extends keymgr_random_vseq;
     end
 
     `uvm_info(`gfn, $sformatf("Directly go to Disabled from %0s", current_state.name), UVM_MEDIUM)
-    ral.start.en.set(1'b1);
     `DV_CHECK_RANDOMIZE_WITH_FATAL(ral.control_shadowed.operation,
                                    // All values not enumerated below behave the same as disable
                                    !(value inside {keymgr_pkg::OpAdvance,
                                                    keymgr_pkg::OpGenId,
                                                    keymgr_pkg::OpGenSwOut,
                                                    keymgr_pkg::OpGenHwOut});)
-    csr_update(.csr(ral.start));
+    csr_update(.csr(ral.control_shadowed));
+    csr_wr(.ptr(ral.start), .value(1));
 
     wait_op_done();
     if (get_check_en()) `DV_CHECK_EQ(current_state, keymgr_pkg::StDisabled)


### PR DESCRIPTION
several fixes for recent design changes
1. add covergroup for start
2. fix start bit predict
3. change to use csr_wr for start reg
4. fix shadow reg test. When storage error occurs on control_shadowed,
   we can't issue operation as the reg is locked
5. fix keymgr_direct_to_disabled_vseq. need to program start CSRs
Signed-off-by: Weicai Yang <weicai@google.com>