### PR TITLE
[bazel] prepare to build `rom_ext_image_tools` with bazel

### DIFF
--- a/sw/host/Cargo.toml
+++ b/sw/host/Cargo.toml
@@ -6,6 +6,8 @@
 members = [
     "opentitanlib",
     "opentitantool",
+    "rom_ext_image_tools/signer",
+    "rom_ext_image_tools/signer/image",
 ]
 
 [workspace.metadata.raze]

--- a/sw/host/rom_ext_image_tools/signer/Cargo.toml
+++ b/sw/host/rom_ext_image_tools/signer/Cargo.toml
@@ -8,11 +8,6 @@ version = "0.1.0"
 authors = ["lowRISC contributors"]
 edition = "2018"
 
-[workspace]
-members = [
-    "image"
-]
-
 [profile.dev]
 lto = false
 opt-level = 2

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -25,7 +25,7 @@ _DEPENDENCIES = {
         "num-bigint-dig": "@raze__num_bigint_dig__0_7_0//:num_bigint_dig",
         "num-traits": "@raze__num_traits__0_2_14//:num_traits",
         "num_enum": "@raze__num_enum__0_5_4//:num_enum",
-        "rand": "@raze__rand__0_8_4//:rand",
+        "rand": "@raze__rand__0_8_5//:rand",
         "regex": "@raze__regex__1_5_4//:regex",
         "rusb": "@raze__rusb__0_8_1//:rusb",
         "safe-ftdi": "@raze__safe_ftdi__0_3_0//:safe_ftdi",
@@ -60,6 +60,17 @@ _DEPENDENCIES = {
         "structopt": "@raze__structopt__0_3_25//:structopt",
         "thiserror": "@raze__thiserror__1_0_30//:thiserror",
     },
+    "sw/host/rom_ext_image_tools/signer": {
+        "anyhow": "@raze__anyhow__1_0_46//:anyhow",
+        "object": "@raze__object__0_25_3//:object",
+        "thiserror": "@raze__thiserror__1_0_30//:thiserror",
+        "zerocopy": "@raze__zerocopy__0_5_0//:zerocopy",
+    },
+    "sw/host/rom_ext_image_tools/signer/image": {
+        "memoffset": "@raze__memoffset__0_6_5//:memoffset",
+        "thiserror": "@raze__thiserror__1_0_30//:thiserror",
+        "zerocopy": "@raze__zerocopy__0_5_0//:zerocopy",
+    },
 }
 
 # EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of proc_macro dependencies for the Rust targets of that package.
@@ -69,6 +80,10 @@ _PROC_MACRO_DEPENDENCIES = {
     "sw/host/opentitanlib/opentitantool_derive": {
     },
     "sw/host/opentitantool": {
+    },
+    "sw/host/rom_ext_image_tools/signer": {
+    },
+    "sw/host/rom_ext_image_tools/signer/image": {
     },
 }
 
@@ -80,6 +95,10 @@ _DEV_DEPENDENCIES = {
     },
     "sw/host/opentitantool": {
     },
+    "sw/host/rom_ext_image_tools/signer": {
+    },
+    "sw/host/rom_ext_image_tools/signer/image": {
+    },
 }
 
 # EXPERIMENTAL -- MAY CHANGE AT ANY TIME: A mapping of package names to a set of proc_macro dev dependencies for the Rust targets of that package.
@@ -89,6 +108,10 @@ _DEV_PROC_MACRO_DEPENDENCIES = {
     "sw/host/opentitanlib/opentitantool_derive": {
     },
     "sw/host/opentitantool": {
+    },
+    "sw/host/rom_ext_image_tools/signer": {
+    },
+    "sw/host/rom_ext_image_tools/signer/image": {
     },
 }
 
@@ -249,6 +272,15 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__adler__1_0_2",
+        url = "https://crates.io/api/v1/crates/adler/1.0.2/download",
+        type = "tar.gz",
+        strip_prefix = "adler-1.0.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.adler-1.0.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__aho_corasick__0_7_18",
         url = "https://crates.io/api/v1/crates/aho-corasick/0.7.18/download",
         type = "tar.gz",
@@ -289,20 +321,20 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__autocfg__0_1_7",
-        url = "https://crates.io/api/v1/crates/autocfg/0.1.7/download",
+        name = "raze__autocfg__0_1_8",
+        url = "https://crates.io/api/v1/crates/autocfg/0.1.8/download",
         type = "tar.gz",
