### PR TITLE
[dv/kmac] kmac key not valid case

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -134,6 +134,25 @@
       tests: ["{variant}_error"]
     }
     {
+      name: key_error
+      desc: ''' Test kmac responses correctly when keymgr app sends request but key is not valid.
+            **Stimulus**:
+            - Configure kmac and send keymgr request, but did not set valid bit for keymgr key
+              input.
+            - Wait randomly clock cycles.
+            - Issue `err_processed`, then wait for the keymgr interface handshake to finish.
+            - Repeat the above sequence a few times.
+            - Issue correct kmac request from app or sw interface.
+
+            **Check**:
+            - Check error related registers including `err_code`, `status`, and `interrupt`.
+            - Check keymgr interface responses with all zero digests and error bit is set.
+            - Check kmac can resume normal functionalities after processing this error case.
+            '''
+      milestone: V2
+      tests: ["{variant}_key_error"]
+    }
+    {
       name: lc_escalation
       desc: '''
             Randomly set `lc_escalate_en` to value that is not `Off` during Kmac operations.

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -38,6 +38,7 @@ filesets:
       - seq_lib/kmac_burst_write_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_app_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_key_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_lc_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
@@ -30,7 +30,7 @@ class kmac_error_vseq extends kmac_app_vseq;
 
   constraint kmac_err_type_c {
     if (en_kmac_err) {
-      kmac_err_type != kmac_pkg::ErrNone;
+      (kmac_err_type inside {kmac_pkg::ErrNone, kmac_pkg::ErrKeyNotValid}) == 0;
     } else {
       kmac_err_type == kmac_pkg::ErrNone;
     }
@@ -44,11 +44,6 @@ class kmac_error_vseq extends kmac_app_vseq;
     (kmac_err_type == kmac_pkg::ErrUnexpectedModeStrength) -> (en_app == 0);
 
     (kmac_err_type == kmac_pkg::ErrSwCmdSequence) -> (en_app == 0);
-
-    if (kmac_err_type == kmac_pkg::ErrKeyNotValid) {
-      en_app == 1;
-      app_mode == AppKeymgr;
-    }
   }
 
 endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_key_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_key_error_vseq.sv
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Trigger KeyNotValid error by not providing valid keymgr key during kmac transaction.
+// TODO(#10704): current RTL only supports this error in app mode.
+class kmac_key_error_vseq extends kmac_app_vseq;
+
+  `uvm_object_utils(kmac_key_error_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {
+    num_trans inside {[1:20]};
+  }
+
+  virtual task body();
+    kmac_pkg::err_t kmac_err;
+    cfg.en_scb = 0;
+    check_keymgr_rsp_nonblocking();
+
+    for (int i = 0; i < num_trans; i++) begin
+      bit [7:0] share0[];
+      bit [7:0] share1[];
+
+      `uvm_info(`gfn, $sformatf("iteration: %0d/%0d", i, num_trans), UVM_LOW)
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      kmac_err_type = kmac_pkg::ErrKeyNotValid;
+      kmac_err = '{valid: 1'b1,
+                   code: kmac_pkg::ErrKeyNotValid,
+                   info: '0};
+      app_mode = AppKeymgr;
+
+      kmac_init();
+      `uvm_info(`gfn, "kmac_init done", UVM_LOW)
+
+      set_prefix();
+
+      write_key_shares();
+
+      if (cfg.enable_masking && entropy_mode == EntropyModeSw) begin
+        `uvm_info(`gfn, "providing SW entropy", UVM_HIGH)
+        provide_sw_entropy();
+      end
+
+      fork begin : isolation_fork
+        fork
+          send_kmac_app_req(app_mode);
+          wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_req.valid);
+        join_any;
+        disable fork;
+      end join
+
+      // Wait randomly time before check status and issue err_processed.
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 10_000));
+
+      // TODO(#10835): Check with designer if sha3_idle should be set to 0.
+      csr_rd_check(.ptr(ral.status), .compare_value(ral.status.get_reset()));
+      csr_rd_check(.ptr(ral.err_code), .compare_value(kmac_err));
+      check_err();
+    end
+
+    // TODO: enable scb and run normal sequence, then add this sequence to stress_all sequence.
+    // cfg.en_scb = 1;
+    // super.body();
+  endtask
+
+  // While scb is not enabled, this task checks that during KeyNotValid error case, app interface
+  // to keymgr will always return 0 digest value, and assert error when the process is done.
+  virtual task check_keymgr_rsp_nonblocking();
+    fork begin
+      while (cfg.en_scb == 0) begin
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.ready == 1);
+        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.digest_share0, '0)
+        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.digest_share1, '0)
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.ready == 0);
+      end
+    end join_none
+
+    fork begin
+      while (cfg.en_scb == 0) begin
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.done == 1);
+        `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.error, 1)
+        wait (cfg.m_kmac_app_agent_cfg[app_mode].vif.kmac_data_rsp.done == 0);
+      end
+    end join_none
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -15,5 +15,6 @@
 `include "kmac_burst_write_vseq.sv"
 `include "kmac_app_vseq.sv"
 `include "kmac_error_vseq.sv"
+`include "kmac_key_error_vseq.sv"
 `include "kmac_lc_escalation_vseq.sv"
 `include "kmac_stress_all_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -146,6 +146,10 @@
       uvm_test_seq: kmac_error_vseq
     }
     {
+      name: "{variant}_key_error"
+      uvm_test_seq: kmac_key_error_vseq
+    }
+    {
       name: "{variant}_lc_escalation"
       uvm_test_seq: kmac_lc_escalation_vseq
       run_opts: ["+disable_lc_asserts=1"]


### PR DESCRIPTION
This PR separates the key not valid case from key_errors because it is
quite complicate for scb to handle it.
The following PR will clean up kmac scb and add this sequence to
stress_all sequence list.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>