### PR TITLE
[otbn,dv] Make sure we're writing bad data in otbn_*mem_err_vseq

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -246,4 +246,43 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     dmem_util.write(BUS_AW'(phys_idx) * 32, scr_data);
   endfunction
 
+  // Strip off integrity bits from data
+  function logic [255:0] strip_integrity_wlen(logic [311:0] data);
+    logic [255:0] ret;
+    for (int i = 0; i < 8; ++i) begin
+      ret[32*i +: 32] = data[39*i +: 32];
+    end
+    return ret;
+  endfunction
+
+  // Add new known-good integrity bits to data
+  function logic [311:0] add_integrity_wlen(logic [255:0] data);
+    logic [311:0] ret;
+    for (int i = 0; i < 8; ++i) begin
+      logic [31:0] w32 = data[32*i +: 32];
+      ret[39*i +: 39] = prim_secded_pkg::prim_secded_inv_39_32_enc(w32);
+    end
+    return ret;
+  endfunction
+
+  // Fix integrity bits of data
+  function logic [311:0] fix_integrity_wlen(logic [311:0] data);
+    return add_integrity_wlen(strip_integrity_wlen(data));
+  endfunction
+
+  // Strip off integrity bits from IMEM
+  function logic [31:0] strip_integrity_32(logic [38:0] data);
+    return data[31:0];
+  endfunction
+
+  // Add new known-good integrity bits to data
+  function logic [38:0] add_integrity_32(logic [31:0] data);
+    return prim_secded_pkg::prim_secded_inv_39_32_enc(data);
+  endfunction
+
+  // Fix integrity bits of data
+  function logic [38:0] fix_integrity_32(logic [38:0] data);
+    return add_integrity_32(strip_integrity_32(data));
+  endfunction
+
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_dmem_err_vseq.sv
@@ -35,7 +35,8 @@ class otbn_dmem_err_vseq extends otbn_base_vseq;
     @(cfg.clk_rst_vif.cbn);
 
     for (int i = 0; i < 2 * otbn_reg_pkg::OTBN_DMEM_SIZE / 32; i++) begin
-      bit[311:0] good_data = cfg.read_dmem_word(i, key, nonce);
+      bit [311:0] old_data = cfg.read_dmem_word(i, key, nonce);
+      bit [311:0] good_data = cfg.fix_integrity_wlen(old_data);
       bit [311:0] bad_data = good_data ^ {8{mask}};
       cfg.write_dmem_word(i, bad_data, key, nonce);
     end

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -34,7 +34,8 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
 
     for (int i = 0; i < otbn_reg_pkg::OTBN_IMEM_SIZE / 4; i++) begin
-      bit [38:0] good_data = cfg.read_imem_word(i, key, nonce);
+      bit [38:0] old_data = cfg.read_imem_word(i, key, nonce);
+      bit [38:0] good_data = cfg.fix_integrity_32(old_data);
       bit [38:0] bad_data = good_data ^ mask;
       cfg.write_imem_word(i, bad_data, key, nonce);
     end


### PR DESCRIPTION
This sometimes caused a problem when chaining dmem/imem error sequences in
a stress sequence. It seems that we were managing to undo a previous
corruption, leaving some words correct again. Oops!