-        strip_prefix = "autocfg-0.1.7",
-        build_file = Label("//third_party/cargo/remote:BUILD.autocfg-0.1.7.bazel"),
+        strip_prefix = "autocfg-0.1.8",
+        build_file = Label("//third_party/cargo/remote:BUILD.autocfg-0.1.8.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "raze__autocfg__1_0_1",
-        url = "https://crates.io/api/v1/crates/autocfg/1.0.1/download",
+        name = "raze__autocfg__1_1_0",
+        url = "https://crates.io/api/v1/crates/autocfg/1.1.0/download",
         type = "tar.gz",
-        strip_prefix = "autocfg-1.0.1",
-        build_file = Label("//third_party/cargo/remote:BUILD.autocfg-1.0.1.bazel"),
+        strip_prefix = "autocfg-1.1.0",
+        build_file = Label("//third_party/cargo/remote:BUILD.autocfg-1.1.0.bazel"),
     )
 
     maybe(
@@ -317,11 +349,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__block_buffer__0_10_0",
-        url = "https://crates.io/api/v1/crates/block-buffer/0.10.0/download",
+        name = "raze__block_buffer__0_10_2",
+        url = "https://crates.io/api/v1/crates/block-buffer/0.10.2/download",
         type = "tar.gz",
-        strip_prefix = "block-buffer-0.10.0",
-        build_file = Label("//third_party/cargo/remote:BUILD.block-buffer-0.10.0.bazel"),
+        strip_prefix = "block-buffer-0.10.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.block-buffer-0.10.2.bazel"),
     )
 
     maybe(
@@ -395,11 +427,20 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__crypto_common__0_1_1",
-        url = "https://crates.io/api/v1/crates/crypto-common/0.1.1/download",
+        name = "raze__crc32fast__1_3_2",
+        url = "https://crates.io/api/v1/crates/crc32fast/1.3.2/download",
         type = "tar.gz",
-        strip_prefix = "crypto-common-0.1.1",
-        build_file = Label("//third_party/cargo/remote:BUILD.crypto-common-0.1.1.bazel"),
+        strip_prefix = "crc32fast-1.3.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.crc32fast-1.3.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__crypto_common__0_1_2",
+        url = "https://crates.io/api/v1/crates/crypto-common/0.1.2/download",
+        type = "tar.gz",
+        strip_prefix = "crypto-common-0.1.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.crypto-common-0.1.2.bazel"),
     )
 
     maybe(
@@ -433,11 +474,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__digest__0_10_1",
-        url = "https://crates.io/api/v1/crates/digest/0.10.1/download",
+        name = "raze__digest__0_10_2",
+        url = "https://crates.io/api/v1/crates/digest/0.10.2/download",
         type = "tar.gz",
-        strip_prefix = "digest-0.10.1",
-        build_file = Label("//third_party/cargo/remote:BUILD.digest-0.10.1.bazel"),
+        strip_prefix = "digest-0.10.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.digest-0.10.2.bazel"),
     )
 
     maybe(
@@ -488,6 +529,15 @@ def raze_fetch_remote_crates():
         sha256 = "3de9ad4541d99dc22b59134e7ff8dc3d6c988c89ecd7324bf10a8362b07a2afa",
         strip_prefix = "erased-serde-0.3.16",
         build_file = Label("//third_party/cargo/remote:BUILD.erased-serde-0.3.16.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__flate2__1_0_22",
+        url = "https://crates.io/api/v1/crates/flate2/1.0.22/download",
+        type = "tar.gz",
+        strip_prefix = "flate2-1.0.22",
+        build_file = Label("//third_party/cargo/remote:BUILD.flate2-1.0.22.bazel"),
     )
 
     maybe(
@@ -601,11 +651,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__libm__0_2_1",
-        url = "https://crates.io/api/v1/crates/libm/0.2.1/download",
+        name = "raze__libm__0_2_2",
+        url = "https://crates.io/api/v1/crates/libm/0.2.2/download",
         type = "tar.gz",
-        strip_prefix = "libm-0.2.1",
-        build_file = Label("//third_party/cargo/remote:BUILD.libm-0.2.1.bazel"),
+        strip_prefix = "libm-0.2.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.libm-0.2.2.bazel"),
     )
 
     maybe(
@@ -682,6 +732,24 @@ def raze_fetch_remote_crates():
         sha256 = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a",
         strip_prefix = "memchr-2.4.1",
         build_file = Label("//third_party/cargo/remote:BUILD.memchr-2.4.1.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__memoffset__0_6_5",
+        url = "https://crates.io/api/v1/crates/memoffset/0.6.5/download",
+        type = "tar.gz",
+        strip_prefix = "memoffset-0.6.5",
+        build_file = Label("//third_party/cargo/remote:BUILD.memoffset-0.6.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__miniz_oxide__0_4_4",
+        url = "https://crates.io/api/v1/crates/miniz_oxide/0.4.4/download",
+        type = "tar.gz",
+        strip_prefix = "miniz_oxide-0.4.4",
+        build_file = Label("//third_party/cargo/remote:BUILD.miniz_oxide-0.4.4.bazel"),
     )
 
     maybe(
@@ -768,6 +836,15 @@ def raze_fetch_remote_crates():
         sha256 = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3",
         strip_prefix = "number_prefix-0.4.0",
         build_file = Label("//third_party/cargo/remote:BUILD.number_prefix-0.4.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__object__0_25_3",
+        url = "https://crates.io/api/v1/crates/object/0.25.3/download",
+        type = "tar.gz",
+        strip_prefix = "object-0.25.3",
+        build_file = Label("//third_party/cargo/remote:BUILD.object-0.25.3.bazel"),
     )
 
     maybe(
@@ -871,11 +948,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__rand__0_8_4",
-        url = "https://crates.io/api/v1/crates/rand/0.8.4/download",
+        name = "raze__rand__0_8_5",
+        url = "https://crates.io/api/v1/crates/rand/0.8.5/download",
         type = "tar.gz",
-        strip_prefix = "rand-0.8.4",
-        build_file = Label("//third_party/cargo/remote:BUILD.rand-0.8.4.bazel"),
+        strip_prefix = "rand-0.8.5",
+        build_file = Label("//third_party/cargo/remote:BUILD.rand-0.8.5.bazel"),
     )
 
     maybe(
@@ -894,15 +971,6 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         strip_prefix = "rand_core-0.6.3",
         build_file = Label("//third_party/cargo/remote:BUILD.rand_core-0.6.3.bazel"),
-    )
-
-    maybe(
-        http_archive,
-        name = "raze__rand_hc__0_3_1",
-        url = "https://crates.io/api/v1/crates/rand_hc/0.3.1/download",
-        type = "tar.gz",
-        strip_prefix = "rand_hc-0.3.1",
-        build_file = Label("//third_party/cargo/remote:BUILD.rand_hc-0.3.1.bazel"),
     )
 
     maybe(

--- a/third_party/cargo/remote/BUILD.CoreFoundation-sys-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.CoreFoundation-sys-0.1.4.bazel
@@ -74,6 +74,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=CoreFoundation-sys",
         "manual",
     ],
     version = "0.1.4",

--- a/third_party/cargo/remote/BUILD.IOKit-sys-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.IOKit-sys-0.1.5.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=IOKit-sys",
         "manual",
     ],
     version = "0.1.5",

--- a/third_party/cargo/remote/BUILD.adler-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.adler-1.0.2.bazel
@@ -26,30 +26,31 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "0BSD OR (MIT OR Apache-2.0)"
 ])
 
 # Generated Targets
 
+# Unsupported target "bench" with type "bench" omitted
+
 rust_library(
-    name = "crypto_common",
+    name = "adler",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
+        "crate-name=adler",
         "manual",
     ],
-    version = "0.1.1",
+    version = "1.0.2",
     # buildifier: leave-alone
     deps = [
-        "@raze__generic_array__0_14_5//:generic_array",
     ],
 )

--- a/third_party/cargo/remote/BUILD.aho-corasick-0.7.18.bazel
+++ b/third_party/cargo/remote/BUILD.aho-corasick-0.7.18.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=aho_corasick",
         "manual",
     ],
     version = "0.7.18",

--- a/third_party/cargo/remote/BUILD.ansi_term-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.ansi_term-0.11.0.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=ansi_term",
         "manual",
     ],
     version = "0.11.0",

--- a/third_party/cargo/remote/BUILD.anyhow-1.0.46.bazel
+++ b/third_party/cargo/remote/BUILD.anyhow-1.0.46.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=anyhow",
         "manual",
     ],
     version = "1.0.46",

--- a/third_party/cargo/remote/BUILD.atty-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.atty-0.2.14.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=atty",
         "manual",
     ],
     version = "0.2.14",

