### PR TITLE
[dv] Key Sideload Parameter Support

### DIFF
--- a/hw/dv/sv/key_sideload_agent/key_sideload_agent.core
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_agent.core
@@ -18,6 +18,7 @@ filesets:
       - key_sideload_agent_cov.sv: {is_include_file: true}
       - key_sideload_driver.sv: {is_include_file: true}
       - key_sideload_monitor.sv: {is_include_file: true}
+      - key_sideload_sequencer.sv: {is_include_file: true}
       - key_sideload_agent.sv: {is_include_file: true}
       - seq_lib/key_sideload_base_seq.sv: {is_include_file: true}
       - seq_lib/key_sideload_set_seq.sv: {is_include_file: true}

--- a/hw/dv/sv/key_sideload_agent/key_sideload_agent.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_agent.sv
@@ -2,30 +2,32 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_agent extends dv_base_agent #(
-  .CFG_T          (key_sideload_agent_cfg),
-  .DRIVER_T       (key_sideload_driver),
-  .SEQUENCER_T    (key_sideload_sequencer),
-  .MONITOR_T      (key_sideload_monitor),
-  .COV_T          (key_sideload_agent_cov)
+class key_sideload_agent#(
+  parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends dv_base_agent #(
+  .CFG_T          (key_sideload_agent_cfg#(KEY_T)),
+  .DRIVER_T       (key_sideload_driver#(KEY_T)),
+  .SEQUENCER_T    (key_sideload_sequencer#(KEY_T)),
+  .MONITOR_T      (key_sideload_monitor#(KEY_T)),
+  .COV_T          (key_sideload_agent_cov#(KEY_T))
 );
 
-  `uvm_component_utils(key_sideload_agent)
+  `uvm_component_utils(key_sideload_agent#(KEY_T))
 
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     // get key_sideload_if handle
-    if (!uvm_config_db#(virtual key_sideload_if)::get(this, "", "vif", cfg.vif)) begin
+    if (!uvm_config_db#(virtual key_sideload_if#(KEY_T))::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get key_sideload_if handle from uvm_config_db")
     end
   endfunction
 
   virtual task run_phase(uvm_phase phase);
-    key_sideload_set_seq p_seq;
+    key_sideload_set_seq#(KEY_T) p_seq;
     if (cfg.start_default_seq) begin
-      p_seq = key_sideload_set_seq::type_id::create("p_seq", this);
+      p_seq = key_sideload_set_seq#(KEY_T)::type_id::create("p_seq", this);
       forever begin
         `DV_CHECK_RANDOMIZE_FATAL(p_seq)
         p_seq.start(sequencer);

--- a/hw/dv/sv/key_sideload_agent/key_sideload_agent_cfg.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_agent_cfg.sv
@@ -2,14 +2,17 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_agent_cfg extends dv_base_agent_cfg;
+class key_sideload_agent_cfg #(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends dv_base_agent_cfg;
+
 
   // interface handle used by driver, monitor & the sequencer, via cfg handle
-  virtual key_sideload_if vif;
+  virtual key_sideload_if#(.KEY_T(KEY_T)) vif;
 
   bit start_default_seq = 1;
 
-  `uvm_object_utils_begin(key_sideload_agent_cfg)
+  `uvm_object_utils_begin(key_sideload_agent_cfg#(.KEY_T(KEY_T)))
   `uvm_object_utils_end
 
   `uvm_object_new

--- a/hw/dv/sv/key_sideload_agent/key_sideload_agent_cov.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_agent_cov.sv
@@ -2,8 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_agent_cov extends dv_base_agent_cov #(key_sideload_agent_cfg);
-  `uvm_component_utils(key_sideload_agent_cov)
+class key_sideload_agent_cov #(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends dv_base_agent_cov #(key_sideload_agent_cfg#(KEY_T));
+  `uvm_component_utils(key_sideload_agent_cov#(KEY_T))
 
   // the base class provides the following handles for use:
   // key_sideload_agent_cfg: cfg

--- a/hw/dv/sv/key_sideload_agent/key_sideload_agent_pkg.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_agent_pkg.sv
@@ -19,10 +19,6 @@ package key_sideload_agent_pkg;
   typedef class key_sideload_item;
   typedef class key_sideload_agent_cfg;
 
-  // reuse dv_base_sequencer as is with the right parameter set
-  typedef dv_base_sequencer #(.ITEM_T(key_sideload_item),
-                              .CFG_T (key_sideload_agent_cfg)) key_sideload_sequencer;
-
   // functions
 
   // package sources
@@ -31,6 +27,7 @@ package key_sideload_agent_pkg;
   `include "key_sideload_agent_cov.sv"
   `include "key_sideload_driver.sv"
   `include "key_sideload_monitor.sv"
+  `include "key_sideload_sequencer.sv"
   `include "key_sideload_seq_list.sv"
   `include "key_sideload_agent.sv"
 

--- a/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_driver.sv
@@ -2,9 +2,11 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_driver extends dv_base_driver #(.ITEM_T(key_sideload_item),
-                                              .CFG_T (key_sideload_agent_cfg));
-  `uvm_component_utils(key_sideload_driver)
+class key_sideload_driver#(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends dv_base_driver #(.ITEM_T(key_sideload_item#(KEY_T)),
+                           .CFG_T (key_sideload_agent_cfg#(KEY_T)));
+  `uvm_component_utils(key_sideload_driver#(KEY_T))
 
   // the base class provides the following handles for use:
   // key_sideload_agent_cfg: cfg

--- a/hw/dv/sv/key_sideload_agent/key_sideload_if.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_if.sv
@@ -3,8 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 interface key_sideload_if #(
-  parameter type KEY_T = keymgr_pkg::hw_key_req_t,
-  parameter int  KeyWidth = keymgr_pkg::KeyWidth
+  parameter type KEY_T = keymgr_pkg::hw_key_req_t
 ) (
   input logic clk_i,
   input logic rst_ni,

--- a/hw/dv/sv/key_sideload_agent/key_sideload_item.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_item.sv
@@ -2,17 +2,20 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_item extends uvm_sequence_item;
+class key_sideload_item #(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends uvm_sequence_item;
+  localparam int KeyWidth = ($bits(KEY_T)-1)/keymgr_pkg::Shares;
 
   // random variables
-  rand bit                            valid;
-  rand bit [keymgr_pkg::KeyWidth-1:0] key0;
-  rand bit [keymgr_pkg::KeyWidth-1:0] key1;
-  rand int unsigned                   rsp_delay = 1;
+  rand bit                valid;
+  rand bit [KeyWidth-1:0] key0;
+  rand bit [KeyWidth-1:0] key1;
+  rand int unsigned       rsp_delay = 1;
 
   constraint rsp_delay_constraint_c {rsp_delay inside {[1:10]};}
 
-  `uvm_object_utils_begin(key_sideload_item)
+  `uvm_object_utils_begin(key_sideload_item#(KEY_T))
     `uvm_field_int(valid, UVM_DEFAULT)
     `uvm_field_int(key0,  UVM_DEFAULT)
     `uvm_field_int(key1,  UVM_DEFAULT)

--- a/hw/dv/sv/key_sideload_agent/key_sideload_monitor.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_monitor.sv
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_monitor extends dv_base_monitor #(
-    .ITEM_T (key_sideload_item),
-    .CFG_T  (key_sideload_agent_cfg),
-    .COV_T  (key_sideload_agent_cov)
+class key_sideload_monitor #(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends dv_base_monitor #(
+    .ITEM_T (key_sideload_item#(KEY_T)),
+    .CFG_T  (key_sideload_agent_cfg#(KEY_T)),
+    .COV_T  (key_sideload_agent_cov#(KEY_T))
   );
-  `uvm_component_utils(key_sideload_monitor)
+  `uvm_component_utils(key_sideload_monitor#(KEY_T))
 
   // the base class provides the following handles for use:
   // key_sideload_agent_cfg: cfg
@@ -26,10 +28,10 @@ class key_sideload_monitor extends dv_base_monitor #(
 
   // collect transactions forever - already forked in dv_base_monitor::run_phase
   virtual protected task collect_trans(uvm_phase phase);
-    key_sideload_item prev_item;
-    key_sideload_item curr_item;
-    prev_item = key_sideload_item::type_id::create("prev_item");
-    curr_item = key_sideload_item::type_id::create("curr_item");
+    key_sideload_item#(KEY_T) prev_item;
+    key_sideload_item#(KEY_T) curr_item;
+    prev_item = key_sideload_item#(KEY_T)::type_id::create("prev_item");
+    curr_item = key_sideload_item#(KEY_T)::type_id::create("curr_item");
     forever begin
       @(posedge cfg.vif.clk_i or negedge cfg.vif.rst_ni);
       if (!cfg.vif.rst_ni) continue;

--- a/hw/dv/sv/key_sideload_agent/key_sideload_sequencer.sv
+++ b/hw/dv/sv/key_sideload_agent/key_sideload_sequencer.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class key_sideload_sequencer #(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+)  extends dv_base_sequencer #(
+    .ITEM_T (key_sideload_item#(KEY_T)),
+    .CFG_T  (key_sideload_agent_cfg#(KEY_T))
+);
+  `uvm_component_param_utils(key_sideload_sequencer#(KEY_T))
+  `uvm_component_new
+
+endclass

--- a/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_base_seq.sv
+++ b/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_base_seq.sv
@@ -2,12 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_base_seq extends dv_base_seq #(
-    .REQ         (key_sideload_item),
-    .CFG_T       (key_sideload_agent_cfg),
-    .SEQUENCER_T (key_sideload_sequencer)
+class key_sideload_base_seq #(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends dv_base_seq #(
+    .REQ         (key_sideload_item#(KEY_T)),
+    .CFG_T       (key_sideload_agent_cfg#(KEY_T)),
+    .SEQUENCER_T (key_sideload_sequencer#(KEY_T))
   );
-  `uvm_object_utils(key_sideload_base_seq)
+  `uvm_object_utils(key_sideload_base_seq#(KEY_T))
 
   `uvm_object_new
 

--- a/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
+++ b/hw/dv/sv/key_sideload_agent/seq_lib/key_sideload_set_seq.sv
@@ -2,15 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-class key_sideload_set_seq extends key_sideload_base_seq;
-  `uvm_object_utils(key_sideload_set_seq)
+class key_sideload_set_seq #(
+    parameter type KEY_T = keymgr_pkg::hw_key_req_t
+) extends key_sideload_base_seq #(KEY_T);
+
+  `uvm_object_utils(key_sideload_set_seq#(KEY_T))
 
   `uvm_object_new
-  rand keymgr_pkg::hw_key_req_t sideload_key;
+  rand KEY_T sideload_key;
 
   virtual task body();
-    key_sideload_item item;
-    item = key_sideload_item::type_id::create("item");
+    key_sideload_item#(KEY_T) item;
+    item = key_sideload_item#(KEY_T)::type_id::create("item");
     `DV_CHECK_RANDOMIZE_WITH_FATAL(item,
                                    item.valid == sideload_key.valid;
                                    item.key0 == sideload_key.key[0];

--- a/hw/ip/aes/dv/env/aes_env.sv
+++ b/hw/ip/aes/dv/env/aes_env.sv
@@ -17,9 +17,10 @@ class aes_env extends cip_base_env #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
-    keymgr_sideload_agent = key_sideload_agent::type_id::create("keymgr_sideload_agent", this);
-    uvm_config_db#(key_sideload_agent_cfg)::set(this, "keymgr_sideload_agent*",
-                                                "cfg", cfg.keymgr_sideload_agent_cfg);
+    keymgr_sideload_agent = key_sideload_agent#(keymgr_pkg::hw_key_req_t)::type_id::create(
+      "keymgr_sideload_agent", this);
+    uvm_config_db#(key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t))::set(
+      this, "keymgr_sideload_agent*", "cfg", cfg.keymgr_sideload_agent_cfg);
     if (!uvm_config_db#(virtual pins_if #($bits(lc_ctrl_pkg::lc_tx_t) +1 ))::
          get(this, "", "lc_escalate_vif", cfg.lc_escalate_vif)) begin
       `uvm_fatal(`gfn, "failed to get lc_escalate_vif from uvm_config_db")

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -194,7 +194,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
     list_of_alerts = aes_env_pkg::LIST_OF_ALERTS;
-    keymgr_sideload_agent_cfg = key_sideload_agent_cfg::type_id
+    keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t)::type_id
                                 ::create("keymgr_sideload_agent_cfg");
     keymgr_sideload_agent_cfg.start_default_seq = 0;
     num_edn = 1;

--- a/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_base_vseq.sv
@@ -345,7 +345,7 @@ class aes_base_vseq extends cip_base_vseq #(
   // enable sideload sequence
   // and get it to generate a key a random times
   task start_sideload_seq();
-    sideload_seq = key_sideload_set_seq::type_id::create("sideload_seq");
+    sideload_seq = key_sideload_set_seq#(keymgr_pkg::hw_key_req_t)::type_id::create("sideload_seq");
     `DV_CHECK_RANDOMIZE_FATAL(sideload_seq)
     sideload_seq.start(p_sequencer.key_sideload_sequencer_h);
     forever begin
@@ -357,7 +357,7 @@ class aes_base_vseq extends cip_base_vseq #(
   endtask
 
   task req_sideload_key();
-    req_key_seq = key_sideload_set_seq::type_id::create("req_key_seq");
+    req_key_seq = key_sideload_set_seq#(keymgr_pkg::hw_key_req_t)::type_id::create("req_key_seq");
     `DV_CHECK_RANDOMIZE_WITH_FATAL(req_key_seq, sideload_key.valid == 1;)
     req_key_seq.start(p_sequencer.key_sideload_sequencer_h);
     while (!key_used) begin

--- a/hw/ip/kmac/dv/env/kmac_env.sv
+++ b/hw/ip/kmac/dv/env/kmac_env.sv
@@ -25,9 +25,10 @@ class kmac_env extends cip_base_env #(
     end
 
     // get ext interfaces
-    keymgr_sideload_agent = key_sideload_agent::type_id::create("keymgr_sideload_agent", this);
-    uvm_config_db#(key_sideload_agent_cfg)::set(this, "keymgr_sideload_agent*",
-                                                "cfg", cfg.keymgr_sideload_agent_cfg);
+    keymgr_sideload_agent = key_sideload_agent#(keymgr_pkg::hw_key_req_t)::type_id::create(
+      "keymgr_sideload_agent", this);
+    uvm_config_db#(key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t))::set(
+      this, "keymgr_sideload_agent*", "cfg", cfg.keymgr_sideload_agent_cfg);
 
     // config kmac virtual interface
     if (!uvm_config_db#(kmac_vif)::get(this, "", "kmac_vif", cfg.kmac_vif)) begin

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -46,7 +46,7 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
       m_kmac_app_agent_cfg[i] = kmac_app_agent_cfg::type_id::create(name);
       m_kmac_app_agent_cfg[i].if_mode = dv_utils_pkg::Host;
     end
-    keymgr_sideload_agent_cfg = key_sideload_agent_cfg::type_id
+    keymgr_sideload_agent_cfg = key_sideload_agent_cfg#(keymgr_pkg::hw_key_req_t)::type_id
                                 ::create("keymgr_sideload_agent_cfg");
     void'($value$plusargs("enable_masking=%0d", enable_masking));
     void'($value$plusargs("test_vectors_sha3_variant=%0d", sha3_variant));

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -12,7 +12,7 @@ class otbn_env extends cip_base_env #(
 
   otbn_model_agent   model_agent;
   otbn_trace_monitor trace_monitor;
-  key_sideload_agent keymgr_sideload_agent;
+  otbn_sideload_agent keymgr_sideload_agent;
 
   `uvm_component_new
 
@@ -26,9 +26,9 @@ class otbn_env extends cip_base_env #(
     uvm_config_db#(otbn_model_agent_cfg)::set(this, "model_agent*", "cfg", cfg.model_agent_cfg);
     cfg.model_agent_cfg.en_cov = cfg.en_cov;
 
-    keymgr_sideload_agent = key_sideload_agent::type_id::create("keymgr_sideload_agent", this);
-    uvm_config_db#(key_sideload_agent_cfg)::set(this, "keymgr_sideload_agent*",
-                                                "cfg", cfg.keymgr_sideload_agent_cfg);
+    keymgr_sideload_agent = otbn_sideload_agent::type_id::create("keymgr_sideload_agent", this);
+    uvm_config_db#(otbn_sideload_agent_cfg)::set(this, "keymgr_sideload_agent*",
+                                                  "cfg", cfg.keymgr_sideload_agent_cfg);
 
     if (!uvm_config_db#(virtual otbn_trace_if)::get(this, "", "trace_vif", cfg.trace_vif)) begin
       `uvm_fatal(`gfn, "failed to get otbn_trace_if handle from uvm_config_db")

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -7,7 +7,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   // ext component cfgs
   rand otbn_model_agent_cfg model_agent_cfg;
 
-  rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;
+  rand otbn_sideload_agent_cfg keymgr_sideload_agent_cfg;
 
   `uvm_object_utils_begin(otbn_env_cfg)
   `uvm_object_utils_end
@@ -78,8 +78,8 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     tl_intg_alert_name = "fatal";
 
     model_agent_cfg  = otbn_model_agent_cfg  ::type_id::create("model_agent_cfg");
-    keymgr_sideload_agent_cfg = key_sideload_agent_cfg::type_id
-                                ::create("keymgr_sideload_agent_cfg");
+    keymgr_sideload_agent_cfg = otbn_sideload_agent_cfg::type_id::create(
+      "keymgr_sideload_agent_cfg");
 
     super.initialize(csr_base_addr);
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -48,6 +48,8 @@ package otbn_env_pkg;
   typedef virtual pins_if #(1)     idle_vif;
   typedef virtual otbn_escalate_if escalate_vif;
   typedef logic [TL_AIW-1:0]       tl_source_t;
+  typedef key_sideload_agent#(keymgr_pkg::otbn_key_req_t) otbn_sideload_agent;
+  typedef key_sideload_agent_cfg#(keymgr_pkg::otbn_key_req_t) otbn_sideload_agent_cfg;
 
   // Expected data for a pending read (see exp_read_values in otbn_scoreboard.sv)
   typedef struct packed {

--- a/hw/ip/otbn/dv/uvm/env/otbn_virtual_sequencer.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_virtual_sequencer.sv
@@ -9,6 +9,6 @@ class otbn_virtual_sequencer extends cip_base_virtual_sequencer #(
   `uvm_component_utils(otbn_virtual_sequencer)
   `uvm_component_new
 
-  key_sideload_sequencer key_sideload_sequencer_h;
+  key_sideload_sequencer#(keymgr_pkg::otbn_key_req_t) key_sideload_sequencer_h;
 
 endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -375,7 +375,7 @@ class otbn_base_vseq extends cip_base_vseq #(
     end else begin
       // If absent keys are not allowed, we want to generate our own sequence that doesn't allow
       // keys to be invalid. We send it with a higher priority to override the default sequence.
-      key_sideload_set_seq sideload_seq;
+      key_sideload_set_seq#(keymgr_pkg::otbn_key_req_t) sideload_seq;
       `uvm_create_on(sideload_seq, p_sequencer.key_sideload_sequencer_h)
       while (stop_tokens == 0) begin
         `DV_CHECK_RANDOMIZE_WITH_FATAL(sideload_seq, sideload_key.valid == 1'b1;)

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -39,23 +39,19 @@ module tb;
   // needed for sequences that trigger alerts (locking OTBN) without telling the model.
   `DV_ASSERT_CTRL("otbn_status_assert_en", tb.MatchingStatus_A)
 
-  otbn_key_req_t keymgr_key;
-  hw_key_req_t   sideload_key;
-  key_sideload_if keymgr_if (
+  otbn_key_req_t sideload_key;
+  key_sideload_if#(keymgr_pkg::otbn_key_req_t) keymgr_if (
     .clk_i        (clk),
     .rst_ni       (rst_n),
     .sideload_key (sideload_key)
   );
-  assign keymgr_key.valid  = sideload_key.valid;
-  assign keymgr_key.key[0] = sideload_key.key[0];
-  assign keymgr_key.key[1] = sideload_key.key[1];
 
   otbn_model_if #(
     .ImemSizeByte (otbn_reg_pkg::OTBN_IMEM_SIZE)
   ) model_if (
     .clk_i         (clk),
     .rst_ni        (rst_n),
-    .keymgr_key_i  (keymgr_key)
+    .keymgr_key_i  (sideload_key)
   );
 
 
@@ -145,7 +141,7 @@ module tb;
     .otbn_otp_key_o(otp_key_req),
     .otbn_otp_key_i(otp_key_rsp),
 
-    .keymgr_key_i(keymgr_key)
+    .keymgr_key_i(sideload_key)
   );
 
   bind dut.u_otbn_core otbn_trace_if #(
@@ -294,8 +290,8 @@ module tb;
     uvm_config_db#(escalate_vif)::set(null, "*.env", "escalate_vif", escalate_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual otbn_model_if)::set(null, "*.env.model_agent", "vif", model_if);
-    uvm_config_db#(virtual key_sideload_if)::set(null, "*.env.keymgr_sideload_agent",
-    "vif", keymgr_if);
+    uvm_config_db#(virtual key_sideload_if#(keymgr_pkg::otbn_key_req_t))::set(
+      null, "*.env.keymgr_sideload_agent", "vif", keymgr_if);
 
     uvm_config_db#(virtual otbn_trace_if)::set(null, "*.env", "trace_vif",
                                                dut.u_otbn_core.i_otbn_trace_if);


### PR DESCRIPTION
This PR includes support for parameterisation of key sideload agent. Also includes minor fixes where we use key sideload agent (AES, KMAC and OTBN), in order to use the parameterised version correctly.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>