### PR TITLE
[aes/dv] enable masking

### DIFF
--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -42,6 +42,19 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  build_modes: [
+    {
+      name: aes_no_masking
+      build_opts: ["+define+EN_MASKING=0",
+                   "+define+SBOX_IMPL=aes_pkg::SBoxImplLut" ]
+    }
+    {
+      name: aes_masking
+        build_opts: ["+define+EN_MASKING=1",
+                     "+define+SBOX_IMPL=aes_pkg::SBoxImplDom" ]
+    }
+  ]
+
   // Default UVM test and seq class name.
   uvm_test: aes_base_test
   uvm_test_seq: aes_wake_up_vseq

--- a/hw/ip/aes/dv/aes_masking_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_masking_sim_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim cfg file for AES with masking
+{
+  // Name of the sim cfg variant
+  variant: aes_masking
+
+  // Import the base sram_ctrl sim_cfg file
+  import_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_base_sim_cfg.hjson"]
+
+  // Enable the appropriate build mode for all tests
+  en_build_modes: ["aes_masking"]
+}

--- a/hw/ip/aes/dv/aes_no_masking_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_no_masking_sim_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// sim cfg file for AES without masking
+{
+  // Name of the sim cfg variant
+  variant: aes_no_masking
+
+  // Import the base sram_ctrl sim_cfg file
+  import_cfgs: ["{proj_root}/hw/ip/aes/dv/aes_base_sim_cfg.hjson"]
+
+  // Enable the appropriate build mode for all tests
+  en_build_modes: ["aes_no_masking"]
+}

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -40,9 +40,8 @@ module tb;
                           lc_escalate[$bits(lc_ctrl_pkg::lc_tx_t):1] : lc_ctrl_pkg::Off;
   // dut
   aes #(
-    // for now keep testing the unmasked implementation
-    .SecMasking  ( 0                    ),
-    .SecSBoxImpl ( aes_pkg::SBoxImplLut )
+    .SecMasking  ( `EN_MASKING   ),
+    .SecSBoxImpl ( `SBOX_IMPL    )
   ) dut (
     .clk_i            ( clk                               ),
     .rst_ni           ( rst_n                             ),

--- a/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
+++ b/hw/top_earlgrey/dv/top_earlgrey_sim_cfgs.hjson
@@ -18,7 +18,8 @@
              "{proj_root}/hw/dv/sv/tl_agent/dv/tl_agent_sim_cfg.hjson",
              // IPs.
              "{proj_root}/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson",
-             "{proj_root}/hw/ip/aes/dv/aes_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aes/dv/aes_no_masking_sim_cfg.hjson",
+             "{proj_root}/hw/ip/aes/dv/aes_masking_sim_cfg.hjson",
              "{proj_root}/hw/ip/aon_timer/dv/aon_timer_sim_cfg.hjson",
              "{proj_root}/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson",
              "{proj_root}/hw/ip/csrng/dv/csrng_sim_cfg.hjson",


### PR DESCRIPTION
Enabling masking version of AES

@cindychip is there anything that I need to do to get this into regression or will it happen automatically?
