### PR TITLE
[opentitantool] Remove unused conf structs, and compiler fixes

### DIFF
--- a/sw/host/opentitanlib/src/app/conf.rs
+++ b/sw/host/opentitanlib/src/app/conf.rs
@@ -76,56 +76,6 @@ pub struct SpiConfiguration {
     pub alias_of: Option<String>,
 }
 
-#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
-pub enum FlashAddressMode {
-    Mode3b,
-    Mode4b,
-}
-
-/// Chip programmed via an EEPROM-like SPI protocol.
-#[derive(Deserialize, Clone, Debug)]
-pub struct SpiEeprom {
-    size: u32,
-    erase_block_size: u32,
-    erase_opcode: u8,
-    program_block_size: u32,
-    address_mode: FlashAddressMode,
-    /// Name of spi bus as defined by transport.
-    spi_bus: String,
-    // Possibly add more fields to declare SPI mode/speed
-}
-
-/// Temporary measure to allow external program to implement SPI protocol.
-#[derive(Deserialize, Clone, Debug)]
-pub struct SpiExternalDriver {
-    command: String,
-    /// Name of spi bus as defined by transport.
-    spi_bus: String,
-    // Possibly add more fields to declare SPI mode/speed
-}
-
-/// Defines the protocol used by a particular programmable chip.
-#[derive(Deserialize, Clone, Debug)]
-pub enum FlashDriver {
-    /// Chip programmed via an EEPROM-like SPI protocol.
-    SpiEeprom(SpiEeprom),
-    /// Temporary measure to allow external program to implement SPI protocol.
-    SpiExternalDriver(SpiExternalDriver),
-}
-
-/// Defines the way to reach and program flash storage.
-#[derive(Deserialize, Clone, Debug)]
-pub struct FlashConfiguration {
-    /// The user-visible name of the flash storage.
-    pub name: String,
-    /// Name of the reset pin to be used.
-    pub reset_pin: String,
-    /// Name of the bootloade pin to be held high during reset.
-    pub bootloader_pin: Option<String>,
-    /// Declaration of the particular flashing protocol to be used.
-    pub driver: FlashDriver,
-}
-
 /// Representation of the complete and unresolved content of a single
 /// confguration file.
 #[derive(Deserialize, Clone, Debug)]
@@ -145,7 +95,4 @@ pub struct ConfigurationFile {
     /// List of UART configurations.
     #[serde(default)]
     pub uarts: Vec<UartConfiguration>,
-    /// List of configurations of programmable storage.
-    #[serde(default)]
-    pub flash: Vec<FlashConfiguration>,
 }

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -37,7 +37,6 @@ pub struct TransportWrapper {
     uart_map: HashMap<String, String>,
     spi_map: HashMap<String, String>,
     i2c_map: HashMap<String, String>,
-    flash_map: HashMap<String, conf::FlashConfiguration>,
     pin_conf_map: HashMap<String, PinConfiguration>,
     strapping_conf_map: HashMap<String, HashMap<String, PinConfiguration>>,
 }
@@ -50,7 +49,6 @@ impl TransportWrapper {
             uart_map: HashMap::new(),
             spi_map: HashMap::new(),
             i2c_map: HashMap::new(),
-            flash_map: HashMap::new(),
             pin_conf_map: HashMap::new(),
             strapping_conf_map: HashMap::new(),
         }
@@ -217,10 +215,6 @@ impl TransportWrapper {
             }
             // TODO(#8769): Record baud / parity configration for later
             // use when opening uart.
-        }
-        for flash_conf in file.flash {
-            self.flash_map
-                .insert(flash_conf.name.clone(), flash_conf.clone());
         }
         Ok(())
     }

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -66,7 +66,7 @@ pub type Result<T> = anyhow::Result<T, TransportError>;
 #[macro_export]
 macro_rules! bail {
     ($err:expr $(,)?) => {
-        return Err($err.into());
+        return Err($err.into())
     };
 }
 


### PR DESCRIPTION
Fix compiler warning about semicolons in macros, and remove some
unused declarations from configuration file format.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I67252086410731d847ef1048084c240939d93a99