### PR TITLE
[kmac] Add Random Constant for DefaultSeed

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -108,6 +108,12 @@
       desc:    "Width of the hash counter in the entropy"
       local:   "true"
     }
+    { name:      "RndCnstLfsrSeed"
+      desc:      "Compile-time random data for LFSR default seed"
+      type:      "kmac_pkg::lfsr_seed_t"
+      randcount: "64"
+      randtype:  "data"
+    }
     { name:      "RndCnstLfsrPerm",
       desc:      "Compile-time random permutation for LFSR output",
       type:      "kmac_pkg::lfsr_perm_t"

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -30,6 +30,7 @@ module kmac
   parameter bit SecIdleAcceptSwMsg = 1'b0,
 
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
+  parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter msg_perm_t  RndCnstMsgPerm  = RndCnstMsgPermDefault,
 
   parameter logic [NumAlerts-1:0] AlertAsyncOn = {NumAlerts{1'b1}}
@@ -1118,7 +1119,8 @@ module kmac
     );
 
     kmac_entropy #(
-     .RndCnstLfsrPerm(RndCnstLfsrPerm)
+     .RndCnstLfsrPerm(RndCnstLfsrPerm),
+     .RndCnstLfsrSeed(RndCnstLfsrSeed)
     ) u_entropy (
       .clk_i,
       .rst_ni,

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -8,7 +8,8 @@
 
 module kmac_entropy
   import kmac_pkg::*; #(
-  parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault
+  parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
+  parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault
 ) (
   input clk_i,
   input rst_ni,
@@ -319,6 +320,7 @@ module kmac_entropy
     .StateOutDw(EntropyLfsrW),
     .StatePermEn(1'b1),
     .StatePerm(RndCnstLfsrPerm),
+    .DefaultSeed(RndCnstLfsrSeed),
     .NonLinearOut(1'b1)
   ) u_lfsr (
     .clk_i,

--- a/hw/ip/kmac/rtl/kmac_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_pkg.sv
@@ -92,10 +92,12 @@ package kmac_pkg;
 
   // entropy lfsr related
   parameter int unsigned EntropyLfsrW = 64;
+  typedef logic [EntropyLfsrW-1:0] lfsr_seed_t;
   typedef logic [EntropyLfsrW-1:0][$clog2(EntropyLfsrW)-1:0] lfsr_perm_t;
+  parameter lfsr_seed_t RndCnstLfsrSeedDefault = 64'h47e808241ebaa563;
   parameter lfsr_perm_t RndCnstLfsrPermDefault = {
-    128'h810970222da1b1b1187551c3ff94574a,
-    256'h970d171aa41948cbe3a58167d3b47c268acfcbb2fa627b9c0a2fdf578f4ed32b
+    128'hc4ffd50080c2bba9a263211ef56f8d4b,
+    256'h9da89ed97481a32c5d9a4650abeb9388fcedcab36df411849df5c057473812d3
   };
 
   // These LFSR parameters have been generated with

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -5123,13 +5123,23 @@
           name_top: SecKmacIdleAcceptSwMsg
         }
         {
+          name: RndCnstLfsrSeed
+          desc: Compile-time random data for LFSR default seed
+          type: kmac_pkg::lfsr_seed_t
+          randcount: 64
+          randtype: data
+          name_top: RndCnstKmacLfsrSeed
+          default: 0x2e658548c5420be5
+          randwidth: 64
+        }
+        {
           name: RndCnstLfsrPerm
           desc: Compile-time random permutation for LFSR output
           type: kmac_pkg::lfsr_perm_t
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacLfsrPerm
-          default: 0x58560fbde2b6ca5ec0360ab98e1f13c1cd1ff9b890459ffdb129d5a5ad41aeecf11e430e0d4dc2a26e08e8b76d184257
+          default: 0x60a70d8ab7859f7ce38655c03f06fab96f537d1a60649431fbcff556a6b606cbf4c8790c3835380a89b923b2ddb46112
           randwidth: 384
         }
         {
@@ -5139,7 +5149,7 @@
           randcount: 64
           randtype: perm
           name_top: RndCnstKmacMsgPerm
-          default: 0xb611ea5a679945f8efcd75159e5c4eb1ceeb0da136bba3fd48133074b4f463f279a5b206dfce22175340fb280a402928
+          default: 0x515e0f5e7b6b69cf6cc634475aa9b339997e783b84e6f85f09204cf1d2d3d98a09d296c81b0e90ee2175dcd024cbf2a0
           randwidth: 384
         }
       ]
@@ -5305,7 +5315,7 @@
           randcount: 256
           randtype: data
           name_top: RndCnstOtbnUrndPrngSeed
-          default: 0x4093f0ec256b2646079c10f2f41f73af3fc6afbec695054a0407221fb798ab78
+          default: 0x471a7a682a6260eb4093f0ec256b2646079c10f2f41f73af3fc6afbec695054a
           randwidth: 256
         }
         {
@@ -5315,7 +5325,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstOtbnOtbnKey
-          default: 0xeefa4d4c2e269435471a7a682a6260eb
+          default: 0xf4e341f211c9d00beefa4d4c2e269435
           randwidth: 128
         }
         {
@@ -5325,7 +5335,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstOtbnOtbnNonce
-          default: 0xf4e341f211c9d00b
+          default: 0x8a789bdc189f345c
           randwidth: 64
         }
       ]
