### PR TITLE
[dif] Update DIF checklists and development stages - pt3

### DIFF
--- a/hw/ip/keymgr/data/keymgr.prj.hjson
+++ b/hw/ip/keymgr/data/keymgr.prj.hjson
@@ -7,12 +7,14 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_keymgr",
     revisions: [
       {
         version:            "0.1",
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V2",
+        dif_stage:          "S0",
       }
     ]
 }

--- a/hw/ip/kmac/data/kmac.prj.hjson
+++ b/hw/ip/kmac/data/kmac.prj.hjson
@@ -14,6 +14,7 @@
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V1",
+        dif_stage:          "S1",
         commit_id:          "862155839",
         notes:              "Reaching V1"
       }

--- a/hw/ip/lc_ctrl/data/lc_ctrl.prj.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.prj.hjson
@@ -7,9 +7,11 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_lc_ctrl",
     version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V2",
+    dif_stage:          "S0",
     notes:              "",
 }

--- a/hw/ip/otbn/data/otbn.prj.hjson
+++ b/hw/ip/otbn/data/otbn.prj.hjson
@@ -23,7 +23,7 @@
             life_stage:         "L1",
             design_stage:       "D2",
             verification_stage: "V1",
-            dif_stage:          "S1",
+            dif_stage:          "S2",
         },
     ]
 }

--- a/hw/ip/otp_ctrl/data/otp_ctrl.prj.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.prj.hjson
@@ -23,7 +23,7 @@
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",
-        dif_stage:          "S1",
+        dif_stage:          "S2",
         notes:              "Will fully support test_access tl_if once reggen tool is optimized.",
       }
     ]

--- a/hw/ip/pattgen/data/pattgen.prj.hjson
+++ b/hw/ip/pattgen/data/pattgen.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_pattgen",
     revisions: [
       {
         version:            "1.0",

--- a/sw/device/lib/dif/dif_keymgr.md
+++ b/sw/device/lib/dif/dif_keymgr.md
@@ -5,63 +5,48 @@ title: "Key Manager DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Key Manager DIF]({{< relref "hw/ip/keymgr/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
-Implementation | [DIF_USED_IN_TREE][] | Done        | Not used prior to DIF implementation.
-Tests          | [DIF_TEST_UNIT][]    | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_kmac.md
+++ b/sw/device/lib/dif/dif_kmac.md
@@ -2,68 +2,51 @@
 title: "KMAC DIF Checklist"
 ---
 
-<!--
-NOTE: This is a template checklist document that is required to be copied over
-to `sw/device/lib/dif/dif_kmac.md` for a new DIF that transitions
-from L0 (Specification) to L1 (Development) stage, and updated as needed.
-Once done, please remove this comment before checking it in.
--->
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [KMAC DIF]({{< relref "hw/ip/kmac/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
+<h2>DIF Checklist</h2>
 
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | In Progress |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_lc_ctrl.md
+++ b/sw/device/lib/dif/dif_lc_ctrl.md
@@ -1,63 +1,52 @@
 ---
-title: "Lifecycle controller DIF Checklist"
+title: "Lifecycle Controller DIF Checklist"
 ---
 
-This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Lifecycle controller DIF]({{< relref "hw/ip/lc_ctrl/doc" >}}).
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Lifecycle Controller DIF]({{< relref "hw/ip/lc_ctrl/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
+<h2>DIF Checklist</h2>
 
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Done        |
-Tests          | [DIF_TEST_UNIT][]    | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_otbn.md
+++ b/sw/device/lib/dif/dif_otbn.md
@@ -5,63 +5,48 @@ title: "OTBN DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [OTBN DIF]({{< relref "hw/ip/otbn/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Done        |
-Tests          | [DIF_TEST_UNIT][]    | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -7,7 +7,8 @@
 
 /**
  * @file
- * @brief <a href="/hw/ip/otp_ctrl/doc/">OTP</a> Device Interface Functions
+ * @brief <a href="/hw/ip/otp_ctrl/doc/">OTP Controller</a> Device Interface
+ * Functions
  */
 
 #include <stdint.h>

--- a/sw/device/lib/dif/dif_otp_ctrl.md
+++ b/sw/device/lib/dif/dif_otp_ctrl.md
@@ -1,63 +1,52 @@
 ---
-title: "OTP DIF Checklist"
+title: "OTP Controller DIF Checklist"
 ---
 
-This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [OTP DIF]({{< relref "hw/ip/otp_ctrl/doc" >}}).
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [OTP Controller DIF]({{< relref "hw/ip/otp_ctrl/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
+<h2>DIF Checklist</h2>
 
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Done        |
-Tests          | [DIF_TEST_UNIT][]    | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_pattgen.md
+++ b/sw/device/lib/dif/dif_pattgen.md
@@ -1,0 +1,52 @@
+---
+title: "Pattern Generator DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Pattern Generator DIF]({{< relref "hw/ip/pattgen/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+<h2>DIF Checklist</h2>
+
+<h3>S1</h3>
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+
+<h3>S2</h3>
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+
+<h3>S3</h3>
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}


### PR DESCRIPTION
This PR updates the DIF checklists and development stages for the following IPs, to match the updated DIF milestone checklist merged in #10777:
- keymgr
- kmac
- lc_ctrl
- otbn
- otp_ctrl
- pattgen

This partially addresses #10504.