### PR TITLE
[dv] Update countermeasure verification

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cfg.sv
@@ -13,6 +13,7 @@ class cip_base_env_cfg #(type RAL_T = dv_base_reg_block) extends dv_base_env_cfg
 
   // Override this alert name at `initialize` if it's not as below
   string              tl_intg_alert_name = "fatal_fault";
+  string              sec_cm_alert_name  = "fatal_fault";
 
   // If there is a bit in an "alert cause" register that will be set by a corrupt bus access, this
   // should be the name of that field (with syntax "reg.field"). Used by cip_base_scoreboard to

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__sec_cm_fi.svh
@@ -25,12 +25,9 @@ endtask : post_run_sec_cm_fi_vseq
 // - Verify any operations that follow fail (as applicable).
 // refer to ip/keymgr/dv/env/seq_lib/keymgr_common_vseq.sv as an example
 virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
-  // TODO, it's better to unify these to one alert
-  string sec_cm_alert_name = cfg.tl_intg_alert_name;
-
-  `DV_CHECK_FATAL(sec_cm_alert_name inside {cfg.list_of_alerts},
+  `DV_CHECK_FATAL(cfg.sec_cm_alert_name inside {cfg.list_of_alerts},
                   $sformatf("sec_cm_alert_name (%s) is not inside %p",
-                            sec_cm_alert_name, cfg.list_of_alerts))
+                            cfg.sec_cm_alert_name, cfg.list_of_alerts))
 
   `uvm_info(`gfn, $sformatf("expected fatal alert is triggered for %s", if_proxy.sec_cm_type.name),
             UVM_LOW)
@@ -38,7 +35,7 @@ virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
   // This is a fatal alert and design keeps sending it until reset is issued.
   // Check alerts are triggered for a few times
   repeat (5) begin
-    wait_alert_trigger(sec_cm_alert_name, .wait_complete(1));
+    wait_alert_trigger(cfg.sec_cm_alert_name, .wait_complete(1));
   end
 endtask : check_sec_cm_fi_resp
 

--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -18,7 +18,8 @@ interface prim_count_if #(
   prim_count_pkg::prim_count_style_e cnt_style = CntStyle;
 
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
-  string signal_forced;
+  string signal_forced = $sformatf("%s.gen_cnts[0].u_cnt_flop.gen_generic.u_impl_generic.q_o",
+                                   path);
 
   class prim_count_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
     `uvm_object_new
@@ -46,13 +47,7 @@ interface prim_count_if #(
   endclass
 
   prim_count_if_proxy if_proxy;
-
   initial begin
-    case (cnt_style)
-      prim_count_pkg::CrossCnt: signal_forced = $sformatf("%s.up_cnt_q", path);
-      prim_count_pkg::DupCnt: signal_forced = $sformatf("%s.up_cnt_q[0]", path);
-      default: `uvm_fatal(msg_id, $sformatf("unsupported style %s", cnt_style.name()))
-    endcase
     `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced), , msg_id)
 
     // Store the proxy object for TB to use

--- a/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
+++ b/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Generic countermeasure interface for double LFSR
+//
+// This contains a proxy class and store the object in sec_cm_pkg, which can be used in vseq to
+// control inject_fault and restore_fault
+interface prim_double_lfsr_if #(
+  parameter int Width = 2
+) (
+  input clk_i,
+  input rst_ni);
+
+  string msg_id = $sformatf("%m");
+
+  string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
+  string signal_forced = $sformatf("%s.lfsr_state[0]", path);
+  string signal_for_restore = $sformatf("%s.lfsr_state[1]", path);
+
+  class prim_double_lfsr_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
+    `uvm_object_new
+
+    logic[Width-1:0] orig_value;
+
+    virtual task inject_fault();
+      logic[Width-1:0] force_value;
+
+      @(negedge clk_i);
+      `DV_CHECK(uvm_hdl_read(signal_forced, orig_value))
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value,
+                                         force_value != orig_value;)
+
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, force_value))
+      `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
+                                  signal_forced, orig_value, force_value), UVM_LOW)
+
+      @(posedge clk_i);
+    endtask
+
+    virtual task restore_fault();
+      logic[Width-1:0] restore_value;
+      `DV_CHECK(uvm_hdl_read(signal_for_restore, restore_value))
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, restore_value))
+      `uvm_info(msg_id, $sformatf("Forcing %s to matching value %0d", signal_forced, restore_value),
+                UVM_LOW)
+    endtask
+  endclass
+
+  prim_double_lfsr_if_proxy if_proxy;
+
+  initial begin
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_forced), , msg_id)
+    `DV_CHECK_FATAL(uvm_hdl_check_path(signal_for_restore), , msg_id)
+
+    // Store the proxy object for TB to use
+    if_proxy = new("if_proxy");
+    if_proxy.sec_cm_type = sec_cm_pkg::SecCmPrimDoubleLfsr;
+    if_proxy.path = path;
+    sec_cm_pkg::sec_cm_if_proxy_q.push_back(if_proxy);
+
+    `uvm_info(msg_id, $sformatf("Interface proxy class is added for %s", path), UVM_MEDIUM)
+  end
+endinterface