@@ -5496,7 +5506,7 @@
           randcount: 64
           randtype: data
           name_top: RndCnstKeymgrLfsrSeed
-          default: 0x8a789bdc189f345c
+          default: 0x9df4de1e830f9365
           randwidth: 64
         }
         {

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -2198,6 +2198,7 @@ module top_earlgrey #(
     .ReuseShare(KmacReuseShare),
     .SecCmdDelay(SecKmacCmdDelay),
     .SecIdleAcceptSwMsg(SecKmacIdleAcceptSwMsg),
+    .RndCnstLfsrSeed(RndCnstKmacLfsrSeed),
     .RndCnstLfsrPerm(RndCnstKmacLfsrPerm),
     .RndCnstMsgPerm(RndCnstKmacMsgPerm)
   ) u_kmac (

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -147,16 +147,21 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // kmac
   ////////////////////////////////////////////
+  // Compile-time random data for LFSR default seed
+  parameter kmac_pkg::lfsr_seed_t RndCnstKmacLfsrSeed = {
+    64'h2E658548C5420BE5
+  };
+
   // Compile-time random permutation for LFSR output
   parameter kmac_pkg::lfsr_perm_t RndCnstKmacLfsrPerm = {
-    128'h58560FBDE2B6CA5EC0360AB98E1F13C1,
-    256'hCD1FF9B890459FFDB129D5A5AD41AEECF11E430E0D4DC2A26E08E8B76D184257
+    128'h60A70D8AB7859F7CE38655C03F06FAB9,
+    256'h6F537D1A60649431FBCFF556A6B606CBF4C8790C3835380A89B923B2DDB46112
   };
 
   // Compile-time random permutation for LFSR Message output
   parameter kmac_pkg::msg_perm_t RndCnstKmacMsgPerm = {
-    128'hB611EA5A679945F8EFCD75159E5C4EB1,
-    256'hCEEB0DA136BBA3FD48133074B4F463F279A5B206DFCE22175340FB280A402928
+    128'h515E0F5E7B6B69CF6CC634475AA9B339,
+    256'h997E783B84E6F85F09204CF1D2D3D98A09D296C81B0E90EE2175DCD024CBF2A0
   };
 
   ////////////////////////////////////////////
@@ -164,17 +169,17 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Default seed of the PRNG used for URND.
   parameter otbn_pkg::urnd_prng_seed_t RndCnstOtbnUrndPrngSeed = {
-    256'h4093F0EC256B2646079C10F2F41F73AF3FC6AFBEC695054A0407221FB798AB78
+    256'h471A7A682A6260EB4093F0EC256B2646079C10F2F41F73AF3FC6AFBEC695054A
   };
 
   // Compile-time random reset value for IMem/DMem scrambling key.
   parameter otp_ctrl_pkg::otbn_key_t RndCnstOtbnOtbnKey = {
-    128'hEEFA4D4C2E269435471A7A682A6260EB
+    128'hF4E341F211C9D00BEEFA4D4C2E269435
   };
 
   // Compile-time random reset value for IMem/DMem scrambling nonce.
   parameter otp_ctrl_pkg::otbn_nonce_t RndCnstOtbnOtbnNonce = {
-    64'hF4E341F211C9D00B
+    64'h8A789BDC189F345C
   };
 
   ////////////////////////////////////////////
@@ -182,7 +187,7 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter keymgr_pkg::lfsr_seed_t RndCnstKeymgrLfsrSeed = {
-    64'h8A789BDC189F345C
+    64'h9DF4DE1E830F9365
   };
 
   // Compile-time random permutation for LFSR output


### PR DESCRIPTION
kmac_entropy now has Random Constant (64bit) for the default seed of its
LFSR.