### PR TITLE
[otbn,dv] Fix assertion in RND FSM checking

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_rnd_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_rnd_if.sv
@@ -149,7 +149,7 @@ interface otbn_rnd_if (
   `ASSERT_EDGE(IDLE,        READING,     rnd_req_i)
   `ASSERT_EDGE(IDLE,        PREFETCHING, rnd_prefetch_req_i)
   `ASSERT_EDGE(READING,     FULL,        edn_rnd_ack_i)
-  `ASSERT_EDGE(PREFETCHING, READING,     rnd_req_i)
+  `ASSERT_EDGE(PREFETCHING, READING,     rnd_req_i && !edn_rnd_ack_i)
   `ASSERT_EDGE(PREFETCHING, FULL,        edn_rnd_ack_i)
   `ASSERT_EDGE(FULL,        IDLE,        rnd_req_i)
 


### PR DESCRIPTION
If we are prefetching and a response comes in from the
EDN (`edn_rnd_ack_i`) at the same time as an instruction reads from
RND (`rnd_req_i`), we go to the "full" state, not the "reading" state.

The FSM I'd sketched out in the assertions was bogus: when both of
those signals are asserted at the same time, we can't go into both
READING and FULL states!
