### PR TITLE
[mask_rom] Configure watchdog using OTP value

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -417,6 +417,18 @@
       default: "64",
       local: "true"
     },
+    { name: "RomWatchdogBiteThresholdCyclesOffset",
+      desc: "Offset of ROM_WATCHDOG_BITE_THRESHOLD_CYCLES",
+      type: "int",
+      default: "1364",
+      local: "true"
+    },
+    { name: "RomWatchdogBiteThresholdCyclesSize",
+      desc: "Size of ROM_WATCHDOG_BITE_THRESHOLD_CYCLES",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
     { name: "OwnerSwCfgDigestOffset",
       desc: "Offset of OWNER_SW_CFG_DIGEST",
       type: "int",

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -204,6 +204,10 @@
                     name: "ROM_ALERT_PHASE_CYCLES",
                     size: "64"
                 }
+                {
+                    name: "ROM_WATCHDOG_BITE_THRESHOLD_CYCLES",
+                    size: "4"
+                }
             ],
             desc: '''Software configuration partition for
             data that changes software behavior, specifically

--- a/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
+++ b/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
@@ -26,6 +26,7 @@ It has been generated with ./util/design/gen-otp-mmap.py
 |         |                |            |      32bit       |                ROM_ALERT_ACCUM_THRESH                 |     0x4F4      |     16     |
 |         |                |            |      32bit       |               ROM_ALERT_TIMEOUT_CYCLES                |     0x504      |     16     |
 |         |                |            |      32bit       |                ROM_ALERT_PHASE_CYCLES                 |     0x514      |     64     |
+|         |                |            |      32bit       |          ROM_WATCHDOG_BITE_THRESHOLD_CYCLES           |     0x554      |     4      |
 |         |                |            |      64bit       |   [OWNER_SW_CFG_DIGEST](#Reg_owner_sw_cfg_digest_0)   |     0x678      |     8      |
 |    3    |     HW_CFG     |     80     |      32bit       |                       DEVICE_ID                       |     0x680      |     32     |
 |         |                |            |      32bit       |                      MANUF_STATE                      |     0x6A0      |     32     |

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -306,7 +306,8 @@ package otp_ctrl_part_pkg;
     }),
     6400'({
       64'h39EB436F1D5AF2D7,
-      2336'h0, // unallocated space
+      2304'h0, // unallocated space
+      32'h0,
       512'h0,
       128'h0,
       128'h0,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -63,6 +63,8 @@ package otp_ctrl_reg_pkg;
   parameter int RomAlertTimeoutCyclesSize = 16;
   parameter int RomAlertPhaseCyclesOffset = 1300;
   parameter int RomAlertPhaseCyclesSize = 64;
+  parameter int RomWatchdogBiteThresholdCyclesOffset = 1364;
+  parameter int RomWatchdogBiteThresholdCyclesSize = 4;
   parameter int OwnerSwCfgDigestOffset = 1656;
   parameter int OwnerSwCfgDigestSize = 8;
   parameter int HwCfgOffset = 1664;

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -517,21 +517,31 @@ cc_library(
     hdrs = ["watchdog.h"],
     deps = [
         "//hw/ip/aon_timer/data:aon_timer_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/ip/pwrmgr/data/autogen:pwrmgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
 )
 
 cc_test(
     name = "watchdog_unittest",
     srcs = ["watchdog_unittest.cc"],
+    defines = [
+        "OT_OFF_TARGET_TEST",
+    ],
     deps = [
         ":watchdog",
         "//hw/ip/aon_timer/data:aon_timer_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
+        "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "//sw/device/silicon_creator/lib/drivers:mock_otp",
         "@googletest//:gtest_main",
     ],
 )
@@ -550,5 +560,6 @@ opentitan_functest(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:test_main",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -448,12 +448,15 @@ sw_silicon_creator_lib_driver_watchdog = declare_dependency(
     'sw_silicon_creator_lib_driver_watchdog',
     sources: [
       hw_ip_aon_timer_reg_h,
+      hw_ip_otp_ctrl_reg_h,
       hw_ip_pwrmgr_reg_h,
       'watchdog.c',
     ],
     dependencies: [
       sw_lib_mmio,
-      sw_lib_abs_mmio,
+      sw_silicon_creator_lib_base_sec_mmio,
+      sw_silicon_creator_lib_driver_lifecycle,
+      sw_silicon_creator_lib_driver_otp,
     ],
   ),
 )
@@ -463,16 +466,17 @@ test('sw_silicon_creator_lib_driver_watchdog_unittest', executable(
     sources: [
       'watchdog_unittest.cc',
       hw_ip_aon_timer_reg_h,
+      hw_ip_otp_ctrl_reg_h,
       hw_ip_pwrmgr_reg_h,
       'watchdog.c',
     ],
     dependencies: [
       sw_vendor_gtest,
-      sw_silicon_creator_lib_base_mock_abs_mmio,
+      sw_silicon_creator_lib_base_mock_sec_mmio,
     ],
     native: true,
-    c_args: ['-DMOCK_ABS_MMIO'],
-    cpp_args: ['-DMOCK_ABS_MMIO'],
+    c_args: ['-DMOCK_ABS_MMIO', '-DOT_OFF_TARGET_TEST'],
+    cpp_args: ['-DMOCK_ABS_MMIO', '-DOT_OFF_TARGET_TEST'],
   ),
   suite: 'mask_rom',
 )

--- a/sw/device/silicon_creator/lib/drivers/watchdog.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog.c
@@ -5,42 +5,80 @@
 #include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 
 #include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
 
 #include "aon_timer_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
 #include "pwrmgr_regs.h"
 
 enum {
   kBase = TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR,
   kPwrMgrBase = TOP_EARLGREY_PWRMGR_AON_BASE_ADDR,
-  // The AON domain is always clocked at 200 Hz.
-  // TODO(lowRISC/opentitan#7385): update this after the AON frequency is
-  // formally defined in the project.
-  kAonTimerRate = 200000,
+
+  kCtrlEnable = 1 << AON_TIMER_WDOG_CTRL_ENABLE_BIT,
+  kCtrlDisable = 0 << AON_TIMER_WDOG_CTRL_ENABLE_BIT,
 };
 
-void watchdog_init(uint32_t timeout_ms) {
+void watchdog_init(lifecycle_state_t lc_state) {
+  // Disable the watchdog bite when in test and RMA lifecycle states.
+  hardened_bool_t enable = kHardenedBoolTrue;
+  switch (lc_state) {
+    case kLcStateTest:
+      enable = kHardenedBoolFalse;
+      HARDENED_CHECK_EQ(lc_state, kLcStateTest);
+      break;
+    case kLcStateRma:
+      enable = kHardenedBoolFalse;
+      HARDENED_CHECK_EQ(lc_state, kLcStateRma);
+      break;
+    default:
+      break;
+  }
+
+  uint32_t threshold =
+      otp_read32(OTP_CTRL_PARAM_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES_OFFSET);
+  watchdog_configure(threshold, enable);
+}
+
+void watchdog_configure(uint32_t threshold, hardened_bool_t enable) {
   // Tell pwrmgr we want watchdog reset events to reset the chip.
-  abs_mmio_write32(
+  sec_mmio_write32(
       kPwrMgrBase + PWRMGR_RESET_EN_REG_OFFSET,
       bitfield_bit32_write(
           0, kTopEarlgreyPowerManagerResetRequestsAonTimerAonAonTimerRstReq,
           true));
   abs_mmio_write32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
 
-  // Disable the watchdog before reconfiguring it.
-  abs_mmio_write32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET, 0);
-  abs_mmio_write32(kBase + AON_TIMER_WKUP_CTRL_REG_OFFSET, 0);
-  // Configure the watchdog to bite at the requested timeout.
-  abs_mmio_write32(kBase + AON_TIMER_WKUP_COUNT_REG_OFFSET, 0);
+  // Set the watchdog bite and bark thresholds.
+  sec_mmio_write32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET, kCtrlDisable);
   abs_mmio_write32(kBase + AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
-  abs_mmio_write32(kBase + AON_TIMER_WKUP_THOLD_REG_OFFSET, UINT32_MAX);
   abs_mmio_write32(kBase + AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET, UINT32_MAX);
-  abs_mmio_write32(kBase + AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET,
-                   timeout_ms * (kAonTimerRate / 1000));
-  if (timeout_ms) {
-    abs_mmio_write32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET, 1);
+  sec_mmio_write32(kBase + AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET, threshold);
+
+  // Enable or disable the watchdog as requested.
+  uint32_t ctrl = kCtrlEnable;
+  if (enable == kHardenedBoolFalse) {
+    ctrl = kCtrlDisable;
+    HARDENED_CHECK_EQ(enable, kHardenedBoolFalse);
   }
+  sec_mmio_write32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET, ctrl);
+
+  // Read back the control register to ensure it was set as expected.
+  if ((abs_mmio_read32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET) & kCtrlEnable) !=
+      kCtrlEnable) {
+    HARDENED_CHECK_EQ(enable, kHardenedBoolFalse);
+  }
+
+  // Redundantly re-request the pwrmgr configuration sync since it isn't
+  // possible to use sec_mmio for it.
+  abs_mmio_write32(kPwrMgrBase + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+}
+
+void watchdog_disable(void) {
+  sec_mmio_write32(kBase + AON_TIMER_WDOG_CTRL_REG_OFFSET, kCtrlDisable);
 }
 
 void watchdog_pet(void) {

--- a/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
@@ -5,72 +5,93 @@
 #include "sw/device/silicon_creator/lib/drivers/watchdog.h"
 
 #include "gtest/gtest.h"
-#include "sw/device/lib/base/mmio.h"
 #include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 
 #include "aon_timer_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
 #include "pwrmgr_regs.h"
 
 namespace watchdog_unittest {
 namespace {
-
-constexpr uint32_t kAonTimerRate = 200000;
+using ::testing::Return;
 
 class WatchdogTest : public mask_rom_test::MaskRomTest {
  protected:
   uint32_t pwrmgr_ = TOP_EARLGREY_PWRMGR_AON_BASE_ADDR;
   uint32_t wdog_ = TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR;
-  mask_rom_test::MockAbsMmio mmio_;
+  mask_rom_test::MockAbsMmio abs_;
+  mask_rom_test::MockSecMmio sec_;
+  mask_rom_test::MockOtp otp_;
 };
 
-TEST_F(WatchdogTest, InitializeEnable) {
-  constexpr uint32_t kTimeoutMs = 100;
-  constexpr uint32_t kBiteThreshold = kTimeoutMs * (kAonTimerRate / 1000);
+TEST_F(WatchdogTest, InitializeNoOtp) {
+  constexpr std::array<lifecycle_state_t, 2> kLifecycleStates = {kLcStateTest,
+                                                                 kLcStateRma};
+  for (const auto lc : kLifecycleStates) {
+    const uint32_t kBiteThreshold = 0x12345678;
+    EXPECT_CALL(
+        otp_, read32(OTP_CTRL_PARAM_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES_OFFSET))
+        .WillOnce(Return(kBiteThreshold));
 
-  EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_RESET_EN_REG_OFFSET,
-                     {
-                         {PWRMGR_RESET_EN_EN_1_BIT, true},
-                     });
-  EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
-
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WKUP_CTRL_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WKUP_COUNT_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WKUP_THOLD_REG_OFFSET, 0xFFFFFFFF);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET, 0xFFFFFFFF);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET,
-                     kBiteThreshold);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET, 1);
-
-  watchdog_init(kTimeoutMs);
+    EXPECT_SEC_WRITE32(pwrmgr_ + PWRMGR_RESET_EN_REG_OFFSET,
+                       {
+                           {PWRMGR_RESET_EN_EN_1_BIT, true},
+                       });
+    EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                       0 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
+    EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
+    EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET,
+                       std::numeric_limits<uint32_t>::max());
+    EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET,
+                       kBiteThreshold);
+    EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                       0 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
+    EXPECT_ABS_READ32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                      0 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
+    EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    watchdog_init(lc);
+  }
 }
 
-TEST_F(WatchdogTest, InitializeDisable) {
-  // Using a timeout of zero as the argument to the initialization function
-  // disables the watchdog.
-  constexpr uint32_t kTimeoutMs = 0;
-  constexpr uint32_t kBiteThreshold = kTimeoutMs * (kAonTimerRate / 1000);
+TEST_F(WatchdogTest, InitializeOtp) {
+  constexpr std::array<lifecycle_state_t, 3> kLifecycleStates = {
+      kLcStateDev, kLcStateProd, kLcStateProdEnd};
+  for (const auto lc : kLifecycleStates) {
+    const uint32_t kBiteThreshold = 0x12345678;
+    EXPECT_CALL(
+        otp_, read32(OTP_CTRL_PARAM_ROM_WATCHDOG_BITE_THRESHOLD_CYCLES_OFFSET))
+        .WillOnce(Return(kBiteThreshold));
 
-  EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_RESET_EN_REG_OFFSET,
-                     {
-                         {PWRMGR_RESET_EN_EN_1_BIT, true},
-                     });
-  EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    EXPECT_SEC_WRITE32(pwrmgr_ + PWRMGR_RESET_EN_REG_OFFSET,
+                       {
+                           {PWRMGR_RESET_EN_EN_1_BIT, true},
+                       });
+    EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                       0 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
+    EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
+    EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET,
+                       std::numeric_limits<uint32_t>::max());
+    EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET,
+                       kBiteThreshold);
+    EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                       1 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
+    EXPECT_ABS_READ32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                      1 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
+    EXPECT_ABS_WRITE32(pwrmgr_ + PWRMGR_CFG_CDC_SYNC_REG_OFFSET, 1);
+    watchdog_init(lc);
+  }
+}
 
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WKUP_CTRL_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WKUP_COUNT_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_COUNT_REG_OFFSET, 0);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WKUP_THOLD_REG_OFFSET, 0xFFFFFFFF);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_BARK_THOLD_REG_OFFSET, 0xFFFFFFFF);
-  EXPECT_ABS_WRITE32(wdog_ + AON_TIMER_WDOG_BITE_THOLD_REG_OFFSET,
-                     kBiteThreshold);
-  // Initialization is identical in the disabled case except the last
-  // write to AON_TIMER_WKUP_CTRL_REG is omitted.
-
-  watchdog_init(kTimeoutMs);
+TEST_F(WatchdogTest, Disable) {
+  EXPECT_SEC_WRITE32(wdog_ + AON_TIMER_WDOG_CTRL_REG_OFFSET,
+                     0 << AON_TIMER_WDOG_CTRL_ENABLE_BIT);
+  watchdog_disable();
 }
 
 TEST_F(WatchdogTest, Pet) {

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -105,6 +105,7 @@ opentitan_binary(
         "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/lib/drivers:rstmgr",
         "//sw/device/silicon_creator/lib/drivers:uart",
+        "//sw/device/silicon_creator/lib/drivers:watchdog",
     ],
 )
 
@@ -188,6 +189,7 @@ cc_library(
         "//sw/device/lib/testing/test_rom:bootstrap",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:log",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:hmac",
     ],
 )

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -214,6 +214,7 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_lib_driver_rnd,
       sw_silicon_creator_lib_driver_rstmgr,
       sw_silicon_creator_lib_driver_uart,
+      sw_silicon_creator_lib_driver_watchdog,
       sw_silicon_creator_lib_fake_deps,
       sw_silicon_creator_lib_irq_asm,
       sw_silicon_creator_lib_manifest,

--- a/sw/device/silicon_creator/mask_rom/primitive_bootstrap.c
+++ b/sw/device/silicon_creator/mask_rom/primitive_bootstrap.c
@@ -13,6 +13,7 @@
 #include "sw/device/lib/dif/dif_spi_device.h"
 #include "sw/device/lib/flash_ctrl.h"
 #include "sw/device/lib/testing/test_rom/spiflash_frame.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/lib/log.h"


### PR DESCRIPTION
Configure the watchdog timer using an OTP value when in the DEV, PROD and PROD_END lifecycle states. Otherwise use a safe default value (currently 0xffffffff).