### PR TITLE
[dv/kmac] Add support for kmac to receive non ones strb

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -23,8 +23,11 @@ class kmac_app_agent_cfg extends dv_base_agent_cfg;
   // Knob to enable percentage of error response in auto-response sequence.
   int unsigned error_rsp_pct = 0;
 
+  // Knob to allow injecting zeros in strb.
+  bit inject_zero_in_host_strb = 0;
+
   rand push_pull_agent_cfg#(`CONNECT_DATA_WIDTH) m_data_push_agent_cfg;
-  
+
   // KMAC digest share0/1 that can be set from test env.
   kmac_pkg::rsp_digest_t rsp_digest_hs[$];
 

--- a/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
@@ -54,13 +54,24 @@ interface kmac_app_intf (input clk, input rst_n);
   assign kmac_data_rsp = (if_mode == dv_utils_pkg::Device) ?
          {req_data_if.ready, rsp_done, rsp_digest_share0, rsp_digest_share1, rsp_error} : 'z;
 
+  // The following assertions only apply to device mode.
   // strb should never be 0
-  `ASSERT(StrbNotZero_A, kmac_data_req.valid |-> kmac_data_req.strb > 0, clk, !rst_n)
+  `ASSERT(StrbNotZero_A, kmac_data_req.valid |-> kmac_data_req.strb > 0,
+          clk, !rst_n || if_mode == dv_utils_pkg::Host)
 
   // strb should be all 1s unless it's last cycle
   `ASSERT(StrbAllSetIfNotLast_A, kmac_data_req.valid && !kmac_data_req.last |->
-                                 kmac_data_req.strb == '1, clk, !rst_n)
+                                 kmac_data_req.strb == '1,
+                                 clk, !rst_n || if_mode == dv_utils_pkg::Host)
 
+  // Check strb is aligned to LSB, for example: if strb[1]==0, strb[$:2] should be 0 too
+  for (genvar k = 1; k < KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
+    `ASSERT(StrbAlignLSB_A, kmac_data_req.valid && kmac_data_req.strb[k] === 0 |->
+                            kmac_data_req.strb[k+1] === 0,
+                            clk, !rst_n || if_mode == dv_utils_pkg::Host)
+  end
+
+  // The following assertions apply for this interface for all modes.
   // last can only be asserted along with valid
   `ASSERT(LastAssertWithValid_A, kmac_data_req.last |-> kmac_data_req.valid, clk, !rst_n)
 
@@ -69,9 +80,4 @@ interface kmac_app_intf (input clk, input rst_n);
     (kmac_data_req.last && kmac_data_req.valid && kmac_data_rsp.ready) |=>
     !kmac_data_req.valid throughout rsp_done[->1], clk, !rst_n)
 
-  // Check strb is aligned to LSB, for example: if strb[1]==0, strb[$:2] should be 0 too
-  for (genvar k = 1; k < KmacDataIfWidth / 8 - 1; k++) begin : gen_strb_check
-    `ASSERT(StrbAlignLSB_A, kmac_data_req.valid && kmac_data_req.strb[k] === 0 |->
-                            kmac_data_req.strb[k+1] === 0, clk, !rst_n)
-  end
 endinterface

