### PR TITLE
[sw/rom] Updates to sec_mmio write counters 

### DIFF
--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -25,7 +25,6 @@ class MockSecMmio : public GlobalMock<MockSecMmio> {
   MOCK_METHOD(uint32_t, Read32, (uint32_t addr));
   MOCK_METHOD(void, Write32, (uint32_t addr, uint32_t value));
   MOCK_METHOD(void, Write32Shadowed, (uint32_t addr, uint32_t value));
-  MOCK_METHOD(void, WriteIncrement, (uint32_t value));
   MOCK_METHOD(void, CheckValues, (uint32_t rnd_offset));
   MOCK_METHOD(void, CheckCounters, (uint32_t expected_check_count));
 };
@@ -67,14 +66,6 @@ using MockSecMmio = testing::StrictMock<internal::MockSecMmio>;
   EXPECT_CALL(::mask_rom_test::MockSecMmio::Instance(), \
               Write32Shadowed(addr, mock_mmio::ToInt<uint32_t>(__VA_ARGS__)));
 
-/**
- * Expect a write counter increment with a given 32-bit increment value.
- *
- * @param val Increment value.
- */
-#define EXPECT_SEC_WRITE_INCREMENT(val) \
-  EXPECT_CALL(::mask_rom_test::MockSecMmio::Instance(), WriteIncrement(val));
-
 extern "C" {
 
 void sec_mmio_init(void) { MockSecMmio::Instance().Init(); }
@@ -89,10 +80,6 @@ void sec_mmio_write32(uint32_t addr, uint32_t value) {
 
 void sec_mmio_write32_shadowed(uint32_t addr, uint32_t value) {
   MockSecMmio::Instance().Write32Shadowed(addr, value);
-}
-
-void sec_mmio_write_increment(uint32_t value) {
-  MockSecMmio::Instance().WriteIncrement(value);
 }
 
 void sec_mmio_check_values(uint32_t rnd_offset) {

--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -9,6 +9,11 @@
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
+extern "C" {
+// Required by `SEC_MMIO_WRITE_INCREMENT()`.
+volatile sec_mmio_ctx_t sec_mmio_ctx;
+}
+
 namespace mask_rom_test {
 namespace internal {
 /**

--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -107,7 +107,7 @@ void sec_mmio_write32_shadowed(uint32_t addr, uint32_t value) {
 }
 
 void sec_mmio_write_increment(uint32_t value) {
-  sec_mmio_ctx.expected_write_count += value;
+  SEC_MMIO_WRITE_INCREMENT(value);
 }
 
 void sec_mmio_check_values(uint32_t rnd_offset) {

--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -106,10 +106,6 @@ void sec_mmio_write32_shadowed(uint32_t addr, uint32_t value) {
   ++sec_mmio_ctx.write_count;
 }
 
-void sec_mmio_write_increment(uint32_t value) {
-  SEC_MMIO_WRITE_INCREMENT(value);
-}
-
 void sec_mmio_check_values(uint32_t rnd_offset) {
   // Pick a random starting offset.
   uint32_t offset =

--- a/sw/device/silicon_creator/lib/base/sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.h
@@ -30,8 +30,8 @@ extern "C" {
  * Register writes
  *
  * - Perform a number (N) of calls to `sec_mmio_write32()`.
- * - Increment the expected number of writes by N by calling
- *   `sec_mmio_write_increment()`. This is done using a separate function call
+ * - Increment the expected number of writes by N with
+ *   `SEC_MMIO_WRITE_INCREMENT()`. This is done using a separate function call
  *   to be able to detect skip instruciton faults on `sec_mmio_write32()`
  *   calls.
  *
@@ -85,7 +85,7 @@ typedef struct sec_mmio_ctx {
   uint32_t write_count;
   /**
    * Represents the expected number of register write operations. Incremented by
-   * the `sec_mmio_write_increment()` function.
+   * `SEC_MMIO_WRITE_INCREMENT()`.
    */
   uint32_t expected_write_count;
   /**
@@ -116,23 +116,20 @@ extern volatile sec_mmio_ctx_t sec_mmio_ctx;
 /**
  * Increment the expected count of register writes by `value`.
  *
- * This macro is preferred over `sec_mmio_write_increment()` as it doesn't
- * require a function call to update the expected number of writes stored in
- * `sec_mmio_ctx`.
+ * This macro must be used to increment the number of expected register writes
+ * before calling `sec_mmio_check_counters()`.
  *
  * @param value The expected write count increment.
  */
-#define SEC_MMIO_WRITE_INCREMENT(value)           \
-  do {                                            \
-    sec_mmio_ctx.expected_write_count += (value); \
-  } while (0);
+#define SEC_MMIO_WRITE_INCREMENT(value) \
+  (sec_mmio_ctx.expected_write_count += (value))
 
 /**
  * Assert macro used to cross-reference exported sec_mmio expected write counts
  * to their respective functions.
  */
 #define SEC_MMIO_ASSERT_WRITE_INCREMENT(enum_val, expected) \
-  static_assert(enum_val == expected, "Unexpected value for " #enum_val);
+  static_assert(enum_val == expected, "Unexpected value for " #enum_val)
 
 /**
  * Initializes the module.
@@ -176,8 +173,8 @@ uint32_t sec_mmio_read32(uint32_t addr);
  * via `sec_mmio_check_values()`.
  *
  * On successful calls, this function will increment the internal count of
- * writes. The caller is responsible to setting the expected write count by
- * calling `sec_mmio_write_increment()`.
+ * writes. The caller is responsible to setting the expected write count with
+ * `SEC_MMIO_WRITE_INCREMENT()`.
  *
  * An exception is thrown if the comparison operation fails.
  *
@@ -195,8 +192,8 @@ void sec_mmio_write32(uint32_t addr, uint32_t value);
  * values for later comparison via `sec_mmio_check_values()`.
  *
  * On successful calls, this function will increment the internal count of
- * writes. The caller is responsible to setting the expected write count by
- * calling `sec_mmio_write_increment()`.
+ * writes. The caller is responsible to setting the expected write count with
+ * `SEC_MMIO_WRITE_INCREMENT()`.
  *
  * An exception is thrown if the comparison operation fails.
  *
@@ -205,12 +202,6 @@ void sec_mmio_write32(uint32_t addr, uint32_t value);
  */
 void sec_mmio_write32_shadowed(uint32_t addr, uint32_t value);
 
-/**
- * Increment the expected count of register writes by `value`.
- *
- * @param value The expected write count increment.
- */
-void sec_mmio_write_increment(uint32_t value);
 
 /**
  * Checks the expected list of register values.

--- a/sw/device/silicon_creator/lib/base/sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.h
@@ -109,6 +109,31 @@ OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, expected_write_count, 1608);
 OT_ASSERT_MEMBER_OFFSET(sec_mmio_ctx_t, check_count, 1612);
 OT_ASSERT_SIZE(sec_mmio_ctx_t, 1616);  // Checked by linker script.
 
+// The sec_mmio_ctx is referenced here to be able to use it inside the
+// `SEC_MMIO_WRITE_INCREMENT()` macro.
+extern volatile sec_mmio_ctx_t sec_mmio_ctx;
+
+/**
+ * Increment the expected count of register writes by `value`.
+ *
+ * This macro is preferred over `sec_mmio_write_increment()` as it doesn't
+ * require a function call to update the expected number of writes stored in
+ * `sec_mmio_ctx`.
+ *
+ * @param value The expected write count increment.
+ */
+#define SEC_MMIO_WRITE_INCREMENT(value)           \
+  do {                                            \
+    sec_mmio_ctx.expected_write_count += (value); \
+  } while (0);
+
+/**
+ * Assert macro used to cross-reference exported sec_mmio expected write counts
+ * to their respective functions.
+ */
+#define SEC_MMIO_ASSERT_WRITE_INCREMENT(enum_val, expected) \
+  static_assert(enum_val == expected, "Unexpected value for " #enum_val);
+
 /**
  * Initializes the module.
  *

--- a/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
+++ b/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
@@ -12,11 +12,6 @@
 #include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
-extern "C" {
-// Declared in the sec_mmio module.
-extern sec_mmio_ctx_t sec_mmio_ctx;
-}
-
 namespace sec_mmio_unittest {
 namespace {
 using ::testing::Each;
@@ -26,7 +21,7 @@ using ::testing::Eq;
 class SecMmioTest : public mask_rom_test::MaskRomTest {
  protected:
   void SetUp() override { sec_mmio_init(); }
-  sec_mmio_ctx_t *ctx_ = &::sec_mmio_ctx;
+  volatile sec_mmio_ctx_t *ctx_ = &::sec_mmio_ctx;
   mask_rom_test::MockAbsMmio mmio_;
 };
 

--- a/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
+++ b/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
@@ -122,14 +122,6 @@ TEST_F(SecMmioTest, Write32) {
   EXPECT_EQ(ctx_->last_index, 2);
 }
 
-TEST_F(SecMmioTest, CounterInc) {
-  sec_mmio_write_increment(5);
-  EXPECT_EQ(ctx_->expected_write_count, 5);
-
-  sec_mmio_write_increment(10);
-  EXPECT_EQ(ctx_->expected_write_count, 15);
-}
-
 TEST_F(SecMmioTest, CheckValues) {
   EXPECT_ABS_WRITE32(0, 0x12345678);
   EXPECT_ABS_READ32(0, 0x12345678);
@@ -174,7 +166,7 @@ TEST_F(SecMmioTest, CheckCount) {
   EXPECT_ABS_WRITE32(0, 0x12345678);
   EXPECT_ABS_READ32(0, 0x12345678);
   sec_mmio_write32(0, 0x12345678);
-  sec_mmio_write_increment(1);
+  SEC_MMIO_WRITE_INCREMENT(1);
 
   sec_mmio_check_counters(/*expected_check_count=*/0);
   sec_mmio_check_counters(/*expected_check_count=*/1);

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -9,6 +9,7 @@
 
 #include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -216,6 +217,7 @@ static rom_error_t boot_data_entry_write(flash_ctrl_info_page_t page,
                                       .write = kHardenedBoolFalse,
                                       .erase = kHardenedBoolFalse,
                                   });
+  SEC_MMIO_WRITE_INCREMENT(2 * kFlashCtrlSecMmioInfoPermsSet);
   return error;
 }
 
@@ -254,6 +256,7 @@ static rom_error_t boot_data_entry_invalidate(flash_ctrl_info_page_t page,
                                       .write = kHardenedBoolFalse,
                                       .erase = kHardenedBoolFalse,
                                   });
+  SEC_MMIO_WRITE_INCREMENT(2 * kFlashCtrlSecMmioInfoPermsSet);
   return error;
 }
 
@@ -369,6 +372,7 @@ static rom_error_t boot_data_page_info_get(flash_ctrl_info_page_t page,
                                       .write = kHardenedBoolFalse,
                                       .erase = kHardenedBoolFalse,
                                   });
+  SEC_MMIO_WRITE_INCREMENT(2 * kFlashCtrlSecMmioInfoPermsSet);
   return error;
 }
 

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/testing/check.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/test_main.h"
@@ -333,6 +334,8 @@ bool test_main(void) {
   rom_error_t result = kErrorOk;
 
   flash_ctrl_init();
+  SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInit);
+  sec_mmio_check_counters(/*expected_check_count=*/0);
 
   EXECUTE_TEST(result, check_test_data_test);
   EXECUTE_TEST(result, read_empty_default_allowed_test);

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -152,6 +152,7 @@ cc_library(
     name = "keymgr",
     srcs = ["keymgr.c"],
     hdrs = ["keymgr.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -166,12 +167,17 @@ cc_library(
 
 cc_test(
     name = "keymgr_unittest",
-    srcs = ["keymgr_unittest.cc"],
+    srcs = [
+        "keymgr.h",
+        "keymgr.c",
+        "keymgr_unittest.cc"
+    ],
     deps = [
-        ":keymgr",
+        "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/base/freestanding",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib:keymgr_binding",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
         "@googletest//:gtest_main",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -10,6 +10,7 @@ cc_library(
     name = "alert",
     srcs = ["alert.c"],
     hdrs = ["alert.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey:alert_handler_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -32,11 +33,16 @@ cc_library(
 
 cc_test(
     name = "alert_unittest",
-    srcs = ["alert_unittest.cc"],
+    srcs = [
+        "alert.h",
+        "alert.c",
+        "alert_unittest.cc",
+    ],
     deps = [
-        ":alert",
         "//hw/top_earlgrey:alert_handler_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -280,6 +280,7 @@ cc_library(
     name = "otp",
     srcs = ["otp.c"],
     hdrs = ["otp.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -304,9 +305,13 @@ cc_library(
 
 cc_test(
     name = "otp_unittest",
-    srcs = ["otp_unittest.cc"],
+    srcs = [
+        "otp.h",
+        "otp.c",
+        "otp_unittest.cc",
+    ],
     deps = [
-        ":otp",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib:error",

--- a/sw/device/silicon_creator/lib/drivers/alert.c
+++ b/sw/device/silicon_creator/lib/drivers/alert.c
@@ -50,10 +50,8 @@ rom_error_t alert_configure(size_t index, alert_class_t cls,
       ++reg_wr_count;
       break;
     case kAlertClassX:
-      sec_mmio_write_increment(reg_wr_count);
       return kErrorOk;
     default:
-      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadClass;
   }
 
@@ -74,10 +72,9 @@ rom_error_t alert_configure(size_t index, alert_class_t cls,
       ++reg_wr_count;
       break;
     default:
-      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadEnable;
   }
-  sec_mmio_write_increment(reg_wr_count);
+  SEC_MMIO_WRITE_INCREMENT(reg_wr_count);
   return kErrorOk;
 }
 
@@ -116,10 +113,8 @@ rom_error_t alert_local_configure(size_t index, alert_class_t cls,
       ++reg_wr_count;
       break;
     case kAlertClassX:
-      sec_mmio_write_increment(reg_wr_count);
       return kErrorOk;
     default:
-      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadClass;
   }
 
@@ -140,10 +135,9 @@ rom_error_t alert_local_configure(size_t index, alert_class_t cls,
       ++reg_wr_count;
       break;
     default:
-      sec_mmio_write_increment(reg_wr_count);
       return kErrorAlertBadEnable;
   }
-  sec_mmio_write_increment(reg_wr_count);
+  SEC_MMIO_WRITE_INCREMENT(reg_wr_count);
   return kErrorOk;
 }
 
@@ -247,7 +241,7 @@ rom_error_t alert_class_configure(alert_class_t cls,
     ++reg_wr_count;
   }
 
-  sec_mmio_write_increment(reg_wr_count);
+  SEC_MMIO_WRITE_INCREMENT(reg_wr_count);
   return kErrorOk;
 }
 
@@ -256,6 +250,6 @@ rom_error_t alert_ping_enable(void) {
   sec_mmio_write32_shadowed(
       kBase + ALERT_HANDLER_PING_TIMER_EN_SHADOWED_REG_OFFSET, 1);
   sec_mmio_write32(kBase + ALERT_HANDLER_PING_TIMER_REGWEN_REG_OFFSET, 0);
-  sec_mmio_write_increment(/*value=*/2);
+  SEC_MMIO_WRITE_INCREMENT(/*value=*/2);
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
@@ -29,7 +29,6 @@ TEST_F(InitTest, AlertConfigureAlertBadIndex) {
 }
 
 TEST_F(InitTest, AlertConfigureAlertBadClass) {
-  EXPECT_SEC_WRITE_INCREMENT(0);
   EXPECT_EQ(alert_configure(0, (alert_class_t)-1, kAlertEnableNone),
             kErrorAlertBadClass);
 }
@@ -39,18 +38,15 @@ TEST_F(InitTest, AlertConfigureAlertBadEnable) {
   // experience an error when evaluating the enable parameter.
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(1);
   EXPECT_EQ(alert_configure(0, kAlertClassA, (alert_enable_t)-1),
             kErrorAlertBadEnable);
 }
 
 TEST_F(InitTest, AlertConfigureAlertClassXNoOperation) {
-  EXPECT_SEC_WRITE_INCREMENT(0);
   EXPECT_EQ(alert_configure(0, kAlertClassX, kAlertEnableNone), kErrorOk);
 }
 
 TEST_F(InitTest, LocalAlertConfigureAlertClassXNoOperation) {
-  EXPECT_SEC_WRITE_INCREMENT(0);
   EXPECT_EQ(alert_local_configure(0, kAlertClassX, kAlertEnableNone), kErrorOk);
 }
 
@@ -59,7 +55,6 @@ TEST_F(InitTest, AlertConfigure0AsClassA) {
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_0_REG_OFFSET, 0);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_0_REG_OFFSET, 1);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_configure(0, kAlertClassA, kAlertEnableEnabled), kErrorOk);
 }
 
@@ -68,7 +63,6 @@ TEST_F(InitTest, LocalAlertConfigure0AsClassA) {
       base_ + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_0_REG_OFFSET, 0);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_0_REG_OFFSET, 1);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_local_configure(0, kAlertClassA, kAlertEnableEnabled),
             kErrorOk);
 }
@@ -78,7 +72,6 @@ TEST_F(InitTest, AlertConfigure1AsClassB) {
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_1_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_1_REG_OFFSET, 1);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_configure(1, kAlertClassB, kAlertEnableEnabled), kErrorOk);
 }
 
@@ -87,7 +80,6 @@ TEST_F(InitTest, LocalAlertConfigure1AsClassB) {
       base_ + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_1_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_1_REG_OFFSET, 1);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_local_configure(1, kAlertClassB, kAlertEnableEnabled),
             kErrorOk);
 }
