### PR TITLE
[util] Split unused statement into two lines

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -265,7 +265,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_en_ctl_wdata)
   );
-  assign unused_aon_adc_en_ctl_wdata = ^aon_adc_en_ctl_wdata;
+  assign unused_aon_adc_en_ctl_wdata =
+      ^aon_adc_en_ctl_wdata;
 
   logic  aon_adc_pd_ctl_lp_mode_qs_int;
   logic [3:0]  aon_adc_pd_ctl_pwrup_time_qs_int;
@@ -304,7 +305,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_pd_ctl_wdata)
   );
-  assign unused_aon_adc_pd_ctl_wdata = ^aon_adc_pd_ctl_wdata;
+  assign unused_aon_adc_pd_ctl_wdata =
+      ^aon_adc_pd_ctl_wdata;
 
   logic [7:0]  aon_adc_lp_sample_ctl_qs_int;
   logic [7:0] aon_adc_lp_sample_ctl_d;
@@ -339,7 +341,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_lp_sample_ctl_wdata)
   );
-  assign unused_aon_adc_lp_sample_ctl_wdata = ^aon_adc_lp_sample_ctl_wdata;
+  assign unused_aon_adc_lp_sample_ctl_wdata =
+      ^aon_adc_lp_sample_ctl_wdata;
 
   logic [15:0]  aon_adc_sample_ctl_qs_int;
   logic [15:0] aon_adc_sample_ctl_d;
@@ -374,7 +377,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_sample_ctl_wdata)
   );
-  assign unused_aon_adc_sample_ctl_wdata = ^aon_adc_sample_ctl_wdata;
+  assign unused_aon_adc_sample_ctl_wdata =
+      ^aon_adc_sample_ctl_wdata;
 
   logic  aon_adc_fsm_rst_qs_int;
   logic [0:0] aon_adc_fsm_rst_d;
@@ -409,7 +413,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_fsm_rst_wdata)
   );
-  assign unused_aon_adc_fsm_rst_wdata = ^aon_adc_fsm_rst_wdata;
+  assign unused_aon_adc_fsm_rst_wdata =
+      ^aon_adc_fsm_rst_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_0_min_v_0_qs_int;
   logic  aon_adc_chn0_filter_ctl_0_cond_0_qs_int;
@@ -450,7 +455,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_0_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_0_wdata = ^aon_adc_chn0_filter_ctl_0_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_0_wdata =
+      ^aon_adc_chn0_filter_ctl_0_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_1_min_v_1_qs_int;
   logic  aon_adc_chn0_filter_ctl_1_cond_1_qs_int;
@@ -491,7 +497,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_1_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_1_wdata = ^aon_adc_chn0_filter_ctl_1_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_1_wdata =
+      ^aon_adc_chn0_filter_ctl_1_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_2_min_v_2_qs_int;
   logic  aon_adc_chn0_filter_ctl_2_cond_2_qs_int;
@@ -532,7 +539,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_2_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_2_wdata = ^aon_adc_chn0_filter_ctl_2_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_2_wdata =
+      ^aon_adc_chn0_filter_ctl_2_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_3_min_v_3_qs_int;
   logic  aon_adc_chn0_filter_ctl_3_cond_3_qs_int;
@@ -573,7 +581,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_3_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_3_wdata = ^aon_adc_chn0_filter_ctl_3_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_3_wdata =
+      ^aon_adc_chn0_filter_ctl_3_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_4_min_v_4_qs_int;
   logic  aon_adc_chn0_filter_ctl_4_cond_4_qs_int;
@@ -614,7 +623,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_4_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_4_wdata = ^aon_adc_chn0_filter_ctl_4_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_4_wdata =
+      ^aon_adc_chn0_filter_ctl_4_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_5_min_v_5_qs_int;
   logic  aon_adc_chn0_filter_ctl_5_cond_5_qs_int;
@@ -655,7 +665,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_5_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_5_wdata = ^aon_adc_chn0_filter_ctl_5_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_5_wdata =
+      ^aon_adc_chn0_filter_ctl_5_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_6_min_v_6_qs_int;
   logic  aon_adc_chn0_filter_ctl_6_cond_6_qs_int;
@@ -696,7 +707,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_6_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_6_wdata = ^aon_adc_chn0_filter_ctl_6_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_6_wdata =
+      ^aon_adc_chn0_filter_ctl_6_wdata;
 
   logic [9:0]  aon_adc_chn0_filter_ctl_7_min_v_7_qs_int;
   logic  aon_adc_chn0_filter_ctl_7_cond_7_qs_int;
@@ -737,7 +749,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn0_filter_ctl_7_wdata)
   );
-  assign unused_aon_adc_chn0_filter_ctl_7_wdata = ^aon_adc_chn0_filter_ctl_7_wdata;
+  assign unused_aon_adc_chn0_filter_ctl_7_wdata =
+      ^aon_adc_chn0_filter_ctl_7_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_0_min_v_0_qs_int;
   logic  aon_adc_chn1_filter_ctl_0_cond_0_qs_int;
@@ -778,7 +791,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_0_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_0_wdata = ^aon_adc_chn1_filter_ctl_0_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_0_wdata =
+      ^aon_adc_chn1_filter_ctl_0_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_1_min_v_1_qs_int;
   logic  aon_adc_chn1_filter_ctl_1_cond_1_qs_int;
@@ -819,7 +833,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_1_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_1_wdata = ^aon_adc_chn1_filter_ctl_1_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_1_wdata =
+      ^aon_adc_chn1_filter_ctl_1_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_2_min_v_2_qs_int;
   logic  aon_adc_chn1_filter_ctl_2_cond_2_qs_int;
@@ -860,7 +875,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_2_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_2_wdata = ^aon_adc_chn1_filter_ctl_2_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_2_wdata =
+      ^aon_adc_chn1_filter_ctl_2_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_3_min_v_3_qs_int;
   logic  aon_adc_chn1_filter_ctl_3_cond_3_qs_int;
@@ -901,7 +917,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_3_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_3_wdata = ^aon_adc_chn1_filter_ctl_3_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_3_wdata =
+      ^aon_adc_chn1_filter_ctl_3_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_4_min_v_4_qs_int;
   logic  aon_adc_chn1_filter_ctl_4_cond_4_qs_int;
@@ -942,7 +959,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_4_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_4_wdata = ^aon_adc_chn1_filter_ctl_4_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_4_wdata =
+      ^aon_adc_chn1_filter_ctl_4_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_5_min_v_5_qs_int;
   logic  aon_adc_chn1_filter_ctl_5_cond_5_qs_int;
@@ -983,7 +1001,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_5_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_5_wdata = ^aon_adc_chn1_filter_ctl_5_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_5_wdata =
+      ^aon_adc_chn1_filter_ctl_5_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_6_min_v_6_qs_int;
   logic  aon_adc_chn1_filter_ctl_6_cond_6_qs_int;
@@ -1024,7 +1043,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_6_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_6_wdata = ^aon_adc_chn1_filter_ctl_6_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_6_wdata =
+      ^aon_adc_chn1_filter_ctl_6_wdata;
 
   logic [9:0]  aon_adc_chn1_filter_ctl_7_min_v_7_qs_int;
   logic  aon_adc_chn1_filter_ctl_7_cond_7_qs_int;
@@ -1065,7 +1085,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_chn1_filter_ctl_7_wdata)
   );
-  assign unused_aon_adc_chn1_filter_ctl_7_wdata = ^aon_adc_chn1_filter_ctl_7_wdata;
+  assign unused_aon_adc_chn1_filter_ctl_7_wdata =
+      ^aon_adc_chn1_filter_ctl_7_wdata;
 
   logic [1:0]  aon_adc_chn_val_0_adc_chn_value_ext_0_qs_int;
   logic [9:0]  aon_adc_chn_val_0_adc_chn_value_0_qs_int;
