### PR TITLE
[doc/kmac] Update kmac dv doc

### DIFF
--- a/hw/ip/kmac/doc/dv/index.md
+++ b/hw/ip/kmac/doc/dv/index.md
@@ -117,9 +117,7 @@ Some of the most commonly used tasks / functions are as follows:
 
 #### Functional coverage
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
-The following covergroups have been developed to prove that the test intent has been adequately met:
-* cg1:
-* cg2:
+Please refer to the covergroups section under [testplan](#testplan) for coverpoints that are implemented.
 
 ### Self-checking strategy
 #### Scoreboard
@@ -152,5 +150,4 @@ $ $REPO_TOP/util/dvsim/dvsim.py $REPO_TOP/hw/ip/kmac/dv/kmac_sim_cfg.hjson -i km
 ```
 
 ## Testplan
-<!-- TODO: uncomment the line below after adding the Testplan -->
-{{</* testplan "hw/ip/kmac/data/kmac_testplan.hjson" */>}}
+{{< incGenFromIpDesc "../../data/kmac_base_testplan.hjson" "testplan" >}}

--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -115,6 +115,7 @@ config = {
         "hw/ip/gpio/data/gpio_testplan.hjson",
         "hw/ip/hmac/data/hmac_testplan.hjson",
         "hw/ip/i2c/data/i2c_testplan.hjson",
+        "hw/ip/kmac/data/kmac_base_testplan.hjson",
         "hw/ip/keymgr/data/keymgr_testplan.hjson",
         "hw/ip/lc_ctrl/data/lc_ctrl_testplan.hjson",
         "hw/ip/otbn/data/otbn_testplan.hjson",


### PR DESCRIPTION
Two minor updates on kmac dv doc:
1). update the link for testplan.
2). update the functional coverage section to refer to testplan.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>