### PR TITLE
[otbn, rtl] Remove bad assert

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -709,7 +709,6 @@ module otbn
                               otbn_imem_scramble_key_req_busy,
                               idle})
 
-  `ASSERT(OtbnSomeStatesExclusive, $onehot0({locked, busy_execute_q, idle}))
   `ASSERT(OtbnOnlyIdleIfNoActivity, idle |-> ~|{locked,
                                                 busy_execute_q,
                                                 otbn_dmem_scramble_key_req_busy,


### PR DESCRIPTION
locked and busy_execute_q can be asserted together, idle shouldn't be
asserted if either locked or busy_execute_q is asserted but that's
covered by another assertion.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>