### PR TITLE
[ibex] Set ePMP reset values (ROM: LRX, MMIO: LRW, MMWP=1, RLB=1)

### DIFF
--- a/hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh
+++ b/hw/ip/rv_core_ibex/rtl/ibex_pmp_reset.svh
@@ -10,44 +10,44 @@
 // Protection) for more information.
 
 localparam pmp_cfg_t pmp_cfg_rst[16] = '{
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 0
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 1
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 2
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 3
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 4
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 5
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 6
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 7
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 8
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 9
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 10
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 11
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 12
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 13
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}, // region 14
-  '{lock: 1'b0, mode: PMP_MODE_OFF, exec: 1'b0, write: 1'b0, read: 1'b0}  // region 15
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 0
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 1
+  '{lock: 1'b1, mode: PMP_MODE_NAPOT, exec: 1'b1, write: 1'b0, read: 1'b1}, // region 2  [ROM: LRX]
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 3
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 4
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 5
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 6
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 7
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 8
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 9
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 10
+  '{lock: 1'b0, mode: PMP_MODE_TOR,   exec: 1'b0, write: 1'b1, read: 1'b1}, // region 11 [MMIO: LRW]
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 12
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 13
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}, // region 14
+  '{lock: 1'b0, mode: PMP_MODE_OFF,   exec: 1'b0, write: 1'b0, read: 1'b0}  // region 15
 };
 
 // Addresses are given in byte granularity for readibility. A minimum of two
 // bits will be stripped off the bottom (PMPGranularity == 0) with more stripped
 // off at coarser granularities.
 localparam [33:0] pmp_addr_rst[16] = '{
-  34'h0, // region 0
-  34'h0, // region 1
-  34'h0, // region 2
-  34'h0, // region 3
-  34'h0, // region 4
-  34'h0, // region 5
-  34'h0, // region 6
-  34'h0, // region 7
-  34'h0, // region 8
-  34'h0, // region 9
-  34'h0, // region 10
-  34'h0, // region 11
-  34'h0, // region 12
-  34'h0, // region 13
-  34'h0, // region 14
-  34'h0  // region 15
+  34'h00000000, // region 0
+  34'h00000000, // region 1
+  34'h00008ffc, // region 2  [ROM: base=0x0000_8000 size=0x8000 (32KiB)]
+  34'h00000000, // region 3
+  34'h00000000, // region 4
+  34'h00000000, // region 5
+  34'h00000000, // region 6
+  34'h00000000, // region 7
+  34'h00000000, // region 8
+  34'h00000000, // region 9
+  34'h40000000, // region 10 [MMIO: lo=0x4000_0000]
+  34'h42010000, // region 11 [MMIO: hi=0x4201_0000]
+  34'h00000000, // region 12
+  34'h00000000, // region 13
+  34'h00000000, // region 14
+  34'h00000000  // region 15
 };
 
-localparam pmp_mseccfg_t pmp_mseccfg_rst = '{rlb : 1'b0, mmwp: 1'b0, mml: 1'b0};
+localparam pmp_mseccfg_t pmp_mseccfg_rst = '{rlb : 1'b1, mmwp: 1'b1, mml: 1'b0};

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -30,7 +30,7 @@ index 3561ef52f..879c4502c 100644
    reg32 =
        mmio_region_from_addr(PINMUX0_BASE_ADDR + PINMUX_MIO_OUTSEL_0_REG_OFFSET);
 diff --git a/sw/device/lib/testing/test_rom/test_rom_start.S b/sw/device/lib/testing/test_rom/test_rom_start.S
-index ab2fb7bd4..b15fde33a 100644
+index ea9f7e7ba..cf1c931f9 100644
 --- a/sw/device/lib/testing/test_rom/test_rom_start.S
 +++ b/sw/device/lib/testing/test_rom/test_rom_start.S
 @@ -138,47 +138,6 @@ _reset_start:
@@ -78,9 +78,9 @@ index ab2fb7bd4..b15fde33a 100644
 -  li   t0, 0x55aa
 -  sw   t0, EDN_CTRL_REG_OFFSET(a0)
 -