@@ -97,7 +89,6 @@ TEST_F(InitTest, AlertConfigure2AsClassC) {
       base_ + ALERT_HANDLER_ALERT_CLASS_SHADOWED_2_REG_OFFSET, 2);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_2_REG_OFFSET, 1);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_configure(2, kAlertClassC, kAlertEnableEnabled), kErrorOk);
 }
 
@@ -106,7 +97,6 @@ TEST_F(InitTest, LocalAlertConfigure2AsClassC) {
       base_ + ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_2_REG_OFFSET, 2);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_2_REG_OFFSET, 1);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   EXPECT_EQ(alert_local_configure(2, kAlertClassC, kAlertEnableEnabled),
             kErrorOk);
 }
@@ -117,7 +107,6 @@ TEST_F(InitTest, AlertConfigure3AsClassDLocked) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_ALERT_EN_SHADOWED_3_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32(base_ + ALERT_HANDLER_ALERT_REGWEN_3_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(3);
   EXPECT_EQ(alert_configure(3, kAlertClassD, kAlertEnableLocked), kErrorOk);
 }
 
@@ -127,7 +116,6 @@ TEST_F(InitTest, LocalAlertConfigure3AsClassDLocked) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_LOC_ALERT_EN_SHADOWED_3_REG_OFFSET, 1);
   EXPECT_SEC_WRITE32(base_ + ALERT_HANDLER_LOC_ALERT_REGWEN_3_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(3);
   EXPECT_EQ(alert_local_configure(3, kAlertClassD, kAlertEnableLocked),
             kErrorOk);
 }
