### PR TITLE
[kmac,dv] Remove assertion about last signal

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_intf.sv
@@ -72,8 +72,6 @@ interface kmac_app_intf (input clk, input rst_n);
   end
 
   // The following assertions apply for this interface for all modes.
-  // last can only be asserted along with valid
-  `ASSERT(LastAssertWithValid_A, kmac_data_req.last |-> kmac_data_req.valid, clk, !rst_n)
 
   // Done should be asserted after last, before we start another request
   `ASSERT(DoneAssertAfterLast_A,


### PR DESCRIPTION
The app interface has a `valid` signal. When that signal is low, the
interface should be ignored, so there's no need for an assertion about
the value of the `last` signal in this case.

I've just checked and I think the RTL is fine here: the arbiter in
`kmac_app.sv` handles the valid bits properly. Also, the agent that DV
uses to model the app interface sends Xs on these signals when valid
is low, so X propagation would catch if we'd done anything silly.

I'm touching this, by the way, because the failing assertion causes problems with a V2S error test for rom_ctrl. I don't *think* that the injected error causes us to drive the bus badly, so I think the right thing to do is just drop the assertion. (@prajwalaputtappa, for visibility)