### PR TITLE
[openocd] Add CW310 support

### DIFF
--- a/util/openocd/board/lowrisc-earlgrey-cw310.cfg
+++ b/util/openocd/board/lowrisc-earlgrey-cw310.cfg
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Board configuration file: the Earl Grey chip on a Nexys Video FPGA board
+
+source [find interface/bergen-mpsse.cfg]
+source [find target/lowrisc-earlgrey.cfg]
+
+# FIXME: use srst and trst
+reset_config none

--- a/util/openocd/interface/bergen-mpsse.cfg
+++ b/util/openocd/interface/bergen-mpsse.cfg
@@ -1,0 +1,28 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Interface configuration for JTAG on the CW310 Board via on-board
+
+# adapter speed
+# Doesn't matter what you say here, hardware ignores it
+adapter_khz 500
+
+adapter driver ftdi
+transport select jtag
+
+ftdi_vid_pid 0x2b3e 0xc310
+
+# Channel 1 specified on CW
+ftdi_channel 1
+
+# Following forces nRST to '1'
+ftdi_layout_init 0x0078 0x00fb
+
+# Following allows nRST to be controlled by on-board pushbutton
+#ftdi_layout_init 0x0078 0x00eb
+
+# TAP reset (nTRST)
+ftdi_layout_signal nTRST -ndata 0x0010 -oe 0x0010
+
+ftdi_layout_signal sRST -ndata 0x0020 -oe 0x0020


### PR DESCRIPTION
This adds the required files as described in #8739 to allow the CW310 to work with openocd.

Signed-off-by: Colin O'Flynn <coflynn@newae.com>