### PR TITLE
[adc_ctrl] update count increment

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -113,7 +113,7 @@
       fields: [
         { bits: "7:0",
           name: "lp_sample_cnt",
-          desc: "The number of samples in low-power mode when the low-power mode is enabled. After the programmed number is met, ADC won't be powered down any more.",
+          desc: "The number of samples in low-power mode when the low-power mode is enabled. After the programmed number is met, ADC won't be powered down any more.  This value must be 1 or larger.",
           resval: "4",
         }
       ],
@@ -127,7 +127,7 @@
       fields: [
         { bits: "15:0",
           name: "np_sample_cnt",
-          desc: "The number of samples in normal-power mode to meet the debounce spec. used after the low-power mode condition is met or in the normal power mode",
+          desc: "The number of samples in normal-power mode to meet the debounce spec. used after the low-power mode condition is met or in the normal power mode.  This value must be 1 or larger.",
         }
       ]
     }


### PR DESCRIPTION
- instead of always incrementing at NP_1, increment only during eval
  when the match is actually examined.

- update the match comparison since counter is now incremented during
  EVAL stage only.

- this changes the match timing slightly but logically is a bit more
  consistent with the states.