### PR TITLE
[syn] Add option to terminate the synthesis flow earlier (e.g. after analyze or elab)

### DIFF
--- a/hw/syn/tools/dc/parse-syn-report.py
+++ b/hw/syn/tools/dc/parse-syn-report.py
@@ -385,49 +385,68 @@ def get_results(args):
             "flow_warnings": [],
             "analyze_errors": [],
             "analyze_warnings": [],
-            "elab_errors": [],
-            "elab_warnings": [],
-            "compile_errors": [],
-            "compile_warnings": [],
+            # Depending on the termination stage,
+            # these message lists do not exist.
+            "elab_errors": None,
+            "elab_warnings": None,
+            "compile_errors": None,
+            "compile_warnings": None,
         },
-        "timing": {
-            # field for each timing group with tns, wns
-            # and the period if this is a clock
-        },
-        "area": {
-            # gate equivalent of a NAND2 gate
-            "ge": float("nan"),
-            # hierchical report with "comb", "buf", "reg", "macro", "total"
-            "instances": {},
-        },
-        "power": {
-            "net": float("nan"),
-            "int": float("nan"),
-            "leak": float("nan"),
-        },
-        "units": {
-            "voltage": float("nan"),
-            "capacitance": float("nan"),
-            "time": float("nan"),
-            "dynamic": float("nan"),
-            "static": float("nan"),
-        }
     }
 
     results["top"] = args.dut
 
     args.expand_modules = args.expand_modules.strip().split(',')
 
+    # Check whether the termination stage is known and define the
+    # associated reports to be parsed.
+    if args.termination_stage not in ["analyze", "elab", "compile", "reports"]:
+        results['messages']['flow_errors'].append(
+            'Unknown termination stage {}'.format(args.termination_stage))
+
+    # We always run analysis, and we always look at the synthesis log.
     rep_types = [(args.log_path, 'synthesis.log', 'flow', _extract_messages),
-                 (args.rep_path, 'analyze.rpt', 'analyze', _extract_messages),
-                 (args.rep_path, 'elab.rpt', 'elab', _extract_messages),
-                 (args.rep_path, 'compile.rpt', 'compile', _extract_messages),
-                 (args.rep_path, 'gate_equiv.rpt', 'area', _extract_gate_eq),
-                 (args.rep_path, 'area.rpt', 'area', _extract_area),
-                 (args.rep_path, 'clocks.rpt', 'timing', _extract_clocks),
-                 (args.rep_path, 'timing.rpt', 'timing', _extract_timing),
-                 (args.rep_path, 'power.rpt', 'power', _extract_power),
-                 (args.rep_path, 'power.rpt', 'units', _extract_units)]
+                 (args.rep_path, 'analyze.rpt', 'analyze', _extract_messages)]
+
+    if args.termination_stage in ["elab", "compile", "reports"]:
+        rep_types += [(args.rep_path, 'elab.rpt', 'elab', _extract_messages)]
+        results["messages"]["elab_errors"] = []
+        results["messages"]["elab_warnings"] = []
+    if args.termination_stage in ["compile", "reports"]:
+        rep_types += [(args.rep_path, 'compile.rpt', 'compile', _extract_messages)]
+        results["messages"]["compile_errors"] = []
+        results["messages"]["compile_warnings"] = []
+    if args.termination_stage in ["reports"]:
+        rep_types += [(args.rep_path, 'gate_equiv.rpt', 'area', _extract_gate_eq),
+                      (args.rep_path, 'area.rpt', 'area', _extract_area),
+                      (args.rep_path, 'clocks.rpt', 'timing', _extract_clocks),
+                      (args.rep_path, 'timing.rpt', 'timing', _extract_timing),
+                      (args.rep_path, 'power.rpt', 'power', _extract_power),
+                      (args.rep_path, 'power.rpt', 'units', _extract_units)]
+        results.update({
+            "timing": {
+                # field for each timing group with tns, wns
+                # and the period if this is a clock
+            },
+            "area": {
+                # gate equivalent of a NAND2 gate
+                "ge": float("nan"),
+                # hierchical report with "comb", "buf", "reg", "macro", "total"
+                "instances": {},
+            },
+            "power": {
+                "net": float("nan"),
+                "int": float("nan"),
+                "leak": float("nan"),
+            },
+            "units": {
+                "voltage": float("nan"),
+                "capacitance": float("nan"),
+                "time": float("nan"),
+                "dynamic": float("nan"),
+                "static": float("nan"),
+            }
+        })
 
     for path, name, key, handler in rep_types:
         _parse_file(path, name, results, handler, key, args)
@@ -556,6 +575,12 @@ def main():
         type=str,
         default="",
         help="""Comma separated list of modules to expand in area report""")