@@ -1174,7 +1195,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_adc_wakeup_ctl_wdata)
   );
-  assign unused_aon_adc_wakeup_ctl_wdata = ^aon_adc_wakeup_ctl_wdata;
+  assign unused_aon_adc_wakeup_ctl_wdata =
+      ^aon_adc_wakeup_ctl_wdata;
 
   logic [7:0]  aon_filter_status_qs_int;
   logic [7:0] aon_filter_status_d;
@@ -1209,7 +1231,8 @@ module adc_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_filter_status_wdata)
   );
-  assign unused_aon_filter_status_wdata = ^aon_filter_status_wdata;
+  assign unused_aon_filter_status_wdata =
+      ^aon_filter_status_wdata;
 
   // Register instances
   // R[intr_state]: V(False)

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -197,7 +197,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wkup_ctrl_wdata)
   );
-  assign unused_aon_wkup_ctrl_wdata = ^aon_wkup_ctrl_wdata;
+  assign unused_aon_wkup_ctrl_wdata =
+      ^aon_wkup_ctrl_wdata;
 
   logic [31:0]  aon_wkup_thold_qs_int;
   logic [31:0] aon_wkup_thold_d;
@@ -232,7 +233,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wkup_thold_wdata)
   );
-  assign unused_aon_wkup_thold_wdata = ^aon_wkup_thold_wdata;
+  assign unused_aon_wkup_thold_wdata =
+      ^aon_wkup_thold_wdata;
 
   logic [31:0]  aon_wkup_count_qs_int;
   logic [31:0] aon_wkup_count_d;
@@ -267,7 +269,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wkup_count_wdata)
   );
-  assign unused_aon_wkup_count_wdata = ^aon_wkup_count_wdata;
+  assign unused_aon_wkup_count_wdata =
+      ^aon_wkup_count_wdata;
 
   logic  aon_wdog_ctrl_enable_qs_int;
   logic  aon_wdog_ctrl_pause_in_sleep_qs_int;
@@ -305,7 +308,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (aon_wdog_ctrl_regwen),
     .dst_wd_o     (aon_wdog_ctrl_wdata)
   );
-  assign unused_aon_wdog_ctrl_wdata = ^aon_wdog_ctrl_wdata;
+  assign unused_aon_wdog_ctrl_wdata =
+      ^aon_wdog_ctrl_wdata;
 
   logic [31:0]  aon_wdog_bark_thold_qs_int;
   logic [31:0] aon_wdog_bark_thold_d;
@@ -341,7 +345,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (aon_wdog_bark_thold_regwen),
     .dst_wd_o     (aon_wdog_bark_thold_wdata)
   );
-  assign unused_aon_wdog_bark_thold_wdata = ^aon_wdog_bark_thold_wdata;
+  assign unused_aon_wdog_bark_thold_wdata =
+      ^aon_wdog_bark_thold_wdata;
 
   logic [31:0]  aon_wdog_bite_thold_qs_int;
   logic [31:0] aon_wdog_bite_thold_d;
@@ -377,7 +382,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (aon_wdog_bite_thold_regwen),
     .dst_wd_o     (aon_wdog_bite_thold_wdata)
   );
-  assign unused_aon_wdog_bite_thold_wdata = ^aon_wdog_bite_thold_wdata;
+  assign unused_aon_wdog_bite_thold_wdata =
+      ^aon_wdog_bite_thold_wdata;
 
   logic [31:0]  aon_wdog_count_qs_int;
   logic [31:0] aon_wdog_count_d;
@@ -412,7 +418,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wdog_count_wdata)
   );
-  assign unused_aon_wdog_count_wdata = ^aon_wdog_count_wdata;
+  assign unused_aon_wdog_count_wdata =
+      ^aon_wdog_count_wdata;
 
   logic  aon_wkup_cause_qs_int;
   logic [0:0] aon_wkup_cause_d;
@@ -447,7 +454,8 @@ module aon_timer_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wkup_cause_wdata)
   );
-  assign unused_aon_wkup_cause_wdata = ^aon_wkup_cause_wdata;
+  assign unused_aon_wkup_cause_wdata =
+      ^aon_wkup_cause_wdata;
 
   // Register instances
   // R[alert_test]: V(True)

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -1540,7 +1540,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_0_regwen),
     .dst_wd_o     (aon_wkup_detector_en_0_wdata)
   );
-  assign unused_aon_wkup_detector_en_0_wdata = ^aon_wkup_detector_en_0_wdata;
+  assign unused_aon_wkup_detector_en_0_wdata =
+      ^aon_wkup_detector_en_0_wdata;
 
   logic  aon_wkup_detector_en_1_qs_int;
   logic [0:0] aon_wkup_detector_en_1_d;
@@ -1576,7 +1577,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_1_regwen),
     .dst_wd_o     (aon_wkup_detector_en_1_wdata)
   );
-  assign unused_aon_wkup_detector_en_1_wdata = ^aon_wkup_detector_en_1_wdata;
+  assign unused_aon_wkup_detector_en_1_wdata =
+      ^aon_wkup_detector_en_1_wdata;
 
   logic  aon_wkup_detector_en_2_qs_int;
   logic [0:0] aon_wkup_detector_en_2_d;
@@ -1612,7 +1614,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_2_regwen),
     .dst_wd_o     (aon_wkup_detector_en_2_wdata)
   );
-  assign unused_aon_wkup_detector_en_2_wdata = ^aon_wkup_detector_en_2_wdata;
+  assign unused_aon_wkup_detector_en_2_wdata =
+      ^aon_wkup_detector_en_2_wdata;
 
   logic  aon_wkup_detector_en_3_qs_int;
   logic [0:0] aon_wkup_detector_en_3_d;
@@ -1648,7 +1651,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_3_regwen),
     .dst_wd_o     (aon_wkup_detector_en_3_wdata)
   );
-  assign unused_aon_wkup_detector_en_3_wdata = ^aon_wkup_detector_en_3_wdata;
+  assign unused_aon_wkup_detector_en_3_wdata =
+      ^aon_wkup_detector_en_3_wdata;
 
   logic  aon_wkup_detector_en_4_qs_int;
   logic [0:0] aon_wkup_detector_en_4_d;
@@ -1684,7 +1688,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_4_regwen),
     .dst_wd_o     (aon_wkup_detector_en_4_wdata)
   );
-  assign unused_aon_wkup_detector_en_4_wdata = ^aon_wkup_detector_en_4_wdata;
+  assign unused_aon_wkup_detector_en_4_wdata =
+      ^aon_wkup_detector_en_4_wdata;
 
   logic  aon_wkup_detector_en_5_qs_int;
   logic [0:0] aon_wkup_detector_en_5_d;
@@ -1720,7 +1725,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_5_regwen),
     .dst_wd_o     (aon_wkup_detector_en_5_wdata)
   );
-  assign unused_aon_wkup_detector_en_5_wdata = ^aon_wkup_detector_en_5_wdata;
+  assign unused_aon_wkup_detector_en_5_wdata =
+      ^aon_wkup_detector_en_5_wdata;
 
   logic  aon_wkup_detector_en_6_qs_int;
   logic [0:0] aon_wkup_detector_en_6_d;
@@ -1756,7 +1762,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_6_regwen),
     .dst_wd_o     (aon_wkup_detector_en_6_wdata)
   );
-  assign unused_aon_wkup_detector_en_6_wdata = ^aon_wkup_detector_en_6_wdata;
+  assign unused_aon_wkup_detector_en_6_wdata =
+      ^aon_wkup_detector_en_6_wdata;
 
   logic  aon_wkup_detector_en_7_qs_int;
   logic [0:0] aon_wkup_detector_en_7_d;
@@ -1792,7 +1799,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_7_regwen),
     .dst_wd_o     (aon_wkup_detector_en_7_wdata)
   );
