### PR TITLE
[aon_timer,dv] Waiving UVM_WARNING for intr_enable register

### DIFF
--- a/hw/ip/aon_timer/dv/tests/aon_timer_base_test.sv
+++ b/hw/ip/aon_timer/dv/tests/aon_timer_base_test.sv
@@ -17,4 +17,16 @@ class aon_timer_base_test extends cip_base_test #(
   // the base class also looks up UVM_TEST_SEQ plusarg to create and run that seq in
   // the run_phase; as such, nothing more needs to be done
 
+  // Add message demotes here
+  virtual function void add_message_demotes(dv_report_catcher catcher);
+    string msg;
+
+    super.add_message_demotes(catcher);
+
+    // Demote intr_enable register non-existent warnings to infos
+    msg = "\s*Unable to locate register 'intr_enable' in block 'aon_timer_reg_block'*";
+    catcher.add_change_sev("RegModel", msg, UVM_INFO);
+
+  endfunction
+
 endclass : aon_timer_base_test

--- a/hw/ip/aon_timer/dv/tests/aon_timer_test_pkg.sv
+++ b/hw/ip/aon_timer/dv/tests/aon_timer_test_pkg.sv
@@ -6,6 +6,7 @@ package aon_timer_test_pkg;
   // dep packages
   import uvm_pkg::*;
   import cip_base_pkg::*;
+  import dv_utils_pkg::*;
   import aon_timer_env_pkg::*;
 
   // macro includes


### PR DESCRIPTION
This commit includes a demotion of UVM_WARNING into UVM_INFO about
not having an intr_enable register for AON timer. We don't need
intr_enable because it is directly tied to the enables of timers
themselves.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>