### PR TITLE
[dv/kmac] Fix kmac errors sequence

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -2085,15 +2085,9 @@ class kmac_scoreboard extends cip_base_scoreboard #(
             // ErrSwIssuedCmdInAppActive, but for any other command the KMAC will throw a
             // ErrSwCmdSequence.
             if (kmac_cmd_e'(item.a_data) != CmdNone) begin
-              if (kmac_cmd_e'(item.a_data) == CmdStart) begin
-                kmac_err.valid = 1;
-                kmac_err.code  = kmac_pkg::ErrSwIssuedCmdInAppActive;
-                kmac_err.info  = 24'(item.a_data);
-              end begin
-                kmac_err.valid = 1;
-                kmac_err.code  = kmac_pkg::ErrSwCmdSequence;
-                kmac_err.info  = 24'(item.a_data);
-              end
+              kmac_err.valid = 1;
+              kmac_err.code  = kmac_pkg::ErrSwIssuedCmdInAppActive;
+              kmac_err.info  = 24'(item.a_data);
               predict_err(.is_kmac_err(1));
             end
           end else begin

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -141,7 +141,11 @@ class kmac_smoke_vseq extends kmac_base_vseq;
       // Only send a KMAC_APP request when in KMAC mode
       if (en_app) begin
         bit process_key_err_before_app_done = $urandom_range(0, 1);
-        `uvm_info(`gfn, $sformatf("process_key_err_before_app_done: %0b", process_key_err_before_app_done), UVM_HIGH)
+        // Inject error might be disabled by the `send_kmac_req` thread.
+        bit error_injected = 0;
+
+        `uvm_info(`gfn, $sformatf("process_key_err_before_app_done: %0b",
+                  process_key_err_before_app_done), UVM_HIGH)
         fork
           // This thread carries out the "normal" functionality by initiating data transfer
           // over the application interface to the KMAC.
@@ -168,6 +172,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
                       .data(rand_data),
                       .mask(get_rand_contiguous_mask()),
                       .blocking(1));
+            error_injected = 1;
           end : invalid_msgfifo_wr
 
           // This thread will create an error case by writing a SW command to the KMAC
@@ -180,6 +185,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
             wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.valid);
             cfg.clk_rst_vif.wait_clks($urandom_range(25, 250));
             issue_cmd(invalid_cmd);
+            error_injected = 1;
           end : sw_cmd_in_app
 
           // This thread will create an error case by checking that an invalid key has been
@@ -195,6 +201,7 @@ class kmac_smoke_vseq extends kmac_base_vseq;
               read_digest_chunk(KMAC_STATE_SHARE1_BASE, keccak_block_size, share1);
               csr_utils_pkg::wait_no_outstanding_access();
             end
+            error_injected = 1;
           end : check_invalid_key_err
         join
         if (kmac_err_type != kmac_pkg::ErrNone && process_key_err_before_app_done) begin
@@ -206,7 +213,8 @@ class kmac_smoke_vseq extends kmac_base_vseq;
           `uvm_info(`gfn, "finished waiting for kmac_app operation", UVM_HIGH)
 
           if (kmac_err_type inside
-              {kmac_pkg::ErrSwPushedMsgFifo, kmac_pkg::ErrSwIssuedCmdInAppActive}) begin
+              {kmac_pkg::ErrSwPushedMsgFifo, kmac_pkg::ErrSwIssuedCmdInAppActive} &&
+              error_injected) begin
             check_err();
             csr_utils_pkg::wait_no_outstanding_access();
           end

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -247,7 +247,7 @@ package kmac_pkg;
     // This error occurs in below scenario:
     //   - Sw does not send "Start" command to KMAC then writes data into
     //     Msg FIFO
-    //   - Sw writes data into Msg FIFO when KeyMgr is in operating
+    //   - Sw writes data into Msg FIFO when KeyMgr is in operation
     ErrSwPushedMsgFifo = 8'h 02,
 
     // ErrSwIssuedCmdInAppActive


### PR DESCRIPTION
This PR mainly fixes kmac's ErrSwIssuedCmdInAppActive error.
1). In sequence, there are cases that we did not have enough time to
  inject error, then we need to mark a local flag to not expect any
  error interrupt.
2). ErrSwIssuedCmdInAppActive happens when configured in App mode, so
  remove the condition to have command `start`.
3). Fix a small spelling typo.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>