--- a/third_party/cargo/remote/BUILD.autocfg-0.1.8.bazel
+++ b/third_party/cargo/remote/BUILD.autocfg-0.1.8.bazel
@@ -26,55 +26,30 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 # Generated Targets
 
 rust_library(
-    name = "rand",
+    name = "autocfg",
     srcs = glob(["**/*.rs"]),
-    aliases = {
-    },
     crate_features = [
-        "alloc",
-        "default",
-        "getrandom",
-        "libc",
-        "rand_chacha",
-        "rand_hc",
-        "std",
-        "std_rng",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
+        "crate-name=autocfg",
         "manual",
     ],
-    version = "0.8.4",
+    version = "0.1.8",
     # buildifier: leave-alone
     deps = [
-        "@raze__rand_core__0_6_3//:rand_core",
-    ] + selects.with_or({
-        # cfg(not(target_os = "emscripten"))
-        (
-            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
-        ): [
-            "@raze__rand_chacha__0_3_1//:rand_chacha",
-        ],
-        "//conditions:default": [],
-    }) + selects.with_or({
-        # cfg(unix)
-        (
-            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
-        ): [
-            "@raze__libc__0_2_107//:libc",
-        ],
-        "//conditions:default": [],
-    }),
+        "@raze__autocfg__1_1_0//:autocfg",
+    ],
 )

--- a/third_party/cargo/remote/BUILD.autocfg-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.autocfg-1.1.0.bazel
@@ -26,36 +26,39 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
 ])
 
 # Generated Targets
 
+# Unsupported target "integers" with type "example" omitted
+
+# Unsupported target "paths" with type "example" omitted
+
+# Unsupported target "traits" with type "example" omitted
+
+# Unsupported target "versions" with type "example" omitted
+
 rust_library(
-    name = "digest",
+    name = "autocfg",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "alloc",
-        "block-buffer",
-        "core-api",
-        "default",
-        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2018",
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
+        "crate-name=autocfg",
         "manual",
     ],
-    version = "0.10.1",
+    version = "1.1.0",
     # buildifier: leave-alone
     deps = [
-        "@raze__block_buffer__0_10_0//:block_buffer",
-        "@raze__crypto_common__0_1_1//:crypto_common",
-        "@raze__generic_array__0_14_5//:generic_array",
     ],
 )
+
+# Unsupported target "rustflags" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.bitflags-1.3.2.bazel
+++ b/third_party/cargo/remote/BUILD.bitflags-1.3.2.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=bitflags",
         "manual",
     ],
     version = "1.3.2",

--- a/third_party/cargo/remote/BUILD.block-buffer-0.10.2.bazel
+++ b/third_party/cargo/remote/BUILD.block-buffer-0.10.2.bazel
@@ -32,23 +32,26 @@ licenses([
 # Generated Targets
 
 rust_library(
-    name = "version_check",
+    name = "block_buffer",
     srcs = glob(["**/*.rs"]),
     crate_features = [
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=version_check",
+        "crate-name=block-buffer",
         "manual",
     ],
-    version = "0.9.3",
+    version = "0.10.2",
     # buildifier: leave-alone
     deps = [
+        "@raze__generic_array__0_14_5//:generic_array",
     ],
 )
+
+# Unsupported target "mod" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.byteorder-1.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.byteorder-1.4.3.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=byteorder",
         "manual",
     ],
     version = "1.4.3",

--- a/third_party/cargo/remote/BUILD.cc-1.0.71.bazel
+++ b/third_party/cargo/remote/BUILD.cc-1.0.71.bazel
@@ -46,6 +46,7 @@ rust_binary(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=gcc-shim",
         "manual",
     ],
     version = "1.0.71",
@@ -68,6 +69,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=cc",
         "manual",
     ],
     version = "1.0.71",

--- a/third_party/cargo/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-if-0.1.10.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=cfg-if",
         "manual",
     ],
     version = "0.1.10",

--- a/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/third_party/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=cfg-if",
         "manual",
     ],
     version = "1.0.0",

--- a/third_party/cargo/remote/BUILD.clap-2.33.3.bazel
+++ b/third_party/cargo/remote/BUILD.clap-2.33.3.bazel
@@ -53,6 +53,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=clap",
         "manual",
     ],
     version = "2.33.3",

--- a/third_party/cargo/remote/BUILD.console-0.15.0.bazel
+++ b/third_party/cargo/remote/BUILD.console-0.15.0.bazel
@@ -52,6 +52,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=console",
         "manual",
     ],
     version = "0.15.0",

--- a/third_party/cargo/remote/BUILD.cpufeatures-0.2.1.bazel
+++ b/third_party/cargo/remote/BUILD.cpufeatures-0.2.1.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=cpufeatures",
         "manual",
     ],
     version = "0.2.1",

--- a/third_party/cargo/remote/BUILD.crc32fast-1.3.2.bazel
+++ b/third_party/cargo/remote/BUILD.crc32fast-1.3.2.bazel
@@ -30,15 +30,25 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
 
-rust_library(
-    name = "block_buffer",
+cargo_build_script(
+    name = "crc32fast_build_script",
     srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
     crate_features = [
+        "default",
+        "std",
     ],
-    crate_root = "src/lib.rs",
-    data = [],
-    edition = "2018",
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
     rustc_flags = [
         "--cap-lints=allow",
     ],
@@ -46,11 +56,36 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "0.10.0",
-    # buildifier: leave-alone
+    version = "1.3.2",
+    visibility = ["//visibility:private"],
     deps = [
-        "@raze__generic_array__0_14_5//:generic_array",
     ],
 )
 
-# Unsupported target "mod" with type "test" omitted
+# Unsupported target "bench" with type "bench" omitted
+
+rust_library(
+    name = "crc32fast",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "std",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=crc32fast",
+        "manual",
+    ],
+    version = "1.3.2",
+    # buildifier: leave-alone
+    deps = [
+        ":crc32fast_build_script",
+        "@raze__cfg_if__1_0_0//:cfg_if",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.crypto-common-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.crypto-common-0.1.2.bazel
@@ -26,38 +26,31 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
 ])
 
 # Generated Targets
 
-# Unsupported target "integers" with type "example" omitted
-
-# Unsupported target "paths" with type "example" omitted
-
-# Unsupported target "traits" with type "example" omitted
-
-# Unsupported target "versions" with type "example" omitted
-
 rust_library(
-    name = "autocfg",
+    name = "crypto_common",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
+        "crate-name=crypto-common",
         "manual",
     ],
-    version = "1.0.1",
+    version = "0.1.2",
     # buildifier: leave-alone
     deps = [
+        "@raze__generic_array__0_14_5//:generic_array",
     ],
 )
-
-# Unsupported target "rustflags" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.derivative-2.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.derivative-2.2.0.bazel
@@ -45,6 +45,7 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=derivative",
         "manual",
     ],
     version = "2.2.0",

--- a/third_party/cargo/remote/BUILD.derive_more-0.14.1.bazel
+++ b/third_party/cargo/remote/BUILD.derive_more-0.14.1.bazel
@@ -44,6 +44,7 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=derive_more",
         "manual",
     ],
     version = "0.14.1",