@@ -172,7 +160,6 @@ TEST_F(InitTest, AlertConfigureClassA) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSA_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
   EXPECT_SEC_WRITE32(base_ + ALERT_HANDLER_CLASSA_REGWEN_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(8);
   EXPECT_EQ(alert_class_configure(kAlertClassA, &config), kErrorOk);
 }
 
@@ -210,7 +197,6 @@ TEST_F(InitTest, AlertConfigureClassB) {
       base_ + ALERT_HANDLER_CLASSB_PHASE2_CYC_SHADOWED_REG_OFFSET, 100);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSB_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
-  EXPECT_SEC_WRITE_INCREMENT(7);
   EXPECT_EQ(alert_class_configure(kAlertClassB, &config), kErrorOk);
 }
 
@@ -248,7 +234,6 @@ TEST_F(InitTest, AlertConfigureClassC) {
       base_ + ALERT_HANDLER_CLASSC_PHASE2_CYC_SHADOWED_REG_OFFSET, 100);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSC_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
-  EXPECT_SEC_WRITE_INCREMENT(7);
   EXPECT_EQ(alert_class_configure(kAlertClassC, &config), kErrorOk);
 }
 
@@ -286,7 +271,6 @@ TEST_F(InitTest, AlertConfigureClassD) {
       base_ + ALERT_HANDLER_CLASSD_PHASE2_CYC_SHADOWED_REG_OFFSET, 100);
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + ALERT_HANDLER_CLASSD_PHASE3_CYC_SHADOWED_REG_OFFSET, 1000);
-  EXPECT_SEC_WRITE_INCREMENT(7);
   EXPECT_EQ(alert_class_configure(kAlertClassD, &config), kErrorOk);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -117,7 +117,6 @@ TEST_P(InitTest, Initialize) {
   auto info_page = InfoPages().at(kFlashCtrlInfoPageCreatorSecret);
   EXPECT_SEC_WRITE32_SHADOWED(base_ + info_page.cfg_offset, 0);
   EXPECT_SEC_WRITE32(base_ + info_page.cfg_wen_offset, 0);
-  EXPECT_SEC_WRITE_INCREMENT(2);
 
   EXPECT_CALL(
       otp_, read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_FLASH_DATA_DEFAULT_CFG_OFFSET))
