### PR TITLE
[edn/dv] Verify auto_req_mode: reqs_between_reseeds

### DIFF
--- a/hw/dv/sv/csrng_agent/seq_lib/csrng_device_seq.sv
+++ b/hw/dv/sv/csrng_agent/seq_lib/csrng_device_seq.sv
@@ -30,6 +30,7 @@ class csrng_device_seq extends csrng_base_seq;
       end
       start_item(req);
       finish_item(req);
+      get_response(rsp);
     end
   endtask
 

--- a/hw/ip/edn/dv/env/edn_env.sv
+++ b/hw/ip/edn/dv/env/edn_env.sv
@@ -48,6 +48,9 @@ class edn_env extends cip_base_env #(
       m_csrng_agent.m_genbits_push_agent.monitor.analysis_port.connect
           (scoreboard.genbits_fifo.analysis_export);
 
+      m_csrng_agent.m_cmd_push_agent.monitor.analysis_port.connect
+          (scoreboard.cs_cmd_fifo.analysis_export);
+
       for (int i = 0; i < cfg.num_endpoints; i++) begin
         m_endpoint_agent[i].monitor.analysis_port.connect
             (scoreboard.endpoint_fifo[i].analysis_export);

--- a/hw/ip/edn/dv/env/edn_env_pkg.sv
+++ b/hw/ip/edn/dv/env/edn_env_pkg.sv
@@ -24,7 +24,6 @@ package edn_env_pkg;
   // parameters
   parameter uint     MIN_NUM_ENDPOINTS = 1;
   parameter uint     MAX_NUM_ENDPOINTS = 7;
-  parameter uint     MIN_GLEN = 1;
   parameter string   LIST_OF_ALERTS[]  = {"recov_alert","fatal_alert"};
   parameter uint     NUM_ALERTS        = 2;
 

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -12,9 +12,10 @@ class edn_scoreboard extends cip_base_scoreboard #(
   virtual edn_cov_if   cov_vif;
 
   // TLM agent fifos
+  uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(csrng_pkg::CSRNG_CMD_WIDTH)))
+      cs_cmd_fifo;
   uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(csrng_pkg::FIPS_GENBITS_BUS_WIDTH)))
       genbits_fifo;
-
   uvm_tlm_analysis_fifo#(push_pull_item#(.HostDataWidth(FIPS_ENDPOINT_BUS_WIDTH)))
       endpoint_fifo[MAX_NUM_ENDPOINTS];
 
@@ -27,6 +28,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
     super.build_phase(phase);
 
     genbits_fifo = new("genbits_fifo", this);
+    cs_cmd_fifo  = new("cs_cmd_fifo", this);
 
     for (int i = 0; i < cfg.num_endpoints; i++) begin
       endpoint_fifo[i] = new($sformatf("endpoint_fifo[%0d]", i), this);
@@ -46,6 +48,7 @@ class edn_scoreboard extends cip_base_scoreboard #(
 
     fork
       process_genbits_fifo();
+      process_cs_cmd_fifo();
     join_none
 
     for (int i = 0; i < cfg.num_endpoints; i++) begin
@@ -144,6 +147,29 @@ class edn_scoreboard extends cip_base_scoreboard #(
         endpoint_data = genbits_item.h_data >> (i * ENDPOINT_BUS_WIDTH);
         endpoint_data_q.push_back({fips, endpoint_data});
       end
+    end
+  endtask
+
+  task process_cs_cmd_fifo();
+    push_pull_item#(.HostDataWidth(csrng_pkg::CSRNG_CMD_WIDTH))   cs_cmd;
+    bit[3:0]   acmd;
+
+    forever begin
+      cs_cmd_fifo.get(cs_cmd);
+      acmd = cs_cmd.h_data[3:0];
+
+      case (acmd)
+        csrng_pkg::RES: begin
+          cfg.reseed_cnt += 1;
+        end
+        csrng_pkg::GEN: begin
+          cfg.generate_cnt += 1;
+          if (cfg.reseed_cnt == 1) begin
+            cfg.generate_between_reseeds_cnt += 1;
+          end
+        end
+        default: `uvm_info(`gfn, "Not a reseed/generate command", UVM_DEBUG)
+      endcase
     end
   endtask
 

