### PR TITLE
Aes reseed

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -118,6 +118,14 @@
       tests: ["aes_stress"]
     }
     {
+      name: sideload
+      desc: '''
+            Verify that DUT uses sideload correctly when sideload is enabled.
+            and that it ignores any valid on the bus when disabled.'''
+      milestone: V2
+        tests: ["aes_stress", "aes_sideload"]
+    }
+    {
       name: deinitialization
       desc: '''
             Make sure that there is no residual data from latest operation. '''

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -106,6 +106,11 @@
       uvm_test: aes_alert_reset_test
       uvm_test_seq: aes_alert_reset_vseq
     }
+    {
+      name: aes_sideload
+      uvm_test: aes_sideload_test
+      uvm_test_seq: aes_stress_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/aes/dv/cov/aes_cov_if.sv
+++ b/hw/ip/aes/dv/cov/aes_cov_if.sv
@@ -25,6 +25,7 @@ interface aes_cov_if
                                                bit [aes_pkg::AES_MODE_WIDTH-1:0]   aes_mode,
                                                bit [aes_pkg::AES_KEYLEN_WIDTH-1:0] aes_keylen,
                                                bit                                 aes_man_op,
+                                               bit                                 aes_sideload,
                                                bit                                 aes_force_0mask
                                                );
     option.per_instance = 1;
@@ -61,11 +62,13 @@ interface aes_cov_if
        bins manual_mode = { 1'b1 };
       }
 
+    cp_sideload: coverpoint aes_sideload;
+
     cp_force_0_masks: coverpoint aes_force_0mask;
 
     // Cross coverage points
-    // All key_lens are tested in all modes
-    cr_mode_key_len: cross cp_mode, cp_key_len;
+    // All key_lens are tested in all modes with sideload
+    cr_mode_key_len: cross cp_mode, cp_key_len, cp_sideload;
     // all modes are tested in both auto an manual operation
     cr_mode_man_op:  cross cp_mode, cp_manual_operation;
     // All modes used in both incryption and decryption
@@ -138,9 +141,11 @@ interface aes_cov_if
                                          bit [aes_pkg::AES_MODE_WIDTH-1:0]   aes_mode,
                                          bit [aes_pkg::AES_KEYLEN_WIDTH-1:0] aes_keylen,
                                          bit                                 aes_man_op,
+                                         bit                                 aes_sideload,
                                          bit                                 aes_force_0mask
                                          );
-    aes_ctrl_cg_inst.sample(aes_op, aes_mode, aes_keylen, aes_man_op, aes_force_0mask);
+    aes_ctrl_cg_inst.sample(aes_op, aes_mode, aes_keylen, aes_man_op,
+                            aes_sideload, aes_force_0mask);
   endfunction
 
   function automatic void cg_status_sample(bit [31:0] val);

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:dv:push_pull_agent
       - lowrisc:dv:csr_utils
       - lowrisc:dv:aes_model_dpi
+      - lowrisc:dv:key_sideload_agent
       - lowrisc:dv:aes_cov
       - lowrisc:dv:aes_test_vectors
     files:

