### PR TITLE
[clkmgr, util] Change measure_ctrl to shadow types

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -305,15 +305,15 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
       "measure_ctrl_regwen": begin
         if (addr_phase_write) measure_ctrl_regwen = item.a_data;
       end
-      "io_measure_ctrl": begin
+      "io_meas_ctrl_shadowed": begin
       end
-      "io_div2_measure_ctrl": begin
+      "io_div2_meas_ctrl_shadowed": begin
       end
-      "io_div4_measure_ctrl": begin
+      "io_div4_meas_ctrl_shadowed": begin
       end
-      "main_measure_ctrl": begin
+      "main_meas_ctrl_shadowed": begin
       end
-      "usb_measure_ctrl": begin
+      "usb_meas_ctrl_shadowed": begin
       end
       "recov_err_code": begin
         do_read_check = 1'b0;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -63,11 +63,11 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   local function void disable_unnecessary_exclusions();
     ral.get_excl_item().enable_excl("clkmgr_reg_block.clk_enables", 0);
     ral.get_excl_item().enable_excl("clkmgr_reg_block.clk_hints", 0);
-    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_measure_ctrl.en", 0);
-    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_div2_measure_ctrl.en", 0);
-    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_div4_measure_ctrl.en", 0);
-    ral.get_excl_item().enable_excl("clkmgr_reg_block.main_measure_ctrl.en", 0);
-    ral.get_excl_item().enable_excl("clkmgr_reg_block.usb_measure_ctrl.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_meas_ctrl_shadowed.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_div2_meas_ctrl_shadowed.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.io_div4_meas_ctrl_shadowed.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.main_meas_ctrl_shadowed.en", 0);
+    ral.get_excl_item().enable_excl("clkmgr_reg_block.usb_meas_ctrl_shadowed.en", 0);
     `uvm_info(`gfn, "Adjusted exclusions", UVM_MEDIUM)
     ral.get_excl_item().print_exclusions(UVM_MEDIUM);
   endfunction
@@ -176,19 +176,19 @@ class clkmgr_base_vseq extends cip_base_vseq #(
     `uvm_info(`gfn, $sformatf("Disabling frequency measurement for %0s", which.name), UVM_MEDIUM)
     case (which)
       ClkMesrIo: begin
-        csr_wr(.ptr(ral.io_measure_ctrl.en), .value(0));
+        csr_wr(.ptr(ral.io_meas_ctrl_shadowed.en), .value(0));
       end
       ClkMesrIoDiv2: begin
-        csr_wr(.ptr(ral.io_div2_measure_ctrl.en), .value(0));
+        csr_wr(.ptr(ral.io_div2_meas_ctrl_shadowed.en), .value(0));
       end
       ClkMesrIoDiv4: begin
-        csr_wr(.ptr(ral.io_div4_measure_ctrl.en), .value(0));
+        csr_wr(.ptr(ral.io_div4_meas_ctrl_shadowed.en), .value(0));
       end
       ClkMesrMain: begin
-        csr_wr(.ptr(ral.main_measure_ctrl.en), .value(0));
+        csr_wr(.ptr(ral.main_meas_ctrl_shadowed.en), .value(0));
       end
       ClkMesrUsb: begin
-        csr_wr(.ptr(ral.usb_measure_ctrl.en), .value(0));
+        csr_wr(.ptr(ral.usb_meas_ctrl_shadowed.en), .value(0));
       end
       default: ;
     endcase
@@ -204,34 +204,34 @@ class clkmgr_base_vseq extends cip_base_vseq #(
               ), UVM_MEDIUM)
     case (which)
       ClkMesrIo: begin
-        ral.io_measure_ctrl.en.set(1);
-        ral.io_measure_ctrl.min_thresh.set(min_threshold);
-        ral.io_measure_ctrl.max_thresh.set(max_threshold);
-        csr_update(.csr(ral.io_measure_ctrl));
+        ral.io_meas_ctrl_shadowed.en.set(1);
+        ral.io_meas_ctrl_shadowed.lo.set(min_threshold);
+        ral.io_meas_ctrl_shadowed.hi.set(max_threshold);
+        csr_update(.csr(ral.io_meas_ctrl_shadowed));
       end
       ClkMesrIoDiv2: begin