@@ -126,7 +125,6 @@ TEST_P(InitTest, Initialize) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + FLASH_CTRL_DEFAULT_REGION_SHADOWED_REG_OFFSET,
       GetParam().data_write_val);
-  EXPECT_SEC_WRITE_INCREMENT(1);
 
   EXPECT_CALL(
       otp_,
@@ -136,12 +134,11 @@ TEST_P(InitTest, Initialize) {
   EXPECT_SEC_READ32(base_ + info_page.cfg_offset, 0);
   EXPECT_SEC_WRITE32_SHADOWED(base_ + info_page.cfg_offset,
                               GetParam().info_write_val);
-  EXPECT_SEC_WRITE_INCREMENT(1);
+
   info_page = InfoPages().at(kFlashCtrlInfoPageBootData1);
   EXPECT_SEC_READ32(base_ + info_page.cfg_offset, 0);
   EXPECT_SEC_WRITE32_SHADOWED(base_ + info_page.cfg_offset,
                               GetParam().info_write_val);
-  EXPECT_SEC_WRITE_INCREMENT(1);
 
   flash_ctrl_init();
 }
@@ -337,7 +334,6 @@ class ExecTest : public FlashCtrlTest {};
 
 TEST_F(ExecTest, Set) {
   EXPECT_SEC_WRITE32(base_ + FLASH_CTRL_EXEC_REG_OFFSET, UINT32_MAX);
-  EXPECT_SEC_WRITE_INCREMENT(1);
   flash_ctrl_exec_set(UINT32_MAX);
 }
 
@@ -373,7 +369,6 @@ TEST_P(FlashCtrlPermsSetTest, InfoPermsSet) {
     EXPECT_SEC_READ32(base_ + it.second.cfg_offset, GetParam().info_read_val);
     EXPECT_SEC_WRITE32_SHADOWED(base_ + it.second.cfg_offset,
                                 GetParam().info_write_val);
-    EXPECT_SEC_WRITE_INCREMENT(1);
 
     flash_ctrl_info_perms_set(it.first, GetParam().perms);
   }
@@ -385,7 +380,6 @@ TEST_P(FlashCtrlPermsSetTest, DataDefaultPermsSet) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + FLASH_CTRL_DEFAULT_REGION_SHADOWED_REG_OFFSET,
       GetParam().data_write_val);
