### PR TITLE
[flash_ctrl/dif] Fix word_count handling for erase

### DIFF
--- a/sw/device/lib/dif/dif_flash_ctrl.c
+++ b/sw/device/lib/dif/dif_flash_ctrl.c
@@ -369,7 +369,13 @@ dif_result_t dif_flash_ctrl_start_unsafe(
                       transaction.byte_address);
   mmio_region_write32(handle->dev.base_addr, FLASH_CTRL_CONTROL_REG_OFFSET,
                       control_reg | (1u << FLASH_CTRL_CONTROL_START_BIT));
-  handle->words_remaining = transaction.word_count;
+  if (transaction.op == kDifFlashCtrlOpPageErase ||
+      transaction.op == kDifFlashCtrlOpBankErase) {
+    // Erase operations don't use the FIFO
+    handle->words_remaining = 0;
+  } else {
+    handle->words_remaining = transaction.word_count;
+  }
   handle->transaction_pending = true;
   return kDifOk;
 }
@@ -387,9 +393,12 @@ dif_result_t dif_flash_ctrl_start(dif_flash_ctrl_state_t *handle,
   }
 
   const uint32_t max_word_count = FLASH_CTRL_CONTROL_NUM_MASK;
-  if (transaction.word_count - 1 > max_word_count ||
-      transaction.word_count == 0) {
-    return kDifBadArg;
+  if ((transaction.op != kDifFlashCtrlOpPageErase) &&
+      (transaction.op != kDifFlashCtrlOpBankErase)) {
+    if (transaction.word_count - 1 > max_word_count ||
+        transaction.word_count == 0) {
+      return kDifBadArg;
+    }
   }
 
   if (handle->transaction_pending) {

--- a/sw/device/lib/dif/dif_flash_ctrl.h
+++ b/sw/device/lib/dif/dif_flash_ctrl.h
@@ -276,8 +276,8 @@ typedef struct dif_flash_ctrl_transaction {
    */
   uint32_t byte_address;
   /**
-   * Number of 32-bit words to program. Must be in the range [1,4096]
-   * (inclusive).
+   * Number of 32-bit words in the operation. Must be in the range [1,4096]
+   * (inclusive) for program or read operations. Unused for erase operations.
    */
   uint32_t word_count;
 } dif_flash_ctrl_transaction_t;


### PR DESCRIPTION
The word_count / words_remaining handling was forbidding erase
operations from completing, as the transaction functions required a
nonzero word_count and activity on the FIFOs to reduce it to 0 before
completion.

Exempt erase operations from needing any specific word_count, and set
words_remaining to 0.

Co-authored-by: Dave Williams <dave.williams@ensilica.com>
Signed-off-by: Alexander Williams <awill@google.com>

--

Fixes #10847