-        ral.io_div2_measure_ctrl.en.set(1);
-        ral.io_div2_measure_ctrl.min_thresh.set(min_threshold);
-        ral.io_div2_measure_ctrl.max_thresh.set(max_threshold);
-        csr_update(.csr(ral.io_div2_measure_ctrl));
+        ral.io_div2_meas_ctrl_shadowed.en.set(1);
+        ral.io_div2_meas_ctrl_shadowed.lo.set(min_threshold);
+        ral.io_div2_meas_ctrl_shadowed.hi.set(max_threshold);
+        csr_update(.csr(ral.io_div2_meas_ctrl_shadowed));
       end
       ClkMesrIoDiv4: begin
-        ral.io_div4_measure_ctrl.en.set(1);
-        ral.io_div4_measure_ctrl.min_thresh.set(min_threshold);
-        ral.io_div4_measure_ctrl.max_thresh.set(max_threshold);
-        csr_update(.csr(ral.io_div4_measure_ctrl));
+        ral.io_div4_meas_ctrl_shadowed.en.set(1);
+        ral.io_div4_meas_ctrl_shadowed.lo.set(min_threshold);
+        ral.io_div4_meas_ctrl_shadowed.hi.set(max_threshold);
+        csr_update(.csr(ral.io_div4_meas_ctrl_shadowed));
       end
       ClkMesrMain: begin
-        ral.main_measure_ctrl.en.set(1);
-        ral.main_measure_ctrl.min_thresh.set(min_threshold);
-        ral.main_measure_ctrl.max_thresh.set(max_threshold);
-        csr_update(.csr(ral.main_measure_ctrl));
+        ral.main_meas_ctrl_shadowed.en.set(1);
+        ral.main_meas_ctrl_shadowed.lo.set(min_threshold);
+        ral.main_meas_ctrl_shadowed.hi.set(max_threshold);
+        csr_update(.csr(ral.main_meas_ctrl_shadowed));
       end
       ClkMesrUsb: begin
-        ral.usb_measure_ctrl.en.set(1);
-        ral.usb_measure_ctrl.min_thresh.set(min_threshold);
-        ral.usb_measure_ctrl.max_thresh.set(max_threshold);
-        csr_update(.csr(ral.usb_measure_ctrl));
+        ral.usb_meas_ctrl_shadowed.en.set(1);
+        ral.usb_meas_ctrl_shadowed.lo.set(min_threshold);
+        ral.usb_meas_ctrl_shadowed.hi.set(max_threshold);
+        csr_update(.csr(ral.usb_meas_ctrl_shadowed));
       end
       default: ;
     endcase

--- a/hw/ip/clkmgr/dv/tb.sv
+++ b/hw/ip/clkmgr/dv/tb.sv
@@ -74,6 +74,7 @@ module tb;
   clkmgr dut (
     .clk_i (clk),
     .rst_ni(rst_n),
+    .rst_shadowed_ni(rst_n),
 
     .clk_main_i (clk_main),
     .rst_main_ni(rst_main_n),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -269,7 +269,7 @@
         [
           Aon
         ]
-        shadowed: false
+        shadowed: true
         sw: false
         path: rstmgr_aon_resets.rst_por_io_div4_n
         parent: por_aon

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -457,8 +457,8 @@
         },
       ]
     },
