### PR TITLE
[aes] Make IV register readable for software

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -239,9 +239,6 @@
     { name: "KEY.SW_UNREADABLE",
       desc: "Key registers are not readable by software."
     }
-    { name: "IV.CONFIG.SW_UNREADABLE",
-      desc: "IV registers are not readable by software."
-    }
     { name: "DATA_REG.SW_UNREADABLE",
       desc: "Data input and internal state registers are not readable by software."
     }
@@ -405,16 +402,17 @@
       '''
       count: "NumRegsIv",
       cname: "IV",
-      swaccess: "wo",
+      swaccess: "rw",
       hwaccess: "hrw",
       hwext:    "true",
       hwqe:     "true",
       fields: [
         { bits: "31:0", name: "iv", desc: "Initialization Vector" }
       ],
-      tags: [// Updates based on writes to other regs.
+      tags: [// Updated by the HW.
+             // Updates based on writes to other regs.
              // These registers are reset to 0, but the reset also triggers internal operations that clear these registers with pseudo-random data shortly afterwards (See Trigger Register).
-             "excl:CsrHwResetTest:CsrExclCheck"]
+             "excl:CsrAllTests:CsrExclCheck"]
       }
     },
 ##############################################################################

--- a/hw/ip/aes/data/aes_sec_cm_testplan.hjson
+++ b/hw/ip/aes/data/aes_sec_cm_testplan.hjson
@@ -72,12 +72,6 @@
       tests: []
     }
     {
-      name: sec_cm_iv_config_sw_unreadable
-      desc: "Verify the countermeasure(s) IV.CONFIG.SW_UNREADABLE."
-      milestone: V2S
-      tests: []
-    }
-    {
       name: sec_cm_data_reg_sw_unreadable
       desc: "Verify the countermeasure(s) DATA_REG.SW_UNREADABLE."
       milestone: V2S

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -87,7 +87,6 @@ module aes
   // SEC_CM: AUX.CONFIG.SHADOW
   // SEC_CM: AUX.CONFIG.REGWEN
   // SEC_CM: KEY.SW_UNREADABLE
-  // SEC_CM: IV.CONFIG.SW_UNREADABLE
   // SEC_CM: DATA_REG.SW_UNREADABLE
   // Register interface
   logic intg_err_alert;

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -144,13 +144,21 @@ module aes_reg_top (
   logic [31:0] key_share1_6_wd;
   logic key_share1_7_we;
   logic [31:0] key_share1_7_wd;
+  logic iv_0_re;
   logic iv_0_we;
+  logic [31:0] iv_0_qs;
   logic [31:0] iv_0_wd;
+  logic iv_1_re;
   logic iv_1_we;
+  logic [31:0] iv_1_qs;
   logic [31:0] iv_1_wd;
+  logic iv_2_re;
   logic iv_2_we;
+  logic [31:0] iv_2_qs;
   logic [31:0] iv_2_wd;
+  logic iv_3_re;
   logic iv_3_we;
+  logic [31:0] iv_3_qs;
   logic [31:0] iv_3_wd;
   logic data_in_0_we;
   logic [31:0] data_in_0_wd;
@@ -496,14 +504,14 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_0 (
-    .re     (1'b0),
+    .re     (iv_0_re),
     .we     (iv_0_we),
     .wd     (iv_0_wd),
     .d      (hw2reg.iv[0].d),
     .qre    (),
     .qe     (reg2hw.iv[0].qe),
     .q      (reg2hw.iv[0].q),
-    .qs     ()
+    .qs     (iv_0_qs)
   );
 
 
@@ -512,14 +520,14 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_1 (
-    .re     (1'b0),
+    .re     (iv_1_re),
     .we     (iv_1_we),
     .wd     (iv_1_wd),
     .d      (hw2reg.iv[1].d),
     .qre    (),
     .qe     (reg2hw.iv[1].qe),
     .q      (reg2hw.iv[1].q),
-    .qs     ()
+    .qs     (iv_1_qs)
   );
 
 
@@ -528,14 +536,14 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_2 (
-    .re     (1'b0),
+    .re     (iv_2_re),
     .we     (iv_2_we),
     .wd     (iv_2_wd),
     .d      (hw2reg.iv[2].d),
     .qre    (),
     .qe     (reg2hw.iv[2].qe),
     .q      (reg2hw.iv[2].q),
-    .qs     ()
+    .qs     (iv_2_qs)
   );
 
 
@@ -544,14 +552,14 @@ module aes_reg_top (
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_3 (
-    .re     (1'b0),
+    .re     (iv_3_re),
     .we     (iv_3_we),
     .wd     (iv_3_wd),
     .d      (hw2reg.iv[3].d),
     .qre    (),
     .qe     (reg2hw.iv[3].qe),
     .q      (reg2hw.iv[3].q),
-    .qs     ()
+    .qs     (iv_3_qs)
   );
 
 
@@ -1300,15 +1308,19 @@ module aes_reg_top (
   assign key_share1_7_we = addr_hit[16] & reg_we & !reg_error;
 
   assign key_share1_7_wd = reg_wdata[31:0];
+  assign iv_0_re = addr_hit[17] & reg_re & !reg_error;
   assign iv_0_we = addr_hit[17] & reg_we & !reg_error;
 
   assign iv_0_wd = reg_wdata[31:0];
+  assign iv_1_re = addr_hit[18] & reg_re & !reg_error;
   assign iv_1_we = addr_hit[18] & reg_we & !reg_error;
 
   assign iv_1_wd = reg_wdata[31:0];
+  assign iv_2_re = addr_hit[19] & reg_re & !reg_error;
   assign iv_2_we = addr_hit[19] & reg_we & !reg_error;
 
   assign iv_2_wd = reg_wdata[31:0];
+  assign iv_3_re = addr_hit[20] & reg_re & !reg_error;
   assign iv_3_we = addr_hit[20] & reg_we & !reg_error;
 
   assign iv_3_wd = reg_wdata[31:0];
@@ -1435,19 +1447,19 @@ module aes_reg_top (
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[31:0] = iv_0_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[31:0] = iv_1_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[31:0] = iv_2_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[31:0] = iv_3_qs;
       end
 
       addr_hit[21]: begin


### PR DESCRIPTION
This is required to support IV save/restore flows in the software implementation of the crypto library.

This is related to lowRISC/OpenTitan#10532.