### PR TITLE
[sram/dv] Minor update for lc_esc

### DIFF
--- a/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
+++ b/hw/ip/sram_ctrl/dv/env/seq_lib/sram_ctrl_lc_escalation_vseq.sv
@@ -48,7 +48,10 @@ class sram_ctrl_lc_escalation_vseq extends sram_ctrl_multiple_keys_vseq;
         begin
           #lc_esc_delay;
 
-          cfg.lc_vif.drive_lc_esc_en(lc_ctrl_pkg::On);
+          // any non-off value is treated as true
+          cfg.lc_vif.drive_lc_esc_en(get_rand_lc_tx_val(.t_weight(1),
+                                                        .f_weight(0),
+                                                        .other_weight(1)));
           // after escalation, key will become invalid and design will returns invalid integrity
           cfg.disable_d_user_data_intg_check_for_passthru_mem = 1;
         end

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -356,7 +356,8 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
 
   virtual task process_lc_escalation();
     forever begin
-      wait(cfg.lc_vif.lc_esc_en == lc_ctrl_pkg::On);
+      // any non-off value is treated as true
+      wait(cfg.lc_vif.lc_esc_en != lc_ctrl_pkg::Off);
       `uvm_info(`gfn, "LC escalation request detected", UVM_HIGH)
 
       // clear exp_mem, scramble is changed due to escalation.

--- a/hw/ip/sram_ctrl/dv/tb.sv
+++ b/hw/ip/sram_ctrl/dv/tb.sv
@@ -137,6 +137,11 @@ module tb;
         null, "*.env.m_tl_agent_sram_ctrl_prim_reg_block*", "vif", sram_tl_if);
     uvm_config_db#(mem_bkdr_util)::set(null, "*.env", "mem_bkdr_util", m_mem_bkdr_util);
 
+    // Seq may drive lc_escalation with values other than on or off.
+    $assertoff(0, tb.dut.u_prim_lc_sync.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync.PrimLcSyncCheckTransients1_A);
+
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
Update sequence to use random value to enable lc_esc, rather than always
use `On`.
Also  update scb to treat other values as `On`

Signed-off-by: Weicai Yang <weicai@google.com>