### PR TITLE
[dv/otp] Fix tb corner case failure

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_macro_errs_vseq.sv
@@ -14,4 +14,8 @@ class otp_ctrl_macro_errs_vseq extends otp_ctrl_dai_lock_vseq;
     ecc_otp_err inside {OtpEccCorrErr, OtpEccUncorrErr};
   }
 
+  function void pre_randomize();
+    this.no_access_err_c.constraint_mode(0);
+  endfunction
+
 endclass


### PR DESCRIPTION
In nightly regression, there are failures due to tl_intg_err in OTP sw
partitions memory access.
The reason is because I did not get the `is_tl_mem_access_allowed` with
the correct memory width, that certain non-memory CSRs are treated as
memory.

while fixing this issue, this PR did two enhancement:
1). In macro test, remove the randomization constrants to lock sw
  partitions.
2). Add a checking to ensure when fsm goes to fatal state, the checkings
  are done in `is_tl_mem_access_allowed` function already.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>