### PR TITLE
[entropy_src/rtl] Sync FW override mode with main state machine

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1124,6 +1124,43 @@
         },
       ]
     },
+    { name: "FW_OV_SHA3_START",
+      desc: "Firmware override sha3 block start control register",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [// Exclude from writes to these field because they cause side affects.
+             "excl:CsrAllTests:CsrExclAll"]
+      fields: [
+        { bits: "3:0",
+          name: "FW_OV_INSERT_START",
+          desc: '''
+                Setting this field to 0xA will instruct the ENTROPY_SRC main state machine
+                to start the SHA3 process and be ready to accept entropy data. This field should
+                be set prior to writting the FW_OV_WR_DATA register. Once all data has been written,
+                this field should be set to 0x5. Once that happened, the SHA3 block will finish
+                processing and push the result into the ESFINAL FIFO.
+                '''
+          resval: "0x5"
+        },
+      ]
+    },
+    { name:     "FW_OV_WR_FIFO_FULL",
+      desc:     "Firmware override FIFO write full status register",
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      tags: [// Internal HW can modify status register
+             "excl:CsrAllTests:CsrExclCheck"]
+      fields: [
+        { bits: "0",
+          name: "FW_OV_WR_FIFO_FULL",
+          desc: '''"When this bit is clear, writes to the FW_OV_WR_DATA register are allowed.
+                If this bit is set, it is the equivalent to a FIFO full condition, and writes
+                to the FW_OV_WR_DATA register must be delayed until this bit is reset.
+                '''
+        }
+      ]
+    },
     { name: "FW_OV_RD_DATA",
       desc: "Firmware override Observe FIFO read register",
       swaccess: "ro",
@@ -1254,6 +1291,14 @@
           name: "RNG_BIT_ENABLE_FIELD_ALERT",
           desc: '''
                 This bit is set when the RNG_BIT_ENABLE field in the !!CONF register is set to
+                a value other than 0x5 or 0xA.
+                Writing a zero resets this status bit.
+                '''
+        }
+        { bits: "7",
+          name: "FW_OV_SHA3_START_FIELD_ALERT",
+          desc: '''
+                This bit is set when the FW_OV_SHA3_START field in the !!FW_OV_SHA3_START register is set to
                 a value other than 0x5 or 0xA.
                 Writing a zero resets this status bit.
                 '''

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -243,6 +243,10 @@ package entropy_src_reg_pkg;
   } entropy_src_reg2hw_fw_ov_control_reg_t;
 
   typedef struct packed {
+    logic [3:0]  q;
+  } entropy_src_reg2hw_fw_ov_sha3_start_reg_t;
+
+  typedef struct packed {
     logic [31:0] q;
     logic        re;
   } entropy_src_reg2hw_fw_ov_rd_data_reg_t;
@@ -525,6 +529,10 @@ package entropy_src_reg_pkg;
   } entropy_src_hw2reg_extht_fail_counts_reg_t;
 
   typedef struct packed {
+    logic        d;
+  } entropy_src_hw2reg_fw_ov_wr_fifo_full_reg_t;
+
+  typedef struct packed {
     logic [31:0] d;
   } entropy_src_hw2reg_fw_ov_rd_data_reg_t;
 
