### PR TITLE
[dv/kmac] Add a kmac_if interface

### DIFF
--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -18,6 +18,7 @@ filesets:
       - lowrisc:ip:kmac
     files:
       - kmac_env_pkg.sv
+      - kmac_if.sv
       - kmac_env_cfg.sv: {is_include_file: true}
       - kmac_env_cov.sv: {is_include_file: true}
       - kmac_virtual_sequencer.sv: {is_include_file: true}

--- a/hw/ip/kmac/dv/env/kmac_env.sv
+++ b/hw/ip/kmac/dv/env/kmac_env.sv
@@ -25,12 +25,14 @@ class kmac_env extends cip_base_env #(
     end
 
     // get ext interfaces
-    if (!uvm_config_db#(idle_vif)::get(this, "", "idle_vif", cfg.idle_vif)) begin
-      `uvm_fatal(`gfn, "failed to get idle_vif handle from uvm_config_db")
-    end
     keymgr_sideload_agent = key_sideload_agent::type_id::create("keymgr_sideload_agent", this);
     uvm_config_db#(key_sideload_agent_cfg)::set(this, "keymgr_sideload_agent*",
                                                 "cfg", cfg.keymgr_sideload_agent_cfg);
+
+    // config kmac virtual interface
+    if (!uvm_config_db#(kmac_vif)::get(this, "", "kmac_vif", cfg.kmac_vif)) begin
+      `uvm_fatal(`gfn, "failed to get kmac_vif from uvm_config_db")
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -5,7 +5,7 @@
 class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
 
   // ext interfaces
-  idle_vif        idle_vif;
+  kmac_vif kmac_vif;
 
   rand kmac_app_agent_cfg m_kmac_app_agent_cfg[kmac_pkg::NumAppIntf];
   rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -166,8 +166,8 @@ package kmac_env_pkg;
     ErrStSqueezing
   } kmac_err_st_e;
 
-  typedef virtual pins_if#(1)       idle_vif;
   typedef virtual key_sideload_if   sideload_vif;
+  typedef virtual kmac_if           kmac_vif;
 
   // Helper functions that returns the KMAC key size in bytes/words/blocks
   function automatic int get_key_size_bytes(kmac_pkg::key_len_e len);

--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -1,0 +1,16 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface kmac_if(input clk_i, input rst_ni);
+
+  lc_ctrl_pkg::lc_tx_t lc_escalate_en_i;
+
+  logic idle_o;
+  logic en_masking_o;
+
+  function automatic void drive_lc_escalate(lc_ctrl_pkg::lc_tx_t val);
+    lc_escalate_en_i = val;
+  endfunction
+
+endinterface

--- a/hw/ip/kmac/dv/tb.sv
+++ b/hw/ip/kmac/dv/tb.sv
@@ -16,21 +16,19 @@ module tb;
 
   wire clk, rst_n, rst_shadowed_n;
   wire devmode;
-  wire idle;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
   // keymgr/kmac sideload wires
   keymgr_pkg::hw_key_req_t kmac_sideload_key;
   // kmac_app interfaces
   kmac_pkg::app_req_t [kmac_pkg::NumAppIntf-1:0] app_req;
   kmac_pkg::app_rsp_t [kmac_pkg::NumAppIntf-1:0] app_rsp;
-  logic en_masking;
 
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   rst_shadowed_if rst_shadowed_if(.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
+  kmac_if kmac_if(.clk_i(clk), .rst_ni(rst_n));
 
   pins_if #(1)                   devmode_if(devmode);
-  pins_if #(1)                   idle_if(idle);
   pins_if #(NUM_MAX_INTERRUPTS)  intr_if(interrupts);
 
   tl_if tl_if(.clk(clk), .rst_n(rst_n));
@@ -64,7 +62,7 @@ module tb;
     .alert_tx_o         (alert_tx ),
 
     // life cycle escalation input
-    .lc_escalate_en_i   (lc_ctrl_pkg::Off ),
+    .lc_escalate_en_i   (kmac_if.lc_escalate_en_i ),
 
     // KeyMgr sideload key interface
     .keymgr_key_i       (kmac_sideload_key),
@@ -82,10 +80,10 @@ module tb;
     .intr_kmac_err_o    (interrupts[KmacErr]       ),
 
     // Idle interface
-    .idle_o             (idle),
+    .idle_o             (kmac_if.idle_o ),
 
     // TODO: check this output signal.
-    .en_masking_o       (en_masking),
+    .en_masking_o       (kmac_if.en_masking_o ),
 
     // EDN interface
     .clk_edn_i          (edn_clk                           ),
@@ -113,9 +111,9 @@ module tb;
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
-    uvm_config_db#(virtual pins_if#(1))::set(null, "*.env", "idle_vif", idle_if);
     uvm_config_db#(virtual key_sideload_if)::set(null, "*.env.keymgr_sideload_agent*",
                                                  "vif", sideload_if);
+    uvm_config_db#(virtual kmac_if)::set(null, "*.env", "kmac_vif", kmac_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
Add a kmac_if interface to:
1). Drive lc_escalation input.
2). Replace the extra pin `idle` and add it to kmac interface.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>