### PR TITLE
[aes/dv] Fix NIST vector test

### DIFF
--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -133,7 +133,7 @@ class aes_base_vseq extends cip_base_vseq #(
 
 
   virtual task write_iv(bit  [3:0][31:0] iv, bit do_b2b);
-    foreach (iv[i]) csr_wr(.ptr(ral.iv[i]), .value(iv[0]), .blocking(~do_b2b));
+    foreach (iv[i]) csr_wr(.ptr(ral.iv[i]), .value(iv[i]), .blocking(~do_b2b));
   endtask
 
 


### PR DESCRIPTION
There were three issues causing this test to fail:
1. The test was not correctly configuring the DUT for decryption. This has been introduced recently when modifying the main control register.
2. The test did not wait for the DUT to be idle before writing the IV. This has been introduced recently when adding the key-touch-force-reseed feature.
3. The IV got not correctly configured. Only the first word was written but to all 4 IV registers.

All three issues are solved with this commit.

This fixes lowRISC/OpenTitan#10544.