### PR TITLE
[edn/rtl] Add filter to cmd_req_done status

### DIFF
--- a/hw/ip/edn/data/edn.hjson
+++ b/hw/ip/edn/data/edn.hjson
@@ -247,7 +247,7 @@
           desc: '''
                 This bit indicates when the command interface is ready to accept commands.
                 '''
-          resval: "1"
+          resval: "0"
         }
         { bits: "1",
           name: "CMD_STS",

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -598,7 +598,7 @@ module edn_reg_top (
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
+    .RESVAL  (1'h0)
   ) u_sw_cmd_sts_cmd_rdy (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),


### PR DESCRIPTION
When the hardware interfaces run (boot or auto request modes) the
cmd_req_done status bit should not be set.
Only in response to a software command should this status bit be set.
Also updated the behavior of rdy_sts to wait for boot sm to be done.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>