### PR TITLE
[fpv/flash_ctrl] Fix compile error

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -786,7 +786,7 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; #(
   logic [DataWidth-1:0] rma_data;
   always_ff @(posedge clk_i) begin
     if (rma_start && rvalid_i && rready_o) begin
-      rma_data <= {rma_data[DataWidth -: BusWidth], rdata_i};
+      rma_data <= {rma_data[(DataWidth-1) -: BusWidth], rdata_i};
     end
   end
 


### PR DESCRIPTION
This PR fixes the compile error due to index out of bound.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>