--- a/hw/dv/sv/sec_cm/sec_cm.core
+++ b/hw/dv/sv/sec_cm/sec_cm.core
@@ -11,12 +11,14 @@ filesets:
       - lowrisc:prim:alert
       - lowrisc:prim:count
       - lowrisc:prim:sparse_fsm
+      - lowrisc:prim:double_lfsr
       - lowrisc:dv:dv_utils
     files:
       - sec_cm_pkg.sv
       - sec_cm_base_if_proxy.sv: {is_include_file: true}
       - prim_count_if.sv
       - prim_sparse_fsm_flop_if.sv
+      - prim_double_lfsr_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/sec_cm/sec_cm_pkg.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_pkg.sv
@@ -16,7 +16,8 @@ package sec_cm_pkg;
 
   typedef enum int {
     SecCmPrimCount,
-    SecCmPrimSparseFsmFlop
+    SecCmPrimSparseFsmFlop,
+    SecCmPrimDoubleLfsr
   } sec_cm_type_e;
 
   `include "sec_cm_base_if_proxy.sv"

--- a/hw/dv/sv/sec_cm/sec_cm_prim_count_bind.core
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_count_bind.core
@@ -2,21 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:sec_cm"
-description: "Common interfaces used in DV"
+name: "lowrisc:dv:sec_cm_prim_count_bind"
+description: "Common bind file for testing prim_count countermeasures"
 
 filesets:
   files_dv:
     depend:
-      - lowrisc:prim:alert
       - lowrisc:prim:count
-      - lowrisc:prim:sparse_fsm
-      - lowrisc:dv:dv_utils
     files:
-      - sec_cm_pkg.sv
-      - sec_cm_base_if_proxy.sv: {is_include_file: true}
-      - prim_count_if.sv
-      - prim_sparse_fsm_flop_if.sv
+      - sec_cm_prim_count_bind.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/sec_cm/sec_cm_prim_count_bind.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_count_bind.sv
@@ -1,0 +1,7 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module sec_cm_prim_count_bind();
+  bind prim_count prim_count_if #(.CntStyle(CntStyle), .Width(Width)) u_prim_count_if (.*);
+endmodule

--- a/hw/dv/sv/sec_cm/sec_cm_prim_double_lfsr_bind.core
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_double_lfsr_bind.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:sec_cm_prim_double_lfsr_bind"
+description: "Common bind file for testing double_lfsr countermeasures"
+
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:prim:double_lfsr
+    files:
+      - sec_cm_prim_double_lfsr_bind.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/sec_cm/sec_cm_prim_double_lfsr_bind.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_double_lfsr_bind.sv
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+module sec_cm_prim_double_lfsr_bind();
+  bind prim_double_lfsr prim_double_lfsr_if #(
+         .Width(LfsrDw)) u_prim_double_lfsr_if (.*);
+endmodule

--- a/hw/dv/sv/sec_cm/sec_cm_prim_sparse_fsm_flop_bind.core
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_sparse_fsm_flop_bind.core
@@ -2,21 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:dv:sec_cm"
-description: "Common interfaces used in DV"
+name: "lowrisc:dv:sec_cm_prim_sparse_fsm_flop_bind"
+description: "Common bind file for testing sparse_fsm countermeasures"
 
 filesets:
   files_dv:
     depend:
-      - lowrisc:prim:alert
-      - lowrisc:prim:count
       - lowrisc:prim:sparse_fsm
-      - lowrisc:dv:dv_utils
     files:
-      - sec_cm_pkg.sv
-      - sec_cm_base_if_proxy.sv: {is_include_file: true}
-      - prim_count_if.sv
-      - prim_sparse_fsm_flop_if.sv
+      - sec_cm_prim_sparse_fsm_flop_bind.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/sec_cm/sec_cm_prim_sparse_fsm_flop_bind.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_sparse_fsm_flop_bind.sv
@@ -2,9 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-module sec_cm_bind();
-  bind prim_count prim_count_if #(.CntStyle(CntStyle), .Width(Width)) u_prim_count_if (.*);
-
+module sec_cm_prim_sparse_fsm_flop_bind();
   bind prim_sparse_fsm_flop prim_sparse_fsm_flop_if #(
          .Width(Width)) u_prim_sparse_fsm_flop_if (.*);
 endmodule

--- a/hw/dv/tools/dvsim/testplans/sec_cm_double_lfsr_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/sec_cm_double_lfsr_testplan.hjson
@@ -1,0 +1,29 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  testpoints: [
+    {
+      name: prim_double_lfsr_check
+      desc: ''' Verify that violating prim_double_lfsr LFSR properties generate a fatal alert.
+
+            Stimulus:
+            - At the falling edge (non-active edge), force one of the LFSR to a different value than
+              the other's.
+            - Randomly force the LFSR back to a normal value to ensure the error is latched and
+              won't go away until reset.
+            - Within the next few cycles, the violation of hardened LFSR property should
+              generate a fatal alert.
+            - Repeat for ALL prim_double_lfsr instances in the DUT.
+
+            Checks:
+            - Check that fatal alert is triggered.
+            - Check that err_code/fault_status is updated correctly and preserved until reset.
+            - Verify any operations that follow fail (as applicable).
+            '''
+      milestone: V2S
+      tests: ["{name}_sec_cm"]
+    }
+  ]
+}
+

--- a/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_env_cfg.sv
@@ -17,6 +17,7 @@ class keymgr_env_cfg extends cip_base_env_cfg #(.RAL_T(keymgr_reg_block));
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = keymgr_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_fault_err";
+    sec_cm_alert_name  = tl_intg_alert_name;
     num_edn = 1;
     has_shadowed_regs = 1;
     super.initialize(csr_base_addr);

--- a/hw/ip/keymgr/dv/keymgr_sim.core
+++ b/hw/ip/keymgr/dv/keymgr_sim.core
@@ -8,6 +8,8 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:keymgr
+      - lowrisc:dv:sec_cm_prim_count_bind
+      - lowrisc:dv:sec_cm_prim_sparse_fsm_flop_bind
 
   files_dv:
     depend:

--- a/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
+++ b/hw/ip/keymgr/dv/keymgr_sim_cfg.hjson
@@ -38,7 +38,7 @@
                 ]
 
   // Add additional tops for simulation.
-  sim_tops: ["keymgr_bind", "sec_cm_bind"]
+  sim_tops: ["keymgr_bind", "sec_cm_prim_count_bind", "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -8,6 +8,8 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
   testpoints: [
     {
@@ -210,6 +212,20 @@
             '''
       milestone: V2
       tests: ["otp_ctrl_stress_all"]
+    }
+    {
+      name: sec_cm_additional_check
+      desc: '''
+            Verify the outcome of injecting faults to security countermeasures.
+
+            Stimulus:
+            As mentioned in `prim_count_check`, `prim_fsm_check` and `prim_double_lfsr_check`.
+
+            Checks:
+            - TODO, add additional checks if applicable.
+            '''
+      milestone: V2S
+      tests: ["otp_ctrl_sec_cm"]
     }
     {
       name: otp_ctrl_low_freq_read

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cfg.sv
@@ -65,6 +65,7 @@ class otp_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(otp_ctrl_core_reg_block
     list_of_alerts = otp_ctrl_env_pkg::LIST_OF_ALERTS;
     num_edn = 1;
     tl_intg_alert_name = "fatal_bus_integ_error";
+    sec_cm_alert_name  = "fatal_check_error";
 
     super.initialize(csr_base_addr);
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -22,6 +22,7 @@ package otp_ctrl_env_pkg;
   import lc_ctrl_dv_utils_pkg::*;
   import mem_bkdr_util_pkg::*;
   import otp_scrambler_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -27,4 +27,44 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
+
+    super.check_sec_cm_fi_resp(if_proxy);
+
+    // TODO, check the status CSR
+    case (if_proxy.sec_cm_type)
+      SecCmPrimCount: begin
+      end
+      SecCmPrimSparseFsmFlop: begin
+      end
+      SecCmPrimDoubleLfsr: begin
+        bit[TL_DW-1:0] status_val;
+
+        // TODO, this fault leads to other other errors as well, most of bits in status are set 1,
+        // confirm with designer to see if that is expected.
+        csr_rd(.ptr(ral.status), .value(status_val));
+        `DV_CHECK_EQ(status_val[OtpLfsrFsmErrIdx], 1)
+      end
+      default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
+    endcase
+
+    // TODO, after fault occurs, OTP operation may be blocked. If so, check here
+  endtask : check_sec_cm_fi_resp
+
+   virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);
+    // TODO, disable all assertons now
+    if (!enable) begin
+      $assertoff(0, "tb.dut");
+    end
+    case (if_proxy.sec_cm_type)
+      SecCmPrimCount: begin
+      end
+      SecCmPrimSparseFsmFlop: begin
+      end
+      SecCmPrimDoubleLfsr: begin
+      end
+      default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
+    endcase
+  endfunction: sec_cm_fi_ctrl_svas
+
 endclass

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim.core
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim.core
@@ -8,6 +8,9 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:otp_ctrl
+      - lowrisc:dv:sec_cm_prim_count_bind
+      - lowrisc:dv:sec_cm_prim_sparse_fsm_flop_bind
+      - lowrisc:dv:sec_cm_prim_double_lfsr_bind
 
   files_dv:
     depend:

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -34,12 +34,16 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["otp_ctrl_bind", "otp_ctrl_cov_bind"]
+  sim_tops: ["otp_ctrl_bind", "otp_ctrl_cov_bind",
+             "sec_cm_prim_sparse_fsm_flop_bind",
+             "sec_cm_prim_count_bind",
+             "sec_cm_prim_double_lfsr_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
3 commits:

[dv] Update countermeasure verification
1. update prim_count_if to force on the actual storage
2. add cfg.sec_cm_alert_name for sec alert
3. split sec_cm_bind to multiple bind files as we can only bind the
   prim_*_if when the design uses the prim
4. update keymgr for above changes
5. fix prim_count assertions

[dv] Add countermeasure verification for double_lfsr

[otp_ctrl/dv] enable sec_cm for otp
A few TODO
1. only test err_code for double lfsr
2. import sec_cm testplan, but more testpoint may need to be added
3. disable all assertions for now

Signed-off-by: Weicai Yang <weicai@google.com>