### PR TITLE
[tlul] Send blanking data unless we have rdata in tlul_adapter_sram

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -288,9 +288,9 @@ module tlul_adapter_sram
                                  error_data_integ;
 
   logic [top_pkg::TL_DW-1:0] d_data;
-  assign d_data = (vld_rd_rsp && d_error) ? error_blanking_data : // TL-UL error
-                  (vld_rd_rsp)            ? rspfifo_rdata.data  : // valid read
-                                            '0;                   // valid write
+  assign d_data = (vld_rd_rsp & ~d_error) ? rspfifo_rdata.data   // valid read
+                                          : error_blanking_data; // write or TL-UL error
+
   // If this a write response with data fields set to 0, we have to set all ECC bits correctly
   // since we are using an inverted Hsiao code.
   logic [DataIntgWidth-1:0] data_intg;


### PR DESCRIPTION
This ensures that we respond with `error_blanking_data` rather than '0
in the case of a TL read that fails its integrity check. The previous
code didn't do that because `vld_rd_rsp` depends on `rdata_i` which, in
turn, depends on `req_o` that we suppress when the transaction is
ill-formed.

If I've understood things properly, this fixes #10818. There's a little more background information there.