-
-      { name: "IO_MEASURE_CTRL",
+  
+    { name: "IO_MEAS_CTRL_SHADOWED",
       desc: '''
         Configuration controls for io measurement.
 
@@ -469,6 +469,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       async: "clk_io_i",
+      shadowed: "true",
+      update_err_alert: "recov_fault",
+      storage_err_alert: "fatal_fault",
       fields: [
         {
           bits: "0",
@@ -484,20 +487,21 @@
 
         {
           bits: "13:4",
-          name: "MAX_THRESH",
+          name: "HI",
           desc: "Max threshold for io measurement",
           resval: "490"
         },
 
         {
           bits: "23:14",
-          name: "MIN_THRESH",
+          name: "LO",
           desc: "Min threshold for io measurement",
           resval: "470"
         },
       ]
     },
-      { name: "IO_DIV2_MEASURE_CTRL",
+  
+    { name: "IO_DIV2_MEAS_CTRL_SHADOWED",
       desc: '''
         Configuration controls for io_div2 measurement.
 
@@ -508,6 +512,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       async: "clk_io_div2_i",
+      shadowed: "true",
+      update_err_alert: "recov_fault",
+      storage_err_alert: "fatal_fault",
       fields: [
         {
           bits: "0",
@@ -523,20 +530,21 @@
 
         {
           bits: "12:4",
-          name: "MAX_THRESH",
+          name: "HI",
           desc: "Max threshold for io_div2 measurement",
           resval: "250"
         },
 
         {
           bits: "21:13",
-          name: "MIN_THRESH",
+          name: "LO",
           desc: "Min threshold for io_div2 measurement",
           resval: "230"
         },
       ]
     },
-      { name: "IO_DIV4_MEASURE_CTRL",
+  
+    { name: "IO_DIV4_MEAS_CTRL_SHADOWED",
       desc: '''
         Configuration controls for io_div4 measurement.
 
@@ -547,6 +555,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       async: "clk_io_div4_i",
+      shadowed: "true",
+      update_err_alert: "recov_fault",
+      storage_err_alert: "fatal_fault",
       fields: [
         {
           bits: "0",
@@ -562,20 +573,21 @@
 
         {
           bits: "11:4",
-          name: "MAX_THRESH",
+          name: "HI",
           desc: "Max threshold for io_div4 measurement",
           resval: "130"
         },
 
         {
           bits: "19:12",
-          name: "MIN_THRESH",
+          name: "LO",
           desc: "Min threshold for io_div4 measurement",
           resval: "110"
         },
       ]
     },
-      { name: "MAIN_MEASURE_CTRL",
+  
+    { name: "MAIN_MEAS_CTRL_SHADOWED",
       desc: '''
         Configuration controls for main measurement.
 
@@ -586,6 +598,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       async: "clk_main_i",
+      shadowed: "true",
+      update_err_alert: "recov_fault",
+      storage_err_alert: "fatal_fault",
       fields: [
         {
           bits: "0",
@@ -601,20 +616,21 @@
 
         {
           bits: "13:4",
-          name: "MAX_THRESH",
+          name: "HI",
           desc: "Max threshold for main measurement",
           resval: "510"
         },
 
         {
           bits: "23:14",
-          name: "MIN_THRESH",
+          name: "LO",
           desc: "Min threshold for main measurement",
           resval: "490"
         },
       ]
     },
-      { name: "USB_MEASURE_CTRL",
+  
+    { name: "USB_MEAS_CTRL_SHADOWED",
       desc: '''
         Configuration controls for usb measurement.
 
@@ -625,6 +641,9 @@
       swaccess: "rw",
       hwaccess: "hro",
       async: "clk_usb_i",
+      shadowed: "true",
+      update_err_alert: "recov_fault",
+      storage_err_alert: "fatal_fault",
       fields: [
         {
           bits: "0",
@@ -640,14 +659,14 @@
 
         {
           bits: "12:4",
-          name: "MAX_THRESH",
+          name: "HI",
           desc: "Max threshold for usb measurement",
           resval: "250"
         },
 
         {
           bits: "21:13",
-          name: "MIN_THRESH",
+          name: "LO",
           desc: "Min threshold for usb measurement",
           resval: "230"
         },
@@ -739,6 +758,46 @@
             usb has timed out.
           '''
         }
+        {
+          bits: "10",
+          name: "IO_UPDATE_ERR",
+          resval: 0,
+          desc: '''
+            !!IO_MEASURE_CTRL_SHADOWED has an update error.
+          '''
+        }
+        {
+          bits: "11",
+          name: "IO_DIV2_UPDATE_ERR",
+          resval: 0,
+          desc: '''
+            !!IO_DIV2_MEASURE_CTRL_SHADOWED has an update error.
+          '''
+        }
+        {
+          bits: "12",
+          name: "IO_DIV4_UPDATE_ERR",
+          resval: 0,
+          desc: '''
+            !!IO_DIV4_MEASURE_CTRL_SHADOWED has an update error.
+          '''
+        }
+        {
+          bits: "13",
+          name: "MAIN_UPDATE_ERR",
+          resval: 0,
+          desc: '''
+            !!MAIN_MEASURE_CTRL_SHADOWED has an update error.
+          '''
+        }
+        {
+          bits: "14",
+          name: "USB_UPDATE_ERR",
+          resval: 0,
+          desc: '''
+            !!USB_MEASURE_CTRL_SHADOWED has an update error.
+          '''
+        }
       ]
     },
 
@@ -752,6 +811,46 @@
           resval: 0
           desc: '''
             Register file has experienced a fatal integrity error.
+          '''
+        },
+        {
+          bits: "1",
+          name: "IO_STORAGE_ERR",
+          resval: 0,
+          desc: '''
+            !!IO_MEASURE_CTRL_SHADOWED has a storage error.
+          '''
+        },
+        {
+          bits: "2",
+          name: "IO_DIV2_STORAGE_ERR",
+          resval: 0,
+          desc: '''
+            !!IO_DIV2_MEASURE_CTRL_SHADOWED has a storage error.
+          '''
+        },
+        {
+          bits: "3",
+          name: "IO_DIV4_STORAGE_ERR",
+          resval: 0,
+          desc: '''
+            !!IO_DIV4_MEASURE_CTRL_SHADOWED has a storage error.
+          '''
+        },
+        {
+          bits: "4",
+          name: "MAIN_STORAGE_ERR",
+          resval: 0,
+          desc: '''
+            !!MAIN_MEASURE_CTRL_SHADOWED has a storage error.
+          '''
+        },
+        {
+          bits: "5",
+          name: "USB_STORAGE_ERR",
+          resval: 0,
+          desc: '''
+            !!USB_MEASURE_CTRL_SHADOWED has a storage error.
           '''
         },
       ]

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -79,65 +79,112 @@ package clkmgr_reg_pkg;
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic [9:0] q;
-    } max_thresh;
+      logic        err_update;
+      logic        err_storage;
+    } hi;
     struct packed {
       logic [9:0] q;
-    } min_thresh;
-  } clkmgr_reg2hw_io_measure_ctrl_reg_t;
+      logic        err_update;
+      logic        err_storage;
+    } lo;
+  } clkmgr_reg2hw_io_meas_ctrl_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic [8:0]  q;
-    } max_thresh;
+      logic        err_update;
+      logic        err_storage;
+    } hi;
     struct packed {
       logic [8:0]  q;
-    } min_thresh;
-  } clkmgr_reg2hw_io_div2_measure_ctrl_reg_t;
+      logic        err_update;
+      logic        err_storage;
+    } lo;
+  } clkmgr_reg2hw_io_div2_meas_ctrl_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic [7:0]  q;
-    } max_thresh;
+      logic        err_update;
+      logic        err_storage;
+    } hi;
     struct packed {
       logic [7:0]  q;
-    } min_thresh;
-  } clkmgr_reg2hw_io_div4_measure_ctrl_reg_t;
+      logic        err_update;
+      logic        err_storage;
+    } lo;
+  } clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic [9:0] q;
-    } max_thresh;
+      logic        err_update;
+      logic        err_storage;
+    } hi;
     struct packed {
       logic [9:0] q;
-    } min_thresh;
-  } clkmgr_reg2hw_main_measure_ctrl_reg_t;
+      logic        err_update;
+      logic        err_storage;
+    } lo;
+  } clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t;
 
   typedef struct packed {
     struct packed {
       logic        q;
+      logic        err_update;
+      logic        err_storage;
     } en;
     struct packed {
       logic [8:0]  q;
-    } max_thresh;
+      logic        err_update;
+      logic        err_storage;
+    } hi;
     struct packed {
       logic [8:0]  q;
-    } min_thresh;
-  } clkmgr_reg2hw_usb_measure_ctrl_reg_t;
+      logic        err_update;
+      logic        err_storage;
+    } lo;
+  } clkmgr_reg2hw_usb_meas_ctrl_shadowed_reg_t;
 
   typedef struct packed {
-    logic        q;
+    struct packed {
+      logic        q;
+    } reg_intg;
+    struct packed {
+      logic        q;
+    } io_storage_err;
+    struct packed {
+      logic        q;
+    } io_div2_storage_err;
+    struct packed {
+      logic        q;
+    } io_div4_storage_err;
+    struct packed {
+      logic        q;
+    } main_storage_err;
+    struct packed {
+      logic        q;
+    } usb_storage_err;
   } clkmgr_reg2hw_fatal_err_code_reg_t;
 
   typedef struct packed {
@@ -204,33 +251,75 @@ package clkmgr_reg_pkg;
       logic        d;
       logic        de;
     } usb_timeout_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_update_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div2_update_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div4_update_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } main_update_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } usb_update_err;
   } clkmgr_hw2reg_recov_err_code_reg_t;
 
   typedef struct packed {
-    logic        d;
-    logic        de;
+    struct packed {
+      logic        d;
+      logic        de;
+    } reg_intg;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div2_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } io_div4_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } main_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } usb_storage_err;
   } clkmgr_hw2reg_fatal_err_code_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    clkmgr_reg2hw_alert_test_reg_t alert_test; // [122:119]
