### PR TITLE
[spi_device,dv] Add new spi_device agent

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -19,6 +19,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   bit partial_byte;       // Transfering less than byte
   bit [3:0] bits_to_transfer; // Bits to transfer if using less than byte
   bit csb_consecutive;            // Don't deassert CSB
+  bit passthrough;                // For passthrough mode
 
   //-------------------------
   // spi_host regs
@@ -64,6 +65,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (csb_sel,        UVM_DEFAULT)
     `uvm_field_int (partial_byte,   UVM_DEFAULT)
     `uvm_field_int (csb_consecutive,    UVM_DEFAULT)
+    `uvm_field_int (passthrough,        UVM_DEFAULT)
     `uvm_field_int (bits_to_transfer,             UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_sck,         UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_sck,     UVM_DEFAULT)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -132,6 +132,23 @@ class spi_device_base_vseq extends cip_base_vseq #(
     cfg.m_spi_agent_cfg.csb_sel = 0;
     cfg.m_spi_agent_cfg.partial_byte = 0;
     cfg.m_spi_agent_cfg.csb_consecutive = 0;
+    cfg.m_spi_agent_cfg.passthrough = 0;
+
+    if (spi_freq_faster) begin
+      cfg.spi_device_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps / core_spi_freq_ratio;
+    end else begin
+      cfg.spi_device_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps * core_spi_freq_ratio;
+    end
+    // update spi_device agent
+    cfg.spi_device_agent_cfg.sck_polarity[0] = sck_polarity;
+    cfg.spi_device_agent_cfg.sck_phase[0] = sck_phase;
+    cfg.spi_device_agent_cfg.host_bit_dir = host_bit_dir;
+    cfg.spi_device_agent_cfg.device_bit_dir = device_bit_dir;
+    cfg.spi_device_agent_cfg.csb_sel = 0;
+    cfg.spi_device_agent_cfg.partial_byte = 0;
+    cfg.spi_device_agent_cfg.csb_consecutive = 0;
+    cfg.spi_device_agent_cfg.passthrough = 0;
+
     // update device rtl
     ral.control.mode.set(spi_mode);
     csr_update(.csr(ral.control));

--- a/hw/ip/spi_device/dv/env/spi_device_env.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env.sv
@@ -11,6 +11,7 @@ class spi_device_env extends cip_base_env #(
   `uvm_component_utils(spi_device_env)
 
   spi_agent m_spi_agent;
+  spi_agent spi_device_agent;
 
   `uvm_component_new
 
@@ -18,8 +19,11 @@ class spi_device_env extends cip_base_env #(
     super.build_phase(phase);
     // build child components
     m_spi_agent = spi_agent::type_id::create("m_spi_agent", this);
-    uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent*", "cfg", cfg.m_spi_agent_cfg);
+    spi_device_agent = spi_agent::type_id::create("spi_device_agent", this);
+    uvm_config_db#(spi_agent_cfg)::set(this, "m_spi_agent", "cfg", cfg.m_spi_agent_cfg);
+    uvm_config_db#(spi_agent_cfg)::set(this, "spi_device_agent", "cfg", cfg.spi_device_agent_cfg);
     cfg.m_spi_agent_cfg.en_cov = cfg.en_cov;
+    cfg.spi_device_agent_cfg.en_cov = cfg.en_cov;
   endfunction
 
   function void connect_phase(uvm_phase phase);
@@ -33,6 +37,7 @@ class spi_device_env extends cip_base_env #(
     if (cfg.m_spi_agent_cfg.is_active) begin
       virtual_sequencer.spi_sequencer_h = m_spi_agent.sequencer;
     end
+    virtual_sequencer.spi_sequencer_d = spi_device_agent.sequencer;
   endfunction
 
 endclass

--- a/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_cfg.sv
@@ -4,11 +4,13 @@
 
 class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block));
   rand spi_agent_cfg  m_spi_agent_cfg;
+  rand spi_agent_cfg  spi_device_agent_cfg;
   bit [TL_AW-1:0]     sram_start_addr;
   bit [TL_AW-1:0]     sram_end_addr;
 
   `uvm_object_utils_begin(spi_device_env_cfg)
     `uvm_field_object(m_spi_agent_cfg, UVM_DEFAULT)
+    `uvm_field_object(spi_device_agent_cfg, UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
@@ -18,6 +20,7 @@ class spi_device_env_cfg extends cip_base_env_cfg #(.RAL_T(spi_device_reg_block)
     super.initialize(csr_base_addr);
     // create spi agent config obj
     m_spi_agent_cfg = spi_agent_cfg::type_id::create("m_spi_agent_cfg");
+    spi_device_agent_cfg = spi_agent_cfg::type_id::create("spi_device_agent_cfg");
     // set num_interrupts & num_alerts which will be used to create coverage and more
     num_interrupts = ral.intr_state.get_n_used_bits();
 

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -45,6 +45,12 @@ package spi_device_env_pkg;
     TpmCrbMode
   } tpm_cfg_mode_e;
 
+  typedef enum {
+    GenericMode,
+    FlashMode,
+    PassthroughMode
+  } device_mode_e;
+
   // alerts
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};

--- a/hw/ip/spi_device/dv/env/spi_device_virtual_sequencer.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_virtual_sequencer.sv
@@ -9,6 +9,7 @@ class spi_device_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(spi_device_virtual_sequencer)
 
   spi_sequencer  spi_sequencer_h;
+  spi_sequencer  spi_sequencer_d;
 
   `uvm_component_new
 

--- a/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
+++ b/hw/ip/spi_device/dv/tests/spi_device_base_test.sv
@@ -13,6 +13,8 @@ class spi_device_base_test extends cip_base_test #(.ENV_T(spi_device_env),
     super.build_phase(phase);
     // configure the spi agent to be in Host mode
     cfg.m_spi_agent_cfg.if_mode = Host;
+    // configure passthrough agent to be in Device mode
+    cfg.spi_device_agent_cfg.if_mode = Device;
   endfunction
 
 endclass : spi_device_base_test


### PR DESCRIPTION
This adds the new spi_device agent at the downstream interface 
for passthrough and flash spi_mode testing.

Signed-off-by: Madhuri Patel <madhuri.patel@ensilica.com>