### PR TITLE
[rv_core_ibex] Update crash_dump format

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.hjson.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.hjson.tpl
@@ -143,11 +143,11 @@
       package: "alert_pkg",
     },
 
-    { struct:  "crash_dump",
+    { struct:  "cpu_crash_dump",
       type:    "uni",
       name:    "cpu_dump",
       act:     "rcv",
-      package: "ibex_pkg",
+      package: "rv_core_ibex_pkg",
     },
 
     { struct:  "mubi4",

--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -52,7 +52,7 @@ module rstmgr
   input alert_pkg::alert_crashdump_t alert_dump_i,
 
   // Interface to cpu crash dump
-  input ibex_pkg::crash_dump_t cpu_dump_i,
+  input rv_core_ibex_pkg::cpu_crash_dump_t cpu_dump_i,
 
   // dft bypass
   input scan_rst_ni,
@@ -478,7 +478,7 @@ module rstmgr
   );
 
   rstmgr_crash_info #(
-    .CrashDumpWidth($bits(ibex_pkg::crash_dump_t))
+    .CrashDumpWidth($bits(rv_core_ibex_pkg::cpu_crash_dump_t))
   ) u_cpu_info (
     .clk_i,
     .rst_ni,

--- a/hw/ip/rstmgr/dv/env/rstmgr_if.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_if.sv
@@ -27,7 +27,7 @@ interface rstmgr_if (
   alert_pkg::alert_crashdump_t                    alert_dump_i;
 
   // Interface to cpu crash dump
-  ibex_pkg::crash_dump_t                          cpu_dump_i;
+  rv_core_ibex_pkg::cpu_crash_dump_t              cpu_dump_i;
 
   // dft bypass
   logic                                           scan_rst_ni;

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -81,7 +81,7 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
       logic [NumSwResets-1:0] exp_ctrl_n;
       const logic [NumSwResets-1:0] sw_rst_all_ones = '1;
       alert_pkg::alert_crashdump_t bogus_alert_dump = '1;
-      ibex_pkg::crash_dump_t bogus_cpu_dump = '1;
+      rv_core_ibex_pkg::cpu_crash_dump_t bogus_cpu_dump = '1;
 
       set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
       csr_rd_check(.ptr(ral.sw_rst_ctrl_n[0]), .compare_value(sw_rst_all_ones),

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_reset_race_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_reset_race_vseq.sv
@@ -25,7 +25,7 @@ class rstmgr_sw_rst_reset_race_vseq extends rstmgr_base_vseq;
     bit [NumSwResets-1:0] exp_ctrl_n;
     bit [NumSwResets-1:0] sw_rst_regwen = '1;
     alert_pkg::alert_crashdump_t bogus_alert_dump = '1;
-    ibex_pkg::crash_dump_t bogus_cpu_dump = '1;
+    rv_core_ibex_pkg::cpu_crash_dump_t bogus_cpu_dump = '1;
     set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
 
     for (int i = 0; i < num_trans; ++i) begin

--- a/hw/ip/rstmgr/rstmgr.core
+++ b/hw/ip/rstmgr/rstmgr.core
@@ -8,11 +8,12 @@ description: "Reset manager component without the generated portions"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:tlul
-      - lowrisc:prim:esc
-      - lowrisc:prim:clock_mux2
-      - lowrisc:prim:lc_sync
       - lowrisc:ip:alert_handler_component
+      - lowrisc:ip:rv_core_ibex_pkg
+      - lowrisc:ip:tlul
+      - lowrisc:prim:clock_mux2
+      - lowrisc:prim:esc
+      - lowrisc:prim:lc_sync
       - lowrisc:prim:mubi
       - lowrisc:prim:sparse_fsm
       - "fileset_ip     ? (lowrisc:ip:rstmgr_pkg)"

--- a/hw/ip/rstmgr/rstmgr_pkg.core
+++ b/hw/ip/rstmgr/rstmgr_pkg.core
@@ -8,11 +8,10 @@ description: "Reset manager package"
 filesets:
   files_rtl:
     depend:
+      - lowrisc:ip:alert_handler_component
       - lowrisc:ip:pwrmgr_pkg
       - lowrisc:ip:rstmgr_reg
       - lowrisc:ip_interfaces:alert_handler_reg
-      - lowrisc:ip:alert_handler_component
-      - lowrisc:ibex:ibex_pkg
       - "fileset_top    ? (lowrisc:systems:rstmgr_pkg)"
       - "fileset_topgen ? (lowrisc:systems:topgen)"
     files:

--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -103,11 +103,11 @@
       package: "",
     },
 
-    { struct:  "crash_dump",
+    { struct:  "cpu_crash_dump",
       type:    "uni",
       name:    "crash_dump",
       act:     "req",
-      package: "ibex_pkg",
+      package: "rv_core_ibex_pkg",
     },
 
     { struct:  "lc_tx",

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_pkg.sv
@@ -13,4 +13,11 @@ package rv_core_ibex_pkg;
     logic [31:0] remap_addr;
   } region_cfg_t;
 
+  typedef struct packed {
+    // previous valid is true only during double fault
+    logic previous_valid;
+    ibex_pkg::crash_dump_t previous;
+    ibex_pkg::crash_dump_t current;
+  } cpu_crash_dump_t;
+
 endpackage // rv_core_ibex_pkg

--- a/hw/ip/rv_core_ibex/rv_core_ibex.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex.core
@@ -11,6 +11,7 @@ filesets:
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:otp_ctrl_pkg
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:ip:rv_core_ibex_pkg
       - lowrisc:ip:tlul
       - lowrisc:ip_interfaces:alert_handler_reg
       - lowrisc:prim:all
@@ -22,7 +23,6 @@ filesets:
       - lowrisc:tlul:adapter_host
 
     files:
-      - rtl/rv_core_ibex_pkg.sv
       - rtl/rv_core_ibex_reg_pkg.sv
       - rtl/rv_core_ibex_cfg_reg_top.sv
       - rtl/rv_core_ibex.sv

--- a/hw/ip/rv_core_ibex/rv_core_ibex_pkg.core
+++ b/hw/ip/rv_core_ibex/rv_core_ibex_pkg.core
@@ -1,0 +1,20 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:ip:rv_core_ibex_pkg:0.1"
+description: "rv_core_ibex package"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ibex:ibex_pkg
+
+    files:
+      - rtl/rv_core_ibex_pkg.sv
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl
+

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -2791,8 +2791,8 @@
         }
         {
           name: cpu_dump
-          struct: crash_dump
-          package: ibex_pkg
+          struct: cpu_crash_dump
+          package: rv_core_ibex_pkg
           type: uni
           act: rcv
           width: 1
@@ -7018,8 +7018,8 @@
         }
         {
           name: crash_dump
-          struct: crash_dump
-          package: ibex_pkg
+          struct: cpu_crash_dump
+          package: rv_core_ibex_pkg
           type: uni
           act: req
           width: 1
@@ -15616,8 +15616,8 @@
       }
       {
         name: cpu_dump
-        struct: crash_dump
-        package: ibex_pkg
+        struct: cpu_crash_dump
+        package: rv_core_ibex_pkg
         type: uni
         act: rcv
         width: 1
@@ -17846,8 +17846,8 @@
       }
       {
         name: crash_dump
-        struct: crash_dump
-        package: ibex_pkg
+        struct: cpu_crash_dump
+        package: rv_core_ibex_pkg
         type: uni
         act: req
         width: 1
@@ -20140,15 +20140,15 @@
         default: "'0"
       }
       {
-        package: ibex_pkg
-        struct: crash_dump
+        package: rv_core_ibex_pkg
+        struct: cpu_crash_dump
         signame: rv_core_ibex_crash_dump
         width: 1
         type: uni
         end_idx: -1
         act: req
         suffix: ""
-        default: ibex_pkg::CRASH_DUMP_DEFAULT
+        default: rv_core_ibex_pkg::CPU_CRASH_DUMP_DEFAULT
       }
       {
         package: pwrmgr_pkg

--- a/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
+++ b/hw/top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
@@ -147,11 +147,11 @@
       package: "alert_pkg",
     },
 
-    { struct:  "crash_dump",
+    { struct:  "cpu_crash_dump",
       type:    "uni",
       name:    "cpu_dump",
       act:     "rcv",
-      package: "ibex_pkg",
+      package: "rv_core_ibex_pkg",
     },
 
     { struct:  "mubi4",

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -58,7 +58,7 @@ module rstmgr
   input alert_pkg::alert_crashdump_t alert_dump_i,
 
   // Interface to cpu crash dump
-  input ibex_pkg::crash_dump_t cpu_dump_i,
+  input rv_core_ibex_pkg::cpu_crash_dump_t cpu_dump_i,
 
   // dft bypass
   input scan_rst_ni,
@@ -1227,7 +1227,7 @@ module rstmgr
   );
 
   rstmgr_crash_info #(
-    .CrashDumpWidth($bits(ibex_pkg::crash_dump_t))
+    .CrashDumpWidth($bits(rv_core_ibex_pkg::cpu_crash_dump_t))
   ) u_cpu_info (
     .clk_i,
     .rst_ni,

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -609,7 +609,7 @@ module top_earlgrey #(
   logic       rv_plic_irq;
   logic       rv_dm_debug_req;
   logic       rv_core_ibex_rst_cpu_n;
-  ibex_pkg::crash_dump_t       rv_core_ibex_crash_dump;
+  rv_core_ibex_pkg::cpu_crash_dump_t       rv_core_ibex_crash_dump;
   pwrmgr_pkg::pwr_cpu_t       rv_core_ibex_pwrmgr;
   spi_device_pkg::passthrough_req_t       spi_device_passthrough_req;
   spi_device_pkg::passthrough_rsp_t       spi_device_passthrough_rsp;


### PR DESCRIPTION
- contains both current and previous crash dump.
- previous crash dump is populated only when a double fault is seen.

Signed-off-by: Timothy Chen <timothytim@google.com>