### PR TITLE
[sw/meson] Override march default from toolchain meson cross files

### DIFF
--- a/meson-config.txt
+++ b/meson-config.txt
@@ -1,0 +1,3 @@
+[constants]
+march = 'rv32imc'
+default_extra_args = []

--- a/meson_init.sh
+++ b/meson_init.sh
@@ -166,4 +166,5 @@ meson $reconf \
   -Dkeep_includes="$FLAGS_keep_includes" \
   -Dcoverage="$FLAGS_coverage" \
   --cross-file="$ARG_toolchain_file" \
+  --cross-file="meson-config.txt" \
   "$OBJ_DIR"


### PR DESCRIPTION
This makes it possible to adopt a toolchain with bitmanip support without
having to adopt bitmanip at the same time. We can also use it to change the
bitmanip extension subsets we want to enable.

This patch was written by Luís Marques.

Signed-off-by: Michael Munday <mike.munday@lowrisc.org>