### PR TITLE
[lint] Minor lint fixes related to unused clocks

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -876,7 +876,7 @@ module csrng_core import csrng_pkg::*; #(
 
   prim_mubi8_sync #(
     .NumCopies(2),
-    .AsyncOn(0)
+    .AsyncOn(1)
   ) u_prim_mubi8_sync_sw_app_read (
     .clk_i,
     .rst_ni,

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -605,7 +605,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_mubi8_sync #(
     .NumCopies(1),
-    .AsyncOn(0)
+    .AsyncOn(1)
   ) u_prim_mubi8_sync_es_fw_over (
     .clk_i,
     .rst_ni,
@@ -2467,7 +2467,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   prim_mubi8_sync #(
     .NumCopies(1),
-    .AsyncOn(0)
+    .AsyncOn(1)
   ) u_prim_mubi8_sync_es_fw_read (
     .clk_i,
     .rst_ni,

--- a/hw/ip/prim/lint/prim_sparse_fsm_flop.waiver
+++ b/hw/ip/prim/lint/prim_sparse_fsm_flop.waiver
@@ -12,3 +12,6 @@ waive -rules {PARAM_NOT_USED} -location {prim_sparse_fsm_flop.sv} -regexp {.*Sta
 
 waive -rules {PARAM_NOT_USED} -location {prim_sparse_fsm_flop.sv} -regexp {.*EnableAlertTriggerSVA.*} \
       -comment "The disable parameter is used only during DV / FPV."
+
+waive -rules {SAME_NAME_TYPE} -location {prim_sparse_fsm_flop.sv} -regexp {.*ResetValue.*} \
+      -comment "The ResetValue parameter is a common name used by many prim types"

--- a/hw/ip/prim/rtl/prim_mubi12_sender.sv
+++ b/hw/ip/prim/rtl/prim_mubi12_sender.sv
@@ -48,10 +48,18 @@ module prim_mubi12_sender
         .out_o(mubi_out[k])
       );
     end
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for sythesis since it is unloaded.
+    mubi12_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi12False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
   end
 
   assign mubi_o = mubi12_t'(mubi_out);

--- a/hw/ip/prim/rtl/prim_mubi12_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi12_sync.sv
@@ -105,10 +105,19 @@ module prim_mubi12_sync
       assign mubi = mubi_sync;
     end
   end else begin : gen_no_flops
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for synthesis since it is unloaded.
+    mubi12_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi12False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
+
     assign mubi = MuBi12Width'(mubi_i);
   end
 

--- a/hw/ip/prim/rtl/prim_mubi16_sender.sv
+++ b/hw/ip/prim/rtl/prim_mubi16_sender.sv
@@ -48,10 +48,18 @@ module prim_mubi16_sender
         .out_o(mubi_out[k])
       );
     end
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for sythesis since it is unloaded.
+    mubi16_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi16False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
   end
 
   assign mubi_o = mubi16_t'(mubi_out);

--- a/hw/ip/prim/rtl/prim_mubi16_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi16_sync.sv
@@ -105,10 +105,19 @@ module prim_mubi16_sync
       assign mubi = mubi_sync;
     end
   end else begin : gen_no_flops
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for synthesis since it is unloaded.
+    mubi16_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi16False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
+
     assign mubi = MuBi16Width'(mubi_i);
   end
 

--- a/hw/ip/prim/rtl/prim_mubi4_sender.sv
+++ b/hw/ip/prim/rtl/prim_mubi4_sender.sv
@@ -48,10 +48,18 @@ module prim_mubi4_sender
         .out_o(mubi_out[k])
       );
     end
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for sythesis since it is unloaded.
+    mubi4_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi4False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
   end
 
   assign mubi_o = mubi4_t'(mubi_out);

--- a/hw/ip/prim/rtl/prim_mubi4_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi4_sync.sv
@@ -105,10 +105,19 @@ module prim_mubi4_sync
       assign mubi = mubi_sync;
     end
   end else begin : gen_no_flops
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for synthesis since it is unloaded.
+    mubi4_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi4False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
+
     assign mubi = MuBi4Width'(mubi_i);
   end
 

--- a/hw/ip/prim/rtl/prim_mubi8_sender.sv
+++ b/hw/ip/prim/rtl/prim_mubi8_sender.sv
@@ -48,10 +48,18 @@ module prim_mubi8_sender
         .out_o(mubi_out[k])
       );
     end
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for sythesis since it is unloaded.
+    mubi8_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi8False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
   end
 
   assign mubi_o = mubi8_t'(mubi_out);

--- a/hw/ip/prim/rtl/prim_mubi8_sync.sv
+++ b/hw/ip/prim/rtl/prim_mubi8_sync.sv
@@ -105,10 +105,19 @@ module prim_mubi8_sync
       assign mubi = mubi_sync;
     end
   end else begin : gen_no_flops
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for synthesis since it is unloaded.
+    mubi8_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi8False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
+
     assign mubi = MuBi8Width'(mubi_i);
   end
 

--- a/util/design/data/prim_mubi_sender.sv.tpl
+++ b/util/design/data/prim_mubi_sender.sv.tpl
@@ -48,10 +48,18 @@ module prim_mubi${n_bits}_sender
         .out_o(mubi_out[k])
       );
     end
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for sythesis since it is unloaded.
+    mubi${n_bits}_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi${n_bits}False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
   end
 
   assign mubi_o = mubi${n_bits}_t'(mubi_out);

--- a/util/design/data/prim_mubi_sync.sv.tpl
+++ b/util/design/data/prim_mubi_sync.sv.tpl
@@ -105,10 +105,19 @@ module prim_mubi${n_bits}_sync
       assign mubi = mubi_sync;
     end
   end else begin : gen_no_flops
-    logic unused_clk;
-    logic unused_rst;
-    assign unused_clk = clk_i;
-    assign unused_rst = rst_ni;
+
+    // This unused companion logic helps remove lint errors
+    // for modules where clock and reset are used for assertions only
+    // This logic will be removed for synthesis since it is unloaded.
+    mubi${n_bits}_t unused_logic;
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+         unused_logic <= MuBi${n_bits}False;
+      end else begin
+         unused_logic <= mubi_i;
+      end
+    end
+
     assign mubi = MuBi${n_bits}Width'(mubi_i);
   end
 


### PR DESCRIPTION
- some of the prim_mubi_sync usage does not use the clock at all.
  This causes the lint tool to throw a CLOCK_USE error.
- in these instances, hardwire the unused clocks / resets to 0.

Signed-off-by: Timothy Chen <timothytim@google.com>