### PR TITLE
[dv/kmac] Add edn_timeout and entropy_mode error cases

### DIFF
--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -153,6 +153,21 @@
       tests: ["{variant}_key_error"]
     }
     {
+      name: edn_timeout_error
+      desc: ''' Test kmac responses correctly when EDN response timeout.
+            Based on kmac app sequence, this sequence write `ral.entropy_period.wait_timer` with
+            the minimal value (timeout after 1 cycle) to ensure a EDN timeout request.
+            **Check**:
+            - Check error related registers including `err_code`, `status`, and `interrupt`.
+            - Check keymgr interface responses with error bit sets to 1.
+            - Check kmac can resume normal functionalities after processing this error case.
+            - Check timeout error will not trigger if the `entropy_mode` is set to SW, or masking
+              is disabled.
+            '''
+      milestone: V2
+      tests: ["{variant}_edn_timeout_error"]
+    }
+    {
       name: lc_escalation
       desc: '''
             Randomly set `lc_escalate_en` to value that is not `Off` during Kmac operations.

--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -167,7 +167,21 @@
       milestone: V2
       tests: ["{variant}_edn_timeout_error"]
     }
-    {
+     {
+      name: entropy_mode_error
+      desc: ''' Test kmac responses correctly when entropy mode is configured incorrectly.
+            Based on kmac edn_timeout sequence, this sequence write incorrect
+            `ral.cfg_shadowed.entropy_mode` before entropy is fetched.
+            **Check**:
+            - Check error related registers including `err_code`, `status`, and `interrupt`.
+            - Check keymgr interface responses with error bit sets to 1.
+            - Check kmac can resume normal functionalities after processing this error case.
+            - Check timeout error will not trigger if masking is disabled.
+            '''
+      milestone: V2
+      tests: ["{variant}_entropy_mode_error"]
+    }
+   {
       name: lc_escalation
       desc: '''
             Randomly set `lc_escalate_en` to value that is not `Off` during Kmac operations.

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -39,6 +39,7 @@ filesets:
       - seq_lib/kmac_app_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_key_error_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_edn_timeout_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_lc_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -40,6 +40,7 @@ filesets:
       - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_key_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_edn_timeout_error_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_entropy_mode_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_lc_escalation_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/ip/kmac/dv/env/kmac_env_pkg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_pkg.sv
@@ -139,6 +139,11 @@ package kmac_env_pkg;
   } kmac_status_e;
 
   typedef enum int {
+    KmacPrescaler = 0,
+    KmacWaitTimer = 16
+  } kmac_entropy_period_e;
+
+  typedef enum int {
     AppKeymgr,
     AppLc,
     AppRom

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -2550,8 +2550,12 @@ class kmac_scoreboard extends cip_base_scoreboard #(
     // Intermediate array for streaming `unmasked_key` into `dpi_key_arr`
     bit [7:0] unmasked_key_bytes[];
 
-    int key_word_len = get_key_size_words(key_len);
-    int key_byte_len = get_key_size_bytes(key_len);
+    int key_word_len, key_byte_len;
+
+    if (cfg.en_scb == 0) return;
+
+    key_word_len = get_key_size_words(key_len);
+    key_byte_len = get_key_size_bytes(key_len);
 
     `uvm_info(`gfn, $sformatf("key_word_len: %0d", key_word_len), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("key_byte_len: %0d", key_byte_len), UVM_HIGH)

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -279,9 +279,20 @@ class kmac_base_vseq extends cip_base_vseq #(
 
     // set interrupts
     cfg_interrupts(.interrupts(enable_intr));
+    // For error cases that does not support in scb, predict its value so can be used in
+    // `check_err` task.
+    if (cfg.en_scb == 0) ral.intr_enable.predict(enable_intr);
     `uvm_info(`gfn, $sformatf("intr[KmacDone] = %0b", enable_intr[KmacDone]), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("intr[KmacFifoEmpty] = %0b", enable_intr[KmacFifoEmpty]), UVM_HIGH)
     `uvm_info(`gfn, $sformatf("intr[KmacErr] = %0b", enable_intr[KmacErr]), UVM_HIGH)