-  EXPECT_SEC_WRITE_INCREMENT(1);
 
   flash_ctrl_data_default_perms_set(GetParam().perms);
 }
@@ -500,7 +494,6 @@ TEST_P(FlashCtrlCfgSetTest, InfoCfgSet) {
     EXPECT_SEC_READ32(base_ + it.second.cfg_offset, GetParam().info_read_val);
     EXPECT_SEC_WRITE32_SHADOWED(base_ + it.second.cfg_offset,
                                 GetParam().info_write_val);
-    EXPECT_SEC_WRITE_INCREMENT(1);
 
     flash_ctrl_info_cfg_set(it.first, GetParam().cfg);
   }
@@ -512,7 +505,6 @@ TEST_P(FlashCtrlCfgSetTest, DataDefaultCfgSet) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + FLASH_CTRL_DEFAULT_REGION_SHADOWED_REG_OFFSET,
       GetParam().data_write_val);
-  EXPECT_SEC_WRITE_INCREMENT(1);
 
   flash_ctrl_data_default_cfg_set(GetParam().cfg);
 }
@@ -607,7 +599,6 @@ TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
     EXPECT_SEC_WRITE32_SHADOWED(base_ + info_page.cfg_offset, 0);
     EXPECT_SEC_WRITE32(base_ + info_page.cfg_wen_offset, 0);
   }