@@ -579,6 +587,10 @@ package entropy_src_reg_pkg;
       logic        d;
       logic        de;
     } rng_bit_enable_field_alert;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fw_ov_sha3_start_field_alert;
     struct packed {
       logic        d;
       logic        de;
@@ -650,27 +662,28 @@ package entropy_src_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    entropy_src_reg2hw_intr_state_reg_t intr_state; // [540:537]
-    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [536:533]
-    entropy_src_reg2hw_intr_test_reg_t intr_test; // [532:525]
-    entropy_src_reg2hw_alert_test_reg_t alert_test; // [524:521]
-    entropy_src_reg2hw_sw_regupd_reg_t sw_regupd; // [520:520]
-    entropy_src_reg2hw_module_enable_reg_t module_enable; // [519:516]
-    entropy_src_reg2hw_conf_reg_t conf; // [515:498]
-    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [497:490]
-    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [489:457]
-    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [456:425]
-    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [424:391]
-    entropy_src_reg2hw_repcnts_thresholds_reg_t repcnts_thresholds; // [390:357]
-    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [356:323]
-    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [322:289]
-    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [288:255]
-    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [254:221]
-    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [220:187]
-    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [186:153]
-    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [152:119]
-    entropy_src_reg2hw_alert_threshold_reg_t alert_threshold; // [118:87]
-    entropy_src_reg2hw_fw_ov_control_reg_t fw_ov_control; // [86:79]
+    entropy_src_reg2hw_intr_state_reg_t intr_state; // [544:541]
+    entropy_src_reg2hw_intr_enable_reg_t intr_enable; // [540:537]
+    entropy_src_reg2hw_intr_test_reg_t intr_test; // [536:529]
+    entropy_src_reg2hw_alert_test_reg_t alert_test; // [528:525]
+    entropy_src_reg2hw_sw_regupd_reg_t sw_regupd; // [524:524]
+    entropy_src_reg2hw_module_enable_reg_t module_enable; // [523:520]
+    entropy_src_reg2hw_conf_reg_t conf; // [519:502]
+    entropy_src_reg2hw_entropy_control_reg_t entropy_control; // [501:494]
+    entropy_src_reg2hw_entropy_data_reg_t entropy_data; // [493:461]
+    entropy_src_reg2hw_health_test_windows_reg_t health_test_windows; // [460:429]
+    entropy_src_reg2hw_repcnt_thresholds_reg_t repcnt_thresholds; // [428:395]
+    entropy_src_reg2hw_repcnts_thresholds_reg_t repcnts_thresholds; // [394:361]
+    entropy_src_reg2hw_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [360:327]
+    entropy_src_reg2hw_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [326:293]
+    entropy_src_reg2hw_bucket_thresholds_reg_t bucket_thresholds; // [292:259]
+    entropy_src_reg2hw_markov_hi_thresholds_reg_t markov_hi_thresholds; // [258:225]
+    entropy_src_reg2hw_markov_lo_thresholds_reg_t markov_lo_thresholds; // [224:191]
+    entropy_src_reg2hw_extht_hi_thresholds_reg_t extht_hi_thresholds; // [190:157]
+    entropy_src_reg2hw_extht_lo_thresholds_reg_t extht_lo_thresholds; // [156:123]
+    entropy_src_reg2hw_alert_threshold_reg_t alert_threshold; // [122:91]
+    entropy_src_reg2hw_fw_ov_control_reg_t fw_ov_control; // [90:83]
+    entropy_src_reg2hw_fw_ov_sha3_start_reg_t fw_ov_sha3_start; // [82:79]
     entropy_src_reg2hw_fw_ov_rd_data_reg_t fw_ov_rd_data; // [78:46]
     entropy_src_reg2hw_fw_ov_wr_data_reg_t fw_ov_wr_data; // [45:13]
     entropy_src_reg2hw_observe_fifo_thresh_reg_t observe_fifo_thresh; // [12:6]
@@ -679,42 +692,43 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1052:1045]
-    entropy_src_hw2reg_regwen_reg_t regwen; // [1044:1043]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1042:1011]
-    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1010:979]
-    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [978:947]
-    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [946:915]
-    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [914:883]
-    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [882:851]
-    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [850:819]
-    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [818:787]
-    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [786:755]
-    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [754:723]
-    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [722:691]
-    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [690:659]
-    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [658:627]
-    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [626:595]
-    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [594:563]
-    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [562:531]
-    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [530:499]
-    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [498:467]
-    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [466:435]
-    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [434:403]
-    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [402:371]
-    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [370:339]
-    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [338:307]
-    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [306:275]
-    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [274:243]
-    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [242:211]
-    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [210:179]
-    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [178:147]
-    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [146:131]
-    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [130:103]
-    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [102:95]
-    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [94:63]
-    entropy_src_hw2reg_debug_status_reg_t debug_status; // [62:42]
-    entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [41:18]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1055:1048]
+    entropy_src_hw2reg_regwen_reg_t regwen; // [1047:1046]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1045:1014]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1013:982]
+    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [981:950]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [949:918]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [917:886]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [885:854]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [853:822]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [821:790]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [789:758]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [757:726]
+    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [725:694]
+    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [693:662]
+    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [661:630]
+    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [629:598]
+    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [597:566]
+    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [565:534]
+    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [533:502]
+    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [501:470]
+    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [469:438]
+    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [437:406]
+    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [405:374]
+    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [373:342]
+    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [341:310]
+    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [309:278]
+    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [277:246]
+    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [245:214]
+    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [213:182]
+    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [181:150]
+    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [149:134]
+    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [133:106]
+    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [105:98]
+    entropy_src_hw2reg_fw_ov_wr_fifo_full_reg_t fw_ov_wr_fifo_full; // [97:97]
+    entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [96:65]
+    entropy_src_hw2reg_debug_status_reg_t debug_status; // [64:44]
+    entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [43:18]
     entropy_src_hw2reg_err_code_reg_t err_code; // [17:0]
   } entropy_src_hw2reg_t;
 
