### PR TITLE
[sw, test, otbn] Add the chip_sw_otbn_op test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1939,7 +1939,7 @@
               pre-computed using a reference model.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_otbn_ecdsa_op_irq"]
     }
     {
       name: chip_sw_otbn_rnd_entropy

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -348,6 +348,13 @@
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }
     {
+      name: chip_sw_otbn_ecdsa_op_irq
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/otbn_ecdsa_op_irq_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=28000000"]
+    }
+    {
       name: chip_sw_kmac_mode_cshake_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_cshake_test:1"]

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -580,12 +580,13 @@ sw_tests += {
   }
 }
 
-otbn_ecdsa_p256_test_lib = declare_dependency(
+otbn_ecdsa_op_irq_test_lib = declare_dependency(
   link_with: static_library(
-    'otbn_ecdsa_p256_test_lib',
-    sources: ['otbn_ecdsa_p256_test.c'],
+    'otbn_ecdsa_op_irq_test_lib',
+    sources: ['otbn_ecdsa_op_irq_test.c'],
     dependencies: [
       sw_lib_testing_entropy_testutils,
+      sw_lib_dif_rv_plic,
       sw_lib_runtime_otbn,
       sw_lib_runtime_log,
       sw_lib_runtime_ibex,
@@ -595,8 +596,8 @@ otbn_ecdsa_p256_test_lib = declare_dependency(
   ),
 )
 sw_tests += {
-  'otbn_ecdsa_p256_test': {
-    'library': otbn_ecdsa_p256_test_lib
+  'otbn_ecdsa_op_irq_test': {
+    'library': otbn_ecdsa_op_irq_test_lib
   }
 }
 

--- a/test/systemtest/earlgrey/config.py
+++ b/test/systemtest/earlgrey/config.py
@@ -50,7 +50,7 @@ TEST_APPS_SELFCHECKING = [
         "targets": ["fpga_cw310"],
     },
     {
-        "name": "otbn_ecdsa_p256_test",
+        "name": "otbn_ecdsa_op_irq_test",
         "targets": ["fpga_cw310"],
     },
     {


### PR DESCRIPTION
# This PR :
## Add the test chip_sw_otbn_op:
- SW test directs the OTBN engine to perform an ECDSA operation.
- SW validates the reception of the otbn done interrupt once the operation is complete.
- SW verifies the correctness of the result with the expected value which is pre-computed using a reference model.
