### PR TITLE
[usbdev, pinmux] Add exclusions

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -310,7 +310,7 @@
                   ]
                   // Random writes to this field may result in pad drive conflicts,
                   // which in turn leads to propagating Xes and assertion failures.
-                  tags: ["excl:CsrNonInitTests:CsrExclWrite"]
+                  tags: ["excl:CsrAllTests:CsrExclWrite"]
                 }
     },
 

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -755,6 +755,8 @@
                 0: Outputs are controlled by the hardware block.
                 1: Outputs are controlled with this register.
                 '''
+          tags: [// Prevent random csr tests from driving conflicting values into the chip
+                 "excl:CsrNonInitTests:CsrExclWrite"]
         }
       ]
     }

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -306,7 +306,7 @@
                   ]
                   // Random writes to this field may result in pad drive conflicts,
                   // which in turn leads to propagating Xes and assertion failures.
-                  tags: ["excl:CsrNonInitTests:CsrExclWrite"]
+                  tags: ["excl:CsrAllTests:CsrExclWrite"]
                 }
     },
 


### PR DESCRIPTION
- add exclusions to prevent pad x propagation in foundry

Signed-off-by: Timothy Chen <timothytim@google.com>