### PR TITLE
[adc_ctrl/dv] Added adc_ctrl_filters_interrupt test 

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_testplan.hjson
@@ -59,7 +59,7 @@
           As filters_polled but with filter parameters fixed during the test.
           '''
       milestone: V2
-      tests: []
+      tests: ["adc_ctrl_filters_polled_fixed"]
     }
     {
       name: filters_interrupt
@@ -81,7 +81,7 @@
           - Check interrupt signal operates as expected.
           '''
       milestone: V2
-      tests: []
+      tests: ["adc_ctrl_filters_interrupt"]
     }
     {
       name: filters_interrupt_fixed
@@ -89,7 +89,7 @@
           As filters_interrupt but with filter parameters fixed during the test.
           '''
       milestone: V2
-      tests: []
+      tests: ["adc_ctrl_filters_interrupt_fixed"]
     }
     {
       name: filters_wakeup

--- a/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
+++ b/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
@@ -56,6 +56,23 @@
       name: adc_ctrl_filters_polled
       uvm_test_seq: adc_ctrl_filters_polled_vseq
     }
+
+    {
+      name: adc_ctrl_filters_polled_fixed
+      uvm_test_seq: adc_ctrl_filters_polled_vseq
+      run_opts: ["+filters_fixed=1"]
+    }
+
+    {
+      name: adc_ctrl_filters_interrupt
+      uvm_test_seq: adc_ctrl_filters_interrupt_vseq
+    }
+
+    {
+      name: adc_ctrl_filters_interrupt_fixed
+      uvm_test_seq: adc_ctrl_filters_interrupt_vseq
+      run_opts: ["+filters_fixed=1"]
+    }
     // TODO: add more tests here
   ]
 

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
@@ -22,6 +22,7 @@ filesets:
       - seq_lib/adc_ctrl_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/adc_ctrl_random_ramp_vseq.sv: {is_include_file: true}
       - seq_lib/adc_ctrl_filters_polled_vseq.sv: {is_include_file: true}
+      - seq_lib/adc_ctrl_filters_interrupt_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
@@ -15,8 +15,14 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
 
   // Test configuration
 
+  // If set use the same filter configuration each iteration
+  bit filters_fixed = 0;
+
   // Basic testing mode
   adc_ctrl_testmode_e testmode;
+
+  // Interrupt control bits
+  rand bit [8:0] adc_intr_ctl;
 
   // Power up / wake up time
   rand int pwrup_time;
@@ -31,6 +37,7 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
 
   `uvm_object_utils_begin(adc_ctrl_env_cfg)
     `uvm_field_enum(adc_ctrl_testmode_e, testmode, UVM_DEFAULT)
+    `uvm_field_int(filters_fixed, UVM_DEFAULT)
     `uvm_field_int(pwrup_time, UVM_DEFAULT)
     `uvm_field_int(wakeup_time, UVM_DEFAULT)
     `uvm_field_int(np_sample_cnt, UVM_DEFAULT)

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_pkg.sv
@@ -55,7 +55,7 @@ package adc_ctrl_env_pkg;
 
   // Type of test we are executing
   typedef enum {
-    AdcCtrlOnehot,
+    AdcCtrlOneShot,
     AdcCtrlNormal,
     AdcCtrlLowpower
   } adc_ctrl_testmode_e;

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_interrupt_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_interrupt_vseq.sv
@@ -1,0 +1,39 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Filters interrupt test sequence
+class adc_ctrl_filters_interrupt_vseq extends adc_ctrl_filters_polled_vseq;
+
+  `uvm_object_utils(adc_ctrl_filters_interrupt_vseq)
+
+  `uvm_object_new
+
+  virtual task configure_adc_ctrl();
+    super.configure_adc_ctrl();
+    // Enable interrupts
+    csr_wr(ral.adc_intr_ctl, cfg.adc_intr_ctl);
+    csr_wr(ral.intr_enable, 'h1);
+  endtask
+
+  // Check the ADC CTRL status after every ADC sample (all channels)
+  virtual task check_adc_ctrl_status();
+    uvm_reg_data_t rdata;
+    forever begin
+      // Wait for all channels
+      wait_all_rx();
+      // Delay to allow register to be updated
+      cfg.clk_aon_rst_vif.wait_clks(10);
+      csr_rd(ral.intr_state, rdata);
+      csr_rd(ral.adc_intr_status, rdata);
+      csr_rd(ral.filter_status, rdata);
+      // Randomly erase intr_status/state
+      if ($urandom_range(0, 10) > 9) begin
+        csr_wr(ral.adc_intr_status, $urandom());
+        csr_wr(ral.filter_status, $urandom());
+        csr_wr(ral.intr_state, $urandom());
+      end
+    end
+  endtask
+
+endclass : adc_ctrl_filters_interrupt_vseq

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_polled_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_polled_vseq.sv
@@ -14,7 +14,7 @@ class adc_ctrl_filters_polled_vseq extends adc_ctrl_base_vseq;
   virtual task pre_start();
     super.pre_start();
     fork
-      check_filter_status();
+      check_adc_ctrl_status();
     join_none
     cfg.testmode = AdcCtrlNormal;
   endtask
@@ -74,13 +74,16 @@ class adc_ctrl_filters_polled_vseq extends adc_ctrl_base_vseq;
       // Now turn off ADC_CTRL
       adc_ctrl_off();
 
+      // Re-randomize configuration if enabled
+      if (!cfg.filters_fixed) `DV_CHECK_RANDOMIZE_FATAL(cfg);
+
     end
     // A short delay to allow all CDC to complete
     cfg.clk_aon_rst_vif.wait_clks($urandom_range(3, 5));
   endtask : body
 
-  // Check the filter status register after every ADC sample (all channels)
-  virtual task check_filter_status();
+  // Check the status registers after every ADC sample (all channels)
+  virtual task check_adc_ctrl_status();
     uvm_reg_data_t rdata;
     forever begin
       // Wait for all channels

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_vseq_list.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_vseq_list.sv
@@ -7,4 +7,5 @@
 `include "adc_ctrl_common_vseq.sv"
 `include "adc_ctrl_random_ramp_vseq.sv"
 `include "adc_ctrl_filters_polled_vseq.sv"
+`include "adc_ctrl_filters_interrupt_vseq.sv"
 

--- a/hw/ip/adc_ctrl/dv/tests/adc_ctrl_base_test.sv
+++ b/hw/ip/adc_ctrl/dv/tests/adc_ctrl_base_test.sv
@@ -19,6 +19,7 @@ class adc_ctrl_base_test extends cip_base_test #(
   virtual function void build_phase(uvm_phase phase);
     bit print_ral = 0;
     bit pwrup_time_chk = 1;
+    bit filters_fixed = 0;
 
     // Defaults - can be overridden by plusargs
     test_timeout_ns = 600_000_000;  // 600ms
@@ -36,6 +37,11 @@ class adc_ctrl_base_test extends cip_base_test #(
     // Enable power up check
     void'($value$plusargs("pwrup_time_chk=%0b", pwrup_time_chk));
     `DV_ASSERT_CTRL_REQ("PwrupTime_A_CTRL", pwrup_time_chk)
+
+    // Enable fixed filters
+    void'($value$plusargs("filters_fixed=%0b", filters_fixed));
+    cfg.filters_fixed = filters_fixed;
+
 
     // Print test config
     `uvm_info(`gfn, cfg.sprint(), UVM_LOW)


### PR DESCRIPTION
- Added tests:
  - adc_ctrl_filters_interrupt
  - adc_ctrl_filters_interrupt_fixed
  - adc_ctrl_filters_polled_fixed
- Added adc_ctrl_filters_interrupt_vseq.sv
- Added filters_fixed to cfg - controls configuration randomization
between test iterations
- Updated scoreboard to model and test interrupt registers
- Renamed virtual function check_filter_status to check_adc_ctrl_status

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>