### PR TITLE
New unr flow

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -120,9 +120,23 @@ cov_unr_build: gen_sv_flist
 	@echo "[make]: cov_unr_build"
 	cd ${sv_flist_gen_dir} && ${cov_unr_build_cmd} ${cov_unr_build_opts}
 
-cov_unr: cov_unr_build
+cov_unr_vcs: cov_unr_build
 	@echo "[make]: cov_unr"
 	cd ${sv_flist_gen_dir} && ${cov_unr_run_cmd} ${cov_unr_run_opts}
+
+cov_unr_xcelium: 
+	@echo "[make]: cov_unr"
+	mkdir -p ${cov_unr_dir}
+	cd ${cov_unr_dir} && ${cov_unr_run_cmd} ${cov_unr_run_opts}
+
+cov_unr_merge:
+	cd ${cov_unr_dir} && ${cov_merge_cmd} -init ${cov_unr_dir}/jgproject/sessionLogs/session_0/unr_imc_coverage_merge.cmd 
+
+ifeq (${SIMULATOR}, xcelium)
+  cov_unr: cov_unr_xcelium cov_unr_merge
+else
+  cov_unr: cov_unr_vcs
+endif
 
 # Merge coverage if there are multiple builds.
 cov_merge:

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -80,6 +80,10 @@
     // Export the cov_report path so that the tcl file can read these as env vars.
     { cov_merge_db_dir: "{cov_merge_db_dir}" },
     { cov_report_dir: "{cov_report_dir}" }
+
+    // Export unr related paths for make
+    {cov_unr_dir:     "{cov_unr_dir}" }
+    {cov_merge_cmd: "{cov_merge_cmd}"}
   ]
 
   // Supported wave dumping formats (in order of preference).

--- a/hw/dv/tools/xcelium/unr.cfg
+++ b/hw/dv/tools/xcelium/unr.cfg
@@ -5,11 +5,10 @@ check_unr -setup
 
 #Setup the clock and reset the design 
 clock -infer
-reset rst_n
+reset ~dut.rst_ni
 get_reset_info
 
 set_prove_time_limit 5m
-
 check_unr -prove
 check_unr -list -type unreachable
 database -export_unicov


### PR DESCRIPTION


------ EDIT ----
I updated the makeflow to run a different flow based on the simulator, if we ever want to support other than vcs and xcelium this needs updating again.

the flow is working correctly, there are two decisions to make.
1.  the tool can be asked to generate a refine file for all the UNRs - I opted for a solution without this as I feel each exclusion should be manually inspected - and excluded.
2. currently the tool assumes the clock to be named rst_ni - if this not the case globally we need to add a clock variable in the hjson - let me know what you think

also TBD @weicaiyang could you fetch this PR and make sure I didn't break the VCS UNR flow?

------ EDIT END ------


@sriyerg 
so I made a mockup for the xcelium UNR flow,
this will break the VCS flow - I am not what the best way to get both in at the same time.

Maybe you can take what I have here and model it into something you would like?

the flow is basically 
1. create a merged cover db with dvsim --cov.
2 run dvsim --cov-unr

- which will trigger unr run on the dvbase

- and then run IMC to merge the results into the original cov db

-  open a GUI for manual expectation of the UNR's and so the user can create a waiver


we probably also want to set the clock in the hjson and export it if to be imported in the unr.cfg
unless all clocks are named rst_ni
Let me know what you think
