### PR TITLE
[dvsim] Add support for tags in testplan

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -33,6 +33,7 @@
             '''
       milestone: V1
       tests: ["chip_sw_uart_tx_rx"]
+      tags: ["gls"]
     }
     {
       name: chip_sw_uart_rx_overflow

--- a/hw/top_earlgrey/doc/dv/index.md
+++ b/hw/top_earlgrey/doc/dv/index.md
@@ -140,5 +140,9 @@ For a list of available tests  to run, please see the 'Tests' column in the [tes
 
 ### Nightly
 
-## Testplan
+## Testplan (RTL simulations)
 {{< incGenFromIpDesc "../../data/chip_testplan.hjson" "testplan" >}}
+
+## Testplan (Gate level simulations)
+Note that the descriptions of the test below may be replicated from the table above.
+{{< incGenFromIpDesc "../../data/chip_testplan.hjson:gls" "testplan" >}}

--- a/site/docs/layouts/shortcodes/incGenFromIpDesc.html
+++ b/site/docs/layouts/shortcodes/incGenFromIpDesc.html
@@ -7,6 +7,13 @@ hjsonPath: Path to an IP description file in Hjson (ip_name.hjson)
   Relative paths are resolved relative to the directory using the shortcode.
   Absolute paths are resolved relative to REPO_TOP.
 
+  This path could also be a testplan described in Hjson
+  (ip_name_testplan.hjson). Testplans may additionally be suffixed with "tags"
+  separated with ":" colon delimiter, such as "ip_name_testplan.hjson:foo:bar".
+  The tags are extracted from the path and appended at the end to construct the
+  path of the generated content, for example:
+  "ip_name_testplan.hjson.foo_bar_testplan"
+
 contentType: Type of generated content to include.
   Valid options: testplan, hwcfg, registers
 
@@ -18,8 +25,14 @@ included by the shortcode here.
 {{ $contentType := .Get 1 }}
 {{ $ipDescFile := (printf "%s.%s" $hjsonPath $contentType) }}
 
+{{ if eq $contentType "testplan" }}
+  {{ $splitTags := split $hjsonPath ":" }}
+  {{ $tags := (cond (gt (len $splitTags) 1) (delimit (after 1 $splitTags) "_") "") }}
+  {{ $ipDescFile = (printf "%s.%s_%s" (index $splitTags 0) $tags $contentType) }}
+{{ end }}
+
 {{ $path := "UNDEF" }}
-{{ if (hasPrefix $hjsonPath "/") }}
+{{ if (hasPrefix $ipDescFile "/") }}
   {{ $path = path.Join .Site.Params.generatedRoot $ipDescFile }}
 {{ else }}
   {{ $path = path.Join .Site.Params.generatedRoot .Page.File.Dir $ipDescFile }}

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -15,10 +15,10 @@ import logging
 import os
 import platform
 import re
+import socket
 import subprocess
 import sys
 import textwrap
-import socket
 from pathlib import Path
 
 import check_tool_requirements
@@ -135,6 +135,7 @@ config = {
         "hw/ip/usbdev/data/usbdev_testplan.hjson",
         "hw/ip/sysrst_ctrl/data/sysrst_ctrl_testplan.hjson",
         "hw/top_earlgrey/data/chip_testplan.hjson",
+        "hw/top_earlgrey/data/chip_testplan.hjson:gls",
         "hw/top_earlgrey/data/standalone_sw_testplan.hjson",
         "util/dvsim/examples/testplanner/foo_testplan.hjson",
     ],
@@ -191,9 +192,14 @@ def generate_hardware_blocks():
 
 def generate_testplans():
     for testplan in config["testplan_definitions"]:
+        # Split the filename into filename and tags, if provided.
+        split = testplan.split(":")
+        filename = split[0]
+        tags = "_".join(split[1:])
         plan = Testplan.Testplan(SRCTREE_TOP.joinpath(testplan),
                                  repo_top=SRCTREE_TOP)
-        plan_path = config["outdir-generated"].joinpath(testplan + '.testplan')
+        plan_filename = f"{filename}.{tags}_testplan"
+        plan_path = config["outdir-generated"].joinpath(plan_filename)
         plan_path.parent.mkdir(parents=True, exist_ok=True)
 
         testplan_html = open(str(plan_path), mode='w')

--- a/util/dvsim/doc/testplanner.md
+++ b/util/dvsim/doc/testplanner.md
@@ -40,13 +40,35 @@ The following attributes are used to define each testpoint, at minimum:
 
     Full [Markdown]({{< relref "doc/rm/markdown_usage_style" >}}) syntax is supported when writing the description.
 
-* **tests: list of written test(s) for a testpoint**
+* **tests: list of written test(s) for this testpoint**
 
     The testplan is written in the initial work stage of the verification [life-cycle]({{< relref "doc/project/development_stages#hardware-verification-stages" >}}).
     Later, when the DV engineer writes the tests, they may not map one-to-one to a testpoint - it may be possible that a written test satisfactorilly addresses multiple testpoints; OR it may also be possible that a testpoint needs to be split into multiple smaller tests.
     To cater to these needs, we provide the ability to set a list of written tests for each testpoint.
     It is used to not only indicate the current progress so far into each milestone, but also map the simulation results to the testpoints to generate the final report table.
     This list is initially empty - it is gradually updated as tests are written.
+
+* **tags: list of tags relevant for this testpoint**
+
+    Tags represent the need to run the same testpoint under specific conditions, in additional platforms or with a specific set of build / runtime options.
+    At the moment, tags are not strictly defined - users are free to come up with their own set of tags.
+    The following examples of tags illustrate the usage:
+
+```hjson
+  // Run this testpoint on verilator and fpga as well.
+  tags: ["verilator", "fpga_cw310"]
+
+  // Run this testpoint in gate level and with poweraware.
+  tags: ["gls", "pa"]
+
+  // Run this testpoint with mask ROM (will use test ROM by default).
+  tags: ["mask_rom"]
+
+  // Run this testpoint as a post-Si test vector on the tester.
+  tags: ["vector"]
+```
+
+    The testplan from the documentation point of view, can be filtered by a tag (or a set of tags), so that the generated testplan table only includes (or excludes) those testpoints.
 
 If the need arises, more attributes may be added relatively easily.
 
@@ -80,6 +102,7 @@ Here's an example:
       tests: ["foo_feature2_test1",
               "foo_feature2_test2",
               "foo_feature2_test3"]
+      tags: ["gls"]
     }
     ...
   ]
@@ -221,7 +244,23 @@ $ ./util/dvsim/testplanner.py \
     -s util/dvsim/examples/testplanner/foo_sim_results.hjson
 ```
 
-Note that the simulations results HJson file used for mapping the results to the testplan is for illustration.
+Filter the testplan by tags "foo" and "bar":
+```console
+$ ./util/dvsim/testplanner.py \
+    util/dvsim/examples/testplanner/foo_testplan.hjson:foo:bar \
+    -s util/dvsim/examples/testplanner/foo_sim_results.hjson
+
+Filter the testplan by excluding the testspoints tagged "foo":
+```console
+$ ./util/dvsim/testplanner.py \
+    util/dvsim/examples/testplanner/foo_testplan.hjson:-foo \
+    -s util/dvsim/examples/testplanner/foo_sim_results.hjson
+```
+
+To filter by tags, simply append the testplan path with the requested tags with ":" delimiter as shown in the example above.
+Prefixing the tag with minus sign ('-') will exclude the testpoints that contain that tag.
+
+Note that the simulations results Hjson file used for mapping the results to the testplan in the examples above (`foo_sim_results.hjson`) is for illustration.
 `dvsim` does not generate such a file - it invokes the `Testplan` class APIs directly to map the simulation results.
 
 Generate simulation result tables in HTML to a file:


### PR DESCRIPTION
This change allows testpoints to be annotated with tags so that the
testplan can be filtered as needed.

For example, a known set of tests can be run in both, DV and in
Verilator. Or, some set of tests may need to be run in GLS  / PA /
post-Si vectors. Rather than freshly create a separate testplan to
capture these needs (which will end up replicating the existing aspects
of the testpoint), tags allow us to represent these needs in the same
existing testplan.

This is just a proof of concept - the implementation may change if it
does not fit well with our requirements.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>