### PR TITLE
[sw] Rename usleep() to indicate that it spins rather than sleeps

### DIFF
--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -20,7 +20,7 @@ void demo_gpio_startup(dif_gpio_t *gpio) {
   // Give a LED pattern as startup indicator for 5 seconds.
   CHECK_DIF_OK(dif_gpio_write_all(gpio, 0xff00));
   for (int i = 0; i < 32; ++i) {
-    usleep(5 * 1000);  // 5 ms
+    busy_spin_micros(5 * 1000);  // 5 ms
     CHECK_DIF_OK(dif_gpio_write(gpio, 8 + (i % 8), (i / 8) % 2));
   }
   CHECK_DIF_OK(dif_gpio_write_all(gpio, 0x0000));  // All LEDs off.

--- a/sw/device/examples/hello_world/hello_world.c
+++ b/sw/device/examples/hello_world/hello_world.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
 
   uint32_t gpio_state = 0;
   while (true) {
-    usleep(10 * 1000);  // 10 ms
+    busy_spin_micros(10 * 1000);  // 10 ms
     gpio_state = demo_gpio_to_log_echo(&gpio, gpio_state);
     demo_spi_to_log_echo(&spi, &spi_config);
     demo_uart_to_uart_and_gpio_echo(&uart, &gpio);

--- a/sw/device/lib/runtime/hart.c
+++ b/sw/device/lib/runtime/hart.c
@@ -9,7 +9,7 @@
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/runtime/ibex.h"
 
-void usleep(uint32_t usec) {
+void busy_spin_micros(uint32_t usec) {
   uint64_t cycles = kClockFreqCpuHz * usec / 1000000;
   uint64_t start = ibex_mcycle_read();
   while ((ibex_mcycle_read() - start) < cycles) {

--- a/sw/device/lib/runtime/hart.h
+++ b/sw/device/lib/runtime/hart.h
@@ -30,7 +30,7 @@ inline void wait_for_interrupt(void) { asm volatile("wfi"); }
  *
  * @param usec Duration in microseconds.
  */
-void usleep(uint32_t usec);
+void busy_spin_micros(uint32_t usec);
 
 /**
  * Immediately halt program execution.

--- a/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_functest.c
@@ -32,7 +32,7 @@ static rom_error_t watchdog_pet_test(void) {
     watchdog_pet();
 
     // Sleep for 1ms.
-    usleep(1 * 1000);
+    busy_spin_micros(1 * 1000);
   }
   watchdog_disable();
   return kErrorOk;
@@ -46,7 +46,7 @@ static rom_error_t watchdog_configure_disabled_test(void) {
   watchdog_configure(threshold, kHardenedBoolFalse);
 
   // Sleep for 5ms.
-  usleep(5 * 1000);
+  busy_spin_micros(5 * 1000);
   return kErrorOk;
 }
 
@@ -58,7 +58,7 @@ static rom_error_t watchdog_bite_test(void) {
   watchdog_configure(threshold, kHardenedBoolTrue);
 
   // Sleep for 6ms.
-  usleep(6 * 1000);
+  busy_spin_micros(6 * 1000);
 
   watchdog_disable();
   return kErrorUnknown;

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -91,7 +91,7 @@ bool test_main(void) {
     // Executing the wdog bite reset during sleep test.
 
     // Wait for the remaining time to the wdog bark.
-    usleep(WDOG_BARK_TIME_US);
+    busy_spin_micros(WDOG_BARK_TIME_US);
     CHECK_DIF_OK(dif_aon_timer_irq_is_pending(
         &aon_timer, kDifAonTimerIrqWkupTimerExpired, &is_pending));
     CHECK(is_pending);
@@ -100,7 +100,7 @@ bool test_main(void) {
 
     CHECK_DIF_OK(dif_aon_timer_irq_acknowledge(
         &aon_timer, kDifAonTimerIrqWkupTimerExpired));
-    usleep(WDOG_BITE_TIME_US - WDOG_BARK_TIME_US + 10);
+    busy_spin_micros(WDOG_BITE_TIME_US - WDOG_BARK_TIME_US + 10);
     LOG_ERROR("Should have got a watchdog reset");
   } else if (rst_info == kDifRstmgrResetInfoWatchdog) {
     LOG_INFO("Booting for the third time due to wdog bite reset");

--- a/sw/device/tests/aon_timer_smoketest.c
+++ b/sw/device/tests/aon_timer_smoketest.c
@@ -22,7 +22,7 @@ static void aon_timer_test_wakeup_timer(dif_aon_timer_t *aon) {
   // to be on a cautious side - lets keep it at 100 for now).
   aon_timer_testutils_wakeup_config(aon, 1);
 
-  usleep(100);
+  busy_spin_micros(100);
 
   // Make sure that the timer has expired.
   bool is_pending;
@@ -41,7 +41,7 @@ static void aon_timer_test_watchdog_timer(dif_aon_timer_t *aon) {
   // counter. Delay to compensate for AON Timer 200kHz clock (less should
   // suffice, but to be on a cautious side - lets keep it at 100 for now).
   aon_timer_testutils_watchdog_config(aon, 1, UINT32_MAX, false);
-  usleep(100);
+  busy_spin_micros(100);
 
   // Make sure that the timer has expired.
   bool is_pending;

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -56,14 +56,14 @@ static void wdog_bite_test(const dif_aon_timer_t *aon_timer,
   config_wdog(aon_timer, pwrmgr, bark_time_us, bite_time_us);
 
   // Wait bark time and check that the bark interrupt requested.
-  usleep(bark_time_us);
+  busy_spin_micros(bark_time_us);
   bool is_pending = false;
   CHECK_DIF_OK(dif_aon_timer_irq_is_pending(
       aon_timer, kDifAonTimerIrqWdogTimerBark, &is_pending));
   CHECK(is_pending);
 
   // Wait for the remaining time to the wdog bite.
-  usleep(bite_time_us - bark_time_us);
+  busy_spin_micros(bite_time_us - bark_time_us);
   // If we arrive here the test must fail.
   CHECK(false, "Timeout waiting for Wdog bite reset!");
 }

--- a/sw/device/tests/coverage_test.c
+++ b/sw/device/tests/coverage_test.c
@@ -20,7 +20,7 @@ static void spin_45(uint8_t state) {
 static void spin_180(void) {
   for (uint8_t state = 0; state < 4; ++state) {
     spin_45(state);
-    usleep(100 * 1000);  // 0.1s
+    busy_spin_micros(100 * 1000);  // 0.1s
   }
 }
 

--- a/sw/device/tests/rv_plic_smoketest.c
+++ b/sw/device/tests/rv_plic_smoketest.c
@@ -135,7 +135,7 @@ static void execute_test(dif_uart_t *uart) {
   CHECK_DIF_OK(dif_uart_irq_force(uart, kDifUartIrqRxOverflow));
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_rx_overflow_handled) {
-    usleep(10);
+    busy_spin_micros(10);
   }
   CHECK(uart_rx_overflow_handled, "RX overflow IRQ has not been handled!");
 
@@ -144,7 +144,7 @@ static void execute_test(dif_uart_t *uart) {
   CHECK_DIF_OK(dif_uart_irq_force(uart, kDifUartIrqTxEmpty));
   // Check if the IRQ has occured and has been handled appropriately.
   if (!uart_tx_empty_handled) {
-    usleep(10);
+    busy_spin_micros(10);
   }
   CHECK(uart_tx_empty_handled, "TX empty IRQ has not been handled!");
 }

--- a/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
+++ b/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
@@ -71,7 +71,7 @@ bool test_main(void) {
     usbdev_force_dx_pullup(kDnSel, false);
 
     // give the hardware a chance to recognize the wakeup values are the same
-    usleep(20);  // 20us
+    busy_spin_micros(20);  // 20us
 
     // Enable low power on the next WFI with default settings.
     pwrmgr_testutils_enable_low_power(


### PR DESCRIPTION
This function was previously incorrectly renamed from a spinning-related name to `usleep()`, which confuses it with an equivalent POSIX function that has a very distinct effect.