### PR TITLE
[prim_dom_and_2share] Switch to single randomness input and prim_xor2/prim_flop_en

### DIFF
--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -171,8 +171,7 @@ module keccak_2share
       assign c = rand_i[x*$bits(sheet_t)+:$bits(sheet_t)];
 
       prim_dom_and_2share #(
-        .DW ($bits(sheet_t)), // sheet
-        .EnNegedge(0)         // takes two cycle to complete DOM
+        .DW ($bits(sheet_t)) // sheet
       ) u_dom (
         .clk_i,
         .rst_ni,

--- a/hw/ip/kmac/rtl/keccak_2share.sv
+++ b/hw/ip/kmac/rtl/keccak_2share.sv
@@ -155,7 +155,7 @@ module keccak_2share
       assign sheet1[0] = phase2_in[0][X2];
       assign sheet1[1] = phase2_in[1][X2];
 
-      logic [$bits(sheet_t)-1:0] a0, a1, b0, b1, c0, c1, q0, q1;
+      logic [$bits(sheet_t)-1:0] a0, a1, b0, b1, c, q0, q1;
 
       // Convert sheet_t to 1D array
       // TODO: Make this smarter :)
@@ -167,13 +167,8 @@ module keccak_2share
 
       // This keccak_f implementation doesn't use the states as entropy sources.
       // It rather receives the entropy from random number generator.
-      // The module needs 1600b of entropy per round (3 cycles). It is expensive
-      // to make 1600b entropy in every three cycles.
-      //
-      // It is recommended to duplicates smaller size of entropy but expands to
-      // 1600b by not concatenating but shuffling.
-      assign c0 = rand_i[x*$bits(sheet_t)+:$bits(sheet_t)];
-      assign c1 = rand_i[x*$bits(sheet_t)+:$bits(sheet_t)];
+      // The module needs 1600b of entropy per round (3 cycles).
+      assign c = rand_i[x*$bits(sheet_t)+:$bits(sheet_t)];
 
       prim_dom_and_2share #(
         .DW ($bits(sheet_t)), // sheet
@@ -186,9 +181,8 @@ module keccak_2share
         .a1_i      (a1),
         .b0_i      (b0),
         .b1_i      (b1),
-        .c_valid_i (rand_valid_i),
-        .c0_i      (c0),
-        .c1_i      (c1),
+        .z_valid_i (rand_valid_i),
+        .z_i       (c),
         .q0_o      (q0),
         .q1_o      (q1)
       );

--- a/hw/ip/prim/rtl/prim_dom_and_2share.sv
+++ b/hw/ip/prim/rtl/prim_dom_and_2share.sv
@@ -26,8 +26,7 @@
 `include "prim_assert.sv"
 
 module prim_dom_and_2share #(
-  parameter int DW = 64, // Input width
-  parameter int EnNegedge  = 0 // Enable negedge of clk for register
+  parameter int DW = 64 // Input width
 ) (
   input clk_i,
   input rst_ni,
@@ -95,10 +94,6 @@ module prim_dom_and_2share #(
     .in1_i ( {t0_q,   t1_q}   ),
     .out_o ( {q0_o,   q1_o}   )
   );
-
-  // Negative Edge isn't yet supported. Need inverted clock and use
-  // inside always_ff not `negedge clk_i`.
-  `ASSERT_INIT(NegedgeNotSupported_A, EnNegedge == 0)
 
   // DOM AND should be same as unmasked computation
   // TODO: Put assumption that input need to be stable for at least two cycles


### PR DESCRIPTION
This PR contains two commits:
1. Switch to a single randomness input as in the paper. Previously, we were using two but they always had to be driven the same value for correct operation anyway.
2. Use prim_xor2/prim_flop_en instead of inline synthesis contraints/comments as in the AES S-Boxes. This is more portable.