### PR TITLE
[dv/rstmgr] Test rst_cpu_i input

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr_testplan.hjson
+++ b/hw/ip/rstmgr/data/rstmgr_testplan.hjson
@@ -20,6 +20,7 @@
             Checks the behavior of rstmgr when receiving various reset requests.
 
             **Stimulus**:
+            - Send a scan reset.
             - Send a low power entry reset.
             - Send a peripheral reset request.
             - Send a debug reset.
@@ -153,6 +154,23 @@
             - Verify the `alert_info` is only captured when enabled.
             - Verify the `alert_info` contents at each `alert_info_ctrl.index`
               matches the expected value.
+            '''
+      milestone: V2
+      tests: ["rstmgr_reset"]
+    }
+    {
+      name: reset_info_capture
+      desc: '''Test the capture blocking effect of rst_cpu_n input.
+
+            After an AON reset reset capture is blocked until the input
+            rst_cpu_n goes inactive.
+
+            **Stimulus**:
+            - Wait for a random number of resets before setting rst_cpu_n
+              inactive.
+
+            **Checks**:
+            - Non-AON resets prior to this event don't capture.
             '''
       milestone: V2
       tests: ["rstmgr_reset"]


### PR DESCRIPTION
This input affects reset recording functionality.
Introduce a controllable responder that automatically sets
rst_cpu_n input in response to resets_o.rst_sys_n.
Disable this responder to check the capture functionality
controlled by rst_cpu_n.

Signed-off-by: Guillermo Maturana <maturana@google.com>