### PR TITLE
[rstmgr] Correctly handle non-always-on por_ni

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -86,8 +86,8 @@ module rstmgr
         .NumCopies(1),
         .AsyncOn(0)
       ) u_por_scanmode_sync (
-        .clk_i(1'b0),  // unused clock
-        .rst_ni(1'b1), // unused reset
+        .clk_i,
+        .rst_ni,
         .mubi_i(scanmode_i),
         .mubi_o(por_scanmode)
       );
@@ -256,8 +256,8 @@ module rstmgr
     .NumCopies(1),
     .AsyncOn(0)
   ) u_ctrl_scanmode_sync (
-    .clk_i(1'b0),  // unused clock
-    .rst_ni(1'b1), // unused reset
+    .clk_i,
+    .rst_ni,
     .mubi_i(scanmode_i),
     .mubi_o(rst_ctrl_scanmode)
   );
@@ -267,9 +267,8 @@ module rstmgr
     .clk_i,
     .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
-    .rst_ni,
     .rst_req_i(pwr_i.rst_lc_req),
-    .rst_parent_ni({PowerDomains{1'b1}}),
+    .rst_parent_ni(rst_por_aon_n),
     .rst_no(rst_lc_src_n)
   );
 
@@ -278,7 +277,6 @@ module rstmgr
     .clk_i,
     .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
-    .rst_ni,
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),
     .rst_parent_ni(rst_lc_src_n),
     .rst_no(rst_sys_src_n)
@@ -323,8 +321,8 @@ module rstmgr
     .NumCopies(${len(leaf_rsts)}),
     .AsyncOn(0)
     ) u_leaf_rst_scanmode_sync  (
-    .clk_i(1'b0),  // unused clock
-    .rst_ni(1'b1), // unused reset
+    .clk_i,
+    .rst_ni,
     .mubi_i(scanmode_i),
     .mubi_o(leaf_rst_scanmode)
  );

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -132,16 +132,16 @@ interface rstmgr_cascading_sva_if (
   `CASCADED_ASSERTS(CascadeEffAonToRstPorIoDiv4, effective_aon_rst_n[0],
                     resets_o.rst_por_io_div4_n[0], SyncCycles, clk_io_div4_i)
 
-  // The internal reset is triggered by one of the generated reset outputs.
-  logic [rstmgr_pkg::PowerDomains-1:0] local_rst_n;
+  // The internal reset is triggered by one of synchronized por.
+  logic [rstmgr_pkg::PowerDomains-1:0] por_rst_n;
   always_comb
-    local_rst_n = {rstmgr_pkg::PowerDomains{resets_o.rst_por_io_div4_n[rstmgr_pkg::DomainAonSel]}};
+    por_rst_n = resets_o.rst_por_aon_n;
 
   logic [rstmgr_pkg::PowerDomains-1:0] local_rst_or_lc_req_n;
-  always_comb local_rst_or_lc_req_n = local_rst_n & ~rst_lc_req;
+  always_comb local_rst_or_lc_req_n = por_rst_n & ~rst_lc_req;
 
   logic [rstmgr_pkg::PowerDomains-1:0] lc_rst_or_sys_req_n;
-  always_comb lc_rst_or_sys_req_n = rst_lc_src_n & ~rst_sys_req;
+  always_comb lc_rst_or_sys_req_n = por_rst_n & ~rst_sys_req;
 
   for (genvar pd = 0; pd < rstmgr_pkg::PowerDomains; ++pd) begin : g_power_domains
     // The root lc reset is triggered either by the internal reset, or by the pwr_i.rst_lc_req

--- a/hw/ip/rstmgr/lint/rstmgr.waiver
+++ b/hw/ip/rstmgr/lint/rstmgr.waiver
@@ -10,3 +10,13 @@ set_clock_drivers prim_clock_buf
 
 waive -rules TERMINAL_STATE -location {rstmgr_cnsty_chk.sv} -regexp {Terminal state 'Error' is detected} \
       -comment "Intentional terminal state"
+
+# All leaf resets have a reset multiplexer for scan reset
+waive -rules RESET_MUX -location {rstmgr.sv rstmgr_por.sv rstmgr_ctrl.sv} -regexp {Asynchronous reset '(resets_o\.)?rst_[A-Za-z_0-9]+_n(\[[0-9:]+\])?' is driven by a multiplexer} \
+      -comment "This is dedicated reset infrastructure, and hence permissible"
+
+waive -rules RESET_USE -location {rstmgr.sv} -regexp {'rst_n\[1\]' is connected to 'rstmgr_ctrl' port 'rst_ni*} \
+      -comment "Parent Non always on resets are combined with the always on reset first before being used as resets"
+
+waive -rules RESET_USE -location {rstmgr.sv} -regexp {rst_lc_src_n.* is connected to 'rstmgr_ctrl' port 'rst_parent_ni.*} \
+      -comment "Parent resets are used synchronously instead of directly as async resets"

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -370,7 +370,7 @@
       clock_srcs: {clk_i: "io_div4", clk_aon_i: "aon", clk_main_i: "main", clk_io_i: "io", clk_usb_i: "usb",
                    clk_io_div2_i: "io_div2", clk_io_div4_i: "io_div4"},
       clock_group: "powerup",
-      reset_connections: {rst_ni: "por_io_div4"},
+      reset_connections: {rst_ni: "por_io_div4"}
       domain: ["Aon"],
       base_addr: "0x40410000",
       attr: "templated",

--- a/hw/top_earlgrey/ip/rstmgr/lint/rstmgr.waiver
+++ b/hw/top_earlgrey/ip/rstmgr/lint/rstmgr.waiver
@@ -5,3 +5,11 @@
 # waiver file for rstmgr
 
 set_reset_drivers prim_clock_mux2 prim_flop prim_flop_2sync
+
+# All leaf resets have a reset multiplexer for scan reset
+waive -rules RESET_MUX -location {rstmgr.sv} -regexp {Asynchronous reset .*resets_o.* is driven by a multiplexer} \
+      -comment "This is dedicated reset infrastructure, thus permissible"
+
+# All leaf resets have a reset multiplexer for scan reset
+waive -rules RESET_MUX -location {rstmgr.sv} -regexp {Asynchronous reset .*resets_o.* is driven by a multiplexer} \
+      -comment "This is dedicated reset infrastructure, thus permissible"

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -89,8 +89,8 @@ module rstmgr
         .NumCopies(1),
         .AsyncOn(0)
       ) u_por_scanmode_sync (
-        .clk_i(1'b0),  // unused clock
-        .rst_ni(1'b1), // unused reset
+        .clk_i,
+        .rst_ni,
         .mubi_i(scanmode_i),
         .mubi_o(por_scanmode)
       );
@@ -259,8 +259,8 @@ module rstmgr
     .NumCopies(1),
     .AsyncOn(0)
   ) u_ctrl_scanmode_sync (
-    .clk_i(1'b0),  // unused clock
-    .rst_ni(1'b1), // unused reset
+    .clk_i,
+    .rst_ni,
     .mubi_i(scanmode_i),
     .mubi_o(rst_ctrl_scanmode)
   );
@@ -270,9 +270,8 @@ module rstmgr
     .clk_i,
     .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
-    .rst_ni,
     .rst_req_i(pwr_i.rst_lc_req),
-    .rst_parent_ni({PowerDomains{1'b1}}),
+    .rst_parent_ni(rst_por_aon_n),
     .rst_no(rst_lc_src_n)
   );
 
@@ -281,7 +280,6 @@ module rstmgr
     .clk_i,
     .scanmode_i(prim_mubi_pkg::mubi4_test_true_strict(rst_ctrl_scanmode[0])),
     .scan_rst_ni,
-    .rst_ni,
     .rst_req_i(pwr_i.rst_sys_req | {PowerDomains{ndm_req_valid}}),
     .rst_parent_ni(rst_lc_src_n),
     .rst_no(rst_sys_src_n)
@@ -326,8 +324,8 @@ module rstmgr
     .NumCopies(19),
     .AsyncOn(0)
     ) u_leaf_rst_scanmode_sync  (
-    .clk_i(1'b0),  // unused clock
-    .rst_ni(1'b1), // unused reset
+    .clk_i,
+    .rst_ni,
     .mubi_i(scanmode_i),
     .mubi_o(leaf_rst_scanmode)
  );


### PR DESCRIPTION
- fixes https://github.com/lowRISC/opentitan/issues/10682
- The fix in https://github.com/lowRISC/opentitan/pull/8010 was incomplete. The non-always-on por_ni was fed in
  to rstmgr, however the non-always-on lc_src_rst did not take effect
  based on por_ni asserting.
- This fix uses the internal por reset directly as the parent reset for lc/sys
  reset nodes.  This ensures that if the external por_n_i drops for any reason,
  even if clocks are killed, the internal nodes are all reset as well.