### PR TITLE
[rv_dm dv] Implement full debug mem RAL via Hjson, and fix common tests

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_mem.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_mem.sv
@@ -11,6 +11,11 @@ class dv_base_mem extends uvm_mem;
   // if mem doesn't support partial write, doing that will result d_error = 1
   local bit mem_partial_write_support;
 
+  // Modifies the expectation of writes / reads to RO / WO mem. By default it should be an error
+  // response, but some implementations may choose to just ignore it.
+  local bit write_to_ro_mem_ok;
+  local bit read_to_wo_mem_ok;
+
   // if data integrity is passthru, mem stores integrity along with data but it won't check the
   // data integrity
   local bit data_intg_passthru;
@@ -39,6 +44,22 @@ class dv_base_mem extends uvm_mem;
   function bit get_data_intg_passthru();
     return data_intg_passthru;
   endfunction : get_data_intg_passthru
+
+  function void set_write_to_ro_mem_ok(bit ok);
+    write_to_ro_mem_ok = ok;
+  endfunction
+
+  function bit get_write_to_ro_mem_ok();
+    return write_to_ro_mem_ok;
+  endfunction
+
+  function void set_read_to_wo_mem_ok(bit ok);
+    read_to_wo_mem_ok = ok;
+  endfunction
+
+  function bit get_read_to_wo_mem_ok();
+    return read_to_wo_mem_ok;
+  endfunction
 
   // rewrite this function to support "WO" access type for mem
   function void configure(uvm_reg_block  parent,

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -29,6 +29,16 @@ class dv_base_reg_block extends uvm_reg_block;
 
   addr_range_t mapped_addr_ranges[$];
 
+  // Indicates whether accesses to unmapped regions of this block returns an error response (0).
+  protected bit unmapped_access_ok;
+
+  // Indicates whether byte writes are supported (enabled by default).
+  // TODO: Remove this in future - this is really a property of the physical interface that is used
+  // to access design through this RAL model (a.k.a, the map & adapter), and not the RAL model
+  // itself. This information should be sought using uvm_reg_adapter::supports_byte_enable instead.
+  // This is added for ease of rv_dm testbench development.
+  protected bit supports_byte_enable = 1'b1;
+
   bit has_unmapped_addrs;
   addr_range_t unmapped_addr_ranges[$];
 
@@ -50,6 +60,22 @@ class dv_base_reg_block extends uvm_reg_block;
   // Returns the CSR exclusion item attached to the block.
   virtual function csr_excl_item get_excl_item();
     return csr_excl;
+  endfunction
+
+  function void set_unmapped_access_ok(bit ok);
+    unmapped_access_ok = ok;
+  endfunction
+
+  function bit get_unmapped_access_ok();
+    return unmapped_access_ok;
+  endfunction
+
+  function void set_support_byte_enable(bit enable);
+    supports_byte_enable = enable;
+  endfunction
+
+  function bit get_supports_byte_enable();
+    return supports_byte_enable;
   endfunction
 
   // provide build function to supply base addr

--- a/hw/dv/sv/tl_agent/tl_reg_adapter.sv
+++ b/hw/dv/sv/tl_agent/tl_reg_adapter.sv
@@ -69,7 +69,11 @@ class tl_reg_adapter #(type ITEM_T = tl_seq_item) extends uvm_reg_adapter;
           a_addr    == rw.addr;
           a_data    == rw.data;
           a_mask[0] == 1;
-          $countones(a_mask) > (msb / 8);)
+          if (supports_byte_enable) {
+            $countones(a_mask) > (msb / 8);
+          } else {
+            a_mask  == '1;
+          })
     end
     if (cfg.csr_access_abort_pct_in_adapter > $urandom_range(0, 100)) begin
       bus_req.req_abort_after_a_valid_len = 1;

