### PR TITLE
[kmac] Rename LFSR Redundancy to PRNG.LFSR.REDUN

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -176,7 +176,7 @@
     { name: "FSM.SPARSE"
       desc: "FSMs in KMAC are sparsely encoded."
     }
-    { name: "LFSR.REDUN"
+    { name: "PRNG.LFSR.REDUN"
       desc: "LFSR in the entropy generator uses prim_double_lfsr"
     }
     { name: "CTR.REDUN"

--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -48,8 +48,8 @@
       tests: []
     }
     {
-      name: sec_cm_lfsr_redun
-      desc: "Verify the countermeasure(s) LFSR.REDUN."
+      name: sec_cm_prng_lfsr_redun
+      desc: "Verify the countermeasure(s) PRNG.LFSR.REDUN."
       milestone: V2S
       tests: []
     }

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -312,7 +312,7 @@ module kmac_entropy
   // We employ two redundant LFSRs to guard against FI attacks.
   // If any of the two is glitched and the two LFSR states do not agree,
   // KMAC reports the fatal error via alert interface.
-  // SEC_CM: LFSR.REDUN
+  // SEC_CM: PRNG.LFSR.REDUN
   prim_double_lfsr #(
     .LfsrDw(EntropyLfsrW),
     .EntropyDw(EntropyLfsrW),


### PR DESCRIPTION
As discussed in D2S review meeting, this commit changes the LFSR.REDUN
countermeasure name to PRNG.LFSR.REDUN.
