### PR TITLE
[flash_ctrl] Add Test For The RMA Feature

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -58,15 +58,13 @@
       tests: ["flash_ctrl_host_dir_rd"]
     }
     {
-      name: host_ctrl_hw_if
+      name: rma_hw_if
       desc: '''
-            Perform read of seed materials via Hardware Interface of the Flash Protocol Controller.
-            Perform RMA entry request and check afterwards that software has no granted access.
-            During RMA entry, check if content of flash is wiped out via Host Interface direct
-            reads.
+            Perform RMA entry requests and check afterwards that the  software has no access to 
+            the Flash.  After RMA entry, verify that the content of the flash is wiped out.
             '''
       milestone: V2
-      tests: []
+      tests: ["flash_ctrl_hw_rma"]
     }
     {
       name: host_controller_arb
@@ -230,11 +228,12 @@
     {
       name: isolation_partition
       desc: '''
-            Verify the isolated information partitions. Accessiblity is controlled by the Life Cycle Controller
-            
+            Verify the isolated information partitions. Accessablity is controlled by Life
+            Cycle Controller.  Verify Partition can be erase, written and programmed, with
+            HW control, and wipes after an RMA.
             '''
       milestone: V2
-      tests: []
+      tests: ["flash_ctrl_hw_rma"]
     }
     {
       name: interrupts

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -40,6 +40,7 @@ filesets:
       - seq_lib/flash_ctrl_phy_arb_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_hw_sec_otp_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_erase_suspend_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_hw_rma_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -78,10 +78,26 @@ package flash_ctrl_env_pkg;
       seed_valid: 1'b0
   };
 
-  // For Secret Partitions
+  // For Secret Partitions and RMA
   parameter uint FlashSecretPartWords = 8;  // Size Of Secret Part - (8x32=256 Bits)
   parameter uint FlashCreatorPartStartAddr = 32'h00000800;  // Info Partition Page 1
   parameter uint FlashOwnerPartStartAddr = 32'h00001000;  // Info Partition Page 2
+  parameter uint FlashIsolPartStartAddr = 32'h00001800;
+
+  parameter uint FlashData0StartAddr = 32'h00000000;
+  parameter uint FlashData0EndAddr = 32'h00080000;
+  parameter uint FlashData1StartAddr = 32'h00080000;
+  parameter uint FlashData1EndAddr = 32'h00100000;
+
+  parameter uint FullPageNumWords = 512;  // 32 Cycles of 16 Words = 512 Words
+  parameter uint FullBankNumWords = 131072;  // 8192 Cycles of 16 Words = 131072 Words
+
+  parameter uint MaxNumPages = 256;  // Number of Pages in a Bank
+  parameter uint FIFO_DEPTH = 16;  // Depth of the Program and Read FIFO in words
+
+  // Read Check Parameters
+  parameter bit READ_CHECK_NORM = 0;  // Check Read Data via the Backdoor
+  parameter bit READ_CHECK_EXPLICIT = 1;  // Check Read Data Explicitly
 
   // types
   typedef enum int {
@@ -111,10 +127,12 @@ package flash_ctrl_env_pkg;
   } flash_dv_part_e;
 
   // Special Partitions
-  typedef enum logic [1:0] {
+  typedef enum logic [2:0] {
     FlashCreatorPart = 0,
     FlashOwnerPart   = 1,
-    FlashIsolPart    = 2
+    FlashIsolPart    = 2,
+    FlashData0Part   = 3,
+    FlashData1Part   = 4
   } flash_sec_part_e;
 
   typedef struct packed {

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -15,8 +15,8 @@ interface flash_ctrl_if ();
   lc_tx_t                           lc_owner_seed_sw_rw_en = lc_ctrl_pkg::Off;
   lc_tx_t                           lc_seed_hw_rd_en = lc_ctrl_pkg::On;
 
-  lc_tx_t                           lc_iso_part_sw_rd_en = lc_ctrl_pkg::On;
-  lc_tx_t                           lc_iso_part_sw_wr_en = lc_ctrl_pkg::On;
+  lc_tx_t                           lc_iso_part_sw_rd_en = lc_ctrl_pkg::Off;
+  lc_tx_t                           lc_iso_part_sw_wr_en = lc_ctrl_pkg::Off;
 
   lc_tx_t                           lc_nvm_debug_en = lc_ctrl_pkg::Off;
   lc_tx_t                           lc_escalate_en = lc_ctrl_pkg::Off;

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -95,6 +95,9 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Timeout for erase transaction
   uint erase_timeout_ns;
 
+  // Timeout for read transaction
+  uint read_timeout_ns;
+
   // Enable/Disable the Secret Seeds and Keys during Initialisation
   bit en_init_keys_seeds;
 
@@ -185,6 +188,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
     check_mem_post_tran = 1'b1;
 
     prog_timeout_ns = 10_000_000;  // 10ms
+
+    read_timeout_ns = 10_000_000;  // 10ms
 
     erase_timeout_ns = 120_000_000;  // 120ms
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -1,0 +1,322 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+//  name: rma_hw_if
+//  desc: '''
+//        Perform RMA entry requests and check afterwards that the  software has no access to
+//        the Flash.  After RMA entry, verify that the content of the flash is wiped out.
+//        '''
+//  milestone: V2
+//  tests: ["flash_ctrl_hw_rma"]
+//
+//  name: isolation_partition
+//  desc: '''
+//        Verify the isolated information partitions. Accessablity is controlled by Life
+//        Cycle Controller.  Verify Partition can be erase, written and programmed, with
+//        HW control, and wipes after an RMA.
+//        '''
+//  milestone: V2
+//  tests: [flash_ctrl_hw_rma"]
+
+// flash_ctrl_hw_rma Test
+
+// Pseudo Code
+// Initialise (All)
+// Loop {
+//   Erase Partitions(#)
+//   Program Partitions(#)
+//   Read Partitions(#)
+//   RMA REQUEST (Random Seed)
+//   Check Software has NO Access to the FLASH
+//   Reset DUT (No Flash Init)
+//   Initialise
+//   Read Partitions#() Compare Data (MISMATCH Expected)
+//     (additionally check Data Read is not all 1's
+//     indicating Erase but not RMA Wipe)
+// }
+// #Random Order : Creator(page), Owner(page), Isolation(page),
+//                 Data0(random page), Data1(random page)
+
+import lc_ctrl_pkg::*;
+
+class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
+  `uvm_object_utils(flash_ctrl_hw_rma_vseq)
+
+  `uvm_object_new
+
+  // Class Members
+  data_q_t flash_creator_data;
+  data_q_t flash_owner_data;
+  data_q_t flash_isol_data;
+  data_q_t flash_data0_data;
+  data_q_t flash_data1_data;
+  uint     data0_part_addr;
+  uint     data0_part_num_words;
+  uint     data1_part_addr;
+  uint     data1_part_num_words;
+
+  // Configure sequence knobs to tailor it to this seq
+  virtual function void configure_vseq();
+
+    // Enable NO memory protection regions
+    cfg.seq_cfg.num_en_mp_regions   = 0;
+    cfg.seq_cfg.poll_fifo_status_pc = 0;
+
+    // Enable Checks Post Transaction
+    cfg.seq_cfg.check_mem_post_tran = 1;
+
+    // Randomize the 'Keys and Seeds' Setting to prove
+    // this has no effect on the RMA
+    cfg.seq_cfg.en_init_keys_seeds = $urandom;
+
+  endfunction : configure_vseq
+
+  // Body
+  task body();
+
+    // Local Variables
+    logic [RmaSeedWidth-1:0] rma_seed;
+
+    `uvm_info(`gfn, "FLASH_CTRL_HW_RMA", UVM_LOW)
+
+    // RMA TESTS
+
+    // INITIALIZE FLASH REGIONS
+    init_data_part();
+    init_info_part();
+
+    // Delay
+    cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+    // Iterate
+    num_trans = 2;  // Fixed Number of Iterations as Test time is VERY LONG
+    for (int i=0; i<num_trans; i++) begin
+
+      `uvm_info(`gfn, $sformatf("Iteration : %0d", i+1), UVM_LOW)
+
+      // Delay
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+      // Select Data Partition Start Address an Num Words for this iteration
+      set_rand_data_page(FlashData0Part, data0_part_addr, data0_part_num_words);
+      set_rand_data_page(FlashData1Part, data1_part_addr, data1_part_num_words);
+
+      // ERASE
+
+      `uvm_info(`gfn, "ERASE", UVM_LOW)
+      do_flash_ops(flash_ctrl_pkg::FlashOpErase, READ_CHECK_NORM);
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+      // PROGRAM
+
+      `uvm_info(`gfn, "PROGRAM", UVM_LOW)
+      do_flash_ops(flash_ctrl_pkg::FlashOpProgram, READ_CHECK_NORM);
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+      // READ (Compare Expected Data with Data Read : EXPECT DATA MATCH)
+
+      `uvm_info(`gfn, "READ", UVM_LOW)
+      do_flash_ops(flash_ctrl_pkg::FlashOpRead, READ_CHECK_NORM);
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+      // SEND RMA REQUEST (Erases the Flash and Writes Random Data To All Partitions)
+
+      `uvm_info(`gfn, "RMA REQUEST", UVM_LOW)
+      rma_seed = $urandom;  // Random RMA Seed
+      send_rma_req(rma_seed);
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+      // CHECK HOST SOFTWARE HAS NO ACCESS TO THE FLASH
+
+      // Attempt to Read from FLASH Controller
+      do_flash_ctrl_access_check();
+
+      // RESET DUT
+
+      `uvm_info(`gfn, "RESET", UVM_LOW)
+      lc_ctrl_if_rst();  // Restore lc_ctrl_if to Reset Values
+      cfg.seq_cfg.disable_flash_init = 1;  // Disable Flash Random Initialisation
+      apply_reset();
+
+      // INITIALIZE FLASH REGIONS
+
+      init_data_part();
+      init_info_part();
+
+      // READ (Compare Expected Data with Data Read : EXPECT DATA MISMATCH or STATUS FAIL)
+
+      // After Reset and DUT Initialisation, Check the FLASH is written randomly and its contents
+      // mismatch against its contents before the RMA took place.
+      // This may get an occasional Hit ~ 1 in 32^2-1, per location
+      // Additionally check that the Flash has not just been Erased, but has been overwritten.
+
+      `uvm_info(`gfn, "READ", UVM_LOW)
+
+      do_flash_ops(flash_ctrl_pkg::FlashOpRead, READ_CHECK_EXPLICIT);
+      cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+
+    end
+
+  endtask : body
+
+  virtual task init_data_part();
+
+    // DATA PARTITION
+
+    flash_mp_region_cfg_t mp_regions [flash_ctrl_pkg::MpRegions];
+    bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+    bit default_region_read_en;
+    bit default_region_program_en;
+    bit default_region_erase_en;
+
+    // No Protection Regions
+    foreach (mp_regions[i]) begin
+      mp_regions[i].en = 0;
+    end
+
+    // Configure MP Regions
+    foreach (mp_regions[i]) begin
+      flash_ctrl_mp_region_cfg(i, mp_regions[i]);
+    end
+
+    default_region_read_en    = 1'b1;
+    default_region_program_en = 1'b1;
+    default_region_erase_en   = 1'b1;
+
+    // Write to Default MP Regions
+    flash_ctrl_default_region_cfg(.read_en    (default_region_read_en),
+                                  .program_en (default_region_program_en),
+                                  .erase_en   (default_region_erase_en));
+
+    // Configure Bank Erasability
+    foreach (bank_erase_en[i]) begin
+      bank_erase_en[i] = 1;
+    end
+    flash_ctrl_bank_erase_cfg(.bank_erase_en(bank_erase_en));
+
+  endtask : init_data_part
+
+  virtual task init_info_part();
+
+    // INFO REGION
+
+    flash_bank_mp_info_page_cfg_t info_regions [flash_ctrl_reg_pkg::NumInfos0];
+
+    // Enable All Info Regions for Read, Program and Erase
+
+    foreach (info_regions[i]) begin
+      info_regions[i].en         = 1;
+      info_regions[i].read_en    = 1;
+      info_regions[i].program_en = 1;
+      info_regions[i].erase_en   = 1;
+    end
+
+    foreach (info_regions[i]) begin
+      flash_ctrl_mp_info_page_cfg(.bank(0), .info_part(0), .page(i), .page_cfg(info_regions[i]));
+    end
+
+  endtask : init_info_part
+
+  // Task to perform randomly ordered selected Flash Operations on thr Flash
+  virtual task do_flash_ops (input flash_op_e op, input bit cmp = READ_CHECK_NORM);
+
+    uint order_q [$] = '{0, 1, 2, 3, 4};  // Operation Order Queue
+    order_q.shuffle();  // Shuffle Queue Items
+
+    // Process in random order
+    foreach (order_q[i]) begin
+      unique case(order_q[i])
+        0 : do_flash_op_rma(FlashCreatorPart, op, flash_creator_data, cmp, 0, 0);
+        1 : do_flash_op_rma(FlashOwnerPart,   op, flash_owner_data,   cmp, 0, 0);
+        2 : do_flash_op_rma(FlashIsolPart,    op, flash_isol_data,    cmp, 0, 0);
+        3 : do_flash_op_rma(FlashData0Part,   op, flash_data0_data,   cmp,  data0_part_addr,
+              data0_part_num_words);
+        4 : do_flash_op_rma(FlashData1Part,   op, flash_data1_data,   cmp,  data1_part_addr,
+              data1_part_num_words);
+        default: `uvm_error(`gfn, "Unrecognised Flash Operation, FAIL")
+      endcase
+    end
+  endtask : do_flash_ops
+
+  // Task to check for No access to Flash Controller following an RMA
+  virtual task do_flash_ctrl_access_check();
+
+    // Local Variables
+    flash_op_t flash_op;
+    data_q_t   data;
+    bit        result;
+
+    `uvm_info(`gfn, "Attempting to READ from Flash", UVM_INFO)
+
+    // Attempt to Read from FLASH, No Access Expected after RMA
+    flash_op.op = flash_ctrl_pkg::FlashOpRead;
+
+    // Select a Random Partition to try to Read From
+    randcase
+      1 : begin flash_op.addr = FlashCreatorPartStartAddr;  // Flash Creator Part
+                flash_op.partition = FlashPartInfo;
+                cfg.flash_ctrl_vif.lc_seed_hw_rd_en         = lc_ctrl_pkg::On;
+                cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
+          end
+      1 : begin flash_op.addr = FlashOwnerPartStartAddr;  // Flash Owner Part
+                flash_op.partition = FlashPartInfo;
+                cfg.flash_ctrl_vif.lc_seed_hw_rd_en       = lc_ctrl_pkg::On;
+                cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en = lc_ctrl_pkg::On;
+          end
+      1 : begin flash_op.addr = FlashIsolPartStartAddr;  // Flash Isolation Part
+                flash_op.partition = FlashPartData;
+                cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en = lc_ctrl_pkg::On;
+                cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en = lc_ctrl_pkg::On;
+          end
+      1 : begin flash_op.addr = FlashData0StartAddr;  // Flash Data0 Part
+                flash_op.partition = FlashPartData;
+          end
+      1 : begin flash_op.addr = FlashData1StartAddr;  // Flash Data1 Part
+                flash_op.partition = FlashPartData;
+          end
+    endcase
+
+    // Arbitrary num_words - Access should fail on the first attempt
+    flash_op.num_words  = $urandom_range(8, 16);
+    flash_op.erase_type = $urandom ? flash_ctrl_pkg::FlashErasePage :
+                                     flash_ctrl_pkg::FlashEraseBank;
+
+    // Start Read Operation
+    flash_ctrl_start_op(flash_op);
+
+    // Timeout Expected
+    wait_flash_op_done_expect_timeout(.timeout_ns(cfg.seq_cfg.read_timeout_ns), .result(result));
+
+    // Expect a Timeout
+    if (result == 1)
+      `uvm_info(`gfn,  "Timeout Seen - Flash Not Accessible By Software, Expected, PASS", UVM_LOW)
+    else
+      `uvm_error(`gfn, "Timeout Not Seen - Flash Accessible By Software, Unexpected, FAIL")
+
+  endtask : do_flash_ctrl_access_check
+
+  // Task to Select a Random Data Partition Page, and return its address
+  virtual task set_rand_data_page(input flash_sec_part_e part, output uint addr,
+                                  output uint num_words);
+
+    // Local Variables
+    uint page;
+
+    // Select a Random Data Partition Page
+    page = $urandom_range(0, MaxNumPages-1);
+
+    // Assign Address based on Partition Selected, and fixed number of words
+    unique case (part)
+      FlashData0Part: addr = FlashData0StartAddr+(page*(FullPageNumWords*4)); // Base+Page Offset
+      FlashData1Part: addr = FlashData1StartAddr+(page*(FullPageNumWords*4)); // Base+Page Offset
+      default : `uvm_error(`gfn, "Unrecognised Partition, FAIL")
+    endcase
+    num_words = FullPageNumWords;
+
+    `uvm_info(`gfn, $sformatf("Test Chose : %s : page : %0d, addr = 0x%0x, num_words : %0d",
+      part.name(), page, addr, num_words), UVM_LOW)
+
+  endtask : set_rand_data_page
+
+endclass : flash_ctrl_hw_rma_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -15,3 +15,4 @@
 `include "flash_ctrl_phy_arb_vseq.sv"
 `include "flash_ctrl_hw_sec_otp_vseq.sv"
 `include "flash_ctrl_erase_suspend_vseq.sv"
+`include "flash_ctrl_hw_rma_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -102,6 +102,12 @@
       run_opts: ["+zero_delays=1"]
       reseed: 5
     }
+    {
+      name: flash_ctrl_hw_rma
+      uvm_test_seq: flash_ctrl_hw_rma_vseq
+      run_opts: ["+test_timeout_ns=10000000000"]
+      reseed: 3
+    }
   
   ]
 


### PR DESCRIPTION
Test the Flash RMA Functionality

Flash Partitions are Erased, Programmed and then Wiped by the RMA.  After the RMA has completed,
The test checks that SW Access to the FLASH is denied, and after a subsequent Reset, the Flash
is confirmed to be set to data other than that previously programmed.
Each run of the test performs 4 RMA cycles, seperated by a Reset.

Signed-off-by: TIM EWINS <tim.ewins@ensilica.com>