### PR TITLE
[dv/kmac] add lc_escalate_en sequence

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -134,6 +134,20 @@
       tests: ["{variant}_error"]
     }
     {
+      name: lc_escalation
+      desc: '''
+            Randomly set `lc_escalate_en` to value that is not `Off` during Kmac operations.
+
+            **Checks**:
+            - Fatal alert fires continuously until reset is issued.
+            - Status fields: `alert_fatal_fault` is set to 1 and `sha3_idle` is reset to 0.
+            - Kmac does not accept any SW or APP requests.
+            - Digest window always output all 0s.
+            '''
+      milestone: V2
+      tests: ["{variant}_lc_escalation"]
+    }
+    {
       name: entropy_timers
       desc: ''' Test entropy interface for KMAC.
 

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -38,6 +38,7 @@ filesets:
       - seq_lib/kmac_burst_write_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_app_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_lc_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -8,9 +8,13 @@ interface kmac_if(input clk_i, input rst_ni);
 
   logic idle_o;
   logic en_masking_o;
+  logic [kmac_pkg::NumAppIntf-1:0] app_err_o;
 
   function automatic void drive_lc_escalate(lc_ctrl_pkg::lc_tx_t val);
     lc_escalate_en_i = val;
   endfunction
 
+  // TODO(#10804): confirm with designer if we need to set app_err_o as error.
+  // `ASSERT(LcEscalationAppErr_A, lc_escalate_en_i != lc_ctrl_pkg::Off |->
+  //        ##3 ((app_err_o == 3'b111) throughout (rst_ni == 1)))
 endinterface

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -265,14 +265,17 @@ class kmac_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task kmac_vif_init();
+    // Any value that is not `lc_ctrl_pkg::On` is considered `lc_ctrl_pkg::Off`.
     cfg.kmac_vif.drive_lc_escalate(lc_ctrl_pkg::Off);
   endtask
 
   // setup basic kmac features
-  virtual task kmac_init();
+  virtual task kmac_init(bit wait_init = 1);
     // Wait for KMAC to reach idle state
-    wait (cfg.kmac_vif.idle_o == 1);
-    `uvm_info(`gfn, "reached idle state", UVM_HIGH)
+    if (wait_init) begin
+      wait (cfg.kmac_vif.idle_o == 1);
+      `uvm_info(`gfn, "reached idle state", UVM_HIGH)
+    end
 
     // set interrupts
     cfg_interrupts(.interrupts(enable_intr));

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_lc_escalation_vseq.sv
@@ -1,0 +1,73 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class kmac_lc_escalation_vseq extends kmac_app_vseq;
+
+  `uvm_object_utils(kmac_lc_escalation_vseq)
+  `uvm_object_new
+
+  virtual task body();
+    fork begin : isolation_fork
+      fork
+        begin
+          super.body();
+        end
+        begin
+          cfg.clk_rst_vif.wait_clks($urandom_range(1, 500_000));
+          cfg.kmac_vif.drive_lc_escalate(
+              get_rand_lc_tx_val(.t_weight(1), .f_weight(0), .other_weight(1)));
+          cfg.en_scb = 0;
+          check_fatal_alert_nonblocking("fatal_fault_err");
+        end
+      join_any;
+      wait_no_outstanding_access();
+      disable fork;
+    end join
+
+    // Check only if lc_escalate_en is not `Off`.
+    if (cfg.en_scb == 0) begin
+      kmac_pkg::kmac_cmd_e rand_cmd;
+      bit [7:0] share[];
+      cfg.clk_rst_vif.wait_clks($urandom_range(5, 100));
+
+      // Randomly turns off lc_escalate_en.
+      if ($urandom_range(0, 1)) begin
+        cfg.clk_rst_vif.wait_clks(10);
+        cfg.kmac_vif.drive_lc_escalate(lc_ctrl_pkg::Off);
+      end
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      `DV_CHECK_STD_RANDOMIZE_FATAL(rand_cmd)
+
+      // Check if kmac will accept any SW request.
+      check_lc_escalate_status();
+      kmac_init(0);
+      set_prefix();
+      write_key_shares();
+      provide_sw_entropy();
+      issue_cmd(rand_cmd);
+      write_msg(msg);
+      check_lc_escalate_status();
+      read_digest_chunk(KMAC_STATE_SHARE0_BASE, keccak_block_size, share);
+      foreach (share[i]) `DV_CHECK_EQ_FATAL(share[i], '0)
+      read_digest_chunk(KMAC_STATE_SHARE1_BASE, keccak_block_size, share);
+      foreach (share[i]) `DV_CHECK_EQ_FATAL(share[i], '0)
+
+      // TODO: Add checking for kmac app request.
+    end
+  endtask
+
+  virtual task post_start();
+    expect_fatal_alerts = 1;
+    super.post_start();
+  endtask
+
+  virtual task check_lc_escalate_status();
+    csr_rd_check(.ptr(ral.status.alert_fatal_fault), .compare_value(1'b1));
+    csr_rd_check(.ptr(ral.status.sha3_idle), .compare_value(1'b0));
+    // TODO(#10804): confirm with designer if we need an error code here.
+    // csr_rd_check(.ptr(ral.err_code), .compare_value(?));
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -15,4 +15,5 @@
 `include "kmac_burst_write_vseq.sv"
 `include "kmac_app_vseq.sv"
 `include "kmac_error_vseq.sv"
+`include "kmac_lc_escalation_vseq.sv"
 `include "kmac_stress_all_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -146,6 +146,11 @@
       uvm_test_seq: kmac_error_vseq
     }
     {
+      name: "{variant}_lc_escalation"
+      uvm_test_seq: kmac_lc_escalation_vseq
+      run_opts: ["+disable_lc_asserts=1"]
+    }
+    {
       name: kmac_stress_all
       run_opts: ["+test_timeout_ns=10_000_000_000",
                  "+test_vectors_dir={build_dir}/src/lowrisc_dv_test_vectors_0"]

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -460,11 +460,11 @@ module kmac_core
           st == StKmacMsg && process_latched |=> !process_latched)
 
   // Assume configuration is stable during the operation
-  `ASSUME(KmacEnStable_M, $changed(kmac_en_i) |-> st == StKmacIdle)
-  `ASSUME(ModeStable_M, $changed(mode_i) |-> st == StKmacIdle)
-  `ASSUME(StrengthStable_M, $changed(strength_i) |-> st == StKmacIdle)
-  `ASSUME(KeyLengthStable_M, $changed(key_len_i) |-> st == StKmacIdle)
-  `ASSUME(KeyDataStable_M, $changed(key_data_i) |-> st == StKmacIdle)
+  `ASSUME(KmacEnStable_M, $changed(kmac_en_i) |-> st inside {StKmacIdle, StTerminalError})
+  `ASSUME(ModeStable_M, $changed(mode_i) |-> st inside {StKmacIdle, StTerminalError})
+  `ASSUME(StrengthStable_M, $changed(strength_i) |-> st inside {StKmacIdle, StTerminalError})
+  `ASSUME(KeyLengthStable_M, $changed(key_len_i) |-> st inside {StKmacIdle, StTerminalError})
+  `ASSUME(KeyDataStable_M, $changed(key_data_i) |-> st inside {StKmacIdle, StTerminalError})
 
   // no acked to MsgFIFO in StKmacMsg
   `ASSERT(AckOnlyInMessageState_A,

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -821,9 +821,11 @@ module sha3pad
   // If it is end of the message, the state moves to StPad and send the request
   `ASSERT(CompleteBlockWhenProcess_A,
     $rose(process_latched) && (!end_of_block && !sent_blocksize )
-    && !(st inside {StPrefixWait, StMessageWait}) |-> ##[1:5] keccak_valid_o)
+    && !(st inside {StPrefixWait, StMessageWait}) |-> ##[1:5] keccak_valid_o,
+    clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
   // If `process_i` is asserted, eventually sha3pad trigger run signal
-  `ASSERT(ProcessToRun_A, process_i |-> strong(##[2:$] keccak_run_o))
+  `ASSERT(ProcessToRun_A, process_i |-> strong(##[2:$] keccak_run_o),
+    clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
 
   // If process_i asserted, completion shall be asserted shall be asserted
   //`ASSERT(ProcessToAbsorbed_A, process_i |=> strong(##[24*Share:$] absorbed_o))
@@ -841,7 +843,8 @@ module sha3pad
   // Keccak control interface
   // Keccak run triggered -> completion should come
   `ASSUME(RunThenComplete_M,
-    keccak_run_o |-> strong(##[24*Share:$] keccak_complete_i))
+    keccak_run_o |-> strong(##[24*Share:$] keccak_complete_i),
+    clk_i, !rst_ni || lc_escalate_en_i != lc_ctrl_pkg::Off)
 
   // No partial write is allowed for Message FIFO interface
   `ASSUME(NoPartialMsgFifo_M,


### PR DESCRIPTION
This PR has two commits:
1). Add DV sequence to drive lc_escalete_en_i signal and check kmac goes to terminal state.
2). Update design assertions to handle lc_escalate_en_i.