### PR TITLE
[util, dv] Auto-generate and add testplan for security countermeasures

### DIFF
--- a/hw/Makefile
+++ b/hw/Makefile
@@ -97,6 +97,7 @@ blk-hjson      = $(PRJ_DIR)/hw/ip/$*/$(dir_hjson)/$*.hjson
 $(ips_reg): %_reg: | $(REG_OUTPUT_DV_DIR)
 	$(if $(wildcard $(blk-gen-script)),$(blk-gen-script))
 	${PRJ_DIR}/util/regtool.py ${toolflags} -r $(blk-hjson)
+	${PRJ_DIR}/util/regtool.py --sec-cm-testplan $(blk-hjson)
 	${PRJ_DIR}/util/regtool.py -s -t $(REG_OUTPUT_DV_DIR) $(blk-hjson)
 
 # Register generation for otp_ctrl also depends on running gen-otp-mmap.py

--- a/hw/ip/adc_ctrl/data/adc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../adc_ctrl/data/adc_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../adc_ctrl/data/adc_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
@@ -8,7 +8,8 @@
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "adc_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/aes/data/aes_sec_cm_testplan.hjson
+++ b/hw/ip/aes/data/aes_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../aes/data/aes.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../aes/data/aes_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -6,7 +6,8 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "aes_sec_cm_testplan.hjson"]
   testpoints: [
    // {
    //   name: default_setting

--- a/hw/ip/aon_timer/data/aon_timer_sec_cm_testplan.hjson
+++ b/hw/ip/aon_timer/data/aon_timer_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../aon_timer/data/aon_timer.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../aon_timer/data/aon_timer_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/aon_timer/data/aon_timer_testplan.hjson
+++ b/hw/ip/aon_timer/data/aon_timer_testplan.hjson
@@ -8,7 +8,8 @@
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "aon_timer_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke
@@ -40,7 +41,7 @@
             - Register writes to WKUP_CTRL while running.
 
             **Checks**:
-            - WKUP_COUNT should reflect expected -and changed- passing of real time 
+            - WKUP_COUNT should reflect expected -and changed- passing of real time
             regardless of its changing prescaler value.
             '''
       milestone: V2
@@ -76,7 +77,7 @@
       desc: '''
         Includes possible values of all registers of AON timer. For 32b registers, bins are
         introduced in order to simplfy coverage. Maximum and minimum values are collected in
-        a seperate bin to guarantee that they are checked. 32 separate bins are auto-generated 
+        a separate bin to guarantee that they are checked. 32 separate bins are auto-generated
         in order to distrubute values evenly.
       '''
     }

--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -8,7 +8,10 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     // TODO: Top-level specific Hjson imported here. This will likely be resolved
+                     // once we move to IPgen flow.
+                     "hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke
@@ -53,7 +56,7 @@
             This test runs multiple rounds, and on each one it randomizes
              `ip_clk_en` and `scanmode_i`, and the initial setting of
              `clk_enables`, it sends a CSR write to `csr_enables` with this
-             initial value followed by a write that flips all bits. 
+             initial value followed by a write that flips all bits.
 
             **Checks**:
             - The scoreboard checks the gated clock activities against its

--- a/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_sec_cm_testplan.hjson
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../csrng/data/csrng.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../csrng/data/csrng_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_config_regwen
+      desc: "Verify the countermeasure(s) CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_config_mubi
+      desc: "Verify the countermeasure(s) CONFIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_intersig_mubi
+      desc: "Verify the countermeasure(s) INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_sparse
+      desc: "Verify the countermeasure(s) FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctr_redun
+      desc: "Verify the countermeasure(s) CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_sw_genbits_bus_consistency
+      desc: "Verify the countermeasure(s) SW_GENBITS.BUS.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_tile_link_bus_integrity
+      desc: "Verify the countermeasure(s) TILE_LINK.BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/csrng/data/csrng_testplan.hjson
+++ b/hw/ip/csrng/data/csrng_testplan.hjson
@@ -7,13 +7,14 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "csrng_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke
       desc: '''
-	    Verify sending instantiate/generate cmds via SW path.
-	    Verify reading genbits via SW path.
+      Verify sending instantiate/generate cmds via SW path.
+      Verify reading genbits via SW path.
             '''
       milestone: V1
       tests: ["csrng_smoke"]
@@ -96,7 +97,7 @@
             - which_fifo_state_err (0 to 15), 16 different fifos
             - which_err_code (0 to 51), 26 possible fatal errors, plus 26 ERR_CODE_TEST bits test
             - which_fifo_err (0 to 2), fifo write/read/state errors
-            - which_invalid_mubi (0 to 2), 3 possible invalid mubi4 fields 
+            - which_invalid_mubi (0 to 2), 3 possible invalid mubi4 fields
             '''
     }
   ]