+
+    if (kmac_err_type == ErrWaitTimerExpired && entropy_mode == EntropyModeEdn &&
+        cfg.enable_masking) begin
+      csr_wr(.ptr(ral.entropy_period), .value(1'b1 << KmacWaitTimer));
+    end else begin
+      // TODO: write random large values that can avoid timeout.
+      csr_wr(.ptr(ral.entropy_period), .value(0));
+    end
 
     // setup CFG csr with default random values
     ral.cfg_shadowed.kmac_en.set(kmac_en);
@@ -313,7 +324,7 @@ class kmac_base_vseq extends cip_base_vseq #(
     csr_rd(.ptr(ral.status), .value(data));
   endtask
 
-  virtual task check_err(clear_err = 1'b1);
+  virtual task check_err(bit clear_err = 1'b1);
     bit [TL_DW-1:0] err_data;
     // wait for several cycles to allow interrupt to propagate
     cfg.clk_rst_vif.wait_clks(10);
@@ -343,12 +354,13 @@ class kmac_base_vseq extends cip_base_vseq #(
       if (kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode) begin
         `DV_CHECK_MEMBER_RANDOMIZE_FATAL(entropy_mode)
         ral.cfg_shadowed.entropy_mode.set(entropy_mode);
+        // Need to pulse `entropy_ready` once we signal that SW has finished processing
+        // the entropy-related errors, otherwise FSM will be infinitely looping in Reset state
+        // csr_wr(.ptr(ral.cfg_shadowed.entropy_ready), .value(1'b1));
+        ral.cfg_shadowed.entropy_ready.set(1);
       end
       csr_update(.csr(ral.cfg_shadowed));
 
-      // Need to pulse `entropy_ready` once we signal that SW has finished processing
-      // the entropy-related errors, otherwise FSM will be infinitely looping in Reset state
-      csr_wr(.ptr(ral.cfg_shadowed.entropy_ready), .value(1'b1));
     end else if (kmac_err_type == kmac_pkg::ErrKeyNotValid) begin
       ral.cfg_shadowed.err_processed.set(1);
       csr_update(.csr(ral.cfg_shadowed));

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
@@ -40,15 +40,20 @@ class kmac_edn_timeout_error_vseq extends kmac_app_vseq;
 
   virtual task pre_start();
     super.pre_start();
-    if (cfg.enable_masking) begin
-      $assertoff(0, "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
-      $assertoff(0, "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
-      $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
-      $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
-    end
+    if (cfg.enable_masking) disable_asserts();
     cfg.en_scb = 0;
     check_keymgr_rsp_nonblocking();
   endtask
+
+  virtual function void disable_asserts();
+    $assertoff(0,
+      "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
+    $assertoff(0,
+      // verilog_lint: waive line-length-exceeds-max
+      "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
+    $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
+    $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+  endfunction
 
   virtual task post_start();
     super.post_start();
@@ -59,10 +64,14 @@ class kmac_edn_timeout_error_vseq extends kmac_app_vseq;
 
   // Because scb is disabled, use sequence to check if `err_code` is correct.
   virtual task check_err(bit clear_err = 1'b1);
+    super.check_err(clear_err);
+    check_err_code();
+  endtask
+
+  virtual task check_err_code();
     kmac_pkg::err_t kmac_err = '{valid: 1'b1,
                                  code: kmac_pkg::ErrWaitTimerExpired,
                                  info: '0};
-    super.check_err(clear_err);
     csr_rd_check(.ptr(ral.err_code), .compare_value(kmac_err));
   endtask
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_edn_timeout_error_vseq.sv
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Trigger ErrWaitTimerExpired error by setting edn timeout to a very small value.
+// This sequence will check:
+// - Kmac error interrupt is set via check_err() task.
+// - Kmac output correct err_code.
+// - Kmac can finish the operation without hanging.
+// - Check error bit in keymgr app interface.
+class kmac_edn_timeout_error_vseq extends kmac_app_vseq;
+
+  `uvm_object_utils(kmac_edn_timeout_error_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {
+    num_trans inside {[1:20]};
+  }
+
+  constraint kmac_err_type_c {
+    if (en_kmac_err) {
+      kmac_err_type == kmac_pkg::ErrWaitTimerExpired;
+      entropy_fast_process == 0;
+    } else {
+      kmac_err_type == kmac_pkg::ErrNone;
+    }
+  }
+
+  constraint en_err_c {
+    en_kmac_err dist {
+      0 :/ 2,
+      1 :/ 8
+    };
+  }
+
+  function void pre_randomize();
+    this.disable_err_c.constraint_mode(0);
+    this.en_app_c.constraint_mode(0);
+  endfunction
+
+  virtual task pre_start();
+    super.pre_start();
+    if (cfg.enable_masking) begin
+      $assertoff(0, "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckHoldReq");
+      $assertoff(0, "tb.dut.gen_entropy.u_edn_req.u_prim_sync_reqack_data.u_prim_sync_reqack.SyncReqAckAckNeedsReq");
+      $assertoff(0, "tb.edn_if[0].ReqHighUntilAck_A");
+      $assertoff(0, "tb.edn_if[0].AckAssertedOnlyWhenReqAsserted_A");
+    end
+    cfg.en_scb = 0;
+    check_keymgr_rsp_nonblocking();
+  endtask
+
+  virtual task post_start();
+    super.post_start();
+
+    // TODO: enable scb and run normal sequence, then add this sequence to stress_all sequence.
+    // cfg.en_scb = 1;
+  endtask
+
+  // Because scb is disabled, use sequence to check if `err_code` is correct.
+  virtual task check_err(bit clear_err = 1'b1);
+    kmac_pkg::err_t kmac_err = '{valid: 1'b1,
+                                 code: kmac_pkg::ErrWaitTimerExpired,
+                                 info: '0};
+    super.check_err(clear_err);
+    csr_rd_check(.ptr(ral.err_code), .compare_value(kmac_err));
+  endtask
+
+  virtual task check_keymgr_rsp_nonblocking();
+    fork begin
+      while (cfg.en_scb == 0 && entropy_fetched == 0) begin
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.done == 1);
+        if (cfg.enable_masking && entropy_mode == EntropyModeEdn) begin
+          `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.error, 1)
+        end
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.done == 0);
+      end
+    end join_none
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_entropy_mode_error_vseq.sv
@@ -1,0 +1,49 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Trigger ErrIncorrectEntropyMode error by setting incorrect entropy configuration.
+// This sequence will check:
+// - Kmac error interrupt is set via check_err() task.
+// - Kmac output correct err_code.
+// - Kmac can finish the operation without hanging.
+// - Check error bit in keymgr app interface.
+class kmac_entropy_mode_error_vseq extends kmac_edn_timeout_error_vseq;
+
+  `uvm_object_utils(kmac_entropy_mode_error_vseq)
+  `uvm_object_new
+
+  constraint kmac_err_type_c {
+    if (en_kmac_err) {
+      kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode;
+    } else {
+      kmac_err_type == kmac_pkg::ErrNone;
+    }
+  }
+
+  // No assertions to disable.
+  virtual function void disable_asserts();
+  endfunction
+
+  virtual task check_err_code();
+    kmac_pkg::err_t kmac_err = '{valid: 1'b1,
+                                 code: kmac_pkg::ErrIncorrectEntropyMode,
+                                 info: '0};
+    csr_rd_check(.ptr(ral.err_code), .compare_value(kmac_err));
+  endtask
+
+  virtual task check_keymgr_rsp_nonblocking();
+    fork begin
+      while (cfg.en_scb == 0 && entropy_fetched == 0) begin
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.done == 1);
+        if (cfg.enable_masking && entropy_mode == ErrIncorrectEntropyMode) begin
+          if (entropy_fetched == 0) begin
+            `DV_CHECK_EQ(cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.error, 1)
+          end
+        end
+        wait (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.kmac_data_rsp.done == 0);
+      end
+    end join_none
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
@@ -30,7 +30,8 @@ class kmac_error_vseq extends kmac_app_vseq;
 
   constraint kmac_err_type_c {
     if (en_kmac_err) {
-      (kmac_err_type inside {kmac_pkg::ErrNone, kmac_pkg::ErrKeyNotValid}) == 0;
+      (kmac_err_type inside
+          {kmac_pkg::ErrNone, kmac_pkg::ErrKeyNotValid, kmac_pkg::ErrWaitTimerExpired}) == 0;
     } else {
       kmac_err_type == kmac_pkg::ErrNone;
     }

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_error_vseq.sv
@@ -31,7 +31,11 @@ class kmac_error_vseq extends kmac_app_vseq;
   constraint kmac_err_type_c {
     if (en_kmac_err) {
       (kmac_err_type inside
-          {kmac_pkg::ErrNone, kmac_pkg::ErrKeyNotValid, kmac_pkg::ErrWaitTimerExpired}) == 0;
+          {kmac_pkg::ErrNone,
+           // Below error cases are verified in separate testbench.
+           kmac_pkg::ErrKeyNotValid,
+           kmac_pkg::ErrWaitTimerExpired,
+           kmac_pkg::ErrIncorrectEntropyMode}) == 0;
     } else {
       kmac_err_type == kmac_pkg::ErrNone;
     }

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -115,14 +115,16 @@ class kmac_smoke_vseq extends kmac_base_vseq;
       kmac_init();
       `uvm_info(`gfn, "kmac_init done", UVM_HIGH)
 
-      if (cfg.enable_masking && kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode) begin
-        check_err();
-      end
-
       if (cfg.enable_masking && kmac_err_type == kmac_pkg::ErrWaitTimerExpired &&
           entropy_mode == EntropyModeEdn) begin
         if (entropy_fetched == 0) check_err();
       end else if (cfg.enable_masking && entropy_mode == EntropyModeEdn) begin
+        entropy_fetched = 1;
+      end
+
+      if (cfg.enable_masking && kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode) begin
+        if (!entropy_fetched) check_err();
+      end else if (cfg.enable_masking) begin
         entropy_fetched = 1;
       end
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_smoke_vseq.sv
@@ -17,6 +17,9 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
   rand kmac_app_e app_mode;
 
+  // Set this bit to one if entropy fetched successfully without timeout error.
+  bit entropy_fetched;
+
   constraint num_trans_c {
     num_trans inside {[1:200]};
     if (cfg.smoke_test) {
@@ -114,6 +117,13 @@ class kmac_smoke_vseq extends kmac_base_vseq;
 
       if (cfg.enable_masking && kmac_err_type == kmac_pkg::ErrIncorrectEntropyMode) begin
         check_err();
+      end
+
+      if (cfg.enable_masking && kmac_err_type == kmac_pkg::ErrWaitTimerExpired &&
+          entropy_mode == EntropyModeEdn) begin
+        if (entropy_fetched == 0) check_err();
+      end else if (cfg.enable_masking && entropy_mode == EntropyModeEdn) begin
+        entropy_fetched = 1;
       end
 
       set_prefix();

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -16,5 +16,6 @@
 `include "kmac_app_vseq.sv"
 `include "kmac_error_vseq.sv"
 `include "kmac_key_error_vseq.sv"
+`include "kmac_edn_timeout_error_vseq.sv"
 `include "kmac_lc_escalation_vseq.sv"
 `include "kmac_stress_all_vseq.sv"

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -17,5 +17,6 @@
 `include "kmac_error_vseq.sv"
 `include "kmac_key_error_vseq.sv"
 `include "kmac_edn_timeout_error_vseq.sv"
+`include "kmac_entropy_mode_error_vseq.sv"
 `include "kmac_lc_escalation_vseq.sv"
 `include "kmac_stress_all_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -150,6 +150,11 @@
       uvm_test_seq: kmac_key_error_vseq
     }
     {
+      name: "{variant}_edn_timeout_error"
+      uvm_test_seq: kmac_edn_timeout_error_vseq
+      reseed: 20
+    }
+    {
       name: "{variant}_lc_escalation"
       uvm_test_seq: kmac_lc_escalation_vseq
       run_opts: ["+disable_lc_asserts=1"]

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -154,7 +154,12 @@
       uvm_test_seq: kmac_edn_timeout_error_vseq
       reseed: 20
     }
-    {
+     {
+      name: "{variant}_entropy_mode_error"
+      uvm_test_seq: kmac_entropy_mode_error_vseq
+      reseed: 20
+    }
+   {
       name: "{variant}_lc_escalation"
       uvm_test_seq: kmac_lc_escalation_vseq
       run_opts: ["+disable_lc_asserts=1"]


### PR DESCRIPTION
This PR has two commits for two error cases:
1). Edn timeout
2). Entropy_mode configuration incorrect.

We will disable scb for both of these two cases because KMAC will continue operate with incorrect entropy data,
so it is hard to monitor that in cycle accurate scoreboard.

I separate them into two test because it is easier to debug, and eventually we can still run both error cases back to back with stress_all test.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>