--- a/hw/ip/kmac/data/kmac_base_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_base_testplan.hjson
@@ -111,6 +111,18 @@
       tests: ["{variant}_app"]
     }
     {
+      name: app_with_partial_data
+      desc: '''
+            Basd on the kmac_app test, this test will send partial data from application interface
+            by sending `strb` with values other than `8'hFF`.
+            Because the scoreboard is cycle accurate and does not support this feature, this test
+            will not check `status` and `intr_state` registers, but will check other registers and
+            all interface data including digest.
+            '''
+      milestone: V2
+      tests: ["{variant}_app_with_partial_data"]
+   }
+   {
       name: error
       desc: '''
             Try several error sequences:

--- a/hw/ip/kmac/dv/env/kmac_env.core
+++ b/hw/ip/kmac/dv/env/kmac_env.core
@@ -37,6 +37,7 @@ filesets:
       - seq_lib/kmac_test_vectors_kmac_xof_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_burst_write_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_app_vseq.sv: {is_include_file: true}
+      - seq_lib/kmac_app_with_partial_data_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_key_error_vseq.sv: {is_include_file: true}
       - seq_lib/kmac_edn_timeout_error_vseq.sv: {is_include_file: true}

--- a/hw/ip/kmac/dv/env/kmac_env_cfg.sv
+++ b/hw/ip/kmac/dv/env/kmac_env_cfg.sv
@@ -13,6 +13,9 @@ class kmac_env_cfg extends cip_base_env_cfg #(.RAL_T(kmac_reg_block));
   // Masked KMAC is the default configuration
   bit enable_masking = 1;
 
+  // Disable scb cycle accurate check ("status" and "intr_state" registers).
+  bit do_cycle_accurate_check = 1;
+
   // These values are used by the test vector tests to select the correct vector text files.
   // These are unused by all other tests.
   int sha3_variant;

--- a/hw/ip/kmac/dv/env/kmac_scoreboard.sv
+++ b/hw/ip/kmac/dv/env/kmac_scoreboard.sv
@@ -404,6 +404,7 @@ class kmac_scoreboard extends cip_base_scoreboard #(
             app_mux_sel = SelNone;
             case (app_st)
               StIdle: begin
+                app_fsm_active = 0;
                 if (!in_kmac_app &&
                     (cfg.m_kmac_app_agent_cfg[AppKeymgr].vif.req_data_if.valid ||
                      cfg.m_kmac_app_agent_cfg[AppLc].vif.req_data_if.valid ||
@@ -2403,6 +2404,9 @@ class kmac_scoreboard extends cip_base_scoreboard #(
 
     // On reads, if do_read_check, is set, then check mirrored_value against item.d_data
     if (data_phase_read && csr_name != "") begin
+      if (!cfg.do_cycle_accurate_check && csr_name inside {"intr_state", "status"}) begin
+        do_read_check = 0;
+      end
       if (do_read_check) begin
         `DV_CHECK_EQ(csr.get_mirrored_value(), item.d_data,
                      $sformatf("reg name: %0s", csr.get_full_name()))

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_app_with_partial_data_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_app_with_partial_data_vseq.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// TODO(#10996): Based on kmac_app sequence, drive partial data by sending `strb` value that is not
+// always equal to `8'hFF`.
+class kmac_app_with_partial_data_vseq extends kmac_app_vseq;
+
+  `uvm_object_utils(kmac_app_with_partial_data_vseq)
+  `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    for (int i = 0; i < kmac_pkg::NumAppIntf; i++) begin
+      cfg.m_kmac_app_agent_cfg[i].inject_zero_in_host_strb = 1;
+    end
+    cfg.do_cycle_accurate_check = 0;
+  endtask
+
+endclass

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_vseq_list.sv
@@ -14,6 +14,7 @@
 `include "kmac_test_vectors_kmac_xof_vseq.sv"
 `include "kmac_burst_write_vseq.sv"
 `include "kmac_app_vseq.sv"
+`include "kmac_app_with_partial_data_vseq.sv"
 `include "kmac_error_vseq.sv"
 `include "kmac_key_error_vseq.sv"
 `include "kmac_edn_timeout_error_vseq.sv"

--- a/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
+++ b/hw/ip/kmac/dv/kmac_base_sim_cfg.hjson
@@ -142,6 +142,11 @@
       uvm_test_seq: kmac_app_vseq
     }
     {
+      name: "{variant}_app_with_partial_data"
+      uvm_test_seq: kmac_app_with_partial_data_vseq
+      reseed: 10
+    }
+    {
       name: "{variant}_error"
       uvm_test_seq: kmac_error_vseq
     }


### PR DESCRIPTION
This PR supports kmac receive strb from app interface that is not all
ones via these changes:

1). Update kmac_app_agent host agent to support sending partial data with strb != `1.
  To enable this feature, user can set `cfg.inject_zero_in_host_strb` to 1.

2). Update kmac scb to support this feature.
  Current kmac scb is cycle accurate with the assumption that kmac app
  interface will always receive full data. This change will require scb
  update. To avoid the massive change, we disable the cycle accurate
  check in scb, but will ensure the digest is correct.

3). Add a separate test to check partial data. Filed an issue for future improvement: https://github.com/lowRISC/opentitan/issues/10966

Signed-off-by: Cindy Chen <chencindy@opentitan.org>