### PR TITLE
[sw/silicon_creator] Harden SHUTDOWN_IF_ERROR

### DIFF
--- a/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
+++ b/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
@@ -173,54 +173,53 @@ TEST_F(SecMmioTest, CheckCount) {
   EXPECT_EQ(ctx_->check_count, 2);
 }
 
-// Negative test cases trigger assertions, which are caugth by `ASSERT_DEATH`
-// calls. All test cases use lambda functions to wrap expectations and work
-// around issue google/googletest#1004.
+// Negative test cases trigger assertions, which are caugth by `EXPECT_DEATH`
+// calls.
 class SecMmioDeathTest : public SecMmioTest {};
 
 TEST_F(SecMmioDeathTest, Read32OrDieSimulatedFault) {
-  ASSERT_DEATH(
-      [] {
+  EXPECT_DEATH(
+      {
         EXPECT_ABS_READ32(0, 0x12345678);
         EXPECT_ABS_READ32(0, 0);
         sec_mmio_read32(0);
-      }(),
+      },
       "");
 }
 
 TEST_F(SecMmioDeathTest, Write32SimulatedFault) {
-  ASSERT_DEATH(
-      [] {
+  EXPECT_DEATH(
+      {
         EXPECT_ABS_WRITE32(0, 0x12345678);
         EXPECT_ABS_READ32(0, 0);
         sec_mmio_write32(0, 0x12345678);
-      }(),
+      },
       "");
 }
 
 TEST_F(SecMmioDeathTest, CheckValuesSimulatedFault) {
-  ASSERT_DEATH(
-      [] {
+  EXPECT_DEATH(
+      {
         EXPECT_ABS_WRITE32(0, 0x12345678);
         EXPECT_ABS_READ32(0, 0x12345678);
         sec_mmio_write32(0, 0x12345678);
 
         EXPECT_ABS_READ32(0, 0);
         sec_mmio_check_values(/*rnd_offset=*/0);
-      }(),
+      },
       "");
 }
 
 TEST_F(SecMmioDeathTest, CheckCountWriteMismatch) {
   // The developer forgot to increment the write counter, or an attacker
   // glitched the sec write operation.
-  ASSERT_DEATH(
-      [] {
+  EXPECT_DEATH(
+      {
         EXPECT_ABS_WRITE32(0, 0x12345678);
         EXPECT_ABS_READ32(0, 0x12345678);
         sec_mmio_write32(0, 0x12345678);
         sec_mmio_check_counters(/*expected_check_count=*/0);
-      }(),
+      },
       "");
 }
 

--- a/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
@@ -124,7 +124,7 @@ class LifecycleDeathTest : public LifecycleTest,
                            public testing::WithParamInterface<uint32_t> {};
 
 TEST_P(LifecycleDeathTest, InvalidState) {
-  ASSERT_DEATH(
+  EXPECT_DEATH(
       {
         EXPECT_SEC_READ32(base_ + LC_CTRL_LC_STATE_REG_OFFSET, GetParam());
         lifecycle_state_get();

--- a/sw/device/silicon_creator/lib/shutdown.h
+++ b/sw/device/silicon_creator/lib/shutdown.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 #include <stdnoreturn.h>
 
+#include "sw/device/lib/base/hardened.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -22,12 +23,13 @@ extern "C" {
  *
  * @param expr_ An expression which results in an rom_error_t.
  */
-#define SHUTDOWN_IF_ERROR(expr_) \
-  do {                           \
-    rom_error_t error = (expr_); \
-    if (error != kErrorOk) {     \
-      shutdown_finalize(error);  \
-    }                            \
+#define SHUTDOWN_IF_ERROR(expr_)         \
+  do {                                   \
+    rom_error_t error_ = expr_;          \
+    if (launder32(error_) != kErrorOk) { \
+      shutdown_finalize(error_);         \
+    }                                    \
+    HARDENED_CHECK_EQ(error_, kErrorOk); \
   } while (false)
 
 /**

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -599,8 +599,12 @@ TEST_F(ShutdownTest, FlashKill) {
 TEST_F(ShutdownTest, ShutdownIfErrorOk) { SHUTDOWN_IF_ERROR(kErrorOk); }
 
 TEST_F(ShutdownTest, ShutdownIfErrorUnknown) {
-  ExpectFinalize(kErrorUnknown);
-  SHUTDOWN_IF_ERROR(kErrorUnknown);
+  EXPECT_DEATH(
+      {
+        ExpectFinalize(kErrorUnknown);
+        SHUTDOWN_IF_ERROR(kErrorUnknown);
+      },
+      "");
 }
 
 TEST_F(ShutdownTest, SoftwareEscalate) {

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -560,7 +560,7 @@ TEST_F(ShutdownTest, InitializeManufacturing) {
 class ShutdownDeathTest : public ShutdownTest {};
 
 TEST_F(ShutdownDeathTest, InitializeInvalid) {
-  ASSERT_DEATH(
+  EXPECT_DEATH(
       {
         SetupOtpReads();
         shutdown_init(static_cast<lifecycle_state_t>(0));

--- a/sw/device/silicon_creator/lib/sigverify_unittest.cc
+++ b/sw/device/silicon_creator/lib/sigverify_unittest.cc
@@ -170,7 +170,7 @@ INSTANTIATE_TEST_SUITE_P(NonTestOperationalStates, SigverifyInNonTestStates,
 class SigverifyInNonTestStatesDeathTest : public SigverifyInLcState {};
 
 TEST_P(SigverifyInNonTestStatesDeathTest, BadOtpValue) {
-  ASSERT_DEATH(
+  EXPECT_DEATH(
       {
         EXPECT_CALL(
             otp_,
@@ -222,7 +222,7 @@ TEST_F(SigverifyInTestStates, BadSignatureIbex) {
 class SigverifyBadLcStateDeathTest : public SigverifyInLcState {};
 
 TEST_F(SigverifyBadLcStateDeathTest, BadLcState) {
-  ASSERT_DEATH(
+  EXPECT_DEATH(
       {
         uint32_t flash_exec = 0;
         sigverify_rsa_verify(&kSignature, &key_, &kTestDigest,

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_unittest.cc
@@ -180,7 +180,7 @@ TEST_P(BadKeyIdTypeDeathTest, BadKeyType) {
   };
   const sigverify_rsa_key_t *key;
 
-  ASSERT_DEATH(
+  EXPECT_DEATH(
       {
         ExpectKeysPtrGet(keys);
         sigverify_rsa_key_get(key_id, GetParam(), &key);
@@ -206,7 +206,7 @@ TEST_P(NonOperationalStateDeathTest, BadKey) {
   std::tie(key_index, lc_state) = GetParam();
   const sigverify_rsa_key_t *key;
 
-  ASSERT_DEATH(
+  EXPECT_DEATH(
       {
         ExpectKeysPtrGet(kMockKeys);
         sigverify_rsa_key_get(


### PR DESCRIPTION
This PR hardens the `SHUTDOWN_IF_ERROR()` macro and fixes #10549.