--- a/hw/ip/rv_dm/data/rv_dm_debug_mem.hjson
+++ b/hw/ip/rv_dm/data/rv_dm_debug_mem.hjson
@@ -1,0 +1,156 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Expansion of debug memory within rv_dm used for DV purposes.
+//
+// The debug memory region is specified in the PULP debug system documentation here:
+// https://github.com/pulp-platform/riscv-dbg/blob/master/doc/debug-system.md
+//
+// The debug module exposes a 16kB memory called debug memory. It has a ROM portion (debug ROM),
+// some memory mapped CSRs and a RAM portion (program buffer). This region is accessible over the TL
+// interface only if debug mode is active.
+//
+// The OpenTitan RV_DM implementation that wraps around the PULP developed debug module only creates
+// an empty "window" to this space in the adjoining `rv_dm.hjson`, since there is no need to carve
+// out the region explicitly for RTL generation. For DV purposes, we fully specify that region to
+// make the common DV tests more effective.
+//
+// TODO: Most of the CSRs below are required to be parameterized to the number of Harts the debug
+// module caters to, which in case of RV_DM is 1. Consider making this actually parameterized to
+// more accurately reflect the state of the design.
+// The address skips and jumps were also obtained from the documentation page referenced above. They
+// are expected to be stable, given that this Hjson is written manually.
+{ name: "rv_dm_debug_mem",
+  clocking: [
+    {clock: "clk_i", reset: "rst_ni"}
+  ]
+  bus_interfaces: [
+    { protocol: "tlul", direction: "device" }
+  ],
+  regwidth: "32",
+  registers: [
+    { skipto: "0x100" }
+    { name: "HALTED",
+      desc: "Write to this address to acknowledge that the core has halted.",
+      swaccess: "wo",
+      hwaccess: "hrw", // updated by write to RESUMING
+      fields: [
+        { bits: "0",
+          resval: "0"
+        },
+      ]
+    },
+    { name: "GOING",
+      desc: "Write to this address to acknowledge that the core is executing.",
+      swaccess: "wo",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          resval: "0"
+        },
+      ]
+    },
+    { name: "RESUMING",
+      desc: "Write to this address to acknowledge that the core is resuming non-debug operation.",
+      swaccess: "wo",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          resval: "0"
+        },
+      ]
+    },
+    { name: "EXCEPTION",
+      desc: "An exception was triggered while the core was in debug mode.",
+      swaccess: "wo",
+      hwaccess: "hro",
+      fields: [
+        { bits: "0",
+          resval: "0"
+        },
+      ]
+    },
+    { skipto: "0x300" }
+    { name: "WHERETO",
+      desc: "TODO: No description provided in the spec.",
+      swaccess: "ro",
+      hwaccess: "hrw",
+      fields: [
+        { bits: "31:0",
+          resval: "0"
+        },
+      ]
+    },
+    { skipto: "0x338" }
+    { multireg: {
+        cname: "ABSTRACTCMD"
+        name:  "ABSTRACTCMD"
+        desc:  "TODO: No description provided in the spec."
+        count: "10"
+        swaccess: "ro"
+        hwaccess: "hro"
+        fields: [
+          { bits: "31:0"
+            resval: "0"
+          }
+        ]
+        tags: [// TODO: It is unclear how to predict these values.
+               "excl:CsrAllTests:CsrExclCheck"]
+      }
+    },
+    { multireg: {
+        cname: "PROGRAM_BUFFER"
+        name:  "PROGRAM_BUFFER"
+        desc:  "TODO: No description provided in the spec."
+        count: "8"
+        swaccess: "ro"
+        hwaccess: "hro"
+        fields: [
+          { bits: "31:0"
+            resval: "0"
+          }
+        ]
+      }
+    },
+    { multireg: {
+        cname: "DATAADDR"
+        name:  "DATAADDR"
+        desc:  "TODO: No description provided in the spec."
+        count: "2"
+        swaccess: "rw"
+        hwaccess: "hro"
+        fields: [
+          { bits: "31:0"
+            resval: "0"
+          }
+        ]
+        tags: [// TODO: Write-read-check will work after "activating" the debug module via JTAG.
+               "excl:CsrNonInitTests:CsrExclWriteCheck"]
+      }
+    },
+    { skipto: "0x400" }
+    { multireg: {
+        cname: "FLAGS"
+        name:  "FLAGS"
+        desc:  "TODO: No description provided in the spec."
+        count: "256"
+        swaccess: "ro"
+        hwaccess: "hro"
+        fields: [
+          { bits: "31:0"
+            resval: "0"
+          }
+        ]
+      }
+    },
+    // ROM size (given as `items` below) must be a power of two.
+    { window: {
+        name: "ROM"
+        items: "512" // 2 KiB
+        swaccess: "ro",
+        desc: '''Access window into the debug ROM.'''
+      }
+    },
+  ]
+}

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -30,6 +30,12 @@ generate:
     parameters:
       name: rv_dm
       ip_hjson: ../../data/rv_dm.hjson
+  debug_mem_ral:
+    generator: ralgen
+    parameters:
+      name: rv_dm_debug_mem
+      ip_hjson: ../../data/rv_dm_debug_mem.hjson
+
 
 targets:
   default:
@@ -37,3 +43,4 @@ targets:
       - files_dv
     generate:
       - ral
