### PR TITLE
[rom_ctrl, dv] Fix for rom_ctrl_kmac_err_chk regression failure

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
@@ -12,15 +12,15 @@ class rom_ctrl_kmac_err_chk_vseq extends rom_ctrl_base_vseq;
     uvm_reg_data_t act_val;
 
     cfg.m_kmac_agent_cfg.error_rsp_pct = 100;
-    cfg.scoreboard.set_exp_alert("fatal", .is_fatal(1'b1), .max_delay(10000));
+    cfg.scoreboard.set_exp_alert("fatal", .is_fatal(1'b1), .max_delay(100000));
     fork
       begin
         ral.fatal_alert_cause.predict(.value('b1), .kind(UVM_PREDICT_READ), .be(4'hF));
-        wait_alert_trigger ("fatal", .max_wait_cycle(10000), .wait_complete(1));
+        wait_alert_trigger ("fatal", .max_wait_cycle(100000), .wait_complete(1));
         csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
       end
       begin
-        repeat(3) wait_alert_trigger ("fatal", .max_wait_cycle(10000), .wait_complete(1));
+        repeat(3) wait_alert_trigger ("fatal", .max_wait_cycle(100000), .wait_complete(1));
       end
     join
     uvm_hdl_read("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.state_q", rdata_state);


### PR DESCRIPTION
Fatal alert is not triggered unless error response is signalled from
Kmac. Kmac signals an error only after kmac_data_o.last is asserted.
Last is asserted after all the address spaces in the rom is read and
sent to KMAC. Ths depends on the delay between ready-valid handshake.
Therefore, delay to expect the alert has been increased to ensure that
we wait till last has been asserted.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>