### PR TITLE
[hmac_enc, tests] Introduce IRQ part of the hmac_enc chip level test 

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1622,7 +1622,7 @@
             the HMAC done and FIFO empty interrupts as a part of this test.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_hmac_enc_irq"]
     }
     {
       name: chip_sw_hmac_idle

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -395,6 +395,12 @@
       run_opts: ["+sw_test_timeout_ns=22000000"]
     }
     {
+      name: chip_sw_hmac_enc_irq_test
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/hmac_enc_irq_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_kmac_mode_cshake_test
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_cshake_test:1"]

--- a/sw/device/lib/testing/autogen/isr_testutils.c
+++ b/sw/device/lib/testing/autogen/isr_testutils.c
@@ -35,7 +35,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
 void isr_testutils_adc_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, adc_ctrl_isr_ctx adc_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, adc_ctrl_isr_ctx_t adc_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_adc_ctrl_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -70,7 +70,7 @@ void isr_testutils_adc_ctrl_isr(
 }
 
 void isr_testutils_alert_handler_isr(
-    plic_isr_ctx_t plic_ctx, alert_handler_isr_ctx alert_handler_ctx,
+    plic_isr_ctx_t plic_ctx, alert_handler_isr_ctx_t alert_handler_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_alert_handler_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -107,7 +107,7 @@ void isr_testutils_alert_handler_isr(
 }
 
 void isr_testutils_aon_timer_isr(
-    plic_isr_ctx_t plic_ctx, aon_timer_isr_ctx aon_timer_ctx,
+    plic_isr_ctx_t plic_ctx, aon_timer_isr_ctx_t aon_timer_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_aon_timer_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -143,7 +143,7 @@ void isr_testutils_aon_timer_isr(
 }
 
 void isr_testutils_csrng_isr(
-    plic_isr_ctx_t plic_ctx, csrng_isr_ctx csrng_ctx,
+    plic_isr_ctx_t plic_ctx, csrng_isr_ctx_t csrng_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_csrng_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -177,7 +177,7 @@ void isr_testutils_csrng_isr(
                                         plic_irq_id));
 }
 
-void isr_testutils_edn_isr(plic_isr_ctx_t plic_ctx, edn_isr_ctx edn_ctx,
+void isr_testutils_edn_isr(plic_isr_ctx_t plic_ctx, edn_isr_ctx_t edn_ctx,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_edn_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -212,7 +212,7 @@ void isr_testutils_edn_isr(plic_isr_ctx_t plic_ctx, edn_isr_ctx edn_ctx,
 }
 
 void isr_testutils_entropy_src_isr(
-    plic_isr_ctx_t plic_ctx, entropy_src_isr_ctx entropy_src_ctx,
+    plic_isr_ctx_t plic_ctx, entropy_src_isr_ctx_t entropy_src_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_entropy_src_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -249,7 +249,7 @@ void isr_testutils_entropy_src_isr(
 }
 
 void isr_testutils_flash_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, flash_ctrl_isr_ctx flash_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, flash_ctrl_isr_ctx_t flash_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_flash_ctrl_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -284,7 +284,7 @@ void isr_testutils_flash_ctrl_isr(
                                         plic_irq_id));
 }
 
-void isr_testutils_gpio_isr(plic_isr_ctx_t plic_ctx, gpio_isr_ctx gpio_ctx,
+void isr_testutils_gpio_isr(plic_isr_ctx_t plic_ctx, gpio_isr_ctx_t gpio_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_gpio_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -318,7 +318,7 @@ void isr_testutils_gpio_isr(plic_isr_ctx_t plic_ctx, gpio_isr_ctx gpio_ctx,
                                         plic_irq_id));
 }
 
-void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx hmac_ctx,
+void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx_t hmac_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_hmac_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -352,7 +352,7 @@ void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx hmac_ctx,
                                         plic_irq_id));
 }
 
-void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx i2c_ctx,
+void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx_t i2c_ctx,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_i2c_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -387,7 +387,7 @@ void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx i2c_ctx,
 }
 
 void isr_testutils_keymgr_isr(
-    plic_isr_ctx_t plic_ctx, keymgr_isr_ctx keymgr_ctx,
+    plic_isr_ctx_t plic_ctx, keymgr_isr_ctx_t keymgr_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_keymgr_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -421,7 +421,7 @@ void isr_testutils_keymgr_isr(
                                         plic_irq_id));
 }
 
