### PR TITLE
[spi_host] Fix bug around invalid direction detection.

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -186,7 +186,7 @@ module spi_host
         test_speed_inval = 1'b0;
       end
       Dual, Quad: begin
-        test_dir_inval   = (reg2hw.command.direction.q != Bidir);
+        test_dir_inval   = (reg2hw.command.direction.q == Bidir);
         test_speed_inval = 1'b0;
       end
       default: begin


### PR DESCRIPTION
Dual and Qual mode transactions are invalid if the are bidirectional.
Previously this code flagged an error if such segments were anything
but bidirectional.

Bug first noted in #10680.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>