### PR TITLE
[bazel] change name of mask ROM keys bazel build target

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -226,7 +226,7 @@ cc_library(
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
         "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:rnd",
-        "//sw/device/silicon_creator/mask_rom/keys:test_keys",
+        "//sw/device/silicon_creator/mask_rom/keys:test_public_keys",
     ],
 )
 
@@ -252,7 +252,7 @@ cc_test(
         "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
         "//sw/device/silicon_creator/lib/drivers:mock_rnd",
-        "//sw/device/silicon_creator/mask_rom/keys:test_keys",
+        "//sw/device/silicon_creator/mask_rom/keys:test_public_keys",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/mask_rom/keys/BUILD
+++ b/sw/device/silicon_creator/mask_rom/keys/BUILD
@@ -5,8 +5,13 @@
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
-    name = "test_keys",
+    name = "test_public_keys",
     hdrs = [
         "test_key_0_rsa_3072_exp_f4.h",
     ],
+)
+
+filegroup(
+    name = "test_private_key_0",
+    srcs = ["test_key_0_rsa_3072_exp_f4.der"],
 )


### PR DESCRIPTION
The bazel build target that contains the public keys to be included in
the mask ROM was named "test_keys". However, this target contains the
public keys. This commit renames the build target to be more specific,
i.e., the target name is now "test_public_keys".

This enables adding a filegroup target for each (test-only) private key,
which is needed to integrate image signing into bazel. This addresses a
task in #10864.

Signed-off-by: Timothy Trippel <ttrippel@google.com>