### PR TITLE
[opentitantool] Support C2D2 with HyperDebug driver

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -39,6 +39,7 @@ rust_library(
         "src/transport/cw310/spi.rs",
         "src/transport/cw310/uart.rs",
         "src/transport/cw310/usb.rs",
+        "src/transport/hyperdebug/c2d2.rs",
         "src/transport/hyperdebug/gpio.rs",
         "src/transport/hyperdebug/i2c.rs",
         "src/transport/hyperdebug/mod.rs",

--- a/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
@@ -1,0 +1,78 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use std::rc::Rc;
+
+use crate::io::gpio::{GpioPin, PinMode, PullMode};
+use crate::transport::hyperdebug::{Error, Flavor, Inner, StandardFlavor, VID_GOOGLE};
+
+/// The C2D2 (Case Closed Debugging Debugger) is used to bring up GSC and EC chips sitting
+/// inside a Chrome OS devices, such that those GSC chips can provide Case Closed Debugging
+/// support to allow bringup of the rest of the Chrome OS device.  C2D2 devices happen to speak
+/// almost exactly the same USB protocol as HyperDebug.  This `Flavor` implementation defines
+/// the few deviations: USB PID value, and the handling of GSC reset signal.
+pub struct C2d2Flavor {}
+
+impl C2d2Flavor {
+    const PID_C2D2: u16 = 0x5041;
+}
+
+impl Flavor for C2d2Flavor {
+    fn gpio_pin(inner: &Rc<Inner>, pinname: &str) -> Result<Rc<dyn GpioPin>> {
+        if pinname == "SPIVREF_RSVD_H1VREF_H1_RST_ODL" {
+            return Ok(Rc::new(C2d2ResetPin::open(inner)?));
+        }
+        StandardFlavor::gpio_pin(inner, pinname)
+    }
+
+    fn get_default_usb_vid() -> u16 {
+        VID_GOOGLE
+    }
+
+    fn get_default_usb_pid() -> u16 {
+        Self::PID_C2D2
+    }
+}
+
+pub struct C2d2ResetPin {
+    inner: Rc<Inner>,
+}
+
+impl C2d2ResetPin {
+    pub fn open(inner: &Rc<Inner>) -> Result<Self> {
+        Ok(Self {
+            inner: Rc::clone(inner),
+        })
+    }
+}
+
+impl GpioPin for C2d2ResetPin {
+    /// Reads the value of the the reset pin.
+    fn read(&self) -> Result<bool> {
+        let mut result: Result<bool> =
+            Err(Error::CommunicationError("No output from gpioget").into());
+        self.inner
+            .execute_command("gpioget SPIVREF_RSVD_H1VREF_H1_RST_ODL", |line| {
+                result = Ok(line.trim_start().starts_with("1"))
+            })?;
+        result
+    }
+
+    /// Sets the value of the GPIO reset pin by means of the special h1_reset command.
+    fn write(&self, value: bool) -> Result<()> {
+        self.inner
+            .execute_command(&format!("h1_reset {}", if value { 0 } else { 1 }), |_| {})
+    }
+
+    /// Sets the mode of the GPIO pin as input, output, or open drain I/O.
+    fn set_mode(&self, _mode: PinMode) -> Result<()> {
+        bail!(Error::UnsupportedOperationError)
+    }
+
+    /// Sets the weak pull resistors of the GPIO pin.
+    fn set_pull_mode(&self, _mode: PullMode) -> Result<()> {
+        bail!(Error::UnsupportedOperationError)
+    }
+}

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use std::rc::Rc;
 
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
-use crate::transport::hyperdebug::{Error, Hyperdebug, Inner};
+use crate::transport::hyperdebug::{Error, Inner};
 
 pub struct HyperdebugGpioPin {
     inner: Rc<Inner>,
@@ -14,9 +14,9 @@ pub struct HyperdebugGpioPin {
 }
 
 impl HyperdebugGpioPin {
-    pub fn open(hyperdebug: &Hyperdebug, pinname: &str) -> Result<Self> {
+    pub fn open(inner: &Rc<Inner>, pinname: &str) -> Result<Self> {
         let result = Self {
-            inner: Rc::clone(&hyperdebug.inner),
+            inner: Rc::clone(inner),
             pinname: pinname.to_string(),
         };
         Ok(result)

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -7,8 +7,8 @@ use std::cmp;
 use std::rc::Rc;
 use zerocopy::{AsBytes, FromBytes};
 
-use crate::io::i2c::{I2cError, Bus, Transfer};
-use crate::transport::hyperdebug::{BulkInterface, Error, Hyperdebug, Inner};
+use crate::io::i2c::{Bus, I2cError, Transfer};
+use crate::transport::hyperdebug::{BulkInterface, Error, Inner};
 
 pub struct HyperdebugI2cBus {
     inner: Rc<Inner>,
@@ -65,15 +65,15 @@ impl RspTransfer {
 }
 
 impl HyperdebugI2cBus {
-    pub fn open(hyperdebug: &Hyperdebug, idx: u8) -> Result<Self> {
-        let mut usb_handle = hyperdebug.inner.usb_device.borrow_mut();
+    pub fn open(inner: &Rc<Inner>, i2c_interface: &BulkInterface, idx: u8) -> Result<Self> {
+        let mut usb_handle = inner.usb_device.borrow_mut();
 
         // Exclusively claim I2C interface, preparing for bulk transfers.
-        usb_handle.claim_interface(hyperdebug.i2c_interface.interface)?;
+        usb_handle.claim_interface(i2c_interface.interface)?;
 
         Ok(Self {
-            inner: Rc::clone(&hyperdebug.inner),
-            interface: hyperdebug.i2c_interface,
+            inner: Rc::clone(&inner),
+            interface: *i2c_interface,
             bus_idx: idx,
             max_read_size: 0x8000 as usize,
             max_write_size: 0x1000 as usize,

--- a/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/uart.rs
@@ -12,14 +12,13 @@ use std::time::Duration;
 
 use crate::io::uart::Uart;
 use crate::transport::hyperdebug::Error;
-use crate::transport::hyperdebug::Hyperdebug;
 
 pub struct HyperdebugUart {
     port: RefCell<Box<dyn serialport::SerialPort>>,
 }
 
 impl HyperdebugUart {
-    pub fn open(_hyperdebug: &Hyperdebug, tty: &Path) -> Result<Self> {
+    pub fn open(tty: &Path) -> Result<Self> {
         let port = serialport::new(tty.to_str().ok_or(Error::UnicodePathError)?, 115_200)
             .timeout(Duration::from_millis(100))
             .open()

--- a/sw/host/opentitantool/src/backend/hyperdebug.rs
+++ b/sw/host/opentitantool/src/backend/hyperdebug.rs
@@ -3,15 +3,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use opentitanlib::transport::hyperdebug::Hyperdebug;
+use opentitanlib::transport::hyperdebug::{Flavor, Hyperdebug};
 use opentitanlib::transport::Transport;
 
 use crate::backend::BackendOpts;
 
-pub fn create(args: &BackendOpts) -> Result<Box<dyn Transport>> {
-    Ok(Box::new(Hyperdebug::open(
+pub fn create<T: 'static + Flavor>(args: &BackendOpts) -> Result<Box<dyn Transport>> {
+    Ok(Box::new(Hyperdebug::<T>::open(
         args.usb_vid,
-        args.usb_vid,
+        args.usb_pid,
         args.usb_serial.as_deref(),
     )?))
 }

--- a/sw/host/opentitantool/src/backend/mod.rs
+++ b/sw/host/opentitantool/src/backend/mod.rs
@@ -9,6 +9,8 @@ use thiserror::Error;
 
 use opentitanlib::app::conf::ConfigurationFile;
 use opentitanlib::app::TransportWrapper;
+use opentitanlib::transport::hyperdebug::c2d2::C2d2Flavor;
+use opentitanlib::transport::hyperdebug::StandardFlavor;
 use opentitanlib::transport::{EmptyTransport, Transport};
 use opentitanlib::util::parse_int::ParseInt;
 
@@ -50,7 +52,8 @@ pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
         "" => create_empty_transport(),
         "verilator" => verilator::create(&args.verilator_opts),
         "ultradebug" => ultradebug::create(args),
-        "hyperdebug" => hyperdebug::create(args),
+        "hyperdebug" => hyperdebug::create::<StandardFlavor>(args),
+        "c2d2" => hyperdebug::create::<C2d2Flavor>(args),
         "cw310" => cw310::create(args),
         _ => Err(Error::UnknownInterface(args.interface.clone()).into()),
     }?);


### PR DESCRIPTION
The Google C2D2 uses almost the same USB protocol as HyperDebug, and
can be used for bootstrapping and getting access to the serial console
of Dauntless (and possibly future OpenTitan) chips sitting inside
chromebooks.

Change-Id: I2c215ef4fd01566c2e0588233890627832f921ca