@@ -764,13 +778,15 @@ package entropy_src_reg_pkg;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET = 8'h a8;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET = 8'h ac;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h b0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h b4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h b8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h bc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h c0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h c4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h c8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h cc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_SHA3_START_OFFSET = 8'h b4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET = 8'h b8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h bc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h c0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h c4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h c8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h cc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h d0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h d4;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] ENTROPY_SRC_INTR_TEST_RESVAL = 4'h 0;
@@ -836,6 +852,7 @@ package entropy_src_reg_pkg;
   parameter logic [15:0] ENTROPY_SRC_ALERT_SUMMARY_FAIL_COUNTS_RESVAL = 16'h 0;
   parameter logic [31:0] ENTROPY_SRC_ALERT_FAIL_COUNTS_RESVAL = 32'h 0;
   parameter logic [7:0] ENTROPY_SRC_EXTHT_FAIL_COUNTS_RESVAL = 8'h 0;
+  parameter logic [0:0] ENTROPY_SRC_FW_OV_WR_FIFO_FULL_RESVAL = 1'h 0;
   parameter logic [31:0] ENTROPY_SRC_FW_OV_RD_DATA_RESVAL = 32'h 0;
   parameter logic [31:0] ENTROPY_SRC_FW_OV_WR_DATA_RESVAL = 32'h 0;
   parameter logic [28:0] ENTROPY_SRC_DEBUG_STATUS_RESVAL = 29'h 0;
@@ -887,6 +904,8 @@ package entropy_src_reg_pkg;
     ENTROPY_SRC_ALERT_FAIL_COUNTS,
     ENTROPY_SRC_EXTHT_FAIL_COUNTS,
     ENTROPY_SRC_FW_OV_CONTROL,
+    ENTROPY_SRC_FW_OV_SHA3_START,
+    ENTROPY_SRC_FW_OV_WR_FIFO_FULL,
     ENTROPY_SRC_FW_OV_RD_DATA,
     ENTROPY_SRC_FW_OV_WR_DATA,
     ENTROPY_SRC_OBSERVE_FIFO_THRESH,
@@ -897,7 +916,7 @@ package entropy_src_reg_pkg;
   } entropy_src_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] ENTROPY_SRC_PERMIT [52] = '{
+  parameter logic [3:0] ENTROPY_SRC_PERMIT [54] = '{
     4'b 0001, // index[ 0] ENTROPY_SRC_INTR_STATE
     4'b 0001, // index[ 1] ENTROPY_SRC_INTR_ENABLE
     4'b 0001, // index[ 2] ENTROPY_SRC_INTR_TEST
@@ -943,13 +962,15 @@ package entropy_src_reg_pkg;
     4'b 1111, // index[42] ENTROPY_SRC_ALERT_FAIL_COUNTS
     4'b 0001, // index[43] ENTROPY_SRC_EXTHT_FAIL_COUNTS
     4'b 0001, // index[44] ENTROPY_SRC_FW_OV_CONTROL
