### PR TITLE
[sw/silicon_creator] Harden boot_data read functions

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -259,9 +259,9 @@ static rom_error_t boot_data_entry_invalidate(flash_ctrl_info_page_t page,
 
 /**
  * A struct that stores some information about the first empty and last valid
- * entries in a flash info page.
+ * entries in the active flash info page.
  */
-typedef struct boot_data_page_info {
+typedef struct active_page_info {
   /**
    * Info page.
    */
@@ -282,31 +282,33 @@ typedef struct boot_data_page_info {
    * Index of the last valid entry in the page.
    */
   size_t last_valid_index;
-  /**
-   * Last valid entry in the page.
-   */
-  boot_data_t last_valid_entry;
-} boot_data_page_info_t;
+} active_page_info_t;
 
 /**
- * Populates a page info struct for the given page.
+ * Updates the given active page info struct and last valid boot data entry
+ * using the given page.
  *
  * This function performs a forward search to find the first empty boot data
  * entry followed by a backward search to find the last valid boot data entry.
- * Reads must be enabled for the given page before this function is called, see
- * `boot_data_page_info_get()`.
+ * If the page has an entry that is newer than the one passed in, this function
+ * updates `page_info` and `boot_data`. Reads must be enabled for the given page
+ * before this function is called, see `boot_data_page_info_get()`.
  *
  * @param page A boot data page.
- * @param[out] page_info Page info struct for the given page.
+ * @param[in,out] page_info Active page info struct. Updated if the given page
+ * has a newer entry.
+ * @param[in,out] boot_data Last valid boot data entry found so far. Updated if
+ * the given page has a newer entry.
  * @return The result of the operation.
  */
-static rom_error_t boot_data_page_info_get_impl(
-    flash_ctrl_info_page_t page, boot_data_page_info_t *page_info) {
+static rom_error_t boot_data_page_info_update_impl(
+    flash_ctrl_info_page_t page, active_page_info_t *page_info,
+    boot_data_t *boot_data) {
   uint32_t sniff_results[kBootDataEntriesPerPage];
 
-  page_info->page = page;
-  page_info->has_empty_entry = kHardenedBoolFalse;
-  page_info->has_valid_entry = kHardenedBoolFalse;
+  boot_data_t buf;
+  size_t first_empty_index = kBootDataEntriesPerPage;
+  hardened_bool_t has_empty_entry = kHardenedBoolFalse;
 
   // Perform a forward search to find the first empty entry.
   for (size_t i = 0; i < kBootDataEntriesPerPage; ++i) {
@@ -315,31 +317,47 @@ static rom_error_t boot_data_page_info_get_impl(
     RETURN_IF_ERROR(boot_data_sniff(page, i, &sniff_results[i]));
     // Check all words of this entry only if it can be empty.
     if (sniff_results[i] == kBootDataEmptyWordValue) {
-      RETURN_IF_ERROR(
-          boot_data_entry_read(page, i, &page_info->last_valid_entry));
-      if (boot_data_is_empty(&page_info->last_valid_entry) ==
-          kHardenedBoolTrue) {
-        page_info->first_empty_index = i;
-        page_info->has_empty_entry = kHardenedBoolTrue;
+      RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
+      if (boot_data_is_empty(&buf) == kHardenedBoolTrue) {
+        first_empty_index = i;
+        has_empty_entry = kHardenedBoolTrue;
         break;
       }
     }
   }
 
   // Perform a backward search to find the last valid entry.
-  size_t start_index = (page_info->has_empty_entry == kHardenedBoolTrue)
-                           ? page_info->first_empty_index - 1
+  hardened_bool_t has_valid_entry = kHardenedBoolFalse;
+  size_t last_valid_index = kBootDataEntriesPerPage;
+  size_t start_index = (has_empty_entry == kHardenedBoolTrue)
+                           ? first_empty_index - 1
                            : kBootDataEntriesPerPage - 1;
   for (size_t i = start_index; i < kBootDataEntriesPerPage; --i) {
     // Check the digest only if this entry can be valid.
     if (sniff_results[i] == kBootDataIdentifier) {
-      RETURN_IF_ERROR(
-          boot_data_entry_read(page, i, &page_info->last_valid_entry));
-      if (boot_data_check(&page_info->last_valid_entry) == kErrorOk) {
-        page_info->last_valid_index = i;
-        page_info->has_valid_entry = kHardenedBoolTrue;
+      RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
+      if (boot_data_check(&buf) == kErrorOk) {
+        has_valid_entry = kHardenedBoolTrue;
+        last_valid_index = i;
         break;
       }
+    }
+  }
+
+  // Update `page_info` and `boot_data` if an entry has not been found yet
+  // or if this entry is newer.
+  if (has_valid_entry == kHardenedBoolTrue) {
+    if (page_info->has_valid_entry == kHardenedBoolFalse ||
+        (page_info->has_valid_entry == kHardenedBoolTrue &&
+         buf.counter > boot_data->counter)) {
+      *page_info = (active_page_info_t){
+          .page = page,
+          .has_empty_entry = has_empty_entry,
+          .first_empty_index = first_empty_index,
+          .has_valid_entry = has_valid_entry,
+          .last_valid_index = last_valid_index,
+      };
+      *boot_data = buf;
     }
   }
 
@@ -347,23 +365,29 @@ static rom_error_t boot_data_page_info_get_impl(
 }
 
 /**
- * Handles read permissions and populates a page info struct for the given page.
+ * Handles read permissions and updates the active page info struct and last
+ * valid boot data entry using the given page.
  *
  * This function wraps the actual implementation to enable and disable reads for
  * the given page, see `boot_data_page_info_get_impl()`.
  *
  * @param page A boot data page.
- * @param[out] page_info Page info struct for the given page.
+ * @param[in,out] page_info Active page info struct. Updated if the given page
+ * has a newer entry.
+ * @param[in,out] boot_data Last valid boot data entry found so far. Updated if
+ * the given page has a newer entry.
  * @return The result of the operation.
  */
-static rom_error_t boot_data_page_info_get(flash_ctrl_info_page_t page,
-                                           boot_data_page_info_t *page_info) {
+static rom_error_t boot_data_page_info_update(flash_ctrl_info_page_t page,
+                                              active_page_info_t *page_info,
+                                              boot_data_t *boot_data) {
   flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
                                       .read = kHardenedBoolTrue,
                                       .write = kHardenedBoolFalse,
                                       .erase = kHardenedBoolFalse,
                                   });
-  rom_error_t error = boot_data_page_info_get_impl(page, page_info);
+  rom_error_t error =
+      boot_data_page_info_update_impl(page, page_info, boot_data);
   flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
                                       .read = kHardenedBoolFalse,
                                       .write = kHardenedBoolFalse,
@@ -373,42 +397,32 @@ static rom_error_t boot_data_page_info_get(flash_ctrl_info_page_t page,
 }
 
 /**
- * Finds the active info page and returns its page info struct.
+ * Finds the active info page and returns its page info struct and last boot
+ * data entry.
  *
  * The active info page is the one that has the newest valid boot data entry,
  * i.e. the entry with the greatest counter value.
  *
  * @param[out] page_info Page info struct of the active info page.
+ * @param[out] boot_data Last valid boot data entry.
  * @return The result of the operation.
  */
-static rom_error_t boot_data_active_page_find(
-    boot_data_page_info_t *page_info) {
-  boot_data_page_info_t page_infos[2];
+static rom_error_t boot_data_active_page_find(active_page_info_t *page_info,
+                                              boot_data_t *boot_data) {
+  *page_info = (active_page_info_t){
+      .page = (flash_ctrl_info_page_t)0,
+      .has_empty_entry = kHardenedBoolFalse,
+      .first_empty_index = kBootDataEntriesPerPage,
+      .has_valid_entry = kHardenedBoolFalse,
+      .last_valid_index = kBootDataEntriesPerPage,
+  };
+
   for (size_t i = 0; i < ARRAYSIZE(kPages); ++i) {
-    RETURN_IF_ERROR(boot_data_page_info_get(kPages[i], &page_infos[i]));
+    RETURN_IF_ERROR(
+        boot_data_page_info_update(kPages[i], page_info, boot_data));
   }
 
-  if (page_infos[0].has_valid_entry == kHardenedBoolTrue &&
-      page_infos[1].has_valid_entry == kHardenedBoolTrue) {
-    if (page_infos[0].last_valid_entry.counter >
-        page_infos[1].last_valid_entry.counter) {
-      *page_info = page_infos[0];
-      return kErrorOk;
-    } else if (page_infos[1].last_valid_entry.counter >
-               page_infos[0].last_valid_entry.counter) {
-      *page_info = page_infos[1];
-      return kErrorOk;
-    } else {
-      return kErrorBootDataNotFound;
-    }
-  } else if (page_infos[0].has_valid_entry == kHardenedBoolTrue) {
-    *page_info = page_infos[0];
-    return kErrorOk;
-  } else if (page_infos[1].has_valid_entry == kHardenedBoolTrue) {
-    *page_info = page_infos[1];
-    return kErrorOk;
-  }
-  return kErrorBootDataNotFound;
+  return kErrorOk;
 }
 
 /**
@@ -464,17 +478,14 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
 }
 
 rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data) {
-  boot_data_page_info_t active_page;
-  rom_error_t error = boot_data_active_page_find(&active_page);
-  switch (error) {
-    case kErrorOk:
-      *boot_data = active_page.last_valid_entry;
+  active_page_info_t active_page;
+  RETURN_IF_ERROR(boot_data_active_page_find(&active_page, boot_data));
+  switch (active_page.has_valid_entry) {
+    case kHardenedBoolTrue:
       return kErrorOk;
-    case kErrorBootDataNotFound:
+    case kHardenedBoolFalse:
       // TODO(#8779): Recovery paths for failures in prod life cycle states?
       return boot_data_default_get(lc_state, boot_data);
-    default:
-      return error;
   }
 }
 
@@ -482,13 +493,14 @@ rom_error_t boot_data_write(const boot_data_t *boot_data) {
   boot_data_t new_entry = *boot_data;
   new_entry.is_valid = kBootDataValidEntry;
   new_entry.identifier = kBootDataIdentifier;
-  boot_data_page_info_t active_page;
-  rom_error_t error = boot_data_active_page_find(&active_page);
+  active_page_info_t active_page;
+  boot_data_t last_entry;
+  RETURN_IF_ERROR(boot_data_active_page_find(&active_page, &last_entry));
 
-  if (error == kErrorOk) {
+  if (active_page.has_valid_entry == kHardenedBoolTrue) {
     // Note: Not checking for wraparound since a successful write will
     // invalidate the old entry.
-    new_entry.counter = active_page.last_valid_entry.counter + 1;
+    new_entry.counter = last_entry.counter + 1;
     boot_data_digest_compute(&new_entry, &new_entry.digest);
     if (active_page.has_empty_entry == kHardenedBoolTrue) {
       RETURN_IF_ERROR(boot_data_entry_write(active_page.page,
@@ -506,15 +518,13 @@ rom_error_t boot_data_write(const boot_data_t *boot_data) {
     // across both pages.
     RETURN_IF_ERROR(boot_data_entry_invalidate(active_page.page,
                                                active_page.last_valid_index));
-  } else if (error == kErrorBootDataNotFound) {
+  } else {
     // Erase the first page and write the entry there if the active page cannot
     // be found, i.e. the storage is not initialized yet.
     new_entry.counter = kBootDataDefault.counter + 1;
     boot_data_digest_compute(&new_entry, &new_entry.digest);
     RETURN_IF_ERROR(
         boot_data_entry_write(kPages[0], 0, &new_entry, kHardenedBoolTrue));
-  } else {
-    return error;
   }
 
   return kErrorOk;

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -123,7 +123,7 @@ static rom_error_t boot_data_sniff(flash_ctrl_info_page_t page, size_t index,
   *masked_identifier = 0;
   uint32_t buf[3];
   const uint32_t offset = index * sizeof(boot_data_t) + kIsValidOffset;
-  RETURN_IF_ERROR(flash_ctrl_info_read(page, offset, 3, buf));
+  HARDENED_RETURN_IF_ERROR(flash_ctrl_info_read(page, offset, 3, buf));
   *masked_identifier = buf[0] & buf[1] & buf[2];
   return kErrorOk;
 }
@@ -316,57 +316,86 @@ static rom_error_t boot_data_page_info_update_impl(
   uint32_t sniff_results[kBootDataEntriesPerPage];
 
   boot_data_t buf;
-  size_t first_empty_index = kBootDataEntriesPerPage;
-  hardened_bool_t has_empty_entry = kHardenedBoolFalse;
 
   // Perform a forward search to find the first empty entry.
-  for (size_t i = 0; i < kBootDataEntriesPerPage; ++i) {
+  hardened_bool_t has_empty_entry = kHardenedBoolFalse;
+  size_t i = 0;
+  for (; launder32(i) < kBootDataEntriesPerPage; ++i) {
     // Read and cache the identifier to quickly determine if an entry can be
     // empty or valid.
-    RETURN_IF_ERROR(boot_data_sniff(page, i, &sniff_results[i]));
+    HARDENED_RETURN_IF_ERROR(boot_data_sniff(page, i, &sniff_results[i]));
     // Check all words of this entry only if it can be empty.
     if (sniff_results[i] == kBootDataEmptyWordValue) {
-      RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
-      if (boot_data_is_empty(&buf) == kHardenedBoolTrue) {
-        first_empty_index = i;
-        has_empty_entry = kHardenedBoolTrue;
+      HARDENED_RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
+      has_empty_entry = boot_data_is_empty(&buf);
+      if (launder32(has_empty_entry) == kHardenedBoolTrue) {
+        HARDENED_CHECK_EQ(has_empty_entry, kHardenedBoolTrue);
         break;
       }
+      HARDENED_CHECK_EQ(has_empty_entry, kHardenedBoolFalse);
     }
   }
+  // At the end of this loop, `i` is the index of the first empty entry if any
+  // and `kBootDataEntriesPerPage` otherwise.
+  HARDENED_CHECK_LE(i, kBootDataEntriesPerPage);
+  size_t first_empty_index = i;
 
   // Perform a backward search to find the last valid entry.
   hardened_bool_t has_valid_entry = kHardenedBoolFalse;
-  size_t last_valid_index = kBootDataEntriesPerPage;
-  size_t start_index = (has_empty_entry == kHardenedBoolTrue)
-                           ? first_empty_index - 1
-                           : kBootDataEntriesPerPage - 1;
-  for (size_t i = start_index; i < kBootDataEntriesPerPage; --i) {
+  i = first_empty_index - 1;
+  size_t j = 0;
+  for (; launder32(i) < first_empty_index && launder32(j) < first_empty_index;
+       --i, ++j) {
     // Check the digest only if this entry can be valid.
     if (sniff_results[i] == kBootDataIdentifier) {
-      RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
-      if (boot_data_check(&buf) == kErrorOk) {
-        has_valid_entry = kHardenedBoolTrue;
-        last_valid_index = i;
+      HARDENED_RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
+      rom_error_t is_valid = boot_data_check(&buf);
+      if (launder32(is_valid) == kErrorOk) {
+        HARDENED_CHECK_EQ(is_valid, kErrorOk);
+        static_assert(kErrorOk == (rom_error_t)kHardenedBoolTrue,
+                      "kErrorOk must be equal to kHardenedBoolTrue");
+        has_valid_entry = (hardened_bool_t)is_valid;
         break;
       }
+      HARDENED_CHECK_EQ(is_valid, kErrorBootDataInvalid);
     }
   }
+  // At the end of this loop, `i` is the index of the last valid entry if any
+  // and `UINT32_MAX`, otherwise. `j` must be less than or equal to
+  // `first_empty_index`.
+  HARDENED_CHECK_LE(j, first_empty_index);
 
-  // Update `page_info` and `boot_data` if an entry has not been found yet
-  // or if this entry is newer.
-  if (has_valid_entry == kHardenedBoolTrue) {
-    if (page_info->has_valid_entry == kHardenedBoolFalse ||
-        (page_info->has_valid_entry == kHardenedBoolTrue &&
-         buf.counter > boot_data->counter)) {
+  if (launder32(has_valid_entry) == kHardenedBoolTrue) {
+    HARDENED_CHECK_EQ(has_valid_entry, kHardenedBoolTrue);
+    if (launder32(page_info->has_valid_entry) == kHardenedBoolFalse) {
+      // Update `page_info` and `boot_data` since this is the first valid entry.
+      HARDENED_CHECK_EQ(page_info->has_valid_entry, kHardenedBoolFalse);
       *page_info = (active_page_info_t){
           .page = page,
           .has_empty_entry = has_empty_entry,
           .first_empty_index = first_empty_index,
           .has_valid_entry = has_valid_entry,
-          .last_valid_index = last_valid_index,
+          .last_valid_index = i,
       };
       *boot_data = buf;
+    } else if (launder32(page_info->has_valid_entry) == kHardenedBoolTrue &&
+               launder32(buf.counter) > boot_data->counter) {
+      // Update `page_info` and `boot_data` since this entry is newer.
+      HARDENED_CHECK_EQ(page_info->has_valid_entry, kHardenedBoolTrue);
+      HARDENED_CHECK_GT(buf.counter, boot_data->counter);
+      *page_info = (active_page_info_t){
+          .page = page,
+          .has_empty_entry = has_empty_entry,
+          .first_empty_index = first_empty_index,
+          .has_valid_entry = has_valid_entry,
+          .last_valid_index = i,
+      };
+      *boot_data = buf;
+    } else {
+      HARDENED_CHECK_EQ(page_info->has_valid_entry, kHardenedBoolTrue);
+      // Counters cannot be equal if we have two valid entries since they are
+      // incremented at each write.
+      HARDENED_CHECK_LT(buf.counter, boot_data->counter);
     }
   }
 
@@ -426,10 +455,12 @@ static rom_error_t boot_data_active_page_find(active_page_info_t *page_info,
       .last_valid_index = kBootDataEntriesPerPage,
   };
 
-  for (size_t i = 0; i < ARRAYSIZE(kPages); ++i) {
-    RETURN_IF_ERROR(
+  size_t i = 0;
+  for (; launder32(i) < ARRAYSIZE(kPages); ++i) {
+    HARDENED_RETURN_IF_ERROR(
         boot_data_page_info_update(kPages[i], page_info, boot_data));
   }
+  HARDENED_CHECK_EQ(i, ARRAYSIZE(kPages));
 
   return kErrorOk;
 }

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -72,13 +72,22 @@ static void boot_data_digest_compute(const void *boot_data,
  * @return Whether the entry is empty.
  */
 static hardened_bool_t boot_data_is_empty(const void *boot_data) {
-  for (size_t i = 0; i < kBootDataNumWords; ++i) {
-    if (read_32(boot_data) != kBootDataEmptyWordValue) {
-      return kHardenedBoolFalse;
-    }
+  static_assert(kBootDataEmptyWordValue == UINT32_MAX,
+                "kBootDataEmptyWordValue must be UINT32_MAX");
+  size_t i = 0;
+  hardened_bool_t is_empty = kHardenedBoolTrue;
+  uint32_t res = kBootDataEmptyWordValue;
+  for (; launder32(i) < kBootDataNumWords; ++i) {
+    res &= read_32(boot_data);
+    is_empty &= read_32(boot_data);
     boot_data = (char *)boot_data + sizeof(uint32_t);
   }
-  return kHardenedBoolTrue;
+  HARDENED_CHECK_EQ(i, kBootDataNumWords);
+  if (launder32(res) == kBootDataEmptyWordValue) {
+    HARDENED_CHECK_EQ(res, kBootDataEmptyWordValue);
+    return is_empty;
+  }
+  return kHardenedBoolFalse;
 }
 
 /**

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -479,13 +479,17 @@ static rom_error_t boot_data_default_get(lifecycle_state_t lc_state,
 
 rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data) {
   active_page_info_t active_page;
-  RETURN_IF_ERROR(boot_data_active_page_find(&active_page, boot_data));
-  switch (active_page.has_valid_entry) {
+  HARDENED_RETURN_IF_ERROR(boot_data_active_page_find(&active_page, boot_data));
+  switch (launder32(active_page.has_valid_entry)) {
     case kHardenedBoolTrue:
+      HARDENED_CHECK_EQ(active_page.has_valid_entry, kHardenedBoolTrue);
       return kErrorOk;
     case kHardenedBoolFalse:
+      HARDENED_CHECK_EQ(active_page.has_valid_entry, kHardenedBoolFalse);
       // TODO(#8779): Recovery paths for failures in prod life cycle states?
       return boot_data_default_get(lc_state, boot_data);
+    default:
+      HARDENED_UNREACHABLE();
   }
 }
 

--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -472,8 +472,7 @@ rom_error_t boot_data_read(lifecycle_state_t lc_state, boot_data_t *boot_data) {
       return kErrorOk;
     case kErrorBootDataNotFound:
       // TODO(#8779): Recovery paths for failures in prod life cycle states?
-      RETURN_IF_ERROR(boot_data_default_get(lc_state, boot_data));
-      return kErrorOk;
+      return boot_data_default_get(lc_state, boot_data);
     default:
       return error;
   }


### PR DESCRIPTION
This PR hardens boot_data read functions, i.e. boot_data functions that are used in mask rom.

The second commit moves the `last_valid_entry` field out of the page info struct and updates `boot_data_page_info_get_impl()` to eliminate a struct copy. Thus, the changes in this PR actually slightly improve the performance according to the cycle count from `boot_data_functest` (~9000 -> ~8000).

Please see the individual commits for more details.