### PR TITLE
[sw/silicon_creator] Move GlobalMock out of silicon_creator.

### DIFF
--- a/sw/device/lib/base/testing/BUILD
+++ b/sw/device/lib/base/testing/BUILD
@@ -5,6 +5,12 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "global_mock",
+    testonly = True,
+    hdrs = ["global_mock.h"],
+)
+
+cc_library(
     name = "testing",
     srcs = [
         "mock_mmio.cc",

--- a/sw/device/lib/base/testing/BUILD
+++ b/sw/device/lib/base/testing/BUILD
@@ -6,7 +6,6 @@ package(default_visibility = ["//visibility:public"])
 
 cc_library(
     name = "global_mock",
-    testonly = True,
     hdrs = ["global_mock.h"],
 )
 

--- a/sw/device/lib/base/testing/global_mock.h
+++ b/sw/device/lib/base/testing/global_mock.h
@@ -1,0 +1,76 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_Lib_TESTING_GLOBAL_MOCK_H_
+#define OPENTITAN_SW_DEVICE_Lib_TESTING_GLOBAL_MOCK_H_
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace global_mock {
+
+/**
+ * Base class for mocks used in unit tests.
+ *
+ * If a class `Mock` derives from `GlobalMock<Mock>`, `GlobalMock<Mock>`
+ * ensures that there is at most one instance of `Mock` at a time (checked at
+ * runtime) and makes this instance globally accessible via the static `Mock
+ * &Instance()` method.
+ *
+ * Mock classes should be globally accessible so that mock functions can call
+ * their methods during tests. They can also be strict or nice depending on
+ * tests' needs. Mock classes that satisfy both requirements can be defined as
+ * follows:
+ *
+ *     namespace global_mock {
+ *     namespace internal {
+ *     class MockFoo : public GlobalMock<MockFoo> {
+ *       ...
+ *     };
+ *     }  // namespace internal
+ *     // Type alias for making `internal::MockFoo` a strict mock.
+ *     using MockFoo = testing::StrictMock<internal::MockFoo>;
+ *     // Type alias for making `internal::MockFoo` a nice mock if needed.
+ *     using NiceMockFoo = testing::NiceMock<internal::MockFoo>;
+ *     ...
+ *     }  // namespace mask_rom_test
+ *
+ * This construction also ensures that we cannot have `MockFoo` and
+ * `NiceMockFoo` instantiated at the same time since they both derive from the
+ * same class, i.e. `GlobalMock<internal::MockFoo>`.
+ */
+template <typename Mock>
+class GlobalMock {
+ public:
+  GlobalMock() {
+    if (instance_ != nullptr) {
+      throw std::runtime_error("Mock is already instantiated.");
+    }
+    instance_ = static_cast<Mock *>(this);
+  }
+
+  // Note: Destructors of mock classes must be virtual for `testing::StrictMock`
+  // and `testing::NiceMock` to work correctly.
+  virtual ~GlobalMock() { instance_ = nullptr; }
+
+  static Mock &Instance() {
+    if (instance_ == nullptr) {
+      throw std::runtime_error("Mock is not instantiated yet.");
+    }
+    return *instance_;
+  }
+
+  GlobalMock(const GlobalMock &) = delete;
+  GlobalMock &operator=(const GlobalMock &) = delete;
+  GlobalMock(GlobalMock &&) = delete;
+  GlobalMock &operator=(GlobalMock &&) = delete;
+
+ private:
+  static Mock *instance_;
+};
+template <typename Mock>
+Mock *GlobalMock<Mock>::instance_ = nullptr;
+
+}  // namespace global_mock
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_GLOBAL_MOCK_H_

--- a/sw/device/lib/base/testing/global_mock.h
+++ b/sw/device/lib/base/testing/global_mock.h
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef OPENTITAN_SW_DEVICE_Lib_TESTING_GLOBAL_MOCK_H_
-#define OPENTITAN_SW_DEVICE_Lib_TESTING_GLOBAL_MOCK_H_
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_TESTING_GLOBAL_MOCK_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_TESTING_GLOBAL_MOCK_H_
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -73,4 +73,4 @@ template <typename Mock>
 Mock *GlobalMock<Mock>::instance_ = nullptr;
 
 }  // namespace global_mock
-#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_GLOBAL_MOCK_H_
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_TESTING_GLOBAL_MOCK_H_

--- a/sw/device/lib/base/testing/meson.build
+++ b/sw/device/lib/base/testing/meson.build
@@ -12,6 +12,20 @@ sw_lib_testing_bitfield = declare_dependency(
   )
 )
 
