### PR TITLE
[sw/silicon_creator] Add checks for loop completion and `lc_shift` to `shutdown_init()`

### DIFF
--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -100,22 +100,26 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
   // Get the enable and escalation settings for all four alert classes.
   // Each of these OTP words is composed of 4 byte enums with the enable and
   // escalate configs per alert class (a/b/c/d).
+  size_t i = 0;
+  rom_error_t error = kErrorOk;
   uint32_t class_enable = otp_read32(OTP_CTRL_PARAM_ROM_ALERT_CLASS_EN_OFFSET);
   uint32_t class_escalate =
       otp_read32(OTP_CTRL_PARAM_ROM_ALERT_ESCALATION_OFFSET);
   alert_enable_t enable[ALERT_CLASSES];
   alert_escalate_t escalate[ALERT_CLASSES];
-  for (size_t i = 0; i < ALERT_CLASSES; ++i) {
+  for (i = 0; launder32(i) < ALERT_CLASSES; ++i) {
     enable[i] = (alert_enable_t)bitfield_field32_read(
         class_enable, (bitfield_field32_t){.mask = 0xff, .index = i * 8});
     escalate[i] = (alert_escalate_t)bitfield_field32_read(
         class_escalate, (bitfield_field32_t){.mask = 0xff, .index = i * 8});
   }
+  if (i != ALERT_CLASSES) {
+    error = kErrorUnknown;
+  }
 
   // For each alert, read its corresponding OTP word and extract the class
   // configuration for the current lifecycle state.
-  rom_error_t error = kErrorOk;
-  for (size_t i = 0; i < ALERT_HANDLER_ALERT_CLASS_SHADOWED_MULTIREG_COUNT;
+  for (i = 0; launder32(i) < ALERT_HANDLER_ALERT_CLASS_SHADOWED_MULTIREG_COUNT;
        ++i) {
     uint32_t value = otp_read32(OTP_CTRL_PARAM_ROM_ALERT_CLASSIFICATION_OFFSET +
                                 i * sizeof(uint32_t));
@@ -128,10 +132,14 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
       error = e;
     }
   }
+  if (i != ALERT_HANDLER_ALERT_CLASS_SHADOWED_MULTIREG_COUNT) {
+    error = kErrorUnknown;
+  }
 
   // For each local alert, read its corresponding OTP word and extract the class
   // configuration for the current lifecycle state.
-  for (size_t i = 0; i < ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT;
+  for (i = 0;
+       launder32(i) < ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT;
        ++i) {
     uint32_t value =
         otp_read32(OTP_CTRL_PARAM_ROM_LOCAL_ALERT_CLASSIFICATION_OFFSET +
@@ -145,6 +153,9 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
       error = e;
     }
   }
+  if (i != ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT) {
+    error = kErrorUnknown;
+  }
 
   // For each alert class, configure the various escalation parameters.
   const alert_class_t kClasses[] = {
@@ -154,17 +165,21 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
       kAlertClassD,
   };
   alert_class_config_t config;
-  for (size_t i = 0; i < ALERT_CLASSES; ++i) {
+  for (i = 0; launder32(i) < ALERT_CLASSES; ++i) {
     config.enabled = enable[i];
     config.escalation = escalate[i];
     config.accum_threshold = otp_read32(
         OTP_CTRL_PARAM_ROM_ALERT_ACCUM_THRESH_OFFSET + i * sizeof(uint32_t));
     config.timeout_cycles = otp_read32(
         OTP_CTRL_PARAM_ROM_ALERT_TIMEOUT_CYCLES_OFFSET + i * sizeof(uint32_t));
-    for (size_t phase = 0; phase < ARRAYSIZE(config.phase_cycles); ++phase) {
+    size_t phase = 0;
+    for (; launder32(phase) < ARRAYSIZE(config.phase_cycles); ++phase) {
       config.phase_cycles[phase] = otp_read32(
           OTP_CTRL_PARAM_ROM_ALERT_PHASE_CYCLES_OFFSET +
           (i * ARRAYSIZE(config.phase_cycles) + phase) * sizeof(uint32_t));
+    }
+    if (phase != ARRAYSIZE(config.phase_cycles)) {
+      error = kErrorUnknown;
     }
 
     rom_error_t e = alert_class_configure(kClasses[i], &config);
@@ -173,6 +188,9 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
       // program them all.
       error = e;
     }
+  }
+  if (i != ALERT_CLASSES) {
+    error = kErrorUnknown;
   }
   return error;
 }

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -69,8 +69,17 @@ static size_t clsindex(alert_class_t cls) {
 }
 
 rom_error_t shutdown_init(lifecycle_state_t lc_state) {
+  // `lc_shift` values for different lifecycle states.
+  enum {
+    kLcShiftProd = 0,
+    kLcShiftProdEnd = 8,
+    kLcShiftDev = 16,
+    kLcShiftRma = 24,
+  };
+
   // Are we in a lifecycle state which needs alert configuration?
   uint32_t lc_shift;
+  uint32_t lc_shift_masked;
   switch (launder32(lc_state)) {
     case kLcStateTest:
       HARDENED_CHECK_EQ(lc_state, kLcStateTest);
@@ -79,19 +88,25 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
       return kErrorOk;
     case kLcStateProd:
       HARDENED_CHECK_EQ(lc_state, kLcStateProd);
-      lc_shift = 0;
+      lc_shift = kLcShiftProd;
+      // First operand is laundered to prevent constant-folding of
+      // xor-of-constants.
+      lc_shift_masked = launder32(kLcShiftProd) ^ kLcStateProd;
       break;
     case kLcStateProdEnd:
       HARDENED_CHECK_EQ(lc_state, kLcStateProdEnd);
-      lc_shift = 8;
+      lc_shift = kLcShiftProdEnd;
+      lc_shift_masked = launder32(kLcShiftProdEnd) ^ kLcStateProdEnd;
       break;
     case kLcStateDev:
       HARDENED_CHECK_EQ(lc_state, kLcStateDev);
-      lc_shift = 16;
+      lc_shift = kLcShiftDev;
+      lc_shift_masked = launder32(kLcShiftDev) ^ kLcStateDev;
       break;
     case kLcStateRma:
       HARDENED_CHECK_EQ(lc_state, kLcStateRma);
-      lc_shift = 24;
+      lc_shift = kLcShiftRma;
+      lc_shift_masked = launder32(kLcShiftRma) ^ kLcStateRma;
       break;
     default:
       HARDENED_UNREACHABLE();
@@ -154,6 +169,11 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
     }
   }
   if (i != ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT) {
+    error = kErrorUnknown;
+  }
+
+  // Check `lc_shift` value.
+  if ((lc_shift_masked ^ lc_state) != lc_shift) {
     error = kErrorUnknown;
   }
 


### PR DESCRIPTION
This PR adds checks for loop completion and `lc_shift` to `shutdown_init()` while keeping the overall flow as is, i.e. continue on error, as we discussed offline.

[disassembly](https://gist.github.com/ca87c39c44c8f5eff5e5058b6d9de3eb)