-  assign unused_aon_wkup_detector_en_7_wdata = ^aon_wkup_detector_en_7_wdata;
+  assign unused_aon_wkup_detector_en_7_wdata =
+      ^aon_wkup_detector_en_7_wdata;
 
   logic [2:0]  aon_wkup_detector_0_mode_0_qs_int;
   logic  aon_wkup_detector_0_filter_0_qs_int;
@@ -1832,7 +1840,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_0_regwen),
     .dst_wd_o     (aon_wkup_detector_0_wdata)
   );
-  assign unused_aon_wkup_detector_0_wdata = ^aon_wkup_detector_0_wdata;
+  assign unused_aon_wkup_detector_0_wdata =
+      ^aon_wkup_detector_0_wdata;
 
   logic [2:0]  aon_wkup_detector_1_mode_1_qs_int;
   logic  aon_wkup_detector_1_filter_1_qs_int;
@@ -1872,7 +1881,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_1_regwen),
     .dst_wd_o     (aon_wkup_detector_1_wdata)
   );
-  assign unused_aon_wkup_detector_1_wdata = ^aon_wkup_detector_1_wdata;
+  assign unused_aon_wkup_detector_1_wdata =
+      ^aon_wkup_detector_1_wdata;
 
   logic [2:0]  aon_wkup_detector_2_mode_2_qs_int;
   logic  aon_wkup_detector_2_filter_2_qs_int;
@@ -1912,7 +1922,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_2_regwen),
     .dst_wd_o     (aon_wkup_detector_2_wdata)
   );
-  assign unused_aon_wkup_detector_2_wdata = ^aon_wkup_detector_2_wdata;
+  assign unused_aon_wkup_detector_2_wdata =
+      ^aon_wkup_detector_2_wdata;
 
   logic [2:0]  aon_wkup_detector_3_mode_3_qs_int;
   logic  aon_wkup_detector_3_filter_3_qs_int;
@@ -1952,7 +1963,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_3_regwen),
     .dst_wd_o     (aon_wkup_detector_3_wdata)
   );
-  assign unused_aon_wkup_detector_3_wdata = ^aon_wkup_detector_3_wdata;
+  assign unused_aon_wkup_detector_3_wdata =
+      ^aon_wkup_detector_3_wdata;
 
   logic [2:0]  aon_wkup_detector_4_mode_4_qs_int;
   logic  aon_wkup_detector_4_filter_4_qs_int;
@@ -1992,7 +2004,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_4_regwen),
     .dst_wd_o     (aon_wkup_detector_4_wdata)
   );
-  assign unused_aon_wkup_detector_4_wdata = ^aon_wkup_detector_4_wdata;
+  assign unused_aon_wkup_detector_4_wdata =
+      ^aon_wkup_detector_4_wdata;
 
   logic [2:0]  aon_wkup_detector_5_mode_5_qs_int;
   logic  aon_wkup_detector_5_filter_5_qs_int;
@@ -2032,7 +2045,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_5_regwen),
     .dst_wd_o     (aon_wkup_detector_5_wdata)
   );
-  assign unused_aon_wkup_detector_5_wdata = ^aon_wkup_detector_5_wdata;
+  assign unused_aon_wkup_detector_5_wdata =
+      ^aon_wkup_detector_5_wdata;
 
   logic [2:0]  aon_wkup_detector_6_mode_6_qs_int;
   logic  aon_wkup_detector_6_filter_6_qs_int;
@@ -2072,7 +2086,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_6_regwen),
     .dst_wd_o     (aon_wkup_detector_6_wdata)
   );
-  assign unused_aon_wkup_detector_6_wdata = ^aon_wkup_detector_6_wdata;
+  assign unused_aon_wkup_detector_6_wdata =
+      ^aon_wkup_detector_6_wdata;
 
   logic [2:0]  aon_wkup_detector_7_mode_7_qs_int;
   logic  aon_wkup_detector_7_filter_7_qs_int;
@@ -2112,7 +2127,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_7_regwen),
     .dst_wd_o     (aon_wkup_detector_7_wdata)
   );
-  assign unused_aon_wkup_detector_7_wdata = ^aon_wkup_detector_7_wdata;
+  assign unused_aon_wkup_detector_7_wdata =
+      ^aon_wkup_detector_7_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_0_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_0_d;
@@ -2148,7 +2164,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_0_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_0_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_0_wdata = ^aon_wkup_detector_cnt_th_0_wdata;
+  assign unused_aon_wkup_detector_cnt_th_0_wdata =
+      ^aon_wkup_detector_cnt_th_0_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_1_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_1_d;
@@ -2184,7 +2201,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_1_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_1_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_1_wdata = ^aon_wkup_detector_cnt_th_1_wdata;
+  assign unused_aon_wkup_detector_cnt_th_1_wdata =
+      ^aon_wkup_detector_cnt_th_1_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_2_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_2_d;
@@ -2220,7 +2238,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_2_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_2_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_2_wdata = ^aon_wkup_detector_cnt_th_2_wdata;
+  assign unused_aon_wkup_detector_cnt_th_2_wdata =
+      ^aon_wkup_detector_cnt_th_2_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_3_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_3_d;
@@ -2256,7 +2275,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_3_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_3_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_3_wdata = ^aon_wkup_detector_cnt_th_3_wdata;
+  assign unused_aon_wkup_detector_cnt_th_3_wdata =
+      ^aon_wkup_detector_cnt_th_3_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_4_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_4_d;
@@ -2292,7 +2312,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_4_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_4_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_4_wdata = ^aon_wkup_detector_cnt_th_4_wdata;
+  assign unused_aon_wkup_detector_cnt_th_4_wdata =
+      ^aon_wkup_detector_cnt_th_4_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_5_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_5_d;
@@ -2328,7 +2349,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_5_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_5_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_5_wdata = ^aon_wkup_detector_cnt_th_5_wdata;
+  assign unused_aon_wkup_detector_cnt_th_5_wdata =
+      ^aon_wkup_detector_cnt_th_5_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_6_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_6_d;
@@ -2364,7 +2386,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_6_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_6_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_6_wdata = ^aon_wkup_detector_cnt_th_6_wdata;
+  assign unused_aon_wkup_detector_cnt_th_6_wdata =
+      ^aon_wkup_detector_cnt_th_6_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_7_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_7_d;
@@ -2400,7 +2423,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_7_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_7_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_7_wdata = ^aon_wkup_detector_cnt_th_7_wdata;
+  assign unused_aon_wkup_detector_cnt_th_7_wdata =
+      ^aon_wkup_detector_cnt_th_7_wdata;
 
   logic  aon_wkup_cause_cause_0_qs_int;
   logic  aon_wkup_cause_cause_1_qs_int;
@@ -2449,7 +2473,8 @@ module pinmux_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wkup_cause_wdata)
   );
-  assign unused_aon_wkup_cause_wdata = ^aon_wkup_cause_wdata;
+  assign unused_aon_wkup_cause_wdata =
+      ^aon_wkup_cause_wdata;
 
   // Register instances
   // R[alert_test]: V(True)

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -230,7 +230,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_cfg_regwen),
     .dst_wd_o     (core_cfg_wdata)
   );
-  assign unused_core_cfg_wdata = ^core_cfg_wdata;
+  assign unused_core_cfg_wdata =
+      ^core_cfg_wdata;
 
   logic  core_pwm_en_en_0_qs_int;
   logic  core_pwm_en_en_1_qs_int;
@@ -276,7 +277,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_pwm_en_regwen),
     .dst_wd_o     (core_pwm_en_wdata)
   );
-  assign unused_core_pwm_en_wdata = ^core_pwm_en_wdata;
+  assign unused_core_pwm_en_wdata =
+      ^core_pwm_en_wdata;
 
   logic  core_invert_invert_0_qs_int;
   logic  core_invert_invert_1_qs_int;