--- a/third_party/cargo/remote/BUILD.deser-hjson-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.deser-hjson-1.0.2.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=deser-hjson",
         "manual",
     ],
     version = "1.0.2",

--- a/third_party/cargo/remote/BUILD.digest-0.10.2.bazel
+++ b/third_party/cargo/remote/BUILD.digest-0.10.2.bazel
@@ -32,23 +32,30 @@ licenses([
 # Generated Targets
 
 rust_library(
-    name = "version_check",
+    name = "digest",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "alloc",
+        "block-buffer",
+        "core-api",
+        "default",
+        "std",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=version_check",
+        "crate-name=digest",
         "manual",
     ],
-    version = "0.9.3",
+    version = "0.10.2",
     # buildifier: leave-alone
     deps = [
+        "@raze__block_buffer__0_10_2//:block_buffer",
+        "@raze__crypto_common__0_1_2//:crypto_common",
     ],
 )

--- a/third_party/cargo/remote/BUILD.directories-4.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.directories-4.0.1.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=directories",
         "manual",
     ],
     version = "4.0.1",

--- a/third_party/cargo/remote/BUILD.dirs-sys-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.dirs-sys-0.3.6.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=dirs-sys",
         "manual",
     ],
     version = "0.3.6",

--- a/third_party/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
+++ b/third_party/cargo/remote/BUILD.encode_unicode-0.3.6.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=encode_unicode",
         "manual",
     ],
     version = "0.3.6",

--- a/third_party/cargo/remote/BUILD.env_logger-0.8.4.bazel
+++ b/third_party/cargo/remote/BUILD.env_logger-0.8.4.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=env_logger",
         "manual",
     ],
     version = "0.8.4",

--- a/third_party/cargo/remote/BUILD.erased-serde-0.3.16.bazel
+++ b/third_party/cargo/remote/BUILD.erased-serde-0.3.16.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=erased-serde",
         "manual",
     ],
     version = "0.3.16",

--- a/third_party/cargo/remote/BUILD.flate2-1.0.22.bazel
+++ b/third_party/cargo/remote/BUILD.flate2-1.0.22.bazel
@@ -1,0 +1,117 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "compress_file" with type "example" omitted
+
+# Unsupported target "deflatedecoder-bufread" with type "example" omitted
+
+# Unsupported target "deflatedecoder-read" with type "example" omitted
+
+# Unsupported target "deflatedecoder-write" with type "example" omitted
+
+# Unsupported target "deflateencoder-bufread" with type "example" omitted
+
+# Unsupported target "deflateencoder-read" with type "example" omitted
+
+# Unsupported target "deflateencoder-write" with type "example" omitted
+
+# Unsupported target "gzbuilder" with type "example" omitted
+
+# Unsupported target "gzdecoder-bufread" with type "example" omitted
+
+# Unsupported target "gzdecoder-read" with type "example" omitted
+
+# Unsupported target "gzdecoder-write" with type "example" omitted
+
+# Unsupported target "gzencoder-bufread" with type "example" omitted
+
+# Unsupported target "gzencoder-read" with type "example" omitted
+
+# Unsupported target "gzencoder-write" with type "example" omitted
+
+# Unsupported target "gzmultidecoder-bufread" with type "example" omitted
+
+# Unsupported target "gzmultidecoder-read" with type "example" omitted
+
+# Unsupported target "zlibdecoder-bufread" with type "example" omitted
+
+# Unsupported target "zlibdecoder-read" with type "example" omitted
+
+# Unsupported target "zlibdecoder-write" with type "example" omitted
+
+# Unsupported target "zlibencoder-bufread" with type "example" omitted
+
+# Unsupported target "zlibencoder-read" with type "example" omitted
+
+# Unsupported target "zlibencoder-write" with type "example" omitted
+
+rust_library(
+    name = "flate2",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+        "default",
+        "miniz_oxide",
+        "rust_backend",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=flate2",
+        "manual",
+    ],
+    version = "1.0.22",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__cfg_if__1_0_0//:cfg_if",
+        "@raze__crc32fast__1_3_2//:crc32fast",
+        "@raze__libc__0_2_107//:libc",
+        "@raze__miniz_oxide__0_4_4//:miniz_oxide",
+    ],
+)
+
+# Unsupported target "async-reader" with type "test" omitted
+
+# Unsupported target "early-flush" with type "test" omitted
+
+# Unsupported target "empty-read" with type "test" omitted
+
+# Unsupported target "gunzip" with type "test" omitted
+
+# Unsupported target "tokio" with type "test" omitted
+
+# Unsupported target "zero-write" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.generic-array-0.14.5.bazel
+++ b/third_party/cargo/remote/BUILD.generic-array-0.14.5.bazel
@@ -43,6 +43,7 @@ cargo_build_script(
     build_script_env = {
     },
     crate_features = [
+        "more_lengths",
     ],
     crate_root = "build.rs",
     data = glob(["**"]),
@@ -65,6 +66,7 @@ rust_library(
     name = "generic_array",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "more_lengths",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -74,6 +76,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=generic_array",
         "manual",
     ],
     version = "0.14.5",

--- a/third_party/cargo/remote/BUILD.getrandom-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.getrandom-0.2.3.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=getrandom",
         "manual",
     ],
     version = "0.2.3",

--- a/third_party/cargo/remote/BUILD.heck-0.3.3.bazel
+++ b/third_party/cargo/remote/BUILD.heck-0.3.3.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=heck",
         "manual",
     ],
     version = "0.3.3",

--- a/third_party/cargo/remote/BUILD.hermit-abi-0.1.19.bazel
+++ b/third_party/cargo/remote/BUILD.hermit-abi-0.1.19.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=hermit-abi",
         "manual",
     ],
     version = "0.1.19",

--- a/third_party/cargo/remote/BUILD.hex-0.4.3.bazel
+++ b/third_party/cargo/remote/BUILD.hex-0.4.3.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=hex",
         "manual",
     ],
     version = "0.4.3",

--- a/third_party/cargo/remote/BUILD.humantime-2.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.humantime-2.1.0.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=humantime",
         "manual",
     ],
     version = "2.1.0",

--- a/third_party/cargo/remote/BUILD.indicatif-0.16.2.bazel
+++ b/third_party/cargo/remote/BUILD.indicatif-0.16.2.bazel
@@ -79,6 +79,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=indicatif",
         "manual",
     ],
     version = "0.16.2",

--- a/third_party/cargo/remote/BUILD.itoa-0.4.8.bazel
+++ b/third_party/cargo/remote/BUILD.itoa-0.4.8.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=itoa",
         "manual",
     ],
     version = "0.4.8",