+      - debug_mem_ral

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.sv
@@ -18,6 +18,9 @@ class rv_dm_env extends cip_base_env #(
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
 
+    // TODO(#10765): The debug mem RAL space does not support byte access at this time.
+    m_tl_reg_adapters[cfg.rom_ral_name].supports_byte_enable = 1'b0;
+
     // set knobs
     if (cfg.zero_delays) begin
       cfg.m_tl_sba_agent_cfg.a_valid_delay_min = 0;

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -10,7 +10,7 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
   rand tl_agent_cfg   m_tl_sba_agent_cfg;
 
   // A constant that can be referenced from anywhere.
-  string rom_ral_name = "rv_dm_rom_reg_block";
+  string rom_ral_name = "rv_dm_debug_mem_reg_block";
 
   `uvm_object_utils_begin(rv_dm_env_cfg)
     `uvm_field_object(m_jtag_agent_cfg, UVM_DEFAULT)
@@ -27,14 +27,14 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     ral_model_names.push_back(rom_ral_name);
 
     // both RAL models use same clock frequency
-    clk_freqs_mhz["rv_dm_rom_reg_block"] = clk_freq_mhz;
+    clk_freqs_mhz["rv_dm_debug_mem_reg_block"] = clk_freq_mhz;
 
     super.initialize(csr_base_addr);
     `uvm_info(`gfn, $sformatf("ral_model_names: %0p", ral_model_names), UVM_LOW)
 
-    // default TLUL supports 1 outstanding item, the sram TLUL supports 2 outstanding items.
+    // Both, the regs and the debug mem TL device (in the DUT) only support 1 outstanding.
     m_tl_agent_cfgs[RAL_T::type_name].max_outstanding_req = 1;
-    m_tl_agent_cfgs[rom_ral_name].max_outstanding_req = 2;
+    m_tl_agent_cfgs[rom_ral_name].max_outstanding_req = 1;
 
     // Create jtag agent config obj
     m_jtag_agent_cfg = jtag_agent_cfg::type_id::create("m_jtag_agent_cfg");
@@ -45,6 +45,36 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     m_tl_sba_agent_cfg =  tl_agent_cfg::type_id::create("m_tl_sba_agent_cfg");
     m_tl_sba_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_tl_sba_agent_cfg.is_active = 1'b1;
+  endfunction
+
+  protected virtual function void post_build_ral_settings(dv_base_reg_block ral);
+    // The backdoor HDL paths are set incorrectly on the debug mem RAL structures by the reggen
+    // tool. We just remove all HDL paths and skip backdoor writes entirely.
+    // TODO: Enable backdoor writes later.
+    if (ral.get_name() == rom_ral_name) begin
+      rv_dm_debug_mem_reg_block debug_mem_ral;
+      uvm_reg regs[$];
+
+      ral.get_registers(regs);
+      foreach (regs[i]) begin
+        regs[i].clear_hdl_path("ALL");
+      end
+
+      // ROM within debug mem supports partial accesses, but strangely, the TL adapter does not
+      // allow byte accesses. See #10765.
+      `downcast(debug_mem_ral, ral)
+      debug_mem_ral.rom.set_mem_partial_write_support(1);
+
+      // ROM within the debug mem is RO - it ignores writes instead of throwing an error response.
+      debug_mem_ral.rom.set_write_to_ro_mem_ok(1);
+
+      // TODO(#10837): Accesses to unmapped regions of debug mem RAL space does not return an error
+      // response. Fix this if design is updated.
+      debug_mem_ral.set_unmapped_access_ok(1);
+
+      //TODO(#10765): We don't support byte writes at this time.
+      debug_mem_ral.set_support_byte_enable(1'b0);
+    end
   endfunction
 
 endclass

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
@@ -14,7 +14,7 @@ package rv_dm_env_pkg;
   import dv_base_reg_pkg::*;
   import csr_utils_pkg::*;
   import rv_dm_regs_ral_pkg::*;
-  import rv_dm_rom_ral_pkg::*;
+  import rv_dm_debug_mem_ral_pkg::*;
   import rv_dm_reg_pkg::NrHarts;
   import rv_dm_reg_pkg::NumAlerts;
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_base_vseq.sv
@@ -11,15 +11,25 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   `uvm_object_utils(rv_dm_base_vseq)
   `uvm_object_new
 
+  // Randomize the initial inputs to the DUT.
+  rand lc_ctrl_pkg::lc_tx_t   lc_hw_debug_en;
+  rand prim_mubi_pkg::mubi4_t scanmode;
+  rand logic [NUM_HARTS-1:0]  unavailable;
+
+  task pre_start();
+    // Initialize the input signals with defaults at the start of the sim.
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(lc_hw_debug_en)
+    cfg.rv_dm_vif.lc_hw_debug_en <= lc_hw_debug_en;
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(scanmode)
+    cfg.rv_dm_vif.scanmode <= scanmode;
+    `DV_CHECK_MEMBER_RANDOMIZE_FATAL(unavailable)
+    cfg.rv_dm_vif.unavailable <= unavailable;
+    super.pre_start();
+  endtask
+
   virtual task dut_init(string reset_kind = "HARD");