-  EXPECT_SEC_WRITE_INCREMENT(2 * no_owner_access.size());
 
   flash_ctrl_creator_info_pages_lockdown();
 }

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -63,18 +63,20 @@ static rom_error_t expected_state_check(uint32_t expected_state) {
 }
 
 rom_error_t keymgr_init(uint16_t entropy_reseed_interval) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kKeymgrSecMmioInit, 1);
   RETURN_IF_ERROR(expected_state_check(kKeymgrStateReset));
   uint32_t reg = bitfield_field32_write(
       0, KEYMGR_RESEED_INTERVAL_SHADOWED_VAL_FIELD, entropy_reseed_interval);
   sec_mmio_write32_shadowed(kBase + KEYMGR_RESEED_INTERVAL_SHADOWED_REG_OFFSET,
                             reg);
-  sec_mmio_write_increment(/*value=*/1);
   return kErrorOk;
 }
 
 void keymgr_sw_binding_set(
     const keymgr_binding_value_t *binding_value_sealing,
     const keymgr_binding_value_t *binding_value_attestation) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kKeymgrSecMmioSwBindingSet, 17);
+
   // Write and lock (rw0c) the software binding value. This register is unlocked
   // by hardware upon a successful state transition.
   for (size_t i = 0; i < ARRAYSIZE(binding_value_sealing->data); ++i) {
@@ -88,7 +90,6 @@ void keymgr_sw_binding_set(
         binding_value_attestation->data[i]);
   }
   sec_mmio_write32(kBase + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
-  sec_mmio_write_increment(/*value=*/17);
 }
 
 void keymgr_sw_binding_unlock_wait(void) {
@@ -98,19 +99,19 @@ void keymgr_sw_binding_unlock_wait(void) {
 }
 
 void keymgr_creator_max_ver_set(uint32_t max_key_ver) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kKeymgrSecMmioCreatorMaxVerSet, 2);
   // Write and lock (rw0c) the max key version.
   sec_mmio_write32_shadowed(
       kBase + KEYMGR_MAX_CREATOR_KEY_VER_SHADOWED_REG_OFFSET, max_key_ver);
   sec_mmio_write32(kBase + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
-  sec_mmio_write_increment(/*value=*/2);
 }
 
 void keymgr_owner_int_max_ver_set(uint32_t max_key_ver) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kKeymgrSecMmioOwnerIntMaxVerSet, 2);
   // Write and lock (rw0c) the max key version.
   sec_mmio_write32_shadowed(
       kBase + KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET, max_key_ver);
   sec_mmio_write32(kBase + KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET, 0);