--- a/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_base_vseq.sv
@@ -48,7 +48,7 @@ class edn_base_vseq extends cip_base_vseq #(
     if (cfg.boot_req_mode == MuBi4True) begin
       wr_cmd(.cmd_type("boot_ins"), .acmd(csrng_pkg::INS), .clen(0), .flags(0), .glen(0));
       wr_cmd(.cmd_type("boot_gen"), .acmd(csrng_pkg::GEN), .clen(0), .flags(0),
-             .glen(cfg.num_boot_genbits));
+             .glen(cfg.num_boot_reqs));
     end
 
     // Enable edn, set modes

--- a/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
@@ -9,7 +9,8 @@ class edn_genbits_vseq extends edn_base_vseq;
   push_pull_host_seq#(edn_pkg::FIPS_ENDPOINT_BUS_WIDTH)
       m_endpoint_pull_seq[MAX_NUM_ENDPOINTS];
 
-  uint   num_requesters, num_requests, num_genbits, endpoint_q[$];
+  uint   num_requesters, extra_requester, num_boot_reqs, num_auto_reqs,
+         num_ep_reqs, num_cs_reqs, num_reqs_between_reseeds, endpoint_q[$];
 
   task body();
     super.body();
@@ -19,27 +20,34 @@ class edn_genbits_vseq extends edn_base_vseq;
       endpoint_q.push_back(i);
     end
     endpoint_q.shuffle();
+
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_requesters,
                                        num_requesters inside { [1:cfg.num_endpoints] };)
     endpoint_q = endpoint_q[0:num_requesters - 1];
 
-    for (int i = 0; i < num_requesters; i++) begin
-      // Calculate num_requests -> glen
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_requests,
-                                         num_requests inside
-                                             { [cfg.min_num_requests:cfg.max_num_requests] };
-                                         num_requests % 4 == 0;)
-      num_genbits += num_requests/4;
+    // Determine boot_req_mode/auto_req_mode variables
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(extra_requester,
+                                       extra_requester inside
+                                       { [0:num_requesters - 1] };)
 
-      if ((i == 0) && (cfg.boot_req_mode == MuBi4True)) begin
-        // TODO: Not hard-coded 4
-        num_requests += cfg.num_boot_genbits * 4;
+    for (int i = 0; i < num_requesters; i++) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_ep_reqs,
+                                         num_ep_reqs inside
+                                             { [cfg.min_num_ep_reqs:cfg.max_num_ep_reqs] };
+                                         // TODO: Make num_ep_reqs not 4*num_cs_reqs
+                                         num_ep_reqs % 4 == 0;)
+      num_cs_reqs += num_ep_reqs/(csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH);
+
+      if (i == extra_requester) begin
+        if (cfg.boot_req_mode == MuBi4True) begin
+          num_ep_reqs += cfg.num_boot_reqs * (csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH);
+        end
       end
 
       // Create/Configure endpoint_pull_seq
       m_endpoint_pull_seq[endpoint_q[i]] = push_pull_host_seq#(FIPS_ENDPOINT_BUS_WIDTH)::
           type_id::create($sformatf("m_endpoint_pull_seq[%0d]", endpoint_q[i]));
-      m_endpoint_pull_seq[endpoint_q[i]].num_trans = num_requests;
+      m_endpoint_pull_seq[endpoint_q[i]].num_trans = num_ep_reqs;
     end
 
     // Start endpoint_pull sequences
@@ -54,15 +62,20 @@ class edn_genbits_vseq extends edn_base_vseq;
     end
 
     if (cfg.auto_req_mode == MuBi4True) begin
