### PR TITLE
[entropy_src] Document & Implement THRESHOLD_SCOPE

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -244,8 +244,13 @@
           name: "THRESHOLD_SCOPE",
           mubi: true,
           desc: '''
-                Setting this field to kMuBi4True will enable threshold scope mode.
-                TODO(#9759): add more description.
+                This field controls the scope (either by-line or by-sum) of the health checks.
+                If set to kMuBi4True, the Adaptive Proportion and Markov Tests will accumulate all
+                RNG input lines into a single score, and thresholds will be applied to the sum all
+                the entropy input lines.  If set to kMuBi4False, the RNG input lines are all scored
+                individually.  A statistical deviation in any one input line, be it due to
+                coincidence or failure, will force rejection of the sample, and count toward the
+                total alert count.
                 '''
           resval: false
         },

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -121,6 +121,7 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     ral.conf.entropy_data_reg_enable.set(cfg.entropy_data_reg_enable);
     ral.conf.rng_bit_enable.set(cfg.rng_bit_enable);
     ral.conf.rng_bit_sel.set(cfg.rng_bit_sel);
+    ral.conf.threshold_scope.set(cfg.ht_threshold_scope);
     csr_update(.csr(ral.conf));
 
     // Register write enable lock is on be default

--- a/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_smoke_test.sv
@@ -17,6 +17,7 @@ class entropy_src_smoke_test extends entropy_src_base_test;
     cfg.boot_mode_retry_limit       = 10;
     cfg.route_software_pct          = 100;
     cfg.entropy_data_reg_enable_pct = 100;
+    cfg.ht_threshold_scope_pct      = 100;
 
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 

--- a/hw/ip/entropy_src/entropy_src.core
+++ b/hw/ip/entropy_src/entropy_src.core
@@ -14,6 +14,7 @@ filesets:
       - lowrisc:prim:lfsr
       - lowrisc:prim:sparse_fsm
       - lowrisc:prim:max_tree
+      - lowrisc:prim:sum_tree
       - lowrisc:ip:tlul
       - lowrisc:ip:sha3
       - lowrisc:ip:otp_ctrl_pkg

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -286,9 +286,11 @@ module entropy_src
     u_entropy_src_core.u_prim_count_window_cntr,
     alert_tx_o[1])
 
