### PR TITLE
[lint] Add new assertion macro to trigger static lint errors

### DIFF
--- a/hw/ip/aes/lint/aes.waiver
+++ b/hw/ip/aes/lint/aes.waiver
@@ -68,6 +68,3 @@ waive -rules {RESET_USE} -location {aes_ctr.sv} -regexp {'rst_ni' is connected t
 
 waive -rules {ONE_BRANCH} -location {aes_sel_buf_chk.sv} -regexp {unique case statement has only one branch} \
       -comment "check for legal combinations only, assert error signal otherwise"
-
-waive -rules {MIXED_SIGN} -location {aes_control_fsm.sv} -regexp {Signed operand '(prng_reseed_rate_i == PER_1 ? BlockCtrWidth'(0) : prng_reseed_rate_i == PER_64 ? BlockCtrWidth'(63) : prng_reseed_rate_i == PER_8K ? BlockCtrWidth'(8191) : BlockCtrWidth'(0))' and unsigned operand 'block_ctr_decr ? gen_block_ctr.block_ctr_q - BlockCtrWidth'(1) : gen_block_ctr.block_ctr_q' encountered in a conditional expression} \
-      -comment "In line with our style guide, BlockCtrWidth'(x) results in a signed operand"

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -6,6 +6,8 @@
 //
 // This module controls the interplay of input/output registers and the AES cipher core.
 
+`include "prim_assert.sv"
+
 module aes_control
   import aes_pkg::*;
   import aes_reg_pkg::*;
@@ -117,6 +119,10 @@ module aes_control
 
   // Optional delay of manual start trigger
   logic start_trigger;
+
+  // Create a lint error to reduce the risk of accidentally enabling this feature.
+  `ASSERT_STATIC_LINT_ERROR(AesSecStartTriggerDelayNonDefault, SecStartTriggerDelay == 0)
+
   if (SecStartTriggerDelay > 0) begin : gen_start_delay
     // Delay the manual start trigger input for SCA measurements.
     localparam int unsigned WidthCounter = $clog2(SecStartTriggerDelay+1);
@@ -134,10 +140,6 @@ module aes_control
         count_q <= count_d;
       end
     end
-
-    // Create a lint error to reduce the risk of accidentally enabling this feature.
-    logic sec_start_trigger_delay;
-    assign sec_start_trigger_delay = count_q[0];
 
   end else begin : gen_no_start_delay
     // Directly forward the manual start trigger input.

--- a/hw/ip/aes/rtl/aes_core.sv
+++ b/hw/ip/aes/rtl/aes_core.sv
@@ -927,6 +927,10 @@ module aes_core
   logic unused_alert_signals;
   assign unused_alert_signals = ^reg2hw.alert_test;
 
+  // Unused inputs
+  logic unused_idle;
+  assign unused_idle = reg2hw.status.idle.q;
+
   ////////////////
   // Assertions //
   ////////////////

--- a/hw/ip/aes/rtl/aes_prng_clearing.sv
+++ b/hw/ip/aes/rtl/aes_prng_clearing.sv
@@ -50,11 +50,9 @@ module aes_prng_clearing import aes_pkg::*;
   // the SecSkipPRNGReseeding parameter is set. Performing the reseeding without proper entropy
   // provided from CSRNG would result in quickly repeating, fully deterministic PRNG output,
   // which prevents meaningful SCA resistance evaluations.
-  if (SecSkipPRNGReseeding) begin : gen_skip_prng_reseeding
-    // Create a lint error to reduce the risk of accidentally enabling this feature.
-    logic sec_skip_prng_reseeding;
-    assign sec_skip_prng_reseeding = SecSkipPRNGReseeding;
-  end
+
+  // Create a lint error to reduce the risk of accidentally enabling this feature.
+  `ASSERT_STATIC_LINT_ERROR(AesSecSkipPRNGReseedingNonDefault, SecSkipPRNGReseeding == 0)
 
   // LFSR control
   assign lfsr_en = data_req_i & data_ack_o;

--- a/hw/ip/aes/rtl/aes_prng_masking.sv
+++ b/hw/ip/aes/rtl/aes_prng_masking.sv
@@ -77,11 +77,9 @@ module aes_prng_masking import aes_pkg::*;
   // the SecSkipPRNGReseeding parameter is set. Performing the reseeding without proper entropy
   // provided from CSRNG would result in quickly repeating, fully deterministic PRNG output,
   // which prevents meaningful SCA resistance evaluations.
-  if (SecSkipPRNGReseeding) begin : gen_skip_prng_reseeding
-    // Create a lint error to reduce the risk of accidentally enabling this feature.
-    logic sec_skip_prng_reseeding;
-    assign sec_skip_prng_reseeding = SecSkipPRNGReseeding;
-  end
+
+  // Create a lint error to reduce the risk of accidentally enabling this feature.
+  `ASSERT_STATIC_LINT_ERROR(AesSecSkipPRNGReseedingNonDefault, SecSkipPRNGReseeding == 0)
 
   // PRNG control
   assign prng_en = data_update_i;
@@ -193,11 +191,9 @@ module aes_prng_masking import aes_pkg::*;
        phase_q                                     ? {perm[0], perm[NumChunks-1:1]} : perm;
 
   // Create a lint error to reduce the risk of accidentally enabling this feature.
-  if (SecAllowForcingMasks) begin : gen_allow_forcing_masks
-    logic sec_allow_forcing_masks;
-    assign sec_allow_forcing_masks = force_zero_masks_i;
+  `ASSERT_STATIC_LINT_ERROR(AesSecAllowForcingMasksNonDefault, SecAllowForcingMasks == 0)
 
-  end else begin : gen_unused_force_masks
+  if (SecAllowForcingMasks == 0) begin : gen_unused_force_masks
     logic unused_force_zero_masks;
     assign unused_force_zero_masks = force_zero_masks_i;
   end

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -321,6 +321,9 @@ module kmac
     end
   end
 
+  // Create a lint error to reduce the risk of accidentally enabling this feature.
+  `ASSERT_STATIC_LINT_ERROR(KmacSecCmdDelayNonDefault, SecCmdDelay == 0)
+
   if (SecCmdDelay > 0) begin : gen_cmd_delay_buf
     // Delay and buffer commands for SCA measurements.
     localparam int unsigned WidthCounter = $clog2(SecCmdDelay+1);
@@ -385,10 +388,6 @@ module kmac
         end
       end
     end
-
-    // Create a lint error to reduce the risk of accidentally enabling this feature.
-    logic sec_cmd_delay_dummy;
-    assign sec_cmd_delay_dummy = cmd_update;
 
   end else begin : gen_no_cmd_delay_buf
     // Directly forward signals from register IF.

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -368,6 +368,9 @@ module kmac_app
     .state_o ( st_raw )
   );
 
+  // Create a lint error to reduce the risk of accidentally enabling this feature.
+  `ASSERT_STATIC_LINT_ERROR(KmacSecIdleAcceptSwMsgNonDefault, SecIdleAcceptSwMsg == 0)
+
   // Next State & output logic
   // SEC_CM: FSM.SPARSE
   always_comb begin
@@ -528,12 +531,6 @@ module kmac_app
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin
       st_d = StTerminalError;
     end
-  end
-
-  if (SecIdleAcceptSwMsg != 1'b0) begin : gen_lint_err
-    // Create a lint error to reduce the risk of accidentally enabling this feature.
-    logic sec_idle_accept_sw_msg_dummy;
-    assign sec_idle_accept_sw_msg_dummy = (st == StIdle);
   end
 
   //////////////

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -33,6 +33,16 @@
          `PRIM_STRINGIFY(__name));                                                       \
 `endif
 
+// This macro is suitable for conditionally triggering lint errors, e.g., if a Sec parameter takes
+// on a non-default value. This may be required for pre-silicon/FPGA evaluation but we don't want
+// to allow this for tapeout.
+`define ASSERT_STATIC_LINT_ERROR(__name, __prop)     \
+  localparam int __name = (__prop) ? 1 : 2;          \
+  always_comb begin                                  \
+    logic unused_assert_static_lint_error;           \
+    unused_assert_static_lint_error = __name'(1'b1); \
+  end
+
 // The basic helper macros are actually defined in "implementation headers". The macros should do
 // the same thing in each case (except for the dummy flavour), but in a way that the respective
 // tools support.


### PR DESCRIPTION
This is useful for detecting non-default Sec parameters. For details, refer to #10721.