### PR TITLE
[kmac] Default LFSR seed to EDN

### DIFF
--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -299,14 +299,8 @@ module kmac_entropy
   // LFSR =====================================================================
   //// FSM controls the seed enable signal `lfsr_seed_en`.
   //// Seed selection
-  always_comb begin
-    unique case (mode_q)
-      EntropyModeNone: lfsr_seed = '0;
-      EntropyModeEdn:  lfsr_seed = entropy_data_i;
-      EntropyModeSw:   lfsr_seed = seed_data_i;
-      default:         lfsr_seed = '0;
-    endcase
-  end
+  //// Default value to entropy data_i
+  assign lfsr_seed = (mode_q == EntropyModeSw) ? seed_data_i : entropy_data_i ;
   `ASSERT_KNOWN(ModeKnown_A, mode_i)
 
   // We employ two redundant LFSRs to guard against FI attacks.


### PR DESCRIPTION
As discussed in D2S review meeting, LFSR seed value is now default to
EDN entropy to mistakenly use all zero seed.