### PR TITLE
[bazel] Solving warnings and flakiness in bazel tests

### DIFF
--- a/sw/device/examples/hello_usbdev/BUILD
+++ b/sw/device/examples/hello_usbdev/BUILD
@@ -28,6 +28,8 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/examples:demos",
         "//sw/device/lib:pinmux",
+        "//sw/device/lib:usb",
+        "//sw/device/lib:usb_simpleserial",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/crt",
         "//sw/device/lib/dif:gpio",
@@ -40,7 +42,5 @@ cc_library(
         "//sw/device/lib/testing/test_framework",
         "//sw/device/lib/testing/test_framework:ottf_isrs",
         "//sw/device/lib/testing/test_rom_ext",
-        "//sw/device/lib:usb",
-        "//sw/device/lib:usb_simpleserial",
     ],
 )

--- a/sw/device/lib/BUILD
+++ b/sw/device/lib/BUILD
@@ -58,7 +58,7 @@ cc_library(
     name = "usb",
     srcs = [
         "usb_controlep.c",
-        "usbdev.c"
+        "usbdev.c",
     ],
     hdrs = [
         "usb_consts.h",

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -112,7 +112,7 @@ class KmacTest : public testing::Test, public mock_mmio::MmioTest {
    * @param size Len of the buffer.
    */
   void setExpectedMessageByte(const uint8_t *message, const size_t size) {
-    for (int i = 0; i < size; ++i) {
+    for (size_t i = 0; i < size; ++i) {
       EXPECT_WRITE8(KMAC_MSG_FIFO_REG_OFFSET, message[i]);
     }
   }
@@ -158,7 +158,7 @@ class AbsorbalignmentMessage : public KmacTest {};
 TEST_F(AbsorbalignmentMessage, Success) {
   uint8_t buffer[kMsg_.size() + sizeof(uint32_t)];
 
-  for (int i = 0; i < sizeof(uint32_t); i++) {
+  for (size_t i = 0; i < sizeof(uint32_t); i++) {
     uint8_t *pMsg = &buffer[i];
     std::copy(kMsg_.begin(), kMsg_.end(), pMsg);
 

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -46,7 +46,7 @@ opentitan_functest(
     name = "boot_data_functest",
     srcs = ["boot_data_functest.c"],
     verilator = verilator_params(
-        timeout = "long",
+        timeout = "eternal",
     ),
     deps = [
         ":boot_data",
@@ -425,8 +425,6 @@ opentitan_functest(
         ":sigverify_mod_exp_ibex",
         ":sigverify_mod_exp_otbn",
         ":sigverify_testvectors",
-        ":sigverify_mod_exp_ibex",
-        ":sigverify_mod_exp_otbn",
         ":test_main",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -33,8 +33,8 @@ cc_library(
     name = "mock_abs_mmio",
     testonly = True,
     hdrs = [
-        "//sw/device/lib/base:abs_mmio_h",
         "mock_abs_mmio.h",
+        "//sw/device/lib/base:abs_mmio_h",
     ],
     defines = ["MOCK_ABS_MMIO"],
     deps = [
@@ -73,8 +73,8 @@ cc_library(
 cc_test(
     name = "sec_mmio_unittest",
     srcs = [
-        "sec_mmio.h",
         "sec_mmio.c",
+        "sec_mmio.h",
         "sec_mmio_unittest.cc",
     ],
     defines = ["OT_OFF_TARGET_TEST"],

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -4,7 +4,7 @@
 
 package(default_visibility = ["//visibility:public"])
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_functest")
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_functest", "verilator_params")
 
 cc_library(
     name = "alert",
@@ -79,8 +79,8 @@ cc_library(
 cc_test(
     name = "flash_ctrl_unittest",
     srcs = [
-        "flash_ctrl.h",
         "flash_ctrl.c",
+        "flash_ctrl.h",
         "flash_ctrl_unittest.cc",
     ],
     defines = [
@@ -170,10 +170,10 @@ cc_test(
     deps = [
         ":keymgr",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
-        "//sw/device/lib/testing:pwrmgr_testutils",
         "@googletest//:gtest_main",
     ],
 )
@@ -227,8 +227,8 @@ cc_library(
 cc_test(
     name = "lifecycle_unittest",
     srcs = [
-        "lifecycle.h",
         "lifecycle.c",
+        "lifecycle.h",
         "lifecycle_unittest.cc",
     ],
     defines = [
@@ -288,7 +288,7 @@ cc_library(
     testonly = True,
     hdrs = [
         "mock_otp.h",
-        "otp.h"
+        "otp.h",
     ],
     deps = [
         "//sw/device/silicon_creator/testing:mask_rom_test",
@@ -382,7 +382,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/lib/base:abs_mmio",
-    ]
+    ],
 )
 
 opentitan_functest(
@@ -495,6 +495,9 @@ cc_test(
 opentitan_functest(
     name = "watchdog_functest",
     srcs = ["watchdog_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         ":retention_sram",
         ":rstmgr",

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -228,10 +228,10 @@ cc_library(
 cc_test(
     name = "sigverify_keys_unittest",
     srcs = [
-        "//sw/device/silicon_creator/lib:sigverify_src_for_keys_unittest",
         "sigverify_keys.c",
         "sigverify_keys.h",
         "sigverify_keys_unittest.cc",
+        "//sw/device/silicon_creator/lib:sigverify_src_for_keys_unittest",
     ],
     defines = ["OT_OFF_TARGET_TEST"],
     deps = [

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -47,6 +47,9 @@ opentitan_functest(
 opentitan_functest(
     name = "entropy_src_smoketest",
     srcs = ["entropy_src_smoketest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         "//sw/device/lib/dif:entropy_src",
     ],
@@ -56,16 +59,16 @@ opentitan_functest(
     name = "gpio_smoketest",
     srcs = ["gpio_smoketest.c"],
     verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator"
-        ],
         args = [
             "--verilator-args=--trace",
             "console",
             "--timeout=3600",
             "--exit-failure=FAIL",
             "--exit-success=PASS",
+        ],
+        tags = [
+            "cpu:4",
+            "failing_verilator",
         ],
     ),
     deps = [

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -80,11 +80,11 @@ rust_test(
     ],
     crate = ":opentitanlib",
     data = [
-        "src/util/testdata/hello.txt",
-        "src/util/testdata/world.txt",
         "src/otp/testdata/lc_ctrl_state.hjson",
         "src/otp/testdata/otp_ctrl_img_dev.hjson",
         "src/otp/testdata/otp_ctrl_mmap.hjson",
         "src/otp/testdata/output.vmem",
+        "src/util/testdata/hello.txt",
+        "src/util/testdata/world.txt",
     ],
 )

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -9,8 +9,8 @@ package(default_visibility = ["//visibility:public"])
 otbn_binary(
     name = "run_rsa_verify_3072_rr_modexp",
     srcs = [
-        "//sw/vendor:veri-titan/gen/rsa_verify_3072.s",
         "rsa_verify_3072_rr.s",
         "run_rsa_verify_3072_rr_modexp.s",
+        "//sw/vendor:veri-titan/gen/rsa_verify_3072.s",
     ],
 )


### PR DESCRIPTION
This PR captures a bunch of small test configurations and fixes for issues that cause warnings when I build and test PRs with bazel.

* //sw/device/silicon_creator/lib:verilator_boot_data_functest is flaky
with a long timeout so I've adjusted it to eternal to make it repeatable
and to prevent running it when we're under time pressure

* The entropy_smoketest and the verilator_watchdog_functest are flaky with a
default timeout so I've increased them to long (900s)

* I ran `bazel run //:buildifier_fix so it will be cleaner when run on
other systems and commits.

Also addressing the following warnings that appear during a SW build:

* sw/device/lib/dif/dif_kmac_unittest.cc:115:23: warning: comparison of
integer expressions of different signedness: 'int' and 'const size_t'
{aka 'const long unsigned int'} [-Wsign-compare]
```
  115 |     for (int i = 0; i < size; ++i) {
      |                     ~~^~~~~~
```

* sw/device/lib/dif/dif_kmac_unittest.cc:161:21: warning:
comparison of integer expressions of different signedness: 'int'
and 'long unsigned int' [-Wsign-compare]
```
  161 |   for (int i = 0; i < sizeof(uint32_t); i++) {
      |                   ~~^~~~~~~~~~~~~~~~~~
```

Signed-off-by: Drew Macrae <drewmacrae@google.com>