--- a/hw/ip/edn/data/edn_sec_cm_testplan.hjson
+++ b/hw/ip/edn/data/edn_sec_cm_testplan.hjson
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../edn/data/edn.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../edn/data/edn_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_config_regwen
+      desc: "Verify the countermeasure(s) CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_config_mubi
+      desc: "Verify the countermeasure(s) CONFIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_main_sm_fsm_sparse
+      desc: "Verify the countermeasure(s) MAIN_SM.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ack_sm_fsm_sparse
+      desc: "Verify the countermeasure(s) ACK_SM.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctr_redun
+      desc: "Verify the countermeasure(s) CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_main_sm_ctr_local_esc
+      desc: "Verify the countermeasure(s) MAIN_SM.CTR.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_cs_rdata_bus_consistency
+      desc: "Verify the countermeasure(s) CS_RDATA.BUS.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_tile_link_bus_integrity
+      desc: "Verify the countermeasure(s) TILE_LINK.BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -7,7 +7,8 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "edn_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_sec_cm_testplan.hjson
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../entropy_src/data/entropy_src.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../entropy_src/data/entropy_src_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_config_regwen
+      desc: "Verify the countermeasure(s) CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_config_mubi
+      desc: "Verify the countermeasure(s) CONFIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_config_redun
+      desc: "Verify the countermeasure(s) CONFIG.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_intersig_mubi
+      desc: "Verify the countermeasure(s) INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_main_sm_fsm_sparse
+      desc: "Verify the countermeasure(s) MAIN_SM.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ack_sm_fsm_sparse
+      desc: "Verify the countermeasure(s) ACK_SM.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_rng_bkgn_chk
+      desc: "Verify the countermeasure(s) RNG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctr_redun
+      desc: "Verify the countermeasure(s) CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctr_local_esc
+      desc: "Verify the countermeasure(s) CTR.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esfinal_rdata_bus_consistency
+      desc: "Verify the countermeasure(s) ESFINAL_RDATA.BUS.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_tile_link_bus_integrity
+      desc: "Verify the countermeasure(s) TILE_LINK.BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -7,7 +7,8 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "entropy_src_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../flash_ctrl/data/flash_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../flash_ctrl/data/flash_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_sparse
+      desc: "Verify the countermeasure(s) FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scramble_key_sideload
+      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -10,7 +10,10 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     // TODO: Top-level specific Hjson imported here. This will likely be resolved
+                     // once we move to IPgen flow.
+                     "hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/gpio/data/gpio_sec_cm_testplan.hjson
+++ b/hw/ip/gpio/data/gpio_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../gpio/data/gpio.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../gpio/data/gpio_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/gpio/data/gpio_testplan.hjson
+++ b/hw/ip/gpio/data/gpio_testplan.hjson
@@ -7,7 +7,8 @@
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "gpio_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/hmac/data/hmac_sec_cm_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../hmac/data/hmac.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../hmac/data/hmac_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/hmac/data/hmac_testplan.hjson
+++ b/hw/ip/hmac/data/hmac_testplan.hjson
@@ -7,7 +7,8 @@
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hmac_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/i2c/data/i2c_sec_cm_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../i2c/data/i2c.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../i2c/data/i2c_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/i2c/data/i2c_testplan.hjson
+++ b/hw/ip/i2c/data/i2c_testplan.hjson
@@ -6,7 +6,8 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "i2c_sec_cm_testplan.hjson"]
   testpoints: [
     //-----------------------------------------------
     // Tests for I2C DUT in HOST mode

--- a/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_sec_cm_testplan.hjson
@@ -1,0 +1,141 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../keymgr/data/keymgr.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../keymgr/data/keymgr_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_config_shadow
+      desc: "Verify the countermeasure(s) CONFIG.SHADOW."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_op_config_regwen
+      desc: "Verify the countermeasure(s) OP.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_reseed_config_regwen
+      desc: "Verify the countermeasure(s) RESEED.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_sw_binding_config_regwen
+      desc: "Verify the countermeasure(s) SW_BINDING.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_max_key_ver_config_regwen
+      desc: "Verify the countermeasure(s) MAX_KEY_VER.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lc_ctrl_intersig_mubi
+      desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_constants_consistency
+      desc: "Verify the countermeasure(s) CONSTANTS.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_intersig_consistency
+      desc: "Verify the countermeasure(s) INTERSIG.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_hw_key_sw_noaccess
+      desc: "Verify the countermeasure(s) HW.KEY.SW_NOACCESS."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_output_keys_ctrl_redun
+      desc: "Verify the countermeasure(s) OUTPUT_KEYS.CTRL.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctrl_fsm_sparse
+      desc: "Verify the countermeasure(s) CTRL.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_data_fsm_sparse
+      desc: "Verify the countermeasure(s) DATA.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctrl_fsm_local_esc
+      desc: "Verify the countermeasure(s) CTRL.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctrl_fsm_global_esc
+      desc: "Verify the countermeasure(s) CTRL.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctrl_ctr_redun
+      desc: "Verify the countermeasure(s) CTRL.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kmac_if_fsm_sparse
+      desc: "Verify the countermeasure(s) KMAC_IF.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kmac_if_ctr_redun
+      desc: "Verify the countermeasure(s) KMAC_IF.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_reseed_ctr_redun
+      desc: "Verify the countermeasure(s) RESEED.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/keymgr/data/keymgr_testplan.hjson
+++ b/hw/ip/keymgr/data/keymgr_testplan.hjson
@@ -10,7 +10,8 @@
                      "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "keymgr_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -9,7 +9,8 @@
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "kmac_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../kmac/data/kmac.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../kmac/data/kmac_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,129 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../lc_ctrl/data/lc_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../lc_ctrl/data/lc_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_transition_config_regwen
+      desc: "Verify the countermeasure(s) TRANSITION.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_manuf_state_sparse
+      desc: "Verify the countermeasure(s) MANUF.STATE.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_transition_ctr_sparse
+      desc: "Verify the countermeasure(s) TRANSITION.CTR.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_manuf_state_bkgn_chk
+      desc: "Verify the countermeasure(s) MANUF.STATE.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_transition_ctr_bkgn_chk
+      desc: "Verify the countermeasure(s) TRANSITION.CTR.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_state_config_sparse
+      desc: "Verify the countermeasure(s) STATE.CONFIG.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_main_fsm_sparse
+      desc: "Verify the countermeasure(s) MAIN.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kmac_fsm_sparse
+      desc: "Verify the countermeasure(s) KMAC.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_main_fsm_local_esc
+      desc: "Verify the countermeasure(s) MAIN.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_main_fsm_global_esc
+      desc: "Verify the countermeasure(s) MAIN.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_main_ctrl_flow_consistency
+      desc: "Verify the countermeasure(s) MAIN.CTRL_FLOW.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_intersig_mubi
+      desc: "Verify the countermeasure(s) INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_token_valid_ctrl_mubi
+      desc: "Verify the countermeasure(s) TOKEN_VALID.CTRL.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_token_digest
+      desc: "Verify the countermeasure(s) TOKEN.DIGEST."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_token_mux_ctrl_redun
+      desc: "Verify the countermeasure(s) TOKEN_MUX.CTRL.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_token_valid_mux_redun
+      desc: "Verify the countermeasure(s) TOKEN_VALID.MUX.REDUN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson
@@ -5,9 +5,9 @@
   name: "lc_ctrl"
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
-                     // TODO: temp commented out stress_test
-                     // "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"
+                     "lc_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../otbn/data/otbn.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../otbn/data/otbn_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scramble_key_sideload
+      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -9,7 +9,8 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson",
+                     "otbn_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,297 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../otp_ctrl/data/otp_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../otp_ctrl/data/otp_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_secret_mem_scramble
+      desc: "Verify the countermeasure(s) SECRET.MEM.SCRAMBLE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_mem_digest
+      desc: "Verify the countermeasure(s) PART.MEM.DIGEST."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_dai_fsm_sparse
+      desc: "Verify the countermeasure(s) DAI.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kdi_fsm_sparse
+      desc: "Verify the countermeasure(s) KDI.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lci_fsm_sparse
+      desc: "Verify the countermeasure(s) LCI.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_fsm_sparse
+      desc: "Verify the countermeasure(s) PART.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scrmbl_fsm_sparse
+      desc: "Verify the countermeasure(s) SCRMBL.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_timer_fsm_sparse
+      desc: "Verify the countermeasure(s) TIMER.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_dai_ctr_redun
+      desc: "Verify the countermeasure(s) DAI.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kdi_seed_ctr_redun
+      desc: "Verify the countermeasure(s) KDI_SEED.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kdi_entropy_ctr_redun
+      desc: "Verify the countermeasure(s) KDI_ENTROPY.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lci_ctr_redun
+      desc: "Verify the countermeasure(s) LCI.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_ctr_redun
+      desc: "Verify the countermeasure(s) PART.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scrmbl_ctr_redun
+      desc: "Verify the countermeasure(s) SCRMBL.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_timer_integ_ctr_redun
+      desc: "Verify the countermeasure(s) TIMER_INTEG.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_timer_cnsty_ctr_redun
+      desc: "Verify the countermeasure(s) TIMER_CNSTY.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_timer_lfsr_redun
+      desc: "Verify the countermeasure(s) TIMER.LFSR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_dai_fsm_local_esc
+      desc: "Verify the countermeasure(s) DAI.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lci_fsm_local_esc
+      desc: "Verify the countermeasure(s) LCI.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kdi_fsm_local_esc
+      desc: "Verify the countermeasure(s) KDI.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_fsm_local_esc
+      desc: "Verify the countermeasure(s) PART.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scrmbl_fsm_local_esc
+      desc: "Verify the countermeasure(s) SCRMBL.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_timer_fsm_local_esc
+      desc: "Verify the countermeasure(s) TIMER.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_dai_fsm_global_esc
+      desc: "Verify the countermeasure(s) DAI.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lci_fsm_global_esc
+      desc: "Verify the countermeasure(s) LCI.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_kdi_fsm_global_esc
+      desc: "Verify the countermeasure(s) KDI.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_fsm_global_esc
+      desc: "Verify the countermeasure(s) PART.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scrmbl_fsm_global_esc
+      desc: "Verify the countermeasure(s) SCRMBL.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_timer_fsm_global_esc
+      desc: "Verify the countermeasure(s) TIMER.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_data_reg_integrity
+      desc: "Verify the countermeasure(s) PART.DATA_REG.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_data_reg_bkgn_chk
+      desc: "Verify the countermeasure(s) PART.DATA_REG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_mem_regren
+      desc: "Verify the countermeasure(s) PART.MEM.REGREN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_mem_sw_unreadable
+      desc: "Verify the countermeasure(s) PART.MEM.SW_UNREADABLE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_part_mem_sw_unwritable
+      desc: "Verify the countermeasure(s) PART.MEM.SW_UNWRITABLE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lc_part_mem_sw_noaccess
+      desc: "Verify the countermeasure(s) LC_PART.MEM.SW_NOACCESS."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_access_ctrl_mubi
+      desc: "Verify the countermeasure(s) ACCESS.CTRL.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_token_valid_ctrl_mubi
+      desc: "Verify the countermeasure(s) TOKEN_VALID.CTRL.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lc_ctrl_intersig_mubi
+      desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_test_bus_lc_gated
+      desc: "Verify the countermeasure(s) TEST.BUS.LC_GATED."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_direct_access_config_regwen
+      desc: "Verify the countermeasure(s) DIRECT_ACCESS.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_check_trigger_config_regwen
+      desc: "Verify the countermeasure(s) CHECK_TRIGGER.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_check_config_regwen
+      desc: "Verify the countermeasure(s) CHECK.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_macro_mem_integrity
+      desc: "Verify the countermeasure(s) MACRO.MEM.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_macro_mem_cm
+      desc: "Verify the countermeasure(s) MACRO.MEM.CM."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -10,7 +10,8 @@
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "otp_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: wake_up

--- a/hw/ip/pattgen/data/pattgen_sec_cm_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../pattgen/data/pattgen.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../pattgen/data/pattgen_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/pattgen/data/pattgen_testplan.hjson
+++ b/hw/ip/pattgen/data/pattgen_testplan.hjson
@@ -8,7 +8,8 @@
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"],
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "pattgen_sec_cm_testplan.hjson"],
   testpoints: [
     {
       name: smoke
@@ -144,7 +145,7 @@
     {
       name: inter_cg
       desc: '''
-            intr_cg is defined in cip_base_env_cov and 
+            intr_cg is defined in cip_base_env_cov and
             referenced in pattgen_scoreboard
             '''
     }
@@ -200,7 +201,7 @@
             Covers various data_0 values of the channel0 seed pattern ranges,
             to ensure that Pattgen can operate successfully on different pattern lengths.
             we will cover that an acceptable distribution of lengths has been seen,
-            and specifically cover corner cases. The covergroup takes data from 
+            and specifically cover corner cases. The covergroup takes data from
             TL_UL scoreboard input
             '''
     }

--- a/hw/ip/pinmux/data/pinmux_sec_cm_testplan.hjson
+++ b/hw/ip/pinmux/data/pinmux_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../pinmux/data/pinmux.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../pinmux/data/pinmux_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/pwm/data/pwm_sec_cm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../pwm/data/pwm.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../pwm/data/pwm_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/pwm/data/pwm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_testplan.hjson
@@ -5,9 +5,10 @@
     name: "pwm"
     import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                        "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                       "hw/dv/tools/dvsim/testplans/enable_reg_testplan.hjson",                      
+                       "hw/dv/tools/dvsim/testplans/enable_reg_testplan.hjson",
                        "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                       "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"],
+                       "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                       "pwm_sec_cm_testplan.hjson"],
     testpoints: [
         {
             name: smoke

--- a/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../pwrmgr/data/pwrmgr.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../pwrmgr/data/pwrmgr_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_sparse
+      desc: "Verify the countermeasure(s) FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -7,7 +7,10 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     // TODO: Top-level specific Hjson imported here. This will likely be resolved
+                     // once we move to IPgen flow.
+                     "hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/rom_ctrl/data/rom_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,111 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rom_ctrl/data/rom_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rom_ctrl/data/rom_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_checker_ctr_consistency
+      desc: "Verify the countermeasure(s) CHECKER.CTR.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_checker_ctrl_flow_consistency
+      desc: "Verify the countermeasure(s) CHECKER.CTRL_FLOW.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_checker_fsm_local_esc
+      desc: "Verify the countermeasure(s) CHECKER.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_compare_ctrl_flow_consistency
+      desc: "Verify the countermeasure(s) COMPARE.CTRL_FLOW.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_compare_ctr_consistency
+      desc: "Verify the countermeasure(s) COMPARE.CTR.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_sparse
+      desc: "Verify the countermeasure(s) FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_mem_scramble
+      desc: "Verify the countermeasure(s) MEM.SCRAMBLE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_mem_digest
+      desc: "Verify the countermeasure(s) MEM.DIGEST."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_intersig_mubi
+      desc: "Verify the countermeasure(s) INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_bus_local_esc
+      desc: "Verify the countermeasure(s) BUS.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_mux_mubi
+      desc: "Verify the countermeasure(s) MUX.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_mux_consistency
+      desc: "Verify the countermeasure(s) MUX.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctrl_redun
+      desc: "Verify the countermeasure(s) CTRL.REDUN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -7,7 +7,8 @@
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "rom_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke
@@ -28,7 +29,7 @@
             - Check that the memory accesses return expected data
             - Check that pwrmgr_data_o.good is not asserted in first iteration.
             - Check that pwrmgr_data_o.good is asserted in second iteration.
-            - Check that tile link accesses are blocked till pwrmgr_data_o.done is asserted. 
+            - Check that tile link accesses are blocked till pwrmgr_data_o.done is asserted.
             '''
       milestone: V1
       tests: ["rom_ctrl_smoke"]
@@ -37,7 +38,7 @@
       name: corrupt_sig_fatal_chk
       desc: '''
             Corrupt integrity of signals like the select signal to addr mux.
-            
+
             **Checks**:
             - Check that fatal error is flagged.
             '''
@@ -52,7 +53,7 @@
       milestone: V2
       tests: ["rom_ctrl_stress_all"]
     }
-    
+
   ]
   covergroups: [
     {
@@ -71,9 +72,9 @@
       desc: '''
             -Collect coverage on the two TLUL interfaces, specifically checking
             that we see requests around the same time as the rom check completes.
-            - Collect coverage to ensure that a_valid goes high when rom check 
-            is in progress. This ensures that the scenario where TL accesses are 
-            blocked until the ROM check is done is covered. 
+            - Collect coverage to ensure that a_valid goes high when rom check
+            is in progress. This ensures that the scenario where TL accesses are
+            blocked until the ROM check is done is covered.
             '''
     }
     {

--- a/hw/ip/rstmgr/data/rstmgr_sec_cm_testplan.hjson
+++ b/hw/ip/rstmgr/data/rstmgr_sec_cm_testplan.hjson
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rstmgr/data/rstmgr.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rstmgr/data/rstmgr_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scan_intersig_mubi
+      desc: "Verify the countermeasure(s) SCAN.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_leaf_rst_bkgn_chk
+      desc: "Verify the countermeasure(s) LEAF.RST.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_leaf_rst_shadow
+      desc: "Verify the countermeasure(s) LEAF.RST.SHADOW."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_leaf_fsm_sparse
+      desc: "Verify the countermeasure(s) LEAF.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_sw_rst_config_regwen
+      desc: "Verify the countermeasure(s) SW_RST.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_dump_ctrl_config_regwen
+      desc: "Verify the countermeasure(s) DUMP_CTRL.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/rstmgr/data/rstmgr_testplan.hjson
+++ b/hw/ip/rstmgr/data/rstmgr_testplan.hjson
@@ -6,7 +6,10 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     // TODO: Top-level specific Hjson imported here. This will likely be resolved
+                     // once we move to IPgen flow.
+                     "hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex_sec_cm_testplan.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex_sec_cm_testplan.hjson
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rv_core_ibex/data/rv_core_ibex.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rv_core_ibex/data/rv_core_ibex_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scramble_key_sideload
+      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex_testplan.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex_testplan.hjson
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "rv_core_ibex"
+  import_testplans: ["rv_core_ibex_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: riscv_arithmetic_basic_test

--- a/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rv_dm/data/rv_dm.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rv_dm/data/rv_dm_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/rv_dm/data/rv_dm_testplan.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_testplan.hjson
@@ -8,7 +8,8 @@
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "rv_dm_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/rv_timer/data/rv_timer_sec_cm_testplan.hjson
+++ b/hw/ip/rv_timer/data/rv_timer_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rv_timer/data/rv_timer.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rv_timer/data/rv_timer_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/rv_timer/data/rv_timer_testplan.hjson
+++ b/hw/ip/rv_timer/data/rv_timer_testplan.hjson
@@ -6,7 +6,8 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "rv_timer_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: random

--- a/hw/ip/spi_device/data/spi_device_sec_cm_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../spi_device/data/spi_device.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../spi_device/data/spi_device_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/spi_device/data/spi_device_testplan.hjson
+++ b/hw/ip/spi_device/data/spi_device_testplan.hjson
@@ -7,7 +7,8 @@
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "spi_device_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/spi_host/data/spi_host_sec_cm_testplan.hjson
+++ b/hw/ip/spi_host/data/spi_host_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../spi_host/data/spi_host.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../spi_host/data/spi_host_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/spi_host/data/spi_host_testplan.hjson
+++ b/hw/ip/spi_host/data/spi_host_testplan.hjson
@@ -6,9 +6,9 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     // TODO: comment out for V2
-                     //"hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"],
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "spi_host_sec_cm_testplan.hjson"],
   testpoints: [
     {
       name: smoke

--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -10,7 +10,8 @@
                      "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson",
                      "hw/dv/sv/mem_bkdr_scb/data/mem_access_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "sram_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/sram_ctrl/data/sram_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,117 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../sram_ctrl/data/sram_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../sram_ctrl/data/sram_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctrl_config_regwen
+      desc: "Verify the countermeasure(s) CTRL.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_exec_config_regwen
+      desc: "Verify the countermeasure(s) EXEC.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_exec_config_mubi
+      desc: "Verify the countermeasure(s) EXEC.CONFIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_exec_intersig_mubi
+      desc: "Verify the countermeasure(s) EXEC.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lc_escalate_en_intersig_mubi
+      desc: "Verify the countermeasure(s) LC_ESCALATE_EN.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lc_hw_debug_en_intersig_mubi
+      desc: "Verify the countermeasure(s) LC_HW_DEBUG_EN.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_mem_integrity
+      desc: "Verify the countermeasure(s) MEM.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_mem_scramble
+      desc: "Verify the countermeasure(s) MEM.SCRAMBLE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_addr_scramble
+      desc: "Verify the countermeasure(s) ADDR.SCRAMBLE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_instr_bus_lc_gated
+      desc: "Verify the countermeasure(s) INSTR.BUS.LC_GATED."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_key_global_esc
+      desc: "Verify the countermeasure(s) KEY.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_key_local_esc
+      desc: "Verify the countermeasure(s) KEY.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctr_redun
+      desc: "Verify the countermeasure(s) CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scramble_key_sideload
+      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../sysrst_ctrl/data/sysrst_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../sysrst_ctrl/data/sysrst_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl_testplan.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl_testplan.hjson
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 {
   name: "sysrst_ctrl"
-  // TODO: remove the common testplans if not applicable
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "sysrst_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke
@@ -41,15 +41,15 @@
       name: combo_detect_ec_rst
       desc: '''
             Verify the combo detection with ec_rst action.
-                                     
-            * Trigger the input keys by configuring COM_SEL_CTL_0 register.                                            
-            * Set the combo duration via the COM_DET_CTL_0 register.                                                   
-            * Select the action to be taken by configuring COM_OUT_CTL_0 register.                                     
-            * Set the pulse width via EC_RST_CTL register only to raise ec_rst action.                                 
-            * Read the COMBO_INTR_STATUS register to check if the interrupt is raised and 
-              clear the interrupt. 
-            * NOTE: This is a directed test with no random values for V1 milestone, 
-              further this test will be randomized. 
+
+            * Trigger the input keys by configuring COM_SEL_CTL_0 register.
+            * Set the combo duration via the COM_DET_CTL_0 register.
+            * Select the action to be taken by configuring COM_OUT_CTL_0 register.
+            * Set the pulse width via EC_RST_CTL register only to raise ec_rst action.
+            * Read the COMBO_INTR_STATUS register to check if the interrupt is raised and
+              clear the interrupt.
+            * NOTE: This is a directed test with no random values for V1 milestone,
+              further this test will be randomized.
             '''
       milestone: V1
       tests: ["sysrst_ctrl_combo_detect_ec_rst"]
@@ -59,13 +59,13 @@
       name: combo_detect
       desc: '''
             Verify the combo detection with random action.
-                                        
-            * Trigger the input keys by configuring COM_SEL_CTL_0 register.                                            
-            * Set the random combo duration via the COM_DET_CTL_0 register.                                                   
+
+            * Trigger the input keys by configuring COM_SEL_CTL_0 register.
+            * Set the random combo duration via the COM_DET_CTL_0 register.
             * Randomly select the action to be taken by configuring COM_OUT_CTL_0 register.
-            * Set the pulse width via EC_RST_CTL register.                                                                   
-            * Read the COMBO_INTR_STATUS register to check if the interrupt is raised and clear the 
-              interrupt. 
+            * Set the pulse width via EC_RST_CTL register.
+            * Read the COMBO_INTR_STATUS register to check if the interrupt is raised and clear the
+              interrupt.
             '''
       milestone: V2
       tests: ["sysrst_ctrl_combo_detect"]
@@ -77,9 +77,9 @@
             Verify the auto block key output feature.
 
             * Trigger the input keys combo.
-            * Set the debounce timer value in AUTO_BLOCK_DEBOUNCE_CTL register.                                                                                                     
+            * Set the debounce timer value in AUTO_BLOCK_DEBOUNCE_CTL register.
             * Select the output override value by configuring AUTO_BLOCK_OUT_CTL register.
-            * Check whether the input keys stays low for the selected debounce time.                                                                       
+            * Check whether the input keys stays low for the selected debounce time.
             * Read the AUTO_BLOCK_OUT_CTL register to check if the output key is overridden.
             '''
       milestone: V2
@@ -89,12 +89,12 @@
     {
       name: keyboard_input_triggered_interrupt
       desc: '''
-            Verify the keyboard and input triggered interrupt feature by detecting the edge 
+            Verify the keyboard and input triggered interrupt feature by detecting the edge
             transitions on input pins.
 
-            * Set the input signals and edge transition by configuring KEY_INTR_CTL register.                                                                                             
-            * Set the debounce timer value via KEY_INTR_DEBOUNCE_CTL register.                                                                                                        
-            * Read the KEY_INTR_STATUS register to check if the interrupt caused and 
+            * Set the input signals and edge transition by configuring KEY_INTR_CTL register.
+            * Set the debounce timer value via KEY_INTR_DEBOUNCE_CTL register.
+            * Read the KEY_INTR_STATUS register to check if the interrupt caused and
               clear the interrupt.
             '''
       milestone: V2
@@ -106,7 +106,7 @@
       desc: '''
             Verify the keyboard inversion feature by override logic.
 
-            * Select the output signals to override via PIN_OUT_CTL register. 
+            * Select the output signals to override via PIN_OUT_CTL register.
             * Allow the output signals to override the value via PIN_ALLOWED_CTL register.
             * Set the override value to the output signal via PIN_OUT_VALUE register.
             '''
@@ -119,7 +119,8 @@
       desc: '''
             Verify the pin input value accessibilty.
 
-            * Trigger the key[0,1,2], ac_present_in, pwrb_in, ec_rst_in_l input pins with random values.
+            * Trigger the key[0,1,2], ac_present_in, pwrb_in, ec_rst_in_l input pins with random
+              values.
             * Read the PIN_IN_VALUE register and check if the read value is same as input value.
             '''
       milestone: V2
@@ -131,8 +132,8 @@
       desc: '''
             Verify the EC and power on reset.
 
-            * Enable the override value by writing to PIN_ALLOWED_CTL.EC_RST_L_1 
-              and PIN_OUT_CTL.EC_RST_L register. 
+            * Enable the override value by writing to PIN_ALLOWED_CTL.EC_RST_L_1
+              and PIN_OUT_CTL.EC_RST_L register.
             * Make sure ec_rst_out_l is asserted even after opentitan reset is released.
             * Set PIN_OUT_CTL.EC_RST_L to 0 to release the ec_rst_out_l reset.
             '''
@@ -146,8 +147,8 @@
             Verify the flash write protect.
 
             * Make sure flash_wp_out_l signal is asserted low by reading PIN_OUT_CTL.flash_wp_l.
-            * Enable the override function by setting PIN_OUT_CTL.FLASH_WP_L to value 1. 
-            * Check if flash_wp_out_l is released. 
+            * Enable the override function by setting PIN_OUT_CTL.FLASH_WP_L to value 1.
+            * Check if flash_wp_out_l is released.
             '''
       milestone: V2
       tests: ["sysrst_ctrl_flash_wr_prot_out"]
@@ -156,15 +157,16 @@
     {
       name: ultra_low_power_test
       desc: '''
-            Verify the ultra low power feature. 
+            Verify the ultra low power feature.
 
-            * Configure ULP_AC_DEBOUNCE_CTL, ULP_LID_DEBOUNCE_CTL and 
-              ULP_PWRB_DEBOUNCE_CTL register to set the debounce timer value. 
+            * Configure ULP_AC_DEBOUNCE_CTL, ULP_LID_DEBOUNCE_CTL and
+              ULP_PWRB_DEBOUNCE_CTL register to set the debounce timer value.
             * Disable the bus clock to check detection logic works in sleep mode.
             * Trigger the ac_present_i, lid_open_in, ec_rst_l_i input keys.
-            * Turn on the bus clock to read the status register.                                                                   
-            * Read the WKUP_STATUS register to check if the event has occured.                                                                         
-            * Read the ULP_STATUS register and check if the ultra low power wakeup event is detected.
+            * Turn on the bus clock to read the status register.
+            * Read the WKUP_STATUS register to check if the event has occured.
+            * Read the ULP_STATUS register and check if the ultra low power wakeup event is
+              detected.
             '''
       milestone: V2
       tests: ["sysrst_ctrl_ultra_low_pwr"]
@@ -181,13 +183,13 @@
     {
       name: sysrst_ctrl_key_intr_cg
       desc: '''
-            Cover the FSM for input key pressed and released. 
+            Cover the FSM for input key pressed and released.
             '''
     }
     {
       name: sysrst_ctrl_timerfsm_cg
       desc: '''
-            Cover the timer based FSM model for different debounce time. 
+            Cover the timer based FSM model for different debounce time.
             '''
     }
     {

--- a/hw/ip/trial1/data/trial1_sec_cm_testplan.hjson
+++ b/hw/ip/trial1/data/trial1_sec_cm_testplan.hjson
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+{
+  testpoints: [
+  ]
+}

--- a/hw/ip/uart/data/uart_sec_cm_testplan.hjson
+++ b/hw/ip/uart/data/uart_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../uart/data/uart.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../uart/data/uart_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/uart/data/uart_testplan.hjson
+++ b/hw/ip/uart/data/uart_testplan.hjson
@@ -6,7 +6,8 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "uart_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/usbdev/data/usbdev_sec_cm_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../usbdev/data/usbdev.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../usbdev/data/usbdev_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip/usbdev/data/usbdev_testplan.hjson
+++ b/hw/ip/usbdev/data/usbdev_testplan.hjson
@@ -7,7 +7,8 @@
   import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson"]
+                     "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "usbdev_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/usbuart/data/usbuart_sec_cm_testplan.hjson
+++ b/hw/ip/usbuart/data/usbuart_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../usbuart/data/usbuart.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../usbuart/data/usbuart_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/ip_templates/alert_handler/data/alert_handler_testplan.hjson
@@ -12,7 +12,9 @@
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_basic_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_additional_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/esc_agent_basic_testplan.hjson",
-                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson"]
+                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson"
+                     // Generated in IP gen area (hw/{top}/ip_autogen).
+                     "alert_handler_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../clkmgr/data/clkmgr.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../clkmgr/data/clkmgr_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_timeout_clk_bkgn_chk
+      desc: "Verify the countermeasure(s) TIMEOUT.CLK.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_meas_clk_bkgn_chk
+      desc: "Verify the countermeasure(s) MEAS.CLK.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lc_ctrl_intersig_mubi
+      desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lc_ctrl_clk_handshake_intersig_mubi
+      desc: "Verify the countermeasure(s) LC_CTRL_CLK_HANDSHAKE.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_clk_handshake_intersig_mubi
+      desc: "Verify the countermeasure(s) CLK_HANDSHAKE.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_jitter_config_mubi
+      desc: "Verify the countermeasure(s) JITTER.CONFIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_meas_config_regwen
+      desc: "Verify the countermeasure(s) MEAS.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_clk_ctrl_config_regwen
+      desc: "Verify the countermeasure(s) CLK_CTRL.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../flash_ctrl/data/flash_ctrl.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../flash_ctrl/data/flash_ctrl_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_sparse
+      desc: "Verify the countermeasure(s) FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scramble_key_sideload
+      desc: "Verify the countermeasure(s) SCRAMBLE.KEY.SIDELOAD."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../pinmux/data/pinmux.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../pinmux/data/pinmux_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../pwrmgr/data/pwrmgr.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../pwrmgr/data/pwrmgr_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_sparse
+      desc: "Verify the countermeasure(s) FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr_sec_cm_testplan.hjson
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rstmgr/data/rstmgr.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rstmgr/data/rstmgr_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_scan_intersig_mubi
+      desc: "Verify the countermeasure(s) SCAN.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_leaf_rst_bkgn_chk
+      desc: "Verify the countermeasure(s) LEAF.RST.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_leaf_rst_shadow
+      desc: "Verify the countermeasure(s) LEAF.RST.SHADOW."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_leaf_fsm_sparse
+      desc: "Verify the countermeasure(s) LEAF.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_sw_rst_config_regwen
+      desc: "Verify the countermeasure(s) SW_RST.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_dump_ctrl_config_regwen
+      desc: "Verify the countermeasure(s) DUMP_CTRL.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_sec_cm_testplan.hjson
@@ -1,0 +1,153 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../alert_handler/data/alert_handler.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../alert_handler/data/alert_handler_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_config_shadow
+      desc: "Verify the countermeasure(s) CONFIG.SHADOW."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_config_regwen
+      desc: "Verify the countermeasure(s) PING_TIMER.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_config_regwen
+      desc: "Verify the countermeasure(s) ALERT.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_loc_config_regwen
+      desc: "Verify the countermeasure(s) ALERT_LOC.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_class_config_regwen
+      desc: "Verify the countermeasure(s) CLASS.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_intersig_diff
+      desc: "Verify the countermeasure(s) ALERT.INTERSIG.DIFF."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_lpg_intersig_mubi
+      desc: "Verify the countermeasure(s) LPG.INTERSIG.MUBI."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_intersig_diff
+      desc: "Verify the countermeasure(s) ESC.INTERSIG.DIFF."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_alert_rx_intersig_bkgn_chk
+      desc: "Verify the countermeasure(s) ALERT_RX.INTERSIG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_tx_intersig_bkgn_chk
+      desc: "Verify the countermeasure(s) ESC_TX.INTERSIG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_rx_intersig_bkgn_chk
+      desc: "Verify the countermeasure(s) ESC_RX.INTERSIG.BKGN_CHK."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_fsm_sparse
+      desc: "Verify the countermeasure(s) ESC_TIMER.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_fsm_sparse
+      desc: "Verify the countermeasure(s) PING_TIMER.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_fsm_local_esc
+      desc: "Verify the countermeasure(s) ESC_TIMER.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_fsm_local_esc
+      desc: "Verify the countermeasure(s) PING_TIMER.FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_fsm_global_esc
+      desc: "Verify the countermeasure(s) ESC_TIMER.FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_accu_ctr_redun
+      desc: "Verify the countermeasure(s) ACCU.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_esc_timer_ctr_redun
+      desc: "Verify the countermeasure(s) ESC_TIMER.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_ctr_redun
+      desc: "Verify the countermeasure(s) PING_TIMER.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ping_timer_lfsr_redun
+      desc: "Verify the countermeasure(s) PING_TIMER.LFSR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler_testplan.hjson
@@ -12,7 +12,9 @@
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_basic_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/alert_agent_additional_testplan.hjson",
                      "hw/dv/sv/alert_esc_agent/data/esc_agent_basic_testplan.hjson",
-                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson"]
+                     "hw/dv/sv/alert_esc_agent/data/esc_agent_additional_testplan.hjson"
+                     // Generated in IP gen area (hw/{top}/ip_autogen).
+                     "alert_handler_sec_cm_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/data/rv_plic_sec_cm_testplan.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../rv_plic/data/rv_plic.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../rv_plic/data/rv_plic_testplan.hjson
+{
+  testpoints: [
+    {
+      name: sec_cm_bus_integrity
+      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      milestone: V2S
+      tests: []
+    }
+  ]
+}

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -13,6 +13,7 @@ import shutil
 import subprocess
 import sys
 from collections import OrderedDict
+from pathlib import Path
 
 from Deploy import CompileSim, CovAnalyze, CovMerge, CovReport, CovUnr, RunTest
 from FlowCfg import FlowCfg
@@ -291,7 +292,8 @@ class SimCfg(FlowCfg):
         # Regressions
         # Parse testplan if provided.
         if self.testplan != "":
-            self.testplan = Testplan(self.testplan, repo_top=self.proj_root)
+            self.testplan = Testplan(self.testplan,
+                                     repo_top=Path(self.proj_root))
             # Extract tests in each milestone and add them as regression target.
             self.regressions.extend(self.testplan.get_milestone_regressions())
         else:
@@ -362,7 +364,6 @@ class SimCfg(FlowCfg):
         for item in set(self.items) - items_matched:
             log.warning(f"Item {item} did not match any regressions or "
                         f"tests in {self.flow_cfg_file}.")
-
 
         # Merge the global build and run opts
         Tests.merge_global_opts(self.run_list, self.pre_build_cmds,

--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional, Union
 import logging
 
 import reggen.gen_rtl
+import reggen.gen_sec_cm_testplan
 from mako import exceptions as mako_exceptions  # type: ignore
 from mako.lookup import TemplateLookup as MakoTemplateLookup  # type: ignore
 from reggen.ip_block import IpBlock
@@ -281,6 +282,8 @@ class IpBlockRenderer(IpTemplateRendererBase):
             # TODO: Pass on template parameters to reggen? Or enable the user
             # to set a different set of parameters in the renderer?
             reggen.gen_rtl.gen_rtl(obj, str(rtl_path))
+            reggen.gen_sec_cm_testplan.gen_sec_cm_testplan(
+                obj, output_dir_staging / 'data')
 
             # Write IP configuration (to reproduce the generation process).
             # TODO: Should the ipconfig file be written to the instance name,

--- a/util/reggen/gen_sec_cm_testplan.py
+++ b/util/reggen/gen_sec_cm_testplan.py
@@ -1,0 +1,65 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the initial testplan for the listed countermeasures."""
+
+import logging as log
+from pathlib import Path
+
+import hjson  # type: ignore
+from mako import exceptions  # type: ignore
+from mako.lookup import TemplateLookup  # type: ignore
+from pkg_resources import resource_filename
+
+from .ip_block import IpBlock
+
+
+def gen_sec_cm_testplan(block: IpBlock, outdir: str) -> int:
+    """Generate the security countermeasures testplan.
+
+    A new testplan is created only if it does not exist yet. If it already
+    exists, then it checks if the list of countermeasures match the list
+    of countermeasures in the design specification Hjson. If not, it throws
+    an error to prompt the user to keep the testplan up-to-date manually.
+    """
+    if not block.countermeasures:
+        return 0
+
+    outfile = Path(outdir) / f"{block.name.lower()}_sec_cm_testplan.hjson"
+    if outfile.exists():
+        names_from_testplan = []
+        with open(outfile, "r", encoding='UTF-8') as f:
+            data = hjson.load(f)
+            try:
+                names_from_testplan = [tp["name"] for tp in data["testpoints"]]
+            except KeyError as e:
+                raise KeyError(f"Malformed testplan {outfile}:\n{e}")
+
+        # Check if the testpoint names match the list in the design spec.
+        names_from_spec = [
+            "sec_cm_{}".format(str(cm).lower().replace(".", "_"))
+            for cm in block.countermeasures
+        ]
+
+        if sorted(names_from_spec) != sorted(names_from_testplan):
+            log.error("The generated security countermeasures testplan "
+                      f"{outfile} is stale. Please manually update it "
+                      "with the newly added (or removed) countermeasures.\n"
+                      f"Deltas:\nSpec: {names_from_spec}\n"
+                      f"Testplan: {names_from_testplan}.")
+            return 1
+
+        return 0
+
+    lookup = TemplateLookup(directories=[resource_filename('reggen', '.')])
+    sec_cm_testplan_tpl = lookup.get_template('sec_cm_testplan.hjson.tpl')
+    with open(outfile, 'w', encoding='UTF-8') as f:
+        try:
+            f.write(
+                sec_cm_testplan_tpl.render(block=block,
+                                           block_name=block.name.lower()))
+        except:  # noqa F722 for template Exception handling
+            log.error(exceptions.text_error_template().render())
+            return 1
+
+    return 0

--- a/util/reggen/sec_cm_testplan.hjson.tpl
+++ b/util/reggen/sec_cm_testplan.hjson.tpl
@@ -1,0 +1,40 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Security countermeasures testplan extracted from the IP Hjson using reggen.
+//
+// This testplan is auto-generated only the first time it is created. This is
+// because this testplan needs to be hand-editable. It is possible that these
+// testpoints can go out of date if the spec is updated with new
+// countermeasures. When `reggen` is invoked when this testplan already exists,
+// It checks if the list of testpoints is up-to-date and enforces the user to
+// make further manual updates.
+//
+// These countermeasures and their descriptions can be found here:
+// .../${block_name}/data/${block_name}.hjson
+//
+// It is possible that the testing of some of these countermeasures may already
+// be covered as a testpoint in a different testplan. This duplication is ok -
+// the test would have likely already been developed. We simply map those tests
+// to the testpoints below using the `tests` key.
+//
+// Please ensure that this testplan is imported in:
+// .../${block_name}/data/${block_name}_testplan.hjson
+{
+<%
+def get_sec_cm_testpoint_name(cm):
+    cm_name = str(cm).lower().replace(".", "_")
+    return f"sec_cm_{cm_name}"
+%>\
+  testpoints: [
+% for cm in block.countermeasures:
+    {
+      name: ${get_sec_cm_testpoint_name(cm)}
+      desc: "Verify the countermeasure(s) ${str(cm)}."
+      milestone: V2S
+      tests: []
+    }
+% endfor
+  ]
+}

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -11,10 +11,10 @@ import re
 import sys
 from pathlib import Path
 
-from reggen import (gen_cheader, gen_dv, gen_fpv, gen_html,
-                    gen_json, gen_rtl, gen_rust, gen_selfdoc, version)
-from reggen.ip_block import IpBlock
+from reggen import (gen_cheader, gen_dv, gen_fpv, gen_html, gen_json, gen_rtl,
+                    gen_rust, gen_sec_cm_testplan, gen_selfdoc, version)
 from reggen.countermeasure import CounterMeasure
+from reggen.ip_block import IpBlock
 
 DESC = """regtool, generate register info from Hjson source"""
 
@@ -61,6 +61,9 @@ def main():
     parser.add_argument('-r',
                         action='store_true',
                         help='Output as SystemVerilog RTL')
+    parser.add_argument('--sec-cm-testplan',
+                        action='store_true',
+                        help='Generate security countermeasures testplan.')
     parser.add_argument('-s',
                         action='store_true',
                         help='Output as UVM Register class')
@@ -123,6 +126,7 @@ def main():
                      ('d', ('html', None)), ('doc', ('doc', None)),
                      ('r', ('rtl', 'rtl')), ('s', ('dv', 'dv')),
                      ('f', ('fpv', 'fpv/vip')), ('cdefines', ('cdh', None)),
+                     ('sec_cm_testplan', ('sec_cm_testplan', 'data')),
                      ('rust', ('rs', None))]
     format = None
     dirspec = None
@@ -146,8 +150,7 @@ def main():
         if len(tokens) != 2:
             raise ValueError('Entry {} in list of parameter defaults to '
                              'apply is {!r}, which is not of the form '
-                             'param=value.'
-                             .format(idx, raw_param))
+                             'param=value.'.format(idx, raw_param))
         params.append((tokens[0], tokens[1]))
 
     # Define either outfile or outdir (but not both), depending on the output
@@ -207,6 +210,8 @@ def main():
     else:
         if format == 'rtl':
             return gen_rtl.gen_rtl(obj, outdir)
+        if format == 'sec_cm_testplan':
+            return gen_sec_cm_testplan.gen_sec_cm_testplan(obj, outdir)
         if format == 'dv':
             return gen_dv.gen_dv(obj, args.dv_base_names, outdir)
         if format == 'fpv':
@@ -237,7 +242,8 @@ def main():
             if format == 'html':
                 return gen_html.gen_html(obj, outfile)
             elif format == 'cdh':
-                return gen_cheader.gen_cdefines(obj, outfile, src_lic, src_copy)
+                return gen_cheader.gen_cdefines(obj, outfile, src_lic,
+                                                src_copy)
             elif format == 'rs':
                 return gen_rust.gen_rust(obj, outfile, src_lic, src_copy)
             else:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -24,7 +24,7 @@ from ipgen import (IpBlockRenderer, IpConfig, IpDescriptionOnlyRenderer,
                    IpTemplate, TemplateRenderError)
 from mako import exceptions
 from mako.template import Template
-from reggen import access, gen_rtl, window
+from reggen import access, gen_rtl, gen_sec_cm_testplan, window
 from reggen.inter_signal import InterSignal
 from reggen.ip_block import IpBlock
 from reggen.countermeasure import CounterMeasure
@@ -243,6 +243,7 @@ def generate_regfile_from_path(hjson_path: Path,
     rtl_names = CounterMeasure.search_rtl_files(sv_files)
     obj.check_cm_annotations(rtl_names, str(hjson_path))
     gen_rtl.gen_rtl(obj, str(generated_rtl_path))
+    gen_sec_cm_testplan.gen_sec_cm_testplan(obj, hjson_path.parent)
 
 
 def generate_pinmux(top, out_path):


### PR DESCRIPTION
The first commit updates the reggen tool to parse the countermeasures and add a new testplan for it if not already created. 

The second commit uses the reggen tool updates to create the required testplans for all IPs. 