### PR TITLE
[sysrst_ctrl] Update the debouncer behavior

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -55,6 +55,13 @@ if {$env(DUT_TOP) == "rv_dm"} {
   clock -rate {cio_csb_i, cio_sd_i} cio_sck_i
   reset -expr {!rst_ni cio_csb_i}
 
+} elseif {$env(DUT_TOP) == "sysrst_ctrl"} {
+  clock clk_i -both_edges
+  clock clk_aon_i
+  clock -rate {tl_i} clk_i
+  clock -rate {cio_ac_present_i, cio_ec_rst_l_i, cio_key0_in_i, cio_key1_in_i, cio_key2_in_i, cio_pwrb_in_i, cio_lid_open_i} clk_aon_i
+  reset -expr {!rst_ni !rst_aon_ni}
+
 } elseif {$env(DUT_TOP) == "usbuart"} {
   clock clk_i -both_edges
   clock clk_usb_48mhz_i

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl.sv
@@ -134,12 +134,12 @@ module sysrst_ctrl
   // Autoblock //
   ///////////////
 
-  // This module operates on both synchronized and unsynchronized signals.
-  // I.e., the passthrough signals are NOT synchronnous to the AON clock.
+  // The registers in this module run on the AON clock.
+  // However, the passthrough signals are NOT synchronous to the AON clock.
   logic pwrb_out_hw, key0_out_hw, key1_out_hw, key2_out_hw;
   sysrst_ctrl_autoblock u_sysrst_ctrl_autoblock (
-    .clk_aon_i,
-    .rst_aon_ni,
+    .clk_i(clk_aon_i),
+    .rst_ni(rst_aon_ni),
     // (Optionally) inverted input signals on AON clock
     .aon_pwrb_int_i(aon_pwrb_int),
     // (Optionally) inverted input signals (not synced to AON clock)

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_detect.sv
@@ -2,91 +2,318 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// Debounces the input signal and detects level changes.
+// Debounce and detector module.
+//
+// The module is able to detect either low/high levels, or transitions to low/high levels (edges).
+// The event type to trigger on can be configured via the EventType parameter.
+//
+// Whenever a trigger event is seen at the input (for instance a transition to low) the module first
+// backs off for the amount of debounce cycles configured through cfg_debounce_timer_i. Then the
+// module samples the input value again and if it still matches the active level (low in this
+// example), the module goes into detection mode. In detection mode, the module checks whether the
+// trigger signal remains stable for the number of cycles configured via cfg_detect_timer_i. If it
+// does, event_detected_pulse_o will be pulsed high for one cycle and event_detected_o will be held
+// high until the input trigger value changes.
+//
+// Note that if the module is configured as "Sticky", the module needs to be explicitly disabled
+// and enabled again in order to reset the internal FSM into its idle state.
+//
 
-module sysrst_ctrl_detect #(
-  parameter int unsigned TimerWidth = 16,
-  // If this parameter is set to 1, an edge is required for detection.
-  // Otherwise the correct level (e.g. low for h2l) is sufficient.
-  parameter bit EdgeDetect = 0,
+module sysrst_ctrl_detect
+  import sysrst_ctrl_pkg::*;
+#(
+  // The module only contains one counter to implement both timers.
+  // The width of that counter is set to the maximum of the two values below.
+  parameter int unsigned DebounceTimerWidth = 16,
+  parameter int unsigned DetectTimerWidth = 32,
+  // Determines the event type that the detector should be sensitive to.
+  parameter event_t      EventType = LowLevel,
   // If this parameter is set to 1, the l2h_detected_o and h2l_detected_o conditions can only be
   // reset by disabling the corresponding detector (cfg_l2h_en_i or cfg_h2l_en_i).
-  parameter bit Sticky = 0
+  parameter bit          Sticky = 0
 ) (
-  input                         clk_i,
-  input                         rst_ni,
-  input                         trigger_i,
-  input        [TimerWidth-1:0] cfg_timer_i,
-  input                         cfg_l2h_en_i,
-  input                         cfg_h2l_en_i,
-  output logic                  l2h_detected_o,
-  output logic                  h2l_detected_o,
-  output logic                  l2h_detected_pulse_o,
-  output logic                  h2l_detected_pulse_o
-
+  input                                 clk_i,
+  input                                 rst_ni,
+  // Trigger input signal.
+  input                                 trigger_i,
+  // Debounce and detection timer thresholds.
+  input        [DebounceTimerWidth-1:0] cfg_debounce_timer_i,
+  input        [DetectTimerWidth-1:0]   cfg_detect_timer_i,
+  // Enables the detector module.
+  // Note that the internal state machine can be reset to its idle state by disabling the module.
+  input                                 cfg_enable_i,
+  // Held high after detection of the event as long as the trigger level is correct.
+  output logic                          event_detected_o,
+  // Pulsed high for one cycle when the event is detected.
+  output logic                          event_detected_pulse_o
 );
 
-  logic trigger_debounced_d;
-  prim_filter_ctr #(
-    .AsyncOn(0), // input signal has already been synced to the AON clock
-    .CntWidth(TimerWidth)
-  ) u_prim_filter_ctr (
-    .clk_i,
-    .rst_ni,
-    .enable_i(1'b1),
-    .filter_i(trigger_i),
-    .thresh_i(cfg_timer_i),
-    .filter_o(trigger_debounced_d)
-  );
+  //////////////////
+  // Detect Event //
+  //////////////////
 
-  logic h2l_event, l2h_event;
-  if (EdgeDetect) begin : gen_edge_detect
-    logic trigger_debounced_q;
-    assign l2h_event = trigger_debounced_d & ~trigger_debounced_q;
-    assign h2l_event = ~trigger_debounced_d & trigger_debounced_q;
+  // This just decodes the active level needed for detection.
+  logic trigger_active;
+  if (EventType inside {LowLevel, EdgeToLow}) begin : gen_trigger_active_low
+    assign trigger_active = (trigger_i == 1'b0);
+  end else begin : gen_trigger_active_high
+    assign trigger_active = (trigger_i == 1'b1);
+  end
 
-    always_ff @(posedge clk_i or negedge rst_ni) begin : p_reg
+  // In case of edge events, we also need to detect the transition.
+  logic trigger_event;
+  if (EventType inside {EdgeToLow, EdgeToHigh}) begin : gen_trigger_event_edge
+    // This flop is always active, no matter the enable state.
+    logic trigger_active_q;
+    always_ff @(posedge clk_i or negedge rst_ni) begin : p_trigger_reg
       if (!rst_ni) begin
-        trigger_debounced_q <= 1'b0;
+        trigger_active_q <= 1'b0;
       end else begin
-        trigger_debounced_q <= trigger_debounced_d;
+        trigger_active_q <= trigger_active;
       end
     end
-  end else begin : gen_level_only
-    // In this case we just look at the signal level.
-    assign l2h_event = trigger_debounced_d;
-    assign h2l_event = ~trigger_debounced_d;
+
+    assign trigger_event = trigger_active & ~trigger_active_q;
+  // In case of level events, the event is equal to the level being active.
+  end else begin : gen_trigger_event_level
+    assign trigger_event = trigger_active;
   end
 
-  logic h2l_detected_d, h2l_detected_q;
-  logic l2h_detected_d, l2h_detected_q;
-  if (Sticky) begin : gen_sticky
-    // Keep detected event until detector is disabled.
-    assign l2h_detected_d = (cfg_l2h_en_i) ? (l2h_event | l2h_detected_q) : 1'b0;
-    assign h2l_detected_d = (cfg_h2l_en_i) ? (h2l_event | h2l_detected_q) : 1'b0;
-  end else begin : gen_not_sticky
-    // Deassert automatically if the level does not remain stable after event.
-    assign l2h_detected_d = (~trigger_debounced_d) ? 1'b0                         :
-                            (cfg_l2h_en_i)         ? (l2h_event | l2h_detected_q) :
-                                                     1'b0;
-    assign h2l_detected_d = (trigger_debounced_d) ? 1'b0                         :
-                            (cfg_h2l_en_i)        ? (h2l_event | h2l_detected_q) :
-                                                    1'b0;
-  end
+  /////////////////
+  // Timer Logic //
+  /////////////////
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
+  // Take the maximum width of both timer values.
+  localparam int unsigned TimerWidth =
+      (DetectTimerWidth > DebounceTimerWidth) ? DetectTimerWidth : DebounceTimerWidth;
+
+  logic cnt_en, cnt_clr;
+  logic [TimerWidth-1:0] cnt_d, cnt_q;
+  assign cnt_d = (cnt_clr) ? '0           :
+                 (cnt_en)  ? cnt_q + 1'b1 :
+                             cnt_q;
+
+
+  logic cnt_done, thresh_sel;
+  logic [TimerWidth-1:0] thresh;
+  assign thresh = (thresh_sel) ? TimerWidth'(cfg_detect_timer_i) :
+                                 TimerWidth'(cfg_debounce_timer_i);
+  assign cnt_done = (cnt_q >= thresh);
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_cnt_reg
     if (!rst_ni) begin
-      l2h_detected_q <= 1'b0;
-      h2l_detected_q <= 1'b0;
+      cnt_q <= '0;
     end else begin
-      l2h_detected_q <= l2h_detected_d;
-      h2l_detected_q <= h2l_detected_d;
+      cnt_q <= cnt_d;
     end
   end
 
-  assign l2h_detected_o = l2h_detected_d;
-  assign h2l_detected_o = h2l_detected_d;
-  assign l2h_detected_pulse_o = l2h_detected_d & ~l2h_detected_q;
-  assign h2l_detected_pulse_o = h2l_detected_d & ~h2l_detected_q;
+  /////////
+  // FSM //
+  /////////
 
-endmodule
+  typedef enum logic [1:0] {
+    IdleSt,
+    DebounceSt,
+    DetectSt,
+    StableSt
+  } state_t;
+
+  state_t state_d, state_q;
+
+  always_comb begin : p_fsm
+    state_d = state_q;
+
+    // Counter controls (clear has priority).
+    cnt_clr = 1'b0;
+    cnt_en = 1'b0;
+
+    // Detected outputs
+    event_detected_o = 1'b0;
+    event_detected_pulse_o = 1'b0;
+
+    // Threshold select
+    // 0: debounce
+    // 1: detect
+    thresh_sel = 1'b0;
+
+    unique case (state_q)
+      ////////////////////////////////////////////
+      // We are waiting for the event to occur.
+      // This can be either a specific level or edge,
+      // depending on the configuration.
+      IdleSt: begin
+        // Stay here if the detector is disabled.
+        if (trigger_event && cfg_enable_i) begin
+          state_d = DebounceSt;
+          cnt_en = 1'b1;
+        end else begin
+          cnt_clr = 1'b1;
+        end
+      end
+      ////////////////////////////////////////////
+      // If an event has occurred, we back off for
+      // the amount of debounce cycles configured.
+      // Once the timer has expired, we sample the
+      // signal again and check whether it has the
+      // correct level. If so, we move on to the
+      // detection stage, otherwise we fall back.
+      DebounceSt: begin
+        cnt_en = 1'b1;
+        // Unconditionally go back to idle if the detector is disabled.
+        if (!cfg_enable_i) begin
+          state_d = IdleSt;
+          cnt_clr = 1'b1;
+        end else if (cnt_done) begin
+          cnt_clr = 1'b1;
+          if (trigger_active) begin
+            state_d = DetectSt;
+          end else begin
+            state_d = IdleSt;
+          end
+        end
+      end
+      ////////////////////////////////////////////
+      // Once the debounce period has passed, we
+      // check whether the signal remains stable
+      // throughout the entire detection period.
+      // If it is not stable at any cycle, we fall
+      // back to idle.
+      DetectSt: begin
+        thresh_sel = 1'b1;
+        cnt_en = 1'b1;
+        // Go back to idle if either the trigger level is not active anymore, or if the
+        // detector is disabled.
+        if (!cfg_enable_i || !trigger_active) begin
+          state_d = IdleSt;
+          cnt_clr = 1'b1;
+        // If the trigger is active, count up.
+        end else begin
+          if (cnt_done) begin
+            state_d = StableSt;
+            cnt_clr = 1'b1;
+            event_detected_o = 1'b1;
+            event_detected_pulse_o = 1'b1;
+          end
+        end
+      end
+      ////////////////////////////////////////////
+      // At this point we have detected the event
+      // and monitor whether the signal remains stable.
+      StableSt: begin
+        cnt_clr = 1'b1;
+        // Go back to idle if either the trigger level is not active anymore, or if the detector is
+        // disabled. Note that if the detector is sticky, it has to be explicitly disabled in order
+        // to go back to the idle state.
+        if (!cfg_enable_i || (!trigger_active && !Sticky)) begin
+          state_d = IdleSt;
+        // Otherwise keep the event detected output signal high.
+        end else begin
+          event_detected_o = 1'b1;
+        end
+      end
+      ////////////////////////////////////////////
+      // This is a full case statement
+      default: ;
+    endcase // state_q
+  end
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin : p_fsm_reg
+    if (!rst_ni) begin
+      state_q <= IdleSt;
+    end else begin
+      state_q <= state_d;
+    end
+  end
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+  `ASSERT(DisabledIdleSt_A, !cfg_enable_i |=> state_q == IdleSt)
+  `ASSERT(DisabledNoDetection_A, !cfg_enable_i |-> !event_detected_o && !event_detected_pulse_o)
+
+  if (EventType inside {LowLevel, EdgeToLow}) begin : gen_low_level_sva
+    `ASSERT(LowLevelEvent_A, !trigger_i === trigger_active)
+  end else begin: gen_high_level_sva
+    `ASSERT(HighLevelEvent_A, trigger_i === trigger_active)
+  end
+
+  if (EventType == LowLevel) begin : gen_low_event_sva
+    `ASSERT(LowLevelEvent_A, !trigger_i === trigger_event)
+  end else if (EventType == HighLevel) begin : gen_high_event_sva
+    `ASSERT(HighLevelEvent_A, trigger_i === trigger_event)
+  end else if (EventType == EdgeToLow) begin : gen_edge_to_low_event_sva
+    `ASSERT(EdgeToLowEvent_A, !trigger_i && $past(trigger_i) |-> trigger_event)
+  end else if (EventType == EdgeToLow) begin : gen_edge_to_high_event_sva
+    `ASSERT(EdgeToHighEvent_A, trigger_i && !$past(trigger_i) |-> trigger_event)
+  end
+
+  `ASSERT(EnterDebounceSt_A,
+      state_q == IdleSt && cfg_enable_i && trigger_event
+      |=>
+      state_q == DebounceSt)
+
+  `ASSERT(EnterDetectSt_A,
+      state_q == DebounceSt && cnt_q >= cfg_debounce_timer_i && trigger_active && cfg_enable_i
+      |=>
+      state_q == DetectSt)
+
+  `ASSERT(DetectStDropOut_A,
+      state_q == DetectSt && !trigger_active && cfg_enable_i
+      |=>
+      state_q == IdleSt)
+
+  `ASSERT(EnterStableSt_A,
+      state_q == DetectSt && cnt_q >= cfg_detect_timer_i && trigger_active && cfg_enable_i
+      |=>
+      state_q == StableSt)
+
+  `ASSERT(StayInStableSt,
+      state_q == StableSt && trigger_active && cfg_enable_i
+      |=>
+      state_q == StableSt)
+
+  if (Sticky) begin : gen_sticky_sva
+    `ASSERT(StableStDropOut_A,
+        state_q == StableSt && cfg_enable_i && !trigger_active
+        |=>
+        state_q == StableSt)
+  end else begin : gen_not_sticky_sva
+    `ASSERT(StableStDropOut_A,
+        state_q == StableSt && cfg_enable_i && !trigger_active
+        |=>
+        state_q == IdleSt)
+  end
+
+  `ASSERT(DetectedOut_A,
+      state_q == StableSt && trigger_active && cfg_enable_i ||
+      state_q == DetectSt && cnt_q >= cfg_detect_timer_i && trigger_active && cfg_enable_i
+      |->
+      event_detected_o)
+
+  `ASSERT(DetectedPulseOut_A,
+      state_q == DetectSt && cnt_q >= cfg_detect_timer_i && trigger_active && cfg_enable_i
+      |->
+      event_detected_pulse_o)
+
+  `ASSERT(PulseIsPulse_A,
+      event_detected_pulse_o |=> !event_detected_pulse_o)
+
+  // Counter does not wrap around unless it is explicitly cleared
+  `ASSERT(CntNoWrap_A,
+      !cnt_clr
+      |=>
+      cnt_q >= $past(cnt_q))
+
+  `ASSERT(CntClr_A,
+      cnt_clr
+      |=>
+      cnt_q == '0)
+
+  `ASSERT(CntIncr_A,
+      cnt_en && !cnt_clr
+      |=>
+      cnt_q == $past(cnt_q) + 1)
+
+endmodule : sysrst_ctrl_detect

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_pkg.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_pkg.sv
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package sysrst_ctrl_pkg;
+
+  typedef enum logic [1:0] {
+    LowLevel,
+    HighLevel,
+    EdgeToLow,
+    EdgeToHigh
+  } event_t;
+
+endpackage : sysrst_ctrl_pkg

--- a/hw/ip/sysrst_ctrl/sysrst_ctrl.core
+++ b/hw/ip/sysrst_ctrl/sysrst_ctrl.core
@@ -56,6 +56,10 @@ targets:
       - files_rtl
     toplevel: sysrst_ctrl
 
+  formal:
+    filesets:
+      - files_rtl
+    toplevel: sysrst_ctrl
 
   lint:
     <<: *default_target

--- a/hw/ip/sysrst_ctrl/sysrst_ctrl.core
+++ b/hw/ip/sysrst_ctrl/sysrst_ctrl.core
@@ -14,6 +14,7 @@ filesets:
     files:
       - rtl/sysrst_ctrl_reg_pkg.sv
       - rtl/sysrst_ctrl_reg_top.sv
+      - rtl/sysrst_ctrl_pkg.sv
       - rtl/sysrst_ctrl_autoblock.sv
       - rtl/sysrst_ctrl_comboact.sv
       - rtl/sysrst_ctrl_pin.sv

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -533,6 +533,13 @@
                rel_path: "hw/ip/sram_ctrl/{sub_flow}/{tool}"
                cov: false
              }
+             { name: sysrst_ctrl
+               dut: sysrst_ctrl
+               fusesoc_core: lowrisc:ip:sysrst_ctrl
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/sysrst_ctrl/{sub_flow}/{tool}"
+               cov: true
+             }
              {
                name: uart
                dut: uart


### PR DESCRIPTION
This makes the debounce behavior more similar to the initial design, as it corresponds better to the intended programming model. That means that the debouncer logic is implemented using an FSM + counter, rather than using an instance of `prim_filter`.

Design-wise however, this still uses the approach that reuses one common detector module for all debounce and detect use cases within `sysrst_ctrl`.

The PR also adds an FPV target to prove embedded assertions.

-------------------------------
@cindychip: I have added you mainly for the FPV part.

-------------------------------

CC @patel-madhuri: apologies for the back and forth on this. I hope this is the last alignment that is needed.