### PR TITLE
[dif/rstmgr] Remove non-global DIF result codes

### DIFF
--- a/sw/device/lib/dif/dif_rstmgr.c
+++ b/sw/device/lib/dif/dif_rstmgr.c
@@ -334,16 +334,16 @@ dif_result_t dif_rstmgr_cpu_info_dump_read(
   return kDifOk;
 }
 
-dif_rstmgr_software_reset_result_t dif_rstmgr_software_reset(
-    const dif_rstmgr_t *handle, dif_rstmgr_peripheral_t peripheral,
-    dif_rstmgr_software_reset_t reset) {
+dif_result_t dif_rstmgr_software_reset(const dif_rstmgr_t *handle,
+                                       dif_rstmgr_peripheral_t peripheral,
+                                       dif_rstmgr_software_reset_t reset) {
   if (handle == NULL || peripheral >= RSTMGR_PARAM_NUM_SW_RESETS) {
-    return kDifRstmgrSoftwareResetBadArg;
+    return kDifBadArg;
   }
 
   mmio_region_t base_addr = handle->base_addr;
   if (rstmgr_software_reset_is_locked(base_addr, peripheral)) {
-    return kDifRstmgrSoftwareResetLocked;
+    return kDifLocked;
   }
 
   switch (reset) {
@@ -358,10 +358,10 @@ dif_rstmgr_software_reset_result_t dif_rstmgr_software_reset(
       rstmgr_software_reset_hold(base_addr, peripheral, false);
       break;
     default:
-      return kDifRstmgrSoftwareResetError;
+      return kDifError;
   }
 
-  return kDifRstmgrSoftwareResetOk;
+  return kDifOk;
 }
 
 dif_result_t dif_rstmgr_software_reset_is_held(

--- a/sw/device/lib/dif/dif_rstmgr.h
+++ b/sw/device/lib/dif/dif_rstmgr.h
@@ -288,32 +288,6 @@ dif_result_t dif_rstmgr_cpu_info_dump_read(
     size_t dump_size, size_t *segments_read);
 
 /**
- * The result of a Reset Manager software reset operation.
- */
-typedef enum dif_rstmgr_software_reset_result {
-  /**
-   * Indicates that the operation succeeded.
-   */
-  kDifRstmgrSoftwareResetOk = kDifOk,
-  /**
-   * Indicates some unspecified failure.
-   */
-  kDifRstmgrSoftwareResetError = kDifError,
-  /**
-   * Indicates that some parameter passed into a function failed a
-   * precondition.
-   *
-   * When this value is returned, no hardware operations occurred.
-   */
-  kDifRstmgrSoftwareResetBadArg = kDifBadArg,
-  /**
-   * Indicates that this operation has been locked out, and can never
-   * succeed until hardware reset.
-   */
-  kDifRstmgrSoftwareResetLocked,
-} dif_rstmgr_software_reset_result_t;
-
-/**
  * Asserts or de-asserts software reset for the requested peripheral.
  *
  * @param handle A Reset Manager handle.
@@ -322,9 +296,9 @@ typedef enum dif_rstmgr_software_reset_result {
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_rstmgr_software_reset_result_t dif_rstmgr_software_reset(
-    const dif_rstmgr_t *handle, dif_rstmgr_peripheral_t peripheral,
-    dif_rstmgr_software_reset_t reset);
+dif_result_t dif_rstmgr_software_reset(const dif_rstmgr_t *handle,
+                                       dif_rstmgr_peripheral_t peripheral,
+                                       dif_rstmgr_software_reset_t reset);
 
 /**
  * Queries whether the requested peripheral is held in reset.

--- a/sw/device/lib/dif/dif_rstmgr_unittest.cc
+++ b/sw/device/lib/dif/dif_rstmgr_unittest.cc
@@ -566,7 +566,7 @@ TEST_F(SoftwareResetTest, SoftwareResetIsLocked) {
 
     EXPECT_EQ(dif_rstmgr_software_reset(&rstmgr_, bit_index,
                                         kDifRstmgrSoftwareResetHold),
-              kDifRstmgrSoftwareResetLocked);
+              kDifLocked);
   }
 }
 


### PR DESCRIPTION
We maintain global DIF return codes (`dif_result_t`) to use across DIF libraries. The reset manager had a DIF that did not use these. This commit fixes this.

Signed-off-by: Timothy Trippel <ttrippel@google.com>