### PR TITLE
[entropy_src/rtl] Standardize Ext. Health Test Interface

### DIFF
--- a/hw/ip/entropy_src/doc/_index.md
+++ b/hw/ip/entropy_src/doc/_index.md
@@ -158,7 +158,8 @@ Below is a description of this interface:
 - active: signal to indicate when the test should run, and is register driven.
 - thresh_hi: field to indicate what high threshold the test should use, and is register driven.
 - thresh_lo: field to indicate what low threshold the test should use, and is register driven.
-- window: field to indicate what the size of the test window is, and is register driven.
+- window_wrap_pulse: field to indicate the end of the current window.
+- threshold_scope: field to indicate whether the thresholds are intended to be applied to all entropy lines collectively or on a line-by-line basis, to be read from a register.
 - test_cnt: generic test count result, to be read from a register.
 - test_fail_hi_pulse: indication that a high threshold comparison failed, to be read from a register.
 - test_fail_lo_pulse: indication that a low threshold comparison failed, to be read from a register.

--- a/hw/ip/entropy_src/rtl/entropy_src.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src.sv
@@ -260,7 +260,7 @@ module entropy_src
   `ASSERT_KNOWN(EsXhtActiveKnownO_A, entropy_src_xht_o.active)
   `ASSERT_KNOWN(EsXhtThreshHiKnownO_A, entropy_src_xht_o.thresh_hi)
   `ASSERT_KNOWN(EsXhtThreshLoKnownO_A, entropy_src_xht_o.thresh_lo)
-  `ASSERT_KNOWN(EsXhtWindowKnownO_A, entropy_src_xht_o.window)
+  `ASSERT_KNOWN(EsXhtWindowKnownO_A, entropy_src_xht_o.window_wrap_pulse)
 
   // Alerts
   `ASSERT_KNOWN(AlertTxKnownO_A, alert_tx_o)

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -1876,7 +1876,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign entropy_src_xht_o.active = extht_active;
   assign entropy_src_xht_o.thresh_hi = extht_hi_threshold;
   assign entropy_src_xht_o.thresh_lo = extht_lo_threshold;
-  assign entropy_src_xht_o.window = health_test_window;
+  assign entropy_src_xht_o.window_wrap_pulse = health_test_done_pulse;
+  assign entropy_src_xht_o.threshold_scope = threshold_scope;
   // get inputs from external health test
   assign extht_event_cnt = entropy_src_xht_i.test_cnt;
   assign extht_hi_fail_pulse = entropy_src_xht_i.test_fail_hi_pulse;

--- a/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_pkg.sv
@@ -65,7 +65,8 @@ package entropy_src_pkg;
     logic active;
     logic [15:0] thresh_hi;
     logic [15:0] thresh_lo;
-    logic [15:0] window;
+    logic window_wrap_pulse;
+    logic threshold_scope;
   } entropy_src_xht_req_t;
 
   typedef struct packed {


### PR DESCRIPTION
In preparation for creating an agent for the external health test,
this commit updates the extht interface to make it more consistent
with the current implementation of the other health checks.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>