--- a/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.lazy_static-1.4.0.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=lazy_static",
         "manual",
     ],
     version = "1.4.0",

--- a/third_party/cargo/remote/BUILD.libc-0.2.107.bazel
+++ b/third_party/cargo/remote/BUILD.libc-0.2.107.bazel
@@ -81,6 +81,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=libc",
         "manual",
     ],
     version = "0.2.107",

--- a/third_party/cargo/remote/BUILD.libftdi1-sys-1.1.1.bazel
+++ b/third_party/cargo/remote/BUILD.libftdi1-sys-1.1.1.bazel
@@ -91,6 +91,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=libftdi1-sys",
         "manual",
     ],
     version = "1.1.1",

--- a/third_party/cargo/remote/BUILD.libm-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.libm-0.2.2.bazel
@@ -30,11 +30,42 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
+
+cargo_build_script(
+    name = "libm_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.2.2",
+    visibility = ["//visibility:private"],
+    deps = [
+    ],
+)
 
 rust_library(
-    name = "rand_hc",
+    name = "libm",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "default",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -44,11 +75,12 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=libm",
         "manual",
     ],
-    version = "0.3.1",
+    version = "0.2.2",
     # buildifier: leave-alone
     deps = [
-        "@raze__rand_core__0_6_3//:rand_core",
+        ":libm_build_script",
     ],
 )

--- a/third_party/cargo/remote/BUILD.libudev-0.2.0.bazel
+++ b/third_party/cargo/remote/BUILD.libudev-0.2.0.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=libudev",
         "manual",
     ],
     version = "0.2.0",

--- a/third_party/cargo/remote/BUILD.libudev-sys-0.1.4.bazel
+++ b/third_party/cargo/remote/BUILD.libudev-sys-0.1.4.bazel
@@ -81,6 +81,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=libudev-sys",
         "manual",
     ],
     version = "0.1.4",

--- a/third_party/cargo/remote/BUILD.libusb1-sys-0.5.0.bazel
+++ b/third_party/cargo/remote/BUILD.libusb1-sys-0.5.0.bazel
@@ -76,6 +76,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=libusb1-sys",
         "manual",
     ],
     version = "0.5.0",

--- a/third_party/cargo/remote/BUILD.log-0.4.14.bazel
+++ b/third_party/cargo/remote/BUILD.log-0.4.14.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=log",
         "manual",
     ],
     version = "0.4.14",

--- a/third_party/cargo/remote/BUILD.mach-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.mach-0.1.2.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=mach",
         "manual",
     ],
     version = "0.1.2",

--- a/third_party/cargo/remote/BUILD.mach-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.mach-0.2.3.bazel
@@ -49,6 +49,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=mach",
         "manual",
     ],
     version = "0.2.3",

--- a/third_party/cargo/remote/BUILD.memchr-2.4.1.bazel
+++ b/third_party/cargo/remote/BUILD.memchr-2.4.1.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=memchr",
         "manual",
     ],
     version = "2.4.1",

--- a/third_party/cargo/remote/BUILD.memoffset-0.6.5.bazel
+++ b/third_party/cargo/remote/BUILD.memoffset-0.6.5.bazel
@@ -26,23 +26,47 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # Apache-2.0 from expression "Apache-2.0 OR MIT"
+    "notice",  # MIT from expression "MIT"
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
+# buildifier: disable=load-on-top
+load(
+    "@rules_rust//cargo:cargo_build_script.bzl",
+    "cargo_build_script",
+)
 
-# Unsupported target "integers" with type "example" omitted
-
-# Unsupported target "paths" with type "example" omitted
-
-# Unsupported target "traits" with type "example" omitted
-
-# Unsupported target "versions" with type "example" omitted
+cargo_build_script(
+    name = "memoffset_build_script",
+    srcs = glob(["**/*.rs"]),
+    build_script_env = {
+    },
+    crate_features = [
+        "default",
+    ],
+    crate_root = "build.rs",
+    data = glob(["**"]),
+    edition = "2015",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+    version = "0.6.5",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@raze__autocfg__1_1_0//:autocfg",
+    ],
+)
 
 rust_library(
-    name = "autocfg",
+    name = "memoffset",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "default",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -52,12 +76,12 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=memoffset",
         "manual",
     ],
-    version = "0.1.7",
+    version = "0.6.5",
     # buildifier: leave-alone
     deps = [
+        ":memoffset_build_script",
     ],
 )
-
-# Unsupported target "rustflags" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.miniz_oxide-0.4.4.bazel
+++ b/third_party/cargo/remote/BUILD.miniz_oxide-0.4.4.bazel
@@ -26,7 +26,7 @@ package(default_visibility = [
 ])
 
 licenses([
-    "notice",  # MIT from expression "MIT OR Apache-2.0"
+    "notice",  # MIT from expression "MIT OR (Zlib OR Apache-2.0)"
 ])
 
 # Generated Targets
@@ -38,12 +38,11 @@ load(
 )
 
 cargo_build_script(
-    name = "libm_build_script",
+    name = "miniz_oxide_build_script",
     srcs = glob(["**/*.rs"]),
     build_script_env = {
     },
     crate_features = [
-        "default",
     ],
     crate_root = "build.rs",
     data = glob(["**"]),
@@ -55,17 +54,17 @@ cargo_build_script(
         "cargo-raze",
         "manual",
     ],
-    version = "0.2.1",
+    version = "0.4.4",
     visibility = ["//visibility:private"],
     deps = [
+        "@raze__autocfg__1_1_0//:autocfg",
     ],
 )
 
 rust_library(
-    name = "libm",
+    name = "miniz_oxide",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "default",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -75,11 +74,13 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=miniz_oxide",
         "manual",
     ],
-    version = "0.2.1",
+    version = "0.4.4",
     # buildifier: leave-alone
     deps = [
-        ":libm_build_script",
+        ":miniz_oxide_build_script",
+        "@raze__adler__1_0_2//:adler",
     ],
 )

--- a/third_party/cargo/remote/BUILD.nix-0.16.1.bazel
+++ b/third_party/cargo/remote/BUILD.nix-0.16.1.bazel
@@ -73,6 +73,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=nix",
         "manual",
     ],
     version = "0.16.1",

--- a/third_party/cargo/remote/BUILD.nix-0.17.0.bazel
+++ b/third_party/cargo/remote/BUILD.nix-0.17.0.bazel
@@ -73,6 +73,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=nix",
         "manual",
     ],
     version = "0.17.0",

--- a/third_party/cargo/remote/BUILD.num-bigint-dig-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.num-bigint-dig-0.7.0.bazel
@@ -63,7 +63,7 @@ cargo_build_script(
     version = "0.7.0",
     visibility = ["//visibility:private"],
     deps = [
-        "@raze__autocfg__0_1_7//:autocfg",
+        "@raze__autocfg__0_1_8//:autocfg",
     ],
 )
 
