### PR TITLE
[foundry CI/ dv] Fix foundary failure

### DIFF
--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -201,7 +201,7 @@ module prim_count import prim_count_pkg::*; #(
   // If the up counter reaches its max value, the value won't increment or change, unless there is
   // a fault injection
   `ASSERT(MaxUpCntStable_A, up_cnt_q[0] == max_val && !clr_i && !set_i |=>
-          $stable(up_cnt_q[0]) || err_o)
+          $stable(up_cnt_q[0]) || err_o || $past(err_o))
 
   // This logic that will be assign to one, when user adds macro
   // ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT to check the error with alert, in case that prim_count


### PR DESCRIPTION
This is due to update in #10539, which changed to deposit a backdoor
value into actual flops, but flop has different implementations. prefer
to make this implementation independent, so changed back to force on the
wire, and use force-release instead of deposit

Signed-off-by: Weicai Yang <weicai@google.com>