### PR TITLE
[aes/dv/doc] cleaned up section on functional coverage

### DIFF
--- a/hw/ip/aes/doc/dv/index.md
+++ b/hw/ip/aes/doc/dv/index.md
@@ -106,18 +106,8 @@ Most tests use the aes_stress_vseq sequence as test sequence, and achieves diffe
 
 #### Functional coverage'
 To ensure high quality constrained random stimulus, it is necessary to develop a functional coverage model.
-The following cover groups have been developed to prove that the test intent has been adequately met.
-
-* aes_ctrl_cg: this cover group checks that all parts of the control register have been exercised. 
-A few crosses are also included to ensure that we have seen all both forward and inverse for all modes.
-Similarly that we have tried all possible key_sizes in all modes, and that all have been tried both in auto and manual mode.
-More importantly for AES which is a security critical IP it also verifies that all illegal states have been seen.
-* aes_status_cg: makes sure all possible states has been seen.
-* aes_trigger_cg: verify that all parts of the trigger register was exercised.
-A cross also checks that we tried to clear all fields possible at once.
-
-(WIP) coverage points to come
-A temporary functional coverage plan can be found here [coverage_plan]({{< relref "hw/dv/tools/README.md">}})
+The model will cover that the test plan is exercising the expected test points and that  we cover all functionality.
+The functional coverage plan can be found here [coverage_plan](#testplan)
 
 
 


### PR DESCRIPTION
Cleaned up section on functional coverage to match the style of how other IPs document this section