### PR TITLE
[sw/silicon_creator] Add flash_ctrl_data_erase_verify

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -73,19 +73,19 @@ static void boot_data_digest_compute(const void *boot_data,
  * @return Whether the entry is empty.
  */
 static hardened_bool_t boot_data_is_empty(const void *boot_data) {
-  static_assert(kBootDataEmptyWordValue == UINT32_MAX,
-                "kBootDataEmptyWordValue must be UINT32_MAX");
+  static_assert(kFlashCtrlErasedWord == UINT32_MAX,
+                "kFlashCtrlErasedWord must be UINT32_MAX");
   size_t i = 0;
   hardened_bool_t is_empty = kHardenedBoolTrue;
-  uint32_t res = kBootDataEmptyWordValue;
+  uint32_t res = kFlashCtrlErasedWord;
   for (; launder32(i) < kBootDataNumWords; ++i) {
     res &= read_32(boot_data);
     is_empty &= read_32(boot_data);
     boot_data = (char *)boot_data + sizeof(uint32_t);
   }
   HARDENED_CHECK_EQ(i, kBootDataNumWords);
-  if (launder32(res) == kBootDataEmptyWordValue) {
-    HARDENED_CHECK_EQ(res, kBootDataEmptyWordValue);
+  if (launder32(res) == kFlashCtrlErasedWord) {
+    HARDENED_CHECK_EQ(res, kFlashCtrlErasedWord);
     return is_empty;
   }
   return kHardenedBoolFalse;
@@ -97,7 +97,7 @@ static hardened_bool_t boot_data_is_empty(const void *boot_data) {
  *
  * This function can be used to quickly determine if an entry can be empty or
  * valid. Due to the values chosen for valid and invalid entries,
- * `masked_identifier` will be `kBootDataEmptyWordValue` for entries that can be
+ * `masked_identifier` will be `kFlashCtrlErasedWord` for entries that can be
  * empty, `kBootDataIdentifier` for entries that are not invalidated, and `0`
  * for invalidated entries.
  *
@@ -328,7 +328,7 @@ static rom_error_t boot_data_page_info_update_impl(
     // empty or valid.
     HARDENED_RETURN_IF_ERROR(boot_data_sniff(page, i, &sniff_results[i]));
     // Check all words of this entry only if it can be empty.
-    if (sniff_results[i] == kBootDataEmptyWordValue) {
+    if (sniff_results[i] == kFlashCtrlErasedWord) {
       HARDENED_RETURN_IF_ERROR(boot_data_entry_read(page, i, &buf));
       has_empty_entry = boot_data_is_empty(&buf);
       if (launder32(has_empty_entry) == kHardenedBoolTrue) {

--- a/sw/device/silicon_creator/lib/boot_data.h
+++ b/sw/device/silicon_creator/lib/boot_data.h
@@ -6,6 +6,7 @@
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_BOOT_DATA_H_
 
 #include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
 #include "sw/device/silicon_creator/lib/drivers/hmac.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/error.h"
@@ -82,12 +83,6 @@ enum {
    */
   kBootDataInvalidEntry = 0,
   /**
-   * Value of a word in flash after erase.
-   *
-   * This value is used to determine if an entry is empty or not.
-   */
-  kBootDataEmptyWordValue = UINT32_MAX,
-  /**
    * Size of `boot_data_t` in words.
    */
   kBootDataNumWords = sizeof(boot_data_t) / sizeof(uint32_t),
@@ -117,8 +112,8 @@ enum {
 static_assert(kBootDataInvalidEntry != kBootDataValidEntry,
               "Invalidation values cannot be equal.");
 static_assert(kBootDataValidEntry ==
-                  (kBootDataEmptyWordValue << 32 | kBootDataEmptyWordValue),
-              "kBootDataValidEntry words must be kBootDataEmptyWordValue");
+                  ((uint64_t)kFlashCtrlErasedWord << 32 | kFlashCtrlErasedWord),
+              "kBootDataValidEntry words must be kFlashCtrlErasedWord");
 
 /**
  * Reads the boot data stored in the flash info partition.

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -36,10 +36,6 @@ enum {
    * Base address of the flash_ctrl registers.
    */
   kBase = TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR,
-  /**
-   * Base address of the flash memory.
-   */
-  kMemBase = TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR,
 };
 
 /**
@@ -211,10 +207,10 @@ static rom_error_t write(uint32_t addr, flash_ctrl_partition_t partition,
  * @return Base address of the given page.
  */
 static uint32_t info_page_addr(flash_ctrl_info_page_t info_page) {
-#define INFO_PAGE_ADDR_CASE_(name_, value_, bank_, page_)       \
-  case (name_):                                                 \
-    HARDENED_CHECK_EQ(launder32(info_page), (name_));           \
-    return kMemBase + (bank_)*FLASH_CTRL_PARAM_BYTES_PER_BANK + \
+#define INFO_PAGE_ADDR_CASE_(name_, value_, bank_, page_) \
+  case (name_):                                           \
+    HARDENED_CHECK_EQ(launder32(info_page), (name_));     \
+    return (bank_)*FLASH_CTRL_PARAM_BYTES_PER_BANK +      \
            (page_)*FLASH_CTRL_PARAM_BYTES_PER_PAGE;
 
   switch (launder32(info_page)) {

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -90,7 +90,19 @@ static void transaction_start(transaction_params_t params) {
       bitfield_bit32_read(params.partition, FLASH_CTRL_PARTITION_BIT_IS_INFO);
   const uint32_t info_type = bitfield_field32_read(
       params.partition, FLASH_CTRL_PARTITION_FIELD_INFO_TYPE);
-  const bool bank_erase = params.erase_type == kFlashCtrlEraseTypeBank;
+  bool bank_erase = true;
+  switch (launder32(params.erase_type)) {
+    case kFlashCtrlEraseTypeBank:
+      HARDENED_CHECK_EQ(params.erase_type, kFlashCtrlEraseTypeBank);
+      bank_erase = true;
+      break;
+    case kFlashCtrlEraseTypePage:
+      HARDENED_CHECK_EQ(params.erase_type, kFlashCtrlEraseTypePage);
+      bank_erase = false;
+      break;
+    default:
+      HARDENED_UNREACHABLE();
+  }
   uint32_t reg = bitfield_bit32_write(0, FLASH_CTRL_CONTROL_START_BIT, true);
   reg =
       bitfield_field32_write(reg, FLASH_CTRL_CONTROL_OP_FIELD, params.op_type);

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -314,6 +314,16 @@ rom_error_t flash_ctrl_data_erase(uint32_t addr,
                                   flash_ctrl_erase_type_t erase_type);
 
 /**
+ * Verifies that a data partition page or bank was erased.
+ *
+ * @param addr Address that falls within the bank or page erased.
+ * @param erase_type Whether to verify a page or a bank.
+ * @return Result of the operation.
+ */
+rom_error_t flash_ctrl_data_erase_verify(uint32_t addr,
+                                         flash_ctrl_erase_type_t erase_type);
+
+/**
  * Erases an information partition page or bank.
  *
  * @param info_page Information page to erase for page erases, or a page within

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -277,15 +277,26 @@ rom_error_t flash_ctrl_info_write(flash_ctrl_info_page_t info_page,
                                   uint32_t offset, uint32_t word_count,
                                   const void *data);
 
+/*
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 5 -m 2 -n 32 \
+ *     -s 2181785819 --language=c
+ *
+ * Minimum Hamming distance: 14
+ * Maximum Hamming distance: 14
+ * Minimum Hamming weight: 14
+ * Maximum Hamming weight: 18
+ */
+
 typedef enum flash_ctrl_erase_type {
   /**
    * Erase a page.
    */
-  kFlashCtrlEraseTypePage = 0,
+  kFlashCtrlEraseTypePage = 0xaf0eab8b,
   /**
    * Erase a bank.
    */
-  kFlashCtrlEraseTypeBank = 1,
+  kFlashCtrlEraseTypeBank = 0x80329be9,
 } flash_ctrl_erase_type_t;
 
 /**

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -155,6 +155,15 @@ enum {
   kFlashCtrlSecMmioInit = 5,
 };
 
+
+
+/**
+ * Value of a word in flash after erase.
+ */
+enum {
+  kFlashCtrlErasedWord = UINT32_MAX,
+};
+
 /**
  * Kicks of the initialization of the flash controller.
  *

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -603,5 +603,89 @@ TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
   flash_ctrl_creator_info_pages_lockdown();
 }
 
+struct EraseVerifyCase {
+  /**
+   * Address.
+   */
+  uint32_t addr;
+  /**
+   * Truncated address aligned to closest lower page/bank.
+   */
+  uint32_t aligned_addr;
+  /**
+   * Erase type.
+   */
+  flash_ctrl_erase_type_t erase_type;
+  /**
+   * Value of the last word read from flash (for testing failure cases).
+   */
+  uint32_t last_word_val;
+  /**
+   * Expected return value.
+   */
+  rom_error_t error;
+};
+
+class EraseVerifyTest : public FlashCtrlTest,
+                        public testing::WithParamInterface<EraseVerifyCase> {};
+
+TEST_P(EraseVerifyTest, DataEraseVerify) {
+  size_t byte_count;
+  switch (GetParam().erase_type) {
+    case kFlashCtrlEraseTypeBank:
+      byte_count = FLASH_CTRL_PARAM_BYTES_PER_BANK;
+      break;
+    case kFlashCtrlEraseTypePage:
+      byte_count = FLASH_CTRL_PARAM_BYTES_PER_PAGE;
+      break;
+    default:
+      FAIL();
+  }
+
+  size_t i = 0;
+  for (; i < byte_count - sizeof(uint32_t); i += sizeof(uint32_t)) {
+    EXPECT_ABS_READ32(
+        TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + GetParam().aligned_addr + i,
+        kFlashCtrlErasedWord);
+  }
+  EXPECT_ABS_READ32(
+      TOP_EARLGREY_FLASH_CTRL_MEM_BASE_ADDR + GetParam().aligned_addr + i,
+      GetParam().last_word_val);
+
+  EXPECT_EQ(
+      flash_ctrl_data_erase_verify(GetParam().addr, GetParam().erase_type),
+      GetParam().error);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    AllCases, EraseVerifyTest,
+    testing::Values(
+        // Verify first page.
+        EraseVerifyCase{
+            .addr = 0,
+            .aligned_addr = 0,
+            .erase_type = kFlashCtrlEraseTypePage,
+            .last_word_val = kFlashCtrlErasedWord,
+            .error = kErrorOk,
+        },
+        // Verify 10th page, unaligned address.
+        EraseVerifyCase{
+            .addr = 10 * FLASH_CTRL_PARAM_BYTES_PER_PAGE + 128,
+            .aligned_addr = 10 * FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+            .erase_type = kFlashCtrlEraseTypePage,
+            .last_word_val = kFlashCtrlErasedWord,
+            .error = kErrorOk,
+        },
+        // Fail to verify 10th page, unaligned address.
+        EraseVerifyCase{
+            .addr = 10 * FLASH_CTRL_PARAM_BYTES_PER_PAGE + 128,
+            .aligned_addr = 10 * FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+            .erase_type = kFlashCtrlEraseTypePage,
+            .last_word_val = 0xfffffff0,
+            .error = kErrorFlashCtrlDataEraseVerify,
+        }  // Note: No cases for bank erases since the test times out due to
+           // large number of expectations.
+        ));
+
 }  // namespace
 }  // namespace flash_ctrl_unittest

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -100,6 +100,7 @@ enum module_ {
   X(kErrorFlashCtrlInfoWrite,         ERROR_(4, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlDataErase,         ERROR_(5, kModuleFlashCtrl, kInternal)), \
   X(kErrorFlashCtrlInfoErase,         ERROR_(6, kModuleFlashCtrl, kInternal)), \
+  X(kErrorFlashCtrlDataEraseVerify,   ERROR_(7, kModuleFlashCtrl, kInternal)), \
   X(kErrorSecMmioRegFileSize,         ERROR_(0, kModuleSecMmio, kResourceExhausted)), \
   X(kErrorSecMmioReadFault,           ERROR_(1, kModuleSecMmio, kInternal)), \
   X(kErrorSecMmioWriteFault,          ERROR_(2, kModuleSecMmio, kInternal)), \


### PR DESCRIPTION
This PR adds `flash_ctrl_data_erase_verify()` which will be used by mask ROM bootstrap and hardens the `flash_ctrl_erase_type_t` enum.