### PR TITLE
[otbn,dv] OTP Key Agent Instantiated for Scrambling in OTBN

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -370,11 +370,16 @@ int OtbnModel::check() const {
 
   good &= OtbnTraceChecker::get().Finish();
 
-  try {
-    good &= check_dmem(*iss);
-  } catch (const std::exception &err) {
-    std::cerr << "Failed to check DMEM: " << err.what() << "\n";
-    return -1;
+  // Check DMEM only when we are about to start Secure Wipe because otherwise
+  // we would not have a valid scrambling key anymore. That would result with
+  // not getting a valid nonce and therefore an error.
+  if (iss->get_mirrored().wipe_start) {
+    try {
+      good &= check_dmem(*iss);
+    } catch (const std::exception &err) {
+      std::cerr << "Failed to check DMEM: " << err.what() << "\n";
+      return -1;
+    }
   }
 
   try {

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -9,6 +9,10 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
 
   rand otbn_sideload_agent_cfg keymgr_sideload_agent_cfg;
 
+  rand otp_key_agent_cfg key_cfg;
+
+  virtual clk_rst_if otp_clk_rst_vif;
+
   `uvm_object_utils_begin(otbn_env_cfg)
   `uvm_object_utils_end
 
@@ -62,6 +66,12 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   // Copied from dv_base_agent_cfg so that we can use a monitor without defining a separate agent.
   int ok_to_end_delay_ns = 1000;
 
+  // otp clk freq
+  rand uint otp_freq_mhz;
+  constraint otp_freq_mhz_c {
+    `DV_COMMON_CLK_CONSTRAINT(otp_freq_mhz)
+  }
+
   function void initialize(bit [31:0] csr_base_addr = '1);
     num_edn = 2;
     // Tell the CIP base code not to look for a "devmode" interface. OTBN doesn't have one.
@@ -80,6 +90,10 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
     model_agent_cfg  = otbn_model_agent_cfg  ::type_id::create("model_agent_cfg");
     keymgr_sideload_agent_cfg = otbn_sideload_agent_cfg::type_id::create(
       "keymgr_sideload_agent_cfg");
+
+
+    // Build OTP Key cfg object
+    key_cfg = otp_key_agent_cfg::type_id::create("key_cfg");
 
     super.initialize(csr_base_addr);
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -11,6 +11,7 @@ package otbn_env_pkg;
   import dv_base_reg_pkg::*;
   import tl_agent_pkg::*;
   import cip_base_pkg::*;
+  import push_pull_agent_pkg::*;
   import otbn_model_pkg::*;
   import otbn_model_agent_pkg::*;
   import otbn_memutil_pkg::*;
@@ -44,12 +45,19 @@ package otbn_env_pkg;
   parameter uint NUM_ALERTS = otbn_reg_pkg::NumAlerts;
   parameter uint NUM_EDN = 2;
 
+  // Number of bits in the otp_ctrl_pkg::otbn_otp_key_rsp_t struct:
+  parameter int KEY_RSP_DATA_SIZE = $bits(otp_ctrl_pkg::otbn_otp_key_rsp_t);
+
   // typedefs
   typedef virtual pins_if #(1)     idle_vif;
   typedef virtual otbn_escalate_if escalate_vif;
   typedef logic [TL_AIW-1:0]       tl_source_t;
   typedef key_sideload_agent#(keymgr_pkg::otbn_key_req_t) otbn_sideload_agent;
   typedef key_sideload_agent_cfg#(keymgr_pkg::otbn_key_req_t) otbn_sideload_agent_cfg;
+
+  typedef push_pull_agent#(.DeviceDataWidth(KEY_RSP_DATA_SIZE)) otp_key_agent;
+  typedef push_pull_agent_cfg#(.DeviceDataWidth(KEY_RSP_DATA_SIZE)) otp_key_agent_cfg;
+  typedef virtual push_pull_if#(.DeviceDataWidth(KEY_RSP_DATA_SIZE)) otp_key_vif;
 
   // Expected data for a pending read (see exp_read_values in otbn_scoreboard.sv)
   typedef struct packed {


### PR DESCRIPTION
This commit includes a new agent in OTBN DV environment called
otp_key_agent. It is a simple push-pull device for handling
communication between OTP and OTBN.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>