### PR TITLE
[sw] Add build/ to .bazelignore.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,5 @@
 hw/ip/prim/util/vendor/google_verible_verilog_syntax_py
 sw/vendor/google_googletest
+
+# TODO: once Meson is no longer used, remove the line below.
+build


### PR DESCRIPTION
Fixes build errors generated when running bazel after building docs with meson by making bazel ignore everything in the `build/` directory. Thanks to @drewmacrae for this fix!

For archival purposes/in case anyone is having the same issue, the build errors I was getting before looked like this:
```
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:5:11: no such package 'third_party/py/dataclasses': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /home/jadep/opentitan/third_party/py/dataclasses and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:verible_verilog_syntax_py'
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:5:11: no such package 'verilog/tools/syntax': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /home/jadep/opentitan/verilog/tools/syntax and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:verible_verilog_syntax_py'
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:5:11: no such package '@python_anytree//': The repository '@python_anytree' could not be resolved and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:verible_verilog_syntax_py'
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:29:10: no such package 'verilog/tools/syntax': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /home/jadep/opentitan/verilog/tools/syntax and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:print_modules'
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:29:10: no such package '@python_anytree//': The repository '@python_anytree' could not be resolved and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:print_modules'
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:43:10: no such package 'verilog/tools/syntax': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /home/jadep/opentitan/verilog/tools/syntax and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:print_tree'
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:43:10: no such package '@python_anytree//': The repository '@python_anytree' could not be resolved and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:print_tree'
ERROR: /home/jadep/opentitan/build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py/BUILD:17:8: no such package 'verilog/tools/syntax': BUILD file not found in any of the following directories. Add a BUILD file to a directory to mark it as a package.
 - /home/jadep/opentitan/verilog/tools/syntax and referenced by '//build/docs/hw/ip/prim/util/vendor/google_verible_verilog_syntax_py:verible_verilog_syntax_py_test'
ERROR: Evaluation of query "rdeps(//..., //hw:verilator)" failed: errors were encountered while computing transitive closure
```