### PR TITLE
[otbn,dv] Include pending stores in ISS DMEM dumps

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/dmem.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/dmem.py
@@ -142,7 +142,11 @@ class Dmem:
 
         '''
         ret = b''
-        for u32 in self.data:
+        for idx, u32 in enumerate(self.data):
+            # If there's a pending store, apply it. This matches the RTL, where
+            # we only observe the memory after that store has landed.
+            u32 = self.pending.get(idx, u32)
+
             if u32 is None:
                 ret += struct.pack('<BI', 0, 0)
             else:


### PR DESCRIPTION
This matches the timing that we see on the RTL side, fixing
some (honestly very confusing!) mismatches that came up in a stress
test.
