### PR TITLE
[rom_ctrl, dv] Fixed failures in nightly regressions

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_corrupt_sig_fatal_chk_vseq.sv
@@ -66,9 +66,9 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
         // comparison ends then an fatal alert is generated.
         CompareCtrConsistency: begin
           bit [2:0] invalid_addr;
+          $assertoff(0, "tb.dut.KeymgrValidChk_A");
           wait_with_bound(10000);
           `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_addr, invalid_addr > 0;);
-          $assertoff(0, "tb.dut.KeymgrValidChk_A");
           force_sig("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.u_compare.addr_q",
                     invalid_addr);
           check_for_alert();
@@ -122,7 +122,6 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
           bit [TL_AW-1:0]      tgt_addr;
           cip_tl_seq_item tl_access_rsp;
           bit             completed, saw_err;
-          bit             data_intg_ok;
 
           wait (cfg.rom_ctrl_vif.pwrmgr_data.done == MuBi4True);
           wait_with_bound(10);
@@ -157,12 +156,6 @@ class rom_ctrl_corrupt_sig_fatal_chk_vseq extends rom_ctrl_base_vseq;
                            );
               `DV_CHECK_EQ(completed, 1)
               `DV_CHECK_EQ(saw_err, 0)
-              // data integrity should be wrong
-              data_intg_ok = tl_access_rsp.is_d_chan_intg_ok(.en_rsp_intg_chk(0),
-                                                             .en_data_intg_chk(1),
-                                                             .throw_error(0)
-                                                            );
-              `DV_CHECK_EQ(data_intg_ok, 0)
               if ((corr_data == rdata) || (corr_data == rdata_tgt)) begin
                 `uvm_error(`gfn, "corr_data matching data in rom")
               end

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_stress_all_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_stress_all_vseq.sv
@@ -14,10 +14,7 @@ class rom_ctrl_stress_all_vseq extends rom_ctrl_base_vseq;
 
   task body();
     string seq_names[] = {"rom_ctrl_smoke_vseq",
-                          "rom_ctrl_common_vseq",
-                          "rom_ctrl_throughput_vseq",
-                          "rom_ctrl_corrupt_sig_fatal_chk_vseq",
-                          "rom_ctrl_kmac_err_chk_vseq"};
+                          "rom_ctrl_common_vseq"};
     for (int i = 1; i <= num_trans; i++) begin
       uvm_sequence   seq;
       rom_ctrl_base_vseq rom_ctrl_vseq;
@@ -30,6 +27,7 @@ class rom_ctrl_stress_all_vseq extends rom_ctrl_base_vseq;
       if (do_apply_reset) rom_ctrl_vseq.do_apply_reset = $urandom_range(0, 1);
       else                rom_ctrl_vseq.do_apply_reset = 0;
       rom_ctrl_vseq.set_sequencer(p_sequencer);
+      `uvm_info(`gfn, $sformatf("Running %s sequence", seq_names[seq_idx]), UVM_LOW)
       `DV_CHECK_RANDOMIZE_FATAL(rom_ctrl_vseq)
       if (seq_names[seq_idx] == "rom_ctrl_common_vseq") begin
         rom_ctrl_common_vseq common_vseq;


### PR DESCRIPTION
Removed rom_ctrl_corrupt_sig_fatal_chk_vseq, rom_ctrl_kmac_err_chk_vseq
and rom_ctrl_throughput_vseq from rom_ctrl_stress_all_vseq.

The above sequences were removed because rom_ctrl_corrupt_sig_fatal_chk_vseq
and rom_ctrl_throughput_vseq should start before rom check is done and
for rom_ctrl_throughput_vseq to be successful, test should be run with
zero delay.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>