### PR TITLE
[adc_ctrl] Adjust debounce counter behavior to match spec. 

### DIFF
--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
@@ -141,13 +141,14 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
     printer.print_array_footer();
   endfunction
 
-  virtual function void do_copy(uvm_object rhs);
-    type_id::T rhs_;  // type_id::T == this class (set in `uvm_object_utils)
-    super.do_copy(rhs);
-    $cast(rhs_, rhs);
-
-    // Implement filter_cfg
-    filter_cfg = rhs_.filter_cfg;
-  endfunction
+  //virtual function void do_copy(uvm_object rhs);
+  //  type_id::T rhs_;  // type_id::T == this class (set in `uvm_object_utils)
+  //  `downcast(rhs_, rhs);
+  //  super.do_copy(rhs);
+  //
+  //
+  //  // Implement filter_cfg
+  //  filter_cfg = rhs_.filter_cfg;
+  //endfunction
 
 endclass

--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_fsm.sv
@@ -379,9 +379,8 @@ module adc_ctrl_fsm
           end else if (np_sample_cnt_q < np_sample_cnt_thresh) begin
             fsm_state_d = NP_0;
             np_sample_cnt_en = 1'b1;
-          end else if (np_sample_cnt_q == np_sample_cnt_thresh) begin
+          end else if (np_sample_cnt_q >= np_sample_cnt_thresh) begin
             fsm_state_d = NP_DONE;
-            np_sample_cnt_clr = 1'b1;
           end
         end
       end
@@ -391,7 +390,6 @@ module adc_ctrl_fsm
         adc_ctrl_done_o = 1'b1;
         fsm_state_d = NP_0;
       end
-
 
       default: fsm_state_d = PWRDN;
     endcase


### PR DESCRIPTION
- previously, after a successful match during continuous mode, the controller
  would reset the count and continue making matches

- the spec'd behavior is that the count would only reset if a non-match is seen

- fixes #10843