### PR TITLE
Update scb to generate intg for unmapped address in xbar

### DIFF
--- a/hw/dv/sv/sec_cm/prim_count_if.sv
+++ b/hw/dv/sv/sec_cm/prim_count_if.sv
@@ -13,6 +13,10 @@ interface prim_count_if #(
   input clk_i,
   input rst_ni);
 
+  `include "dv_macros.svh"
+  `include "uvm_macros.svh"
+  import uvm_pkg::*;
+
   string msg_id = $sformatf("%m");
 
   prim_count_pkg::prim_count_style_e cnt_style = CntStyle;

--- a/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
+++ b/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
@@ -12,6 +12,10 @@ interface prim_double_lfsr_if #(
   input clk_i,
   input rst_ni);
 
+  `include "dv_macros.svh"
+  `include "uvm_macros.svh"
+  import uvm_pkg::*;
+
   string msg_id = $sformatf("%m");
 
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -12,6 +12,10 @@ interface prim_sparse_fsm_flop_if #(
   input clk_i,
   input rst_ni);
 
+  `include "dv_macros.svh"
+  `include "uvm_macros.svh"
+  import uvm_pkg::*;
+
   localparam int MaxFlipBits = 2;
 
   string msg_id = $sformatf("%m");

--- a/hw/ip/tlul/generic_dv/env/seq_lib/xbar_seq_err_item.sv
+++ b/hw/ip/tlul/generic_dv/env/seq_lib/xbar_seq_err_item.sv
@@ -5,7 +5,7 @@
 // ---------------------------------------------
 // TileLink sequence item with all protocol related constraint disabled
 // ---------------------------------------------
-class xbar_seq_err_item extends tl_seq_item;
+class xbar_seq_err_item extends cip_tl_seq_item;
 
   `uvm_object_utils(xbar_seq_err_item)
   `uvm_object_new

--- a/hw/ip/tlul/generic_dv/env/xbar_env.core
+++ b/hw/ip/tlul/generic_dv/env/xbar_env.core
@@ -8,6 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:dv:dv_lib
+      - lowrisc:dv:cip_lib
       - lowrisc:dv:tl_agent
       - lowrisc:dv:scoreboard
     files:

--- a/hw/ip/tlul/generic_dv/env/xbar_env.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env.sv
@@ -21,6 +21,11 @@ class xbar_env extends dv_base_env#(.CFG_T              (xbar_env_cfg),
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
+
+    // use cip_tl_seq_item to create tl_seq_item with correct integrity values and obtain integrity
+    // related functions
+    tl_seq_item::type_id::set_type_override(cip_tl_seq_item::get_type());
+
     // Connect TileLink host and device agents
     host_agent = new[cfg.num_hosts];
     foreach (host_agent[i]) begin

--- a/hw/ip/tlul/generic_dv/env/xbar_env_pkg.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_env_pkg.sv
@@ -12,6 +12,7 @@ package xbar_env_pkg;
   import dv_utils_pkg::*;
   import tl_agent_pkg::*;
   import dv_lib_pkg::*;
+  import cip_base_pkg::*;
 
   typedef struct {
     string                      device_name;

--- a/hw/ip/tlul/generic_dv/env/xbar_scoreboard.sv
+++ b/hw/ip/tlul/generic_dv/env/xbar_scoreboard.sv
@@ -104,7 +104,7 @@ class xbar_scoreboard extends scoreboard_pkg::scoreboard #(.ITEM_T(tl_seq_item),
       if (modified_tr.d_opcode == tlul_pkg::AccessAck) modified_tr.d_data = 0;
       transformed_tr = {modified_tr};
     end else begin
-      tl_seq_item rsp;
+      cip_tl_seq_item rsp;
       `downcast(rsp, tr.clone());
       rsp.d_source    = tr.a_source;
       rsp.d_size      = tr.a_size;
@@ -112,6 +112,8 @@ class xbar_scoreboard extends scoreboard_pkg::scoreboard #(.ITEM_T(tl_seq_item),
       rsp.d_data      = rsp.a_opcode == tlul_pkg::Get ? '1 : 0;
       rsp.d_opcode    = rsp.a_opcode == tlul_pkg::Get ?
                         tlul_pkg::AccessAckData : tlul_pkg::AccessAck;
+      rsp.d_user      = rsp.compute_d_user;
+
       transformed_tr  = {rsp};
     end
   endfunction

--- a/hw/ip/tlul/generic_dv/tests/xbar_error_test.sv
+++ b/hw/ip/tlul/generic_dv/tests/xbar_error_test.sv
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// override tl_seq_item with xbar_seq_err_item to disable TL protocol related constraint
+// override cip_tl_seq_item with xbar_seq_err_item to disable TL protocol related constraint
 class xbar_error_test extends xbar_base_test;
   `uvm_component_utils(xbar_error_test)
   `uvm_component_new
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-    tl_seq_item::type_id::set_type_override(xbar_seq_err_item::get_type());
+    cip_base_pkg::cip_tl_seq_item::type_id::set_type_override(xbar_seq_err_item::get_type());
   endfunction : build_phase
 
   virtual task run_phase(uvm_phase phase);


### PR DESCRIPTION
First commit is to fix missing pkg import in interfaces

Second commit is the DV side update for https://github.com/lowRISC/opentitan/issues/10778 and https://github.com/lowRISC/opentitan/pull/11001
1. include cip_lib to have the `compute_d_user` function
2. call `compute_d_user` to generate d_user with correct integrity for xbar unmapped item

Depends on design update https://github.com/lowRISC/opentitan/pull/11042