### PR TITLE
[cdc] GPIO Waiver cleanup and split waived report

### DIFF
--- a/hw/cdc/tools/verixcdc/run-cdc.tcl
+++ b/hw/cdc/tools/verixcdc/run-cdc.tcl
@@ -25,6 +25,7 @@ set CONSTRAINT         [get_env_var "CONSTRAINT"]
 set FOUNDRY_CONSTRAINT [get_env_var "FOUNDRY_CONSTRAINT"]
 set PARAMS             [get_env_var "PARAMS"]
 set CDC_WAIVER_FILE    [get_env_var "CDC_WAIVER_FILE"]
+set CDC_WAIVER_DIR     [file dirname $CDC_WAIVER_FILE]
 set ENV_FILE           [get_env_var "ENV_FILE"]
 
 # Used to disable some SDC constructs that are not needed by CDC.
@@ -139,7 +140,11 @@ report_policy -verbose -skip_empty_summary_status -compat -output vcdc.rpt ALL
 file mkdir ../REPORT/
 
 foreach mod $modules {
-  report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.$mod.rpt -module $mod ALL
+  report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.$mod.rpt -module $mod {NEW TO_BE_FIXED DEFERRED}
 }
+
+# Report waived in a separate file
+report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.rpt {NEW TO_BE_FIXED DEFERRED}
+report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.waived.rpt {WAIVED}
 
 # report_messages -output verix_cdc.rpt

--- a/hw/top_earlgrey/cdc/cdc_waivers.gpio.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.gpio.tcl
@@ -8,7 +8,7 @@
 #  ReconSignal==""
 #  MultiClockDomains=="IO_DIV2_CLK::IO_DIV4_CLK"
 
-set_rule_status -rule { W_RECON_GROUPS } -status { Waived }     \
+set_rule_status -rule {W_RECON_GROUPS} -status {Waived}         \
    -expression {(ControlSignal=~"*u_gpio.gen_filter*") &&       \
                 (ReconSignal=~"*u_gpio.u_reg.u_intr_state.q*")} \
    -comment {filters are converged into the interrupt status registers. Each bit is independent}

--- a/hw/top_earlgrey/cdc/cdc_waivers.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.tcl
@@ -11,13 +11,16 @@
 #   -comment {}
 # set_rule_status -rule { S_CONF_ENV } -status { Waived } -all_rule_data \
 #   -comment {}
+
+
 # Assumes modules defined in run-cdc.tcl
-if {[info exists $modules] == 0} {
-  puts "modules variable is not defined."
-} else {
-  foreach mod $modules {
-    if {[file exists "cdc_waivers.$mod.tcl"]} {
-      source "cdc_waivers.$mod.tcl"
-    }
+
+if {[info exists modules] == 0} {
+  error "modules variable does not exist!" 99
+}
+
+foreach mod $modules {
+  if {[file exists $CDC_WAIVER_DIR/cdc_waivers.$mod.tcl]} {
+    source $CDC_WAIVER_DIR/cdc_waivers.$mod.tcl
   }
 }


### PR DESCRIPTION
[cdc] Split waived errors
    
    Generating `vcdc.waived.rpt` for waived violations and excluding the
    waived violations from the module reports.

[cdc] Working version of CDC waivers
    
    * Waiver should not have spaces between the status braces.
      changed to `-status {Waived}`
    
    * `[info exists ...]` should use variable name not the value of variable
      changed to `[info exists modules]` in `cdc_waivers.tcl`
    
    * waiver directory is used to source individual waiver files.
      defined `CDC_WAIVER_DIR`