### PR TITLE
[sw] Move rust version to 1.58.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -110,7 +110,7 @@ load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 rust_repositories(
     edition = "2018",
-    version = "1.53.0",
+    version = "1.58.0",
 )
 
 load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
   OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
   VERIBLE_VERSION: v0.0-1213-g9e5c085
-  RUST_VERSION: 1.55.0
+  RUST_VERSION: 1.58.0
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1
   # This controls where builds happen, and gets picked up by build_consts.sh.

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -38,7 +38,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'rust': {
-        'min_version': '1.55.0',
+        'min_version': '1.58.0',
         'as_needed': True
     },
     'vivado': {

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -11,7 +11,7 @@ ARG OPENOCD_VERSION=0.11.0
 ARG VERIBLE_VERSION=v0.0-1213-g9e5c085
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20220210-1
-ARG RUST_VERSION=1.55.0
+ARG RUST_VERSION=1.58.0
 
 # Main container image.
 FROM ubuntu:18.04 AS opentitan


### PR DESCRIPTION
Currently using rust 1.55.0 in CI and Docker, and it the version listed in the tool requirements. Bazel is currently building with rust 1.53.0. Move everything to use rust 1.58.0.