### PR TITLE
[fpga] Optimize AES placement to speed up place and route on CW310

### DIFF
--- a/hw/top_earlgrey/data/placement.xdc
+++ b/hw/top_earlgrey/data/placement.xdc
@@ -2,13 +2,19 @@
 # See here (https://www.xilinx.com/support/answers/66386.html)
 # See also this link (https://github.com/lowRISC/opentitan/pull/8138#issuecomment-916696830)
 # for a thorough explanation of why such a custom placement helps.
-# Note the placement location was not chosen through any systematic means, but through trial
-# and error, it may become necessary in the future to tweak this if other congestion
-# issues arise.
+#
+# The placement location has been chosen by evaluating the resulting place and route times of
+# all possible options.
+#
+# The most suitable locations include: X0Y4, X0Y2, X1Y6, X1Y5
+# The following locations lead to excessive implementation times: X0Y0, X0Y6, X1Y1
+#
+# The evaluation has been performed using commit 85910ce3c2dfd94f860f4002b4be0cd0985aa058.
+# It may become necessary in the future to tweak this if other congestion issues arise.
 
-# Clock net "top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]" driven by instance "top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/gen_gate.gen_bufhce.u_bufhce" located at site "BUFHCE_X1Y0"
+# Clock net "top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]" driven by instance "top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/gen_gate.gen_bufhce.u_bufhce" located at site "BUFHCE_X0Y4"
 #startgroup
 create_pblock {CLKAG_top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]}
 add_cells_to_pblock [get_pblocks  {CLKAG_top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]}] [get_cells -filter { PRIMITIVE_GROUP != I/O && IS_PRIMITIVE==1 && PRIMITIVE_LEVEL !=INTERNAL } -of_object [get_pins -filter {DIRECTION==IN} -of_objects [get_nets -hierarchical -filter {PARENT=="top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]"}]]]
-resize_pblock [get_pblocks {CLKAG_top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]}] -add {CLOCKREGION_X1Y0:CLOCKREGION_X1Y0}
+resize_pblock [get_pblocks {CLKAG_top_earlgrey/u_clkmgr_aon/u_clk_main_aes_cg/gen_xilinx.u_impl_xilinx/clocks_o[clk_main_aes]}] -add {CLOCKREGION_X0Y4:CLOCKREGION_X0Y4}
 #endgroup


### PR DESCRIPTION
This placement constraint can have a notable impact on the time needed for place and route and thus overall FPGA implementation time. To identify the most suitable location, FPGA implementations with all possible locations have been performed based on commit 85910ce3c2dfd94f860f4002b4be0cd0985aa058. The now chosen location should improve place and route times by roughly 10-20%.