-void isr_testutils_kmac_isr(plic_isr_ctx_t plic_ctx, kmac_isr_ctx kmac_ctx,
+void isr_testutils_kmac_isr(plic_isr_ctx_t plic_ctx, kmac_isr_ctx_t kmac_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_kmac_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -455,7 +455,7 @@ void isr_testutils_kmac_isr(plic_isr_ctx_t plic_ctx, kmac_isr_ctx kmac_ctx,
                                         plic_irq_id));
 }
 
-void isr_testutils_otbn_isr(plic_isr_ctx_t plic_ctx, otbn_isr_ctx otbn_ctx,
+void isr_testutils_otbn_isr(plic_isr_ctx_t plic_ctx, otbn_isr_ctx_t otbn_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_otbn_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -490,7 +490,7 @@ void isr_testutils_otbn_isr(plic_isr_ctx_t plic_ctx, otbn_isr_ctx otbn_ctx,
 }
 
 void isr_testutils_otp_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, otp_ctrl_isr_ctx otp_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, otp_ctrl_isr_ctx_t otp_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_otp_ctrl_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -525,7 +525,7 @@ void isr_testutils_otp_ctrl_isr(
 }
 
 void isr_testutils_pattgen_isr(
-    plic_isr_ctx_t plic_ctx, pattgen_isr_ctx pattgen_ctx,
+    plic_isr_ctx_t plic_ctx, pattgen_isr_ctx_t pattgen_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_pattgen_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -560,7 +560,7 @@ void isr_testutils_pattgen_isr(
 }
 
 void isr_testutils_pwrmgr_isr(
-    plic_isr_ctx_t plic_ctx, pwrmgr_isr_ctx pwrmgr_ctx,
+    plic_isr_ctx_t plic_ctx, pwrmgr_isr_ctx_t pwrmgr_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_pwrmgr_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -595,7 +595,7 @@ void isr_testutils_pwrmgr_isr(
 }
 
 void isr_testutils_rv_timer_isr(
-    plic_isr_ctx_t plic_ctx, rv_timer_isr_ctx rv_timer_ctx,
+    plic_isr_ctx_t plic_ctx, rv_timer_isr_ctx_t rv_timer_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_rv_timer_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -631,7 +631,7 @@ void isr_testutils_rv_timer_isr(
 }
 
 void isr_testutils_spi_device_isr(
-    plic_isr_ctx_t plic_ctx, spi_device_isr_ctx spi_device_ctx,
+    plic_isr_ctx_t plic_ctx, spi_device_isr_ctx_t spi_device_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_device_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -667,7 +667,7 @@ void isr_testutils_spi_device_isr(
 }
 
 void isr_testutils_spi_host_isr(
-    plic_isr_ctx_t plic_ctx, spi_host_isr_ctx spi_host_ctx,
+    plic_isr_ctx_t plic_ctx, spi_host_isr_ctx_t spi_host_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_host_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -702,7 +702,7 @@ void isr_testutils_spi_host_isr(
 }
 
 void isr_testutils_sysrst_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, sysrst_ctrl_isr_ctx sysrst_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, sysrst_ctrl_isr_ctx_t sysrst_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_sysrst_ctrl_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -738,7 +738,7 @@ void isr_testutils_sysrst_ctrl_isr(
                                         plic_irq_id));
 }
 
-void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx uart_ctx,
+void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_uart_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.
@@ -773,7 +773,7 @@ void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx uart_ctx,
 }
 
 void isr_testutils_usbdev_isr(
-    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx usbdev_ctx,
+    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx_t usbdev_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_usbdev_irq_t *irq_serviced) {
   // Claim the IRQ at the PLIC.

--- a/sw/device/lib/testing/autogen/isr_testutils.h
+++ b/sw/device/lib/testing/autogen/isr_testutils.h
@@ -68,7 +68,7 @@ typedef struct adc_ctrl_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} adc_ctrl_isr_ctx;
+} adc_ctrl_isr_ctx_t;
 
 /**
  * A handle to a alert_handler ISR context struct.
@@ -90,7 +90,7 @@ typedef struct alert_handler_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} alert_handler_isr_ctx;
+} alert_handler_isr_ctx_t;
 
 /**
  * A handle to a aon_timer ISR context struct.
@@ -112,7 +112,7 @@ typedef struct aon_timer_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} aon_timer_isr_ctx;
+} aon_timer_isr_ctx_t;
 
 /**
  * A handle to a csrng ISR context struct.
@@ -134,7 +134,7 @@ typedef struct csrng_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} csrng_isr_ctx;
+} csrng_isr_ctx_t;
 
 /**
  * A handle to a edn ISR context struct.
@@ -156,7 +156,7 @@ typedef struct edn_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} edn_isr_ctx;
+} edn_isr_ctx_t;
 
 /**
  * A handle to a entropy_src ISR context struct.
@@ -178,7 +178,7 @@ typedef struct entropy_src_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} entropy_src_isr_ctx;
+} entropy_src_isr_ctx_t;
 
 /**
  * A handle to a flash_ctrl ISR context struct.
@@ -200,7 +200,7 @@ typedef struct flash_ctrl_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} flash_ctrl_isr_ctx;
+} flash_ctrl_isr_ctx_t;
 
 /**
  * A handle to a gpio ISR context struct.
@@ -222,7 +222,7 @@ typedef struct gpio_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} gpio_isr_ctx;
+} gpio_isr_ctx_t;
 
 /**
  * A handle to a hmac ISR context struct.
@@ -244,7 +244,7 @@ typedef struct hmac_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} hmac_isr_ctx;
+} hmac_isr_ctx_t;
 
 /**
  * A handle to a i2c ISR context struct.
@@ -266,7 +266,7 @@ typedef struct i2c_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} i2c_isr_ctx;
+} i2c_isr_ctx_t;
 
 /**
  * A handle to a keymgr ISR context struct.
@@ -288,7 +288,7 @@ typedef struct keymgr_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} keymgr_isr_ctx;
+} keymgr_isr_ctx_t;
 
 /**
  * A handle to a kmac ISR context struct.
@@ -310,7 +310,7 @@ typedef struct kmac_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} kmac_isr_ctx;
+} kmac_isr_ctx_t;
 
 /**
  * A handle to a otbn ISR context struct.
@@ -332,7 +332,7 @@ typedef struct otbn_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} otbn_isr_ctx;
+} otbn_isr_ctx_t;
 
 /**
  * A handle to a otp_ctrl ISR context struct.
@@ -354,7 +354,7 @@ typedef struct otp_ctrl_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} otp_ctrl_isr_ctx;
+} otp_ctrl_isr_ctx_t;
 
 /**
  * A handle to a pattgen ISR context struct.
@@ -376,7 +376,7 @@ typedef struct pattgen_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} pattgen_isr_ctx;
+} pattgen_isr_ctx_t;
 
 /**
  * A handle to a pwrmgr ISR context struct.
@@ -398,7 +398,7 @@ typedef struct pwrmgr_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} pwrmgr_isr_ctx;
+} pwrmgr_isr_ctx_t;
 
 /**
  * A handle to a rv_timer ISR context struct.
@@ -420,7 +420,7 @@ typedef struct rv_timer_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} rv_timer_isr_ctx;
+} rv_timer_isr_ctx_t;
 
 /**
  * A handle to a spi_device ISR context struct.
@@ -442,7 +442,7 @@ typedef struct spi_device_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} spi_device_isr_ctx;
+} spi_device_isr_ctx_t;
 
 /**
  * A handle to a spi_host ISR context struct.
@@ -464,7 +464,7 @@ typedef struct spi_host_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} spi_host_isr_ctx;
+} spi_host_isr_ctx_t;
 
 /**
  * A handle to a sysrst_ctrl ISR context struct.
@@ -486,7 +486,7 @@ typedef struct sysrst_ctrl_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} sysrst_ctrl_isr_ctx;
+} sysrst_ctrl_isr_ctx_t;
 
 /**
  * A handle to a uart ISR context struct.
@@ -508,7 +508,7 @@ typedef struct uart_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} uart_isr_ctx;
+} uart_isr_ctx_t;
 
 /**
  * A handle to a usbdev ISR context struct.
@@ -530,7 +530,7 @@ typedef struct usbdev_isr_ctx {
    * Whether or not a single IRQ is expected to be encountered in the ISR.
    */
   bool is_only_irq;
-} usbdev_isr_ctx;
+} usbdev_isr_ctx_t;
 
 /**
  * Services an adc_ctrl IRQ.
@@ -542,7 +542,7 @@ typedef struct usbdev_isr_ctx {
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_adc_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, adc_ctrl_isr_ctx adc_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, adc_ctrl_isr_ctx_t adc_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_adc_ctrl_irq_t *irq_serviced);
 
@@ -556,7 +556,7 @@ void isr_testutils_adc_ctrl_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_alert_handler_isr(
-    plic_isr_ctx_t plic_ctx, alert_handler_isr_ctx alert_handler_ctx,
+    plic_isr_ctx_t plic_ctx, alert_handler_isr_ctx_t alert_handler_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_alert_handler_irq_t *irq_serviced);
 
@@ -570,7 +570,7 @@ void isr_testutils_alert_handler_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_aon_timer_isr(
-    plic_isr_ctx_t plic_ctx, aon_timer_isr_ctx aon_timer_ctx,
+    plic_isr_ctx_t plic_ctx, aon_timer_isr_ctx_t aon_timer_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_aon_timer_irq_t *irq_serviced);
 
@@ -584,7 +584,7 @@ void isr_testutils_aon_timer_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_csrng_isr(
-    plic_isr_ctx_t plic_ctx, csrng_isr_ctx csrng_ctx,
+    plic_isr_ctx_t plic_ctx, csrng_isr_ctx_t csrng_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_csrng_irq_t *irq_serviced);
 
@@ -597,7 +597,7 @@ void isr_testutils_csrng_isr(
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
-void isr_testutils_edn_isr(plic_isr_ctx_t plic_ctx, edn_isr_ctx edn_ctx,
+void isr_testutils_edn_isr(plic_isr_ctx_t plic_ctx, edn_isr_ctx_t edn_ctx,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_edn_irq_t *irq_serviced);
 
@@ -611,7 +611,7 @@ void isr_testutils_edn_isr(plic_isr_ctx_t plic_ctx, edn_isr_ctx edn_ctx,
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_entropy_src_isr(
-    plic_isr_ctx_t plic_ctx, entropy_src_isr_ctx entropy_src_ctx,
+    plic_isr_ctx_t plic_ctx, entropy_src_isr_ctx_t entropy_src_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_entropy_src_irq_t *irq_serviced);
 
@@ -625,7 +625,7 @@ void isr_testutils_entropy_src_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_flash_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, flash_ctrl_isr_ctx flash_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, flash_ctrl_isr_ctx_t flash_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_flash_ctrl_irq_t *irq_serviced);
 
@@ -638,7 +638,7 @@ void isr_testutils_flash_ctrl_isr(
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
-void isr_testutils_gpio_isr(plic_isr_ctx_t plic_ctx, gpio_isr_ctx gpio_ctx,
+void isr_testutils_gpio_isr(plic_isr_ctx_t plic_ctx, gpio_isr_ctx_t gpio_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_gpio_irq_t *irq_serviced);
 
@@ -651,7 +651,7 @@ void isr_testutils_gpio_isr(plic_isr_ctx_t plic_ctx, gpio_isr_ctx gpio_ctx,
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
-void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx hmac_ctx,
+void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx_t hmac_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_hmac_irq_t *irq_serviced);
 
@@ -664,7 +664,7 @@ void isr_testutils_hmac_isr(plic_isr_ctx_t plic_ctx, hmac_isr_ctx hmac_ctx,
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
-void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx i2c_ctx,
+void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx_t i2c_ctx,
                            top_earlgrey_plic_peripheral_t *peripheral_serviced,
                            dif_i2c_irq_t *irq_serviced);
 
@@ -678,7 +678,7 @@ void isr_testutils_i2c_isr(plic_isr_ctx_t plic_ctx, i2c_isr_ctx i2c_ctx,
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_keymgr_isr(
-    plic_isr_ctx_t plic_ctx, keymgr_isr_ctx keymgr_ctx,
+    plic_isr_ctx_t plic_ctx, keymgr_isr_ctx_t keymgr_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_keymgr_irq_t *irq_serviced);
 
@@ -691,7 +691,7 @@ void isr_testutils_keymgr_isr(
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
-void isr_testutils_kmac_isr(plic_isr_ctx_t plic_ctx, kmac_isr_ctx kmac_ctx,
+void isr_testutils_kmac_isr(plic_isr_ctx_t plic_ctx, kmac_isr_ctx_t kmac_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_kmac_irq_t *irq_serviced);
 
@@ -704,7 +704,7 @@ void isr_testutils_kmac_isr(plic_isr_ctx_t plic_ctx, kmac_isr_ctx kmac_ctx,
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
-void isr_testutils_otbn_isr(plic_isr_ctx_t plic_ctx, otbn_isr_ctx otbn_ctx,
+void isr_testutils_otbn_isr(plic_isr_ctx_t plic_ctx, otbn_isr_ctx_t otbn_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_otbn_irq_t *irq_serviced);
 
@@ -718,7 +718,7 @@ void isr_testutils_otbn_isr(plic_isr_ctx_t plic_ctx, otbn_isr_ctx otbn_ctx,
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_otp_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, otp_ctrl_isr_ctx otp_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, otp_ctrl_isr_ctx_t otp_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_otp_ctrl_irq_t *irq_serviced);
 
@@ -732,7 +732,7 @@ void isr_testutils_otp_ctrl_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_pattgen_isr(
-    plic_isr_ctx_t plic_ctx, pattgen_isr_ctx pattgen_ctx,
+    plic_isr_ctx_t plic_ctx, pattgen_isr_ctx_t pattgen_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_pattgen_irq_t *irq_serviced);
 
@@ -746,7 +746,7 @@ void isr_testutils_pattgen_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_pwrmgr_isr(
-    plic_isr_ctx_t plic_ctx, pwrmgr_isr_ctx pwrmgr_ctx,
+    plic_isr_ctx_t plic_ctx, pwrmgr_isr_ctx_t pwrmgr_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_pwrmgr_irq_t *irq_serviced);
 
@@ -760,7 +760,7 @@ void isr_testutils_pwrmgr_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_rv_timer_isr(
-    plic_isr_ctx_t plic_ctx, rv_timer_isr_ctx rv_timer_ctx,
+    plic_isr_ctx_t plic_ctx, rv_timer_isr_ctx_t rv_timer_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_rv_timer_irq_t *irq_serviced);
 
@@ -774,7 +774,7 @@ void isr_testutils_rv_timer_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_spi_device_isr(
-    plic_isr_ctx_t plic_ctx, spi_device_isr_ctx spi_device_ctx,
+    plic_isr_ctx_t plic_ctx, spi_device_isr_ctx_t spi_device_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_device_irq_t *irq_serviced);
 
@@ -788,7 +788,7 @@ void isr_testutils_spi_device_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_spi_host_isr(
-    plic_isr_ctx_t plic_ctx, spi_host_isr_ctx spi_host_ctx,
+    plic_isr_ctx_t plic_ctx, spi_host_isr_ctx_t spi_host_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_spi_host_irq_t *irq_serviced);
 
@@ -802,7 +802,7 @@ void isr_testutils_spi_host_isr(
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_sysrst_ctrl_isr(
-    plic_isr_ctx_t plic_ctx, sysrst_ctrl_isr_ctx sysrst_ctrl_ctx,
+    plic_isr_ctx_t plic_ctx, sysrst_ctrl_isr_ctx_t sysrst_ctrl_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_sysrst_ctrl_irq_t *irq_serviced);
 
@@ -815,7 +815,7 @@ void isr_testutils_sysrst_ctrl_isr(
  * serviced.
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
-void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx uart_ctx,
+void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx_t uart_ctx,
                             top_earlgrey_plic_peripheral_t *peripheral_serviced,
                             dif_uart_irq_t *irq_serviced);
 
@@ -829,7 +829,7 @@ void isr_testutils_uart_isr(plic_isr_ctx_t plic_ctx, uart_isr_ctx uart_ctx,
  * @param[out] irq_serviced Out param for the IRQ that was serviced.
  */
 void isr_testutils_usbdev_isr(
-    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx usbdev_ctx,
+    plic_isr_ctx_t plic_ctx, usbdev_isr_ctx_t usbdev_ctx,
     top_earlgrey_plic_peripheral_t *peripheral_serviced,
     dif_usbdev_irq_t *irq_serviced);
 

--- a/sw/device/lib/testing/hmac_testutils.c
+++ b/sw/device/lib/testing/hmac_testutils.c
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/testing/hmac_testutils.h"
+
+#include "sw/device/lib/dif/dif_hmac.h"
+#include "sw/device/lib/testing/check.h"
+
+void hmac_testutils_check_message_length(const dif_hmac_t *hmac,
+                                         uint64_t expected_sent_bits) {
+  uint64_t sent_bits;
+  CHECK_DIF_OK(dif_hmac_get_message_length(hmac, &sent_bits));
+
+  // 64bit formatting is not supported, so split into hi and lo hex 32bit
+  // values. These should appear as 64bit hex values in the debug output.
+  CHECK(expected_sent_bits == sent_bits,
+        "Message length mismatch. "
+        "Expected 0x%08x%08x bits but got 0x%08x%08x bits.",
+        (uint32_t)(expected_sent_bits >> 32), (uint32_t)expected_sent_bits,
+        (uint32_t)(sent_bits >> 32), (uint32_t)sent_bits);
+}

--- a/sw/device/lib/testing/hmac_testutils.h
+++ b/sw/device/lib/testing/hmac_testutils.h
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_HMAC_TESTUTILS_H_
+#define OPENTITAN_SW_DEVICE_LIB_TESTING_HMAC_TESTUTILS_H_
+
+#include <assert.h>
+#include <stdint.h>
+
+#include "sw/device/lib/dif/dif_hmac.h"
+
+/**
+ * Read and compare the length of the message in the HMAC engine to the length
+ * of the message sent in bits.
+ */
+void hmac_testutils_check_message_length(const dif_hmac_t *hmac,
+                                         uint64_t expected_sent_bits);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_HMAC_TESTUTILS_H_

--- a/sw/device/lib/testing/meson.build
+++ b/sw/device/lib/testing/meson.build
@@ -188,6 +188,21 @@ sw_lib_testing_lc_ctrl_testutils = declare_dependency(
   ),
 )
 
