### PR TITLE
[sram/dv] Update test names

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -27,7 +27,7 @@
                 were executed correctly using the `mem_bkdr_util`
             '''
       milestone: V1
-      tests: ["{variant}_smoke"]
+      tests: ["{name}_smoke"]
     }
     {
       name: multiple_keys
@@ -45,7 +45,7 @@
                 intervals
             '''
       milestone: V2
-      tests: ["{variant}_multiple_keys"]
+      tests: ["{name}_multiple_keys"]
     }
     {
       name: stress_pipeline
@@ -55,7 +55,7 @@
             stress the encryption pipeline.
             '''
       milestone: V2
-      tests: ["{variant}_stress_pipeline"]
+      tests: ["{name}_stress_pipeline"]
     }
     {
       name: bijection
@@ -76,7 +76,7 @@
             This process will be repeated for a number of new key seeds.
             '''
       milestone: V2
-      tests: ["{variant}_bijection"]
+      tests: ["{name}_bijection"]
     }
     {
       name: access_during_key_req
@@ -89,7 +89,7 @@
                   should be reflected in TB.
             '''
       milestone: V2
-      tests: ["{variant}_access_during_key_req"]
+      tests: ["{name}_access_during_key_req"]
     }
     {
       name: lc_escalation
@@ -104,7 +104,7 @@
             couple of memory accesses just to make sure everything is still in working order.
             '''
       milestone: V2
-      tests: ["{variant}_lc_escalation"]
+      tests: ["{name}_lc_escalation"]
     }
     {
       name: executable
@@ -122,7 +122,7 @@
             configured to be executable.
             '''
       milestone: V2
-      tests: ["{variant}_executable"]
+      tests: ["{name}_executable"]
     }
     {
       name: partial_access
@@ -133,7 +133,7 @@
             Reuse the `smoke` and `stress_pipeline` by setting `partial_access_pct` = 90%
             '''
       milestone: V2
-      tests: ["{variant}_partial_access", "{variant}_partial_access_b2b"]
+      tests: ["{name}_partial_access", "{name}_partial_access_b2b"]
     }
     {
       name: max_throughput
@@ -145,7 +145,7 @@
             With partial write, it needs 2 extra cycles per partial write.
             '''
       milestone: V2
-      tests: ["{variant}_max_throughput", "{variant}_throughput_w_partial_write"]
+      tests: ["{name}_max_throughput", "{name}_throughput_w_partial_write"]
     }
     {
       name: regwen
@@ -163,7 +163,7 @@
             locked.
             '''
       milestone: V2
-      tests: ["{variant}_regwen"]
+      tests: ["{name}_regwen"]
     }
     {
       name: stress_all

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -79,59 +79,59 @@
   // List of test specifications.
   tests: [
     {
-      name: "{variant}_smoke"
+      name: "{name}_smoke"
       uvm_test_seq: sram_ctrl_smoke_vseq
     }
     {
-      name: "{variant}_multiple_keys"
+      name: "{name}_multiple_keys"
       uvm_test_seq: sram_ctrl_multiple_keys_vseq
     }
     {
-      name: "{variant}_bijection"
+      name: "{name}_bijection"
       uvm_test_seq: sram_ctrl_bijection_vseq
       run_opts: ["+test_timeout_ns=1000000000"]
     }
     {
-      name: "{variant}_stress_pipeline"
+      name: "{name}_stress_pipeline"
       uvm_test_seq: sram_ctrl_stress_pipeline_vseq
       run_opts: ["+zero_delays=1"]
     }
     {
-      name: "{variant}_partial_access"
+      name: "{name}_partial_access"
       uvm_test_seq: sram_ctrl_smoke_vseq
       run_opts: ["+partial_access_pct=90"]
     }
     {
-      name: "{variant}_partial_access_b2b"
+      name: "{name}_partial_access_b2b"
       uvm_test_seq: sram_ctrl_stress_pipeline_vseq
       run_opts: ["+partial_access_pct=90"]
     }
     {
-      name: "{variant}_max_throughput"
+      name: "{name}_max_throughput"
       uvm_test_seq: sram_ctrl_throughput_vseq
       run_opts: ["+zero_delays=1 +partial_access_pct=0"]
     }
     {
-      name: "{variant}_throughput_w_partial_write"
+      name: "{name}_throughput_w_partial_write"
       uvm_test_seq: sram_ctrl_throughput_vseq
       run_opts: ["+zero_delays=1 +partial_access_pct=20"]
     }
     {
-      name: "{variant}_lc_escalation"
+      name: "{name}_lc_escalation"
       uvm_test_seq: sram_ctrl_lc_escalation_vseq
     }
     {
-      name: "{variant}_access_during_key_req"
+      name: "{name}_access_during_key_req"
       uvm_test_seq: sram_ctrl_access_during_key_req_vseq
       // Need to make sure no sram access when we just request new key or init, so use zero_delays
       run_opts: ["+zero_delays=1"]
     }
     {
-      name: "{variant}_executable"
+      name: "{name}_executable"
       uvm_test_seq: sram_ctrl_executable_vseq
     }
     {
-      name: "{variant}_regwen"
+      name: "{name}_regwen"
       uvm_test_seq: sram_ctrl_regwen_vseq
     }
     // Below 2 tests are same as the tests in dvsim/tests/mem_tests.hjson


### PR DESCRIPTION
Some tests is `sram_ctrl_ret|main_*`, some are `sram_ctrl_*` if they're
from common tests.
Now changed to `sram_ctrl_*` for all

Signed-off-by: Weicai Yang <weicai@google.com>