### PR TITLE
[dv/unr] Blackbox common security modules from UNR flow

### DIFF
--- a/hw/dv/tools/vcs/unr.cfg
+++ b/hw/dv/tools/vcs/unr.cfg
@@ -10,8 +10,8 @@
 # Provide the reset specification: signal_name, active_value, num clk cycles reset to be active
 -reset rst_ni 0 20
 
-# Black box some of the modules
-# -blackBoxes -type design *
+# Black box common security modules
+ -blackBoxes -type design prim_count+prim_spare_fsm+prim_double_lfsr
 
 # Name of the generated exclusion file
 -save_exclusion $SCRATCH_PATH/cov_unr/unr_exclude.el


### PR DESCRIPTION
This PR blackbox common security prim modules: prim_count,
prim_double_lfsr, prim_sparse_fsm_flop from the UNR flow.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>