### PR TITLE
[aes] Convert Masking and SBoxImpl parameters to Sec parameters

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -28,17 +28,17 @@
       local:   "false",
       expose:  "false"
     },
-    { name:    "Masking",
+    { name:    "SecMasking",
       type:    "bit",
       default: "1'b1",
       desc:    '''
         Disable (0) or enable (1) first-order masking of the AES cipher core.
-        Masking requires the use of a masked S-Box, see SBoxImpl parameter.
+        Masking requires the use of a masked S-Box, see SecSBoxImpl parameter.
       '''
       local:   "false",
       expose:  "true"
     },
-    { name:    "SBoxImpl",
+    { name:    "SecSBoxImpl",
       type:    "aes_pkg::sbox_impl_e",
       default: "aes_pkg::SBoxImplDom",
       desc:    '''

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -36,8 +36,8 @@ module tb;
   // dut
   aes #(
     // for now keep testing the unmasked implementation
-    .Masking  ( 0                    ),
-    .SBoxImpl ( aes_pkg::SBoxImplLut )
+    .SecMasking  ( 0                    ),
+    .SecSBoxImpl ( aes_pkg::SBoxImplLut )
   ) dut (
     .clk_i            ( clk                               ),
     .rst_ni           ( rst_n                             ),

--- a/hw/ip/aes/pre_syn/tcl/lr_synth_flow_var_setup.tcl
+++ b/hw/ip/aes/pre_syn/tcl/lr_synth_flow_var_setup.tcl
@@ -19,8 +19,8 @@ set_flow_var rpt_out "./${lr_synth_out_dir}/reports" "Report output directory"
 set_flow_bool_var flatten 1 "flatten"
 set_flow_bool_var timing_run 0 "timing run"
 set_flow_bool_var aes_192_enable 1 "Enable support of 192-bit key length"
-set_flow_bool_var masking 1 "Enable 1st order masking of the AES cipher core"
-set_flow_var s_box_impl 4 "AES S-Box implementation"
+set_flow_bool_var sec_masking 1 "Enable 1st order masking of the AES cipher core"
+set_flow_var sec_s_box_impl 4 "AES S-Box implementation"
 
 source $lr_synth_config_file
 

--- a/hw/ip/aes/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/aes/pre_syn/tcl/yosys_run_synth.tcl
@@ -23,9 +23,9 @@ yosys "read_verilog -sv $lr_synth_out_dir/generated/*.v"
 # To print the available parameters.
 if { $lr_synth_top_module != "aes_sbox" && $lr_synth_top_module != "aes_sub_bytes" && $lr_synth_top_module != "aes_reduced_round"} {
   yosys "chparam -set AES192Enable $lr_synth_aes_192_enable $lr_synth_top_module"
-  yosys "chparam -set Masking $lr_synth_masking $lr_synth_top_module"
+  yosys "chparam -set SecMasking $lr_synth_sec_masking $lr_synth_top_module"
 }
-yosys "chparam -set SBoxImpl $lr_synth_s_box_impl $lr_synth_top_module"
+yosys "chparam -set SecSBoxImpl $lr_synth_sec_s_box_impl $lr_synth_top_module"
 
 # Remap Xilinx Vivado "dont_touch" attributes to Yosys "keep" attributes.
 yosys "attrmap -tocase keep -imap dont_touch=\"yes\" keep=1 -imap dont_touch=\"no\" keep=0 -remove keep=0"

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -11,11 +11,11 @@ module aes
   import aes_reg_pkg::*;
 #(
   parameter bit          AES192Enable          = 1, // Can be 0 (disable), or 1 (enable).
-  parameter bit          Masking               = 1, // Can be 0 (no masking), or
+  parameter bit          SecMasking            = 1, // Can be 0 (no masking), or
                                                     // 1 (first-order masking) of the cipher
                                                     // core. Masking requires the use of a
-                                                    // masked S-Box, see SBoxImpl parameter.
-  parameter sbox_impl_e  SBoxImpl              = SBoxImplDom, // See aes_pkg.sv
+                                                    // masked S-Box, see SecSBoxImpl parameter.
+  parameter sbox_impl_e  SecSBoxImpl           = SBoxImplDom, // See aes_pkg.sv
   parameter int unsigned SecStartTriggerDelay  = 0, // Manual start trigger delay, useful for
                                                     // SCA measurements. A value of e.g. 40
                                                     // allows the processor to go into sleep
@@ -154,8 +154,8 @@ module aes
   // AES core
   aes_core #(
     .AES192Enable             ( AES192Enable             ),
-    .Masking                  ( Masking                  ),
-    .SBoxImpl                 ( SBoxImpl                 ),
+    .SecMasking               ( SecMasking               ),
+    .SecSBoxImpl              ( SecSBoxImpl              ),
     .SecStartTriggerDelay     ( SecStartTriggerDelay     ),
     .SecAllowForcingMasks     ( SecAllowForcingMasks     ),
     .SecSkipPRNGReseeding     ( SecSkipPRNGReseeding     ),

--- a/hw/ip/aes/rtl/aes_cipher_control.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control.sv
@@ -10,8 +10,8 @@
 
 module aes_cipher_control import aes_pkg::*;
 #(
-  parameter bit         Masking  = 0,
-  parameter sbox_impl_e SBoxImpl = SBoxImplLut
+  parameter bit         SecMasking  = 0,
+  parameter sbox_impl_e SecSBoxImpl = SBoxImplDom
 ) (
   input  logic                    clk_i,
   input  logic                    rst_ni,
@@ -151,8 +151,8 @@ module aes_cipher_control import aes_pkg::*;
   for (genvar i = 0; i < Sp2VWidth; i++) begin : gen_fsm
     if (SP2V_LOGIC_HIGH[i] == 1'b1) begin : gen_fsm_p
       aes_cipher_control_fsm_p #(
-        .Masking  ( Masking  ),
-        .SBoxImpl ( SBoxImpl )
+        .SecMasking  ( SecMasking  ),
+        .SecSBoxImpl ( SecSBoxImpl )
       ) u_aes_cipher_control_fsm_i (
         .clk_i                 ( clk_i                    ),
         .rst_ni                ( rst_ni                   ),
@@ -214,8 +214,8 @@ module aes_cipher_control import aes_pkg::*;
       );
     end else begin : gen_fsm_n
       aes_cipher_control_fsm_n #(
-        .Masking  ( Masking  ),
-        .SBoxImpl ( SBoxImpl )
+        .SecMasking  ( SecMasking  ),
+        .SecSBoxImpl ( SecSBoxImpl )
       ) u_aes_cipher_control_fsm_i (
         .clk_i                 ( clk_i                    ),
         .rst_ni                ( rst_ni                   ),

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_n.sv
@@ -13,8 +13,8 @@
 
 module aes_cipher_control_fsm_n import aes_pkg::*;
 #(
-  parameter bit         Masking  = 0,
-  parameter sbox_impl_e SBoxImpl = SBoxImplLut
+  parameter bit         SecMasking  = 0,
+  parameter sbox_impl_e SecSBoxImpl = SBoxImplDom
 ) (
   input  logic             clk_i,
   input  logic             rst_ni,
@@ -236,8 +236,8 @@ module aes_cipher_control_fsm_n import aes_pkg::*;
   // negated outputs, important output signals are inverted further below. Thanks to the prim_buf
   // synthesis optimization barriers, tools will push the inverters into the regular FSM.
   aes_cipher_control_fsm #(
-    .Masking  ( Masking  ),
-    .SBoxImpl ( SBoxImpl )
+    .SecMasking  ( SecMasking  ),
+    .SecSBoxImpl ( SecSBoxImpl )
   ) u_aes_cipher_control_fsm (
     .clk_i                 ( clk_i                 ),
     .rst_ni                ( rst_ni                ),

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm_p.sv
@@ -9,8 +9,8 @@
 
 module aes_cipher_control_fsm_p import aes_pkg::*;
 #(
-  parameter bit         Masking  = 0,
-  parameter sbox_impl_e SBoxImpl = SBoxImplLut
+  parameter bit         SecMasking  = 0,
+  parameter sbox_impl_e SecSBoxImpl = SBoxImplDom
 ) (
   input  logic             clk_i,
   input  logic             rst_ni,
@@ -228,8 +228,8 @@ module aes_cipher_control_fsm_p import aes_pkg::*;
   /////////////////
 
   aes_cipher_control_fsm #(
-    .Masking  ( Masking  ),
-    .SBoxImpl ( SBoxImpl )
+    .SecMasking  ( SecMasking  ),
+    .SecSBoxImpl ( SecSBoxImpl )
   ) u_aes_cipher_control_fsm (
     .clk_i                 ( clk_i                  ),
     .rst_ni                ( rst_ni                 ),

--- a/hw/ip/aes/rtl/aes_control.sv
+++ b/hw/ip/aes/rtl/aes_control.sv
@@ -12,7 +12,7 @@ module aes_control
   import aes_pkg::*;
   import aes_reg_pkg::*;
 #(
-  parameter bit          Masking              = 0,
+  parameter bit          SecMasking           = 0,
   parameter int unsigned SecStartTriggerDelay = 0
 ) (
   input  logic                      clk_i,
@@ -247,7 +247,7 @@ module aes_control
   for (genvar i = 0; i < Sp2VWidth; i++) begin : gen_fsm
     if (SP2V_LOGIC_HIGH[i] == 1'b1) begin : gen_fsm_p
       aes_control_fsm_p #(
-        .Masking ( Masking )
+        .SecMasking ( SecMasking )
       ) u_aes_control_fsm_i (
         .clk_i                     ( clk_i                         ),
         .rst_ni                    ( rst_ni                        ),
@@ -338,7 +338,7 @@ module aes_control
       );
     end else begin : gen_fsm_n
       aes_control_fsm_n #(
-        .Masking ( Masking )
+        .SecMasking ( SecMasking )
       ) u_aes_control_fsm_i (
         .clk_i                     ( clk_i                         ),
         .rst_ni                    ( rst_ni                        ),

--- a/hw/ip/aes/rtl/aes_control_fsm_n.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_n.sv
@@ -18,7 +18,7 @@ module aes_control_fsm_n
   import aes_pkg::*;
   import aes_reg_pkg::*;
 #(
-  parameter bit Masking = 0
+  parameter bit SecMasking = 0
 ) (
   input  logic                                    clk_i,
   input  logic                                    rst_ni,
@@ -334,7 +334,7 @@ module aes_control_fsm_n
   // negated outputs, important output signals are inverted further below. Thanks to the prim_buf
   // synthesis optimization barriers, tools will push the inverters into the regular FSM.
   aes_control_fsm #(
-    .Masking ( Masking )
+    .SecMasking ( SecMasking )
   ) u_aes_control_fsm (
     .clk_i                     ( clk_i                         ),
     .rst_ni                    ( rst_ni                        ),

--- a/hw/ip/aes/rtl/aes_control_fsm_p.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm_p.sv
@@ -14,7 +14,7 @@ module aes_control_fsm_p
   import aes_pkg::*;
   import aes_reg_pkg::*;
 #(
-  parameter bit Masking = 0
+  parameter bit SecMasking = 0
 ) (
   input  logic                                    clk_i,
   input  logic                                    rst_ni,
@@ -326,7 +326,7 @@ module aes_control_fsm_p
   /////////////////
 
   aes_control_fsm #(
-    .Masking ( Masking )
+    .SecMasking ( SecMasking )
   ) u_aes_control_fsm (
     .clk_i                     ( clk_i                         ),
     .rst_ni                    ( rst_ni                        ),

--- a/hw/ip/aes/rtl/aes_reduced_round.sv
+++ b/hw/ip/aes/rtl/aes_reduced_round.sv
@@ -8,7 +8,7 @@
 
 module aes_reduced_round import aes_pkg::*;
 #(
-  parameter sbox_impl_e SBoxImpl = SBoxImplLut
+  parameter sbox_impl_e SecSBoxImpl = SBoxImplDom
 ) (
   input  logic                              clk_i,
   input  logic                              rst_ni,
@@ -35,7 +35,7 @@ module aes_reduced_round import aes_pkg::*;
 
   // A single reduced (no AddKey) round of the cipher data path
   aes_sub_bytes #(
-    .SBoxImpl ( SBoxImpl )
+    .SecSBoxImpl ( SecSBoxImpl )
   ) u_aes_sub_bytes (
     .clk_i     ( clk_i             ),
     .rst_ni    ( rst_ni            ),

--- a/hw/ip/aes/rtl/aes_sub_bytes.sv
+++ b/hw/ip/aes/rtl/aes_sub_bytes.sv
@@ -6,7 +6,7 @@
 
 module aes_sub_bytes import aes_pkg::*;
 #(
-  parameter sbox_impl_e SBoxImpl = SBoxImplLut
+  parameter sbox_impl_e SecSBoxImpl = SBoxImplDom
 ) (
   input  logic                              clk_i,
   input  logic                              rst_ni,
@@ -74,7 +74,7 @@ module aes_sub_bytes import aes_pkg::*;
       assign in_prd[i][j] = {out_prd[i][aes_rot_int(j,4)], prd_i[i][j]};
 
       aes_sbox #(
-        .SBoxImpl ( SBoxImpl )
+        .SecSBoxImpl ( SecSBoxImpl )
       ) u_aes_sbox_ij (
         .clk_i     ( clk_i                ),
         .rst_ni    ( rst_ni               ),

--- a/hw/ip/aes/rtl/aes_wrap.sv
+++ b/hw/ip/aes/rtl/aes_wrap.sv
@@ -8,13 +8,13 @@ module aes_wrap
   import aes_pkg::*;
 #(
   parameter bit         AES192Enable = 1,           // Can be 0 (disable), or 1 (enable).
-  parameter bit         Masking      = 1,           // Can be 0 (no masking), or
+  parameter bit         SecMasking   = 1,           // Can be 0 (no masking), or
                                                     // 1 (first-order masking) of the cipher
                                                     // core. Masking requires the use of a
                                                     // masked S-Box, see SBoxImpl parameter.
                                                     // Note: currently, constant masks are
                                                     // used, this is of course not secure.
-  parameter sbox_impl_e SBoxImpl     = SBoxImplDom  // See aes_pkg.sv
+  parameter sbox_impl_e SecSBoxImpl  = SBoxImplDom  // See aes_pkg.sv
 ) (
   input  logic         clk_i,
   input  logic         rst_ni,
@@ -79,8 +79,8 @@ module aes_wrap
   // DUT
   aes #(
     .AES192Enable(AES192Enable),
-    .Masking(Masking),
-    .SBoxImpl(SBoxImpl)
+    .SecMasking(SecMasking),
+    .SecSBoxImpl(SecSBoxImpl)
   ) aes (
     .clk_i           (clk_i),
     .rst_ni          (rst_ni),

--- a/hw/ip/csrng/lint/csrng.vlt
+++ b/hw/ip/csrng/lint/csrng.vlt
@@ -4,3 +4,10 @@
 //
 // waiver file for csrng
 
+`verilator_config
+
+// CSRNG intentionally uses an unmasked AES implementation.
+lint_off -rule WIDTH -file "*/rtl/aes_cipher_control_fsm.sv" -match "Operator ASSIGN expects 1 bits on the Assign RHS, but Assign RHS's EXTEND generates 2 bits."
+lint_off -rule WIDTH -file "*/rtl/aes_sbox.sv"               -match "Operator ASSIGN expects 1 bits on the Assign RHS, but Assign RHS's EXTEND generates 2 bits."
+lint_off -rule WIDTH -file "*/rtl/aes_key_expand.sv"         -match "Operator ASSIGN expects 1 bits on the Assign RHS, but Assign RHS's EXTEND generates 2 bits."
+lint_off -rule WIDTH -file "*/rtl/aes_cipher_core.sv"        -match "Operator ASSIGN expects 1 bits on the Assign RHS, but Assign RHS's EXTEND generates 2 bits."

--- a/hw/ip/csrng/lint/csrng.waiver
+++ b/hw/ip/csrng/lint/csrng.waiver
@@ -6,4 +6,3 @@
 
 waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_arbiter_ppc.sv} -regexp {.*has word width which is single bit wide.*} \
       -comment "Usage case specific to CSRNG and how the arbiter is used."
-

--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -95,8 +95,8 @@ module csrng_block_encrypt import csrng_pkg::*; #(
 
   aes_cipher_core #(
     .AES192Enable ( 1'b0 ),  // AES192Enable disabled
-    .Masking      ( 1'b0 ),  // Masking disable
-    .SBoxImpl     ( SBoxImpl )
+    .SecMasking   ( 1'b0 ),  // Masking disable
+    .SecSBoxImpl  ( SBoxImpl )
   ) u_aes_cipher_core   (
     .clk_i              (clk_i),
     .rst_ni             (rst_ni),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4767,8 +4767,8 @@
       }
       param_decl:
       {
-        Masking: "1"
-        SBoxImpl: aes_pkg::SBoxImplDom
+        SecMasking: "1"
+        SecSBoxImpl: aes_pkg::SBoxImplDom
       }
       clock_connections:
       {
@@ -4791,24 +4791,24 @@
           name_top: AesAES192Enable
         }
         {
-          name: Masking
+          name: SecMasking
           desc:
             '''
             Disable (0) or enable (1) first-order masking of the AES cipher core.
-            Masking requires the use of a masked S-Box, see SBoxImpl parameter.
+            Masking requires the use of a masked S-Box, see SecSBoxImpl parameter.
             '''
           type: bit
           default: "1"
           expose: "true"
-          name_top: AesMasking
+          name_top: SecAesMasking
         }
         {
-          name: SBoxImpl
+          name: SecSBoxImpl
           desc: Selection of the S-Box implementation. See aes_pkg.sv.
           type: aes_pkg::sbox_impl_e
           default: aes_pkg::SBoxImplDom
           expose: "true"
-          name_top: AesSBoxImpl
+          name_top: SecAesSBoxImpl
         }
         {
           name: SecStartTriggerDelay

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -568,8 +568,8 @@
       clock_group: "trans",
       reset_connections: {rst_ni: "sys", rst_edn_ni: "sys"},
       param_decl: {
-        Masking: "1",
-        SBoxImpl: "aes_pkg::SBoxImplDom"
+        SecMasking: "1",
+        SecSBoxImpl: "aes_pkg::SBoxImplDom"
       }
       base_addr: "0x41100000",
     },

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -971,8 +971,8 @@ module chip_earlgrey_cw310 #(
 // Also need to add AST simulation and FPGA emulation models for things like entropy source -
 // otherwise Verilator / FPGA will hang.
   top_earlgrey #(
-    .AesMasking(1'b1),
-    .AesSBoxImpl(aes_pkg::SBoxImplDom),
+    .SecAesMasking(1'b1),
+    .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -976,8 +976,8 @@ module chip_earlgrey_nexysvideo #(
 // Also need to add AST simulation and FPGA emulation models for things like entropy source -
 // otherwise Verilator / FPGA will hang.
   top_earlgrey #(
-    .AesMasking(1'b0),
-    .AesSBoxImpl(aes_pkg::SBoxImplLut),
+    .SecAesMasking(1'b0),
+    .SecAesSBoxImpl(aes_pkg::SBoxImplLut),
     .KmacEnMasking(1'b0),
     .KeymgrKmacEnMasking(0),
     .SecAesStartTriggerDelay(0),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -50,8 +50,8 @@ module top_earlgrey #(
   parameter logic [31:0] RvDmIdcodeValue = 32'h 0000_0001,
   // parameters for rv_plic
   // parameters for aes
-  parameter bit AesMasking = 1,
-  parameter aes_pkg::sbox_impl_e AesSBoxImpl = aes_pkg::SBoxImplDom,
+  parameter bit SecAesMasking = 1,
+  parameter aes_pkg::sbox_impl_e SecAesSBoxImpl = aes_pkg::SBoxImplDom,
   parameter int unsigned SecAesStartTriggerDelay = 0,
   parameter bit SecAesAllowForcingMasks = 1'b0,
   parameter bit SecAesSkipPRNGReseeding = 1'b0,
@@ -2139,8 +2139,8 @@ module top_earlgrey #(
   aes #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[37:36]),
     .AES192Enable(1'b1),
-    .Masking(AesMasking),
-    .SBoxImpl(AesSBoxImpl),
+    .SecMasking(SecAesMasking),
+    .SecSBoxImpl(SecAesSBoxImpl),
     .SecStartTriggerDelay(SecAesStartTriggerDelay),
     .SecAllowForcingMasks(SecAesAllowForcingMasks),
     .SecSkipPRNGReseeding(SecAesSkipPRNGReseeding),

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -157,8 +157,8 @@ module chip_englishbreakfast_verilator (
   prim_mubi_pkg::mubi4_t io_clk_bypass;
   // Top-level design
   top_englishbreakfast #(
-    .AesMasking(1'b1),
-    .AesSBoxImpl(aes_pkg::SBoxImplDom),
+    .SecAesMasking(1'b1),
+    .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1192,8 +1192,8 @@ module chip_${top["name"]}_${target["name"]} (
 // otherwise Verilator / FPGA will hang.
   top_${top["name"]} #(
 % if target["name"] == "cw310":
-    .AesMasking(1'b1),
-    .AesSBoxImpl(aes_pkg::SBoxImplDom),
+    .SecAesMasking(1'b1),
+    .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),
@@ -1205,8 +1205,8 @@ module chip_${top["name"]}_${target["name"]} (
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
 % elif target["name"] == "cw305":
-    .AesMasking(1'b1),
-    .AesSBoxImpl(aes_pkg::SBoxImplDom),
+    .SecAesMasking(1'b1),
+    .SecAesSBoxImpl(aes_pkg::SBoxImplDom),
     .SecAesStartTriggerDelay(40),
     .SecAesAllowForcingMasks(1'b1),
     .SecAesSkipPRNGReseeding(1'b1),
@@ -1215,8 +1215,8 @@ module chip_${top["name"]}_${target["name"]} (
     .RvCoreIbexBranchTargetALU(0),
     .RvCoreIbexWritebackStage(0),
 % else:
-    .AesMasking(1'b0),
-    .AesSBoxImpl(aes_pkg::SBoxImplLut),
+    .SecAesMasking(1'b0),
+    .SecAesSBoxImpl(aes_pkg::SBoxImplLut),
     .KmacEnMasking(1'b0),
     .KeymgrKmacEnMasking(0),
     .SecAesStartTriggerDelay(0),


### PR DESCRIPTION
These two parameters are security critical and we should reduce the risk of accidentally setting non-default values for these for tapeouts.

Important notes:
- This PR is depends on #10817, please only review the last commit.
- As I can't run AscentLint, I couldn't correctly set up the waiver for CSRNG where we use an unmasked AES implementation. I would need some feedback from someone with access to get this right.