### PR TITLE
[aon_timer,dv] Adding stress_all_vseq

### DIFF
--- a/hw/ip/aon_timer/dv/env/aon_timer_env.core
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env.core
@@ -22,6 +22,7 @@ filesets:
       - seq_lib/aon_timer_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/aon_timer_prescaler_vseq.sv: {is_include_file: true}
       - seq_lib/aon_timer_jump_vseq.sv: {is_include_file: true}
+      - seq_lib/aon_timer_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
+++ b/hw/ip/aon_timer/dv/env/aon_timer_env_cfg.sv
@@ -25,6 +25,8 @@ class aon_timer_env_cfg extends cip_base_env_cfg #(.RAL_T(aon_timer_reg_block));
     list_of_alerts = aon_timer_env_pkg::LIST_OF_ALERTS;
     super.initialize(csr_base_addr);
 
+    m_tl_agent_cfg.max_outstanding_req = 1;
+
     // set num_interrupts & num_alerts
     begin
       uvm_reg rg = ral.get_reg_by_name("intr_state");

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_stress_all_vseq.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_stress_all_vseq.sv
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class aon_timer_stress_all_vseq extends aon_timer_base_vseq;
+  `uvm_object_utils(aon_timer_stress_all_vseq)
+
+  `uvm_object_new
+
+  constraint num_trans_c {
+    num_trans inside {[3:6]};
+  }
+
+  task body();
+    string seq_names[] = {"aon_timer_smoke_vseq",
+                          "aon_timer_prescaler_vseq",
+                          "aon_timer_jump_vseq",
+                          "aon_timer_common_vseq"};
+
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence        seq;
+      aon_timer_base_vseq aon_timer_vseq;
+      uint                seq_idx = $urandom_range(0, seq_names.size - 1);
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(aon_timer_vseq, seq)
+
+      // if upper seq disables do_apply_reset for this seq, then can't issue reset
+      // as upper seq may drive reset
+      if (do_apply_reset) aon_timer_vseq.do_apply_reset = $urandom_range(0, 1);
+      else                aon_timer_vseq.do_apply_reset = 0;
+
+      aon_timer_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_FATAL(aon_timer_vseq)
+      if (seq_names[seq_idx] == "aon_timer_common_vseq") begin
+        aon_timer_common_vseq common_vseq;
+        `downcast(common_vseq, aon_timer_vseq);
+        common_vseq.common_seq_type = "intr_test";
+      end
+
+      aon_timer_vseq.start(p_sequencer);
+    end
+  endtask : body
+
+endclass

--- a/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_vseq_list.sv
+++ b/hw/ip/aon_timer/dv/env/seq_lib/aon_timer_vseq_list.sv
@@ -7,3 +7,4 @@
 `include "aon_timer_prescaler_vseq.sv"
 `include "aon_timer_jump_vseq.sv"
 `include "aon_timer_common_vseq.sv"
+`include "aon_timer_stress_all_vseq.sv"


### PR DESCRIPTION
This commit includes addition of `stress_all_vseq` to AON timer, and a small configuration update for regarding TL outstanding request cap.