### PR TITLE
[entropy_src/rtl] Add missing fips_enable recov alert

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1938,6 +1938,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
 
   assign recov_alert_o =
          es_enable_pfa ||
+         fips_enable_pfa ||
          entropy_data_reg_en_pfa ||
          boot_bypass_disable_pfa ||
          health_test_clr_pfa ||


### PR DESCRIPTION
Recoverable alerts have both a status register and an input to the module output.
The fips_enable field is missing on the output module pin.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>