+# global mock class
+sw_lib_testing_global_mock = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_global_mock',
+    sources: [
+      'global_mock.h'
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+    ],
+    native: true,
+  ),
+)
+
 sw_lib_testing_memory = declare_dependency(
   link_with: static_library(
     'memory',

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -37,6 +37,7 @@ cc_library(
     hdrs = ["mock_boot_data.h"],
     deps = [
         ":boot_data_intf",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -177,6 +178,7 @@ cc_test(
     deps = [
         ":error",
         ":log",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/lib/drivers:uart",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
@@ -217,6 +219,7 @@ cc_library(
     hdrs = ["mock_manifest.h"],
     deps = [
         ":manifest_intf",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -269,6 +272,7 @@ cc_library(
     hdrs = ["mock_shutdown.h"],
     deps = [
         ":shutdown_intf",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -508,6 +512,7 @@ cc_library(
     ],
     deps = [
         ":sigverify_internal",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -15,7 +15,7 @@ cc_library(
     defines = ["MOCK_CSR"],
     deps = [
         "//sw/device/lib/base",
-        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "//sw/device/lib/base/testing:global_mock",
         "@googletest//:gtest",
     ],
 )
@@ -39,6 +39,7 @@ cc_library(
     defines = ["MOCK_ABS_MMIO"],
     deps = [
         "//sw/device/lib/base/testing",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -65,6 +66,7 @@ cc_library(
     ],
     deps = [
         "//sw/device/lib/base/testing",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],

--- a/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_abs_mmio.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_MOCK_ABS_MMIO_H_
 
 #include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for abs_mmio.c.
  */
-class MockAbsMmio : public GlobalMock<MockAbsMmio> {
+class MockAbsMmio : public global_mock::GlobalMock<MockAbsMmio> {
  public:
   MOCK_METHOD(uint8_t, Read8, (uint32_t addr));
   MOCK_METHOD(void, Write8, (uint32_t addr, uint8_t value));

--- a/sw/device/silicon_creator/lib/base/mock_csr.h
+++ b/sw/device/silicon_creator/lib/base/mock_csr.h
@@ -8,13 +8,13 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/csr.h"
-#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+#include "sw/device/lib/base/testing/global_mock.h"
 
 namespace mock_csr {
 
 namespace internal {
 
-class MockCsr : public ::mask_rom_test::GlobalMock<MockCsr> {
+class MockCsr : public ::global_mock::GlobalMock<MockCsr> {
  public:
   MOCK_METHOD(uint32_t, Read, (uint32_t csr));
   MOCK_METHOD(void, Write, (uint32_t csr, uint32_t value));

--- a/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
+++ b/sw/device/silicon_creator/lib/base/mock_sec_mmio.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_MOCK_SEC_MMIO_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BASE_MOCK_SEC_MMIO_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
@@ -19,7 +20,7 @@ namespace internal {
 /**
  * Mock class for abs_mmio.c.
  */
-class MockSecMmio : public GlobalMock<MockSecMmio> {
+class MockSecMmio : public global_mock::GlobalMock<MockSecMmio> {
  public:
   MOCK_METHOD(void, Init, ());
   MOCK_METHOD(uint32_t, Read32, (uint32_t addr));

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -28,6 +28,7 @@ cc_library(
         "mock_alert.h",
     ],
     deps = [
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -127,6 +128,7 @@ cc_library(
     hdrs = ["mock_hmac.h"],
     deps = [
         ":hmac",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -235,6 +237,7 @@ cc_library(
         "mock_lifecycle.h",
     ],
     deps = [
+      "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -308,6 +311,7 @@ cc_library(
         "otp.h",
     ],
     deps = [
+      "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],
@@ -324,6 +328,7 @@ cc_test(
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
         "//sw/device/silicon_creator/testing:mask_rom_test",
@@ -414,6 +419,7 @@ cc_library(
         "rnd.h",
     ],
     deps = [
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],

--- a/sw/device/silicon_creator/lib/drivers/mock_alert.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_alert.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_ALERT_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_ALERT_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/drivers/alert.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for alert.c.
  */
-class MockAlert : public GlobalMock<MockAlert> {
+class MockAlert : public global_mock::GlobalMock<MockAlert> {
  public:
   MOCK_METHOD(rom_error_t, alert_configure,
               (size_t, alert_class_t, alert_enable_t));

--- a/sw/device/silicon_creator/lib/drivers/mock_hmac.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_hmac.h
@@ -5,8 +5,9 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_HMAC_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_HMAC_H_
 
-#include "sw/device/lib/testing/mask_rom_test.h"
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 namespace mask_rom_test {
 namespace internal {
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for hmac.c.
  */
-class MockHmac : public GlobalMock<MockHmac> {
+class MockHmac : public global_mock::GlobalMock<MockHmac> {
  public:
   MOCK_METHOD(void, sha256_init, ());
   MOCK_METHOD(rom_error_t, sha256_update, (const void *, size_t));

--- a/sw/device/silicon_creator/lib/drivers/mock_lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_lifecycle.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_LIFECYCLE_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_LIFECYCLE_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for lifecycle.c.
  */
-class MockLifecycle : public GlobalMock<MockLifecycle> {
+class MockLifecycle : public global_mock::GlobalMock<MockLifecycle> {
  public:
   MOCK_METHOD(lifecycle_state_t, State, ());
   MOCK_METHOD(uint32_t, RawState, ());

--- a/sw/device/silicon_creator/lib/drivers/mock_otp.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_otp.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_OTP_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_OTP_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for otp.c.
  */
-class MockOtp : public GlobalMock<MockOtp> {
+class MockOtp : public global_mock::GlobalMock<MockOtp> {
  public:
   MOCK_METHOD(uint32_t, read32, (uint32_t address));
   MOCK_METHOD(uint32_t, read64, (uint32_t address));

--- a/sw/device/silicon_creator/lib/drivers/mock_rnd.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_rnd.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RND_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RND_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for rnd.c.
  */
-class MockRnd : public GlobalMock<MockRnd> {
+class MockRnd : public global_mock::GlobalMock<MockRnd> {
  public:
   MOCK_METHOD(uint32_t, Uint32, ());
 };

--- a/sw/device/silicon_creator/lib/log_unittest.cc
+++ b/sw/device/silicon_creator/lib/log_unittest.cc
@@ -5,6 +5,7 @@
 #include "sw/device/silicon_creator/lib/log.h"
 
 #include "gtest/gtest.h"
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/drivers/uart.h"
 #include "sw/device/silicon_creator/lib/error.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
@@ -14,7 +15,7 @@ namespace log_unittest {
 namespace internal {
 // Create a mock for shutdown functions.
 // TODO: move mock UART into its own header file.
-class MockUart : public ::mask_rom_test::GlobalMock<MockUart> {
+class MockUart : public ::global_mock::GlobalMock<MockUart> {
  public:
   MOCK_METHOD(void, UartPutchar, (char));
 };

--- a/sw/device/silicon_creator/lib/mock_boot_data.h
+++ b/sw/device/silicon_creator/lib/mock_boot_data.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_BOOT_DATA_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_BOOT_DATA_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/boot_data.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for boot_data.
  */
-class MockBootData : public GlobalMock<MockBootData> {
+class MockBootData : public global_mock::GlobalMock<MockBootData> {
  public:
   MOCK_METHOD(rom_error_t, Read,
               (lifecycle_state_t lc_state, boot_data_t *boot_data));

--- a/sw/device/silicon_creator/lib/mock_manifest.h
+++ b/sw/device/silicon_creator/lib/mock_manifest.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_MANIFEST_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_MANIFEST_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for manifest.h.
  */
-class MockManifest : public GlobalMock<MockManifest> {
+class MockManifest : public global_mock::GlobalMock<MockManifest> {
  public:
   MOCK_METHOD(rom_error_t, Check, (const manifest_t *));
   MOCK_METHOD(manifest_digest_region_t, DigestRegion, (const manifest_t *));

--- a/sw/device/silicon_creator/lib/mock_shutdown.h
+++ b/sw/device/silicon_creator/lib/mock_shutdown.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SHUTDOWN_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SHUTDOWN_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/shutdown.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for shutdown.
  */
-class MockShutdown : public GlobalMock<MockShutdown> {
+class MockShutdown : public global_mock::GlobalMock<MockShutdown> {
  public:
   MOCK_METHOD(shutdown_error_redact_t, RedactPolicy, ());
   MOCK_METHOD(uint32_t, Redact, (rom_error_t, shutdown_error_redact_t));

--- a/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_ibex.h
+++ b/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_ibex.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_IBEX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_IBEX_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,8 @@ namespace internal {
 /**
  * Mock class for sigverify_mod_exp_ibex.c
  */
-class MockSigverifyModExpIbex : public GlobalMock<MockSigverifyModExpIbex> {
+class MockSigverifyModExpIbex
+    : public global_mock::GlobalMock<MockSigverifyModExpIbex> {
  public:
   MOCK_METHOD(rom_error_t, mod_exp,
               (const sigverify_rsa_key_t *, const sigverify_rsa_buffer_t *,

--- a/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h
+++ b/sw/device/silicon_creator/lib/mock_sigverify_mod_exp_otbn.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_OTBN_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_MOCK_SIGVERIFY_MOD_EXP_OTBN_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/sigverify_mod_exp.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,8 @@ namespace internal {
 /**
  * Mock class for sigverify_mod_exp_otbn.c
  */
-class MockSigverifyModExpOtbn : public GlobalMock<MockSigverifyModExpOtbn> {
+class MockSigverifyModExpOtbn
+    : public global_mock::GlobalMock<MockSigverifyModExpOtbn> {
  public:
   MOCK_METHOD(rom_error_t, mod_exp,
               (const sigverify_rsa_key_t *, const sigverify_rsa_buffer_t *,

--- a/sw/device/silicon_creator/lib/shutdown_unittest.cc
+++ b/sw/device/silicon_creator/lib/shutdown_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/lib/base/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_alert.h"
@@ -37,7 +38,7 @@ rom_error_t log_printf(const char *fmt, ...) { return kErrorOk; }
 // TODO(lowRISC/opentitan#7148): Refactor mocks into their own headers.
 namespace internal {
 // Create a mock for shutdown functions.
-class MockShutdown : public ::mask_rom_test::GlobalMock<MockShutdown> {
+class MockShutdown : public ::global_mock::GlobalMock<MockShutdown> {
  public:
   MOCK_METHOD(void, shutdown_report_error, (rom_error_t));
   MOCK_METHOD(void, shutdown_software_escalate, ());

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -27,6 +27,7 @@ cc_library(
     testonly = True,
     hdrs = ["mock_boot_policy_ptrs.h"],
     deps = [
+        "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest",
     ],

--- a/sw/device/silicon_creator/mask_rom/mock_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/mock_boot_policy_ptrs.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_MOCK_BOOT_POLICY_PTRS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_MOCK_BOOT_POLICY_PTRS_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/mask_rom/boot_policy_ptrs.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,7 @@ namespace internal {
 /**
  * Mock class for boot_policy_ptrs.h
  */
-class MockBootPolicyPtrs : public GlobalMock<MockBootPolicyPtrs> {
+class MockBootPolicyPtrs : public global_mock::GlobalMock<MockBootPolicyPtrs> {
  public:
   MOCK_METHOD(const manifest_t *, ManifestA, ());
   MOCK_METHOD(const manifest_t *, ManifestB, ());

--- a/sw/device/silicon_creator/mask_rom/mock_sigverify_keys_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/mock_sigverify_keys_ptrs.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_MOCK_SIGVERIFY_KEYS_PTRS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_MOCK_SIGVERIFY_KEYS_PTRS_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,8 @@ namespace internal {
 /**
  * Mock class for sigverify_keys_ptrs.h
  */
-class MockSigverifyKeysPtrs : public GlobalMock<MockSigverifyKeysPtrs> {
+class MockSigverifyKeysPtrs
+    : public global_mock::GlobalMock<MockSigverifyKeysPtrs> {
  public:
   MOCK_METHOD(const sigverify_mask_rom_key_t *, RsaKeysPtrGet, ());
   MOCK_METHOD(size_t, NumRsaKeysGet, ());

--- a/sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/mock_rom_ext_boot_policy_ptrs.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_MOCK_ROM_EXT_BOOT_POLICY_PTRS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_MOCK_ROM_EXT_BOOT_POLICY_PTRS_H_
 
+#include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -14,7 +15,8 @@ namespace internal {
 /**
  * Mock class for rom_ext_boot_policy_ptrs.h
  */
-class MockRomExtBootPolicyPtrs : public GlobalMock<MockRomExtBootPolicyPtrs> {
+class MockRomExtBootPolicyPtrs
+    : public global_mock::GlobalMock<MockRomExtBootPolicyPtrs> {
  public:
   MOCK_METHOD(const manifest_t *, ManifestA, ());
   MOCK_METHOD(const manifest_t *, ManifestB, ());

--- a/sw/device/silicon_creator/testing/mask_rom_test.h
+++ b/sw/device/silicon_creator/testing/mask_rom_test.h
@@ -11,68 +11,6 @@
 namespace mask_rom_test {
 
 /**
- * Base class for mocks used in Mask ROM unit tests.
- *
- * If a class `Mock` derives from `GlobalMock<Mock>`, `GlobalMock<Mock>`
- * ensures that there is at most one instance of `Mock` at a time (checked at
- * runtime) and makes this instance globally accessible via the static `Mock
- * &Instance()` method.
- *
- * Mock classes should be globally accessible so that mock functions can call
- * their methods during tests. They can also be strict or nice depending on
- * tests' needs. Mock classes that satisfy both requirements can be defined as
- * follows:
- *
- *     namespace mask_rom_test {
- *     namespace internal {
- *     class MockFoo : public GlobalMock<MockFoo> {
- *       ...
- *     };
- *     }  // namespace internal
- *     // Type alias for making `internal::MockFoo` a strict mock.
- *     using MockFoo = testing::StrictMock<internal::MockFoo>;
- *     // Type alias for making `internal::MockFoo` a nice mock if needed.
- *     using NiceMockFoo = testing::NiceMock<internal::MockFoo>;
- *     ...
- *     }  // namespace mask_rom_test
- *
- * This construction also ensures that we cannot have `MockFoo` and
- * `NiceMockFoo` instantiated at the same time since they both derive from the
- * same class, i.e. `GlobalMock<internal::MockFoo>`.
- */
-template <typename Mock>
-class GlobalMock {
- public:
-  GlobalMock() {
-    if (instance_ != nullptr) {
-      throw std::runtime_error("Mock is already instantiated.");
-    }
-    instance_ = static_cast<Mock *>(this);
-  }
-
-  // Note: Destructors of mock classes must be virtual for `testing::StrictMock`
-  // and `testing::NiceMock` to work correctly.
-  virtual ~GlobalMock() { instance_ = nullptr; }
-
-  static Mock &Instance() {
-    if (instance_ == nullptr) {
-      throw std::runtime_error("Mock is not instantiated yet.");
-    }
-    return *instance_;
-  }
-
-  GlobalMock(const GlobalMock &) = delete;
-  GlobalMock &operator=(const GlobalMock &) = delete;
-  GlobalMock(GlobalMock &&) = delete;
-  GlobalMock &operator=(GlobalMock &&) = delete;
-
- private:
-  static Mock *instance_;
-};
-template <typename Mock>
-Mock *GlobalMock<Mock>::instance_ = nullptr;
-
-/**
  * Test fixture for mask ROM tests.
  *
  * Test suites should derive their test fixtures from this class. This class


### PR DESCRIPTION
This PR moves the `GlobalMock` class, used for mask ROM unit tests, out of `silicon_creator` so it can be used by other parts of the codebase (in particular, by the `abs_mmio` mock; `abs_mmio` moved out of `silicon_creator` in #10402, and in order to move its mock we will also need to move `GlobalMock`).