### PR TITLE
[dv] Add cip_lc_tx_cov_if to sample lc_esc coverage

### DIFF
--- a/hw/dv/sv/cip_lib/cip_lc_tx_cov_if.sv
+++ b/hw/dv/sv/cip_lib/cip_lc_tx_cov_if.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface cip_lc_tx_cov_if(input [3:0] val, input rst_ni);
+  import uvm_pkg::*;
+  import dv_base_reg_pkg::*;
+
+  typedef mubi_cov #(.Width(4),
+                     .ValueTrue(lc_ctrl_pkg::On),
+                     .ValueFalse(lc_ctrl_pkg::Off)) lc_tx_cov;
+  lc_tx_cov cov;
+  initial begin
+    cov = lc_tx_cov::type_id::create($sformatf("%m"));
+    forever begin
+      @(val or rst_ni);
+      if (rst_ni === 1) cov.sample(val);
+    end
+  end
+endinterface

--- a/hw/dv/sv/cip_lib/cip_lib.core
+++ b/hw/dv/sv/cip_lib/cip_lib.core
@@ -35,6 +35,7 @@ filesets:
       - seq_lib/cip_tl_host_single_seq.sv: {is_include_file: true}
       - cip_base_test.sv: {is_include_file: true}
       - cip_mubi_cov_if.sv
+      - cip_lc_tx_cov_if.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_bind.sv
+++ b/hw/ip/sram_ctrl/dv/cov/sram_ctrl_cov_bind.sv
@@ -15,4 +15,8 @@ module sram_ctrl_cov_bind;
     .mubi   (otp_en_sram_ifetch_i)
   );
 
+  bind sram_ctrl cip_lc_tx_cov_if u_lc_escalate_en_cov_if (
+    .rst_ni (rst_ni),
+    .val    (lc_escalate_en_i)
+  );
 endmodule


### PR DESCRIPTION
lc_tx_t On/Off value are different than mubi4, so need to create another
interface

Use this interface in sram_ctrl for lc_esc port
Signed-off-by: Weicai Yang <weicai@google.com>