### PR TITLE
[lc_ctrl, dv] Add lc_ctrl_jtag_smoke to smoke regr

### DIFF
--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -213,7 +213,8 @@
   regressions: [
     {
       name: smoke
-      tests: ["lc_ctrl_smoke"]
+      tests: ["lc_ctrl_smoke",
+              "lc_ctrl_jtag_smoke"]
     }
     {
       name: jtag


### PR DESCRIPTION
This PR adds LC ctrl JTAG smoke test to the smoke suite run in CI. The
reason for this addition is to ensure changes to the JTAG agent which is
shared with other testbenches do not break the LC ctrl testbench.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>