### PR TITLE
[top/chip/syn] Remove AST_BYPASS_CLK define in ASIC target

### DIFF
--- a/hw/top_earlgrey/chip_earlgrey_asic.core
+++ b/hw/top_earlgrey/chip_earlgrey_asic.core
@@ -62,7 +62,6 @@ targets:
     default_tool: verilator
     parameters:
       - SYNTHESIS=true
-      - AST_BYPASS_CLK=true
     tools:
       verilator:
         mode: lint-only
@@ -77,7 +76,6 @@ targets:
     default_tool: icarus
     parameters:
       - SYNTHESIS=true
-      - AST_BYPASS_CLK=true
     toplevel: chip_earlgrey_asic
 
   formal:

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -115,7 +115,6 @@ targets:
     default_tool: verilator
     parameters:
       - SYNTHESIS=true
-      - AST_BYPASS_CLK=true
     tools:
       verilator:
         mode: lint-only
@@ -130,7 +129,6 @@ targets:
     default_tool: icarus
     parameters:
       - SYNTHESIS=true
-      - AST_BYPASS_CLK=true
     toplevel: top_earlgrey
 
   formal:


### PR DESCRIPTION
In the meantime, AST has been updated so that it compiles properly on our end when passed through DC synthesis and AscentLint, without having to define the `AST_BYPASS_CLK` macro.

Hence, the `AST_BYPASS_CLK` macro does not have to be defined anymore for these targets (that was a workaround to get things going).

See also #9468 and #9548 for context.

Closes #9468 and #9548.