-    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [118:111]
-    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [110:107]
-    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [106:103]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [102:98]
-    clkmgr_reg2hw_io_measure_ctrl_reg_t io_measure_ctrl; // [97:77]
-    clkmgr_reg2hw_io_div2_measure_ctrl_reg_t io_div2_measure_ctrl; // [76:58]
-    clkmgr_reg2hw_io_div4_measure_ctrl_reg_t io_div4_measure_ctrl; // [57:41]
-    clkmgr_reg2hw_main_measure_ctrl_reg_t main_measure_ctrl; // [40:20]
-    clkmgr_reg2hw_usb_measure_ctrl_reg_t usb_measure_ctrl; // [19:1]
-    clkmgr_reg2hw_fatal_err_code_reg_t fatal_err_code; // [0:0]
+    clkmgr_reg2hw_alert_test_reg_t alert_test; // [127:124]
+    clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [123:116]
+    clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [115:112]
+    clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [111:108]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [107:103]
+    clkmgr_reg2hw_io_meas_ctrl_shadowed_reg_t io_meas_ctrl_shadowed; // [102:82]
+    clkmgr_reg2hw_io_div2_meas_ctrl_shadowed_reg_t io_div2_meas_ctrl_shadowed; // [81:63]
+    clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t io_div4_meas_ctrl_shadowed; // [62:46]
+    clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t main_meas_ctrl_shadowed; // [45:25]
+    clkmgr_reg2hw_usb_meas_ctrl_shadowed_reg_t usb_meas_ctrl_shadowed; // [24:6]
+    clkmgr_reg2hw_fatal_err_code_reg_t fatal_err_code; // [5:0]
   } clkmgr_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [31:22]