@@ -322,7 +324,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_invert_regwen),
     .dst_wd_o     (core_invert_wdata)
   );
-  assign unused_core_invert_wdata = ^core_invert_wdata;
+  assign unused_core_invert_wdata =
+      ^core_invert_wdata;
 
   logic [15:0]  core_pwm_param_0_phase_delay_0_qs_int;
   logic  core_pwm_param_0_htbt_en_0_qs_int;
@@ -362,7 +365,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_pwm_param_0_regwen),
     .dst_wd_o     (core_pwm_param_0_wdata)
   );
-  assign unused_core_pwm_param_0_wdata = ^core_pwm_param_0_wdata;
+  assign unused_core_pwm_param_0_wdata =
+      ^core_pwm_param_0_wdata;
 
   logic [15:0]  core_pwm_param_1_phase_delay_1_qs_int;
   logic  core_pwm_param_1_htbt_en_1_qs_int;
@@ -402,7 +406,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_pwm_param_1_regwen),
     .dst_wd_o     (core_pwm_param_1_wdata)
   );
-  assign unused_core_pwm_param_1_wdata = ^core_pwm_param_1_wdata;
+  assign unused_core_pwm_param_1_wdata =
+      ^core_pwm_param_1_wdata;
 
   logic [15:0]  core_pwm_param_2_phase_delay_2_qs_int;
   logic  core_pwm_param_2_htbt_en_2_qs_int;
@@ -442,7 +447,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_pwm_param_2_regwen),
     .dst_wd_o     (core_pwm_param_2_wdata)
   );
-  assign unused_core_pwm_param_2_wdata = ^core_pwm_param_2_wdata;
+  assign unused_core_pwm_param_2_wdata =
+      ^core_pwm_param_2_wdata;
 
   logic [15:0]  core_pwm_param_3_phase_delay_3_qs_int;
   logic  core_pwm_param_3_htbt_en_3_qs_int;
@@ -482,7 +488,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_pwm_param_3_regwen),
     .dst_wd_o     (core_pwm_param_3_wdata)
   );
-  assign unused_core_pwm_param_3_wdata = ^core_pwm_param_3_wdata;
+  assign unused_core_pwm_param_3_wdata =
+      ^core_pwm_param_3_wdata;
 
   logic [15:0]  core_pwm_param_4_phase_delay_4_qs_int;
   logic  core_pwm_param_4_htbt_en_4_qs_int;
@@ -522,7 +529,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_pwm_param_4_regwen),
     .dst_wd_o     (core_pwm_param_4_wdata)
   );
-  assign unused_core_pwm_param_4_wdata = ^core_pwm_param_4_wdata;
+  assign unused_core_pwm_param_4_wdata =
+      ^core_pwm_param_4_wdata;
 
   logic [15:0]  core_pwm_param_5_phase_delay_5_qs_int;
   logic  core_pwm_param_5_htbt_en_5_qs_int;
@@ -562,7 +570,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_pwm_param_5_regwen),
     .dst_wd_o     (core_pwm_param_5_wdata)
   );
-  assign unused_core_pwm_param_5_wdata = ^core_pwm_param_5_wdata;
+  assign unused_core_pwm_param_5_wdata =
+      ^core_pwm_param_5_wdata;
 
   logic [15:0]  core_duty_cycle_0_a_0_qs_int;
   logic [15:0]  core_duty_cycle_0_b_0_qs_int;
@@ -600,7 +609,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_duty_cycle_0_regwen),
     .dst_wd_o     (core_duty_cycle_0_wdata)
   );
-  assign unused_core_duty_cycle_0_wdata = ^core_duty_cycle_0_wdata;
+  assign unused_core_duty_cycle_0_wdata =
+      ^core_duty_cycle_0_wdata;
 
   logic [15:0]  core_duty_cycle_1_a_1_qs_int;
   logic [15:0]  core_duty_cycle_1_b_1_qs_int;
@@ -638,7 +648,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_duty_cycle_1_regwen),
     .dst_wd_o     (core_duty_cycle_1_wdata)
   );
-  assign unused_core_duty_cycle_1_wdata = ^core_duty_cycle_1_wdata;
+  assign unused_core_duty_cycle_1_wdata =
+      ^core_duty_cycle_1_wdata;
 
   logic [15:0]  core_duty_cycle_2_a_2_qs_int;
   logic [15:0]  core_duty_cycle_2_b_2_qs_int;
@@ -676,7 +687,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_duty_cycle_2_regwen),
     .dst_wd_o     (core_duty_cycle_2_wdata)
   );
-  assign unused_core_duty_cycle_2_wdata = ^core_duty_cycle_2_wdata;
+  assign unused_core_duty_cycle_2_wdata =
+      ^core_duty_cycle_2_wdata;
 
   logic [15:0]  core_duty_cycle_3_a_3_qs_int;
   logic [15:0]  core_duty_cycle_3_b_3_qs_int;
@@ -714,7 +726,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_duty_cycle_3_regwen),
     .dst_wd_o     (core_duty_cycle_3_wdata)
   );
-  assign unused_core_duty_cycle_3_wdata = ^core_duty_cycle_3_wdata;
+  assign unused_core_duty_cycle_3_wdata =
+      ^core_duty_cycle_3_wdata;
 
   logic [15:0]  core_duty_cycle_4_a_4_qs_int;
   logic [15:0]  core_duty_cycle_4_b_4_qs_int;
@@ -752,7 +765,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_duty_cycle_4_regwen),
     .dst_wd_o     (core_duty_cycle_4_wdata)
   );
-  assign unused_core_duty_cycle_4_wdata = ^core_duty_cycle_4_wdata;
+  assign unused_core_duty_cycle_4_wdata =
+      ^core_duty_cycle_4_wdata;
 
   logic [15:0]  core_duty_cycle_5_a_5_qs_int;
   logic [15:0]  core_duty_cycle_5_b_5_qs_int;
@@ -790,7 +804,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_duty_cycle_5_regwen),
     .dst_wd_o     (core_duty_cycle_5_wdata)
   );
-  assign unused_core_duty_cycle_5_wdata = ^core_duty_cycle_5_wdata;
+  assign unused_core_duty_cycle_5_wdata =
+      ^core_duty_cycle_5_wdata;
 
   logic [15:0]  core_blink_param_0_x_0_qs_int;
   logic [15:0]  core_blink_param_0_y_0_qs_int;
@@ -828,7 +843,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_blink_param_0_regwen),
     .dst_wd_o     (core_blink_param_0_wdata)
   );
-  assign unused_core_blink_param_0_wdata = ^core_blink_param_0_wdata;
+  assign unused_core_blink_param_0_wdata =
+      ^core_blink_param_0_wdata;
 
   logic [15:0]  core_blink_param_1_x_1_qs_int;
   logic [15:0]  core_blink_param_1_y_1_qs_int;
@@ -866,7 +882,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_blink_param_1_regwen),
     .dst_wd_o     (core_blink_param_1_wdata)
   );
-  assign unused_core_blink_param_1_wdata = ^core_blink_param_1_wdata;
+  assign unused_core_blink_param_1_wdata =
+      ^core_blink_param_1_wdata;
 
   logic [15:0]  core_blink_param_2_x_2_qs_int;
   logic [15:0]  core_blink_param_2_y_2_qs_int;
@@ -904,7 +921,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_blink_param_2_regwen),
     .dst_wd_o     (core_blink_param_2_wdata)
   );
-  assign unused_core_blink_param_2_wdata = ^core_blink_param_2_wdata;
+  assign unused_core_blink_param_2_wdata =
+      ^core_blink_param_2_wdata;
 
   logic [15:0]  core_blink_param_3_x_3_qs_int;
   logic [15:0]  core_blink_param_3_y_3_qs_int;
