### PR TITLE
[prim] Move sec_cm assertion to an include file in prim_assert

### DIFF
--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -229,7 +229,6 @@ module aes
   `ASSERT_KNOWN(EdnReqKnown, edn_o)
   `ASSERT_KNOWN(AlertTxKnown, alert_tx_o)
 
-`ifndef SYNTHESIS
   // Alert assertions for sparse FSMs.
   for (genvar i = 0; i < Sp2VWidth; i++) begin : gen_control_fsm_svas
     if (SP2V_LOGIC_HIGH[i] == 1'b1) begin : gen_control_fsm_svas_p
@@ -272,6 +271,4 @@ module aes
           alert_tx_o[1])
     end
   end
-`endif
-
 endmodule

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -1327,7 +1327,6 @@ module kmac
   // Command input should be onehot0
   `ASSUME(CmdOneHot0_M, reg2hw.cmd.cmd.qe |-> $onehot0(reg2hw.cmd.cmd.q))
 
-`ifndef SYNTHESIS
   // redundant counter error
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(SentMsgCountCheck_A, u_sha3.u_pad.u_sentmsg_count,
                                          alert_tx_o[1])
@@ -1353,5 +1352,4 @@ module kmac
     `ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT(DoubleLfsrCheck_A,
         gen_entropy.u_entropy.u_lfsr, alert_tx_o[1])
   end
-`endif
 endmodule

--- a/hw/ip/prim/prim_assert.core
+++ b/hw/ip/prim/prim_assert.core
@@ -12,6 +12,7 @@ filesets:
       - rtl/prim_assert_dummy_macros.svh : {is_include_file : true}
       - rtl/prim_assert_yosys_macros.svh : {is_include_file : true}
       - rtl/prim_assert_standard_macros.svh : {is_include_file : true}
+      - rtl/prim_assert_sec_cm.svh : {is_include_file : true}
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -130,4 +130,6 @@
    `COVER(__name, __prop, __clk, __rst)                                                     \
 `endif
 
+`include "prim_assert_sec_cm.svh"
+
 `endif // PRIM_ASSERT_SV

--- a/hw/ip/prim/rtl/prim_assert_sec_cm.svh
+++ b/hw/ip/prim/rtl/prim_assert_sec_cm.svh
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// // Macros and helper code for security countermeasures.
+
+`ifndef PRIM_ASSERT_SEC_CM_SVH
+`define PRIM_ASSERT_SEC_CM_SVH
+
+// Helper macros
+`define ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_, ERR_NAME_) \
+  `ASSERT(NAME_, $rose(PRIM_HIER_.ERR_NAME_) |-> ##[1:MAX_CYCLES_] $rose(ALERT_.alert_p)) \
+  `ifdef INC_ASSERT \
+  assign PRIM_HIER_.unused_assert_connected = 1'b1; \
+  `endif
+
+// macros for security countermeasures
+`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_ = 5) \
+  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_, err_o)
+
+`define ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_ = 5) \
+  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_, err_o)
+
+`define ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_ = 5) \
+  `ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_, unused_valid_st)
+
+`endif // PRIM_ASSERT_SEC_CM_SVH

--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -210,8 +210,3 @@ module prim_count import prim_count_pkg::*; #(
   `endif
 endmodule // prim_count
 
-`define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_ = 5) \
-  `ASSERT(NAME_, $rose(PRIM_HIER_.err_o) |-> ##[1:MAX_CYCLES_] $rose(ALERT_.alert_p)) \
-  `ifdef INC_ASSERT \
-  assign PRIM_HIER_.unused_assert_connected = 1'b1; \
-  `endif

--- a/hw/ip/prim/rtl/prim_double_lfsr.sv
+++ b/hw/ip/prim/rtl/prim_double_lfsr.sv
@@ -89,7 +89,7 @@ module prim_double_lfsr #(
   assign err_o = lfsr_state[0] != lfsr_state[1];
 
   // This logic that will be assign to one, when user adds macro
-  // ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT to check the error with alert, in case that prim_count
+  // ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT to check the error with alert, in case that prim_count
   // is used in design without adding this assertion check.
   `ifdef INC_ASSERT
   logic unused_assert_connected;
@@ -97,8 +97,3 @@ module prim_double_lfsr #(
   `ASSERT_INIT_NET(AssertConnected_A, unused_assert_connected === 1'b1 || !EnableAlertTriggerSVA)
   `endif
 endmodule : prim_double_lfsr
-`define ASSERT_PRIM_DOUBLE_LFSR_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_ = 5) \
-  `ASSERT(NAME_, $rose(PRIM_HIER_.err_o) |-> ##[1:MAX_CYCLES_] $rose(ALERT_.alert_p)) \
-  `ifdef INC_ASSERT \
-  assign PRIM_HIER_.unused_assert_connected = 1'b1; \
-  `endif

--- a/hw/ip/prim/rtl/prim_sparse_fsm_flop.sv
+++ b/hw/ip/prim/rtl/prim_sparse_fsm_flop.sv
@@ -47,9 +47,3 @@ module prim_sparse_fsm_flop #(
   `endif
 
 endmodule
-
-`define ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_ = 5) \
-  `ASSERT(NAME_, $fell(PRIM_HIER_.unused_valid_st) |-> ##[1:MAX_CYCLES_] $rose(ALERT_.alert_p)) \
-  `ifdef INC_ASSERT \
-  assign PRIM_HIER_.unused_assert_connected = 1'b1; \
-  `endif


### PR DESCRIPTION
Addressed problem raised in #10248 - Yosys only allows macros to be in
an included file

Signed-off-by: Weicai Yang <weicai@google.com>