### PR TITLE
[sramd/dv] Enable sec_cm test for sram

### DIFF
--- a/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl_base_testplan.hjson
@@ -11,6 +11,7 @@
                      "hw/dv/sv/mem_bkdr_scb/data/mem_access_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
                      "sram_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_cfg.sv
@@ -35,6 +35,7 @@ class sram_ctrl_env_cfg #(parameter int AddrWidth = 10)
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = sram_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_error";
+    sec_cm_alert_name  = tl_intg_alert_name;
 
     // Set up second RAL model for SRAM memory and associated collateral
     ral_model_names.push_back(sram_ral_name);

--- a/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
+++ b/hw/ip/sram_ctrl/dv/env/sram_ctrl_env_pkg.sv
@@ -22,6 +22,7 @@ package sram_ctrl_env_pkg;
   import mem_bkdr_util_pkg::*;
   import mem_bkdr_scb_pkg::*;
   import prim_mubi_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -34,13 +34,14 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"
                 "{proj_root}/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson"
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
                 ]
 
   en_build_modes: ["{tool}_memutil_dpi_scrambled_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["sram_ctrl_bind", "sram_ctrl_cov_bind"]
+  sim_tops: ["sram_ctrl_bind", "sram_ctrl_cov_bind", "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
Add additional checks
 - Check alert and `status.init_error` is set.
 -  After injecting faults, reading any address should return 0. #10909

Signed-off-by: Weicai Yang <weicai@google.com>