@@ -942,7 +960,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_blink_param_3_regwen),
     .dst_wd_o     (core_blink_param_3_wdata)
   );
-  assign unused_core_blink_param_3_wdata = ^core_blink_param_3_wdata;
+  assign unused_core_blink_param_3_wdata =
+      ^core_blink_param_3_wdata;
 
   logic [15:0]  core_blink_param_4_x_4_qs_int;
   logic [15:0]  core_blink_param_4_y_4_qs_int;
@@ -980,7 +999,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_blink_param_4_regwen),
     .dst_wd_o     (core_blink_param_4_wdata)
   );
-  assign unused_core_blink_param_4_wdata = ^core_blink_param_4_wdata;
+  assign unused_core_blink_param_4_wdata =
+      ^core_blink_param_4_wdata;
 
   logic [15:0]  core_blink_param_5_x_5_qs_int;
   logic [15:0]  core_blink_param_5_y_5_qs_int;
@@ -1018,7 +1038,8 @@ module pwm_reg_top (
     .dst_regwen_o (core_blink_param_5_regwen),
     .dst_wd_o     (core_blink_param_5_wdata)
   );
-  assign unused_core_blink_param_5_wdata = ^core_blink_param_5_wdata;
+  assign unused_core_blink_param_5_wdata =
+      ^core_blink_param_5_wdata;
 
   // Register instances
   // R[alert_test]: V(True)

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -266,7 +266,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_ec_rst_ctl_regwen),
     .dst_wd_o     (aon_ec_rst_ctl_wdata)
   );
-  assign unused_aon_ec_rst_ctl_wdata = ^aon_ec_rst_ctl_wdata;
+  assign unused_aon_ec_rst_ctl_wdata =
+      ^aon_ec_rst_ctl_wdata;
 
   logic [15:0]  aon_ulp_ac_debounce_ctl_qs_int;
   logic [15:0] aon_ulp_ac_debounce_ctl_d;
@@ -302,7 +303,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_ulp_ac_debounce_ctl_regwen),
     .dst_wd_o     (aon_ulp_ac_debounce_ctl_wdata)
   );
-  assign unused_aon_ulp_ac_debounce_ctl_wdata = ^aon_ulp_ac_debounce_ctl_wdata;
+  assign unused_aon_ulp_ac_debounce_ctl_wdata =
+      ^aon_ulp_ac_debounce_ctl_wdata;
 
   logic [15:0]  aon_ulp_lid_debounce_ctl_qs_int;
   logic [15:0] aon_ulp_lid_debounce_ctl_d;
@@ -338,7 +340,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_ulp_lid_debounce_ctl_regwen),
     .dst_wd_o     (aon_ulp_lid_debounce_ctl_wdata)
   );
-  assign unused_aon_ulp_lid_debounce_ctl_wdata = ^aon_ulp_lid_debounce_ctl_wdata;
+  assign unused_aon_ulp_lid_debounce_ctl_wdata =
+      ^aon_ulp_lid_debounce_ctl_wdata;
 
   logic [15:0]  aon_ulp_pwrb_debounce_ctl_qs_int;
   logic [15:0] aon_ulp_pwrb_debounce_ctl_d;
@@ -374,7 +377,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_ulp_pwrb_debounce_ctl_regwen),
     .dst_wd_o     (aon_ulp_pwrb_debounce_ctl_wdata)
   );
-  assign unused_aon_ulp_pwrb_debounce_ctl_wdata = ^aon_ulp_pwrb_debounce_ctl_wdata;
+  assign unused_aon_ulp_pwrb_debounce_ctl_wdata =
+      ^aon_ulp_pwrb_debounce_ctl_wdata;
 
   logic  aon_ulp_ctl_qs_int;
   logic [0:0] aon_ulp_ctl_d;
@@ -409,7 +413,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_ulp_ctl_wdata)
   );
-  assign unused_aon_ulp_ctl_wdata = ^aon_ulp_ctl_wdata;
+  assign unused_aon_ulp_ctl_wdata =
+      ^aon_ulp_ctl_wdata;
 
   logic  aon_ulp_status_qs_int;
   logic [0:0] aon_ulp_status_d;
@@ -444,7 +449,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_ulp_status_wdata)
   );
-  assign unused_aon_ulp_status_wdata = ^aon_ulp_status_wdata;
+  assign unused_aon_ulp_status_wdata =
+      ^aon_ulp_status_wdata;
 
   logic  aon_wkup_status_qs_int;
   logic [0:0] aon_wkup_status_d;
@@ -479,7 +485,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wkup_status_wdata)
   );
-  assign unused_aon_wkup_status_wdata = ^aon_wkup_status_wdata;
+  assign unused_aon_wkup_status_wdata =
+      ^aon_wkup_status_wdata;
 
   logic  aon_key_invert_ctl_key0_in_qs_int;
   logic  aon_key_invert_ctl_key0_out_qs_int;
@@ -537,7 +544,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_key_invert_ctl_regwen),
     .dst_wd_o     (aon_key_invert_ctl_wdata)
   );
-  assign unused_aon_key_invert_ctl_wdata = ^aon_key_invert_ctl_wdata;
+  assign unused_aon_key_invert_ctl_wdata =
+      ^aon_key_invert_ctl_wdata;
 
   logic  aon_pin_allowed_ctl_bat_disable_0_qs_int;
   logic  aon_pin_allowed_ctl_ec_rst_l_0_qs_int;
@@ -603,7 +611,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_pin_allowed_ctl_regwen),
     .dst_wd_o     (aon_pin_allowed_ctl_wdata)
   );
-  assign unused_aon_pin_allowed_ctl_wdata = ^aon_pin_allowed_ctl_wdata;
+  assign unused_aon_pin_allowed_ctl_wdata =
+      ^aon_pin_allowed_ctl_wdata;
 
   logic  aon_pin_out_ctl_bat_disable_qs_int;
   logic  aon_pin_out_ctl_ec_rst_l_qs_int;
@@ -652,7 +661,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_pin_out_ctl_wdata)
   );
-  assign unused_aon_pin_out_ctl_wdata = ^aon_pin_out_ctl_wdata;
+  assign unused_aon_pin_out_ctl_wdata =
+      ^aon_pin_out_ctl_wdata;
 
   logic  aon_pin_out_value_bat_disable_qs_int;
   logic  aon_pin_out_value_ec_rst_l_qs_int;
@@ -701,7 +711,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_pin_out_value_wdata)
   );
-  assign unused_aon_pin_out_value_wdata = ^aon_pin_out_value_wdata;
+  assign unused_aon_pin_out_value_wdata =
+      ^aon_pin_out_value_wdata;
 
   logic  aon_key_intr_ctl_pwrb_in_h2l_qs_int;
   logic  aon_key_intr_ctl_key0_in_h2l_qs_int;
@@ -759,7 +770,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_key_intr_ctl_regwen),
     .dst_wd_o     (aon_key_intr_ctl_wdata)
   );
-  assign unused_aon_key_intr_ctl_wdata = ^aon_key_intr_ctl_wdata;
+  assign unused_aon_key_intr_ctl_wdata =
+      ^aon_key_intr_ctl_wdata;
 
   logic [15:0]  aon_key_intr_debounce_ctl_qs_int;
   logic [15:0] aon_key_intr_debounce_ctl_d;
@@ -795,7 +807,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_key_intr_debounce_ctl_regwen),
     .dst_wd_o     (aon_key_intr_debounce_ctl_wdata)
   );
-  assign unused_aon_key_intr_debounce_ctl_wdata = ^aon_key_intr_debounce_ctl_wdata;
+  assign unused_aon_key_intr_debounce_ctl_wdata =
+      ^aon_key_intr_debounce_ctl_wdata;
 
   logic [15:0]  aon_auto_block_debounce_ctl_debounce_timer_qs_int;
   logic  aon_auto_block_debounce_ctl_auto_block_enable_qs_int;
