### PR TITLE
[aes/dv] added nist vectors to testplan

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -92,7 +92,7 @@
       desc: '''
             Verify that the DUT handles the NIST test vectors correctly.'''
       milestone: V2
-      tests: []
+      tests: ["aes_nist_vectors"]
     }
     {
       name: performance


### PR DESCRIPTION
This is a simple update, that puts the nist vectors test into the V2 vs its current state

Signed-off-by: Rasmus Madsen <rasmus.madsen@wdc.com>