--- a/hw/ip/aes/dv/env/aes_env.sv
+++ b/hw/ip/aes/dv/env/aes_env.sv
@@ -12,13 +12,27 @@ class aes_env extends cip_base_env #(
 
   `uvm_component_new
 
+  key_sideload_agent keymgr_sideload_agent;
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
+    keymgr_sideload_agent = key_sideload_agent::type_id::create("keymgr_sideload_agent", this);
+    uvm_config_db#(key_sideload_agent_cfg)::set(this, "keymgr_sideload_agent*",
+                                                "cfg", cfg.keymgr_sideload_agent_cfg);
   endfunction
 
   function void connect_phase(uvm_phase phase);
     super.connect_phase(phase);
+    virtual_sequencer.key_sideload_sequencer_h = keymgr_sideload_agent.sequencer;
+
+    // Configure the key sideload sequencer to use UVM_SEQ_ARB_STRICT_FIFO arbitration. This makes
+    // sure that we can inject our own sequence if we need to override the default for a bit.
+    keymgr_sideload_agent.sequencer.set_arbitration(UVM_SEQ_ARB_STRICT_FIFO);
+    // connect keymanager monitor to scoreboard
+    if (cfg.en_scb) begin
+      keymgr_sideload_agent.monitor.analysis_port.connect(scoreboard.key_manager_fifo.analysis_export);
+    end
   endfunction
 
 endclass

--- a/hw/ip/aes/dv/env/aes_env.sv
+++ b/hw/ip/aes/dv/env/aes_env.sv
@@ -31,7 +31,8 @@ class aes_env extends cip_base_env #(
     keymgr_sideload_agent.sequencer.set_arbitration(UVM_SEQ_ARB_STRICT_FIFO);
     // connect keymanager monitor to scoreboard
     if (cfg.en_scb) begin
-      keymgr_sideload_agent.monitor.analysis_port.connect(scoreboard.key_manager_fifo.analysis_export);
+      keymgr_sideload_agent.monitor.analysis_port.connect(
+                        scoreboard.key_manager_fifo.analysis_export);
     end
   endfunction
 

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -8,9 +8,11 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   `uvm_object_utils_end
   `uvm_object_new
 
+
+  rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;
   // test environment constraints //
   typedef enum { VerySlow, Slow, Fast, VeryFast } tl_ul_access_e;
-    //  Message Knobs //
+  //  Message Knobs //
   int                num_messages_min            = 1;
   int                num_messages_max            = 1;
   int                message_len_min             = 128;
@@ -97,6 +99,9 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   // chance of writing data when DUT is ready (for each status poll)
   int                write_prob = 90;
 
+  // sideload enable
+  int                sideload_pct               = 0;
+
 
   ///////////////////////////////
   // dont touch updated by env //
@@ -150,6 +155,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
       end
     endcase // case (host_resp_speed)
 
+
     if (config_error_type[0] == 1'b1) num_corrupt_messages += 1;
   endfunction
 
@@ -179,6 +185,9 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     list_of_alerts = aes_env_pkg::LIST_OF_ALERTS;
+    keymgr_sideload_agent_cfg = key_sideload_agent_cfg::type_id
+                                ::create("keymgr_sideload_agent_cfg");
+    keymgr_sideload_agent_cfg.start_default_seq = 0;
     num_edn = 1;
     has_shadowed_regs = 1;
     super.initialize(csr_base_addr);

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -123,11 +123,11 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
 
   // constraints
-  constraint c_num_messages {num_messages inside {[num_messages_min : num_messages_max]};}
-  constraint c_ref_model    {ref_model    dist   { 0 :/ use_c_model_pct,
+  constraint num_messages_c {num_messages inside {[num_messages_min : num_messages_max]};}
+  constraint ref_model_c    {ref_model    dist   { 0 :/ use_c_model_pct,
                                                    1 :/ (100 - use_c_model_pct)};}
 
-  constraint c_inj_delay    {inj_delay    inside {[inj_min_delay : inj_max_delay]};}
+  constraint inj_delay_c    {inj_delay    inside {[inj_min_delay : inj_max_delay]};}
 
   constraint flip_rst_c { flip_rst dist { 0:/flip_rst_split_pct,
                                           1:/(100-flip_rst_split_pct) };}

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -43,6 +43,8 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
   // use manual operation mode percentage
   int                manual_operation_pct       = 10;
+  // enable reseed on key touch
+  int                reseed_en                  = 1;
 
   // debug / directed test knobs
   // use fixed key
@@ -121,8 +123,11 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   // TL UL contraints //
   rand tl_ul_access_e host_resp_speed;
 
+  rand bit           do_reseed;
+
 
   // constraints
+  constraint do_reseed_c    { if (reseed_en == 0) { do_reseed == 0};}
   constraint num_messages_c {num_messages inside {[num_messages_min : num_messages_max]};}
   constraint ref_model_c    {ref_model    dist   { 0 :/ use_c_model_pct,
                                                    1 :/ (100 - use_c_model_pct)};}

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -16,12 +16,14 @@ package aes_env_pkg;
   import aes_reg_pkg::*;
   import aes_ral_pkg::*;
   import aes_pkg::*;
+  import key_sideload_agent_pkg::*;
 
 
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
 
+  typedef virtual key_sideload_if   sideload_vif;
   // parameters
   parameter string LIST_OF_ALERTS[] = {"recov_ctrl_update_err", "fatal_fault"};
   parameter uint NUM_ALERTS = 2;

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -187,7 +187,7 @@ class aes_message_item extends uvm_sequence_item;
 
   constraint sideload_c {
     sideload_en dist{ 0:/(100-sideload_pct),
-                       1:/sideload_pct};
+                      1:/sideload_pct};
   }
 
   constraint manual_operation_c {

--- a/hw/ip/aes/dv/env/aes_message_item.sv
+++ b/hw/ip/aes/dv/env/aes_message_item.sv
@@ -109,9 +109,9 @@ class aes_message_item extends uvm_sequence_item;
   // Constraints                       //
   ///////////////////////////////////////
 
-  constraint c_data { message_length inside { [message_len_min:message_len_max] };}
+  constraint data_c { message_length inside { [message_len_min:message_len_max] };}
 
-  constraint c_keylen {
+  constraint keylen_c {
     solve has_config_error before aes_keylen;
     solve cfg_error_type before aes_keylen;
     if (!(has_config_error && cfg_error_type.key_len) ) {
@@ -130,26 +130,26 @@ class aes_message_item extends uvm_sequence_item;
     };
   }
 
-  constraint c_key {
+  constraint key_c {
     if (fixed_key_en) {
       aes_key[0] == fixed_key[0],
       aes_key[1] == fixed_key[1]
     };
   }
 
-  constraint c_iv {
+  constraint iv_c {
     if (fixed_iv_en) {
       aes_iv == fixed_iv
     };
   }
 
-  constraint c_operation {
+  constraint operation_c {
      if (fixed_operation_en) {
          aes_operation == fixed_operation
      };
   }
 
-  constraint c_mode {
+  constraint mode_c {
     solve has_config_error before aes_mode;
     solve cfg_error_type before aes_mode;
     if (!(has_config_error && cfg_error_type.mode)) {
@@ -165,7 +165,7 @@ class aes_message_item extends uvm_sequence_item;
      }
    }
 
-  constraint c_has_config_error {
+  constraint has_config_error_c {
     if (error_types.cfg)
       {
       has_config_error dist { 0 :/ (100 - config_error_pct),
@@ -175,7 +175,7 @@ class aes_message_item extends uvm_sequence_item;
   }
 
 
-  constraint c_config_error_type {
+  constraint config_error_type_c {
     solve has_config_error before cfg_error_type;
     solve sideload_en before cfg_error_type;
     if (has_config_error & !sideload_en) {
@@ -185,12 +185,12 @@ class aes_message_item extends uvm_sequence_item;
     }
   }
 
-  constraint c_sideload {
+  constraint sideload_c {
     sideload_en dist{ 0:/(100-sideload_pct),
                        1:/sideload_pct};
   }
 
-  constraint c_manual_operation {
+  constraint manual_operation_c {
     solve sideload_en before manual_operation;
     if (!sideload_en) {
       manual_operation dist { 0:/ (100 - manual_operation_pct),
@@ -268,7 +268,7 @@ class aes_message_item extends uvm_sequence_item;
     for (int i=0; i <8; i++) begin
       str = {str, $sformatf("%h ",aes_key[1][i])};
     end
-    str = {str,  $sformatf("\n\t ----| Key Mask:  \t  \t %0b                               |----\t ",
+    str = {str,  $sformatf("\n\t ----| Key Mask:  \t  \t %0b                             |----\t ",
                            keymask)};
      str = {str,  $sformatf("\n\t ----| Initializaion vector:     \t    \t ")};
     for (int i=0; i <4; i++) begin
@@ -294,7 +294,7 @@ class aes_message_item extends uvm_sequence_item;
    virtual function string print_data();
      string txt="";
 
-     txt = $sformatf("\n\t ----| Printing message data \n\t ----| data length: %d", input_msg.size());
+     txt = $sformatf("\n\t ---| Printing message data \n\t ---| data length: %d", input_msg.size());
      foreach (input_msg[i]) begin
        txt = {txt, $sformatf("\n\t ----| [%0d] 0x%0h \t 0x%0h",i, input_msg[i], output_msg[i])};
      end

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -284,6 +284,7 @@ class aes_seq_item extends uvm_sequence_item;
     operation        = rhs_.operation;
     mode             = rhs_.mode;
     data_in          = rhs_.data_in;
+    data_in_vld      = rhs_.data_in_vld;
     key              = rhs_.key;
     key_len          = rhs_.key_len;
     key_vld          = rhs_.key_vld;

--- a/hw/ip/aes/dv/env/aes_seq_item.sv
+++ b/hw/ip/aes/dv/env/aes_seq_item.sv
@@ -33,6 +33,7 @@ class aes_seq_item extends uvm_sequence_item;
   // indicate if the initialization vector is valid
   bit [3:0]       iv_vld;
   aes_mode_e      mode;
+
   bit             en_b2b_transactions  = 1;
   int             b2b_pct              = 80;
 
@@ -65,6 +66,8 @@ class aes_seq_item extends uvm_sequence_item;
   bit             start_item       = 0;
   // indicate a message was split in two with this item.
   bit             split_item       = 0;
+  // use sideload
+  bit                          sideload_en;
 
 
   ///////////////////////////////////////
@@ -297,6 +300,7 @@ class aes_seq_item extends uvm_sequence_item;
     start_item       = rhs_.start_item;
     split_item       = rhs_.split_item;
     data_was_cleared = rhs_.data_was_cleared;
+    sideload_en      = rhs_.sideload_en;
   endfunction // copy
 
 

--- a/hw/ip/aes/dv/env/aes_virtual_sequencer.sv
+++ b/hw/ip/aes/dv/env/aes_virtual_sequencer.sv
@@ -6,8 +6,8 @@ class aes_virtual_sequencer extends cip_base_virtual_sequencer #(.CFG_T(aes_env_
                                                                  .COV_T(aes_env_cov));
 
   `uvm_component_utils(aes_virtual_sequencer)
