### PR TITLE
[lint] Increase the unroll count

### DIFF
--- a/hw/lint/tools/ascentlint/ascentlint-config.tcl
+++ b/hw/lint/tools/ascentlint/ascentlint-config.tcl
@@ -13,3 +13,7 @@ source "$RI_INSTALL/../Ascent/Lint/lib/policies/lowRISC/LRLR-v1.0.policy"
 set ri_max_total_range_bits 32768
 set ri_max_single_range_bits 32768
 
+# Increase the maximum loop to 3200 (KmacStateW X 2)
+# this is a temporary fix for non-ASCII character in AscentLint log
+set ri_max_loop_unroll 3200 
+


### PR DESCRIPTION
This commit increases Ascentlint max unroll count from 1024 (default) to
3200 (max Kmac state x2)