-    // Initialize input pins with known values.
-    cfg.rv_dm_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
-    cfg.rv_dm_vif.scanmode = prim_mubi_pkg::MuBi4False;
-    cfg.rv_dm_vif.unavailable = '{default:0};
-
     super.dut_init();
-
-    // Randomize the contents of debug ROM once out of reset.
+    // TODO: Randomize the contents of the debug ROM & the program buffer once out of reset.
   endtask
 
   // Have scan reset also applied at the start.
@@ -45,7 +55,7 @@ class rv_dm_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task dut_shutdown();
-    // check for pending rv_dm operations and wait for them to complete
+    // Check for pending rv_dm operations and wait for them to complete.
   endtask
 
 endclass : rv_dm_base_vseq

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_common_vseq.sv
@@ -4,17 +4,25 @@
 
 class rv_dm_common_vseq extends rv_dm_base_vseq;
   `uvm_object_utils(rv_dm_common_vseq)
+  `uvm_object_new
 
   constraint num_trans_c {
     num_trans inside {[1:2]};
   }
-  `uvm_object_new
+
+  // We set these initial inputs to known values to prevent side effects that may affect these
+  // common tests.
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+  constraint unavailable_c {
+    unavailable == 0;
+  }
 
   virtual task body();
-    // Enable access to debug ROM for the common sequences to work.
-    // TODO (lowrisc/opentitan/#10453): Figure out if this needs to be mdified based on the common
-    // test seq that is run.
-    cfg.rv_dm_vif.lc_hw_debug_en = lc_ctrl_pkg::On;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 

--- a/hw/ip/rv_dm/dv/tb.sv
+++ b/hw/ip/rv_dm/dv/tb.sv
@@ -66,11 +66,11 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(
         null, "*.env", "clk_rst_vif_rv_dm_regs_reg_block", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(
-        null, "*.env", "clk_rst_vif_rv_dm_rom_reg_block", clk_rst_if);
+        null, "*.env", "clk_rst_vif_rv_dm_debug_mem_reg_block", clk_rst_if);
     uvm_config_db#(virtual tl_if)::set(
         null, "*.env.m_tl_agent_rv_dm_regs_reg_block*", "vif", regs_tl_if);
     uvm_config_db#(virtual tl_if)::set(
-        null, "*.env.m_tl_agent_rv_dm_rom_reg_block*", "vif", rom_tl_if);
+        null, "*.env.m_tl_agent_rv_dm_debug_mem_reg_block*", "vif", rom_tl_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_sba_agent*", "vif", sba_tl_if);
     uvm_config_db#(virtual jtag_if)::set(null, "*.env.m_jtag_agent*", "vif", jtag_if);
     uvm_config_db#(virtual rv_dm_if)::set(null, "*.env*", "rv_dm_vif", rv_dm_if);

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -199,9 +199,11 @@ def main():
     # If this block has countermeasures, we grep for RTL annotations in all
     # .sv implementation files and check whether they match up with what is
     # defined inside the Hjson.
-    sv_files = Path(infile.name).parents[1].joinpath('rtl').glob('*.sv')
-    rtl_names = CounterMeasure.search_rtl_files(sv_files)
-    obj.check_cm_annotations(rtl_names, infile.name)
+    # Perform this check only when generating the RTL.
+    if format == 'rtl':
+        sv_files = Path(infile.name).parents[1].joinpath('rtl').glob('*.sv')
+        rtl_names = CounterMeasure.search_rtl_files(sv_files)
+        obj.check_cm_annotations(rtl_names, infile.name)
 
     if args.novalidate:
         with outfile:


### PR DESCRIPTION
This is a series of changes made to several parts of the codebase to enable a custom RAL model generation using a separate hand-written Hjson file to represent the debug memory within the rv_dm. 

The end result is to have our comportable dv framework allow the use of a RAL model generated in a pseudo/non-comportable fashion, and effectively leverage our existing common test sequences. 