### PR TITLE
[entropy_src/dv] Add env. support for FW_OV pathway

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -64,6 +64,12 @@
       uvm_test_seq: entropy_src_stress_all_vseq
     }
 
+    {
+      name: entropy_src_fw_ov
+      uvm_test: entropy_src_fw_ov_test
+      uvm_test_seq: entropy_src_fw_ov_vseq
+    }
+
     // TODO: add more tests here
   ]
 

--- a/hw/ip/entropy_src/dv/env/entropy_src_env.core
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env.core
@@ -24,6 +24,7 @@ filesets:
       - seq_lib/entropy_src_common_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_rng_vseq.sv: {is_include_file: true}
+      - seq_lib/entropy_src_fw_ov_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/entropy_src_base_rng_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_fw_ov_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_fw_ov_vseq.sv
@@ -2,19 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class entropy_src_smoke_vseq extends entropy_src_base_vseq;
-  `uvm_object_utils(entropy_src_smoke_vseq)
+class entropy_src_fw_ov_vseq extends entropy_src_base_vseq;
+  `uvm_object_utils(entropy_src_fw_ov_vseq)
 
   `uvm_object_new
 
-  int seed_cnt;
-
   push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH) m_rng_push_seq;
+
+  int word_cnt;
 
   task body();
     super.body();
 
-    seed_cnt = cfg.seed_cnt;
+    // TODO: (Cleanup) do we want to change the cfg field "seed_cnt" to be more general?
+    word_cnt = cfg.seed_cnt;
 
     // Create rng host sequence
     m_rng_push_seq = push_pull_indefinite_host_seq#(entropy_src_pkg::RNG_BUS_WIDTH)::type_id::
@@ -24,18 +25,20 @@ class entropy_src_smoke_vseq extends entropy_src_base_vseq;
       m_rng_push_seq.start(p_sequencer.rng_sequencer_h);
       begin
         do begin
-          int available_seeds;
+          int available_words;
           // Wait for data to arrive for TL consumption via the ENTROPY_DATA register
-          poll(.source(TlSrcEntropyDataReg));
-          // Read all currently available data (but no more than seed_cnt)
-          do_entropy_data_read(.max_bundles(seed_cnt), .bundles_found(available_seeds));
+          poll(.source(TlSrcObserveFIFO));
+          // Read all currently available data (but no more than word_cnt)
+          do_entropy_data_read(.source(TlSrcObserveFIFO), .max_bundles(word_cnt),
+                               .bundles_found(available_words));
           // Update the count of remaining seeds to read
-          seed_cnt -= available_seeds;
-        end while (seed_cnt > 0);
+          word_cnt -= available_words;
+        end while (word_cnt > 0);
         m_rng_push_seq.stop(.hard(0));
         m_rng_push_seq.wait_for_sequence_state(UVM_FINISHED);
       end
     join
+
   endtask : body
 
-endclass : entropy_src_smoke_vseq
+endclass : entropy_src_fw_ov_vseq

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -50,13 +50,13 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4True);
     csr_update(.csr(ral.entropy_control));
     // Wait for data to arrive for TL consumption via the ENTROPY_DATA register
-    csr_spinwait(.ptr(ral.intr_state.es_entropy_valid), .exp_data(1'b1));
+    poll();
     ral.entropy_control.es_route.set(prim_mubi_pkg::MuBi4False);
     csr_update(.csr(ral.entropy_control));
 
     // read all available seeds
     do begin
-      do_entropy_data_read(.seeds_found(seeds_found));
+      do_entropy_data_read(.bundles_found(seeds_found));
     end while (seeds_found > 0);
     `uvm_info(`gfn, "CSR Thread: Seed read Successfully", UVM_HIGH)
   endtask

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_vseq_list.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_vseq_list.sv
@@ -6,4 +6,5 @@
 `include "entropy_src_smoke_vseq.sv"
 `include "entropy_src_common_vseq.sv"
 `include "entropy_src_rng_vseq.sv"
+`include "entropy_src_fw_ov_vseq.sv"
 `include "entropy_src_stress_all_vseq.sv"

--- a/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_fw_ov_test.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class entropy_src_fw_ov_test extends entropy_src_base_test;
+
+  `uvm_component_utils(entropy_src_fw_ov_test)
+  `uvm_component_new
+
+  function void configure_env();
+    super.configure_env();
+
+    cfg.en_scb                      = 1;
+    cfg.fips_window_size            = 2048;
+    cfg.bypass_window_size          = 384;
+    cfg.seed_cnt                    = 12;
+    cfg.boot_mode_retry_limit       = 10;
+    cfg.route_software_pct          = 0;
+    cfg.fw_read_pct                 = 100;
+
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+
+    `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_LOW)
+  endfunction
+endclass : entropy_src_fw_ov_test

--- a/hw/ip/entropy_src/dv/tests/entropy_src_test.core
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_test.core
@@ -12,6 +12,7 @@ filesets:
       - entropy_src_test_pkg.sv
       - entropy_src_base_test.sv: {is_include_file: true}
       - entropy_src_smoke_test.sv: {is_include_file: true}
+      - entropy_src_fw_ov_test.sv: {is_include_file: true}
       - entropy_src_rng_test.sv: {is_include_file: true}
       - entropy_src_stress_all_test.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/entropy_src/dv/tests/entropy_src_test_pkg.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_test_pkg.sv
@@ -16,6 +16,7 @@ package entropy_src_test_pkg;
   `include "entropy_src_base_test.sv"
   `include "entropy_src_smoke_test.sv"
   `include "entropy_src_rng_test.sv"
+  `include "entropy_src_fw_ov_test.sv"
   `include "entropy_src_stress_all_test.sv"
 
 endpackage

--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -13,6 +13,9 @@ package entropy_src_pkg;
   parameter int  CSRNG_BUS_WIDTH = 384;
   parameter int  FIPS_BUS_WIDTH  = 1;
   parameter int  FIPS_CSRNG_BUS_WIDTH = FIPS_BUS_WIDTH + CSRNG_BUS_WIDTH;
+  // TODO: Should this be re-used in the RTL?
+  parameter int  OBSERVE_FIFO_DEPTH = 64;
+
 
   // es entropy i/f
   typedef struct packed {


### PR DESCRIPTION
- Introduce scoreboarding checks for reading the "observe" FIFO
- Creates an fw_ov test to probe this functionality
   - Currently only reads from the observe FIFO

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>