### PR TITLE
[csrng] Update AscentLint waiver

### DIFF
--- a/hw/ip/csrng/lint/csrng.waiver
+++ b/hw/ip/csrng/lint/csrng.waiver
@@ -6,3 +6,5 @@
 
 waive -rules {ONE_BIT_MEM_WIDTH} -location {prim_arbiter_ppc.sv} -regexp {.*has word width which is single bit wide.*} \
       -comment "Usage case specific to CSRNG and how the arbiter is used."
+waive -rules {LHS_TOO_SHORT} -location {aes_cipher_control_fsm.sv aes_cipher_core.sv aes_key_expand.sv aes_sbox.sv} -regexp {Bitlength mismatch between 'unused_assert_static_lint_error' length 1 and.*} \
+      -comment "CSRNG intentionally uses an unmasked AES implementation."


### PR DESCRIPTION
CSRNG uses an unmasked AES cipher core intentionally. We can thus waive all the lint errors related to non-default values for the SecMasking and SecSBoxImpl parameters.

This is related to lowRISC/OpenTitan#10844.