@@ -833,7 +846,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_auto_block_debounce_ctl_regwen),
     .dst_wd_o     (aon_auto_block_debounce_ctl_wdata)
   );
-  assign unused_aon_auto_block_debounce_ctl_wdata = ^aon_auto_block_debounce_ctl_wdata;
+  assign unused_aon_auto_block_debounce_ctl_wdata =
+      ^aon_auto_block_debounce_ctl_wdata;
 
   logic  aon_auto_block_out_ctl_key0_out_sel_qs_int;
   logic  aon_auto_block_out_ctl_key1_out_sel_qs_int;
@@ -879,7 +893,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_auto_block_out_ctl_regwen),
     .dst_wd_o     (aon_auto_block_out_ctl_wdata)
   );
-  assign unused_aon_auto_block_out_ctl_wdata = ^aon_auto_block_out_ctl_wdata;
+  assign unused_aon_auto_block_out_ctl_wdata =
+      ^aon_auto_block_out_ctl_wdata;
 
   logic  aon_com_sel_ctl_0_key0_in_sel_0_qs_int;
   logic  aon_com_sel_ctl_0_key1_in_sel_0_qs_int;
@@ -923,7 +938,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_sel_ctl_0_regwen),
     .dst_wd_o     (aon_com_sel_ctl_0_wdata)
   );
-  assign unused_aon_com_sel_ctl_0_wdata = ^aon_com_sel_ctl_0_wdata;
+  assign unused_aon_com_sel_ctl_0_wdata =
+      ^aon_com_sel_ctl_0_wdata;
 
   logic  aon_com_sel_ctl_1_key0_in_sel_1_qs_int;
   logic  aon_com_sel_ctl_1_key1_in_sel_1_qs_int;
@@ -967,7 +983,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_sel_ctl_1_regwen),
     .dst_wd_o     (aon_com_sel_ctl_1_wdata)
   );
-  assign unused_aon_com_sel_ctl_1_wdata = ^aon_com_sel_ctl_1_wdata;
+  assign unused_aon_com_sel_ctl_1_wdata =
+      ^aon_com_sel_ctl_1_wdata;
 
   logic  aon_com_sel_ctl_2_key0_in_sel_2_qs_int;
   logic  aon_com_sel_ctl_2_key1_in_sel_2_qs_int;
@@ -1011,7 +1028,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_sel_ctl_2_regwen),
     .dst_wd_o     (aon_com_sel_ctl_2_wdata)
   );
-  assign unused_aon_com_sel_ctl_2_wdata = ^aon_com_sel_ctl_2_wdata;
+  assign unused_aon_com_sel_ctl_2_wdata =
+      ^aon_com_sel_ctl_2_wdata;
 
   logic  aon_com_sel_ctl_3_key0_in_sel_3_qs_int;
   logic  aon_com_sel_ctl_3_key1_in_sel_3_qs_int;
@@ -1055,7 +1073,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_sel_ctl_3_regwen),
     .dst_wd_o     (aon_com_sel_ctl_3_wdata)
   );
-  assign unused_aon_com_sel_ctl_3_wdata = ^aon_com_sel_ctl_3_wdata;
+  assign unused_aon_com_sel_ctl_3_wdata =
+      ^aon_com_sel_ctl_3_wdata;
 
   logic [31:0]  aon_com_det_ctl_0_qs_int;
   logic [31:0] aon_com_det_ctl_0_d;
@@ -1091,7 +1110,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_det_ctl_0_regwen),
     .dst_wd_o     (aon_com_det_ctl_0_wdata)
   );
-  assign unused_aon_com_det_ctl_0_wdata = ^aon_com_det_ctl_0_wdata;
+  assign unused_aon_com_det_ctl_0_wdata =
+      ^aon_com_det_ctl_0_wdata;
 
   logic [31:0]  aon_com_det_ctl_1_qs_int;
   logic [31:0] aon_com_det_ctl_1_d;
@@ -1127,7 +1147,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_det_ctl_1_regwen),
     .dst_wd_o     (aon_com_det_ctl_1_wdata)
   );
-  assign unused_aon_com_det_ctl_1_wdata = ^aon_com_det_ctl_1_wdata;
+  assign unused_aon_com_det_ctl_1_wdata =
+      ^aon_com_det_ctl_1_wdata;
 
   logic [31:0]  aon_com_det_ctl_2_qs_int;
   logic [31:0] aon_com_det_ctl_2_d;
@@ -1163,7 +1184,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_det_ctl_2_regwen),
     .dst_wd_o     (aon_com_det_ctl_2_wdata)
   );
-  assign unused_aon_com_det_ctl_2_wdata = ^aon_com_det_ctl_2_wdata;
+  assign unused_aon_com_det_ctl_2_wdata =
+      ^aon_com_det_ctl_2_wdata;
 
   logic [31:0]  aon_com_det_ctl_3_qs_int;
   logic [31:0] aon_com_det_ctl_3_d;
@@ -1199,7 +1221,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_det_ctl_3_regwen),
     .dst_wd_o     (aon_com_det_ctl_3_wdata)
   );
-  assign unused_aon_com_det_ctl_3_wdata = ^aon_com_det_ctl_3_wdata;
+  assign unused_aon_com_det_ctl_3_wdata =
+      ^aon_com_det_ctl_3_wdata;
 
   logic  aon_com_out_ctl_0_bat_disable_0_qs_int;
   logic  aon_com_out_ctl_0_interrupt_0_qs_int;
@@ -1241,7 +1264,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_out_ctl_0_regwen),
     .dst_wd_o     (aon_com_out_ctl_0_wdata)
   );
-  assign unused_aon_com_out_ctl_0_wdata = ^aon_com_out_ctl_0_wdata;
+  assign unused_aon_com_out_ctl_0_wdata =
+      ^aon_com_out_ctl_0_wdata;
 
   logic  aon_com_out_ctl_1_bat_disable_1_qs_int;
   logic  aon_com_out_ctl_1_interrupt_1_qs_int;
@@ -1283,7 +1307,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_out_ctl_1_regwen),
     .dst_wd_o     (aon_com_out_ctl_1_wdata)
   );
-  assign unused_aon_com_out_ctl_1_wdata = ^aon_com_out_ctl_1_wdata;
+  assign unused_aon_com_out_ctl_1_wdata =
+      ^aon_com_out_ctl_1_wdata;
 
   logic  aon_com_out_ctl_2_bat_disable_2_qs_int;
   logic  aon_com_out_ctl_2_interrupt_2_qs_int;
@@ -1325,7 +1350,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_out_ctl_2_regwen),
     .dst_wd_o     (aon_com_out_ctl_2_wdata)
   );
-  assign unused_aon_com_out_ctl_2_wdata = ^aon_com_out_ctl_2_wdata;
+  assign unused_aon_com_out_ctl_2_wdata =
+      ^aon_com_out_ctl_2_wdata;
 
   logic  aon_com_out_ctl_3_bat_disable_3_qs_int;
   logic  aon_com_out_ctl_3_interrupt_3_qs_int;
@@ -1367,7 +1393,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (aon_com_out_ctl_3_regwen),
     .dst_wd_o     (aon_com_out_ctl_3_wdata)
   );
-  assign unused_aon_com_out_ctl_3_wdata = ^aon_com_out_ctl_3_wdata;
+  assign unused_aon_com_out_ctl_3_wdata =
+      ^aon_com_out_ctl_3_wdata;
 
   logic  aon_combo_intr_status_combo0_h2l_qs_int;
   logic  aon_combo_intr_status_combo1_h2l_qs_int;
@@ -1408,7 +1435,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_combo_intr_status_wdata)
   );