-  sec_mmio_write_increment(/*value=*/2);
 }
 
 void keymgr_advance_state(void) {

--- a/sw/device/silicon_creator/lib/drivers/keymgr.h
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.h
@@ -58,6 +58,24 @@ typedef enum keymgr_state {
 } keymgr_state_t;
 
 /**
+ * The following constants represent the expected number of sec_mmio register
+ * writes performed by functions in provided in this module. See
+ * `SEC_MMIO_WRITE_INCREMENT()` for more details.
+ *
+ * Example:
+ * ```
+ *  keymgr_sw_binding_set();
+ *  SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioSwBindingSet);
+ * ```
+ */
+enum {
+  kKeymgrSecMmioInit = 1,
+  kKeymgrSecMmioSwBindingSet = 17,
+  kKeymgrSecMmioCreatorMaxVerSet = 2,
+  kKeymgrSecMmioOwnerIntMaxVerSet = 2,
+};
+
+/**
  * Sets the key manager software binding inputs.
  *
  * @param binding_value_sealing Software binding for sealing value.

--- a/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_functest.c
@@ -232,6 +232,8 @@ rom_error_t keymgr_rom_test(void) {
   ASSERT_OK(keymgr_state_check(kKeymgrStateReset));
   keymgr_sw_binding_set(&kBindingValueRomExt, &kBindingValueRomExt);
   keymgr_creator_max_ver_set(kMaxVerRomExt);
+  SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioSwBindingSet +
+                           kKeymgrSecMmioCreatorMaxVerSet);
   sec_mmio_check_values(/*rnd_offset=*/0);
   sec_mmio_check_counters(/*expected_check_count=*/1);
   return kErrorOk;
@@ -243,8 +245,9 @@ rom_error_t keymgr_rom_ext_test(void) {
 
   const uint16_t kEntropyReseedInterval = 0x1234;
   ASSERT_OK(keymgr_init(kEntropyReseedInterval));
-
+  SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioInit);
   sec_mmio_check_values(/*rnd_offset=*/0);
+
   keymgr_advance_state();
   ASSERT_OK(keymgr_state_check(kKeymgrStateInit));
 
@@ -259,6 +262,8 @@ rom_error_t keymgr_rom_ext_test(void) {
 
   keymgr_sw_binding_set(&kBindingValueBl0, &kBindingValueBl0);
   keymgr_owner_int_max_ver_set(kMaxVerBl0);
+  SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioSwBindingSet +
+                           kKeymgrSecMmioOwnerIntMaxVerSet);
   sec_mmio_check_values(/*rnd_offset=*/0);
 
   keymgr_advance_state();

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -53,7 +53,6 @@ TEST_F(KeymgrTest, Initialize) {
 
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + KEYMGR_RESEED_INTERVAL_SHADOWED_REG_OFFSET, 0u);
-  EXPECT_SEC_WRITE_INCREMENT(1);
   EXPECT_EQ(keymgr_init(0u), kErrorOk);
 }
 
@@ -93,7 +92,6 @@ TEST_F(KeymgrTest, SwBindingValuesSet) {
                      cfg_.binding_value_attestation.data[7]);
 
   EXPECT_SEC_WRITE32(base_ + KEYMGR_SW_BINDING_REGWEN_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(17);
   keymgr_sw_binding_set(&cfg_.binding_value_sealing,
                         &cfg_.binding_value_attestation);
 }
@@ -108,7 +106,6 @@ TEST_F(KeymgrTest, SetCreatorMaxVerKey) {
   EXPECT_SEC_WRITE32_SHADOWED(
       base_ + KEYMGR_MAX_CREATOR_KEY_VER_SHADOWED_REG_OFFSET, cfg_.max_key_ver);
   EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_CREATOR_KEY_VER_REGWEN_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   keymgr_creator_max_ver_set(cfg_.max_key_ver);
 }
 
