### PR TITLE
[mask_rom] Add support for (but do not enable) hardened shadow stack

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -123,6 +123,11 @@ c_cpp_cross_args = [
   # Place each function into its own section (used in conjunction with
   # --gc-sections to remove unused functions from output files).
   '-ffunction-sections',
+  # Hardening
+  # Shadow call stack is disabled because only a subset of the project supports
+  # it.
+  # '-fsanitize=shadow-call-stack',
+  # '-ffixed-x18',
 ]
 
 # Add extra warning flags for cross builds, if they are supported.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.ld
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.ld
@@ -38,6 +38,16 @@ _chip_info_start = _chip_info_end - _chip_info_size;
 _dv_log_offset = 0x0;
 
 /**
+ * This symbol is used as a jump target when an error is detected by the
+ * hardened shadow call stack implementation. We set it to 0 which will
+ * trigger an instruction access exception.
+ *
+ * If a compiler without hardened shadow call stack support is used this
+ * symbol will be ignored.
+ */
+__abi_shutdown$ = 0x0;
+
+/**
  * Physical Memory Protection (PMP) encoded address register values.
  *
  * Some addresses required for PMP entries are known only at link time.

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -106,6 +106,17 @@ _mask_rom_interrupt_vector_c:
   .option pop
 
 /**
+ * Mask ROM shadow stack.
+ */
+
+  .bss
+  .globl _mask_rom_shadow_stack
+  .align 4
+_mask_rom_shadow_stack:
+  .space 256*4
+  .size _mask_rom_shadow_stack, .-_mask_rom_shadow_stack
+
+/**
  * Mask ROM runtime initialization code.
  */
 
@@ -287,6 +298,11 @@ _mask_rom_start_boot:
   // If an exception fires, the handler is conventionally only allowed to clobber
   // memory at addresses below `sp`.
   la sp, (_stack_end - 16)
+
+  // Set up shadow stack pointer.
+  //
+  // The shadow stack, unlike the regular stack, grows upwards.
+  la x18, _mask_rom_shadow_stack
 
   // Set up global pointer.
   //


### PR DESCRIPTION
This change allows the mask ROM to be built with the hardened shadow
stack enabled. For the time being the feature needs to be enabled
manually as only the ROM supports it and it requires a patched LLVM
toolchain.