### PR TITLE
[pinmux/sw] Replace hard-coded with named constant

### DIFF
--- a/sw/device/lib/pinmux.c
+++ b/sw/device/lib/pinmux.c
@@ -84,8 +84,7 @@ void pinmux_init(void) {
   // Configure USBDEV SENSE outputs to be high-Z (IOR0, IOR1)
   reg32 =
       mmio_region_from_addr(PINMUX0_BASE_ADDR + PINMUX_MIO_OUTSEL_0_REG_OFFSET);
-  // TODO(lowRISC/opentitan#10408): replace with named constant
-  reg_value = 2;  // high-Z value
+  reg_value = kTopEarlgreyPinmuxOutselConstantHighZ;
   mask = PINMUX_MIO_OUTSEL_0_OUT_0_MASK;
   // We've got one insel configuration field per register. Hence, we have to
   // convert the enumeration index into a byte address using << 2.


### PR DESCRIPTION
Use the named constant in this pre-DIF software.

Signed-off-by: Alexander Williams <awill@google.com>