-  assign unused_aon_combo_intr_status_wdata = ^aon_combo_intr_status_wdata;
+  assign unused_aon_combo_intr_status_wdata =
+      ^aon_combo_intr_status_wdata;
 
   logic  aon_key_intr_status_pwrb_h2l_qs_int;
   logic  aon_key_intr_status_key0_in_h2l_qs_int;
@@ -1465,7 +1493,8 @@ module sysrst_ctrl_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_key_intr_status_wdata)
   );
-  assign unused_aon_key_intr_status_wdata = ^aon_key_intr_status_wdata;
+  assign unused_aon_key_intr_status_wdata =
+      ^aon_key_intr_status_wdata;
 
   // Register instances
   // R[intr_state]: V(False)

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -298,7 +298,8 @@ module clkmgr_reg_top (
     .dst_regwen_o (io_io_measure_ctrl_regwen),
     .dst_wd_o     (io_io_measure_ctrl_wdata)
   );
-  assign unused_io_io_measure_ctrl_wdata = ^io_io_measure_ctrl_wdata;
+  assign unused_io_io_measure_ctrl_wdata =
+      ^io_io_measure_ctrl_wdata;
 
   logic  io_div2_io_div2_measure_ctrl_en_qs_int;
   logic [8:0]  io_div2_io_div2_measure_ctrl_max_thresh_qs_int;
@@ -338,7 +339,8 @@ module clkmgr_reg_top (
     .dst_regwen_o (io_div2_io_div2_measure_ctrl_regwen),
     .dst_wd_o     (io_div2_io_div2_measure_ctrl_wdata)
   );
-  assign unused_io_div2_io_div2_measure_ctrl_wdata = ^io_div2_io_div2_measure_ctrl_wdata;
+  assign unused_io_div2_io_div2_measure_ctrl_wdata =
+      ^io_div2_io_div2_measure_ctrl_wdata;
 
   logic  io_div4_io_div4_measure_ctrl_en_qs_int;
   logic [7:0]  io_div4_io_div4_measure_ctrl_max_thresh_qs_int;
@@ -378,7 +380,8 @@ module clkmgr_reg_top (
     .dst_regwen_o (io_div4_io_div4_measure_ctrl_regwen),
     .dst_wd_o     (io_div4_io_div4_measure_ctrl_wdata)
   );
-  assign unused_io_div4_io_div4_measure_ctrl_wdata = ^io_div4_io_div4_measure_ctrl_wdata;
+  assign unused_io_div4_io_div4_measure_ctrl_wdata =
+      ^io_div4_io_div4_measure_ctrl_wdata;
 
   logic  main_main_measure_ctrl_en_qs_int;
   logic [9:0]  main_main_measure_ctrl_max_thresh_qs_int;
@@ -418,7 +421,8 @@ module clkmgr_reg_top (
     .dst_regwen_o (main_main_measure_ctrl_regwen),
     .dst_wd_o     (main_main_measure_ctrl_wdata)
   );
-  assign unused_main_main_measure_ctrl_wdata = ^main_main_measure_ctrl_wdata;
+  assign unused_main_main_measure_ctrl_wdata =
+      ^main_main_measure_ctrl_wdata;
 
   logic  usb_usb_measure_ctrl_en_qs_int;
   logic [8:0]  usb_usb_measure_ctrl_max_thresh_qs_int;
@@ -458,7 +462,8 @@ module clkmgr_reg_top (
     .dst_regwen_o (usb_usb_measure_ctrl_regwen),
     .dst_wd_o     (usb_usb_measure_ctrl_wdata)
   );
-  assign unused_usb_usb_measure_ctrl_wdata = ^usb_usb_measure_ctrl_wdata;
+  assign unused_usb_usb_measure_ctrl_wdata =
+      ^usb_usb_measure_ctrl_wdata;
 
   // Register instances
   // R[alert_test]: V(True)

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -2171,7 +2171,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_0_regwen),
     .dst_wd_o     (aon_wkup_detector_en_0_wdata)
   );
-  assign unused_aon_wkup_detector_en_0_wdata = ^aon_wkup_detector_en_0_wdata;
+  assign unused_aon_wkup_detector_en_0_wdata =
+      ^aon_wkup_detector_en_0_wdata;
 
   logic  aon_wkup_detector_en_1_qs_int;
   logic [0:0] aon_wkup_detector_en_1_d;
@@ -2207,7 +2208,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_1_regwen),
     .dst_wd_o     (aon_wkup_detector_en_1_wdata)
   );
-  assign unused_aon_wkup_detector_en_1_wdata = ^aon_wkup_detector_en_1_wdata;
+  assign unused_aon_wkup_detector_en_1_wdata =
+      ^aon_wkup_detector_en_1_wdata;
 
   logic  aon_wkup_detector_en_2_qs_int;
   logic [0:0] aon_wkup_detector_en_2_d;
@@ -2243,7 +2245,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_2_regwen),
     .dst_wd_o     (aon_wkup_detector_en_2_wdata)
   );
-  assign unused_aon_wkup_detector_en_2_wdata = ^aon_wkup_detector_en_2_wdata;
+  assign unused_aon_wkup_detector_en_2_wdata =
+      ^aon_wkup_detector_en_2_wdata;
 
   logic  aon_wkup_detector_en_3_qs_int;
   logic [0:0] aon_wkup_detector_en_3_d;
@@ -2279,7 +2282,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_3_regwen),
     .dst_wd_o     (aon_wkup_detector_en_3_wdata)
   );
-  assign unused_aon_wkup_detector_en_3_wdata = ^aon_wkup_detector_en_3_wdata;
+  assign unused_aon_wkup_detector_en_3_wdata =
+      ^aon_wkup_detector_en_3_wdata;
 
   logic  aon_wkup_detector_en_4_qs_int;
   logic [0:0] aon_wkup_detector_en_4_d;
@@ -2315,7 +2319,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_4_regwen),
     .dst_wd_o     (aon_wkup_detector_en_4_wdata)
   );
-  assign unused_aon_wkup_detector_en_4_wdata = ^aon_wkup_detector_en_4_wdata;
+  assign unused_aon_wkup_detector_en_4_wdata =
+      ^aon_wkup_detector_en_4_wdata;
 
   logic  aon_wkup_detector_en_5_qs_int;
   logic [0:0] aon_wkup_detector_en_5_d;
@@ -2351,7 +2356,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_5_regwen),
     .dst_wd_o     (aon_wkup_detector_en_5_wdata)
   );
-  assign unused_aon_wkup_detector_en_5_wdata = ^aon_wkup_detector_en_5_wdata;
+  assign unused_aon_wkup_detector_en_5_wdata =
+      ^aon_wkup_detector_en_5_wdata;
 
   logic  aon_wkup_detector_en_6_qs_int;
   logic [0:0] aon_wkup_detector_en_6_d;
@@ -2387,7 +2393,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_6_regwen),
     .dst_wd_o     (aon_wkup_detector_en_6_wdata)
   );
-  assign unused_aon_wkup_detector_en_6_wdata = ^aon_wkup_detector_en_6_wdata;
+  assign unused_aon_wkup_detector_en_6_wdata =
+      ^aon_wkup_detector_en_6_wdata;
 
   logic  aon_wkup_detector_en_7_qs_int;
   logic [0:0] aon_wkup_detector_en_7_d;
@@ -2423,7 +2430,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_en_7_regwen),
     .dst_wd_o     (aon_wkup_detector_en_7_wdata)
   );
-  assign unused_aon_wkup_detector_en_7_wdata = ^aon_wkup_detector_en_7_wdata;
+  assign unused_aon_wkup_detector_en_7_wdata =
+      ^aon_wkup_detector_en_7_wdata;
 
   logic [2:0]  aon_wkup_detector_0_mode_0_qs_int;
   logic  aon_wkup_detector_0_filter_0_qs_int;