+
+    parser.add_argument(
+        '--termination-stage',
+        type=str,
+        default="",
+        help="""Can be either 'analyze', 'elab', 'compile' or 'reports'""")
 
     args = parser.parse_args()
     results = get_results(args)

--- a/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson
@@ -14,6 +14,12 @@
       name: foundry_root
       value: ""
     }
+    // The GTECH flow does not create any meaningful ATP reports, hence
+    // we terminate after compilation.
+    {
+      name: termination_stage
+      value: "compile"
+    }
   ]
 
   // Load common dont_touch wildcard constraints for the primitives. No other

--- a/hw/syn/tools/dvsim/common_syn_cfg.hjson
+++ b/hw/syn/tools/dvsim/common_syn_cfg.hjson
@@ -46,17 +46,30 @@
   // Can be used to hook in an additional post elab scripting step.
   post_elab_script: ""
 
+  // By default we run full synthesis including ATP reporting.
+  // This can be overridden with either of the following
+  // values in order to terminate earlier (listed in order):
+  // - "analyze"
+  // - "elab"
+  // - "compile"
+  // - "reports"
+  // Every stage includes the prior stages, and the report parsing script
+  // will expect the associated reports to be available (otherwise an
+  // error will be generated and the flow will fail).
+  termination_stage: "reports"
+
   // Common fail patterns.
   build_fail_patterns: [// FuseSoC build error
                         "^ERROR:.*$"]
 
   exports: [
-    { SYN_ROOT:         "{syn_root}" },
-    { FOUNDRY_ROOT:     "{foundry_root}" },
-    { BUILD_DIR:        "{build_dir}" },
-    { DUT:              "{dut}" },
-    { PARAMS:           "{params}" },
-    { SV_FLIST:         "{sv_flist}" },
-    { POST_ELAB_SCRIPT: "{post_elab_script}" }
+    { SYN_ROOT:          "{syn_root}" },
+    { FOUNDRY_ROOT:      "{foundry_root}" },
+    { BUILD_DIR:         "{build_dir}" },
+    { DUT:               "{dut}" },
+    { PARAMS:            "{params}" },
+    { SV_FLIST:          "{sv_flist}" },
+    { POST_ELAB_SCRIPT:  "{post_elab_script}" }
+    { TERMINATION_STAGE: "{termination_stage}" }
   ]
 }

--- a/hw/syn/tools/dvsim/dc.hjson
+++ b/hw/syn/tools/dvsim/dc.hjson
@@ -2,6 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
+  // Synopsys Design Compiler
+  tool: dc
+
   // Environment variables that are needed in the synthesis script
   exports: [
     { CONSTRAINT:         "{sdc_file}" },
@@ -19,7 +22,8 @@
                 "--expand-depth {expand_depth}",
                 "--log-path {build_dir} ",
                 "--rep-path {build_dir}/REPORTS",
-                "--out-dir {build_dir}"]
+                "--out-dir {build_dir}",
+                "--termination-stage {termination_stage}"]
 
   // By default, 1 level of hierarchy is always expanded in the area report.
   // This can be changed by setting the expansion depth to a higher value,

--- a/hw/top_earlgrey/syn/chip_earlgrey_asic_elab_syn_cfg.hjson
+++ b/hw/top_earlgrey/syn/chip_earlgrey_asic_elab_syn_cfg.hjson
@@ -1,0 +1,15 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // This is an elaboration-only target that is based on the main synthesis flow.
+  import_cfgs: ["{proj_root}/hw/top_earlgrey/syn/chip_earlgrey_asic_syn_cfg.hjson"]
+
+  overrides: [
+    // Run the flow up until after the elab stage.
+    {
+      name: termination_stage
+      value: "elab"
+    }
+  ]
+}


### PR DESCRIPTION
This will allow us to run DC elab regressions in presubmit checks without having to run the full (time consuming) compilation step.

The solution only makes minimal changes to the core Dvsim files so that 

1) Message lists that are assigned `None` (as opposed to an empty list) will cause the summary table to contain `--` (with grey background) instead of the value 0 (with a green background), indicating that the step has not been run.

2) The synthesis flow now returns "passed" status when no errors are present (before, even warnings would lead to a "failed" status, which is not correct).

The bulk of the change affects the Hjson config files and the synthesis report parser script.
I.e., the exit point in the synthesis flow can be specified via an Hjson variable called `termination_stage` that can take on either of the values `analyze`, `elab`, `compile` or `reports`.

The `termination_stage` variable does not directly affect the Dvsim core classes at this time, although we may want to absorb this concept into "build modes" long-term, since that is a native concept within Dvsim (that would require a more involved extension of the `SynCfg` class, however, since build modes are not supported in that class yet).