-    clkmgr_hw2reg_recov_err_code_reg_t recov_err_code; // [21:2]
-    clkmgr_hw2reg_fatal_err_code_reg_t fatal_err_code; // [1:0]
+    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [51:42]
+    clkmgr_hw2reg_recov_err_code_reg_t recov_err_code; // [41:12]
+    clkmgr_hw2reg_fatal_err_code_reg_t fatal_err_code; // [11:0]
   } clkmgr_hw2reg_t;
 
   // Register offsets
@@ -242,11 +331,11 @@ package clkmgr_reg_pkg;
   parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_OFFSET = 6'h 14;
   parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_STATUS_OFFSET = 6'h 18;
   parameter logic [BlockAw-1:0] CLKMGR_MEASURE_CTRL_REGWEN_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] CLKMGR_IO_MEASURE_CTRL_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV2_MEASURE_CTRL_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV4_MEASURE_CTRL_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] CLKMGR_MAIN_MEASURE_CTRL_OFFSET = 6'h 2c;
-  parameter logic [BlockAw-1:0] CLKMGR_USB_MEASURE_CTRL_OFFSET = 6'h 30;
+  parameter logic [BlockAw-1:0] CLKMGR_IO_MEAS_CTRL_SHADOWED_OFFSET = 6'h 20;
+  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED_OFFSET = 6'h 24;
+  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED_OFFSET = 6'h 28;
+  parameter logic [BlockAw-1:0] CLKMGR_MAIN_MEAS_CTRL_SHADOWED_OFFSET = 6'h 2c;
+  parameter logic [BlockAw-1:0] CLKMGR_USB_MEAS_CTRL_SHADOWED_OFFSET = 6'h 30;
   parameter logic [BlockAw-1:0] CLKMGR_RECOV_ERR_CODE_OFFSET = 6'h 34;
   parameter logic [BlockAw-1:0] CLKMGR_FATAL_ERR_CODE_OFFSET = 6'h 38;
 
