### PR TITLE
[spi_host/rtl] Dual mode timing fix

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -367,7 +367,7 @@ module spi_host_fsm
       shift_size = 0;
       start_bit = 3'h0;
     end else begin
-      unique case (cmd_speed_q)
+      unique case (cmd_speed_d)
         Standard: begin
           shift_size = 3'h1;
           start_bit  = 3'h7;


### PR DESCRIPTION
The command speed register is now being read at the correct time
when switching speed between back-to-back segments.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>