-  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck1_A,
-    u_entropy_src_core.u_entropy_src_adaptp_ht.u_prim_count_test_cnt,
-    alert_tx_o[1])
+  for (genvar sh = 0; sh < RngBusWidth; sh = sh+1) begin : gen_bit_cntrs
+    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck1_A,
+      u_entropy_src_core.u_entropy_src_adaptp_ht.gen_cntrs[sh].u_prim_count_test_cnt,
+      alert_tx_o[1])
+  end : gen_bit_cntrs
 
   for (genvar i = 0; i < NumBins; i = i + 1) begin : gen_symbol_match
    `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(CntAlertCheck_A,

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -167,7 +167,6 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                     es_bypass_mode;
   logic                     rst_alert_cntr;
   logic                     threshold_scope;
-  logic                     unused_threshold_scope;
   logic                     threshold_scope_pfe;
   logic                     threshold_scope_pfa;
   logic                     fips_compliance;
@@ -222,7 +221,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic [HalfRegWidth-1:0] adaptp_lo_bypass_threshold_oneway;
   logic                    adaptp_lo_bypass_threshold_wr;
   logic [HalfRegWidth-1:0] adaptp_lo_threshold;
-  logic [HalfRegWidth-1:0] adaptp_event_cnt;
+  logic [HalfRegWidth-1:0] adaptp_hi_event_cnt;
+  logic [HalfRegWidth-1:0] adaptp_lo_event_cnt;
   logic [HalfRegWidth-1:0] adaptp_hi_event_hwm_fips;
   logic [HalfRegWidth-1:0] adaptp_hi_event_hwm_bypass;
   logic [HalfRegWidth-1:0] adaptp_lo_event_hwm_fips;
@@ -1299,7 +1299,6 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign threshold_scope_pfa = mubi4_test_invalid(mubi_thresh_scope);
   assign hw2reg.recov_alert_sts.threshold_scope_field_alert.de = threshold_scope_pfa;
   assign hw2reg.recov_alert_sts.threshold_scope_field_alert.d  = threshold_scope_pfa;
-  assign unused_threshold_scope = threshold_scope;
 
   assign es_route_to_sw = es_route_pfe;
   assign es_bypass_to_sw = es_type_pfe;
@@ -1504,7 +1503,9 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .thresh_hi_i         (adaptp_hi_threshold),
     .thresh_lo_i         (adaptp_lo_threshold),
     .window_wrap_pulse_i (health_test_done_pulse),
-    .test_cnt_o          (adaptp_event_cnt),
+    .threshold_scope_i   (threshold_scope),
+    .test_cnt_hi_o       (adaptp_hi_event_cnt),
+    .test_cnt_lo_o       (adaptp_lo_event_cnt),
     .test_fail_hi_pulse_o(adaptp_hi_fail_pulse),
     .test_fail_lo_pulse_o(adaptp_lo_fail_pulse),
     .count_err_o         (adaptp_cntr_err)
@@ -1519,7 +1520,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .event_i             (health_test_done_pulse && !es_bypass_mode),
-    .value_i             (adaptp_event_cnt),
+    .value_i             (adaptp_hi_event_cnt),
     .value_o             (adaptp_hi_event_hwm_fips)
   );
 
@@ -1531,7 +1532,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .event_i             (health_test_done_pulse && es_bypass_mode),
-    .value_i             (adaptp_event_cnt),
+    .value_i             (adaptp_hi_event_cnt),
     .value_o             (adaptp_hi_event_hwm_bypass)
   );
 
@@ -1561,7 +1562,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .event_i             (health_test_done_pulse && !es_bypass_mode),
-    .value_i             (adaptp_event_cnt),
+    .value_i             (adaptp_lo_event_cnt),
     .value_o             (adaptp_lo_event_hwm_fips)
   );
 
@@ -1573,7 +1574,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rst_ni              (rst_ni),
     .clear_i             (health_test_clr),
     .event_i             (health_test_done_pulse && es_bypass_mode),
-    .value_i             (adaptp_event_cnt),
+    .value_i             (adaptp_lo_event_cnt),
     .value_o             (adaptp_lo_event_hwm_bypass)
   );
 
@@ -1675,6 +1676,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .thresh_hi_i         (markov_hi_threshold),
     .thresh_lo_i         (markov_lo_threshold),
     .window_wrap_pulse_i (health_test_done_pulse),
+    .threshold_scope_i   (threshold_scope),
     .test_cnt_hi_o       (markov_hi_event_cnt),
     .test_cnt_lo_o       (markov_lo_event_cnt),
     .test_fail_hi_pulse_o (markov_hi_fail_pulse),

--- a/hw/ip/entropy_src/rtl/entropy_src_markov_ht.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_markov_ht.sv
@@ -20,6 +20,7 @@ module entropy_src_markov_ht #(
   input logic [RegWidth-1:0]    thresh_hi_i,
   input logic [RegWidth-1:0]    thresh_lo_i,
   input logic                   window_wrap_pulse_i,
+  input logic                   threshold_scope_i,
   output logic [RegWidth-1:0]   test_cnt_hi_o,
   output logic [RegWidth-1:0]   test_cnt_lo_o,
   output logic                  test_fail_hi_pulse_o,
@@ -29,14 +30,11 @@ module entropy_src_markov_ht #(
 
   // signals
   logic [RngBusWidth-1:0] samples_no_match_pulse;
-  logic [RegWidth-1:0] pair_cntr_gt1;
-  logic [RegWidth-1:0] pair_cntr_gt2;
-  logic [RegWidth-1:0] pair_cntr_gt3;
-  logic [RegWidth-1:0] pair_cntr_lt1;
-  logic [RegWidth-1:0] pair_cntr_lt2;
-  logic [RegWidth-1:0] pair_cntr_lt3;
-  logic [RegWidth-1:0] pair_cntr[RngBusWidth];
-  logic [RngBusWidth-1:0] pair_cntr_err;
+  logic [RegWidth-1:0]                  pair_cntr_max;
+  logic [RegWidth-1:0]                  pair_cntr_min, pair_cntr_min_tmp;
+  logic [RegWidth-1:0]                  pair_cntr_sum;
+  logic [RngBusWidth-1:0][RegWidth-1:0] pair_cntr;
+  logic [RngBusWidth-1:0]               pair_cntr_err;
 
   // flops
   logic                toggle_q, toggle_d;
@@ -73,48 +71,79 @@ module entropy_src_markov_ht #(
 
     // pair counter
     prim_count #(
-        .Width(RegWidth),
-        .OutSelDnCnt(1'b0), // count up
-        .CntStyle(prim_count_pkg::DupCnt)
-      ) u_prim_count_pair_cntr (
-        .clk_i,
-        .rst_ni,
-        .clr_i(window_wrap_pulse_i),
-        .set_i(!active_i || clear_i),
-        .set_cnt_i(RegWidth'(0)),
-        .en_i(samples_no_match_pulse[sh]),
-        .step_i(RegWidth'(1)),
-        .cnt_o(pair_cntr[sh]),
-        .err_o(pair_cntr_err[sh])
-      );
-
+      .Width(RegWidth),
+      .OutSelDnCnt(1'b0), // count up
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_prim_count_pair_cntr (
+      .clk_i,
+      .rst_ni,
+      .clr_i(window_wrap_pulse_i),
+      .set_i(!active_i || clear_i),
+      .set_cnt_i(RegWidth'(0)),
+      .en_i(samples_no_match_pulse[sh]),
+      .step_i(RegWidth'(1)),
+      .cnt_o(pair_cntr[sh]),
+      .err_o(pair_cntr_err[sh])
+    );
   end : gen_cntrs
 
-    // create a toggle signal to sample pairs with
-    assign toggle_d =
-                      (!active_i || clear_i) ? '0 :
-                      window_wrap_pulse_i ? '0  :
-                      entropy_bit_vld_i ? (!toggle_q) :
-                      toggle_q;
+  // create a toggle signal to sample pairs with
+  assign toggle_d = (!active_i || clear_i) ? '0 :
+                    window_wrap_pulse_i ? '0  :
+                    entropy_bit_vld_i ? (!toggle_q) :
+                    toggle_q;
 
   // determine the highest counter pair counter value
-  assign pair_cntr_gt1 = (pair_cntr[0] < pair_cntr[1]) ? pair_cntr[1] : pair_cntr[0];
-  assign pair_cntr_gt2 = (pair_cntr_gt1 < pair_cntr[2]) ? pair_cntr[2] : pair_cntr_gt1;
-  assign pair_cntr_gt3 = (pair_cntr_gt2 < pair_cntr[3]) ? pair_cntr[3] : pair_cntr_gt2;
-
+  prim_max_tree #(
+    .NumSrc(RngBusWidth),
+    .Width(RegWidth)
+  ) u_max (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .values_i    (pair_cntr),
+    .valid_i     ({RngBusWidth{1'b1}}),
+    .max_value_o (pair_cntr_max),
+    .max_idx_o   (),
+    .max_valid_o ()
+  );
 
   // determine the lowest counter pair counter value
-  assign pair_cntr_lt1 = (pair_cntr[0] > pair_cntr[1]) ? pair_cntr[1] : pair_cntr[0];
-  assign pair_cntr_lt2 = (pair_cntr_lt1 > pair_cntr[2]) ? pair_cntr[2] : pair_cntr_lt1;
-  assign pair_cntr_lt3 = (pair_cntr_lt2 > pair_cntr[3]) ? pair_cntr[3] : pair_cntr_lt2;
+  // Negate the inputs and outputs of prim_max_tree to find the minimum
+  // For this unsigned application, one's complement negation (i.e. logical inversion) is fine.
+  prim_max_tree #(
+    .NumSrc(RngBusWidth),
+    .Width(RegWidth)
+  ) u_min (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .values_i    (~pair_cntr),
+    .valid_i     ({RngBusWidth{1'b1}}),
+    .max_value_o (pair_cntr_min_tmp),
+    .max_idx_o   (),
+    .max_valid_o ()
+  );
 
+  // Invert the output back.
+  assign pair_cntr_min = ~pair_cntr_min_tmp;
+
+  prim_sum_tree #(
+    .NumSrc(RngBusWidth),
+    .Width(RegWidth)
+  ) u_sum (
+    .clk_i       (clk_i),
+    .rst_ni      (rst_ni),
+    .values_i    (pair_cntr),
+    .valid_i     ({RngBusWidth{1'b1}}),
+    .sum_value_o (pair_cntr_sum),
+    .sum_valid_o ()
+  );
+
+  assign test_cnt_hi_o = threshold_scope_i ? pair_cntr_sum : pair_cntr_max;
+  assign test_cnt_lo_o = threshold_scope_i ? pair_cntr_sum : pair_cntr_min;
 
   // the pulses will be only one clock in length
-  assign test_fail_hi_pulse_o = active_i && window_wrap_pulse_i && (pair_cntr_gt3 > thresh_hi_i);
-  assign test_fail_lo_pulse_o = active_i && window_wrap_pulse_i && (pair_cntr_lt3 < thresh_lo_i);
-  assign test_cnt_hi_o = pair_cntr_gt3;
-  assign test_cnt_lo_o = pair_cntr_lt3;
+  assign test_fail_hi_pulse_o = active_i && window_wrap_pulse_i && (test_cnt_hi_o > thresh_hi_i);
+  assign test_fail_lo_pulse_o = active_i && window_wrap_pulse_i && (test_cnt_lo_o < thresh_lo_i);
   assign count_err_o = (|pair_cntr_err);
-
 
 endmodule

--- a/hw/ip/prim/lint/prim_sum_tree.vlt
+++ b/hw/ip/prim/lint/prim_sum_tree.vlt
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`verilator_config
+
+// Tell the Verilator scheduler to split up these variables into
+// separate pieces when it's figuring out process scheduling. This
+// avoids spurious UNOPTFLAT warnings caused by the fact that the
+// arrays feed into themselves (with different bits for different
+// positions in the tree).
+split_var -module "prim_sum_tree" -var "sum_tree"
+split_var -module "prim_sum_tree" -var "vld_tree"
+
+// The clock and reset are only used for assertions in this module.
+lint_off -rule UNUSED -file "*/rtl/prim_sum_tree.sv" -match "Signal is not used: 'clk_i'"
+lint_off -rule UNUSED -file "*/rtl/prim_sum_tree.sv" -match "Signal is not used: 'rst_ni'"

