### PR TITLE
[otbn,dv] Wait to come out of reset in the stress_all vseq

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -188,6 +188,10 @@ class otbn_base_vseq extends cip_base_vseq #(
     `DV_CHECK_FATAL(stop_tokens == 0)
     running_ = 1'b1;
 
+    // Check that we aren't currently in reset. If we were, this task would otherwise exit
+    // immediately, causing all sorts of confusion. It's a testbench bug if we are.
+    `DV_CHECK_FATAL(!cfg.under_reset)
+
     fork : isolation_fork
       begin
         fork

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stress_all_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_stress_all_vseq.sv
@@ -25,6 +25,13 @@ class otbn_stress_all_vseq extends otbn_base_vseq;
       uint           seq_idx = $urandom_range(0, vseq_names.size() - 1);
       string         cur_vseq_name = vseq_names[seq_idx];
 
+      // If we're running as a subsequence of otbn_stress_all_with_rand_reset and i > 0, the
+      // previous sequence might have exited early when the controlling sequence applied a reset. In
+      // this case, wait until we come back out of reset before running the next one.
+      if (cfg.under_reset) begin
+        cfg.clk_rst_vif.wait_for_reset(.wait_negedge(1'b0), .wait_posedge(1'b1));
+      end
+
       seq = create_seq_by_name(cur_vseq_name);
       `downcast(otbn_vseq, seq)
 


### PR DESCRIPTION
The first commit is a simple tidy-up that will make it more obvious if the bug fixed in the second commit rears its head again.

This sequence is used by `otbn_stress_all_with_rand_reset`. The
sequences that `otbn_stress_all_vseq` calls all exit immediately when
the device goes into reset. We need to make sure we don't immediately
start another sequence (when we're still in reset) because that would,
in turn exit immediately.
