### PR TITLE
[dv] Add mubi_cov for mubi ports

### DIFF
--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/cip_tl_seq_item.sv: {is_include_file: true}
       - seq_lib/cip_tl_host_single_seq.sv: {is_include_file: true}
       - cip_base_test.sv: {is_include_file: true}
+      - cip_mubi_cov_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/cip_lib/cip_mubi_cov_if.sv
+++ b/hw/dv/sv/cip_lib/cip_mubi_cov_if.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface cip_mubi_cov_if #(parameter int Width = 4) (input [Width-1:0] mubi, input rst_ni);
+  import uvm_pkg::*;
+  import dv_base_reg_pkg::*;
+
+  dv_base_mubi_cov mubi_cov;
+  initial begin
+    mubi_cov = dv_base_mubi_cov::type_id::create($sformatf("%m"));
+    mubi_cov.create_cov(Width);
+    forever begin
+      @(mubi or rst_ni);
+      if (rst_ni === 1) mubi_cov.sample(mubi);
+    end
+  end
+endinterface

--- a/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_bind.sv
+++ b/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_bind.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Binds functional coverage interaface to the top level sram_ctrl module.
+module sram_ctrl_cov_bind;
+
+  bind sram_ctrl cip_mubi_cov_if #(.Width(4)) u_hw_debug_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_hw_debug_en_i)
+  );
+
+  bind sram_ctrl cip_mubi_cov_if #(.Width(8)) u_otp_en_sram_ifetch_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (otp_en_sram_ifetch_i)
+  );
+
+endmodule

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -40,7 +40,7 @@
   en_build_modes: ["{tool}_memutil_dpi_scrambled_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["sram_ctrl_bind"]
+  sim_tops: ["sram_ctrl_bind", "sram_ctrl_cov_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_sim.core
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_sim.core
@@ -18,6 +18,7 @@ filesets:
       - lowrisc:dv:sram_ctrl_sva
     files:
       - tb.sv
+      - cov/sram_ctrl_cov_bind.sv
     file_type: systemVerilogSource
 
 targets:


### PR DESCRIPTION
Create interface with mubi covergroup to use it for mubi ports

Enable mubi cov for sram_ctrl mubi ports in the 2nd commits

#10734 need to be merged first, otherwise, this CI will fail
Signed-off-by: Weicai Yang <weicai@google.com>