### PR TITLE
[rtl/rstmgr] Remove superfluous assertion

### DIFF
--- a/hw/ip/rstmgr/rtl/rstmgr_por.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_por.sv
@@ -5,8 +5,6 @@
 // This module stretches the POR
 //
 
-`include "prim_assert.sv"
-
 module rstmgr_por #(
   parameter int FilterStages = 3,
   parameter int unsigned StretchCount = 32
@@ -66,11 +64,6 @@ module rstmgr_por #(
     .sel_i(scanmode_i),
     .clk_o(rst_clean_n)
   );
-
-  // It turns out we can use rst_filter_n[FilterStages-1] instead of &rst_filter_n because any drop
-  // in rst_ni clears all rst_filter_n bits. This assertion checks that property.
-  `ASSERT(FilterInvariant_A, rst_filter_n[FilterStages-1] == &rst_filter_n,
-          clk_i, rst_ni !== 'x)
 
   assign rst_stable = &rst_filter_n;
   assign cnt_en = rst_stable & !rst_no;


### PR DESCRIPTION
It caused trouble in some corner cases, and adds little value.

Signed-off-by: Guillermo Maturana <maturana@google.com>