@@ -86,6 +86,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=num-bigint-dig",
         "manual",
     ],
     version = "0.7.0",
@@ -94,11 +95,11 @@ rust_library(
         ":num_bigint_dig_build_script",
         "@raze__byteorder__1_4_3//:byteorder",
         "@raze__lazy_static__1_4_0//:lazy_static",
-        "@raze__libm__0_2_1//:libm",
+        "@raze__libm__0_2_2//:libm",
         "@raze__num_integer__0_1_44//:num_integer",
         "@raze__num_iter__0_1_42//:num_iter",
         "@raze__num_traits__0_2_14//:num_traits",
-        "@raze__rand__0_8_4//:rand",
+        "@raze__rand__0_8_5//:rand",
         "@raze__serde__1_0_130//:serde",
         "@raze__smallvec__1_8_0//:smallvec",
     ],

--- a/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/third_party/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -59,7 +59,7 @@ cargo_build_script(
     version = "0.1.44",
     visibility = ["//visibility:private"],
     deps = [
-        "@raze__autocfg__1_0_1//:autocfg",
+        "@raze__autocfg__1_1_0//:autocfg",
     ],
 )
 
@@ -84,6 +84,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=num-integer",
         "manual",
     ],
     version = "0.1.44",

--- a/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
+++ b/third_party/cargo/remote/BUILD.num-iter-0.1.42.bazel
@@ -57,7 +57,7 @@ cargo_build_script(
     version = "0.1.42",
     visibility = ["//visibility:private"],
     deps = [
-        "@raze__autocfg__1_0_1//:autocfg",
+        "@raze__autocfg__1_1_0//:autocfg",
     ],
 )
 
@@ -74,6 +74,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=num-iter",
         "manual",
     ],
     version = "0.1.42",

--- a/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/third_party/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -60,7 +60,7 @@ cargo_build_script(
     version = "0.2.14",
     visibility = ["//visibility:private"],
     deps = [
-        "@raze__autocfg__1_0_1//:autocfg",
+        "@raze__autocfg__1_1_0//:autocfg",
     ],
 )
 
@@ -80,6 +80,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=num-traits",
         "manual",
     ],
     version = "0.2.14",

--- a/third_party/cargo/remote/BUILD.num_enum-0.5.4.bazel
+++ b/third_party/cargo/remote/BUILD.num_enum-0.5.4.bazel
@@ -50,6 +50,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=num_enum",
         "manual",
     ],
     version = "0.5.4",

--- a/third_party/cargo/remote/BUILD.num_enum_derive-0.5.4.bazel
+++ b/third_party/cargo/remote/BUILD.num_enum_derive-0.5.4.bazel
@@ -46,6 +46,7 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=num_enum_derive",
         "manual",
     ],
     version = "0.5.4",

--- a/third_party/cargo/remote/BUILD.number_prefix-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.number_prefix-0.4.0.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=number_prefix",
         "manual",
     ],
     version = "0.4.0",

--- a/third_party/cargo/remote/BUILD.object-0.25.3.bazel
+++ b/third_party/cargo/remote/BUILD.object-0.25.3.bazel
@@ -31,10 +31,36 @@ licenses([
 
 # Generated Targets
 
-rust_proc_macro(
-    name = "structopt_derive",
+# Unsupported target "ar" with type "example" omitted
+
+# Unsupported target "dyldcachedump" with type "example" omitted
+
+# Unsupported target "nm" with type "example" omitted
+
+# Unsupported target "objcopy" with type "example" omitted
+
+# Unsupported target "objdump" with type "example" omitted
+
+# Unsupported target "objectmap" with type "example" omitted
+
+# Unsupported target "readobj" with type "example" omitted
+
+rust_library(
+    name = "object",
     srcs = glob(["**/*.rs"]),
     crate_features = [
+        "archive",
+        "coff",
+        "compression",
+        "default",
+        "elf",
+        "flate2",
+        "macho",
+        "pe",
+        "read",
+        "read_core",
+        "std",
+        "unaligned",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -44,16 +70,17 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=structopt-derive",
+        "crate-name=object",
         "manual",
     ],
-    version = "0.4.18",
+    version = "0.25.3",
     # buildifier: leave-alone
     deps = [
-        "@raze__heck__0_3_3//:heck",
-        "@raze__proc_macro2__1_0_32//:proc_macro2",
-        "@raze__proc_macro_error__1_0_4//:proc_macro_error",
-        "@raze__quote__1_0_10//:quote",
-        "@raze__syn__1_0_81//:syn",
+        "@raze__flate2__1_0_22//:flate2",
+        "@raze__memchr__2_4_1//:memchr",
     ],
 )
+
+# Unsupported target "integration" with type "test" omitted
+
+# Unsupported target "parse_self" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.once_cell-1.8.0.bazel
+++ b/third_party/cargo/remote/BUILD.once_cell-1.8.0.bazel
@@ -62,6 +62,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=once_cell",
         "manual",
     ],
     version = "1.8.0",

--- a/third_party/cargo/remote/BUILD.pkg-config-0.3.22.bazel
+++ b/third_party/cargo/remote/BUILD.pkg-config-0.3.22.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=pkg-config",
         "manual",
     ],
     version = "0.3.22",

--- a/third_party/cargo/remote/BUILD.ppv-lite86-0.2.16.bazel
+++ b/third_party/cargo/remote/BUILD.ppv-lite86-0.2.16.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=ppv-lite86",
         "manual",
     ],
     version = "0.2.16",

--- a/third_party/cargo/remote/BUILD.proc-macro-crate-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-crate-1.1.0.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=proc-macro-crate",
         "manual",
     ],
     version = "1.1.0",

--- a/third_party/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -83,6 +83,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=proc-macro-error",
         "manual",
     ],
     version = "1.0.4",

--- a/third_party/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -74,6 +74,7 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=proc-macro-error-attr",
         "manual",
     ],
     version = "1.0.4",

--- a/third_party/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro2-0.4.30.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=proc-macro2",
         "manual",
     ],
     version = "0.4.30",

--- a/third_party/cargo/remote/BUILD.proc-macro2-1.0.32.bazel
+++ b/third_party/cargo/remote/BUILD.proc-macro2-1.0.32.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=proc-macro2",
         "manual",
     ],
     version = "1.0.32",

--- a/third_party/cargo/remote/BUILD.quote-0.6.13.bazel
+++ b/third_party/cargo/remote/BUILD.quote-0.6.13.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=quote",
         "manual",
     ],
     version = "0.6.13",

--- a/third_party/cargo/remote/BUILD.quote-1.0.10.bazel
+++ b/third_party/cargo/remote/BUILD.quote-1.0.10.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=quote",
         "manual",
     ],
     version = "1.0.10",

