### PR TITLE
[ci] Move Verilator build to ci-public pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -285,8 +285,7 @@ jobs:
   displayName: Build Verilator simulation of the Earl Grey toplevel design
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool:
-    vmImage: ubuntu-18.04
+  pool: ci-public
   steps:
   - template: ci/install-package-dependencies.yml
   - bash: |


### PR DESCRIPTION
Though we should give this a go and see if it helps. We may need to up the number of GCP instances in ci-public if we go with this.

Previously this used azure agents, which are slow. Using ci-public
should improve the speed of the verilator build.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>