### PR TITLE
[dv/jtag] Fix close source JTAG error

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_if.sv
+++ b/hw/dv/sv/jtag_agent/jtag_if.sv
@@ -16,7 +16,8 @@ interface jtag_if #(time JtagDefaultTckPeriodNs = 20ns) ();
   bit   tck_en;
   time  tck_period_ns = JtagDefaultTckPeriodNs;
 
-  clocking host_cb @(posedge tck);
+  // Use negedge to drive jtag inputs because design also use posedge clock edge to sample.
+  clocking host_cb @(negedge tck);
     output  tms;
     output  tdi;
     input   tdo;

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
@@ -17,6 +17,9 @@ class jtag_riscv_agent_cfg extends dv_base_agent_cfg;
   // while RV_DM jtag uses the original DM CSR addresses without the normalization.
   bit is_rv_dm = 0;
 
+  // Max attempts to activate rv_dm.
+  int max_rv_dm_activation_attempts = 100;
+
   // status to return if we assert in_reset
   logic [DMI_OPW-1:0] status_in_reset;
 


### PR DESCRIPTION
This PR fixes close source JTAG error due to extra simulation delays
in JTAG external clock and input.
Because we are sampling and driving input at the same clock edge. When we introduce some extra
simulation delay, the simulator does not handle them correctly.

To avoid this issue, this PR drives JTAG input at negedge instead, then at posedge clock, the jtag input
will be stable.

This PR also adds a max attempt to activate RV_DM to avoid simulation
hanging.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>