### PR TITLE
[dv/shadow_reg] update milestone for shadow reg tests

### DIFF
--- a/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
+++ b/hw/dv/tools/dvsim/testplans/shadow_reg_errors_testplan.hjson
@@ -15,7 +15,7 @@
             - Verify the update_error status register field is set to 1.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V1
+      milestone: V2S
       tests: ["{name}_shadow_reg_errors"]
     }
 
@@ -31,7 +31,7 @@
             - Verify the update_error status register field remains the same value.
             - Repeat the above steps a bunch of times.
             '''
-      milestone: V1
+      milestone: V2S
       tests: ["{name}_shadow_reg_errors"]
     }
 


### PR DESCRIPTION
Shadow register tests are security related and should be categorized as
V2S items.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>