--- a/third_party/cargo/remote/BUILD.rand-0.8.5.bazel
+++ b/third_party/cargo/remote/BUILD.rand-0.8.5.bazel
@@ -32,23 +32,42 @@ licenses([
 # Generated Targets
 
 rust_library(
-    name = "version_check",
+    name = "rand",
     srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
     crate_features = [
+        "alloc",
+        "default",
+        "getrandom",
+        "libc",
+        "rand_chacha",
+        "std",
+        "std_rng",
     ],
     crate_root = "src/lib.rs",
     data = [],
-    edition = "2015",
+    edition = "2018",
     rustc_flags = [
         "--cap-lints=allow",
     ],
     tags = [
         "cargo-raze",
-        "crate-name=version_check",
+        "crate-name=rand",
         "manual",
     ],
-    version = "0.9.3",
+    version = "0.8.5",
     # buildifier: leave-alone
     deps = [
-    ],
+        "@raze__rand_chacha__0_3_1//:rand_chacha",
+        "@raze__rand_core__0_6_3//:rand_core",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_107//:libc",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/third_party/cargo/remote/BUILD.rand_chacha-0.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.rand_chacha-0.3.1.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=rand_chacha",
         "manual",
     ],
     version = "0.3.1",

--- a/third_party/cargo/remote/BUILD.rand_core-0.6.3.bazel
+++ b/third_party/cargo/remote/BUILD.rand_core-0.6.3.bazel
@@ -47,6 +47,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=rand_core",
         "manual",
     ],
     version = "0.6.3",

--- a/third_party/cargo/remote/BUILD.raw_tty-0.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.raw_tty-0.1.0.bazel
@@ -47,6 +47,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=raw_tty",
         "manual",
     ],
     version = "0.1.0",

--- a/third_party/cargo/remote/BUILD.redox_syscall-0.2.10.bazel
+++ b/third_party/cargo/remote/BUILD.redox_syscall-0.2.10.bazel
@@ -53,6 +53,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=syscall",
         "manual",
     ],
     version = "0.2.10",

--- a/third_party/cargo/remote/BUILD.redox_users-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.redox_users-0.4.0.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=redox_users",
         "manual",
     ],
     version = "0.4.0",

--- a/third_party/cargo/remote/BUILD.regex-1.5.4.bazel
+++ b/third_party/cargo/remote/BUILD.regex-1.5.4.bazel
@@ -73,6 +73,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=regex",
         "manual",
     ],
     version = "1.5.4",

--- a/third_party/cargo/remote/BUILD.regex-syntax-0.6.25.bazel
+++ b/third_party/cargo/remote/BUILD.regex-syntax-0.6.25.bazel
@@ -55,6 +55,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=regex-syntax",
         "manual",
     ],
     version = "0.6.25",

--- a/third_party/cargo/remote/BUILD.rusb-0.8.1.bazel
+++ b/third_party/cargo/remote/BUILD.rusb-0.8.1.bazel
@@ -82,6 +82,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=rusb",
         "manual",
     ],
     version = "0.8.1",

--- a/third_party/cargo/remote/BUILD.rustc_version-0.2.3.bazel
+++ b/third_party/cargo/remote/BUILD.rustc_version-0.2.3.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=rustc_version",
         "manual",
     ],
     version = "0.2.3",

--- a/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
+++ b/third_party/cargo/remote/BUILD.ryu-1.0.5.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=ryu",
         "manual",
     ],
     version = "1.0.5",

--- a/third_party/cargo/remote/BUILD.safe-ftdi-0.3.0.bazel
+++ b/third_party/cargo/remote/BUILD.safe-ftdi-0.3.0.bazel
@@ -47,6 +47,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=safe-ftdi",
         "manual",
     ],
     version = "0.3.0",

--- a/third_party/cargo/remote/BUILD.semver-0.9.0.bazel
+++ b/third_party/cargo/remote/BUILD.semver-0.9.0.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=semver",
         "manual",
     ],
     version = "0.9.0",

--- a/third_party/cargo/remote/BUILD.semver-parser-0.7.0.bazel
+++ b/third_party/cargo/remote/BUILD.semver-parser-0.7.0.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=semver-parser",
         "manual",
     ],
     version = "0.7.0",

--- a/third_party/cargo/remote/BUILD.serde-1.0.130.bazel
+++ b/third_party/cargo/remote/BUILD.serde-1.0.130.bazel
@@ -84,6 +84,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=serde",
         "manual",
     ],
     version = "1.0.130",

--- a/third_party/cargo/remote/BUILD.serde_derive-1.0.130.bazel
+++ b/third_party/cargo/remote/BUILD.serde_derive-1.0.130.bazel
@@ -75,6 +75,7 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=serde_derive",
         "manual",
     ],
     version = "1.0.130",

--- a/third_party/cargo/remote/BUILD.serde_json-1.0.69.bazel
+++ b/third_party/cargo/remote/BUILD.serde_json-1.0.69.bazel
@@ -77,6 +77,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=serde_json",
         "manual",
     ],
     version = "1.0.69",

--- a/third_party/cargo/remote/BUILD.serialport-4.0.1.bazel
+++ b/third_party/cargo/remote/BUILD.serialport-4.0.1.bazel
@@ -64,6 +64,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=serialport",
         "manual",
     ],
     version = "4.0.1",

--- a/third_party/cargo/remote/BUILD.sha2-0.10.1.bazel
+++ b/third_party/cargo/remote/BUILD.sha2-0.10.1.bazel
@@ -50,13 +50,14 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=sha2",
         "manual",
     ],
     version = "0.10.1",
     # buildifier: leave-alone
     deps = [
         "@raze__cfg_if__1_0_0//:cfg_if",
-        "@raze__digest__0_10_1//:digest",
+        "@raze__digest__0_10_2//:digest",
     ] + selects.with_or({
         # cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))
         (

--- a/third_party/cargo/remote/BUILD.shellwords-1.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.shellwords-1.1.0.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=shellwords",
         "manual",
     ],
     version = "1.1.0",

--- a/third_party/cargo/remote/BUILD.smallvec-1.8.0.bazel
+++ b/third_party/cargo/remote/BUILD.smallvec-1.8.0.bazel
@@ -47,6 +47,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=smallvec",
         "manual",
     ],
     version = "1.8.0",

--- a/third_party/cargo/remote/BUILD.spin-0.5.2.bazel
+++ b/third_party/cargo/remote/BUILD.spin-0.5.2.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=spin",
         "manual",
     ],
     version = "0.5.2",

--- a/third_party/cargo/remote/BUILD.strsim-0.8.0.bazel
+++ b/third_party/cargo/remote/BUILD.strsim-0.8.0.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=strsim",
         "manual",
     ],
     version = "0.8.0",