@@ -265,11 +354,11 @@ package clkmgr_reg_pkg;
     CLKMGR_CLK_HINTS,
     CLKMGR_CLK_HINTS_STATUS,
     CLKMGR_MEASURE_CTRL_REGWEN,
-    CLKMGR_IO_MEASURE_CTRL,
-    CLKMGR_IO_DIV2_MEASURE_CTRL,
-    CLKMGR_IO_DIV4_MEASURE_CTRL,
-    CLKMGR_MAIN_MEASURE_CTRL,
-    CLKMGR_USB_MEASURE_CTRL,
+    CLKMGR_IO_MEAS_CTRL_SHADOWED,
+    CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED,
+    CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED,
+    CLKMGR_MAIN_MEAS_CTRL_SHADOWED,
+    CLKMGR_USB_MEAS_CTRL_SHADOWED,
     CLKMGR_RECOV_ERR_CODE,
     CLKMGR_FATAL_ERR_CODE
   } clkmgr_id_e;
@@ -284,11 +373,11 @@ package clkmgr_reg_pkg;
     4'b 0001, // index[ 5] CLKMGR_CLK_HINTS
     4'b 0001, // index[ 6] CLKMGR_CLK_HINTS_STATUS
     4'b 0001, // index[ 7] CLKMGR_MEASURE_CTRL_REGWEN
-    4'b 0111, // index[ 8] CLKMGR_IO_MEASURE_CTRL
-    4'b 0111, // index[ 9] CLKMGR_IO_DIV2_MEASURE_CTRL
-    4'b 0111, // index[10] CLKMGR_IO_DIV4_MEASURE_CTRL
-    4'b 0111, // index[11] CLKMGR_MAIN_MEASURE_CTRL
-    4'b 0111, // index[12] CLKMGR_USB_MEASURE_CTRL
+    4'b 0111, // index[ 8] CLKMGR_IO_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[ 9] CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[10] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[11] CLKMGR_MAIN_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[12] CLKMGR_USB_MEAS_CTRL_SHADOWED
     4'b 0011, // index[13] CLKMGR_RECOV_ERR_CODE
     4'b 0001  // index[14] CLKMGR_FATAL_ERR_CODE
   };

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -433,7 +433,7 @@ module rstmgr
 
   // Generating resets for por_io_div4
   // Power Domains: ['Aon']