@@ -117,7 +114,6 @@ TEST_F(KeymgrTest, SetOwnerIntMaxVerKey) {
       base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_SHADOWED_REG_OFFSET,
       cfg_.max_key_ver);
   EXPECT_SEC_WRITE32(base_ + KEYMGR_MAX_OWNER_INT_KEY_VER_REGWEN_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(2);
   keymgr_owner_int_max_ver_set(cfg_.max_key_ver);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/otp.c
+++ b/sw/device/silicon_creator/lib/drivers/otp.c
@@ -36,6 +36,6 @@ void otp_read(uint32_t address, uint32_t *data, size_t num_words) {
 }
 
 void otp_creator_sw_cfg_lockdown(void) {
+  SEC_MMIO_ASSERT_WRITE_INCREMENT(kOtpSecMmioCreatorSwCfgLockDown, 1);
   sec_mmio_write32(kBase + OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET, 0);
-  sec_mmio_write_increment(1);
 }

--- a/sw/device/silicon_creator/lib/drivers/otp.h
+++ b/sw/device/silicon_creator/lib/drivers/otp.h
@@ -17,6 +17,21 @@ extern "C" {
 #define OTP_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 
 /**
+ * The following constants represent the expected number of sec_mmio register
+ * writes performed by functions provided by this module. See
+ * `SEC_MMIO_WRITE_INCREMENT()` for more details.
+ *
+ * Example:
+ * ```
+ *  otp_creator_sw_cfg_lockdown();
+ *  SEC_MMIO_WRITE_INCREMENT(kOtpSecMmioCreatorSwCfgLockDown);
+ * ```
+ */
+enum {
+  kOtpSecMmioCreatorSwCfgLockDown = 1,
+};
+
+/**
  * Perform a blocking 32-bit read from the memory mapped software config
  * partitions.
  *

--- a/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otp_unittest.cc
@@ -28,7 +28,6 @@ class OtpTest : public mask_rom_test::MaskRomTest {
 
 TEST_F(OtpTest, CreatorSwCfgLockdown) {
   EXPECT_SEC_WRITE32(base_ + OTP_CTRL_CREATOR_SW_CFG_READ_LOCK_REG_OFFSET, 0);
-  EXPECT_SEC_WRITE_INCREMENT(1);
 
   otp_creator_sw_cfg_lockdown();
 }

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -169,7 +169,7 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
   HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateReset));
   keymgr_sw_binding_set(&manifest->binding_value, &manifest->binding_value);
   keymgr_creator_max_ver_set(manifest->max_key_version);
-  SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioInit + kKeymgrSecMmioSwBindingSet +
+  SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioSwBindingSet +
                            kKeymgrSecMmioCreatorMaxVerSet);
 
   // Check cached life cycle state against the value reported by hardware.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -76,7 +76,10 @@ static rom_error_t mask_rom_init(void) {
   // Initialize the shutdown policy according to lifecycle state.
   lc_state = lifecycle_state_get();
   HARDENED_RETURN_IF_ERROR(shutdown_init(lc_state));
+
   flash_ctrl_init();
+  SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInit);
+
   // Initiaize in-memory copy of the ePMP register configuration.
   mask_rom_epmp_state_init(&epmp);
 
@@ -189,6 +192,7 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
 
   // Enable execution of code from flash if signature is verified.
   flash_ctrl_exec_set(flash_exec);
+  SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioExecSet);
 
   sec_mmio_check_counters(/*expected_check_count=*/4);
 

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -166,6 +166,8 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
   HARDENED_RETURN_IF_ERROR(keymgr_state_check(kKeymgrStateReset));
   keymgr_sw_binding_set(&manifest->binding_value, &manifest->binding_value);
   keymgr_creator_max_ver_set(manifest->max_key_version);
+  SEC_MMIO_WRITE_INCREMENT(kKeymgrSecMmioInit + kKeymgrSecMmioSwBindingSet +
+                           kKeymgrSecMmioCreatorMaxVerSet);
 
   // Check cached life cycle state against the value reported by hardware.
   lifecycle_state_t lc_state_check = lifecycle_state_get();
@@ -187,6 +189,8 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
 
   // Enable execution of code from flash if signature is verified.
   flash_ctrl_exec_set(flash_exec);
+
+  sec_mmio_check_counters(/*expected_check_count=*/4);
 
   // Jump to ROM_EXT entry point.
   uintptr_t entry_point = manifest_entry_point_get(manifest);

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp_test.c
@@ -376,6 +376,7 @@ void mask_rom_main(void) {
   // Enable execution of code in flash.
   flash_ctrl_init();
   flash_ctrl_exec_set(FLASH_CTRL_PARAM_EXEC_EN);
+  SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInit + kFlashCtrlSecMmioExecSet);
 
   // Configure UART0 as stdout.
   uart_init(kUartNCOValue);

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -96,6 +96,8 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
   // reset.
   flash_ctrl_creator_info_pages_lockdown();
   otp_creator_sw_cfg_lockdown();
+  SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioCreatorInfoPagesLockdown);
+
   // Unlock execution of owner stage executable code (text) sections.
   rom_ext_epmp_unlock_owner_stage_rx(&epmp, manifest_code_region_get(manifest));
 

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -96,7 +96,8 @@ static rom_error_t rom_ext_boot(const manifest_t *manifest) {
   // reset.
   flash_ctrl_creator_info_pages_lockdown();
   otp_creator_sw_cfg_lockdown();
-  SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioCreatorInfoPagesLockdown);
+  SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioCreatorInfoPagesLockdown +
+                           kOtpSecMmioCreatorSwCfgLockDown);
 
   // Unlock execution of owner stage executable code (text) sections.
   rom_ext_epmp_unlock_owner_stage_rx(&epmp, manifest_code_region_get(manifest));


### PR DESCRIPTION
* Add SEC_MMIO_INCREMENT macro to be able to increment the expected register write count without requiring an additional function call. It relies on an extern reference to the sec_mmio_ctx to avoid requiring functional tests to explicitly define the context.
* Remove `sec_mmio_write_increment()` calls from the mask rom drivers, and update functional tests and the mask_rom to directly update the  expectation counter.