--- a/hw/ip/prim/lint/prim_sum_tree.waiver
+++ b/hw/ip/prim/lint/prim_sum_tree.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_arbiter
+
+waive -rules {HIER_BRANCH_NOT_READ INPUT_NOT_READ} -location {prim_sum_tree.sv} -regexp {.*'(clk_i|rst_ni)' is not read from in module 'prim_sum_tree'.*} \
+      -comment "clk_ and rst_ni are only used for assertions in this module."

--- a/hw/ip/prim/prim_sum_tree.core
+++ b/hw/ip/prim/prim_sum_tree.core
@@ -1,0 +1,48 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:sum_tree"
+description: "Summation primitive for arbitrary numbers of inputs"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+    files:
+      - rtl/prim_sum_tree.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_sum_tree.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_sum_tree.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl
+
+  formal:
+    filesets:
+      - files_rtl
+    toplevel: prim_sum_tree

--- a/hw/ip/prim/rtl/prim_sum_tree.sv
+++ b/hw/ip/prim/rtl/prim_sum_tree.sv
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Based on prim_max_tree, this module implements an explicit binary tree to find the
+// sum of this inputs. The solution has O(N) area and O(log(N)) delay complexity, and
+// thus scales well with many input sources.
+//
+// Note that only input values marked as "valid" are respected in the maximum computation.
+// Invalid values are treated as 0.
+//
+
+`include "prim_assert.sv"
+
+module prim_sum_tree #(
+  parameter int NumSrc = 32,
+  parameter int Width = 8
+) (
+  // The module is combinational - the clock and reset are only used for assertions.
+  input                         clk_i,
+  input                         rst_ni,
+  input [NumSrc-1:0][Width-1:0] values_i,    // Input values
+  input [NumSrc-1:0]            valid_i,     // Input valid bits
+  output logic [Width-1:0]      sum_value_o, // Summation result
+  output logic                  sum_valid_o  // Whether any of the inputs is valid
+);
+
+  ///////////////////////
+  // Binary tree logic //
+  ///////////////////////
+
+  // This only works with 2 or more sources.
+  `ASSERT_INIT(NumSources_A, NumSrc >= 2)
+
+  // Align to powers of 2 for simplicity.
+  // A full binary tree with N levels has 2**N + 2**N-1 nodes.
+  localparam int NumLevels = $clog2(NumSrc);
+  logic [2**(NumLevels+1)-2:0]               vld_tree;
+  logic [2**(NumLevels+1)-2:0][Width-1:0]    sum_tree;
+
+  for (genvar level = 0; level < NumLevels+1; level++) begin : gen_tree
+    //
+    // level+1   C0   C1   <- "Base1" points to the first node on "level+1",
+    //            \  /         these nodes are the children of the nodes one level below
+    // level       Pa      <- "Base0", points to the first node on "level",
+    //                         these nodes are the parents of the nodes one level above
+    //
+    // hence we have the following indices for the paPa, C0, C1 nodes:
+    // Pa = 2**level     - 1 + offset       = Base0 + offset
+    // C0 = 2**(level+1) - 1 + 2*offset     = Base1 + 2*offset
+    // C1 = 2**(level+1) - 1 + 2*offset + 1 = Base1 + 2*offset + 1
+    //
+    localparam int Base0 = (2**level)-1;
+    localparam int Base1 = (2**(level+1))-1;
+
+    for (genvar offset = 0; offset < 2**level; offset++) begin : gen_level
+      localparam int Pa = Base0 + offset;
+      localparam int C0 = Base1 + 2*offset;
+      localparam int C1 = Base1 + 2*offset + 1;
+
+      // This assigns the input values, their corresponding IDs and valid signals to the tree leafs.
+      if (level == NumLevels) begin : gen_leafs
+        if (offset < NumSrc) begin : gen_assign
+          assign vld_tree[Pa] = valid_i[offset];
+          assign sum_tree[Pa] = values_i[offset];
+        end else begin : gen_tie_off
+          assign vld_tree[Pa] = '0;
+          assign sum_tree[Pa] = '0;
+        end
+      // This creates the node assignments.
+      end else begin : gen_nodes
+        logic [Width-1:0] node_sum; // Local helper variable
+        // In case only one of the parents is valid, forward that one
+        // In case both parents are valid, forward the one with higher value
+        assign node_sum = (vld_tree[C0] & vld_tree[C1]) ? sum_tree[C1] + sum_tree[C0] :
+                          (vld_tree[C0])                ? sum_tree[C0] :
+                          (vld_tree[C1])                ? sum_tree[C1] :
+                          {Width'(0)};
+
+        // Forwarding muxes
+        // Note: these ternaries have triggered a synthesis bug in Vivado versions older
+        // than 2020.2. If the problem resurfaces again, have a look at issue #1408.
+        assign vld_tree[Pa] = vld_tree[C1] | vld_tree[C0];
+        assign sum_tree[Pa] = node_sum;
+      end
+    end : gen_level
+  end : gen_tree
+
+
+  // The results can be found at the tree root
+  assign sum_valid_o = vld_tree[0];
+  assign sum_value_o = sum_tree[0];
+
+  ////////////////
+  // Assertions //
+  ////////////////
+
+`ifdef INC_ASSERT
+  // Helper functions for assertions below.
+  function automatic logic [Width-1:0] sum_value (input logic [NumSrc-1:0][Width-1:0] values_i,
+                                                  input logic [NumSrc-1:0]            valid_i);
+    logic [Width-1:0] sum = '0;
+    for (int k = 0; k < NumSrc; k++) begin
+      if (valid_i[k]) begin
+        sum += values_i[k];
+      end
+    end
+    return sum;
+  endfunction : sum_value
+
+  logic [Width-1:0] sum_value_exp;
+  assign sum_value_exp = sum_value(values_i, valid_i);
+
+  `ASSERT(ValidInImpliesValidOut_A, |valid_i === sum_valid_o)
+  `ASSERT(SumComputation_A, sum_valid_o |-> sum_value_o == sum_value_exp)
+  `ASSERT(SumComputationInvalid_A, !sum_valid_o |-> sum_value_o == '0)
+`endif
+
+endmodule : prim_sum_tree


### PR DESCRIPTION
[entropy_src] Document & Implement THRESHOLD_SCOPE
    
- Documents the THRESHOLD_SCOPE register
- Updates the AdaptP and Markov health tests.  The tests now operate on
   the same scope (either by-line or by-sum) depending on the value of
   THRESHOLD_SCOPE.
- Adds new DV environment configurations and scoreboarding updates to
  reflect the new RTL changes.
    
Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>

Fixes #9759 

~~Note to reviewers: This PR currently contains two commits, as it is based on the register changes made in #10702~~ 
