### PR TITLE
[entropy_src/rtl] Ignore es_type when es_route is false

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1304,7 +1304,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign es_bypass_to_sw = es_type_pfe;
   assign threshold_scope = threshold_scope_pfe;
 
-  assign es_bypass_mode = (!fips_enable_pfe) || es_bypass_to_sw;
+  assign es_bypass_mode = (!fips_enable_pfe) || (es_bypass_to_sw && es_route_to_sw);
 
   // send off to AST RNG for possibly faster entropy generation
   assign rng_fips_o = es_bypass_mode;


### PR DESCRIPTION
If es_route is false, es_type should have no effect on the CSRNG data
Prior to this commit setting control.es_type would send unconditioned
data to the CSRNG port, even if es_route was set to false.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>