### PR TITLE
[dv/otp] remove checking for d_error data

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -409,6 +409,8 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
                     item.sprint(uvm_default_line_printer), is_tl_unmapped_addr, mem_access_err,
                     csr_size_err, tl_item_err, has_intg_err))
 
+      // TODO: check d_data to be all ones when memory related error occurs.
+
       // these errors all have the same outcome. Only sample coverages when there is just one
       // error, so that we know the error actually triggers the outcome
       if (is_tl_unmapped_addr + csr_size_err + mem_byte_access_err + mem_wo_err +

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -1217,8 +1217,6 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                           cfg.ral_models[ral_name].mem_ranges[0].start_addr + VendorTestOffset +
                           VendorTestSize - 1]}) begin
           predict_err(OtpVendorTestErrIdx, OtpAccessError);
-          `DV_CHECK_EQ(item.d_data, 0,
-                       $sformatf("locked mem read mismatch at TLUL addr %0h in VendorTest", addr))
           return 0;
         end
       end
@@ -1227,8 +1225,6 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                           cfg.ral_models[ral_name].mem_ranges[0].start_addr + CreatorSwCfgOffset +
                           CreatorSwCfgSize - 1]}) begin
           predict_err(OtpCreatorSwCfgErrIdx, OtpAccessError);
-          `DV_CHECK_EQ(item.d_data, 0,
-                       $sformatf("locked mem read mismatch at TLUL addr %0h in CreatorSwCfg", addr))
           return 0;
         end
       end
@@ -1237,8 +1233,6 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                           cfg.ral_models[ral_name].mem_ranges[0].start_addr + OwnerSwCfgOffset +
                           OwnerSwCfgSize - 1]}) begin
           predict_err(OtpOwnerSwCfgErrIdx, OtpAccessError);
-          `DV_CHECK_EQ(item.d_data, 0,
-                       $sformatf("locked mem read mismatch at TLUL addr %0h in OwnerSwCfg", addr))
           return 0;
         end
       end
@@ -1251,8 +1245,6 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
         if (ecc_err == OtpEccUncorrErr && !ecc_corr_err_only_part(part_idx)) begin
             predict_err(part_idx, OtpMacroEccUncorrError);
             set_exp_alert("fatal_macro_error", 1, 20);
-            `DV_CHECK_EQ(item.d_data, 0, $sformatf(
-                         "ECC uncorrectable error exp to readout all 0s at TLUL addr %0h", addr))
            return 0;
         end
       end


### PR DESCRIPTION
Override `is_tl_mem_access_allowed` is not the correct place to check
d_data because we should check it at DataPhase.
So added a TODO in cip_base_scb to check d_data instead.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>