### PR TITLE
[sw/ottf] Add manifest to OTTF so mask ROM can (eventually) boot it

### DIFF
--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -105,6 +105,7 @@ cc_library(
         "//sw/device/lib/crt",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",
+        "//sw/device/silicon_creator/lib:manifest_size",
     ],
 )
 

--- a/sw/device/lib/testing/test_framework/ottf.c
+++ b/sw/device/lib/testing/test_framework/ottf.c
@@ -83,6 +83,5 @@ int main(int argc, char **argv) {
   }
 
   // Unreachable code.
-  abort();
   return 1;
 }

--- a/sw/device/lib/testing/test_framework/ottf.ld
+++ b/sw/device/lib/testing/test_framework/ottf.ld
@@ -3,10 +3,26 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 /**
- * Linker script for an OpenTitan flash (test) binaries.
+ * Linker script for OpenTitan OTTF-launched test binaries.
  *
  * Portions of this file are Ibex-specific.
  */
+
+INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+
+/**
+ * Reserving space at the top of the RAM for the stack.
+ */
+_stack_size = 0x2000;
+_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
+_stack_start = _stack_end - _stack_size;
+
+/**
+ * DV Log offset.
+ * TODO: this will need to be different depending on the boot stage the OTTF is
+ * launched at. See lowrisc/opentitan:#10498.
+ */
+_dv_log_offset = 0x10000;
 
 OUTPUT_ARCH(riscv)
 GROUP(-lgcc)
@@ -17,53 +33,37 @@ GROUP(-lgcc)
 __DYNAMIC = 0;
 
 /**
- * Memory definitions are auto-generated.
+ * Marking the entry point correctly for the ELF file. The signer tool will
+ * transfer this value to the `entry_point` field of the manifest, which will
+ * then be used by `mask_rom_boot` or `rom_ext_boot` to handover execution to
+ * the OTTF.
  */
-INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+ENTRY(_ottf_start);
 
 /**
-/* Reserving space at the top of the RAM for the stack.
- * It is zeroed out so a size must be provided.
+ * NOTE: We have to align each section to word boundaries as our current
+ * s19->slm conversion scripts are not able to handle non-word aligned sections.
  */
