### PR TITLE
[opentitantool] Gracefully handle requests for unsupported interfaces

### DIFF
--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -20,6 +20,8 @@ pub enum TransportError {
     UsbGenericError(String),
     #[error("Error opening USB device: {0}")]
     UsbOpenError(String),
+    #[error("Transport does not support {0:?}")]
+    InvalidInterface(TransportInterfaceType),
     #[error("Transport does not support {0:?} instance {1}")]
     InvalidInstance(TransportInterfaceType, String),
     #[error("Encountered non-unicode device path")]

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -79,23 +79,23 @@ pub trait Transport {
 
     /// Returns a SPI [`Target`] implementation.
     fn spi(&self, _instance: &str) -> Result<Rc<dyn Target>> {
-        unimplemented!();
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Spi))
     }
     /// Returns a I2C [`Bus`] implementation.
     fn i2c(&self, _instance: &str) -> Result<Rc<dyn Bus>> {
-        unimplemented!();
+        Err(TransportError::InvalidInterface(TransportInterfaceType::I2c))
     }
     /// Returns a [`Uart`] implementation.
     fn uart(&self, _instance: &str) -> Result<Rc<dyn Uart>> {
-        unimplemented!();
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Uart))
     }
     /// Returns a [`GpioPin`] implementation.
     fn gpio_pin(&self, _instance: &str) -> Result<Rc<dyn GpioPin>> {
-        unimplemented!();
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Gpio))
     }
     /// Invoke non-standard functionality of some Transport implementations.
     fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn Serialize>>> {
-        Err(TransportError::UnsupportedOperation.into())
+        Err(TransportError::UnsupportedOperation)
     }
 }
 


### PR DESCRIPTION
As we plan to introduce a session proxy process, it is not desirable
that the persistent session process could panic!() if a single command
line invocation asks for e.g. I2C, though the particular USB backend
does not support I2C at all.

We already have a TransportError value to be used if asking for e.g. a
UART instance which does not exist: InvalidInstance.  It would be sent
via the TCP protocol and presented by the command line invocation.

This change introduces a new InvalidInterface.  And modifies the
default implementation in the Transport trait to return that instead
of panicking, in case the transport does not support UART, I2C or
whatever kind of interface it is being asked about.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>