### PR TITLE
[kmac] Remove comments

### DIFF
--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -431,8 +431,6 @@ module kmac_app
 
       StAppMsg: begin
         mux_sel = SelApp;
-        // Wait until the completion (done) from KeyMgr?
-        // Or absorb completion?
         if (app_i[app_id].valid && app_o[app_id].ready && app_i[app_id].last) begin
           if (AppCfg[app_id].Mode == AppKMAC) begin
             st_d = StAppOutLen;


### PR DESCRIPTION
As StAppMsg waits the last byte, the existing comment is incorrect.
Removed it.

