### PR TITLE
[csrng/data] Remove excl keywords from hjson file

### DIFF
--- a/hw/ip/csrng/data/csrng.hjson
+++ b/hw/ip/csrng/data/csrng.hjson
@@ -190,7 +190,7 @@
       swaccess: "rw",
       hwaccess: "hro",
       regwen: "REGWEN",
-      tags: [// Internal HW can modify status register
+      tags: [// Keep HW from affecting other registers.
                  "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         {
@@ -415,8 +415,6 @@
       desc: "Hardware detection of error conditions status register",
       swaccess: "ro",
       hwaccess: "hwo",
-      tags: [ // The internal HW can modify the error code registers
-              "excl:CsrAllTests:CsrExclCheck"],
       fields: [
         { bits: "0",
           name: "SFIFO_CMD_ERR",
@@ -661,8 +659,8 @@
       hwaccess: "hro",
       hwqe: "true",
       regwen: "REGWEN",
-      tags: [// Setting this register will force an unwanted fatal alert.
-                 "excl:CsrAllTests:CsrExclWrite"]
+      tags: [// Keep HW from affecting other registers.
+                "excl:CsrAllTests:CsrExclWrite"]
       fields: [
         {
             bits: "4:0",
@@ -678,18 +676,17 @@
         },
       ]
     },
-    { name: "DEBUG_STATUS",
-      desc: "Debug status register",
+    { name: "MAIN_SM_STATE",
+      desc: "Main state machine state debug register",
       swaccess: "ro",
       hwaccess: "hwo",
-      tags: [ // CSRNG internal HW can modify status register
-              "excl:CsrAllTests:CsrExclCheck"]
       fields: [
         { bits: "7:0",
           name: "MAIN_SM_STATE",
           desc: '''This is the state of the CSRNG main state machine.
                 See the RTL file `csrng_main_sm` for the meaning of the values.
                 '''
+          resval: 0x4e
         }
       ]
     },

--- a/hw/ip/csrng/rtl/csrng_core.sv
+++ b/hw/ip/csrng/rtl/csrng_core.sv
@@ -1610,8 +1610,8 @@ module csrng_core import csrng_pkg::*; #(
   // observe state machine
   //--------------------------------------------
 
-  assign hw2reg.debug_status.de = 1'b1;
-  assign hw2reg.debug_status.d = cs_main_sm_state;
+  assign hw2reg.main_sm_state.de = 1'b1;
+  assign hw2reg.main_sm_state.d = cs_main_sm_state;
 
   //--------------------------------------------
   // report csrng request summary

--- a/hw/ip/csrng/rtl/csrng_reg_pkg.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_pkg.sv
@@ -294,7 +294,7 @@ package csrng_reg_pkg;
   typedef struct packed {
     logic [7:0]  d;
     logic        de;
-  } csrng_hw2reg_debug_status_reg_t;
+  } csrng_hw2reg_main_sm_state_reg_t;
 
   // Register -> HW type
   typedef struct packed {
@@ -320,7 +320,7 @@ package csrng_reg_pkg;
     csrng_hw2reg_hw_exc_sts_reg_t hw_exc_sts; // [84:69]
     csrng_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [68:61]
     csrng_hw2reg_err_code_reg_t err_code; // [60:9]
-    csrng_hw2reg_debug_status_reg_t debug_status; // [8:0]
+    csrng_hw2reg_main_sm_state_reg_t main_sm_state; // [8:0]
   } csrng_hw2reg_t;
 
   // Register offsets
@@ -340,7 +340,7 @@ package csrng_reg_pkg;
   parameter logic [BlockAw-1:0] CSRNG_RECOV_ALERT_STS_OFFSET = 7'h 34;
   parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_OFFSET = 7'h 38;
   parameter logic [BlockAw-1:0] CSRNG_ERR_CODE_TEST_OFFSET = 7'h 3c;
-  parameter logic [BlockAw-1:0] CSRNG_DEBUG_STATUS_OFFSET = 7'h 40;
+  parameter logic [BlockAw-1:0] CSRNG_MAIN_SM_STATE_OFFSET = 7'h 40;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] CSRNG_INTR_TEST_RESVAL = 4'h 0;
@@ -373,7 +373,7 @@ package csrng_reg_pkg;
     CSRNG_RECOV_ALERT_STS,
     CSRNG_ERR_CODE,
     CSRNG_ERR_CODE_TEST,
-    CSRNG_DEBUG_STATUS
+    CSRNG_MAIN_SM_STATE
   } csrng_id_e;
 
   // Register width information to check illegal writes
@@ -394,7 +394,7 @@ package csrng_reg_pkg;
     4'b 0011, // index[13] CSRNG_RECOV_ALERT_STS
     4'b 1111, // index[14] CSRNG_ERR_CODE
     4'b 0001, // index[15] CSRNG_ERR_CODE_TEST
-    4'b 0001  // index[16] CSRNG_DEBUG_STATUS
+    4'b 0001  // index[16] CSRNG_MAIN_SM_STATE
   };
 
 endpackage

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -199,7 +199,7 @@ module csrng_reg_top (
   logic err_code_test_we;
   logic [4:0] err_code_test_qs;
   logic [4:0] err_code_test_wd;
-  logic [7:0] debug_status_qs;
+  logic [7:0] main_sm_state_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1567,12 +1567,12 @@ module csrng_reg_top (
   );
 
 
-  // R[debug_status]: V(False)
+  // R[main_sm_state]: V(False)
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (8'h0)
-  ) u_debug_status (
+    .RESVAL  (8'h4e)
+  ) u_main_sm_state (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -1581,15 +1581,15 @@ module csrng_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.debug_status.de),
-    .d      (hw2reg.debug_status.d),
+    .de     (hw2reg.main_sm_state.de),
+    .d      (hw2reg.main_sm_state.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (debug_status_qs)
+    .qs     (main_sm_state_qs)
   );
 
 
@@ -1613,7 +1613,7 @@ module csrng_reg_top (
     addr_hit[13] = (reg_addr == CSRNG_RECOV_ALERT_STS_OFFSET);
     addr_hit[14] = (reg_addr == CSRNG_ERR_CODE_OFFSET);
     addr_hit[15] = (reg_addr == CSRNG_ERR_CODE_TEST_OFFSET);
-    addr_hit[16] = (reg_addr == CSRNG_DEBUG_STATUS_OFFSET);
+    addr_hit[16] = (reg_addr == CSRNG_MAIN_SM_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1817,7 +1817,7 @@ module csrng_reg_top (
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[7:0] = debug_status_qs;
+        reg_rdata_next[7:0] = main_sm_state_qs;
       end
 
       default: begin


### PR DESCRIPTION
To increase coverage safely, certain exclusion tags were removed
from the hjson file.
This is action from the csrng v2 review.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>