### PR TITLE
[sw,test,otbn] Add the chip level tests rng and urng entropy for otbn

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1952,7 +1952,7 @@
               some data.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_otbn_randomness"]
     }
     {
       name: chip_sw_otbn_urnd_entropy
@@ -1961,7 +1961,7 @@
             - Similar to chip_otbn_rnd_entropy, but verifies the URND bits.
             '''
       milestone: V2
-      tests: []
+      tests:  ["chip_sw_otbn_randomness"]
     }
     {
       name: chip_sw_otbn_idle

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -332,6 +332,13 @@
       sw_images: ["sw/device/tests/aon_timer_wdog_bite_reset_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18000000"]
+    }    
+    {
+      name: chip_sw_otbn_randomness
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/otbn_randomness_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=18000000"]
     }
     {
       name: chip_sw_kmac_mode_cshake_test

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -62,8 +62,8 @@ bool test_main() {
   if (rv != 0) {
     uint32_t fail_idx;
     CHECK(otbn_copy_data_from_otbn(&otbn_ctx, /*len_bytes=*/4, kVarFailIdx,
-                                   &fail_idx) == kOtbnOk);
-    LOG_INFO("ERROR: Test with index %d failed.", fail_idx);
+                                   &fail_idx) == kOtbnOk,
+          "ERROR: Test with index %d failed.", fail_idx);
     return false;
   }
 


### PR DESCRIPTION
# This PR adds the following chip level tests:
## chip_sw_otbn_rnd_entropy

- SW initializes the entropy subsystem to generate randomness.
- SW loads an OTBN app that executes instructions to read the RND bits.
- The OTBN app ensures that the values when read consequtively do not match, and its not all 0s or all 1s, as a basic measure to ensure that the entropy subsystem is returning some data.

## chip_sw_otbn_urnd_entropy

- Similar to chip_otbn_rnd_entropy, but verifies the URND bits.