### PR TITLE
[spi_host/doc] Clarify the meaning of COMMAND.LEN

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -371,6 +371,8 @@
                    to send or received a byte will depend on !!COMMAND.SPEED.
                    For dummy segments, (!!COMMAND.DIRECTION == 0), this register
                    controls the number of dummy cycles to issue.
+                   The number of bytes (or dummy cycles) in the segment will be
+                   equal to !!COMMAND.LEN + 1.
                    ''',
           resval: "0x0"
         },


### PR DESCRIPTION
The COMMAND.LEN field encodes the length of a command segment minus 1.
This behavior has already been noted in @cfrantz's draft DIF PR (#8872).

This commit documents this behavior.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>