### PR TITLE
Aes deinit

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -122,7 +122,7 @@
       desc: '''
             Make sure that there is no residual data from latest operation. '''
       milestone: V2
-      tests: []
+      tests: ["aes_deinit"]
     }
   ]
 

--- a/hw/ip/aes/dv/aes_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_sim_cfg.hjson
@@ -111,6 +111,11 @@
       uvm_test: aes_sideload_test
       uvm_test_seq: aes_stress_vseq
     }
+    {
+      name: aes_deinit
+      uvm_test: aes_deinit_test
+      uvm_test_seq: aes_deinit_vseq
+    }
   ]
 
   // List of regressions.

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/aes_stress_vseq.sv: {is_include_file: true}
       - seq_lib/aes_alert_reset_vseq.sv: {is_include_file: true}
       - seq_lib/aes_nist_vectors_vseq.sv: {is_include_file: true}
+      - seq_lib/aes_deinit_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -94,6 +94,12 @@ class aes_base_vseq extends cip_base_vseq #(
   endtask // prng_reseed
 
 
+  virtual task set_force_zero_mask(bit val);
+    ral.ctrl_shadowed.operation.set(val);
+    csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));
+  endtask // set_force_zero_mask
+
+
   virtual task set_operation(bit [1:0] operation);
       ral.ctrl_shadowed.operation.set(operation);
       csr_update(.csr(ral.ctrl_shadowed), .en_shadow_wr(1'b1), .blocking(1));

--- a/hw/ip/aes/dv/env/seq_lib/aes_deinit_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_deinit_vseq.sv
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Will generate a few messages to process
+// will clear the read data and make sure read data
+// is no longer present.
+
+// scoreboard is disabled for this test
+class aes_deinit_vseq extends aes_base_vseq;
+  `uvm_object_utils(aes_deinit_vseq)
+
+  `uvm_object_new
+  aes_message_item   my_message;
+  bit  [3:0][31:0]   data,prev_data;
+  bit                rst_set;
+  bit                back2back = 0;
+  clear_t            clear     = 2'b00;
+  string             txt ="";
+
+  task body();
+    `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES DE-INIT SEQUENCE |----\n %s",
+                              cfg.convert2string()), UVM_LOW)
+
+    fork
+      // start sideload (even if not used)
+      start_sideload_seq();
+    join_none
+
+    // generate list of messages //
+    generate_message_queue();
+
+    // process all messages //
+    while (message_queue.size() > 0 ) begin
+      `uvm_info(`gfn, $sformatf("Starting New Message - messages left %d",
+                                 message_queue.size() ), UVM_MEDIUM)
+
+      my_message = message_queue.pop_back();
+      generate_aes_item_queue(my_message);
+
+      send_msg(my_message.manual_operation, my_message.sideload_en,
+               cfg.unbalanced, cfg.read_prob, cfg.write_prob, rst_set);
+
+      // read output //
+      read_data(prev_data, back2back);
+      read_data(data, back2back);
+
+      if (data != prev_data) begin
+        txt = "Read data ERROR: read data and previous data did not match";
+        txt = {txt, $sformatf("read data \t 0x%0h", data) };
+        txt = {txt, $sformatf("prev data \t 0x%0h", prev_data) };
+        `uvm_fatal(`gfn, $sformatf("%s", txt))
+      end
+
+      // clear the output registers
+      clear.dataout = 1'b1;
+      clear_regs(clear);
+      csr_spinwait(.ptr(ral.status.idle), .exp_data(1'b1));
+      read_data(data, back2back);
+
+      if ((data == prev_data) || (data == 32'h00000000)) begin
+        txt = "\n Read data ERROR: the output register was not cleared correctly";
+        txt = {txt, $sformatf("\n read data \t 0x%0h", data) };
+        txt = {txt, $sformatf("\n prev data \t 0x%0h", prev_data) };
+        `uvm_fatal(`gfn, $sformatf("%s", txt))
+      end
+    end
+
+  endtask : body
+endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
@@ -8,3 +8,4 @@
 `include "aes_common_vseq.sv"
 `include "aes_stress_vseq.sv"
 `include "aes_alert_reset_vseq.sv"
+`include "aes_deinit_vseq.sv"

--- a/hw/ip/aes/dv/tests/aes_deinit_test.sv
+++ b/hw/ip/aes/dv/tests/aes_deinit_test.sv
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class aes_deinit_test extends aes_base_test;
+
+  `uvm_component_utils(aes_deinit_test)
+  `uvm_component_new
+
+
+  virtual function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    configure_env();
+  endfunction
+
+  function void configure_env();
+    super.configure_env();
+    // disable scoreboard for this test
+    cfg.en_scb                   = 0;
+    cfg.error_types              = 0;     // no errors in smoke test
+    cfg.num_messages_min         = 1;
+    cfg.num_messages_max         = 5;
+    // message related knobs
+    cfg.ecb_weight               = 10;
+    cfg.cbc_weight               = 10;
+    cfg.ctr_weight               = 10;
+    cfg.ofb_weight               = 10;
+    cfg.cfb_weight               = 10;
+
+    cfg.message_len_min          = 16;    // one block (16bytes=128bits)
+    cfg.message_len_max          = 128;  //
+    cfg.manual_operation_pct     = 0;
+
+    cfg.fixed_data_en            = 0;
+    cfg.fixed_key_en             = 0;
+
+    cfg.fixed_operation_en       = 0;
+
+    cfg.fixed_keylen_en          = 0;
+
+    cfg.fixed_iv_en              = 0;
+
+    cfg.random_data_key_iv_order = 1;
+
+
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
+  endfunction
+endclass : aes_deinit_test

--- a/hw/ip/aes/dv/tests/aes_test.core
+++ b/hw/ip/aes/dv/tests/aes_test.core
@@ -19,6 +19,7 @@ filesets:
       - aes_clear_test.sv: {is_include_file: true}
       - aes_alert_reset_test.sv: {is_include_file: true}
       - aes_sideload_test.sv: {is_include_file: true}
+      - aes_deinit_test.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/aes/dv/tests/aes_test_pkg.sv
+++ b/hw/ip/aes/dv/tests/aes_test_pkg.sv
@@ -26,4 +26,5 @@ package aes_test_pkg;
   `include "aes_clear_test.sv"
   `include "aes_alert_reset_test.sv"
   `include "aes_sideload_test.sv"
+  `include "aes_deinit_test.sv"
 endpackage


### PR DESCRIPTION
added a simple directed test that verifies that the read data is cleared with random data after a clear.
it is also verified that the read itself does not modify the register content!

FYI the first commit is identical to the one awaiting approval in #10700 