-    4'b 1111, // index[45] ENTROPY_SRC_FW_OV_RD_DATA
-    4'b 1111, // index[46] ENTROPY_SRC_FW_OV_WR_DATA
-    4'b 0001, // index[47] ENTROPY_SRC_OBSERVE_FIFO_THRESH
-    4'b 1111, // index[48] ENTROPY_SRC_DEBUG_STATUS
-    4'b 0011, // index[49] ENTROPY_SRC_RECOV_ALERT_STS
-    4'b 1111, // index[50] ENTROPY_SRC_ERR_CODE
-    4'b 0001  // index[51] ENTROPY_SRC_ERR_CODE_TEST
+    4'b 0001, // index[45] ENTROPY_SRC_FW_OV_SHA3_START
+    4'b 0001, // index[46] ENTROPY_SRC_FW_OV_WR_FIFO_FULL
+    4'b 1111, // index[47] ENTROPY_SRC_FW_OV_RD_DATA
+    4'b 1111, // index[48] ENTROPY_SRC_FW_OV_WR_DATA
+    4'b 0001, // index[49] ENTROPY_SRC_OBSERVE_FIFO_THRESH
+    4'b 1111, // index[50] ENTROPY_SRC_DEBUG_STATUS
+    4'b 0011, // index[51] ENTROPY_SRC_RECOV_ALERT_STS
+    4'b 1111, // index[52] ENTROPY_SRC_ERR_CODE
+    4'b 0001  // index[53] ENTROPY_SRC_ERR_CODE_TEST
   };
 
 endpackage

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -292,6 +292,11 @@ module entropy_src_reg_top (
   logic [3:0] fw_ov_control_fw_ov_mode_wd;
   logic [3:0] fw_ov_control_fw_ov_entropy_insert_qs;
   logic [3:0] fw_ov_control_fw_ov_entropy_insert_wd;
+  logic fw_ov_sha3_start_we;
+  logic [3:0] fw_ov_sha3_start_qs;
+  logic [3:0] fw_ov_sha3_start_wd;
+  logic fw_ov_wr_fifo_full_re;
+  logic fw_ov_wr_fifo_full_qs;
   logic fw_ov_rd_data_re;
   logic [31:0] fw_ov_rd_data_qs;
   logic fw_ov_wr_data_we;
@@ -320,6 +325,8 @@ module entropy_src_reg_top (
   logic recov_alert_sts_threshold_scope_field_alert_wd;
   logic recov_alert_sts_rng_bit_enable_field_alert_qs;
   logic recov_alert_sts_rng_bit_enable_field_alert_wd;
+  logic recov_alert_sts_fw_ov_sha3_start_field_alert_qs;
+  logic recov_alert_sts_fw_ov_sha3_start_field_alert_wd;
   logic recov_alert_sts_fw_ov_mode_field_alert_qs;
   logic recov_alert_sts_fw_ov_mode_field_alert_wd;
   logic recov_alert_sts_fw_ov_entropy_insert_field_alert_qs;
@@ -1928,6 +1935,47 @@ module entropy_src_reg_top (
   );
 
 
+  // R[fw_ov_sha3_start]: V(False)
+  prim_subreg #(
+    .DW      (4),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (4'h5)
+  ) u_fw_ov_sha3_start (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (fw_ov_sha3_start_we),
+    .wd     (fw_ov_sha3_start_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fw_ov_sha3_start.q),
+
+    // to register interface (read)
+    .qs     (fw_ov_sha3_start_qs)
+  );
+
+
+  // R[fw_ov_wr_fifo_full]: V(True)
+  prim_subreg_ext #(
+    .DW    (1)
+  ) u_fw_ov_wr_fifo_full (
+    .re     (fw_ov_wr_fifo_full_re),
+    .we     (1'b0),
+    .wd     ('0),
+    .d      (hw2reg.fw_ov_wr_fifo_full.d),
+    .qre    (),
+    .qe     (),
+    .q      (),
+    .qs     (fw_ov_wr_fifo_full_qs)
+  );
+
+
   // R[fw_ov_rd_data]: V(True)
   prim_subreg_ext #(
     .DW    (32)
@@ -2236,6 +2284,31 @@ module entropy_src_reg_top (
 
     // to register interface (read)
     .qs     (recov_alert_sts_rng_bit_enable_field_alert_qs)
+  );
+
+  //   F[fw_ov_sha3_start_field_alert]: 7:7
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_recov_alert_sts_fw_ov_sha3_start_field_alert (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (recov_alert_sts_we),
+    .wd     (recov_alert_sts_fw_ov_sha3_start_field_alert_wd),
+
+    // from internal hardware
+    .de     (hw2reg.recov_alert_sts.fw_ov_sha3_start_field_alert.de),
+    .d      (hw2reg.recov_alert_sts.fw_ov_sha3_start_field_alert.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (recov_alert_sts_fw_ov_sha3_start_field_alert_qs)
   );
 
   //   F[fw_ov_mode_field_alert]: 8:8
@@ -2668,7 +2741,7 @@ module entropy_src_reg_top (
 
 
 
-  logic [51:0] addr_hit;
+  logic [53:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ENTROPY_SRC_INTR_STATE_OFFSET);
@@ -2716,13 +2789,15 @@ module entropy_src_reg_top (
     addr_hit[42] = (reg_addr == ENTROPY_SRC_ALERT_FAIL_COUNTS_OFFSET);
     addr_hit[43] = (reg_addr == ENTROPY_SRC_EXTHT_FAIL_COUNTS_OFFSET);
     addr_hit[44] = (reg_addr == ENTROPY_SRC_FW_OV_CONTROL_OFFSET);
-    addr_hit[45] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
-    addr_hit[46] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
-    addr_hit[47] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
-    addr_hit[48] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
-    addr_hit[49] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
-    addr_hit[50] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
-    addr_hit[51] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
+    addr_hit[45] = (reg_addr == ENTROPY_SRC_FW_OV_SHA3_START_OFFSET);
+    addr_hit[46] = (reg_addr == ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET);
+    addr_hit[47] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
+    addr_hit[48] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
+    addr_hit[49] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
+    addr_hit[50] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
+    addr_hit[51] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
+    addr_hit[52] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
+    addr_hit[53] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -2781,7 +2856,9 @@ module entropy_src_reg_top (
                (addr_hit[48] & (|(ENTROPY_SRC_PERMIT[48] & ~reg_be))) |
                (addr_hit[49] & (|(ENTROPY_SRC_PERMIT[49] & ~reg_be))) |
                (addr_hit[50] & (|(ENTROPY_SRC_PERMIT[50] & ~reg_be))) |
-               (addr_hit[51] & (|(ENTROPY_SRC_PERMIT[51] & ~reg_be)))));
+               (addr_hit[51] & (|(ENTROPY_SRC_PERMIT[51] & ~reg_be))) |
+               (addr_hit[52] & (|(ENTROPY_SRC_PERMIT[52] & ~reg_be))) |
+               (addr_hit[53] & (|(ENTROPY_SRC_PERMIT[53] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -2931,15 +3008,19 @@ module entropy_src_reg_top (
   assign fw_ov_control_fw_ov_mode_wd = reg_wdata[3:0];
 
   assign fw_ov_control_fw_ov_entropy_insert_wd = reg_wdata[7:4];
-  assign fw_ov_rd_data_re = addr_hit[45] & reg_re & !reg_error;
-  assign fw_ov_wr_data_we = addr_hit[46] & reg_we & !reg_error;
+  assign fw_ov_sha3_start_we = addr_hit[45] & reg_we & !reg_error;
+
+  assign fw_ov_sha3_start_wd = reg_wdata[3:0];
+  assign fw_ov_wr_fifo_full_re = addr_hit[46] & reg_re & !reg_error;
+  assign fw_ov_rd_data_re = addr_hit[47] & reg_re & !reg_error;
+  assign fw_ov_wr_data_we = addr_hit[48] & reg_we & !reg_error;
 
   assign fw_ov_wr_data_wd = reg_wdata[31:0];
-  assign observe_fifo_thresh_we = addr_hit[47] & reg_we & !reg_error;
+  assign observe_fifo_thresh_we = addr_hit[49] & reg_we & !reg_error;
 
   assign observe_fifo_thresh_wd = reg_wdata[6:0];
-  assign debug_status_re = addr_hit[48] & reg_re & !reg_error;
-  assign recov_alert_sts_we = addr_hit[49] & reg_we & !reg_error;
+  assign debug_status_re = addr_hit[50] & reg_re & !reg_error;
+  assign recov_alert_sts_we = addr_hit[51] & reg_we & !reg_error;
 
   assign recov_alert_sts_fips_enable_field_alert_wd = reg_wdata[0];
 
@@ -2950,6 +3031,8 @@ module entropy_src_reg_top (
   assign recov_alert_sts_threshold_scope_field_alert_wd = reg_wdata[3];
 
   assign recov_alert_sts_rng_bit_enable_field_alert_wd = reg_wdata[5];
+
+  assign recov_alert_sts_fw_ov_sha3_start_field_alert_wd = reg_wdata[7];
 
   assign recov_alert_sts_fw_ov_mode_field_alert_wd = reg_wdata[8];
 
@@ -2964,7 +3047,7 @@ module entropy_src_reg_top (
   assign recov_alert_sts_es_bus_cmp_alert_wd = reg_wdata[13];
 
   assign recov_alert_sts_es_thresh_cfg_alert_wd = reg_wdata[14];
-  assign err_code_test_we = addr_hit[51] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[53] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
 
@@ -3198,18 +3281,26 @@ module entropy_src_reg_top (
       end
 
       addr_hit[45]: begin
-        reg_rdata_next[31:0] = fw_ov_rd_data_qs;
+        reg_rdata_next[3:0] = fw_ov_sha3_start_qs;
       end
 
       addr_hit[46]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[0] = fw_ov_wr_fifo_full_qs;
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[6:0] = observe_fifo_thresh_qs;
+        reg_rdata_next[31:0] = fw_ov_rd_data_qs;
       end
 
       addr_hit[48]: begin
+        reg_rdata_next[31:0] = '0;
+      end
+
+      addr_hit[49]: begin
+        reg_rdata_next[6:0] = observe_fifo_thresh_qs;
+      end
+
+      addr_hit[50]: begin
         reg_rdata_next[2:0] = debug_status_entropy_fifo_depth_qs;
         reg_rdata_next[5:3] = debug_status_sha3_fsm_qs;
         reg_rdata_next[6] = debug_status_sha3_block_pr_qs;
@@ -3221,12 +3312,13 @@ module entropy_src_reg_top (
         reg_rdata_next[28:20] = debug_status_main_sm_state_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[51]: begin
         reg_rdata_next[0] = recov_alert_sts_fips_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_entropy_data_reg_en_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_module_enable_field_alert_qs;
         reg_rdata_next[3] = recov_alert_sts_threshold_scope_field_alert_qs;
         reg_rdata_next[5] = recov_alert_sts_rng_bit_enable_field_alert_qs;
+        reg_rdata_next[7] = recov_alert_sts_fw_ov_sha3_start_field_alert_qs;
         reg_rdata_next[8] = recov_alert_sts_fw_ov_mode_field_alert_qs;
         reg_rdata_next[9] = recov_alert_sts_fw_ov_entropy_insert_field_alert_qs;
         reg_rdata_next[10] = recov_alert_sts_es_route_field_alert_qs;
@@ -3236,7 +3328,7 @@ module entropy_src_reg_top (
         reg_rdata_next[14] = recov_alert_sts_es_thresh_cfg_alert_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[52]: begin
         reg_rdata_next[0] = err_code_sfifo_esrng_err_qs;
         reg_rdata_next[1] = err_code_sfifo_observe_err_qs;
         reg_rdata_next[2] = err_code_sfifo_esfinal_err_qs;
@@ -3248,7 +3340,7 @@ module entropy_src_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[53]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 


### PR DESCRIPTION
A new control field has been added to instruct the main state machine
when FW will write data into the pre-conditioner FIFO.
Fixes #10983.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>