### PR TITLE
[Foundry CI/dv] Fix close source OTP smoke test timeout

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -46,8 +46,13 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
   }
 
   constraint num_trans_c {
-    num_trans  inside {[1:2]};
-    num_dai_op inside {[1:50]};
+    if (cfg.smoke_test) {
+      num_trans  inside {[1:2]};
+      num_dai_op inside {[5:10]};
+    } else {
+      num_trans  inside {[1:2]};
+      num_dai_op inside {[1:50]};
+    }
   }
 
   constraint regwens_c {


### PR DESCRIPTION
Close source write takes long simulation time so to avoid timeout, we
issue less read/write if it is CI check.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>