### PR TITLE
Remove incorrect byte count from comment

### DIFF
--- a/sw/otbn/crypto/p384_verify.s
+++ b/sw/otbn/crypto/p384_verify.s
@@ -744,6 +744,6 @@ dptr_y:
 dptr_d:
   .zero 4
 
-/* 768 bytes of scratchpad memory */
+/* Scratchpad memory */
 scratchpad:
   .zero 896


### PR DESCRIPTION
The 896 here is correct and matches a comment about scratchpad memory
layout at the top of `p384_verify`.

(Yes, this is trivial, but it closes #7474)