@@ -2463,7 +2471,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_0_regwen),
     .dst_wd_o     (aon_wkup_detector_0_wdata)
   );
-  assign unused_aon_wkup_detector_0_wdata = ^aon_wkup_detector_0_wdata;
+  assign unused_aon_wkup_detector_0_wdata =
+      ^aon_wkup_detector_0_wdata;
 
   logic [2:0]  aon_wkup_detector_1_mode_1_qs_int;
   logic  aon_wkup_detector_1_filter_1_qs_int;
@@ -2503,7 +2512,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_1_regwen),
     .dst_wd_o     (aon_wkup_detector_1_wdata)
   );
-  assign unused_aon_wkup_detector_1_wdata = ^aon_wkup_detector_1_wdata;
+  assign unused_aon_wkup_detector_1_wdata =
+      ^aon_wkup_detector_1_wdata;
 
   logic [2:0]  aon_wkup_detector_2_mode_2_qs_int;
   logic  aon_wkup_detector_2_filter_2_qs_int;
@@ -2543,7 +2553,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_2_regwen),
     .dst_wd_o     (aon_wkup_detector_2_wdata)
   );
-  assign unused_aon_wkup_detector_2_wdata = ^aon_wkup_detector_2_wdata;
+  assign unused_aon_wkup_detector_2_wdata =
+      ^aon_wkup_detector_2_wdata;
 
   logic [2:0]  aon_wkup_detector_3_mode_3_qs_int;
   logic  aon_wkup_detector_3_filter_3_qs_int;
@@ -2583,7 +2594,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_3_regwen),
     .dst_wd_o     (aon_wkup_detector_3_wdata)
   );
-  assign unused_aon_wkup_detector_3_wdata = ^aon_wkup_detector_3_wdata;
+  assign unused_aon_wkup_detector_3_wdata =
+      ^aon_wkup_detector_3_wdata;
 
   logic [2:0]  aon_wkup_detector_4_mode_4_qs_int;
   logic  aon_wkup_detector_4_filter_4_qs_int;
@@ -2623,7 +2635,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_4_regwen),
     .dst_wd_o     (aon_wkup_detector_4_wdata)
   );
-  assign unused_aon_wkup_detector_4_wdata = ^aon_wkup_detector_4_wdata;
+  assign unused_aon_wkup_detector_4_wdata =
+      ^aon_wkup_detector_4_wdata;
 
   logic [2:0]  aon_wkup_detector_5_mode_5_qs_int;
   logic  aon_wkup_detector_5_filter_5_qs_int;
@@ -2663,7 +2676,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_5_regwen),
     .dst_wd_o     (aon_wkup_detector_5_wdata)
   );
-  assign unused_aon_wkup_detector_5_wdata = ^aon_wkup_detector_5_wdata;
+  assign unused_aon_wkup_detector_5_wdata =
+      ^aon_wkup_detector_5_wdata;
 
   logic [2:0]  aon_wkup_detector_6_mode_6_qs_int;
   logic  aon_wkup_detector_6_filter_6_qs_int;
@@ -2703,7 +2717,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_6_regwen),
     .dst_wd_o     (aon_wkup_detector_6_wdata)
   );
-  assign unused_aon_wkup_detector_6_wdata = ^aon_wkup_detector_6_wdata;
+  assign unused_aon_wkup_detector_6_wdata =
+      ^aon_wkup_detector_6_wdata;
 
   logic [2:0]  aon_wkup_detector_7_mode_7_qs_int;
   logic  aon_wkup_detector_7_filter_7_qs_int;
@@ -2743,7 +2758,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_7_regwen),
     .dst_wd_o     (aon_wkup_detector_7_wdata)
   );
-  assign unused_aon_wkup_detector_7_wdata = ^aon_wkup_detector_7_wdata;
+  assign unused_aon_wkup_detector_7_wdata =
+      ^aon_wkup_detector_7_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_0_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_0_d;
@@ -2779,7 +2795,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_0_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_0_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_0_wdata = ^aon_wkup_detector_cnt_th_0_wdata;
+  assign unused_aon_wkup_detector_cnt_th_0_wdata =
+      ^aon_wkup_detector_cnt_th_0_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_1_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_1_d;
@@ -2815,7 +2832,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_1_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_1_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_1_wdata = ^aon_wkup_detector_cnt_th_1_wdata;
+  assign unused_aon_wkup_detector_cnt_th_1_wdata =
+      ^aon_wkup_detector_cnt_th_1_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_2_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_2_d;
@@ -2851,7 +2869,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_2_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_2_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_2_wdata = ^aon_wkup_detector_cnt_th_2_wdata;
+  assign unused_aon_wkup_detector_cnt_th_2_wdata =
+      ^aon_wkup_detector_cnt_th_2_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_3_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_3_d;
@@ -2887,7 +2906,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_3_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_3_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_3_wdata = ^aon_wkup_detector_cnt_th_3_wdata;
+  assign unused_aon_wkup_detector_cnt_th_3_wdata =
+      ^aon_wkup_detector_cnt_th_3_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_4_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_4_d;
@@ -2923,7 +2943,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_4_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_4_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_4_wdata = ^aon_wkup_detector_cnt_th_4_wdata;
+  assign unused_aon_wkup_detector_cnt_th_4_wdata =
+      ^aon_wkup_detector_cnt_th_4_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_5_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_5_d;
@@ -2959,7 +2980,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_5_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_5_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_5_wdata = ^aon_wkup_detector_cnt_th_5_wdata;
+  assign unused_aon_wkup_detector_cnt_th_5_wdata =
+      ^aon_wkup_detector_cnt_th_5_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_6_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_6_d;
@@ -2995,7 +3017,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_6_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_6_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_6_wdata = ^aon_wkup_detector_cnt_th_6_wdata;
+  assign unused_aon_wkup_detector_cnt_th_6_wdata =
+      ^aon_wkup_detector_cnt_th_6_wdata;
 
   logic [7:0]  aon_wkup_detector_cnt_th_7_qs_int;
   logic [7:0] aon_wkup_detector_cnt_th_7_d;
@@ -3031,7 +3054,8 @@ module pinmux_reg_top (
     .dst_regwen_o (aon_wkup_detector_cnt_th_7_regwen),
     .dst_wd_o     (aon_wkup_detector_cnt_th_7_wdata)
   );
-  assign unused_aon_wkup_detector_cnt_th_7_wdata = ^aon_wkup_detector_cnt_th_7_wdata;
+  assign unused_aon_wkup_detector_cnt_th_7_wdata =
+      ^aon_wkup_detector_cnt_th_7_wdata;
 
   logic  aon_wkup_cause_cause_0_qs_int;
   logic  aon_wkup_cause_cause_1_qs_int;
@@ -3080,7 +3104,8 @@ module pinmux_reg_top (
     .dst_regwen_o (),
     .dst_wd_o     (aon_wkup_cause_wdata)
   );
-  assign unused_aon_wkup_cause_wdata = ^aon_wkup_cause_wdata;
+  assign unused_aon_wkup_cause_wdata =
+      ^aon_wkup_cause_wdata;
 
   // Register instances
   // R[alert_test]: V(True)

--- a/util/reggen/reg_top.sv.tpl
+++ b/util/reggen/reg_top.sv.tpl
@@ -418,7 +418,8 @@ ${field_sig_decl(f, sig_name, r.hwext, r.shadowed, r.async_clk)}\
     .dst_wd_o     (${dst_wd_expr})
   );
       % if r.needs_we():
-  assign unused_${base_name}_${r_name}_wdata = ^${base_name}_${r_name}_wdata;
+  assign unused_${base_name}_${r_name}_wdata =
+      ^${base_name}_${r_name}_wdata;
       % endif
     % endif
   % endfor


### PR DESCRIPTION
- this gets around >100 characters per line errors in some cases

Signed-off-by: Timothy Chen <timothytim@google.com>