### PR TITLE
[fpv/prim_count] Inject fault to ensure counter errors are hit

### DIFF
--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -4,4 +4,10 @@
 {
   sub_flow:    fpv
   import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_formal_cfg.hjson"]
+  stopats: ""
+
+  // Optional vars that need to exported to the env
+  exports: [
+    {STOPATS: '{stopats}'}
+  ]
 }

--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -31,6 +31,10 @@ if {$env(DUT_TOP) == "prim_count_tb"} {
   elaborate -top $env(DUT_TOP) -enable_sva_isunknown -disable_auto_bbox
 }
 
+if {$env(STOPATS) ne ""} {
+  stopat -env $env(STOPATS)
+}
+
 #-------------------------------------------------------------------------
 # specify clock(s) and reset(s)
 #-------------------------------------------------------------------------

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -89,6 +89,66 @@
                cov: false
              }
              {
+               name: prim_dup_up_count_stopat_cnt0_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 0", "-define CntStyle DupCnt"]
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
+               cov: false
+               stopats: "*.up_cnt_q[0]"
+             }
+             {
+               name: prim_dup_up_count_stopat_cnt1_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 0", "-define CntStyle DupCnt"]
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
+               cov: false
+               stopats: "*.up_cnt_q[1]"
+             }
+             {
+               name: prim_cross_up_count_stopat_upcnt_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 0",  "-define CntStyle CrossCnt"]
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
+               cov: false
+               stopats: "*.up_cnt_q[0]"
+             }
+             {
+               name: prim_cross_up_count_stopat_downcnt_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 0",  "-define CntStyle CrossCnt"]
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
+               cov: false
+               stopats: "*.down_cnt"
+             }
+             {
+               name: prim_cross_down_count_stopat_upcnt_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 1", "-define CntStyle CrossCnt"]
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
+               stopats: "*.up_cnt_q[0]"
+               cov: false
+             }
+             {
+               name: prim_cross_down_count_stopat_downcnt_fpv
+               dut: prim_count_tb
+               fusesoc_core: lowrisc:fpv:prim_count_fpv
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               build_opts: ["-define OutSelDnCnt 1", "-define CntStyle CrossCnt"]
+               rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
+               stopats: "*.down_cnt"
+               cov: false
+             }
+             {
                name: prim_lfsr_fpv
                dut: prim_lfsr_tb
                fusesoc_core: lowrisc:fpv:prim_lfsr_fpv


### PR DESCRIPTION
This PR injects errors by inserting stopat to make sure the counters hit
proper error assertions.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>