### PR TITLE
[dv/kmac] Fix shadow reg error due to locked regwen

### DIFF
--- a/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_common_vseq.sv
@@ -20,4 +20,21 @@ class kmac_common_vseq extends kmac_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  virtual function void predict_shadow_reg_status(bit predict_update_err  = 0,
+                                                  bit predict_storage_err = 0);
+    super.predict_shadow_reg_status(predict_update_err, predict_storage_err);
+
+    if (predict_storage_err) begin
+      // For storage error, the kmac `cfg_regwen` register will be set to 0 internally to lock all
+      // cfg related CSRs. Because it is a `RO` register, the logic below manually locks the write
+      // access for its lockable register fields. (If the regwen is `W0C` access policy, the
+      // lockable fields will be updated automatically in `do_predict` function)
+      ral.cfg_regwen.en.set_lockable_flds_access(.lock(1));
+
+      // TODO(Issue #8460) - shadow storage error will clear update error status bit.
+      foreach (cfg.shadow_update_err_status_fields[status_field]) begin
+        void'(status_field.predict(~cfg.shadow_update_err_status_fields[status_field]));
+      end
+    end
+  endfunction
 endclass


### PR DESCRIPTION
This PR has two fixes related to shadow reg:
1). when there is fatal alert, design locks `cfg_regwen` to 0.
Because this is not a common behavior, in `kmac_common_vseq.sv` I
override `predict_shadow_reg_status` to capture this additional change.
2). Tracked in issue #8460 - currently temp align kmac status behavior until design clarifies.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>