### PR TITLE
[edn/rtl] Add fix for auto req mode

### DIFF
--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -96,6 +96,7 @@ module edn_core import edn_pkg::*;
   logic                      boot_wr_cmd_reg;
   logic                      boot_wr_cmd_genfifo;
   logic                      auto_first_ack_wait;
+  logic                      auto_req_mode_busy;
   logic                      auto_set_intr_gate;
   logic                      auto_clr_intr_gate;
 
@@ -501,7 +502,7 @@ module edn_core import edn_pkg::*;
          reseed_cmd_load;
 
   assign sfifo_rescmd_wdata =
-         (auto_req_mode_pfe && main_sm_busy && !auto_first_ack_wait) ? cs_cmd_req_out_q :
+         auto_req_mode_busy ? cs_cmd_req_out_q :
          reseed_cmd_bus;
 
   assign sfifo_rescmd_pop = send_rescmd;
@@ -546,7 +547,7 @@ module edn_core import edn_pkg::*;
 
   assign sfifo_gencmd_wdata =
          boot_wr_cmd_genfifo ? boot_gen_cmd :
-         (auto_req_mode_pfe && main_sm_busy && !auto_first_ack_wait) ? cs_cmd_req_out_q :
+         auto_req_mode_busy ? cs_cmd_req_out_q :
          generate_cmd_bus;
 
   assign sfifo_gencmd_pop = send_gencmd || boot_send_gencmd;
@@ -585,6 +586,7 @@ module edn_core import edn_pkg::*;
     .send_rescmd_o(send_rescmd),
     .cmd_sent_i(cmd_sent),
     .local_escalate_i(edn_cntr_err_sum),
+    .auto_req_mode_busy_o(auto_req_mode_busy),
     .main_sm_busy_o(main_sm_busy),
     .main_sm_err_o(edn_main_sm_err)
   );

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -29,6 +29,7 @@ module edn_main_sm (
   output logic               send_rescmd_o,
   input logic                cmd_sent_i,
   input logic                local_escalate_i,
+  output logic               auto_req_mode_busy_o,
   output logic               main_sm_busy_o,
   output logic               main_sm_err_o
 );
@@ -106,6 +107,7 @@ module edn_main_sm (
     auto_set_intr_gate_o = 1'b0;
     auto_clr_intr_gate_o = 1'b0;
     auto_first_ack_wait_o = 1'b0;
+    auto_req_mode_busy_o = 1'b0;
     capt_gencmd_fifo_cnt_o = 1'b0;
     send_gencmd_o = 1'b0;
     capt_rescmd_fifo_cnt_o = 1'b0;
@@ -176,11 +178,13 @@ module edn_main_sm (
         end
       end
       AutoAckWait: begin
+        auto_req_mode_busy_o = 1'b1;
         if (csrng_cmd_ack_i) begin
           state_d = AutoDispatch;
         end
       end
       AutoDispatch: begin
+        auto_req_mode_busy_o = 1'b1;
         if (!auto_req_mode_i) begin
           main_sm_done_pulse_o = 1'b1;
           state_d = Idle;
@@ -193,20 +197,24 @@ module edn_main_sm (
         end
       end
       AutoCaptGenCnt: begin
+        auto_req_mode_busy_o = 1'b1;
         capt_gencmd_fifo_cnt_o = 1'b1;
         state_d = AutoSendGenCmd;
       end
       AutoSendGenCmd: begin
+        auto_req_mode_busy_o = 1'b1;
         send_gencmd_o = 1'b1;
         if (cmd_sent_i) begin
           state_d = AutoAckWait;
         end
       end
       AutoCaptReseedCnt: begin
+        auto_req_mode_busy_o = 1'b1;
         capt_rescmd_fifo_cnt_o = 1'b1;
         state_d = AutoSendReseedCmd;
       end
       AutoSendReseedCmd: begin
+        auto_req_mode_busy_o = 1'b1;
         send_rescmd_o = 1'b1;
         if (cmd_sent_i) begin
           state_d = AutoAckWait;


### PR DESCRIPTION
When auto request mode is terminated via a control field,
the termination needs to be graceful.
The command bus gating was not using the correct terms to do this.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>