### PR TITLE
[csrng/rtl] Change cs_aes_halt_o to a pulse

### DIFF
--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -1605,7 +1605,8 @@ module csrng_core import csrng_pkg::*; #(
 
   // es to cs halt request to reduce power spikes
   assign cs_aes_halt_d =
-         (ctr_drbg_upd_es_ack && ctr_drbg_gen_es_ack && block_encrypt_quiet);
+         (ctr_drbg_upd_es_ack && ctr_drbg_gen_es_ack && block_encrypt_quiet &&
+          cs_aes_halt_i.cs_aes_halt_req && !cs_aes_halt_q);
 
   assign cs_aes_halt_o.cs_aes_halt_ack = cs_aes_halt_q;
 


### PR DESCRIPTION
To be able to reuse the DV req/ack module for this simple interface,
the cs_aes_halt_o will be a single clock in pulse size.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>