--- a/third_party/cargo/remote/BUILD.structopt-0.3.25.bazel
+++ b/third_party/cargo/remote/BUILD.structopt-0.3.25.bazel
@@ -92,6 +92,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=structopt",
         "manual",
     ],
     version = "0.3.25",

--- a/third_party/cargo/remote/BUILD.syn-0.15.44.bazel
+++ b/third_party/cargo/remote/BUILD.syn-0.15.44.bazel
@@ -89,6 +89,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=syn",
         "manual",
     ],
     version = "0.15.44",

--- a/third_party/cargo/remote/BUILD.syn-1.0.81.bazel
+++ b/third_party/cargo/remote/BUILD.syn-1.0.81.bazel
@@ -97,6 +97,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=syn",
         "manual",
     ],
     version = "1.0.81",

--- a/third_party/cargo/remote/BUILD.synstructure-0.12.6.bazel
+++ b/third_party/cargo/remote/BUILD.synstructure-0.12.6.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=synstructure",
         "manual",
     ],
     version = "0.12.6",

--- a/third_party/cargo/remote/BUILD.termcolor-1.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.termcolor-1.1.2.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=termcolor",
         "manual",
     ],
     version = "1.1.2",

--- a/third_party/cargo/remote/BUILD.terminal_size-0.1.17.bazel
+++ b/third_party/cargo/remote/BUILD.terminal_size-0.1.17.bazel
@@ -48,6 +48,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=terminal_size",
         "manual",
     ],
     version = "0.1.17",

--- a/third_party/cargo/remote/BUILD.textwrap-0.11.0.bazel
+++ b/third_party/cargo/remote/BUILD.textwrap-0.11.0.bazel
@@ -50,6 +50,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=textwrap",
         "manual",
     ],
     version = "0.11.0",

--- a/third_party/cargo/remote/BUILD.thiserror-1.0.30.bazel
+++ b/third_party/cargo/remote/BUILD.thiserror-1.0.30.bazel
@@ -47,6 +47,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=thiserror",
         "manual",
     ],
     version = "1.0.30",

--- a/third_party/cargo/remote/BUILD.thiserror-impl-1.0.30.bazel
+++ b/third_party/cargo/remote/BUILD.thiserror-impl-1.0.30.bazel
@@ -44,6 +44,7 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=thiserror-impl",
         "manual",
     ],
     version = "1.0.30",

--- a/third_party/cargo/remote/BUILD.toml-0.5.8.bazel
+++ b/third_party/cargo/remote/BUILD.toml-0.5.8.bazel
@@ -51,6 +51,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=toml",
         "manual",
     ],
     version = "0.5.8",

--- a/third_party/cargo/remote/BUILD.typenum-1.15.0.bazel
+++ b/third_party/cargo/remote/BUILD.typenum-1.15.0.bazel
@@ -73,6 +73,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=typenum",
         "manual",
     ],
     version = "1.15.0",

--- a/third_party/cargo/remote/BUILD.unicode-segmentation-1.8.0.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-segmentation-1.8.0.bazel
@@ -50,6 +50,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=unicode-segmentation",
         "manual",
     ],
     version = "1.8.0",

--- a/third_party/cargo/remote/BUILD.unicode-width-0.1.9.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-width-0.1.9.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=unicode-width",
         "manual",
     ],
     version = "0.1.9",

--- a/third_party/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-xid-0.1.0.bazel
@@ -45,6 +45,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=unicode-xid",
         "manual",
     ],
     version = "0.1.0",

--- a/third_party/cargo/remote/BUILD.unicode-xid-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.unicode-xid-0.2.2.bazel
@@ -47,6 +47,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=unicode-xid",
         "manual",
     ],
     version = "0.2.2",

--- a/third_party/cargo/remote/BUILD.vcpkg-0.2.15.bazel
+++ b/third_party/cargo/remote/BUILD.vcpkg-0.2.15.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=vcpkg",
         "manual",
     ],
     version = "0.2.15",

--- a/third_party/cargo/remote/BUILD.vec_map-0.8.2.bazel
+++ b/third_party/cargo/remote/BUILD.vec_map-0.8.2.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=vec_map",
         "manual",
     ],
     version = "0.8.2",

--- a/third_party/cargo/remote/BUILD.void-1.0.2.bazel
+++ b/third_party/cargo/remote/BUILD.void-1.0.2.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=void",
         "manual",
     ],
     version = "1.0.2",

--- a/third_party/cargo/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
+++ b/third_party/cargo/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
@@ -46,6 +46,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=wasi",
         "manual",
     ],
     version = "0.10.2+wasi-snapshot-preview1",

--- a/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -115,6 +115,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=winapi",
         "manual",
     ],
     version = "0.3.9",

--- a/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -73,6 +73,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=winapi-i686-pc-windows-gnu",
         "manual",
     ],
     version = "0.4.0",

--- a/third_party/cargo/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-util-0.1.5.bazel
@@ -44,6 +44,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=winapi-util",
         "manual",
     ],
     version = "0.1.5",

--- a/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -73,6 +73,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=winapi-x86_64-pc-windows-gnu",
         "manual",
     ],
     version = "0.4.0",

--- a/third_party/cargo/remote/BUILD.zerocopy-0.5.0.bazel
+++ b/third_party/cargo/remote/BUILD.zerocopy-0.5.0.bazel
@@ -47,6 +47,7 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=zerocopy",
         "manual",
     ],
     version = "0.5.0",

--- a/third_party/cargo/remote/BUILD.zerocopy-derive-0.3.1.bazel
+++ b/third_party/cargo/remote/BUILD.zerocopy-derive-0.3.1.bazel
@@ -44,6 +44,7 @@ rust_proc_macro(
     ],
     tags = [
         "cargo-raze",
+        "crate-name=zerocopy-derive",
         "manual",
     ],
     version = "0.3.1",


### PR DESCRIPTION
To facilitate mask ROM E2E testing, test binaries must be signed in order to be runnable via the mask ROM. To add signing support to bazel for test images, the `rom_ext_signer` tool must be brought under bazel control.

To enable the above, this commit integrates the `rom_ext_image_tools` into the `sw/host` cargo workspace, and re-runs `cargo raze` to generate the appropriate bazel BUILD files for the `rom_ext_image_tools` Rust dependencies.

This addresses a task in #10864.

**_Note: this depends on #10877, and therefore contains an additionally commit that will be removed when the dependency merges._**

Additionally, I apologize for the size this PR, unfortunately it is the direct result of re-running `cargo raze` to autogen the bazel BUILD files for the rust crates that are dependencies in the `sw/host` cargo workspace. Re-running `cargo raze` seemed to update almost every build file for the rust crates in `sw/host`.