### PR TITLE
[lc_ctrl] Add MUBI-like functions to operate on lc_tx_t 

### DIFF
--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -58,10 +58,10 @@ package lc_ctrl_pkg;
     return ~(val inside {On, Off});
   endfunction : lc_tx_test_invalid
 
-  // Convert a 1 input value to a mubi output
-  function automatic lc_tx_t lc_tx_bool_to_mubi(logic val);
+  // Convert a 1 input value to a lc_tx output
+  function automatic lc_tx_t lc_tx_bool_to_lc_tx(logic val);
     return (val ? On : Off);
-  endfunction : lc_tx_bool_to_mubi
+  endfunction : lc_tx_bool_to_lc_tx
 
   // Test whether the multibit value signals an "enabled" condition.
   // The strict version of this function requires

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -49,6 +49,129 @@ package lc_ctrl_pkg;
   parameter int LcKeymgrDivWidth = 128;
   typedef logic [LcKeymgrDivWidth-1:0] lc_keymgr_div_t;
 
+  /////////////////////////////////////////////
+  // Helper Functions for Life Cycle Signals //
+  /////////////////////////////////////////////
+
+  // Test whether the value is supplied is one of the valid enumerations
+  function automatic logic lc_tx_test_invalid(lc_tx_t val);
+    return ~(val inside {On, Off});
+  endfunction : lc_tx_test_invalid
+
+  // Convert a 1 input value to a mubi output
+  function automatic lc_tx_t lc_tx_bool_to_mubi(logic val);
+    return (val ? On : Off);
+  endfunction : lc_tx_bool_to_mubi
+
+  // Test whether the multibit value signals an "enabled" condition.
+  // The strict version of this function requires
+  // the multibit value to equal True.
+  function automatic logic lc_tx_test_true_strict(lc_tx_t val);
+    return On == val;
+  endfunction : lc_tx_test_true_strict
+
+  // Test whether the multibit value signals a "disabled" condition.
+  // The strict version of this function requires
+  // the multibit value to equal False.
+  function automatic logic lc_tx_test_false_strict(lc_tx_t val);
+    return Off == val;
+  endfunction : lc_tx_test_false_strict
+
+  // Test whether the multibit value signals an "enabled" condition.
+  // The loose version of this function interprets all
+  // values other than False as "enabled".
+  function automatic logic lc_tx_test_true_loose(lc_tx_t val);
+    return Off != val;
+  endfunction : lc_tx_test_true_loose
+
+  // Test whether the multibit value signals a "disabled" condition.
+  // The loose version of this function interprets all
+  // values other than True as "disabled".
+  function automatic logic lc_tx_test_false_loose(lc_tx_t val);
+    return On != val;
+  endfunction : lc_tx_test_false_loose
+
+
+  // Performs a logical OR operation between two multibit values.
+  // This treats "act" as logical 1, and all other values are
+  // treated as 0. Truth table:
+  //
+  // A    | B    | OUT
+  //------+------+-----
+  // !act | !act | !act
+  // act  | !act | act
+  // !act | act  | act
+  // act  | act  | act
+  //
+  function automatic lc_tx_t lc_tx_or(lc_tx_t a, lc_tx_t b, lc_tx_t act);
+    logic [TxWidth-1:0] a_in, b_in, act_in, out;
+    a_in = a;
+    b_in = b;
+    act_in = act;
+    for (int k = 0; k < TxWidth; k++) begin
+      if (act_in[k]) begin
+        out[k] = a_in[k] || b_in[k];
+      end else begin
+        out[k] = a_in[k] && b_in[k];
+      end
+    end
+    return lc_tx_t'(out);
+  endfunction : lc_tx_or
+
+  // Performs a logical AND operation between two multibit values.
+  // This treats "act" as logical 1, and all other values are
+  // treated as 0. Truth table:
+  //
+  // A    | B    | OUT
+  //------+------+-----
+  // !act | !act | !act
+  // act  | !act | !act
+  // !act | act  | !act
+  // act  | act  | act
+  //
+  function automatic lc_tx_t lc_tx_and(lc_tx_t a, lc_tx_t b, lc_tx_t act);
+    logic [TxWidth-1:0] a_in, b_in, act_in, out;
+    a_in = a;
+    b_in = b;
+    act_in = act;
+    for (int k = 0; k < TxWidth; k++) begin
+      if (act_in[k]) begin
+        out[k] = a_in[k] && b_in[k];
+      end else begin
+        out[k] = a_in[k] || b_in[k];
+      end
+    end
+    return lc_tx_t'(out);
+  endfunction : lc_tx_and
+
+  // Performs a logical OR operation between two multibit values.
+  // This treats "True" as logical 1, and all other values are
+  // treated as 0.
+  function automatic lc_tx_t lc_tx_or_hi(lc_tx_t a, lc_tx_t b);
+    return lc_tx_or(a, b, On);
+  endfunction : lc_tx_or_hi
+
+  // Performs a logical AND operation between two multibit values.
+  // This treats "True" as logical 1, and all other values are
+  // treated as 0.
+  function automatic lc_tx_t lc_tx_and_hi(lc_tx_t a, lc_tx_t b);
+    return lc_tx_and(a, b, On);
+  endfunction : lc_tx_and_hi
+
+  // Performs a logical OR operation between two multibit values.
+  // This treats "False" as logical 1, and all other values are
+  // treated as 0.
+  function automatic lc_tx_t lc_tx_or_lo(lc_tx_t a, lc_tx_t b);
+    return lc_tx_or(a, b, Off);
+  endfunction : lc_tx_or_lo
+
+  // Performs a logical AND operation between two multibit values.
+  // Tlos treats "False" as logical 1, and all other values are
+  // treated as 0.
+  function automatic lc_tx_t lc_tx_and_lo(lc_tx_t a, lc_tx_t b);
+    return lc_tx_and(a, b, Off);
+  endfunction : lc_tx_and_lo
+
   ////////////////////
   // Main FSM State //
   ////////////////////

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -267,6 +267,10 @@ module rv_core_ibex
             irq_external})
   );
 
+  // Multibit AND computation for fetch enable.
+  lc_ctrl_pkg::lc_tx_t fetch_enable;
+  assign fetch_enable = lc_ctrl_pkg::lc_tx_and_hi(lc_cpu_en[0], pwrmgr_cpu_en[0]);
+
   ibex_top #(
     .PMPEnable                ( PMPEnable                ),
     .PMPGranularity           ( PMPGranularity           ),
@@ -355,8 +359,9 @@ module rv_core_ibex
     .rvfi_mem_rdata,
     .rvfi_mem_wdata,
 `endif
-
-    .fetch_enable_i   (lc_cpu_en[0] == lc_ctrl_pkg::On && pwrmgr_cpu_en[0] == lc_ctrl_pkg::On),
+    // TODO(D2S): this needs to be pulled into both the primary core and into the shadow core
+    // before decoding it to a single bit.
+    .fetch_enable_i   (lc_ctrl_pkg::lc_tx_test_true_strict(fetch_enable)),
     .alert_minor_o    (alert_minor),
     .alert_major_o    (alert_major),
     .core_sleep_o     (pwrmgr_o.core_sleeping)


### PR DESCRIPTION
This is added in order to facilitate a D2S item for `rv_core_ibex`. The intent is not to do a system wide cleanup (i.e. replacing explicit RTL tests ` == ON` / ` == OFF`) since that would have too much design impact right now. This cleanup is deferred to sometime in the future (see also #10561).