-
-
   `uvm_component_new
+
+   key_sideload_sequencer key_sideload_sequencer_h;
 
 endclass : aes_virtual_sequencer

--- a/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_stress_vseq.sv
@@ -9,15 +9,21 @@ class aes_stress_vseq extends aes_base_vseq;
   `uvm_object_new
   aes_message_item my_message;
 
+
   task body();
     `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
                               cfg.convert2string()), UVM_LOW)
 
-    // generate list of messages //
-    generate_message_queue();
-    // process all messages //
 
+    fork
+      // generate list of messages //
+      generate_message_queue();
+      // start sideload (even if not used)
+      start_sideload_seq();
+    join_any
+    // process all messages //
     send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+
 
   endtask : body
 endclass

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -31,8 +31,7 @@ module tb;
   `DV_EDN_IF_CONNECT
   `DV_ALERT_IF_CONNECT
 
-  // for now drive a static key marked as invalid
-  assign keymgr_key = keymgr_pkg::HW_KEY_REQ_DEFAULT;
+  key_sideload_if sideload_if(.clk_i(clk), .rst_ni(rst_n));
 
   // dut
   aes #(
@@ -50,7 +49,7 @@ module tb;
     .rst_edn_ni       ( edn_rst_n                         ),
     .edn_o            ( edn_if[0].req                     ),
     .edn_i            ( {edn_if[0].ack, edn_if[0].d_data} ),
-    .keymgr_key_i     ( keymgr_key                        ),
+    .keymgr_key_i     ( sideload_if.sideload_key          ),
 
     .tl_i             ( tl_if.h2d                         ),
     .tl_o             ( tl_if.d2h                         ),
@@ -69,7 +68,8 @@ module tb;
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
     uvm_config_db#(virtual aes_cov_if)::set(null, "*.env", "aes_cov_if", dut.u_aes_cov_if );
-
+    uvm_config_db#(virtual key_sideload_if)
+                  ::set(null, "*.env.keymgr_sideload_agent*", "vif", sideload_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end

--- a/hw/ip/aes/dv/tests/aes_base_test.sv
+++ b/hw/ip/aes/dv/tests/aes_base_test.sv
@@ -82,6 +82,7 @@ class aes_base_test extends cip_base_test #(
   //  100: random resets
     cfg.error_types                 = 3'b111;
     cfg.config_error_pct            = 0;           // percentage of configuration errors
-    cfg.flip_rst_split_pct           = 60;
+    cfg.flip_rst_split_pct          = 60;
+    cfg.sideload_pct                = 0;
   endfunction
 endclass : aes_base_test

--- a/hw/ip/aes/dv/tests/aes_sideload_test.sv
+++ b/hw/ip/aes/dv/tests/aes_sideload_test.sv
@@ -1,0 +1,50 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class aes_sideload_test extends aes_base_test;
+
+  `uvm_component_utils(aes_sideload_test)
+  `uvm_component_new
+
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    configure_env();
+  endfunction
+
+  function void configure_env();
+    super.configure_env();
+    cfg.error_types              = 0;     // no errors in sideload test
+    cfg.num_messages_min         = 1;
+    cfg.num_messages_max         = 5;
+    // message related knobs
+    cfg.ecb_weight               = 10;
+    cfg.cbc_weight               = 10;
+    cfg.ctr_weight               = 10;
+    cfg.ofb_weight               = 10;
+    cfg.cfb_weight               = 10;
+
+    cfg.message_len_min          = 16;    // one block (16bytes=128bits)
+    cfg.message_len_max          = 128;   //
+    cfg.manual_operation_pct     = 50;    // only non sideload messages
+    cfg.use_key_mask             = 0;
+
+    cfg.fixed_data_en            = 0;
+    cfg.fixed_key_en             = 0;
+
+    cfg.fixed_operation_en       = 0;
+    cfg.fixed_operation          = 0;
+
+    cfg.fixed_keylen_en          = 0;
+    cfg.fixed_keylen             = 3'b001;
+
+    cfg.fixed_iv_en              = 0;
+
+    cfg.random_data_key_iv_order = 0;
+    cfg.read_prob                = 100;
+    cfg.write_prob               = 100;
+    cfg.sideload_pct             = 75;
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+  endfunction
+endclass : aes_sideload_test

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -48,5 +48,6 @@ class aes_stress_test extends aes_base_test;
     cfg.read_prob                = 65;
     cfg.write_prob               = 80;
     cfg.manual_operation_pct     = 30;
+    cfg.sideload_pct             = 30;
   endfunction // configure_env
 endclass : aes_stress_test

--- a/hw/ip/aes/dv/tests/aes_test.core
+++ b/hw/ip/aes/dv/tests/aes_test.core
@@ -18,6 +18,7 @@ filesets:
       - aes_config_error_test.sv: {is_include_file: true}
       - aes_clear_test.sv: {is_include_file: true}
       - aes_alert_reset_test.sv: {is_include_file: true}
+      - aes_sideload_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/aes/dv/tests/aes_test_pkg.sv
+++ b/hw/ip/aes/dv/tests/aes_test_pkg.sv
@@ -25,5 +25,5 @@ package aes_test_pkg;
   `include "aes_config_error_test.sv"
   `include "aes_clear_test.sv"
   `include "aes_alert_reset_test.sv"
-
+  `include "aes_sideload_test.sv"
 endpackage


### PR DESCRIPTION
This PR is, unfortunately, a little big due to changes on RTL side that voided my previous PR.

this PR contains 3 commits.
1. adding support for the sideload (keymanager sideload agent)
2. clean up of some lint issues
3. updates that supported the changes to :

- aes_operation register 
- updates to support aes_aux_ctrl register
- updates to support aes_regwen register
- support for changes to the reseeding behavior

the first and second commit  compiles but tests will fail due to the changed behavior in RTL.
the 3rd commit has a lot of changes to the base sequence as the added registers and the reseed behavior changed a lot of the underlying behavior to get the tests passing again.