### PR TITLE
[dv/otp] Fix tl_intg_err

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -1527,9 +1527,10 @@
         swaccess: "rw0c",
         hwaccess: "hro",
         regwen:   "DIRECT_ACCESS_REGWEN",
-        tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
-                    // so not able to predict this register value automatically
-                    "excl:CsrNonInitTests:CsrExclCheck"],
+        tags:     [ // The value of this register can affect the read access of the this
+                    // partition's memory window. Excluding this register from writing can ensure
+                    // memories have read and write access.
+                    "excl:CsrNonInitTests:CsrExclWrite"],
         fields: [
           { bits:   "0",
             desc: '''
@@ -1547,9 +1548,10 @@
         swaccess: "rw0c",
         hwaccess: "hro",
         regwen:   "DIRECT_ACCESS_REGWEN",
-        tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
-                    // so not able to predict this register value automatically
-                    "excl:CsrNonInitTests:CsrExclCheck"],
+        tags:     [ // The value of this register can affect the read access of the this
+                    // partition's memory window. Excluding this register from writing can ensure
+                    // memories have read and write access.
+                    "excl:CsrNonInitTests:CsrExclWrite"],
         fields: [
           { bits:   "0",
             desc: '''
@@ -1567,9 +1569,10 @@
         swaccess: "rw0c",
         hwaccess: "hro",
         regwen:   "DIRECT_ACCESS_REGWEN",
-        tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
-                    // so not able to predict this register value automatically
-                    "excl:CsrNonInitTests:CsrExclCheck"],
+        tags:     [ // The value of this register can affect the read access of the this
+                    // partition's memory window. Excluding this register from writing can ensure
+                    // memories have read and write access.
+                    "excl:CsrNonInitTests:CsrExclWrite"],
         fields: [
           { bits:   "0",
             desc: '''

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -923,9 +923,10 @@
         swaccess: "rw0c",
         hwaccess: "hro",
         regwen:   "DIRECT_ACCESS_REGWEN",
-        tags:     [ // The enable register "DIRECT_ACCESS_REGWEN" is HW controlled,
-                    // so not able to predict this register value automatically
-                    "excl:CsrNonInitTests:CsrExclCheck"],
+        tags:     [ // The value of this register can affect the read access of the this
+                    // partition's memory window. Excluding this register from writing can ensure
+                    // memories have read and write access.
+                    "excl:CsrNonInitTests:CsrExclWrite"],
         fields: [
           { bits:   "0",
             desc: '''


### PR DESCRIPTION
This tl_intg_err is because there are CSRs that could affect memory
access. Once the csr is set, if memory has integrity error, it will
return FFs, if there isn't integrity error, due to the memory is locked,
it will return 0.
It is hard to auto-predict this in auto-generated CSR test, so I plan to
exclude this register from write.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>