-      // TODO: Doesn't test functionality of max_num_reqs_between_reseeds register
-      csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(cfg.num_reqs_between_reseeds));
+      if (num_cs_reqs <= 2) begin
+        num_reqs_between_reseeds = 1;
+      end
+      else begin
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_reqs_between_reseeds,
+                                           num_reqs_between_reseeds inside
+                                           { [1:num_cs_reqs/2] };)
+      end
+      csr_wr(.ptr(ral.max_num_reqs_between_reseeds), .value(num_reqs_between_reseeds));
       wr_cmd(.cmd_type("reseed"), .acmd(csrng_pkg::RES), .clen(0), .flags(0), .glen(0));
-      wr_cmd(.cmd_type("generate"), .acmd(csrng_pkg::GEN), .clen(0), .flags(4'hF),
-             // .glen(MIN_GLEN));
-             .glen(num_genbits));
+      wr_cmd(.cmd_type("generate"), .acmd(csrng_pkg::GEN), .clen(0), .flags(0),
+             .glen(1));
     end
 
-    // TODO: Make num_requests not 4*num_genbits
     if (cfg.boot_req_mode != MuBi4True) begin
       // Send instantiate cmd
       wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::INS), .clen(0), .flags(4'hF), .glen(0));
@@ -70,12 +83,29 @@ class edn_genbits_vseq extends edn_base_vseq;
 
     if (cfg.auto_req_mode != MuBi4True) begin
       // Send generate cmd
-      wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(1), .glen(num_genbits));
+      wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(1), .glen(num_cs_reqs));
     end
 
+    // Disable auto_req_mode after 2 reseeds
     if (cfg.auto_req_mode == MuBi4True) begin
+      wait (cfg.reseed_cnt == 2)
       ral.ctrl.auto_req_mode.set(MuBi4False);
       csr_update(.csr(ral.ctrl));
+      // Give the hardware time to quiesce
+      cfg.clk_rst_vif.wait_clks(10);
+      `DV_CHECK_EQ(cfg.generate_between_reseeds_cnt, num_reqs_between_reseeds)
+      // End test gracefully
+      if (num_cs_reqs > cfg.generate_cnt) begin
+        // Send generate cmd
+        wr_cmd(.cmd_type("sw"), .acmd(csrng_pkg::GEN), .clen(0), .flags(1),
+               .glen(num_cs_reqs - cfg.generate_cnt));
+      end
+      else if (num_cs_reqs < cfg.generate_cnt) begin
+        m_endpoint_pull_seq[endpoint_q[extra_requester]].num_trans = 4 *
+            (cfg.generate_cnt - num_cs_reqs);
+        m_endpoint_pull_seq[endpoint_q[extra_requester]].start
+            (p_sequencer.endpoint_sequencer_h[endpoint_q[extra_requester]]);
+      end
     end
   endtask
 

--- a/hw/ip/edn/dv/tests/edn_genbits_test.sv
+++ b/hw/ip/edn/dv/tests/edn_genbits_test.sv
@@ -12,12 +12,10 @@ class edn_genbits_test extends edn_base_test;
 
     cfg.boot_req_mode_pct = 30;
     cfg.auto_req_mode_pct = 30;
-    cfg.min_num_boot_genbits = 1;
-    cfg.max_num_boot_genbits = 4;
-    cfg.min_num_reqs_between_reseeds = 1;
-    cfg.max_num_reqs_between_reseeds = 1;
-    cfg.min_num_requests = 4;
-    cfg.max_num_requests = 16;
+    cfg.min_num_boot_reqs = 1;
+    cfg.max_num_boot_reqs = 4;
+    cfg.min_num_ep_reqs   = 4;
+    cfg.max_num_ep_reqs   = 16;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
     `uvm_info(`gfn, $sformatf("%s", cfg.convert2string()), UVM_HIGH)


### PR DESCRIPTION
Randomized reqs_between_reseeds, Added additional CSRNG GEN req or additional endpoint reguests so test always ends gracefully.

Signed-off-by: Steve Nelson <steve.nelson@wdc.com>