-  // Shadowed: False
+  // Shadowed: True
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck)
   ) u_daon_por_io_div4 (
@@ -461,8 +461,33 @@ module rstmgr
   assign cnsty_chk_errs[3][Domain0Sel] = '0;
   assign fsm_errs[3][Domain0Sel] = '0;
   assign rst_en_o.por_io_div4[Domain0Sel] = MuBi4True;
-  assign shadow_cnsty_chk_errs[3] = '0;
-  assign shadow_fsm_errs[3] = '0;
+  rstmgr_leaf_rst #(
+    .SecCheck(SecCheck)
+  ) u_daon_por_io_div4_shadowed (
+    .clk_i,
+    .rst_ni,
+    .leaf_clk_i(clk_io_div4_i),
+    .parent_rst_ni(rst_por_aon_n[DomainAonSel]),
+    .sw_rst_req_ni(1'b1),
+    .scan_rst_ni,
+    .scan_sel(prim_mubi_pkg::mubi4_test_true_strict(leaf_rst_scanmode[3])),
+    .rst_en_o(rst_en_o.por_io_div4_shadowed[DomainAonSel]),
+    .leaf_rst_o(resets_o.rst_por_io_div4_shadowed_n[DomainAonSel]),
+    .err_o(shadow_cnsty_chk_errs[3][DomainAonSel]),
+    .fsm_err_o(shadow_fsm_errs[3][DomainAonSel])
+  );
+
+  if (SecCheck) begin : gen_daon_por_io_div4_shadowed_assert
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
+    DAonPorIoDiv4ShadowedFsmCheck_A,
+    u_daon_por_io_div4_shadowed.gen_rst_chk.u_rst_chk.u_state_regs,
+    alert_tx_o[0])
+  end
+
+  assign resets_o.rst_por_io_div4_shadowed_n[Domain0Sel] = '0;
+  assign shadow_cnsty_chk_errs[3][Domain0Sel] = '0;
+  assign shadow_fsm_errs[3][Domain0Sel] = '0;
+  assign rst_en_o.por_io_div4_shadowed[Domain0Sel] = MuBi4True;
 
   // Generating resets for por_usb
   // Power Domains: ['Aon']

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -36,6 +36,7 @@ package rstmgr_pkg;
     logic [PowerDomains-1:0] rst_por_n;
     logic [PowerDomains-1:0] rst_por_io_n;
     logic [PowerDomains-1:0] rst_por_io_div2_n;
+    logic [PowerDomains-1:0] rst_por_io_div4_shadowed_n;
     logic [PowerDomains-1:0] rst_por_io_div4_n;
     logic [PowerDomains-1:0] rst_por_usb_n;
     logic [PowerDomains-1:0] rst_lc_shadowed_n;
@@ -63,6 +64,7 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io_div2;
+    prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io_div4_shadowed;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_io_div4;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] por_usb;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] lc_shadowed;
@@ -84,7 +86,7 @@ package rstmgr_pkg;
     prim_mubi_pkg::mubi4_t [PowerDomains-1:0] i2c2;
   } rstmgr_rst_en_t;
 
