### PR TITLE
[dv] Add automatic covergroup for all regwen CSRs

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_lockable_field_cov.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_lockable_field_cov.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// coverage object of lockable CSR field and its regwen
+class dv_base_lockable_field_cov extends uvm_object;
+  // mirrored value of the lockable field, which is used to know if new value is written.
+  uvm_reg_data_t field_mirrored_val;
+  // when new written value is different from mirrored value, this will be set.
+  bit            is_new_val_written;
+  // latched the regwen value when a new value is written to this lockable CSR.
+  bit            regwen_val_when_new_value_written;
+
+  `uvm_object_utils(dv_base_lockable_field_cov)
+
+  // Cover these 2 cases
+  // 1. When regwen = 1, write a non-mirrored value to lockable CSR and read it back
+  // 2. When regwen = 0, write a non-mirrored value to lockable CSR and read it back
+  covergroup regwen_val_when_new_value_written_cg(string name) with function sample();
+    option.per_instance = 1;
+    option.name         = name;
+
+    cp_regwen: coverpoint regwen_val_when_new_value_written;
+  endgroup : regwen_val_when_new_value_written_cg
+
+  // use reg_field name as this name
+  function new(string name = "");
+    regwen_val_when_new_value_written_cg = new($sformatf("lockable_field_cov_of_%s", name));
+  endfunction : new
+
+  virtual function void reset(uvm_reg_data_t reset_val);
+    field_mirrored_val = reset_val;
+    is_new_val_written = 0;
+  endfunction
+
+  // invoke at dv_base_reg_field::post_write
+  virtual function void post_write(uvm_reg_data_t new_val, bit regwen_val);
+    if (field_mirrored_val != new_val) begin
+      is_new_val_written                = 1;
+      regwen_val_when_new_value_written = regwen_val;
+      field_mirrored_val                = new_val;
+    end
+  endfunction
+
+  // invoke at dv_base_reg_field::post_read
+  virtual function void post_read();
+    if (is_new_val_written) regwen_val_when_new_value_written_cg.sample();
+  endfunction
+
+endclass : dv_base_lockable_field_cov

--- a/hw/dv/sv/dv_base_reg/dv_base_reg.core
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg.core
@@ -17,6 +17,7 @@ filesets:
       - dv_base_mem.sv: {is_include_file: true}
       - dv_base_reg_block.sv: {is_include_file: true}
       - dv_base_reg_map.sv: {is_include_file: true}
+      - dv_base_lockable_field_cov.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_field.sv
@@ -9,6 +9,11 @@ class dv_base_reg_field extends uvm_reg_field;
   local bit is_intr_test_fld;
   local uvm_reg_data_t staged_val, committed_val, shadowed_val;
 
+  // if this is lockable field, here is its corresponding regwen object
+  // if not, below 2 object will be null
+  local dv_base_reg_field regwen_fld;
+  local dv_base_lockable_field_cov lockable_field_cov;
+
   `uvm_object_utils(dv_base_reg_field)
   `uvm_object_new
 
@@ -99,7 +104,15 @@ class dv_base_reg_field extends uvm_reg_field;
     uvm_reg_block     ral = this.get_parent().get_parent();
     `DV_CHECK_EQ_FATAL(ral.is_locked(), 0, "RAL is locked, cannot add lockable reg or fld!")
     get_flds_from_uvm_object(lockable_obj, `gfn, flds);
-    foreach (flds[i]) lockable_flds.push_back(flds[i]);
+    foreach (flds[i]) begin
+      lockable_flds.push_back(flds[i]);
+      flds[i].regwen_fld = this;
+      flds[i].create_lockable_fld_cov();
+    end
+  endfunction
+
+  function void create_lockable_fld_cov();
+    lockable_field_cov = dv_base_lockable_field_cov::type_id::create(`gfn);
   endfunction
 
   // Returns true if this field can lock the specified register/field, else return false.
@@ -133,6 +146,16 @@ class dv_base_reg_field extends uvm_reg_field;
     if (rw.status == UVM_IS_OK) begin
       dv_base_reg parent_csr = get_dv_base_reg_parent();
       parent_csr.clear_shadow_wr_staged();
+
+      if (lockable_field_cov != null) lockable_field_cov.post_read();
+    end
+  endtask
+
+  virtual task post_write(uvm_reg_item rw);
+    if (rw.status == UVM_IS_OK) begin
+      uvm_reg_data_t field_val = rw.value[0] & ((1 << get_n_bits()) - 1);
+
+      if (lockable_field_cov != null) lockable_field_cov.post_write(field_val, `gmv(regwen_fld));
     end
   endtask
 
@@ -172,6 +195,7 @@ class dv_base_reg_field extends uvm_reg_field;
     set_fld_access(0);
     committed_val = get_mirrored_value();
     shadowed_val  = ~committed_val;
+    if (lockable_field_cov != null) lockable_field_cov.reset(get_reset());
   endfunction
 
   // this function can only be called when this reg is intr_test reg

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_pkg.sv
@@ -113,6 +113,7 @@ package dv_base_reg_pkg;
   endfunction : get_field_val
 
   `include "csr_excl_item.sv"
+  `include "dv_base_lockable_field_cov.sv"
   `include "dv_base_reg_field.sv"
   `include "dv_base_reg.sv"
   `include "dv_base_mem.sv"

--- a/hw/dv/tools/dvsim/testplans/csr_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/csr_testplan.hjson
@@ -80,6 +80,34 @@
       milestone: V1
       tests: ["{name}{intf}_csr_mem_rw_with_rand_reset"]
     }
+    {
+      name: regwen_csr_and_corresponding_lockable_csr
+      desc: '''
+            Verify regwen CSR and its corresponding lockable CSRs.
+            - Randomly access all CSRs
+            - Test when regwen CSR is set, its corresponding lockable CSRs become
+              read-only registers
+
+            Note:
+            - If regwen CSR is HW read-only, this feature can be fully tested by common
+              CSR tests - csr_rw and csr_aliasing.
+            - If regwen CSR is HW updated, a separate test should be created to test it.
+            '''
+      milestone: V1
+      tests: ["{name}{intf}_csr_rw", "{name}{intf}_csr_aliasing"]
+    }
+  ]
+  covergroups: [
+    {
+      name: regwen_val_when_new_value_written_cg
+      desc: '''
+            Cover each lockable reg field with these 2 cases:
+            - When regwen = 1, a different value is written to the lockable CSR field, and a read
+              occurs after that.
+            - When regwen = 0, a different value is written to the lockable CSR field, and a read
+              occurs after that.
+            '''
+    }
   ]
 }
 


### PR DESCRIPTION
Address #7738

Cover each lockable reg field with these 2 cases:
- When regwen = 1, a different value is written to the lockable CSR field, and a read
occurs after that.
- When regwen = 0, a different value is written to the lockable CSR field, and a read
occurs after that.

Testplan is also updated

Signed-off-by: Weicai Yang <weicai@google.com>