### PR TITLE
[dv] Flag illegal ENUMASSIGN warnings as errors

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -94,6 +94,10 @@
                "-error=TMPO",
                // Class objects must not hide other class members due to same name
                "-error=SV-OHCM",
+               // ENUMASSIGN issues can cause LEC warnings later down the road (see #10083
+               // and #10952 for context). The warning is therefore promoted to an error
+               // in simulations in order to catch this as early as possible.
+               "-error=ENUMASSIGN"
                ]
 
   run_opts:   ["-licqueue",

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -37,7 +37,8 @@ module tb;
   key_sideload_if sideload_if(.clk_i(clk), .rst_ni(rst_n));
  //lc_ctrl_pkg::On
   assign lc_escalate_en = lc_escalate[0] ?
-                          lc_escalate[$bits(lc_ctrl_pkg::lc_tx_t):1] : lc_ctrl_pkg::Off;
+                          lc_ctrl_pkg::lc_tx_t'(lc_escalate[$bits(lc_ctrl_pkg::lc_tx_t):1]) :
+                          lc_ctrl_pkg::Off;
   // dut
   aes #(
     // for now keep testing the unmasked implementation

--- a/hw/ip/csrng/dv/tb.sv
+++ b/hw/ip/csrng/dv/tb.sv
@@ -50,9 +50,9 @@ module tb;
     .tl_i                       (tl_if.h2d),
     .tl_o                       (tl_if.d2h),
 
-    .otp_en_csrng_sw_app_read_i (otp_en_cs_sw_app_read),
+    .otp_en_csrng_sw_app_read_i (prim_mubi_pkg::mubi8_t'(otp_en_cs_sw_app_read)),
 
-    .lc_hw_debug_en_i           (lc_hw_debug_en),
+    .lc_hw_debug_en_i           (lc_ctrl_pkg::lc_tx_t'(lc_hw_debug_en)),
 
     .entropy_src_hw_if_o        (entropy_src_if.req),
     .entropy_src_hw_if_i        ({entropy_src_if.ack, entropy_src_if.d_data[entropy_src_pkg::

--- a/hw/ip/entropy_src/dv/tb/tb.sv
+++ b/hw/ip/entropy_src/dv/tb/tb.sv
@@ -50,8 +50,8 @@ module tb;
     .tl_i                         (tl_if.h2d  ),
     .tl_o                         (tl_if.d2h  ),
 
-    .otp_en_entropy_src_fw_read_i (otp_en_es_fw_read),
-    .otp_en_entropy_src_fw_over_i (otp_en_es_fw_over),
+    .otp_en_entropy_src_fw_read_i (prim_mubi_pkg::mubi8_t'(otp_en_es_fw_read)),
+    .otp_en_entropy_src_fw_over_i (prim_mubi_pkg::mubi8_t'(otp_en_es_fw_over)),
 
     .entropy_src_hw_if_o          ({csrng_if.ack,
                                     csrng_if.d_data[entropy_src_pkg::CSRNG_BUS_WIDTH-1:0],

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -290,7 +290,7 @@ interface keymgr_if(input clk, input rst_n);
     keys_a_array[state][cdi_type][dest.name] = trun_key_shares;
   endfunction
 
-  function automatic void clear_sideload_key(bit[2:0] clear_dest);
+  function automatic void clear_sideload_key(keymgr_pkg::keymgr_sideload_clr_e clear_dest);
     // reset from Clear to NotAvail
     if (kmac_sideload_status == SideLoadClear) kmac_sideload_status <= SideLoadNotAvail;
     if (aes_sideload_status == SideLoadClear)  aes_sideload_status  <= SideLoadNotAvail;
@@ -376,19 +376,19 @@ interface keymgr_if(input clk, input rst_n);
       end
       1: begin
         `uvm_info(msg_id, "Force KMC_IF FSM", UVM_LOW)
-        prev_state = tb.dut.u_kmac_if.state_q;
+        prev_state = tb.dut.u_kmac_if.state_raw_q;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_state,
             !(invalid_state inside {KmacIfValidStates});,
             , msg_id)
 
-        force tb.dut.u_kmac_if.state_q = invalid_state;
+        force tb.dut.u_kmac_if.state_raw_q = invalid_state;
         @(posedge clk);
 
         if ($urandom_range(0, 1)) begin
-          force tb.dut.u_kmac_if.state_q = prev_state;
+          force tb.dut.u_kmac_if.state_raw_q = prev_state;
           @(posedge clk);
         end
-        release tb.dut.u_kmac_if.state_q;
+        release tb.dut.u_kmac_if.state_raw_q;
         is_kmac_if_fsm_err = 1;
       end
       1: begin
@@ -423,19 +423,19 @@ interface keymgr_if(input clk, input rst_n);
       end
       1: begin
         `uvm_info(msg_id, "Force ctrl FSM", UVM_LOW)
-        prev_state = tb.dut.u_ctrl.state_q;
+        prev_state = tb.dut.u_ctrl.state_raw_q;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_state,
             !(invalid_state inside {CtrlValidStates});,
             , msg_id)
 
-        force tb.dut.u_ctrl.state_q = invalid_state;
+        force tb.dut.u_ctrl.state_raw_q = invalid_state;
         @(posedge clk);
 
         if ($urandom_range(0, 1)) begin
-          force tb.dut.u_ctrl.state_q = prev_state;
+          force tb.dut.u_ctrl.state_raw_q = prev_state;
           @(posedge clk);
         end
-        release tb.dut.u_ctrl.state_q;
+        release tb.dut.u_ctrl.state_raw_q;
         is_ctrl_fsm_err = 1;
       end
       1: begin

--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -688,7 +688,8 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
           fork
             begin
               cfg.clk_rst_vif.wait_clks(1);
-              cfg.keymgr_vif.clear_sideload_key(`gmv(ral.sideload_clear.val));
+              cfg.keymgr_vif.clear_sideload_key(
+                  keymgr_pkg::keymgr_sideload_clr_e'(`gmv(ral.sideload_clear.val)));
             end
           join_none
         end

--- a/hw/ip/usbdev/dv/tb/tb.sv
+++ b/hw/ip/usbdev/dv/tb/tb.sv
@@ -96,7 +96,7 @@ module tb;
     // Events and debug info from wakeup module
     .usb_aon_bus_reset_i  ('0),
     .usb_aon_sense_lost_i ('0),
-    .usb_state_debug_i    ('0),
+    .usb_state_debug_i    (usbdev_pkg::AwkIdle),
 
     // SOF reference for clock calibration
     .usb_ref_val_o        (),


### PR DESCRIPTION
Illegal ENUM assignments can cause LEC warnings later down the road. The warning is therefore promoted to an error in simulations in order to catch this as early as possible.

See #10083, #10952 for context.

Closes #10952.

Signed-off-by: Michael Schaffner <msf@google.com>