### PR TITLE
[dif] Update DIF milestones and development stages - pt2

### DIFF
--- a/hw/ip/edn/data/edn.prj.hjson
+++ b/hw/ip/edn/data/edn.prj.hjson
@@ -7,8 +7,10 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_edn",
     version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V1",
+    dif_stage:          "S0",
 }

--- a/hw/ip/entropy_src/data/entropy_src.prj.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.prj.hjson
@@ -7,8 +7,10 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_entropy_src",
     version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V1",
+    dif_stage:          "S1",
 }

--- a/hw/ip/flash_ctrl/data/flash_ctrl.prj.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.prj.hjson
@@ -7,10 +7,12 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv"
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_flash_ctrl",
     version:            "0.5",
     life_stage:         "L1",
     design_stage:       "D2",
     verification_stage: "V1",
+    dif_stage:          "S0",
     revisions: [
         {
             version:            "0.1",
@@ -24,6 +26,7 @@
             life_stage:         "L1",
             design_stage:       "D2",
             verification_stage: "V1",
+            dif_stage:          "S0",
             notes:              "DV resource allocation pending.",
         },
     ]

--- a/hw/ip/gpio/data/gpio.prj.hjson
+++ b/hw/ip/gpio/data/gpio.prj.hjson
@@ -22,7 +22,7 @@
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",
-        dif_stage:          "S1",
+        dif_stage:          "S2",
         notes:              "Rolled back to D2 as the register module is updated",
       }
     ]

--- a/hw/ip/hmac/data/hmac.prj.hjson
+++ b/hw/ip/hmac/data/hmac.prj.hjson
@@ -22,7 +22,7 @@
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",
-        dif_stage:          "S0",
+        dif_stage:          "S1",
         notes:              "Rolled back to D2 in order to add the first alert",
       }
     ]

--- a/sw/device/lib/dif/dif_edn.md
+++ b/sw/device/lib/dif/dif_edn.md
@@ -2,68 +2,51 @@
 title: "Entropy Distribution Network DIF Checklist"
 ---
 
-<!--
-NOTE: This is a template checklist document that is required to be copied over
-to `sw/device/lib/dif/dif_edn.md` for a new DIF that transitions
-from L0 (Specification) to L1 (Development) stage, and updated as needed.
-Once done, please remove this comment before checking it in.
--->
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Entropy Distribution Network DIF]({{< relref "hw/ip/edn/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
+<h2>DIF Checklist</h2>
 
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Not Started |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_entropy_src.md
+++ b/sw/device/lib/dif/dif_entropy_src.md
@@ -2,68 +2,51 @@
 title: "Entropy Source DIF Checklist"
 ---
 
-<!--
-NOTE: This is a template checklist document that is required to be copied over
-to `sw/device/lib/dif/dif_entropy_src.md` for a new DIF that transitions
-from L0 (Specification) to L1 (Development) stage, and updated as needed.
-Once done, please remove this comment before checking it in.
--->
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Entropy Source DIF]({{< relref "hw/ip/entropy_src/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
+<h2>DIF Checklist</h2>
 
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | WIP         |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Not Started |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_flash_ctrl.md
+++ b/sw/device/lib/dif/dif_flash_ctrl.md
@@ -1,0 +1,52 @@
+---
+title: "Flash Controller DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Flash Controller DIF]({{< relref "hw/ip/flash_ctrl/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+<h2>DIF Checklist</h2>
+
+<h3>S1</h3>
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+
+<h3>S2</h3>
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
+
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+
+<h3>S3</h3>
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}

--- a/sw/device/lib/dif/dif_gpio.md
+++ b/sw/device/lib/dif/dif_gpio.md
@@ -5,64 +5,48 @@ title: "GPIO DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [GPIO DIF]({{< relref "hw/ip/gpio/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Done        |
-Tests          | [DIF_TEST_UNIT][]    | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref
-"/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_hmac.md
+++ b/sw/device/lib/dif/dif_hmac.md
@@ -5,63 +5,48 @@ title: "HMAC DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [HMAC DIF]({{< relref "hw/ip/hmac/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_smoke][]   | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
-[DIF_TEST_smoke]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Not Started |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_i2c.md
+++ b/sw/device/lib/dif/dif_i2c.md
@@ -5,63 +5,48 @@ title: "I2C DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [I2C DIF]({{< relref "hw/ip/i2c/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_smoke][]   | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
-[DIF_TEST_smoke]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Not Started |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}


### PR DESCRIPTION
This PR updates the DIF milestones and development stages for the following IPs, to match the updated DIF milestone checklist submitted in #10777:
- edn
- entropy_src
- flash_ctrl
- gpio
- hmac
- i2c

This partially addresses #10504.