-   // Zero out the `.bss` segment.
-   la   a0, _bss_start
-   la   a1, _bss_end
+   // Remove address space protections by configuring entry 15 as
+   // read-write-execute for the entire address space and then clearing
+   // all other entries.
 diff --git a/sw/device/sca/aes_serial.c b/sw/device/sca/aes_serial.c
 index a4d57e1c7..d12c776b7 100644
 --- a/sw/device/sca/aes_serial.c

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -179,6 +179,17 @@ _start:
   li   t0, 0x55aa
   sw   t0, EDN_CTRL_REG_OFFSET(a0)
 
+  // Remove address space protections by configuring entry 15 as
+  // read-write-execute for the entire address space and then clearing
+  // all other entries.
+  li   t0, (0x9f << 24) // Locked NAPOT read-write-execute.
+  csrw pmpcfg3, t0
+  li   t0, -1           // NAPOT encoded region covering entire 32-bit address space.
+  csrw pmpaddr15, t0
+  csrw pmpcfg0, zero
+  csrw pmpcfg1, zero
+  csrw pmpcfg2, zero
+
   // Zero out the `.bss` segment.
   la   a0, _bss_start
   la   a1, _bss_end

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
@@ -37,14 +37,6 @@
 /**
  * Configure the CPU's Enhanced Physical Memory Protection (ePMP) feature.
  *
- * The steps are:
- *
- *   1. Enable Rule Locking Bypass (RLB). RLB allows later boot stages to
- *      modify locked PMP entries.
- *   2. Configure access permissions for each address space of interest.
- *   3. Enable Machine Mode Whitelist Policy (MMWP). MMWP stops any access
- *      that does not match a PMP entry.
- *
  * This function follows the standard ILP32 calling convention but does not
  * require a valid stack pointer, thread pointer or global pointer.
  *
@@ -53,15 +45,6 @@
 mask_rom_epmp_init:
   .globl mask_rom_epmp_init
   .type mask_rom_epmp_init, @function
-
-  // Enable Rule Locking Bypass (RLB).
-  csrsi EPMP_MSECCFG, EPMP_MSECCFG_RLB
-
-  // Clear all PMP configuration registers.
-  csrw pmpcfg0, zero
-  csrw pmpcfg1, zero
-  csrw pmpcfg2, zero
-  csrw pmpcfg3, zero
 
   // Pre-encoded addresses defined in linker script.
   .extern _epmp_text_tor_lo
@@ -88,21 +71,11 @@ mask_rom_epmp_init:
   li   t0, NAPOT(TOP_EARLGREY_EFLASH_BASE_ADDR, TOP_EARLGREY_EFLASH_SIZE_BYTES)
   csrw pmpaddr5, t0
 
-  // Free entries
-  csrw pmpaddr6, zero
-  csrw pmpaddr7, zero
-  csrw pmpaddr8, zero
-  csrw pmpaddr9, zero
-
   // MMIO
   li   t0, TOR(0x40000000) // TODO(#7117): generate MMIO start address.
   csrw pmpaddr10, t0
   li   t0, TOR(0x50000000) // TODO(#7117): generate MMIO end address.
   csrw pmpaddr11, t0
-
-  // Free entries
-  csrw pmpaddr12, zero
-  csrw pmpaddr13, zero
 
   // Stack guard
   la   t0, _epmp_stack_guard_na4
@@ -123,10 +96,6 @@ mask_rom_epmp_init:
   csrw pmpcfg1, t1
   csrw pmpcfg2, t2
   csrw pmpcfg3, t3
-
-  // Enable Machine Mode Whitelist Policy (MMWP).
-  // TODO(#5653): Enable Machine Mode Lockdown (MML)?
-  csrsi EPMP_MSECCFG, EPMP_MSECCFG_MMWP
 
   ret
 


### PR DESCRIPTION
After reset ePMP will be configured as follows:

 | Entry | Address Space | Encoding | Permissions |
 |-------|---------------|----------|-------------|
 | 2     | ROM           | NAPOT    | LRX         |
 | 11    | MMIO          | TOR      | LRW         |

Machine mode whitelist policy (MMWP) and rule locking bypass (RLB)
will also be enabled.

This change also modifies the test ROM so that it sets up the ePMP
configuration such that read, write and execute accesses are
permitted anywhere in the address space to match the pre-existing
behavior.

Fixes #7834.