+# HMAC test utilities
+sw_lib_testing_hmac_testutils = declare_dependency(
+  link_with: static_library(
+    'sw_lib_testing_hmac_testutils',
+    sources: [
+      hw_ip_hmac_reg_h,
+      'hmac_testutils.c',
+    ],
+    dependencies: [
+      sw_lib_dif_hmac,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+
 subdir('autogen')
 subdir('test_framework')
 subdir('test_rom')

--- a/sw/device/tests/hmac_enc_irq_test.c
+++ b/sw/device/tests/hmac_enc_irq_test.c
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_hmac.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+/**
+ * HMAC done 50uS timeout, which should be enough even for a 100kHz device.
+ *
+ * https://docs.opentitan.org/hw/ip/hmac/doc/
+ * Final hash calculation takes 360 cycles, which consists of one
+ * block compression and extra HMAC computation.
+ */
+const uint32_t kHmacEncFinishTimeoutUsec = 50;
+
+/**
+ * FIFO empty 10uS timeout, which should be enough even for a 100kHz device.
+ *
+ * https://docs.opentitan.org/hw/ip/hmac/doc/
+ * Single HMAC block compression takes 80 cycles.
+ */
+const uint32_t kHmacEncEmptyTimeoutUsec = 10;
+
+static plic_isr_ctx_t plic_ctx = {
+    .hart_id = kTopEarlgreyPlicTargetIbex0,
+};
+
+static dif_hmac_t hmac;
+static top_earlgrey_plic_peripheral_t peripheral_serviced;
+static dif_hmac_irq_t irq_serviced;
+static hmac_isr_ctx_t hmac_ctx = {
+    .hmac = &hmac,
+    .plic_hmac_start_irq_id = kTopEarlgreyPlicIrqIdHmacHmacDone,
+    .is_only_irq = false,
+};
+
+const test_config_t kTestConfig;
+
+static const dif_hmac_transaction_t kHmacTransactionConfig = {
+    .digest_endianness = kDifHmacEndiannessLittle,
+    .message_endianness = kDifHmacEndiannessLittle,
+};
+
+/**
+ * External ISR.
+ *
+ * Handles all peripheral interrupts on Ibex. PLIC asserts an external interrupt
+ * line to the CPU, which results in a call to this OTTF ISR. This ISR
+ * overrides the default OTTF implementation.
+ */
+void ottf_external_isr(void) {
+  isr_testutils_hmac_isr(plic_ctx, hmac_ctx, &peripheral_serviced,
+                         &irq_serviced);
+}
+
+/**
+ * Enables interrupts required by this test.
+ */
+static void enable_irqs(void) {
+  mmio_region_t base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_plic_init(base_addr, plic_ctx.rv_plic));
+
+  // Enable interrupts in HMAC IP.
+  CHECK_DIF_OK(dif_hmac_irq_set_enabled(hmac_ctx.hmac, kDifHmacIrqHmacDone,
+                                        kDifToggleEnabled));
+  CHECK_DIF_OK(dif_hmac_irq_set_enabled(hmac_ctx.hmac, kDifHmacIrqFifoEmpty,
+                                        kDifToggleEnabled));
+
+  // Enable interrupts in PLIC.
+  rv_plic_testutils_irq_range_enable(plic_ctx.rv_plic, plic_ctx.hart_id,
+                                     kTopEarlgreyPlicIrqIdHmacHmacDone,
+                                     kTopEarlgreyPlicIrqIdHmacFifoEmpty);
+
+  // Enable interrupts in Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+}
+
+/**
+ * Read and compare the length of the message in the HMAC engine to the length
+ * of the message sent in bits.
+ */
+static void check_message_length(uint64_t expected_sent_bits) {
+  uint64_t sent_bits;
+  CHECK_DIF_OK(dif_hmac_get_message_length(&hmac, &sent_bits));
+
+  // 64bit formatting is not supported, so split into hi and lo hex 32bit
+  // values. These should appear as 64bit hex values in the debug output.
+  CHECK(expected_sent_bits == sent_bits,
+        "Message length mismatch. "
+        "Expected 0x%08x%08x bits but got 0x%08x%08x bits.",
+        (uint32_t)(expected_sent_bits >> 32), (uint32_t)expected_sent_bits,
+        (uint32_t)(sent_bits >> 32), (uint32_t)sent_bits);
+}
+
+bool test_main() {
+  mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
+  CHECK_DIF_OK(dif_hmac_init(base_addr, &hmac));
+
+  enable_irqs();
+
+  // The purpose of this test is to ensure that HMAC empty and done interrupts
+  // assert when the conditions are met. Digest is not verified by this
+  // test, which means that a "dummy" data will suffice.
+  size_t sent_bytes;
+  char data[4] = {0xaa, 0xbb, 0xcc, 0xdd};
+  CHECK_DIF_OK(dif_hmac_mode_sha256_start(&hmac, kHmacTransactionConfig));
+  hmac_ctx.expected_irq = kDifHmacIrqFifoEmpty;
+  CHECK_DIF_OK(
+      dif_hmac_fifo_push(&hmac, &data[0], ARRAYSIZE(data), &sent_bytes));
+  check_message_length(32);
+
+  // Spin waiting for the "empty" interrupt.
+  IBEX_SPIN_FOR(irq_serviced == hmac_ctx.expected_irq,
+                kHmacEncEmptyTimeoutUsec);
+
+  // Race conditions could result in a stale value due to `hmac_empty_irq`
+  // being set in the ISR, however, in practice that does not matter.
+  hmac_ctx.expected_irq = kDifHmacIrqHmacDone;
+  CHECK_DIF_OK(dif_hmac_process(&hmac));
+  LOG_INFO("Waiting for HMAC to finish");
+
+  // Spin waiting for the "done" interrupt.
+  IBEX_SPIN_FOR(irq_serviced == hmac_ctx.expected_irq,
+                kHmacEncFinishTimeoutUsec);
+
+  // Finish the HMAC operation.
+  dif_hmac_digest_t dummy_digest;
+  CHECK_DIF_OK(dif_hmac_finish(&hmac, &dummy_digest));
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -907,6 +907,29 @@ sw_tests += {
   }
 }
 
+hmac_enc_irq_test_lib = declare_dependency(
+  link_with: static_library(
+    'hmac_enc_irq_test_lib',
+    sources: ['hmac_enc_irq_test.c'],
+    dependencies: [
+      sw_lib_dif_hmac,
+      sw_lib_dif_rv_plic,
+      sw_lib_irq,
+      sw_lib_mmio,
+      sw_lib_runtime_ibex,
+      sw_lib_runtime_log,
+      sw_lib_testing_isr_testutils,
+      sw_lib_testing_rv_plic_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'hmac_enc_irq_test': {
+    'library': hmac_enc_irq_test_lib,
+  }
+}
+
 ###############################################################################
 # Auto-generated tests
 ###############################################################################

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -118,9 +118,10 @@ hmac_smoketest_lib = declare_dependency(
     sources: ['hmac_smoketest.c'],
     dependencies: [
       sw_lib_dif_hmac,
-      sw_lib_runtime_log,
       sw_lib_mmio,
       sw_lib_runtime_hart,
+      sw_lib_runtime_log,
+      sw_lib_testing_hmac_testutils,
     ],
   ),
 )
@@ -918,6 +919,7 @@ hmac_enc_irq_test_lib = declare_dependency(
       sw_lib_mmio,
       sw_lib_runtime_ibex,
       sw_lib_runtime_log,
+      sw_lib_testing_hmac_testutils,
       sw_lib_testing_isr_testutils,
       sw_lib_testing_rv_plic_testutils,
       top_earlgrey,

--- a/util/autogen_testutils/templates/isr_testutils.c.tpl
+++ b/util/autogen_testutils/templates/isr_testutils.c.tpl
@@ -20,7 +20,7 @@ ${autogen_banner}
   % if ip.irqs:
     void isr_testutils_${ip.name_snake}_isr(
       plic_isr_ctx_t plic_ctx,
-      ${ip.name_snake}_isr_ctx ${ip.name_snake}_ctx,
+      ${ip.name_snake}_isr_ctx_t ${ip.name_snake}_ctx,
       top_earlgrey_plic_peripheral_t *peripheral_serviced,
       dif_${ip.name_snake}_irq_t *irq_serviced) {
 

--- a/util/autogen_testutils/templates/isr_testutils.h.tpl
+++ b/util/autogen_testutils/templates/isr_testutils.h.tpl
@@ -52,7 +52,7 @@ typedef struct plic_isr_ctx {
        * Whether or not a single IRQ is expected to be encountered in the ISR.
        */
       bool is_only_irq;
-    } ${ip.name_snake}_isr_ctx;
+    } ${ip.name_snake}_isr_ctx_t;
 
   % endif
 % endfor
@@ -69,7 +69,7 @@ typedef struct plic_isr_ctx {
      */
     void isr_testutils_${ip.name_snake}_isr(
       plic_isr_ctx_t plic_ctx,
-      ${ip.name_snake}_isr_ctx ${ip.name_snake}_ctx,
+      ${ip.name_snake}_isr_ctx_t ${ip.name_snake}_ctx,
       top_earlgrey_plic_peripheral_t *peripheral_serviced,
       dif_${ip.name_snake}_irq_t *irq_serviced);
 


### PR DESCRIPTION
# Introduction

https://docs.opentitan.org/sw/device/tests/#ip-integration
chip_sw_hmac_enc: "Verify the HMAC done and FIFO empty interrupts as a part of this test"

This change also creates `hmac_testutils` and factors out some of the common functionality between this test and the HMAC smoketest.

# Follow-up PR

Part2, where we: "SW test verifies an HMAC operation with a known key, plain text and digest (pick one of the NIST vectors)"
#10995 

# Testing

Ran in verilator both the IRQ test and the affected HMAC smoketest.

# TODO

Run test in DV make sure it passes.