### PR TITLE
[fpv/script] Mark unreachable as failures

### DIFF
--- a/hw/formal/tools/jaspergold/parse-formal-report.py
+++ b/hw/formal/tools/jaspergold/parse-formal-report.py
@@ -76,7 +76,8 @@ def get_summary(str_buffer):
     summary = extract_messages_count(str_buffer, message_patterns)
 
     summary["pass_rate"] = format_percentage(summary["proven"],
-                                             summary["cex"] + summary["undetermined"])
+                                             summary["cex"] + summary["undetermined"] +
+                                             summary["unreachable"])
     summary["cov_rate"] = format_percentage(summary["covered"], summary["unreachable"])
 
     return summary


### PR DESCRIPTION
Previously `unreachables` are marked as failure only in `cov_rate`.
However, certain assertions can be unreachabled, and we should
categorize that as failure.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>