### PR TITLE
[sw/silicon_creator] Add loop checks to otbn_util

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -265,6 +265,7 @@ cc_library(
     name = "otbn",
     srcs = ["otbn.c"],
     hdrs = ["otbn.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/ip/otbn/data:otbn_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -276,10 +277,19 @@ cc_library(
 
 cc_test(
     name = "otbn_unittest",
-    srcs = ["otbn_unittest.cc"],
+    srcs = [
+        "otbn.c",
+        "otbn.h",
+        "otbn_unittest.cc"
+    ],
+    defines = [
+        "OT_OFF_TARGET_TEST",
+    ],
     deps = [
-        ":otbn",
+        "//hw/ip/otbn/data:otbn_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_abs_mmio",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -501,10 +501,11 @@ test('sw_silicon_creator_lib_driver_otbn_unittest', executable(
     dependencies: [
       sw_vendor_gtest,
       sw_silicon_creator_lib_base_mock_abs_mmio,
+      sw_lib_testing_hardened,
     ],
     native: true,
-    c_args: ['-DMOCK_ABS_MMIO'],
-    cpp_args: ['-DMOCK_ABS_MMIO'],
+    c_args: ['-DMOCK_ABS_MMIO', '-DOT_OFF_TARGET_TEST'],
+    cpp_args: ['-DMOCK_ABS_MMIO', '-DOT_OFF_TARGET_TEST'],
   ),
   suite: 'mask_rom',
 )

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -75,11 +75,13 @@ rom_error_t otbn_imem_write(uint32_t offset_bytes, const uint32_t *src,
   RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnIMemSizeBytes));
 
-  for (size_t i = 0; i < num_words; ++i) {
+  size_t i = 0;
+  for (; launder32(i) < num_words; ++i) {
     abs_mmio_write32(
         kBase + OTBN_IMEM_REG_OFFSET + offset_bytes + i * sizeof(uint32_t),
         src[i]);
   }
+  HARDENED_CHECK_EQ(i, num_words);
 
   return kErrorOk;
 }
@@ -89,11 +91,13 @@ rom_error_t otbn_dmem_write(uint32_t offset_bytes, const uint32_t *src,
   RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
 
-  for (size_t i = 0; i < num_words; ++i) {
+  size_t i = 0;
+  for (; launder32(i) < num_words; ++i) {
     abs_mmio_write32(
         kBase + OTBN_DMEM_REG_OFFSET + offset_bytes + i * sizeof(uint32_t),
         src[i]);
   }
+  HARDENED_CHECK_EQ(i, num_words);
 
   return kErrorOk;
 }
@@ -103,18 +107,22 @@ rom_error_t otbn_dmem_read(uint32_t offset_bytes, uint32_t *dest,
   RETURN_IF_ERROR(
       check_offset_len(offset_bytes, num_words, kOtbnDMemSizeBytes));
 
-  for (size_t i = 0; i < num_words; ++i) {
+  size_t i = 0;
+  for (; launder32(i) < num_words; ++i) {
     dest[i] = abs_mmio_read32(kBase + OTBN_DMEM_REG_OFFSET + offset_bytes +
                               i * sizeof(uint32_t));
   }
+  HARDENED_CHECK_EQ(i, num_words);
 
   return kErrorOk;
 }
 
 void otbn_zero_dmem(void) {
-  for (size_t i = 0; i < kOtbnDMemSizeBytes; i += sizeof(uint32_t)) {
+  size_t i = 0;
+  for (; launder32(i) < kOtbnDMemSizeBytes; i += sizeof(uint32_t)) {
     abs_mmio_write32(kBase + OTBN_DMEM_REG_OFFSET + i, 0u);
   }
+  HARDENED_CHECK_EQ(i, kOtbnDMemSizeBytes / sizeof(uint32_t));
 }
 
 rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {

--- a/sw/device/silicon_creator/lib/otbn_util.h
+++ b/sw/device/silicon_creator/lib/otbn_util.h
@@ -77,14 +77,14 @@ typedef struct otbn {
   /**
    * The application loaded or to be loaded into OTBN.
    *
-   * Only valid if @p app_is_loaded is true.
+   * Only valid if @p app_is_loaded is kHardenedBoolTrue.
    */
   otbn_app_t app;
 
   /**
    * Is the application loaded into OTBN?
    */
-  bool app_is_loaded;
+  hardened_bool_t app_is_loaded;
 
   /**
    * The error bits from the last execution of OTBN.


### PR DESCRIPTION
This change adds loop completion checks to otbn_util functions that copy data between otbn and ibex as an additional fault detection mechanism.