-_stack_size = 0x2000;
-_stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
-_stack_start = _stack_end - _stack_size;
-
-/* DV Log offset (has to be different to other boot stages). */
-_dv_log_offset = 0x10000;
-
-/**
- * The entry point in `ottf_start.S` is called `_start`. This
- * information in the ELF file is not used - instead we use the information in
- * the `.flash_header` section to understand where to start execution of a flash
- * image. We need this declaration so LLD does not error.
- */
-ENTRY(_start);
-
 SECTIONS {
+  .manifest ORIGIN(eflash_virtual) : {
+    KEEP(*(.manifest))
+  } > eflash_virtual
+
   /**
-   * The flash header. This will eventually contain other stuff, like a
-   * signature, but for now it's just the entry point at offset zero.
+   * Ibex interrupt vector. See 'ottf_start.S' for more information.
+   *
+   * This has to be set up at a 256-byte offset, so that we can use it with
+   * Ibex.
    */
-  .flash_header ORIGIN(eflash_virtual) : ALIGN(4) {
-    KEEP(*(.flash_header))
+  .vectors : ALIGN (256){
+    *(.vectors)
   } > eflash_virtual
 
   /**
    * C runtime (CRT) section, containing program initialization code.
-   *
-   * The flash header contains the address of the entry point, _start, which is
-   * inside this section. We keep them together in the linked elf files too.
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-  } > eflash_virtual
-
-  /**
-   * OTTF interrupt vectors. See 'ottf_start.S' for more information.
-   */
-  .vectors : {
-    *(.vectors)
   } > eflash_virtual
 
   /**
@@ -94,7 +94,7 @@ SECTIONS {
    */
   .rodata : ALIGN(4) {
     /* Small read-only data comes before regular read-only data for the same
-     * reasons as in the data section */
+     * reasons as in the data section. */
     *(.srodata)
     *(.srodata.*)
     *(.rodata)
@@ -138,6 +138,7 @@ SECTIONS {
     KEEP(*(__llvm_prf_cnts))
     KEEP(*(__llvm_prf_data))
 
+    /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _data_end = .;
   } > ram_main
@@ -147,12 +148,15 @@ SECTIONS {
    */
   .bss : ALIGN(4) {
     _bss_start = .;
+
     /* Small BSS comes before regular BSS for the same reasons as in the data
      * section. */
     *(.sbss)
     *(.sbss.*)
     *(.bss)
     *(.bss.*)
+
+    /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _bss_end = .;
   } > ram_main

--- a/sw/device/lib/testing/test_framework/ottf_start.S
+++ b/sw/device/lib/testing/test_framework/ottf_start.S
@@ -3,46 +3,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Flash header.
+ * Manifest for boot stages stored in flash.
  *
- * Contains the address of the entry point.
+ * Note, we set the default entry point field (which is the last field in the
+ * manifest struct) to `_ottf_start`. We do this to enable running unsigned test
+ * images with the test ROM, since these images will not be processed by our
+ * signing tool which would otherwise populate this entry point field.
  */
-  .section .flash_header, "a", @progbits
-  .4byte _start
+
+  #include "sw/device/silicon_creator/lib/manifest_size.h"
+
+  .section .manifest, "a"
+  .global kManifest
+
+kManifest:
+  .rept MANIFEST_SIZE - 4
+  .byte 0x0
+  .endr
+  .4byte _ottf_start
 
 /**
- * Ibex-specific interrupt vectors for test flash images.
- *
- * This is similar to the test ROM interrupt vectors configured in the Test ROM
- * (`sw/device/lib/testing/test_rom/test_rom_start.S`), except these are placed
- * in flash, and point to the OTTF ISRs declared in
- * `sw/device/lib/testing/test_framework/ottf_isrs.S`. If you are getting link
- * errors for these symbols, then it's likely you have forgotten to add
- * `ottf_isrs` as a dependency for your executable.
+ * OTTF Interrupt Vector.
  */
 
-  // These symbols are declared in
-  // `sw/device/lib/testing/test_framework/ottf_isrs.S`.
+  .section .vectors, "ax"
+  .option push
+
+  // Disable RISC-V instruction compression: we need all instructions to
+  // be exactly word wide in the interrupt vector.
+  .option norvc
+
+  // Disable RISC-V linker relaxation, as it can compress instructions at
+  // link-time, which we also really don't want.
+  .option norelax
+
+  // These symbols are declared in `ottf_isrs.S`.
   .extern handler_exception
   .extern handler_irq_software
   .extern handler_irq_timer
   .extern handler_irq_external
 
-  // NOTE: The "ax" flag below is necessary to ensure that this section
-  // is allocated space in flash by the linker.
-  .section .vectors, "ax"
-  .option push
-  // Switch off compressed instructions so we know each instruction below is
-  // exactly 4 bytes (one entry).
-  .option norvc
-  // Switch off linker relaxation so that the linker does not reduce the size of
-  // any entries.
-  .option norelax
-
+/**
+ * `_ottf_interrupt_vector` is an ibex-compatible interrupt vector.
+ *
+ * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts. The
+ * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
+ *
+ * Only the following will be used by Ibex:
+ * - Exception Handler (Entry 0)
+ * - Machine Software Interrupt Handler (Entry 3)
+ * - Machine Timer Interrupt Handler (Entry 7)
+ * - Machine External Interrupt Handler (Entry 11)
+ * - Vendor Interrupt Handlers (Entries 16-31)
+ *
+ * More information about Ibex's interrupts can be found here:
+ *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+ */
   .balign 256
-  .global _interrupt_vector
-  .type _interrupt_vector, @function
-_interrupt_vector:
+  .global _ottf_interrupt_vector
+  .type _ottf_interrupt_vector, @function
+_ottf_interrupt_vector:
 
   // RISC-V Standard (Vectored) Interrupt Handlers:
 
@@ -90,66 +110,98 @@ _interrupt_vector:
   unimp
 
   // Set size so vector can be disassembled.
-  .size _interrupt_vector, .-_interrupt_vector
+  .size _ottf_interrupt_vector, .-_ottf_interrupt_vector
 
   .option pop
 
 /**
- * Flash executable runtime initialization code.
+ * OTTF runtime initialization code.
  */
 
-  // NOTE: The "ax" flag below is necessary to ensure that this section
-  // is allocated space in ROM by the linker.
-  .section .crt, "ax", @progbits
+  /**
+   * NOTE: The "ax" flag below is necessary to ensure that this section
+   * is allocated executable space in ROM by the linker.
+   */
+  .section .crt, "ax"
 
 /**
- * Callable entry point for flash.
+ * Entry point.
  *
- * This sets up the stack, zeroes `.bss`, and sets up `.data`.
- * It then jumps into main.
+ * This symbol is jumped to from the test ROM or mask ROM using the
+ * `entry_point` field of the manifest.
  */
-  .globl _start
-  .type _start, @function
-_start:
+  .globl _ottf_start
+  .type _ottf_start, @function
+_ottf_start:
 
-  // Set up the stack. We have no expectation that the rom that
-  // jumps here will have the correct stack start linked in.
-  la sp, _stack_end
+  /**
+   * Set up the stack pointer.
+   *
+   * In RISC-V, the stack grows downwards, so we load the address of the highest
+   * word in the stack into sp. We don't load in `_stack_end`, as that points
+   * beyond the end of RAM, and we always want it to be valid to dereference
+   * `sp`, and we need this to be 128-bit (16-byte) aligned to meet the psABI.
+   *
+   * If an exception fires, the handler is conventionaly only allowed to clobber
+   * memory at addresses below `sp`.
+   */
+  la   sp, (_stack_end - 16)
 
-  // Set up the global pointer. This requires that we disable linker relaxations
-  // (or it will be relaxed to `mv gp, gp`).
-  .option push
-  .option norelax
-  la gp, __global_pointer$
-  .option pop
-
-  // Set up the new interrupt vector.
-  la   t0, (_interrupt_vector + 1)
+  /**
+   * Set well-defined interrupt/exception handlers.
+   *
+   * The lowest two bits should be `0b01` to ensure we use vectored interrupts.
+   */
+  la   t0, (_ottf_interrupt_vector + 1)
   csrw mtvec, t0
 
-  // Zero out the `.bss` segment.
-  la   a0, _bss_start
-  la   a1, _bss_end
-  .extern crt_section_clear
-  call crt_section_clear
+  /**
+   * Setup C Runtime
+   */
 
-  // Initialize the `.data` segment from the `.idata` segment.
+  /**
+   * Initialize the `.data` section in RAM from Flash.
+   */
   la   a0, _data_start
   la   a1, _data_end
   la   a2, _data_init_start
   .extern crt_section_copy
   call crt_section_copy
 
-  // Call the functions in the `.init_array` section.
-  //
-  // This section is typically empty except for executables built with LLVM
-  // coverage enabled. When coverage is enabled, the compiler emits pointers to
-  // the functions that initialize the profile buffer in this section. These
-  // functions must be called before the instrumented functions in the program.
-  //
-  // We use `s0` and `s1` to represent the start and end pointers of
-  // `.init_array`, respectively, and `t0` to store the addresses of the
-  // functions to be called.
+  /**
+   * Initialize the `.bss` section.
+   *
+   * We do this despite zeroing all of SRAM above, so that we still zero `.bss`
+   * once we've enabled SRAM scrambling.
+   */
+  la   a0, _bss_start
+  la   a1, _bss_end
+  .extern crt_section_clear
+  call crt_section_clear
+
+  /**
+   * Setup global pointer.
+   *
+   * This requires that we temporarily disable linker relaxations, or it will be
+   * relaxed to `mv gp, gp`.
+   */
+  .option push
+  .option norelax
+  la gp, __global_pointer$
+  .option pop
+
+ /**
+  * Call the functions in the `.init_array` section.
+  *
+  * This section is typically empty except for executables built with LLVM
+  * coverage enabled. When coverage is enabled, the compiler emits pointers to
+  * the functions that initialize the profile buffer in this section. These
+  * functions must be called before the instrumented functions in the program.
+  *
+  * We use `s0` and `s1` to represent the start and end pointers of
+  * `.init_array`, respectively, and `t0` to store the addresses of the
+  * functions to be called.
+  */
   la   s0, _init_array_start
   la   s1, _init_array_end
   bgeu s0, s1, init_array_loop_end
@@ -160,12 +212,14 @@ init_array_loop:
   bltu s0, s1, init_array_loop
 init_array_loop_end:
 
-  // Jump into the OTTF C entry point. This is your standard C `main()`, so we
-  // need to pass dummy values for `argc` and `argv`.
+ /**
+  * Jump into the OTTF C entry point. This is your standard C `main()`, so we
+  * need to pass dummy values for `argc` and `argv`.
+  */
   li   a0, 0x0  // argc = 0
   li   a1, 0x0  // argv = NULL
   .extern main
   tail main
 
   // Set size so this function can be disassembled.
-  .size _start, .-_start
+  .size _ottf_start, .-_ottf_start

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -56,6 +56,7 @@ cc_library(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/runtime:print",
         "//sw/device/lib/testing/test_framework",
+        "//sw/device/silicon_creator/lib:manifest_intf",
     ],
 )
 

--- a/sw/device/lib/testing/test_rom/bootstrap.c
+++ b/sw/device/lib/testing/test_rom/bootstrap.c
@@ -24,19 +24,8 @@
 
 /**
  * Check if flash is blank to determine if bootstrap is needed.
- *
- * TODO: Update this to check bootstrap pin instead in Verilator.
  */
 static bool bootstrap_requested(void) {
-  // The following flash empty-sniff-check is done this way due to the lack of
-  // clear eflash reset in SIM environments.
-  if (kDeviceType == kDeviceSimVerilator) {
-    mmio_region_t flash_region = mmio_region_from_addr(FLASH_MEM_BASE_ADDR);
-    uint32_t value = mmio_region_read32(flash_region, 0x0);
-    return value == 0 || value == UINT32_MAX;
-  }
-
-  // Initialize GPIO device.
   dif_gpio_t gpio;
   CHECK_DIF_OK(
       dif_gpio_init(mmio_region_from_addr(TOP_EARLGREY_GPIO_BASE_ADDR), &gpio));

--- a/sw/device/lib/testing/test_rom/test_rom.ld
+++ b/sw/device/lib/testing/test_rom/test_rom.ld
@@ -33,13 +33,13 @@ _vflash_size = LENGTH(eflash_virtual);
 _flash_start = ORIGIN(eflash);
 
 /**
- * This symbol points at the header of the flash binary, which contains loading
- * and signing information.
+ * This symbol points at the manifest of the OTTF + test binary, which contains
+ * loading and signing information.
  *
  * See `sw/device/lib/testing/test_framework/ottf.ld`, under the
- * .flash_header section, which populates it.
+ * .manifest section, which populates it.
  */
-_flash_header = _vflash_start;
+_manifest = _vflash_start;
 
 _rom_digest_size = 32;
 _chip_info_size = 128;

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_binary", "opentitan_functest", "verilator_params")
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_functest", "verilator_params")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -184,15 +184,18 @@ cc_test(
 )
 
 cc_library(
+    name = "manifest_size",
+    hdrs = ["manifest_size.h"],
+)
+
+cc_library(
     name = "manifest_intf",
-    hdrs = [
-        "manifest.h",
-        "manifest_size.h",
-    ],
+    hdrs = ["manifest.h"],
     deps = [
         ":epmp_intf",
         ":error",
         ":keymgr_binding",
+        ":manifest_size",
         ":sigverify_internal",
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",


### PR DESCRIPTION
This adds a manifest field to any test images that are run via the ottf_start.S assembly. This includes any tests that use the OTTF itself (e.g., chip-level tests), and tests with a `main()` entrypoint (e.g., "Hello World" example programs).

Note, this just adds the manifest fields to OTTF test binaries, and sets the default entry point to `_ottf_start`. It does not place the manifest in the correct location such that it can be loaded and verified by the mask ROM or ROM_EXT. That will come in a subsequent commit.

This addresses task in #10498.

**_Note: this depends on #10563, and therefore contains an additional commit that will be removed when the dependency is merged._**