### PR TITLE
[entropy_src/dv] Program thresholds before enabling

### DIFF
--- a/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_scoreboard.sv
@@ -1074,13 +1074,19 @@ class entropy_src_scoreboard extends cip_base_scoreboard#(
       end
 
       while (window.size() < window_rng_frames) begin
+        string fmt;
         wait_rng_queue(rng_val, disable_detected);
+
         if (disable_detected) begin
           // Exit this task.
           return;
         end else begin
           window.push_back(rng_val);
           observe_data.push_back(rng_val);
+
+          fmt = "RNG element: %0x, idx: %0d";
+          `uvm_info(`gfn, $sformatf(fmt, rng_val, window.size()), UVM_DEBUG)
+
           // The repetition count is updated continuously.
           // The other health checks only operate on complete windows, and are processed later.
           // TODO: Confirm how repcnt is applied in bit-select mode

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -106,7 +106,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
     csr_update(.csr(ral.entropy_control));
 
     // Thresholds managed in derived vseq classes
-    // TODO: Study how this interacts with sw_regupd/regwen
 
     // FW_OV registers
     ral.fw_ov_control.fw_ov_mode.set(cfg.fw_read_enable);
@@ -126,11 +125,10 @@ class entropy_src_base_vseq extends cip_base_vseq #(
 
     // Register write enable lock is on be default
     // Setting this to zero will lock future writes
-    // TODO Do we need to check main_sm_idle before writing DUT registers?
     csr_wr(.ptr(ral.sw_regupd), .value(cfg.sw_regupd));
 
     // Module_enables (should be done last)
-    ral.module_enable.set(cfg.module_enable); // TODO: Change config here?
+    ral.module_enable.set(cfg.module_enable);
     csr_update(.csr(ral.module_enable));
 
     ral.me_regwen.set(cfg.me_regwen);

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_rng_vseq.sv
@@ -70,7 +70,6 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
   virtual task entropy_src_init();
     int hi_thresh, lo_thresh;
 
-    super.entropy_src_init();
 
     // TODO: RepCnt and RepCntS thresholds
     // TODO: Separate sigmas for bypass and FIPS operation
@@ -108,6 +107,10 @@ class entropy_src_rng_vseq extends entropy_src_base_vseq;
     ral.markov_lo_thresholds.bypass_thresh.set(lo_thresh[15:0]);
     csr_update(.csr(ral.markov_hi_thresholds));
     csr_update(.csr(ral.markov_lo_thresholds));
+
+    // configure the rest of the variables afterwards so that sw_regupd & module_enable get written last
+    super.entropy_src_init();
+
   endtask
 
   //


### PR DESCRIPTION
The health test thresholds (which are configured by test-specific
routines) must be programmed before the module_enable or sw_regupd
registers.  This commit fixes the rng vseq to postpone the base vseq
initialization (the bulk of the register configuration) until after
the thresholds have been loaded.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>