### PR TITLE
[sram/dv] Update scb to check d_data when TL error occurs

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -411,7 +411,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
       // In data read phase, check d_data when d_error = 1.
       if (item.d_error && (item.d_opcode == tlul_pkg::AccessAckData)) begin
-       `DV_CHECK_EQ(item.d_data, 32'hFFFF_FFFF, "d_data mismatch when d_error = 1")
+        check_tl_read_value_after_error(item, ral_name);
       end
 
       // these errors all have the same outcome. Only sample coverages when there is just one
@@ -428,6 +428,10 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
 
     end
     return (is_tl_unmapped_addr || is_tl_err);
+  endfunction
+
+  virtual function void check_tl_read_value_after_error(tl_seq_item item, string ral_name);
+    `DV_CHECK_EQ(item.d_data, 32'hFFFF_FFFF, "d_data mismatch when d_error = 1")
   endfunction
 
   // check if address is mapped

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_scoreboard.sv
@@ -202,6 +202,17 @@ class sram_ctrl_scoreboard #(parameter int AddrWidth = 10) extends cip_base_scor
     return super.predict_tl_err(item, channel, ral_name);
   endfunction
 
+  virtual function void check_tl_read_value_after_error(tl_seq_item item, string ral_name);
+    bit [TL_DW-1:0] exp_data;
+    tlul_pkg::tl_a_user_t a_user = tlul_pkg::tl_a_user_t'(item.a_user);
+
+    // if error occurs when it's an instrution, return all 0 since it's an illegal instruction
+    if (a_user.instr_type == prim_mubi_pkg::MuBi4True) exp_data = 0;
+    else                                               exp_data = '1;
+
+    `DV_CHECK_EQ(item.d_data, exp_data, "d_data mismatch when d_error = 1")
+  endfunction
+
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     kdi_fifo = new("kdi_fifo", this);


### PR DESCRIPTION
In general, it will returns all 1s, but when it's an instruction, it
returns 0. Updated scb for this.

Signed-off-by: Weicai Yang <weicai@google.com>