### PR TITLE
[cdc] Waiver file refining

### DIFF
--- a/hw/top_earlgrey/cdc/cdc_waivers.gpio.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.gpio.tcl
@@ -3,7 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Verix CDC waiver file
+# Expression:
+#  ControlSignal==""
+#  ReconSignal==""
+#  MultiClockDomains=="IO_DIV2_CLK::IO_DIV4_CLK"
 
-set_rule_status -rule { W_RECON_GROUPS } -status { Waived } \
-   -expression {u_gpio.gen_filter} \
-   -comment {filters are reconverged into registers. But it's OK.}
+set_rule_status -rule { W_RECON_GROUPS } -status { Waived }     \
+   -expression {(ControlSignal=~"*u_gpio.gen_filter*") &&       \
+                (ReconSignal=~"*u_gpio.u_reg.u_intr_state.q*")} \
+   -comment {filters are converged into the interrupt status registers. Each bit is independent}


### PR DESCRIPTION
- Revised waiver syntax. `expression`. to waive the Reconvergence
  Warning
