### PR TITLE
[sw,tests] add the test chip_sw_aes_enc

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1555,7 +1555,7 @@
             register. Check the digest registers for correctness against the expected digest value.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_aes_enc"]
     }
     {
       name: chip_sw_aes_entropy

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -371,6 +371,13 @@
       run_opts: ["+sw_test_timeout_ns=28000000"]
     }
     {
+      name: chip_sw_aes_enc
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/aes_smoketest:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=22000000"]
+    }
+    {
       name: chip_sw_kmac_mode_cshake_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_cshake_test:1"]


### PR DESCRIPTION
This PR adds the existing `aes_smoketest` to the test plan to cover the `chip_sw_aes_enc`.