### PR TITLE
[sw/silicon_creator] Randomize iteration order in sigverify_rsa_key_get()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -385,6 +385,19 @@ cc_library(
     ]
 )
 
+cc_library(
+    name = "mock_rnd",
+    testonly = True,
+    hdrs = [
+        "mock_rnd.h",
+        "rnd.h",
+    ],
+    deps = [
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest",
+    ],
+)
+
 opentitan_functest(
     name = "rnd_functest",
     srcs = ["rnd_functest.c"],

--- a/sw/device/silicon_creator/lib/drivers/mock_rnd.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_rnd.h
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RND_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RND_H_
+
+#include "sw/device/silicon_creator/lib/drivers/rnd.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for rnd.c.
+ */
+class MockRnd : public GlobalMock<MockRnd> {
+ public:
+  MOCK_METHOD(uint32_t, Uint32, ());
+};
+
+}  // namespace internal
+
+using MockRnd = testing::StrictMock<internal::MockRnd>;
+
+extern "C" {
+
+uint32_t rnd_uint32(void) { return MockRnd::Instance().Uint32(); }
+
+}  // extern "C"
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RND_H_

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -221,6 +221,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:sigverify_intf",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/lib/drivers:rnd",
         "//sw/device/silicon_creator/mask_rom/keys:test_keys",
     ],
 )
@@ -246,6 +247,7 @@ cc_test(
         "//sw/device/silicon_creator/lib:sigverify_mod_exp_ibex",
         "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
+        "//sw/device/silicon_creator/lib/drivers:mock_rnd",
         "//sw/device/silicon_creator/mask_rom/keys:test_keys",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -25,6 +25,7 @@ sw_silicon_creator_mask_rom_sigverify = declare_dependency(
     dependencies: [
       sw_silicon_creator_lib_sigverify,
       sw_silicon_creator_lib_driver_otp,
+      sw_silicon_creator_lib_driver_rnd,
       sw_lib_bitfield,
     ],
   ),

--- a/sw/device/silicon_creator/mask_rom/mock_sigverify_keys_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/mock_sigverify_keys_ptrs.h
@@ -18,6 +18,7 @@ class MockSigverifyKeysPtrs : public GlobalMock<MockSigverifyKeysPtrs> {
  public:
   MOCK_METHOD(const sigverify_mask_rom_key_t *, RsaKeysPtrGet, ());
   MOCK_METHOD(size_t, NumRsaKeysGet, ());
+  MOCK_METHOD(size_t, RsaKeysStepGet, ());
 };
 
 }  // namespace internal
@@ -33,6 +34,10 @@ const sigverify_mask_rom_key_t *sigverify_rsa_keys_ptr_get() {
 
 size_t sigverify_num_rsa_keys_get() {
   return MockSigverifyKeysPtrs::Instance().NumRsaKeysGet();
+}
+
+size_t sigverify_rsa_keys_step_get() {
+  return MockSigverifyKeysPtrs::Instance().RsaKeysStepGet();
 }
 
 }  // extern "C"

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h
@@ -18,6 +18,13 @@ enum {
    * Number of RSA public keys.
    */
   kSigVerifyNumRsaKeys = 1,
+  /**
+   * Step size to use when checking RSA public keys.
+   *
+   * This must be coprime with and less than `kSigverifyNumRsaKeys`.
+   * Note: Step size is not applicable when `kSigverifyNumRsaKeys` is 1.
+   */
+  kSigverifyRsaKeysStep = 1,
 };
 
 /**
@@ -132,6 +139,16 @@ inline const sigverify_mask_rom_key_t *sigverify_rsa_keys_ptr_get(void) {
  */
 inline size_t sigverify_num_rsa_keys_get(void) { return kSigVerifyNumRsaKeys; }
 
+/**
+ * Returns the step size to use when checking RSA public keys.
+ *
+ * @return Step size that is coprime with and less than the return value of
+ * `sigverify_num_rsa_keys_get()`.
+ */
+inline size_t sigverify_rsa_keys_step_get(void) {
+  return kSigverifyRsaKeysStep;
+}
+
 #else
 
 /**
@@ -139,6 +156,7 @@ inline size_t sigverify_num_rsa_keys_get(void) { return kSigVerifyNumRsaKeys; }
  */
 const sigverify_mask_rom_key_t *sigverify_rsa_keys_ptr_get(void);
 size_t sigverify_num_rsa_keys_get(void);
+size_t sigverify_rsa_keys_step_get(void);
 
 #endif
 


### PR DESCRIPTION
This PR randomizes the iteration order in `sigverify_rsa_key_get()` using a relatively cheap approach (random start index and coprime step size).