### PR TITLE
[sram_ctrl] Align behavior of global and local escalation

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -406,7 +406,7 @@ module sram_ctrl
 
   // Interposing mux logic for initialization with pseudo random data.
   assign sram_req        = tlul_req | init_req;
-  assign tlul_gnt        = sram_gnt & ~init_req;
+  assign tlul_gnt        = sram_gnt & ~init_req & ~local_esc;
   assign sram_we         = tlul_we | init_req;
   assign sram_intg_error = local_esc & ~init_req;
   assign sram_addr       = (init_req) ? init_cnt          : tlul_addr;


### PR DESCRIPTION
Before, global escalation caused the sram_ctrl to block transactions on top of other defenses (like scrapping the key, blanking return data). Local escalation on the other hand did not cause the sram_ctrl to block transactions.

This patch aligns the behavior of both escalations (block transactions), since both are fatal conditions.

See #10909 for context.

Signed-off-by: Michael Schaffner <msf@opentitan.org>