### PR TITLE
[sw/rom] Remove print statements from mask_rom.

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -257,7 +257,6 @@ cc_library(
     deps = [
         ":error",
         "//sw/device/lib/base",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
 )
 
@@ -317,7 +316,7 @@ cc_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
         "//sw/device/silicon_creator/lib/drivers:mock_alert",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
         "//sw/device/silicon_creator/testing:mask_rom_test",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -23,9 +23,11 @@ cc_library(
 cc_library(
     name = "mock_alert",
     testonly = True,
-    hdrs = ["mock_alert.h"],
+    hdrs = [
+        "alert.h",
+        "mock_alert.h",
+    ],
     deps = [
-        ":alert",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -228,9 +230,11 @@ cc_library(
 cc_library(
     name = "mock_lifecycle",
     testonly = True,
-    hdrs = ["mock_lifecycle.h"],
+    hdrs = [
+        "lifecycle.h",
+        "mock_lifecycle.h",
+    ],
     deps = [
-        ":lifecycle",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],

--- a/sw/device/silicon_creator/lib/meson.build
+++ b/sw/device/silicon_creator/lib/meson.build
@@ -4,6 +4,19 @@
 subdir('base')
 subdir('drivers')
 
+# Logging library.
+sw_silicon_creator_lib_log = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_log',
+    sources: [
+      'log.c',
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_driver_uart,
+    ],
+  ),
+)
+
 # Otbn utilities.
 sw_silicon_creator_lib_otbn_util = declare_dependency(
   link_with: static_library(
@@ -112,6 +125,7 @@ sw_silicon_creator_lib_shutdown = declare_dependency(
       sw_lib_abs_mmio,
       sw_lib_hardened,
       sw_silicon_creator_lib_driver_alert,
+      sw_silicon_creator_lib_log,
     ],
   ),
 )
@@ -147,19 +161,6 @@ sw_silicon_creator_lib_irq_asm = declare_dependency(
       hw_ip_rstmgr_reg_h,
       hw_ip_flash_ctrl_reg_h,
       'irq_asm.S',
-    ],
-  ),
-)
-
-# Logging library.
-sw_silicon_creator_lib_log = declare_dependency(
-  link_with: static_library(
-    'sw_silicon_creator_lib_log',
-    sources: [
-      'log.c',
-    ],
-    dependencies: [
-      sw_silicon_creator_lib_driver_uart,
     ],
   ),
 )

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -89,7 +89,6 @@ opentitan_binary(
         "//sw/device/silicon_creator/lib:epmp",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:irq_asm",
-        "//sw/device/silicon_creator/lib:log",
         "//sw/device/silicon_creator/lib:shutdown",
         "//sw/device/silicon_creator/lib:sigverify",
         "//sw/device/silicon_creator/lib:sigverify_intf",

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -23,7 +23,6 @@
 #include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/error.h"
-#include "sw/device/silicon_creator/lib/log.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/lib/sigverify.h"
 #include "sw/device/silicon_creator/mask_rom/boot_policy.h"
@@ -198,7 +197,6 @@ static rom_error_t mask_rom_boot(const manifest_t *manifest,
 
   // Jump to ROM_EXT entry point.
   uintptr_t entry_point = manifest_entry_point_get(manifest);
-  log_printf("rom_ext_entry: 0x%x\r\n", (unsigned int)entry_point);
   ((rom_ext_entry_point *)entry_point)();
 
   return kErrorMaskRomBootFailed;
@@ -230,10 +228,6 @@ static rom_error_t mask_rom_try_boot(void) {
 void mask_rom_main(void) {
   SHUTDOWN_IF_ERROR(mask_rom_init());
 
-  // TODO(lowrisc/opentitan#7894): What (if anything) should we print at
-  // startup?
-  log_printf("OpenTitan: \"version-tag\"\r\n");
-  log_printf("lc_state: 0x%x\r\n", (unsigned int)lifecycle_raw_state_get());
 
   // TODO(lowrisc/opentitan#1513): Switch to EEPROM SPI device bootstrap
   // protocol.

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -214,7 +214,6 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_lib_driver_uart,
       sw_silicon_creator_lib_fake_deps,
       sw_silicon_creator_lib_irq_asm,
-      sw_silicon_creator_lib_log,
       sw_silicon_creator_lib_manifest,
       sw_silicon_creator_lib_shutdown,
       sw_silicon_creator_mask_rom_epmp,


### PR DESCRIPTION
Remove print statements from the mask_rom module and move the raw
lifecycle print statement to the shutdown module.

Signed-off-by: Miguel Osorio <miguelosorio@google.com>