### PR TITLE
[formal/conn] Add three connectivity checks

### DIFF
--- a/hw/top_earlgrey/formal/chip_conn_cfg.hjson
+++ b/hw/top_earlgrey/formal/chip_conn_cfg.hjson
@@ -10,12 +10,15 @@
   fusesoc_core: lowrisc:systems:chip_earlgrey_asic:0.1
 
   conn_csvs_dir: "{proj_root}/hw/top_earlgrey/formal/conn_csvs"
-  conn_csvs: ["{conn_csvs_dir}/clkmgr_ast.csv",
+  conn_csvs: ["{conn_csvs_dir}/aon_timer_clk_rst.csv",
+              "{conn_csvs_dir}/ast_mem_cfg.csv",
+              "{conn_csvs_dir}/clkmgr_ast.csv",
               "{conn_csvs_dir}/clkmgr_idle.csv",
               "{conn_csvs_dir}/clkmgr_peri.csv",
               "{conn_csvs_dir}/clkmgr_trans.csv",
-              "{conn_csvs_dir}/pwrmgr_rstmgr.csv",
-              "{conn_csvs_dir}/ast_mem_cfg.csv"]
+              "{conn_csvs_dir}/otbn_ast.csv",
+              "{conn_csvs_dir}/rom_ctrl_ast.csv",
+              "{conn_csvs_dir}/pwrmgr_rstmgr.csv"]
 
   // TODO: reduce run time and turn on coverage
   cov: false

--- a/hw/top_earlgrey/formal/conn_csvs/aon_timer_clk_rst.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/aon_timer_clk_rst.csv
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run these checks with:
+#  ./util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfg.hjson
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+# Verify that the correct clocks and resets are connected to the AON timer.
+CONNECTION,AON_TIMER_CLK,top_earlgrey.u_aon_timer_aon,clk_i,top_earlgrey.u_clkmgr_aon,clocks_o.clk_io_div4_timers
+CONNECTION,AON_TIMER_CLK_AON,top_earlgrey.u_aon_timer_aon,clk_aon_i,top_earlgrey.u_clkmgr_aon,clocks_o.clk_aon_timers
+
+CONNECTION,AON_TIMER_RST,top_earlgrey.u_aon_timer_aon,rst_ni,top_earlgrey.u_rstmgr_aon,resets_o.rst_lc_io_div4_n[0]
+CONNECTION,AON_TIMER_RST_AON,top_earlgrey.u_aon_timer_aon,rst_aon_ni,top_earlgrey.u_rstmgr_aon,resets_o.rst_lc_aon_n[0]

--- a/hw/top_earlgrey/formal/conn_csvs/otbn_ast.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/otbn_ast.csv
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run these checks with:
+#  ./util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfg.hjson
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+# Verify that the ram_cfg signal from AST is connected to OTBN.
+CONNECTION,OTBN_RAM_CFG_AST,top_earlgrey.u_otbn,ram_cfg_i,u_ast,spram_rm_o

--- a/hw/top_earlgrey/formal/conn_csvs/rom_ctrl_ast.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/rom_ctrl_ast.csv
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Run these checks with:
+#  ./util/dvsim/dvsim.py hw/top_earlgrey/formal/chip_conn_cfg.hjson
+
+,NAME,SRC BLOCK,SRC SIGNAL,DEST BLOCK,DEST SIGNAL,,,,,,
+
+# Verify that the rom_cfg signal from AST is connected to ROM_CTRL.
+CONNECTION,ROM_CTRL_ROM_CFG_AST,top_earlgrey.u_rom_ctrl,rom_cfg_i,u_ast,sprom_rm_o


### PR DESCRIPTION
This PR adds three connectivity checks from top-level testplan:
  - chip_sw_aon_timer_clks_resets
  - chip_otbn_ast_ram_cfg
  - chip_rom_ctrl_ast_rom_cfg

Signed-off-by: Cindy Chen <chencindy@opentitan.org>