### PR TITLE
[dv/kmac] Fix TL integrity sequence error

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -31,8 +31,12 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
     super.initialize(csr_base_addr);
 
     tl_intg_alert_fields[ral.status.alert_fatal_fault] = 1;
+    tl_intg_alert_fields[ral.cfg_regwen.en] = 0;
+    tl_intg_alert_fields[ral.status.sha3_idle] = 0;
     shadow_update_err_status_fields[ral.status.alert_recov_ctrl_update_err] = 1;
     shadow_storage_err_status_fields[ral.status.alert_fatal_fault] = 1;
+    shadow_storage_err_status_fields[ral.cfg_regwen.en] = 0;
+    shadow_storage_err_status_fields[ral.status.sha3_idle] = 0;
 
     for (int i = 0; i < kmac_pkg::NumAppIntf; i++) begin
       string name = $sformatf("m_kmac_app_agent_cfg[%0d]", i);


### PR DESCRIPTION
Because fatal alert can lock up `cfg_regwen`, and push sha3 fsm to error
state. So we add these two fields to kmac_env_cfg.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>