### PR TITLE
[dv] Fix 2 coverage holes

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_pkg.sv
+++ b/hw/dv/sv/cip_lib/cip_base_pkg.sv
@@ -66,7 +66,9 @@ package cip_base_pkg;
     foreach (mems[i]) begin
       dv_base_mem dv_mem;
       `downcast(dv_mem, mems[i], , , msg_id)
-      if (!dv_mem.get_mem_partial_write_support()) has_mem_byte_access_err = 1;
+      if (!dv_mem.get_mem_partial_write_support() && dv_mem.get_access() == "RO") begin
+        has_mem_byte_access_err = 1;
+      end
       if (dv_mem.get_access() == "WO") has_wo_mem = 1;
       if (dv_mem.get_access() == "RO") has_ro_mem = 1;
     end

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -326,6 +326,7 @@ virtual task issue_tl_access_w_intg_err(string ral_name);
     end
   endcase
   tl_access(.addr(addr), .write(write), .data(data), .tl_intg_err_type(tl_intg_err_type),
+            .mask(get_rand_contiguous_mask()),
             .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
 endtask
 


### PR DESCRIPTION
1. Fixed wrong conditon for enabling byte access error
2. Fixed never issuing byte write to memory for integrity error
Signed-off-by: Weicai Yang <weicai@google.com>