### PR TITLE
[aes] De-assert idle after a new key becomes ready, flop idle_o

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -654,6 +654,7 @@
       { bits: "0",
         name: "IDLE",
         resval: "0",
+        hwaccess: "hrw",
         desc:  '''
           The AES unit is idle (1) or busy (0).
           This flag is `0` if one of the following operations is currently running: i) encryption/decryption, ii) register clearing or iii) PRNG reseeding.

--- a/hw/ip/aes/lint/aes.vlt
+++ b/hw/ip/aes/lint/aes.vlt
@@ -40,3 +40,7 @@ split_var -module "aes_masked_inverse_gf2p4*" -var "b0_inv_buf"
 lint_off -rule UNOPTFLAT -file "*/rtl/aes_control_fsm_*.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*u_aes_control_fsm_i.out'"
 lint_off -rule UNOPTFLAT -file "*/rtl/aes_cipher_control_fsm_*.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*u_aes_cipher_control_fsm_i.out'"
 lint_off -rule UNOPTFLAT -file "*/rtl/aes_ctr_fsm_*.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*u_aes_ctr_fsm_i.in'"
+
+// key_init_new_pulse feeds into prng_resee_we_o but there is still no circular dependency.
+lint_off -rule UNOPTFLAT -file "*/rtl/aes_control_fsm_*.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*u_aes_control_fsm_i.prng_reseed_we'"
+lint_off -rule UNOPTFLAT -file "*/rtl/aes_reg_status.sv" -match "Signal unoptimizable: Feedback to clock or circular logic: '*u_aes_control_fsm_i.u_aes_control_fsm.u_reg_status_key_init.new_d'"

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -182,7 +182,7 @@ module aes
     .hw2reg                 ( hw2reg               )
   );
 
-  assign idle_o = hw2reg.status.idle.d;
+  assign idle_o = reg2hw.status.idle.q;
 
   ////////////
   // Alerts //

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -19,6 +19,7 @@ module aes_control
   // Main control signals
   input  logic                      ctrl_qe_i,
   output logic                      ctrl_we_o,
+  input  logic                      ctrl_phase_i,
   input  logic                      ctrl_err_storage_i,
   input  aes_op_e                   op_i,
   input  aes_mode_e                 mode_i,
@@ -250,6 +251,7 @@ module aes_control
 
         .ctrl_qe_i                 ( ctrl_qe_i                     ),
         .ctrl_we_o                 ( mr_ctrl_we[i]                 ), // AND-combine
+        .ctrl_phase_i              ( ctrl_phase_i                  ),
         .ctrl_err_storage_i        ( ctrl_err_storage_i            ),
         .op_i                      ( op_i                          ),
         .mode_i                    ( mode_i                        ),
@@ -340,6 +342,7 @@ module aes_control
 
         .ctrl_qe_i                 ( ctrl_qe_i                     ),
         .ctrl_we_o                 ( mr_ctrl_we[i]                 ), // AND-combine
+        .ctrl_phase_i              ( ctrl_phase_i                  ),
         .ctrl_err_storage_i        ( ctrl_err_storage_i            ),
         .op_i                      ( op_i                          ),
         .mode_i                    ( mode_i                        ),

--- a/hw/ip/aes/rtl/aes_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm.sv
@@ -21,6 +21,7 @@ module aes_control_fsm
   // Main control signals
   input  logic                                    ctrl_qe_i,
   output logic                                    ctrl_we_o,
+  input  logic                                    ctrl_phase_i,
   input  logic                                    ctrl_err_storage_i,
   input  aes_op_e                                 op_i,
   input  aes_mode_e                               mode_i,
@@ -671,14 +672,14 @@ module aes_control_fsm
   /////////////////////
 
   // We only take a new sideload key if sideload is enabled, if the provided sideload key is marked
-  // as valid, and after the control register has been written. After that point we don't update
-  // the key anymore, as we don't have a notion of when it actually changes. This would be required
-  // to trigger decryption key generation for ECB/CBC decryption.
+  // as valid, and after the control register has been written for the second time. After that
+  // point we don't update the key anymore, as we don't have a notion of when it actually changes.
+  // This would be required to trigger decryption key generation for ECB/CBC decryption.
   // To update the sideload key, software has to:
   // 1) wait unitl AES is idle,
   // 2) wait for the key manager to provide the new key,
   // 3) start a new message by writing the control register and providing the IV (if needed).
-  assign key_sideload = sideload_i & key_sideload_valid_i & ctrl_we_q;
+  assign key_sideload = sideload_i & key_sideload_valid_i & ctrl_we_q & ~ctrl_phase_i;
 
   // We only use clean initial keys. Either software/counter has updated
   // - all initial key registers, or

--- a/hw/ip/aes/rtl/aes_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_n.sv
@@ -26,6 +26,7 @@ module aes_control_fsm_n
   // Main control signals
   input  logic                                    ctrl_qe_i,
   output logic                                    ctrl_we_o,
+  input  logic                                    ctrl_phase_i,
   input  logic                                    ctrl_err_storage_i,
   input  aes_op_e                                 op_i,
   input  aes_mode_e                               mode_i,
@@ -124,6 +125,7 @@ module aes_control_fsm_n
 
   localparam int NumInBufBits = $bits({
     ctrl_qe_i,
+    ctrl_phase_i,
     ctrl_err_storage_i,
     op_i,
     mode_i,
@@ -163,6 +165,7 @@ module aes_control_fsm_n
 
   assign in = {
     ctrl_qe_i,
+    ctrl_phase_i,
     ctrl_err_storage_i,
     op_i,
     mode_i,
@@ -208,6 +211,7 @@ module aes_control_fsm_n
   );
 
   logic                                    ctrl_qe;
+  logic                                    ctrl_phase;
   logic                                    ctrl_err_storage;
   aes_op_e                                 op;
   aes_mode_e                               mode;
@@ -244,6 +248,7 @@ module aes_control_fsm_n
   logic                                    output_lost_in_buf;
 
   assign {ctrl_qe,
+          ctrl_phase,
           ctrl_err_storage,
           op,
           mode,
@@ -336,6 +341,7 @@ module aes_control_fsm_n
 
     .ctrl_qe_i                 ( ctrl_qe                       ),
     .ctrl_we_o                 ( ctrl_we                       ),
+    .ctrl_phase_i              ( ctrl_phase                    ),
     .ctrl_err_storage_i        ( ctrl_err_storage              ),
     .op_i                      ( op                            ),
     .mode_i                    ( mode                          ),

--- a/hw/ip/aes/rtl/aes_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_p.sv
@@ -22,6 +22,7 @@ module aes_control_fsm_p
   // Main control signals
   input  logic                                    ctrl_qe_i,
   output logic                                    ctrl_we_o,
+  input  logic                                    ctrl_phase_i,
   input  logic                                    ctrl_err_storage_i,
   input  aes_op_e                                 op_i,
   input  aes_mode_e                               mode_i,
@@ -120,6 +121,7 @@ module aes_control_fsm_p
 
   localparam int NumInBufBits = $bits({
     ctrl_qe_i,
+    ctrl_phase_i,
     ctrl_err_storage_i,
     op_i,
     mode_i,
@@ -159,6 +161,7 @@ module aes_control_fsm_p
 
   assign in = {
     ctrl_qe_i,
+    ctrl_phase_i,
     ctrl_err_storage_i,
     op_i,
     mode_i,
@@ -204,6 +207,7 @@ module aes_control_fsm_p
   );
 
   logic                                    ctrl_qe;
+  logic                                    ctrl_phase;
   logic                                    ctrl_err_storage;
   aes_op_e                                 op;
   aes_mode_e                               mode;
@@ -240,6 +244,7 @@ module aes_control_fsm_p
   logic                                    output_lost_in_buf;
 
   assign {ctrl_qe,
+          ctrl_phase,
           ctrl_err_storage,
           op,
           mode,
@@ -328,6 +333,7 @@ module aes_control_fsm_p
 
     .ctrl_qe_i                 ( ctrl_qe                       ),
     .ctrl_we_o                 ( ctrl_we                       ),
+    .ctrl_phase_i              ( ctrl_phase                    ),
     .ctrl_err_storage_i        ( ctrl_err_storage              ),
     .op_i                      ( op                            ),
     .mode_i                    ( mode                          ),

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -57,6 +57,7 @@ module aes_core
   // Signals
   logic                                       ctrl_qe;
   logic                                       ctrl_we;
+  logic                                       ctrl_phase;
   aes_op_e                                    aes_op_q;
   aes_mode_e                                  aes_mode_q;
   ciph_op_e                                   cipher_op;
@@ -503,6 +504,7 @@ module aes_core
     .rst_shadowed_ni    ( rst_shadowed_ni      ),
     .qe_o               ( ctrl_qe              ),
     .we_i               ( ctrl_we              ),
+    .phase_o            ( ctrl_phase           ),
     .operation_o        ( aes_op_q             ),
     .mode_o             ( aes_mode_q           ),
     .key_len_o          ( key_len_q            ),
@@ -530,6 +532,7 @@ module aes_core
 
     .ctrl_qe_i                 ( ctrl_qe                                ),
     .ctrl_we_o                 ( ctrl_we                                ),
+    .ctrl_phase_i              ( ctrl_phase                             ),
     .ctrl_err_storage_i        ( ctrl_err_storage                       ),
     .op_i                      ( aes_op_q                               ),
     .mode_i                    ( aes_mode_q                             ),

--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -26,6 +26,7 @@ module aes_ctrl_reg_shadowed
   // Main control
   output logic      qe_o, // software wants to write
   input  logic      we_i, // hardware grants software write
+  output logic      phase_o,
   output aes_op_e   operation_o,
   output aes_mode_e mode_o,
   output key_len_e  key_len_o,
@@ -49,6 +50,13 @@ module aes_ctrl_reg_shadowed
   aes_mode_e mode;
   key_len_e  key_len;
   prs_rate_e prng_reseed_rate;
+  logic      phase_operation;
+  logic      phase_mode;
+  logic      phase_key_len;
+  logic      phase_key_sideload;
+  logic      phase_prng_reseed_rate;
+  logic      phase_manual_operation;
+  logic      phase_force_zero_masks;
   logic      err_update_operation;
   logic      err_update_mode;
   logic      err_update_key_len;
@@ -142,7 +150,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.operation.d),
     .qs         (),
-    .phase      (),
+    .phase      (phase_operation),
     .err_update (err_update_operation),
     .err_storage(err_storage_operation)
   );
@@ -163,7 +171,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.mode.d),
     .qs         (),
-    .phase      (),
+    .phase      (phase_mode),
     .err_update (err_update_mode),
     .err_storage(err_storage_mode)
   );
@@ -184,7 +192,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.key_len.d),
     .qs         (),
-    .phase      (),
+    .phase      (phase_key_len),
     .err_update (err_update_key_len),
     .err_storage(err_storage_key_len)
   );
@@ -205,7 +213,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.sideload.d),
     .qs         (),
-    .phase      (),
+    .phase      (phase_key_sideload),
     .err_update (err_update_sideload),
     .err_storage(err_storage_sideload)
   );
@@ -226,7 +234,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.prng_reseed_rate.d),
     .qs         (),
-    .phase      (),
+    .phase      (phase_prng_reseed_rate),
     .err_update (err_update_prng_reseed_rate),
     .err_storage(err_storage_prng_reseed_rate)
   );
@@ -247,7 +255,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.manual_operation.d),
     .qs         (),
-    .phase      (),
+    .phase      (phase_manual_operation),
     .err_update (err_update_manual_operation),
     .err_storage(err_storage_manual_operation)
   );
@@ -268,10 +276,14 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.force_zero_masks.d),
     .qs         (),
-    .phase      (),
+    .phase      (phase_force_zero_masks),
     .err_update (err_update_force_zero_masks),
     .err_storage(err_storage_force_zero_masks)
   );
+
+  // Collect phase signals.
+  assign phase_o = phase_operation | phase_mode | phase_key_len | phase_key_sideload |
+      phase_prng_reseed_rate | phase_manual_operation | phase_force_zero_masks;
 
   // Collect alerts.
   assign err_update_o = err_update_operation | err_update_mode | err_update_key_len |

--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -142,6 +142,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.operation.d),
     .qs         (),
+    .phase      (),
     .err_update (err_update_operation),
     .err_storage(err_storage_operation)
   );
@@ -162,6 +163,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.mode.d),
     .qs         (),
+    .phase      (),
     .err_update (err_update_mode),
     .err_storage(err_storage_mode)
   );
@@ -182,6 +184,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.key_len.d),
     .qs         (),
+    .phase      (),
     .err_update (err_update_key_len),
     .err_storage(err_storage_key_len)
   );
@@ -202,6 +205,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.sideload.d),
     .qs         (),
+    .phase      (),
     .err_update (err_update_sideload),
     .err_storage(err_storage_sideload)
   );
@@ -222,6 +226,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.prng_reseed_rate.d),
     .qs         (),
+    .phase      (),
     .err_update (err_update_prng_reseed_rate),
     .err_storage(err_storage_prng_reseed_rate)
   );
@@ -242,6 +247,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.manual_operation.d),
     .qs         (),
+    .phase      (),
     .err_update (err_update_manual_operation),
     .err_storage(err_storage_manual_operation)
   );
@@ -262,6 +268,7 @@ module aes_ctrl_reg_shadowed
     .qe         (),
     .q          (hw2reg_ctrl_o.force_zero_masks.d),
     .qs         (),
+    .phase      (),
     .err_update (err_update_force_zero_masks),
     .err_storage(err_storage_force_zero_masks)
   );

--- a/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
+++ b/hw/ip/aes/rtl/aes_ctrl_reg_shadowed.sv
@@ -75,7 +75,7 @@ module aes_ctrl_reg_shadowed
 
   // Get and resolve values from register interface.
   assign op = aes_op_e'(reg2hw_ctrl_i.operation.q);
-  always_comb begin : op_get
+  always_comb begin : operation_get
     unique case (op)
       AES_ENC: ctrl_wd.operation = AES_ENC;
       AES_DEC: ctrl_wd.operation = AES_DEC;

--- a/hw/ip/aes/rtl/aes_reg_pkg.sv
+++ b/hw/ip/aes/rtl/aes_reg_pkg.sv
@@ -117,6 +117,9 @@ package aes_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+    } idle;
+    struct packed {
+      logic        q;
     } output_lost;
   } aes_reg2hw_status_reg_t;
 
@@ -217,16 +220,16 @@ package aes_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    aes_reg2hw_alert_test_reg_t alert_test; // [957:954]
-    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [953:690]
-    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [689:426]
-    aes_reg2hw_iv_mreg_t [3:0] iv; // [425:294]
-    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [293:162]
-    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [161:30]
-    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [29:6]
-    aes_reg2hw_ctrl_aux_shadowed_reg_t ctrl_aux_shadowed; // [5:5]
-    aes_reg2hw_trigger_reg_t trigger; // [4:1]
-    aes_reg2hw_status_reg_t status; // [0:0]
+    aes_reg2hw_alert_test_reg_t alert_test; // [958:955]
+    aes_reg2hw_key_share0_mreg_t [7:0] key_share0; // [954:691]
+    aes_reg2hw_key_share1_mreg_t [7:0] key_share1; // [690:427]
+    aes_reg2hw_iv_mreg_t [3:0] iv; // [426:295]
+    aes_reg2hw_data_in_mreg_t [3:0] data_in; // [294:163]
+    aes_reg2hw_data_out_mreg_t [3:0] data_out; // [162:31]
+    aes_reg2hw_ctrl_shadowed_reg_t ctrl_shadowed; // [30:7]
+    aes_reg2hw_ctrl_aux_shadowed_reg_t ctrl_aux_shadowed; // [6:6]
+    aes_reg2hw_trigger_reg_t trigger; // [5:2]
+    aes_reg2hw_status_reg_t status; // [1:0]
   } aes_reg2hw_t;
 
   // HW -> register type

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -853,6 +853,9 @@ module aes_reg_top (
     // to register interface (read)
     .qs     (ctrl_aux_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.ctrl_aux_shadowed.err_update),
     .err_storage (reg2hw.ctrl_aux_shadowed.err_storage)

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -1007,7 +1007,7 @@ module aes_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (),
+    .q      (reg2hw.status.idle.q),
 
     // to register interface (read)
     .qs     (status_idle_qs)

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -2042,6 +2042,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].en.err_storage)
@@ -2072,6 +2075,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].rd_en.err_update),
@@ -2104,6 +2110,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_storage)
@@ -2134,6 +2143,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].erase_en.err_update),
@@ -2166,6 +2178,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_storage)
@@ -2196,6 +2211,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].ecc_en.err_update),
@@ -2228,6 +2246,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_he_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].he_en.err_storage)
@@ -2259,6 +2280,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_base_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].base.err_storage)
@@ -2289,6 +2313,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_size_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].size.err_update),
@@ -2324,6 +2351,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].en.err_storage)
@@ -2354,6 +2384,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].rd_en.err_update),
@@ -2386,6 +2419,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_storage)
@@ -2416,6 +2452,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].erase_en.err_update),
@@ -2448,6 +2487,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_storage)
@@ -2478,6 +2520,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].ecc_en.err_update),
@@ -2510,6 +2555,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_he_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].he_en.err_storage)
@@ -2541,6 +2589,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_base_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].base.err_storage)
@@ -2571,6 +2622,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_size_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].size.err_update),
@@ -2606,6 +2660,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].en.err_storage)
@@ -2636,6 +2693,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].rd_en.err_update),
@@ -2668,6 +2728,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_prog_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_storage)
@@ -2698,6 +2761,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].erase_en.err_update),
@@ -2730,6 +2796,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_scramble_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_storage)
@@ -2760,6 +2829,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].ecc_en.err_update),
@@ -2792,6 +2864,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_he_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].he_en.err_storage)
@@ -2823,6 +2898,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_base_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].base.err_storage)
@@ -2853,6 +2931,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_size_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].size.err_update),
@@ -2888,6 +2969,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].en.err_storage)
@@ -2918,6 +3002,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].rd_en.err_update),
@@ -2950,6 +3037,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_prog_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_storage)
@@ -2980,6 +3070,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].erase_en.err_update),
@@ -3012,6 +3105,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_scramble_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_storage)
@@ -3042,6 +3138,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].ecc_en.err_update),
@@ -3074,6 +3173,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_he_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].he_en.err_storage)
@@ -3105,6 +3207,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_base_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].base.err_storage)
@@ -3135,6 +3240,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_size_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].size.err_update),
@@ -3170,6 +3278,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].en.err_storage)
@@ -3200,6 +3311,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].rd_en.err_update),
@@ -3232,6 +3346,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_prog_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_storage)
@@ -3262,6 +3379,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].erase_en.err_update),
@@ -3294,6 +3414,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_scramble_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_storage)
@@ -3324,6 +3447,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].ecc_en.err_update),
@@ -3356,6 +3482,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_he_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].he_en.err_storage)
@@ -3387,6 +3516,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_base_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].base.err_storage)
@@ -3417,6 +3549,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_size_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].size.err_update),
@@ -3452,6 +3587,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].en.err_storage)
@@ -3482,6 +3620,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].rd_en.err_update),
@@ -3514,6 +3655,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_prog_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_storage)
@@ -3544,6 +3688,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].erase_en.err_update),
@@ -3576,6 +3723,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_scramble_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_storage)
@@ -3606,6 +3756,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].ecc_en.err_update),
@@ -3638,6 +3791,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_he_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].he_en.err_storage)
@@ -3669,6 +3825,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_base_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].base.err_storage)
@@ -3699,6 +3858,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_size_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].size.err_update),
@@ -3734,6 +3896,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].en.err_storage)
@@ -3764,6 +3929,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].rd_en.err_update),
@@ -3796,6 +3964,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_prog_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_storage)
@@ -3826,6 +3997,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].erase_en.err_update),
@@ -3858,6 +4032,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_scramble_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_storage)
@@ -3888,6 +4065,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].ecc_en.err_update),
@@ -3920,6 +4100,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_he_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].he_en.err_storage)
@@ -3951,6 +4134,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_base_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].base.err_storage)
@@ -3981,6 +4167,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_size_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].size.err_update),
@@ -4016,6 +4205,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].en.err_storage)
@@ -4046,6 +4238,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].rd_en.err_update),
@@ -4078,6 +4273,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_prog_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_storage)
@@ -4108,6 +4306,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].erase_en.err_update),
@@ -4140,6 +4341,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_scramble_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_storage)
@@ -4170,6 +4374,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].ecc_en.err_update),
@@ -4202,6 +4409,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_he_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].he_en.err_storage)
@@ -4233,6 +4443,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_base_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].base.err_storage)
@@ -4263,6 +4476,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_size_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].size.err_update),
@@ -4297,6 +4513,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_shadowed_rd_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.rd_en.err_update),
     .err_storage (reg2hw.default_region_shadowed.rd_en.err_storage)
@@ -4327,6 +4546,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (default_region_shadowed_prog_en_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.prog_en.err_update),
@@ -4359,6 +4581,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_shadowed_erase_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.erase_en.err_update),
     .err_storage (reg2hw.default_region_shadowed.erase_en.err_storage)
@@ -4389,6 +4614,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (default_region_shadowed_scramble_en_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.scramble_en.err_update),
@@ -4421,6 +4649,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_shadowed_ecc_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.ecc_en.err_update),
     .err_storage (reg2hw.default_region_shadowed.ecc_en.err_storage)
@@ -4451,6 +4682,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (default_region_shadowed_he_en_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.he_en.err_update),
@@ -4756,6 +4990,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_storage)
@@ -4786,6 +5023,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.err_update),
@@ -4818,6 +5058,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_storage)
@@ -4848,6 +5091,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.err_update),
@@ -4880,6 +5126,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -4911,6 +5160,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -4941,6 +5193,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.err_update),
@@ -4976,6 +5231,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_storage)
@@ -5006,6 +5264,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.err_update),
@@ -5038,6 +5299,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_storage)
@@ -5068,6 +5332,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.err_update),
@@ -5100,6 +5367,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -5131,6 +5401,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -5161,6 +5434,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.err_update),
@@ -5196,6 +5472,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_storage)
@@ -5226,6 +5505,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.err_update),
@@ -5258,6 +5540,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_prog_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_storage)
@@ -5288,6 +5573,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.err_update),
@@ -5320,6 +5608,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_storage)
@@ -5351,6 +5642,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_storage)
@@ -5381,6 +5675,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.err_update),
@@ -5416,6 +5713,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_storage)
@@ -5446,6 +5746,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.err_update),
@@ -5478,6 +5781,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_prog_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_storage)
@@ -5508,6 +5814,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.err_update),
@@ -5540,6 +5849,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_storage)
@@ -5571,6 +5883,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_storage)
@@ -5601,6 +5916,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.err_update),
@@ -5636,6 +5954,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_storage)
@@ -5666,6 +5987,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.err_update),
@@ -5698,6 +6022,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_prog_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_storage)
@@ -5728,6 +6055,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.err_update),
@@ -5760,6 +6090,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_storage)
@@ -5791,6 +6124,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_storage)
@@ -5821,6 +6157,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.err_update),
@@ -5856,6 +6195,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_storage)
@@ -5886,6 +6228,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.err_update),
@@ -5918,6 +6263,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_prog_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_storage)
@@ -5948,6 +6296,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.err_update),
@@ -5980,6 +6331,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_storage)
@@ -6011,6 +6365,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_storage)
@@ -6041,6 +6398,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.err_update),
@@ -6076,6 +6436,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_storage)
@@ -6106,6 +6469,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.err_update),
@@ -6138,6 +6504,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_prog_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_storage)
@@ -6168,6 +6537,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.err_update),
@@ -6200,6 +6572,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_storage)
@@ -6231,6 +6606,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_storage)
@@ -6261,6 +6639,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.err_update),
@@ -6296,6 +6677,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_storage)
@@ -6326,6 +6710,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.err_update),
@@ -6358,6 +6745,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_prog_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_storage)
@@ -6388,6 +6778,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.err_update),
@@ -6420,6 +6813,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_storage)
@@ -6451,6 +6847,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_storage)
@@ -6481,6 +6880,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.err_update),
@@ -6516,6 +6918,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_storage)
@@ -6546,6 +6951,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.err_update),
@@ -6578,6 +6986,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_prog_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_storage)
@@ -6608,6 +7019,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.err_update),
@@ -6640,6 +7054,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_storage)
@@ -6671,6 +7088,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_storage)
@@ -6701,6 +7121,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.err_update),
@@ -6736,6 +7159,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_storage)
@@ -6766,6 +7192,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.err_update),
@@ -6798,6 +7227,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_prog_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_storage)
@@ -6828,6 +7260,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.err_update),
@@ -6860,6 +7295,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_storage)
@@ -6891,6 +7329,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_storage)
@@ -6921,6 +7362,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.err_update),
@@ -6983,6 +7427,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_storage)
@@ -7013,6 +7460,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.err_update),
@@ -7045,6 +7495,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_storage)
@@ -7075,6 +7528,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.err_update),
@@ -7107,6 +7563,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -7138,6 +7597,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -7168,6 +7630,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.err_update),
@@ -7257,6 +7722,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_storage)
@@ -7287,6 +7755,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.err_update),
@@ -7319,6 +7790,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_storage)
@@ -7349,6 +7823,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.err_update),
@@ -7381,6 +7858,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -7412,6 +7892,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -7442,6 +7925,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.err_update),
@@ -7477,6 +7963,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_storage)
@@ -7507,6 +7996,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.err_update),
@@ -7539,6 +8031,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_storage)
@@ -7569,6 +8064,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.err_update),
@@ -7601,6 +8099,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -7632,6 +8133,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -7662,6 +8166,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.err_update),
@@ -7967,6 +8474,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_storage)
@@ -7997,6 +8507,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.err_update),
@@ -8029,6 +8542,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_storage)
@@ -8059,6 +8575,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.err_update),
@@ -8091,6 +8610,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -8122,6 +8644,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -8152,6 +8677,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.err_update),
@@ -8187,6 +8715,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_storage)
@@ -8217,6 +8748,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.err_update),
@@ -8249,6 +8783,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_storage)
@@ -8279,6 +8816,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.err_update),
@@ -8311,6 +8851,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -8342,6 +8885,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -8372,6 +8918,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.err_update),
@@ -8407,6 +8956,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_storage)
@@ -8437,6 +8989,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.err_update),
@@ -8469,6 +9024,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_prog_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_storage)
@@ -8499,6 +9057,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.err_update),
@@ -8531,6 +9092,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_storage)
@@ -8562,6 +9126,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_storage)
@@ -8592,6 +9159,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.err_update),
@@ -8627,6 +9197,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_storage)
@@ -8657,6 +9230,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.err_update),
@@ -8689,6 +9265,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_prog_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_storage)
@@ -8719,6 +9298,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.err_update),
@@ -8751,6 +9333,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_storage)
@@ -8782,6 +9367,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_storage)
@@ -8812,6 +9400,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.err_update),
@@ -8847,6 +9438,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_storage)
@@ -8877,6 +9471,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.err_update),
@@ -8909,6 +9506,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_prog_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_storage)
@@ -8939,6 +9539,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.err_update),
@@ -8971,6 +9574,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_storage)
@@ -9002,6 +9608,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_storage)
@@ -9032,6 +9641,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.err_update),
@@ -9067,6 +9679,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_storage)
@@ -9097,6 +9712,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.err_update),
@@ -9129,6 +9747,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_prog_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_storage)
@@ -9159,6 +9780,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.err_update),
@@ -9191,6 +9815,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_storage)
@@ -9222,6 +9849,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_storage)
@@ -9252,6 +9882,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.err_update),
@@ -9287,6 +9920,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_storage)
@@ -9317,6 +9953,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.err_update),
@@ -9349,6 +9988,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_prog_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_storage)
@@ -9379,6 +10021,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.err_update),
@@ -9411,6 +10056,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_storage)
@@ -9442,6 +10090,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_storage)
@@ -9472,6 +10123,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.err_update),
@@ -9507,6 +10161,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_storage)
@@ -9537,6 +10194,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.err_update),
@@ -9569,6 +10229,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_prog_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_storage)
@@ -9599,6 +10262,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.err_update),
@@ -9631,6 +10297,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_storage)
@@ -9662,6 +10331,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_storage)
@@ -9692,6 +10364,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.err_update),
@@ -9727,6 +10402,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_storage)
@@ -9757,6 +10435,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.err_update),
@@ -9789,6 +10470,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_prog_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_storage)
@@ -9819,6 +10503,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.err_update),
@@ -9851,6 +10538,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_storage)
@@ -9882,6 +10572,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_storage)
@@ -9912,6 +10605,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.err_update),
@@ -9947,6 +10643,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_storage)
@@ -9977,6 +10676,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.err_update),
@@ -10009,6 +10711,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_prog_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_storage)
@@ -10039,6 +10744,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.err_update),
@@ -10071,6 +10779,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_storage)
@@ -10102,6 +10813,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_storage)
@@ -10132,6 +10846,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.err_update),
@@ -10194,6 +10911,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_storage)
@@ -10224,6 +10944,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.err_update),
@@ -10256,6 +10979,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_storage)
@@ -10286,6 +11012,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.err_update),
@@ -10318,6 +11047,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -10349,6 +11081,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -10379,6 +11114,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.err_update),
@@ -10468,6 +11206,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_storage)
@@ -10498,6 +11239,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.err_update),
@@ -10530,6 +11274,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_storage)
@@ -10560,6 +11307,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.err_update),
@@ -10592,6 +11342,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -10623,6 +11376,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -10653,6 +11409,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.err_update),
@@ -10688,6 +11447,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_storage)
@@ -10718,6 +11480,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.err_update),
@@ -10750,6 +11515,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_storage)
@@ -10780,6 +11548,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.err_update),
@@ -10812,6 +11583,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -10843,6 +11617,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -10873,6 +11650,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.err_update),
@@ -10934,6 +11714,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_bank_cfg_shadowed[0].err_update),
     .err_storage (reg2hw.mp_bank_cfg_shadowed[0].err_storage)
@@ -10964,6 +11747,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_bank_cfg_shadowed[1].err_update),

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -479,6 +479,9 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (control_shadowed_operation_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.control_shadowed.operation.err_update),
     .err_storage (reg2hw.control_shadowed.operation.err_storage)
@@ -510,6 +513,9 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (control_shadowed_cdi_sel_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.control_shadowed.cdi_sel.err_update),
     .err_storage (reg2hw.control_shadowed.cdi_sel.err_storage)
@@ -540,6 +546,9 @@ module keymgr_reg_top (
 
     // to register interface (read)
     .qs     (control_shadowed_dest_sel_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.control_shadowed.dest_sel.err_update),
@@ -624,6 +633,9 @@ module keymgr_reg_top (
 
     // to register interface (read)
     .qs     (reseed_interval_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.reseed_interval_shadowed.err_update),
@@ -1373,6 +1385,9 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (max_creator_key_ver_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.max_creator_key_ver_shadowed.err_update),
     .err_storage (reg2hw.max_creator_key_ver_shadowed.err_storage)
@@ -1431,6 +1446,9 @@ module keymgr_reg_top (
     // to register interface (read)
     .qs     (max_owner_int_key_ver_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.max_owner_int_key_ver_shadowed.err_update),
     .err_storage (reg2hw.max_owner_int_key_ver_shadowed.err_storage)
@@ -1488,6 +1506,9 @@ module keymgr_reg_top (
 
     // to register interface (read)
     .qs     (max_owner_key_ver_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.max_owner_key_ver_shadowed.err_update),

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -613,6 +613,9 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_shadowed_kmac_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.kmac_en.err_update),
     .err_storage (reg2hw.cfg_shadowed.kmac_en.err_storage)
@@ -643,6 +646,9 @@ module kmac_reg_top (
 
     // to register interface (read)
     .qs     (cfg_shadowed_kstrength_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.kstrength.err_update),
@@ -675,6 +681,9 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_shadowed_mode_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.mode.err_update),
     .err_storage (reg2hw.cfg_shadowed.mode.err_storage)
@@ -705,6 +714,9 @@ module kmac_reg_top (
 
     // to register interface (read)
     .qs     (cfg_shadowed_msg_endianness_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.msg_endianness.err_update),
@@ -737,6 +749,9 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_shadowed_state_endianness_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.state_endianness.err_update),
     .err_storage (reg2hw.cfg_shadowed.state_endianness.err_storage)
@@ -767,6 +782,9 @@ module kmac_reg_top (
 
     // to register interface (read)
     .qs     (cfg_shadowed_sideload_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.sideload.err_update),
@@ -799,6 +817,9 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_shadowed_entropy_mode_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.entropy_mode.err_update),
     .err_storage (reg2hw.cfg_shadowed.entropy_mode.err_storage)
@@ -829,6 +850,9 @@ module kmac_reg_top (
 
     // to register interface (read)
     .qs     (cfg_shadowed_entropy_fast_process_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.entropy_fast_process.err_update),
@@ -861,6 +885,9 @@ module kmac_reg_top (
     // to register interface (read)
     .qs     (cfg_shadowed_entropy_ready_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.entropy_ready.err_update),
     .err_storage (reg2hw.cfg_shadowed.entropy_ready.err_storage)
@@ -891,6 +918,9 @@ module kmac_reg_top (
 
     // to register interface (read)
     .qs     (cfg_shadowed_err_processed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.err_processed.err_update),

--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -33,6 +33,9 @@ module prim_subreg_shadow
   output logic [DW-1:0] q,
   output logic [DW-1:0] qs,
 
+  // Phase output to HW
+  output logic phase,
+
   // Error conditions
   output logic err_update,
   output logic err_storage
@@ -167,6 +170,9 @@ module prim_subreg_shadow
     .q        ( committed_q  ),
     .qs       ( committed_qs )
   );
+
+  // Output phase for hwext.
+  assign phase = phase_q;
 
   // Error detection - all bits must match.
   assign err_update  = (~staged_q != wr_data) ? phase_q & wr_en : 1'b0;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -2042,6 +2042,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].en.err_storage)
@@ -2072,6 +2075,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].rd_en.err_update),
@@ -2104,6 +2110,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].prog_en.err_storage)
@@ -2134,6 +2143,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].erase_en.err_update),
@@ -2166,6 +2178,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].scramble_en.err_storage)
@@ -2196,6 +2211,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_ecc_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].ecc_en.err_update),
@@ -2228,6 +2246,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_he_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].he_en.err_storage)
@@ -2259,6 +2280,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_base_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[0].base.err_storage)
@@ -2289,6 +2313,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_0_size_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[0].size.err_update),
@@ -2324,6 +2351,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].en.err_storage)
@@ -2354,6 +2384,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].rd_en.err_update),
@@ -2386,6 +2419,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].prog_en.err_storage)
@@ -2416,6 +2452,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].erase_en.err_update),
@@ -2448,6 +2487,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].scramble_en.err_storage)
@@ -2478,6 +2520,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_ecc_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].ecc_en.err_update),
@@ -2510,6 +2555,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_he_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].he_en.err_storage)
@@ -2541,6 +2589,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_base_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[1].base.err_storage)
@@ -2571,6 +2622,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_1_size_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[1].size.err_update),
@@ -2606,6 +2660,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].en.err_storage)
@@ -2636,6 +2693,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].rd_en.err_update),
@@ -2668,6 +2728,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_prog_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].prog_en.err_storage)
@@ -2698,6 +2761,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].erase_en.err_update),
@@ -2730,6 +2796,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_scramble_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].scramble_en.err_storage)
@@ -2760,6 +2829,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_ecc_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].ecc_en.err_update),
@@ -2792,6 +2864,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_he_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].he_en.err_storage)
@@ -2823,6 +2898,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_base_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[2].base.err_storage)
@@ -2853,6 +2931,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_2_size_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[2].size.err_update),
@@ -2888,6 +2969,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].en.err_storage)
@@ -2918,6 +3002,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].rd_en.err_update),
@@ -2950,6 +3037,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_prog_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].prog_en.err_storage)
@@ -2980,6 +3070,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].erase_en.err_update),
@@ -3012,6 +3105,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_scramble_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].scramble_en.err_storage)
@@ -3042,6 +3138,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_ecc_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].ecc_en.err_update),
@@ -3074,6 +3173,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_he_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].he_en.err_storage)
@@ -3105,6 +3207,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_base_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[3].base.err_storage)
@@ -3135,6 +3240,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_3_size_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[3].size.err_update),
@@ -3170,6 +3278,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].en.err_storage)
@@ -3200,6 +3311,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].rd_en.err_update),
@@ -3232,6 +3346,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_prog_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].prog_en.err_storage)
@@ -3262,6 +3379,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].erase_en.err_update),
@@ -3294,6 +3414,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_scramble_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].scramble_en.err_storage)
@@ -3324,6 +3447,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_ecc_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].ecc_en.err_update),
@@ -3356,6 +3482,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_he_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].he_en.err_storage)
@@ -3387,6 +3516,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_base_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[4].base.err_storage)
@@ -3417,6 +3549,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_4_size_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[4].size.err_update),
@@ -3452,6 +3587,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].en.err_storage)
@@ -3482,6 +3620,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].rd_en.err_update),
@@ -3514,6 +3655,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_prog_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].prog_en.err_storage)
@@ -3544,6 +3688,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].erase_en.err_update),
@@ -3576,6 +3723,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_scramble_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].scramble_en.err_storage)
@@ -3606,6 +3756,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_ecc_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].ecc_en.err_update),
@@ -3638,6 +3791,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_he_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].he_en.err_storage)
@@ -3669,6 +3825,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_base_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[5].base.err_storage)
@@ -3699,6 +3858,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_5_size_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[5].size.err_update),
@@ -3734,6 +3896,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].en.err_storage)
@@ -3764,6 +3929,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].rd_en.err_update),
@@ -3796,6 +3964,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_prog_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].prog_en.err_storage)
@@ -3826,6 +3997,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].erase_en.err_update),
@@ -3858,6 +4032,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_scramble_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].scramble_en.err_storage)
@@ -3888,6 +4065,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_ecc_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].ecc_en.err_update),
@@ -3920,6 +4100,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_he_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].he_en.err_storage)
@@ -3951,6 +4134,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_base_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[6].base.err_storage)
@@ -3981,6 +4167,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_6_size_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[6].size.err_update),
@@ -4016,6 +4205,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].en.err_storage)
@@ -4046,6 +4238,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].rd_en.err_update),
@@ -4078,6 +4273,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_prog_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].prog_en.err_storage)
@@ -4108,6 +4306,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].erase_en.err_update),
@@ -4140,6 +4341,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_scramble_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].scramble_en.err_storage)
@@ -4170,6 +4374,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_ecc_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].ecc_en.err_update),
@@ -4202,6 +4409,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_he_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].he_en.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].he_en.err_storage)
@@ -4233,6 +4443,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_base_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].base.err_update),
     .err_storage (reg2hw.mp_region_cfg_shadowed[7].base.err_storage)
@@ -4263,6 +4476,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_region_cfg_shadowed_7_size_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_region_cfg_shadowed[7].size.err_update),
@@ -4297,6 +4513,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_shadowed_rd_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.rd_en.err_update),
     .err_storage (reg2hw.default_region_shadowed.rd_en.err_storage)
@@ -4327,6 +4546,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (default_region_shadowed_prog_en_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.prog_en.err_update),
@@ -4359,6 +4581,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_shadowed_erase_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.erase_en.err_update),
     .err_storage (reg2hw.default_region_shadowed.erase_en.err_storage)
@@ -4389,6 +4614,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (default_region_shadowed_scramble_en_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.scramble_en.err_update),
@@ -4421,6 +4649,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (default_region_shadowed_ecc_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.ecc_en.err_update),
     .err_storage (reg2hw.default_region_shadowed.ecc_en.err_storage)
@@ -4451,6 +4682,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (default_region_shadowed_he_en_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.default_region_shadowed.he_en.err_update),
@@ -4756,6 +4990,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].en.err_storage)
@@ -4786,6 +5023,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].rd_en.err_update),
@@ -4818,6 +5058,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].prog_en.err_storage)
@@ -4848,6 +5091,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].erase_en.err_update),
@@ -4880,6 +5126,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -4911,6 +5160,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -4941,6 +5193,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[0].he_en.err_update),
@@ -4976,6 +5231,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].en.err_storage)
@@ -5006,6 +5264,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].rd_en.err_update),
@@ -5038,6 +5299,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].prog_en.err_storage)
@@ -5068,6 +5332,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].erase_en.err_update),
@@ -5100,6 +5367,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -5131,6 +5401,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -5161,6 +5434,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[1].he_en.err_update),
@@ -5196,6 +5472,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].en.err_storage)
@@ -5226,6 +5505,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].rd_en.err_update),
@@ -5258,6 +5540,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_prog_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].prog_en.err_storage)
@@ -5288,6 +5573,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].erase_en.err_update),
@@ -5320,6 +5608,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_scramble_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].scramble_en.err_storage)
@@ -5351,6 +5642,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_ecc_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[2].ecc_en.err_storage)
@@ -5381,6 +5675,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[2].he_en.err_update),
@@ -5416,6 +5713,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].en.err_storage)
@@ -5446,6 +5746,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].rd_en.err_update),
@@ -5478,6 +5781,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_prog_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].prog_en.err_storage)
@@ -5508,6 +5814,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].erase_en.err_update),
@@ -5540,6 +5849,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_scramble_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].scramble_en.err_storage)
@@ -5571,6 +5883,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_ecc_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[3].ecc_en.err_storage)
@@ -5601,6 +5916,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[3].he_en.err_update),
@@ -5636,6 +5954,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].en.err_storage)
@@ -5666,6 +5987,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].rd_en.err_update),
@@ -5698,6 +6022,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_prog_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].prog_en.err_storage)
@@ -5728,6 +6055,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].erase_en.err_update),
@@ -5760,6 +6090,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_scramble_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].scramble_en.err_storage)
@@ -5791,6 +6124,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_ecc_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[4].ecc_en.err_storage)
@@ -5821,6 +6157,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[4].he_en.err_update),
@@ -5856,6 +6195,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].en.err_storage)
@@ -5886,6 +6228,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].rd_en.err_update),
@@ -5918,6 +6263,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_prog_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].prog_en.err_storage)
@@ -5948,6 +6296,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].erase_en.err_update),
@@ -5980,6 +6331,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_scramble_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].scramble_en.err_storage)
@@ -6011,6 +6365,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_ecc_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[5].ecc_en.err_storage)
@@ -6041,6 +6398,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[5].he_en.err_update),
@@ -6076,6 +6436,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].en.err_storage)
@@ -6106,6 +6469,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].rd_en.err_update),
@@ -6138,6 +6504,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_prog_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].prog_en.err_storage)
@@ -6168,6 +6537,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].erase_en.err_update),
@@ -6200,6 +6572,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_scramble_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].scramble_en.err_storage)
@@ -6231,6 +6606,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_ecc_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[6].ecc_en.err_storage)
@@ -6261,6 +6639,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[6].he_en.err_update),
@@ -6296,6 +6677,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].en.err_storage)
@@ -6326,6 +6710,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].rd_en.err_update),
@@ -6358,6 +6745,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_prog_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].prog_en.err_storage)
@@ -6388,6 +6778,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].erase_en.err_update),
@@ -6420,6 +6813,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_scramble_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].scramble_en.err_storage)
@@ -6451,6 +6847,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_ecc_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[7].ecc_en.err_storage)
@@ -6481,6 +6880,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[7].he_en.err_update),
@@ -6516,6 +6918,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].en.err_storage)
@@ -6546,6 +6951,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].rd_en.err_update),
@@ -6578,6 +6986,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_prog_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].prog_en.err_storage)
@@ -6608,6 +7019,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].erase_en.err_update),
@@ -6640,6 +7054,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_scramble_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].scramble_en.err_storage)
@@ -6671,6 +7088,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_ecc_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[8].ecc_en.err_storage)
@@ -6701,6 +7121,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[8].he_en.err_update),
@@ -6736,6 +7159,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].en.err_storage)
@@ -6766,6 +7192,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].rd_en.err_update),
@@ -6798,6 +7227,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_prog_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].prog_en.err_storage)
@@ -6828,6 +7260,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].erase_en.err_update),
@@ -6860,6 +7295,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_scramble_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].scramble_en.err_storage)
@@ -6891,6 +7329,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_ecc_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info0_page_cfg_shadowed[9].ecc_en.err_storage)
@@ -6921,6 +7362,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info0_page_cfg_shadowed[9].he_en.err_update),
@@ -6983,6 +7427,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].en.err_storage)
@@ -7013,6 +7460,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].rd_en.err_update),
@@ -7045,6 +7495,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].prog_en.err_storage)
@@ -7075,6 +7528,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].erase_en.err_update),
@@ -7107,6 +7563,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -7138,6 +7597,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info1_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -7168,6 +7630,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info1_page_cfg_shadowed[0].he_en.err_update),
@@ -7257,6 +7722,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].en.err_storage)
@@ -7287,6 +7755,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].rd_en.err_update),
@@ -7319,6 +7790,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].prog_en.err_storage)
@@ -7349,6 +7823,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].erase_en.err_update),
@@ -7381,6 +7858,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -7412,6 +7892,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -7442,6 +7925,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[0].he_en.err_update),
@@ -7477,6 +7963,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].en.err_storage)
@@ -7507,6 +7996,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].rd_en.err_update),
@@ -7539,6 +8031,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].prog_en.err_storage)
@@ -7569,6 +8064,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].erase_en.err_update),
@@ -7601,6 +8099,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -7632,6 +8133,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank0_info2_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -7662,6 +8166,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank0_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank0_info2_page_cfg_shadowed[1].he_en.err_update),
@@ -7967,6 +8474,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].en.err_storage)
@@ -7997,6 +8507,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].rd_en.err_update),
@@ -8029,6 +8542,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].prog_en.err_storage)
@@ -8059,6 +8575,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].erase_en.err_update),
@@ -8091,6 +8610,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -8122,6 +8644,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -8152,6 +8677,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[0].he_en.err_update),
@@ -8187,6 +8715,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].en.err_storage)
@@ -8217,6 +8748,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].rd_en.err_update),
@@ -8249,6 +8783,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].prog_en.err_storage)
@@ -8279,6 +8816,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].erase_en.err_update),
@@ -8311,6 +8851,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -8342,6 +8885,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -8372,6 +8918,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[1].he_en.err_update),
@@ -8407,6 +8956,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].en.err_storage)
@@ -8437,6 +8989,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_rd_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].rd_en.err_update),
@@ -8469,6 +9024,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_prog_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].prog_en.err_storage)
@@ -8499,6 +9057,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_erase_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].erase_en.err_update),
@@ -8531,6 +9092,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_scramble_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].scramble_en.err_storage)
@@ -8562,6 +9126,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_ecc_en_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[2].ecc_en.err_storage)
@@ -8592,6 +9159,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_2_he_en_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[2].he_en.err_update),
@@ -8627,6 +9197,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].en.err_storage)
@@ -8657,6 +9230,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_rd_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].rd_en.err_update),
@@ -8689,6 +9265,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_prog_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].prog_en.err_storage)
@@ -8719,6 +9298,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_erase_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].erase_en.err_update),
@@ -8751,6 +9333,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_scramble_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].scramble_en.err_storage)
@@ -8782,6 +9367,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_ecc_en_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[3].ecc_en.err_storage)
@@ -8812,6 +9400,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_3_he_en_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[3].he_en.err_update),
@@ -8847,6 +9438,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].en.err_storage)
@@ -8877,6 +9471,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_rd_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].rd_en.err_update),
@@ -8909,6 +9506,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_prog_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].prog_en.err_storage)
@@ -8939,6 +9539,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_erase_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].erase_en.err_update),
@@ -8971,6 +9574,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_scramble_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].scramble_en.err_storage)
@@ -9002,6 +9608,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_ecc_en_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[4].ecc_en.err_storage)
@@ -9032,6 +9641,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_4_he_en_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[4].he_en.err_update),
@@ -9067,6 +9679,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].en.err_storage)
@@ -9097,6 +9712,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_rd_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].rd_en.err_update),
@@ -9129,6 +9747,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_prog_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].prog_en.err_storage)
@@ -9159,6 +9780,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_erase_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].erase_en.err_update),
@@ -9191,6 +9815,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_scramble_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].scramble_en.err_storage)
@@ -9222,6 +9849,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_ecc_en_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[5].ecc_en.err_storage)
@@ -9252,6 +9882,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_5_he_en_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[5].he_en.err_update),
@@ -9287,6 +9920,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].en.err_storage)
@@ -9317,6 +9953,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_rd_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].rd_en.err_update),
@@ -9349,6 +9988,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_prog_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].prog_en.err_storage)
@@ -9379,6 +10021,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_erase_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].erase_en.err_update),
@@ -9411,6 +10056,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_scramble_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].scramble_en.err_storage)
@@ -9442,6 +10090,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_ecc_en_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[6].ecc_en.err_storage)
@@ -9472,6 +10123,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_6_he_en_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[6].he_en.err_update),
@@ -9507,6 +10161,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].en.err_storage)
@@ -9537,6 +10194,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_rd_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].rd_en.err_update),
@@ -9569,6 +10229,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_prog_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].prog_en.err_storage)
@@ -9599,6 +10262,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_erase_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].erase_en.err_update),
@@ -9631,6 +10297,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_scramble_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].scramble_en.err_storage)
@@ -9662,6 +10331,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_ecc_en_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[7].ecc_en.err_storage)
@@ -9692,6 +10364,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_7_he_en_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[7].he_en.err_update),
@@ -9727,6 +10402,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].en.err_storage)
@@ -9757,6 +10435,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_rd_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].rd_en.err_update),
@@ -9789,6 +10470,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_prog_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].prog_en.err_storage)
@@ -9819,6 +10503,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_erase_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].erase_en.err_update),
@@ -9851,6 +10538,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_scramble_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].scramble_en.err_storage)
@@ -9882,6 +10572,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_ecc_en_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[8].ecc_en.err_storage)
@@ -9912,6 +10605,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_8_he_en_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[8].he_en.err_update),
@@ -9947,6 +10643,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].en.err_storage)
@@ -9977,6 +10676,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_rd_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].rd_en.err_update),
@@ -10009,6 +10711,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_prog_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].prog_en.err_storage)
@@ -10039,6 +10744,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_erase_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].erase_en.err_update),
@@ -10071,6 +10779,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_scramble_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].scramble_en.err_storage)
@@ -10102,6 +10813,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_ecc_en_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info0_page_cfg_shadowed[9].ecc_en.err_storage)
@@ -10132,6 +10846,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info0_page_cfg_shadowed_9_he_en_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info0_page_cfg_shadowed[9].he_en.err_update),
@@ -10194,6 +10911,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].en.err_storage)
@@ -10224,6 +10944,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].rd_en.err_update),
@@ -10256,6 +10979,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].prog_en.err_storage)
@@ -10286,6 +11012,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].erase_en.err_update),
@@ -10318,6 +11047,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -10349,6 +11081,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info1_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -10379,6 +11114,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info1_page_cfg_shadowed_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info1_page_cfg_shadowed[0].he_en.err_update),
@@ -10468,6 +11206,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].en.err_storage)
@@ -10498,6 +11239,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_rd_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].rd_en.err_update),
@@ -10530,6 +11274,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_prog_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].prog_en.err_storage)
@@ -10560,6 +11307,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_erase_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].erase_en.err_update),
@@ -10592,6 +11342,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_scramble_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].scramble_en.err_storage)
@@ -10623,6 +11376,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_ecc_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[0].ecc_en.err_storage)
@@ -10653,6 +11409,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_0_he_en_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[0].he_en.err_update),
@@ -10688,6 +11447,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].en.err_storage)
@@ -10718,6 +11480,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_rd_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].rd_en.err_update),
@@ -10750,6 +11515,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_prog_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].prog_en.err_storage)
@@ -10780,6 +11548,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].erase_en.err_update),
@@ -10812,6 +11583,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_scramble_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].scramble_en.err_storage)
@@ -10843,6 +11617,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_ecc_en_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_update),
     .err_storage (reg2hw.bank1_info2_page_cfg_shadowed[1].ecc_en.err_storage)
@@ -10873,6 +11650,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (bank1_info2_page_cfg_shadowed_1_he_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.bank1_info2_page_cfg_shadowed[1].he_en.err_update),
@@ -10934,6 +11714,9 @@ module flash_ctrl_core_reg_top (
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.mp_bank_cfg_shadowed[0].err_update),
     .err_storage (reg2hw.mp_bank_cfg_shadowed[0].err_storage)
@@ -10964,6 +11747,9 @@ module flash_ctrl_core_reg_top (
 
     // to register interface (read)
     .qs     (mp_bank_cfg_shadowed_erase_en_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.mp_bank_cfg_shadowed[1].err_update),

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -1647,6 +1647,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (ping_timeout_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.ping_timeout_cyc_shadowed.err_update),
     .err_storage (reg2hw.ping_timeout_cyc_shadowed.err_storage)
@@ -1678,6 +1681,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (ping_timer_en_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.ping_timer_en_shadowed.err_update),
@@ -3305,6 +3311,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[0].err_update),
     .err_storage (reg2hw.alert_en_shadowed[0].err_storage)
@@ -3337,6 +3346,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[1].err_update),
@@ -3371,6 +3383,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[2].err_update),
     .err_storage (reg2hw.alert_en_shadowed[2].err_storage)
@@ -3403,6 +3418,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[3].err_update),
@@ -3437,6 +3455,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[4].err_update),
     .err_storage (reg2hw.alert_en_shadowed[4].err_storage)
@@ -3469,6 +3490,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[5].err_update),
@@ -3503,6 +3527,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[6].err_update),
     .err_storage (reg2hw.alert_en_shadowed[6].err_storage)
@@ -3535,6 +3562,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_7_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[7].err_update),
@@ -3569,6 +3599,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_8_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[8].err_update),
     .err_storage (reg2hw.alert_en_shadowed[8].err_storage)
@@ -3601,6 +3634,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_9_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[9].err_update),
@@ -3635,6 +3671,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_10_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[10].err_update),
     .err_storage (reg2hw.alert_en_shadowed[10].err_storage)
@@ -3667,6 +3706,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_11_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[11].err_update),
@@ -3701,6 +3743,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_12_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[12].err_update),
     .err_storage (reg2hw.alert_en_shadowed[12].err_storage)
@@ -3733,6 +3778,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_13_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[13].err_update),
@@ -3767,6 +3815,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_14_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[14].err_update),
     .err_storage (reg2hw.alert_en_shadowed[14].err_storage)
@@ -3799,6 +3850,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_15_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[15].err_update),
@@ -3833,6 +3887,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_16_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[16].err_update),
     .err_storage (reg2hw.alert_en_shadowed[16].err_storage)
@@ -3865,6 +3922,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_17_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[17].err_update),
@@ -3899,6 +3959,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_18_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[18].err_update),
     .err_storage (reg2hw.alert_en_shadowed[18].err_storage)
@@ -3931,6 +3994,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_19_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[19].err_update),
@@ -3965,6 +4031,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_20_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[20].err_update),
     .err_storage (reg2hw.alert_en_shadowed[20].err_storage)
@@ -3997,6 +4066,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_21_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[21].err_update),
@@ -4031,6 +4103,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_22_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[22].err_update),
     .err_storage (reg2hw.alert_en_shadowed[22].err_storage)
@@ -4063,6 +4138,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_23_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[23].err_update),
@@ -4097,6 +4175,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_24_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[24].err_update),
     .err_storage (reg2hw.alert_en_shadowed[24].err_storage)
@@ -4129,6 +4210,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_25_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[25].err_update),
@@ -4163,6 +4247,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_26_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[26].err_update),
     .err_storage (reg2hw.alert_en_shadowed[26].err_storage)
@@ -4195,6 +4282,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_27_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[27].err_update),
@@ -4229,6 +4319,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_28_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[28].err_update),
     .err_storage (reg2hw.alert_en_shadowed[28].err_storage)
@@ -4261,6 +4354,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_29_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[29].err_update),
@@ -4295,6 +4391,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_30_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[30].err_update),
     .err_storage (reg2hw.alert_en_shadowed[30].err_storage)
@@ -4327,6 +4426,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_31_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[31].err_update),
@@ -4361,6 +4463,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_32_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[32].err_update),
     .err_storage (reg2hw.alert_en_shadowed[32].err_storage)
@@ -4393,6 +4498,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_33_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[33].err_update),
@@ -4427,6 +4535,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_34_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[34].err_update),
     .err_storage (reg2hw.alert_en_shadowed[34].err_storage)
@@ -4459,6 +4570,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_35_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[35].err_update),
@@ -4493,6 +4607,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_36_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[36].err_update),
     .err_storage (reg2hw.alert_en_shadowed[36].err_storage)
@@ -4525,6 +4642,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_37_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[37].err_update),
@@ -4559,6 +4679,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_38_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[38].err_update),
     .err_storage (reg2hw.alert_en_shadowed[38].err_storage)
@@ -4591,6 +4714,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_39_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[39].err_update),
@@ -4625,6 +4751,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_40_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[40].err_update),
     .err_storage (reg2hw.alert_en_shadowed[40].err_storage)
@@ -4657,6 +4786,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_41_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[41].err_update),
@@ -4691,6 +4823,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_42_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[42].err_update),
     .err_storage (reg2hw.alert_en_shadowed[42].err_storage)
@@ -4723,6 +4858,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_43_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[43].err_update),
@@ -4757,6 +4895,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_44_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[44].err_update),
     .err_storage (reg2hw.alert_en_shadowed[44].err_storage)
@@ -4789,6 +4930,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_45_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[45].err_update),
@@ -4823,6 +4967,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_46_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[46].err_update),
     .err_storage (reg2hw.alert_en_shadowed[46].err_storage)
@@ -4855,6 +5002,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_47_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[47].err_update),
@@ -4889,6 +5039,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_48_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[48].err_update),
     .err_storage (reg2hw.alert_en_shadowed[48].err_storage)
@@ -4921,6 +5074,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_49_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[49].err_update),
@@ -4955,6 +5111,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_50_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[50].err_update),
     .err_storage (reg2hw.alert_en_shadowed[50].err_storage)
@@ -4987,6 +5146,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_51_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[51].err_update),
@@ -5021,6 +5183,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_52_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[52].err_update),
     .err_storage (reg2hw.alert_en_shadowed[52].err_storage)
@@ -5053,6 +5218,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_53_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[53].err_update),
@@ -5087,6 +5255,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_54_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[54].err_update),
     .err_storage (reg2hw.alert_en_shadowed[54].err_storage)
@@ -5119,6 +5290,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_55_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[55].err_update),
@@ -5153,6 +5327,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_56_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[56].err_update),
     .err_storage (reg2hw.alert_en_shadowed[56].err_storage)
@@ -5185,6 +5362,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_en_shadowed_57_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[57].err_update),
@@ -5219,6 +5399,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_en_shadowed_58_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_en_shadowed[58].err_update),
     .err_storage (reg2hw.alert_en_shadowed[58].err_storage)
@@ -5251,6 +5434,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[0].err_update),
@@ -5285,6 +5471,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[1].err_update),
     .err_storage (reg2hw.alert_class_shadowed[1].err_storage)
@@ -5317,6 +5506,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[2].err_update),
@@ -5351,6 +5543,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[3].err_update),
     .err_storage (reg2hw.alert_class_shadowed[3].err_storage)
@@ -5383,6 +5578,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[4].err_update),
@@ -5417,6 +5615,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[5].err_update),
     .err_storage (reg2hw.alert_class_shadowed[5].err_storage)
@@ -5449,6 +5650,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[6].err_update),
@@ -5483,6 +5687,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_7_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[7].err_update),
     .err_storage (reg2hw.alert_class_shadowed[7].err_storage)
@@ -5515,6 +5722,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_8_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[8].err_update),
@@ -5549,6 +5759,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_9_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[9].err_update),
     .err_storage (reg2hw.alert_class_shadowed[9].err_storage)
@@ -5581,6 +5794,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_10_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[10].err_update),
@@ -5615,6 +5831,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_11_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[11].err_update),
     .err_storage (reg2hw.alert_class_shadowed[11].err_storage)
@@ -5647,6 +5866,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_12_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[12].err_update),
@@ -5681,6 +5903,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_13_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[13].err_update),
     .err_storage (reg2hw.alert_class_shadowed[13].err_storage)
@@ -5713,6 +5938,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_14_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[14].err_update),
@@ -5747,6 +5975,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_15_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[15].err_update),
     .err_storage (reg2hw.alert_class_shadowed[15].err_storage)
@@ -5779,6 +6010,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_16_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[16].err_update),
@@ -5813,6 +6047,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_17_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[17].err_update),
     .err_storage (reg2hw.alert_class_shadowed[17].err_storage)
@@ -5845,6 +6082,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_18_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[18].err_update),
@@ -5879,6 +6119,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_19_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[19].err_update),
     .err_storage (reg2hw.alert_class_shadowed[19].err_storage)
@@ -5911,6 +6154,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_20_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[20].err_update),
@@ -5945,6 +6191,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_21_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[21].err_update),
     .err_storage (reg2hw.alert_class_shadowed[21].err_storage)
@@ -5977,6 +6226,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_22_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[22].err_update),
@@ -6011,6 +6263,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_23_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[23].err_update),
     .err_storage (reg2hw.alert_class_shadowed[23].err_storage)
@@ -6043,6 +6298,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_24_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[24].err_update),
@@ -6077,6 +6335,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_25_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[25].err_update),
     .err_storage (reg2hw.alert_class_shadowed[25].err_storage)
@@ -6109,6 +6370,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_26_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[26].err_update),
@@ -6143,6 +6407,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_27_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[27].err_update),
     .err_storage (reg2hw.alert_class_shadowed[27].err_storage)
@@ -6175,6 +6442,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_28_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[28].err_update),
@@ -6209,6 +6479,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_29_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[29].err_update),
     .err_storage (reg2hw.alert_class_shadowed[29].err_storage)
@@ -6241,6 +6514,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_30_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[30].err_update),
@@ -6275,6 +6551,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_31_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[31].err_update),
     .err_storage (reg2hw.alert_class_shadowed[31].err_storage)
@@ -6307,6 +6586,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_32_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[32].err_update),
@@ -6341,6 +6623,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_33_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[33].err_update),
     .err_storage (reg2hw.alert_class_shadowed[33].err_storage)
@@ -6373,6 +6658,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_34_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[34].err_update),
@@ -6407,6 +6695,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_35_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[35].err_update),
     .err_storage (reg2hw.alert_class_shadowed[35].err_storage)
@@ -6439,6 +6730,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_36_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[36].err_update),
@@ -6473,6 +6767,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_37_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[37].err_update),
     .err_storage (reg2hw.alert_class_shadowed[37].err_storage)
@@ -6505,6 +6802,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_38_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[38].err_update),
@@ -6539,6 +6839,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_39_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[39].err_update),
     .err_storage (reg2hw.alert_class_shadowed[39].err_storage)
@@ -6571,6 +6874,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_40_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[40].err_update),
@@ -6605,6 +6911,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_41_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[41].err_update),
     .err_storage (reg2hw.alert_class_shadowed[41].err_storage)
@@ -6637,6 +6946,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_42_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[42].err_update),
@@ -6671,6 +6983,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_43_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[43].err_update),
     .err_storage (reg2hw.alert_class_shadowed[43].err_storage)
@@ -6703,6 +7018,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_44_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[44].err_update),
@@ -6737,6 +7055,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_45_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[45].err_update),
     .err_storage (reg2hw.alert_class_shadowed[45].err_storage)
@@ -6769,6 +7090,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_46_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[46].err_update),
@@ -6803,6 +7127,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_47_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[47].err_update),
     .err_storage (reg2hw.alert_class_shadowed[47].err_storage)
@@ -6835,6 +7162,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_48_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[48].err_update),
@@ -6869,6 +7199,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_49_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[49].err_update),
     .err_storage (reg2hw.alert_class_shadowed[49].err_storage)
@@ -6901,6 +7234,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_50_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[50].err_update),
@@ -6935,6 +7271,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_51_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[51].err_update),
     .err_storage (reg2hw.alert_class_shadowed[51].err_storage)
@@ -6967,6 +7306,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_52_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[52].err_update),
@@ -7001,6 +7343,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_53_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[53].err_update),
     .err_storage (reg2hw.alert_class_shadowed[53].err_storage)
@@ -7033,6 +7378,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_54_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[54].err_update),
@@ -7067,6 +7415,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_55_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[55].err_update),
     .err_storage (reg2hw.alert_class_shadowed[55].err_storage)
@@ -7099,6 +7450,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_56_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[56].err_update),
@@ -7133,6 +7487,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (alert_class_shadowed_57_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[57].err_update),
     .err_storage (reg2hw.alert_class_shadowed[57].err_storage)
@@ -7165,6 +7522,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (alert_class_shadowed_58_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.alert_class_shadowed[58].err_update),
@@ -8981,6 +9341,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_en_shadowed[0].err_update),
     .err_storage (reg2hw.loc_alert_en_shadowed[0].err_storage)
@@ -9013,6 +9376,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_en_shadowed[1].err_update),
@@ -9047,6 +9413,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_en_shadowed[2].err_update),
     .err_storage (reg2hw.loc_alert_en_shadowed[2].err_storage)
@@ -9079,6 +9448,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_en_shadowed[3].err_update),
@@ -9113,6 +9485,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_4_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_en_shadowed[4].err_update),
     .err_storage (reg2hw.loc_alert_en_shadowed[4].err_storage)
@@ -9145,6 +9520,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_5_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_en_shadowed[5].err_update),
@@ -9179,6 +9557,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (loc_alert_en_shadowed_6_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_en_shadowed[6].err_update),
     .err_storage (reg2hw.loc_alert_en_shadowed[6].err_storage)
@@ -9211,6 +9592,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_0_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_class_shadowed[0].err_update),
@@ -9245,6 +9629,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_1_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_class_shadowed[1].err_update),
     .err_storage (reg2hw.loc_alert_class_shadowed[1].err_storage)
@@ -9277,6 +9664,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_2_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_class_shadowed[2].err_update),
@@ -9311,6 +9701,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_3_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_class_shadowed[3].err_update),
     .err_storage (reg2hw.loc_alert_class_shadowed[3].err_storage)
@@ -9343,6 +9736,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_4_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_class_shadowed[4].err_update),
@@ -9377,6 +9773,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_5_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_class_shadowed[5].err_update),
     .err_storage (reg2hw.loc_alert_class_shadowed[5].err_storage)
@@ -9409,6 +9808,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (loc_alert_class_shadowed_6_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.loc_alert_class_shadowed[6].err_update),
@@ -9658,6 +10060,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en.err_storage)
@@ -9688,6 +10093,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_lock_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.lock.err_update),
@@ -9720,6 +10128,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e0.err_storage)
@@ -9750,6 +10161,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e1.err_update),
@@ -9782,6 +10196,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.en_e2.err_storage)
@@ -9812,6 +10229,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_en_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.en_e3.err_update),
@@ -9844,6 +10264,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e0.err_storage)
@@ -9874,6 +10297,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e1.err_update),
@@ -9906,6 +10332,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classa_ctrl_shadowed.map_e2.err_storage)
@@ -9936,6 +10365,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_ctrl_shadowed_map_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_ctrl_shadowed.map_e3.err_update),
@@ -9995,6 +10427,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_clr_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_clr_shadowed.err_update),
     .err_storage (reg2hw.classa_clr_shadowed.err_storage)
@@ -10042,6 +10477,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_accum_thresh_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_accum_thresh_shadowed.err_update),
     .err_storage (reg2hw.classa_accum_thresh_shadowed.err_storage)
@@ -10073,6 +10511,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_timeout_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_timeout_cyc_shadowed.err_update),
@@ -10106,6 +10547,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_crashdump_trigger_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_crashdump_trigger_shadowed.err_update),
     .err_storage (reg2hw.classa_crashdump_trigger_shadowed.err_storage)
@@ -10137,6 +10581,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_phase0_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_phase0_cyc_shadowed.err_update),
@@ -10170,6 +10617,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_phase1_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_phase1_cyc_shadowed.err_update),
     .err_storage (reg2hw.classa_phase1_cyc_shadowed.err_storage)
@@ -10202,6 +10652,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classa_phase2_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classa_phase2_cyc_shadowed.err_update),
     .err_storage (reg2hw.classa_phase2_cyc_shadowed.err_storage)
@@ -10233,6 +10686,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classa_phase3_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classa_phase3_cyc_shadowed.err_update),
@@ -10323,6 +10779,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en.err_storage)
@@ -10353,6 +10812,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_lock_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.lock.err_update),
@@ -10385,6 +10847,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e0.err_storage)
@@ -10415,6 +10880,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e1.err_update),
@@ -10447,6 +10915,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.en_e2.err_storage)
@@ -10477,6 +10948,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_en_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.en_e3.err_update),
@@ -10509,6 +10983,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e0.err_storage)
@@ -10539,6 +11016,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e1.err_update),
@@ -10571,6 +11051,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classb_ctrl_shadowed.map_e2.err_storage)
@@ -10601,6 +11084,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_ctrl_shadowed_map_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_ctrl_shadowed.map_e3.err_update),
@@ -10660,6 +11146,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_clr_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_clr_shadowed.err_update),
     .err_storage (reg2hw.classb_clr_shadowed.err_storage)
@@ -10707,6 +11196,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_accum_thresh_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_accum_thresh_shadowed.err_update),
     .err_storage (reg2hw.classb_accum_thresh_shadowed.err_storage)
@@ -10738,6 +11230,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_timeout_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_timeout_cyc_shadowed.err_update),
@@ -10771,6 +11266,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_crashdump_trigger_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_crashdump_trigger_shadowed.err_update),
     .err_storage (reg2hw.classb_crashdump_trigger_shadowed.err_storage)
@@ -10802,6 +11300,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_phase0_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_phase0_cyc_shadowed.err_update),
@@ -10835,6 +11336,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_phase1_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_phase1_cyc_shadowed.err_update),
     .err_storage (reg2hw.classb_phase1_cyc_shadowed.err_storage)
@@ -10867,6 +11371,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classb_phase2_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classb_phase2_cyc_shadowed.err_update),
     .err_storage (reg2hw.classb_phase2_cyc_shadowed.err_storage)
@@ -10898,6 +11405,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classb_phase3_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classb_phase3_cyc_shadowed.err_update),
@@ -10988,6 +11498,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en.err_storage)
@@ -11018,6 +11531,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_lock_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.lock.err_update),
@@ -11050,6 +11566,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e0.err_storage)
@@ -11080,6 +11599,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e1.err_update),
@@ -11112,6 +11634,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.en_e2.err_storage)
@@ -11142,6 +11667,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_en_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.en_e3.err_update),
@@ -11174,6 +11702,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e0.err_storage)
@@ -11204,6 +11735,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e1.err_update),
@@ -11236,6 +11770,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classc_ctrl_shadowed.map_e2.err_storage)
@@ -11266,6 +11803,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_ctrl_shadowed_map_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_ctrl_shadowed.map_e3.err_update),
@@ -11325,6 +11865,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_clr_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_clr_shadowed.err_update),
     .err_storage (reg2hw.classc_clr_shadowed.err_storage)
@@ -11372,6 +11915,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_accum_thresh_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_accum_thresh_shadowed.err_update),
     .err_storage (reg2hw.classc_accum_thresh_shadowed.err_storage)
@@ -11403,6 +11949,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_timeout_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_timeout_cyc_shadowed.err_update),
@@ -11436,6 +11985,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_crashdump_trigger_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_crashdump_trigger_shadowed.err_update),
     .err_storage (reg2hw.classc_crashdump_trigger_shadowed.err_storage)
@@ -11467,6 +12019,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_phase0_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_phase0_cyc_shadowed.err_update),
@@ -11500,6 +12055,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_phase1_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_phase1_cyc_shadowed.err_update),
     .err_storage (reg2hw.classc_phase1_cyc_shadowed.err_storage)
@@ -11532,6 +12090,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classc_phase2_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classc_phase2_cyc_shadowed.err_update),
     .err_storage (reg2hw.classc_phase2_cyc_shadowed.err_storage)
@@ -11563,6 +12124,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classc_phase3_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classc_phase3_cyc_shadowed.err_update),
@@ -11653,6 +12217,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.en.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en.err_storage)
@@ -11683,6 +12250,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_lock_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.lock.err_update),
@@ -11715,6 +12285,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e0.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e0.err_storage)
@@ -11745,6 +12318,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e1.err_update),
@@ -11777,6 +12353,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e2.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.en_e2.err_storage)
@@ -11807,6 +12386,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_en_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.en_e3.err_update),
@@ -11839,6 +12421,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e0_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e0.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e0.err_storage)
@@ -11869,6 +12454,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e1_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e1.err_update),
@@ -11901,6 +12489,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e2_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e2.err_update),
     .err_storage (reg2hw.classd_ctrl_shadowed.map_e2.err_storage)
@@ -11931,6 +12522,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_ctrl_shadowed_map_e3_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_ctrl_shadowed.map_e3.err_update),
@@ -11990,6 +12584,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_clr_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_clr_shadowed.err_update),
     .err_storage (reg2hw.classd_clr_shadowed.err_storage)
@@ -12037,6 +12634,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_accum_thresh_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_accum_thresh_shadowed.err_update),
     .err_storage (reg2hw.classd_accum_thresh_shadowed.err_storage)
@@ -12068,6 +12668,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_timeout_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_timeout_cyc_shadowed.err_update),
@@ -12101,6 +12704,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_crashdump_trigger_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_crashdump_trigger_shadowed.err_update),
     .err_storage (reg2hw.classd_crashdump_trigger_shadowed.err_storage)
@@ -12132,6 +12738,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_phase0_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_phase0_cyc_shadowed.err_update),
@@ -12165,6 +12774,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_phase1_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_phase1_cyc_shadowed.err_update),
     .err_storage (reg2hw.classd_phase1_cyc_shadowed.err_storage)
@@ -12197,6 +12809,9 @@ module alert_handler_reg_top (
     // to register interface (read)
     .qs     (classd_phase2_cyc_shadowed_qs),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.classd_phase2_cyc_shadowed.err_update),
     .err_storage (reg2hw.classd_phase2_cyc_shadowed.err_storage)
@@ -12228,6 +12843,9 @@ module alert_handler_reg_top (
 
     // to register interface (read)
     .qs     (classd_phase3_cyc_shadowed_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
 
     // Shadow register error conditions
     .err_update  (reg2hw.classd_phase3_cyc_shadowed.err_update),

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -786,6 +786,9 @@ ${bits.msb}\
       % else:
     .qs     (${qs_expr}),
 
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
     // Shadow register error conditions
     .err_update  (reg2hw.${fsig_name}.err_update),
     .err_storage (reg2hw.${fsig_name}.err_storage)


### PR DESCRIPTION
This commit modifies the generation of the idle bit in the status register to prevent that writes to the main control, key and IV
registers following a write to the main control register or a key register collide with the start of a PRNG reseed operation thereby
getting lost. This is required as with the key_touch_forces_reseed feature, a write to the control register (if sideload is enabled) or the write of the last key register may trigger a PRNG reseed operation.

In addition, the idle_o status bit for the clock manager is flopped to match the corresponding bit in the status register. Previously, it was one clock cycle off.

This is related to lowRISC/OpenTitan#10518.