### PR TITLE
[opentitantool] Use Result<> on all Transport methods

### DIFF
--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -142,10 +142,10 @@ pub trait Target {
     fn set_max_speed(&self, max_speed: u32) -> Result<()>;
 
     /// Returns the maximum number of transfers allowed in a single transaction.
-    fn get_max_transfer_count(&self) -> usize;
+    fn get_max_transfer_count(&self) -> Result<usize>;
 
     /// Maximum chunksize handled by this SPI device.
-    fn max_chunk_size(&self) -> usize;
+    fn max_chunk_size(&self) -> Result<usize>;
 
     fn set_voltage(&self, _voltage: Voltage) -> Result<()> {
         Err(SpiError::InvalidOption("This target does not support set_voltage".to_string()).into())

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -33,7 +33,7 @@ impl UartParams {
 /// A trait which represents a UART.
 pub trait Uart {
     /// Returns the UART baudrate.  May return zero for virtual UARTs.
-    fn get_baudrate(&self) -> u32;
+    fn get_baudrate(&self) -> Result<u32>;
 
     /// Sets the UART baudrate.  May do nothing for virtual UARTs.
     fn set_baudrate(&self, baudrate: u32) -> Result<()>;
@@ -68,5 +68,7 @@ pub enum UartError {
     ReadError(String),
     #[error("Writing: {0}")]
     WriteError(String),
+    #[error("{0}")]
+    GenericError(String),
 }
 

--- a/sw/host/opentitanlib/src/spiflash/flash.rs
+++ b/sw/host/opentitanlib/src/spiflash/flash.rs
@@ -222,7 +222,7 @@ impl SpiFlash {
         progress: impl Fn(u32, u32),
     ) -> Result<()> {
         // Break the read up according to the maximum chunksize the backend can handle.
-        for chunk in buffer.chunks_mut(spi.max_chunk_size()) {
+        for chunk in buffer.chunks_mut(spi.max_chunk_size()?) {
             let op_addr = self.opcode_with_address(SpiFlash::READ, address)?;
             spi.run_transaction(&mut [Transfer::Write(&op_addr), Transfer::Read(chunk)])?;
             address += chunk.len() as u32;

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -34,8 +34,8 @@ impl SerialPortUart {
 
 impl Uart for SerialPortUart {
     /// Returns the UART baudrate.  May return zero for virtual UARTs.
-    fn get_baudrate(&self) -> u32 {
-        self.port.borrow().baud_rate().unwrap()
+    fn get_baudrate(&self) -> Result<u32> {
+        self.port.borrow().baud_rate().wrap(UartError::GenericError)
     }
 
     /// Sets the UART baudrate.  May do nothing for virtual UARTs.

--- a/sw/host/opentitanlib/src/transport/cw310/spi.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/spi.rs
@@ -84,13 +84,13 @@ impl Target for CW310Spi {
         Ok(())
     }
 
-    fn get_max_transfer_count(&self) -> usize {
+    fn get_max_transfer_count(&self) -> Result<usize> {
         // Arbitrary value: number of `Transfers` that can be in a single transaction.
-        42
+        Ok(42)
     }
 
-    fn max_chunk_size(&self) -> usize {
-        65536
+    fn max_chunk_size(&self) -> Result<usize> {
+        Ok(65536)
     }
 
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -280,14 +280,14 @@ impl Target for HyperdebugSpiTarget {
         Ok(())
     }
 
-    fn get_max_transfer_count(&self) -> usize {
+    fn get_max_transfer_count(&self) -> Result<usize> {
         // The protocol imposes no limits to the number of Transfers
         // in a transaction.
-        usize::MAX
+        Ok(usize::MAX)
     }
 
-    fn max_chunk_size(&self) -> usize {
-        self.max_chunk_size
+    fn max_chunk_size(&self) -> Result<usize> {
+        Ok(self.max_chunk_size)
     }
 
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
@@ -75,15 +75,15 @@ impl Target for UltradebugSpi {
         Ok(())
     }
 
-    fn get_max_transfer_count(&self) -> usize {
+    fn get_max_transfer_count(&self) -> Result<usize> {
         // Arbitrary value: number of `Transfers` that can be in a single transaction.
-        42
+        Ok(42)
     }
 
-    fn max_chunk_size(&self) -> usize {
+    fn max_chunk_size(&self) -> Result<usize> {
         // Size of the FTDI read buffer.  We can't perform a read larger than this;
         // the FTDI device simply won't read any more.
-        65536
+        Ok(65536)
     }
 
     fn run_transaction(&self, transaction: &mut [Transfer]) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
@@ -39,8 +39,8 @@ impl UltradebugUart {
 }
 
 impl Uart for UltradebugUart {
-    fn get_baudrate(&self) -> u32 {
-        self.inner.borrow().baudrate
+    fn get_baudrate(&self) -> Result<u32> {
+        Ok(self.inner.borrow().baudrate)
     }
 
     fn set_baudrate(&self, baudrate: u32) -> Result<()> {

--- a/sw/host/opentitanlib/src/transport/verilator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/uart.rs
@@ -28,10 +28,10 @@ impl VerilatorUart {
 }
 
 impl Uart for VerilatorUart {
-    fn get_baudrate(&self) -> u32 {
+    fn get_baudrate(&self) -> Result<u32> {
         // The verilator UART operates at 7200 baud.
         // See `sw/device/lib/arch/device_sim_verilator.c`.
-        7200
+        Ok(7200)
     }
 
     fn set_baudrate(&self, _baudrate: u32) -> Result<()> {


### PR DESCRIPTION
As we plan to introduce a Transport implementation backed by a network
protocol, I/O errors could occur even for the simplest methods (such
as "get baud rate").

This change ensures that every single method in the Transport trait
and its delegates return their value through a transport::Result<...>
to accomodate this future.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>