-  parameter int NumOutputRst = 23 * PowerDomains;
+  parameter int NumOutputRst = 24 * PowerDomains;
 
   // cpu reset requests and status
   typedef struct packed {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -935,53 +935,57 @@ module top_earlgrey #(
     prim_mubi_pkg::mubi4_t unused_rst_en_7;
     assign unused_rst_en_7 = rstmgr_aon_rst_en.por_io_div2[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_8;
-    assign unused_rst_en_8 = rstmgr_aon_rst_en.por_io_div4[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_8 = rstmgr_aon_rst_en.por_io_div4_shadowed[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_9;
-    assign unused_rst_en_9 = rstmgr_aon_rst_en.por_usb[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_9 = rstmgr_aon_rst_en.por_io_div4_shadowed[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_10;
-    assign unused_rst_en_10 = rstmgr_aon_rst_en.por_usb[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_10 = rstmgr_aon_rst_en.por_io_div4[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_11;
-    assign unused_rst_en_11 = rstmgr_aon_rst_en.lc_shadowed[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_11 = rstmgr_aon_rst_en.por_usb[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_12;
-    assign unused_rst_en_12 = rstmgr_aon_rst_en.lc[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_12 = rstmgr_aon_rst_en.por_usb[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_13;
-    assign unused_rst_en_13 = rstmgr_aon_rst_en.lc_shadowed[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_13 = rstmgr_aon_rst_en.lc_shadowed[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_14;
-    assign unused_rst_en_14 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_14 = rstmgr_aon_rst_en.lc[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_15;
-    assign unused_rst_en_15 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_15 = rstmgr_aon_rst_en.lc_shadowed[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_16;
-    assign unused_rst_en_16 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_16 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_17;
-    assign unused_rst_en_17 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_17 = rstmgr_aon_rst_en.lc_io_div4_shadowed[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_18;
-    assign unused_rst_en_18 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_18 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_19;
-    assign unused_rst_en_19 = rstmgr_aon_rst_en.sys[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_19 = rstmgr_aon_rst_en.lc_aon[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_20;
-    assign unused_rst_en_20 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_20 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_21;
-    assign unused_rst_en_21 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_21 = rstmgr_aon_rst_en.sys[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_22;
-    assign unused_rst_en_22 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_22 = rstmgr_aon_rst_en.sys_shadowed[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_23;
-    assign unused_rst_en_23 = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_23 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_24;
-    assign unused_rst_en_24 = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_24 = rstmgr_aon_rst_en.sys_aon[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_25;
-    assign unused_rst_en_25 = rstmgr_aon_rst_en.spi_host1[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_25 = rstmgr_aon_rst_en.spi_device[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_26;
-    assign unused_rst_en_26 = rstmgr_aon_rst_en.usb[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_26 = rstmgr_aon_rst_en.spi_host0[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_27;
-    assign unused_rst_en_27 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_27 = rstmgr_aon_rst_en.spi_host1[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_28;
-    assign unused_rst_en_28 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::Domain0Sel];
+    assign unused_rst_en_28 = rstmgr_aon_rst_en.usb[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_29;
-    assign unused_rst_en_29 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_29 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_30;
-    assign unused_rst_en_30 = rstmgr_aon_rst_en.i2c1[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_30 = rstmgr_aon_rst_en.usbif[rstmgr_pkg::Domain0Sel];
     prim_mubi_pkg::mubi4_t unused_rst_en_31;
-    assign unused_rst_en_31 = rstmgr_aon_rst_en.i2c2[rstmgr_pkg::DomainAonSel];
+    assign unused_rst_en_31 = rstmgr_aon_rst_en.i2c0[rstmgr_pkg::DomainAonSel];
+    prim_mubi_pkg::mubi4_t unused_rst_en_32;
+    assign unused_rst_en_32 = rstmgr_aon_rst_en.i2c1[rstmgr_pkg::DomainAonSel];
+    prim_mubi_pkg::mubi4_t unused_rst_en_33;
+    assign unused_rst_en_33 = rstmgr_aon_rst_en.i2c2[rstmgr_pkg::DomainAonSel];
 
   // Peripheral Instantiation
 
@@ -1768,6 +1772,7 @@ module top_earlgrey #(
       .clk_io_i (clk_io_i),
       .clk_usb_i (clk_usb_i),
       .clk_aon_i (clk_aon_i),
+      .rst_shadowed_ni (rstmgr_aon_resets.rst_por_io_div4_shadowed_n[rstmgr_pkg::DomainAonSel]),
       .rst_ni (rstmgr_aon_resets.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]),
       .rst_main_ni (rstmgr_aon_resets.rst_por_n[rstmgr_pkg::DomainAonSel]),
       .rst_io_ni (rstmgr_aon_resets.rst_por_io_n[rstmgr_pkg::DomainAonSel]),

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -286,11 +286,6 @@ class Register(RegBase):
                               'shadowed flag for {} register'
                               .format(name))
 
-        if async_name and shadowed:
-            raise ValueError(f'{name} is defined as async and shadowed. '
-                             'This is currently not supported. Please file '
-                             'an issue against OpenTitan if this is needed.')
-
         raw_fields = check_list(rd['fields'],
                                 'fields for {} register'.format(name))
         if not raw_fields:


### PR DESCRIPTION
First commit allows shadow registers to be asynchronous. 
Last commit changes `measure_ctrl` to shadow types so the frequency measurements is properly hardened. 