### PR TITLE
[opentitantool] Persistent session support

### DIFF
--- a/sw/host/Cargo.toml
+++ b/sw/host/Cargo.toml
@@ -5,6 +5,7 @@
 [workspace]
 members = [
     "opentitanlib",
+    "opentitansession",
     "opentitantool",
     "rom_ext_image_tools/signer",
     "rom_ext_image_tools/signer/image",

--- a/sw/host/meson.build
+++ b/sw/host/meson.build
@@ -5,4 +5,5 @@
 subdir('vendor')
 subdir('spiflash')
 subdir('rom_ext_image_tools')
+subdir('opentitansession')
 subdir('opentitantool')

--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -44,6 +44,8 @@ rust_library(
         "src/spiflash/flash.rs",
         "src/spiflash/mod.rs",
         "src/spiflash/sfdp.rs",
+        "src/proxy/socket_server.rs",
+        "src/proxy/handler.rs",
         "src/proxy/mod.rs",
         "src/proxy/protocol.rs",
         "src/transport/common/mod.rs",

--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -35,6 +35,8 @@ num-bigint-dig = "0.7.0"
 num-traits = "0.2.14"
 sha2 = "0.10.1"
 humantime = "2.1.0"
+mio = { version = "0.7.0", features = ["os-poll", "net", "os-ext"] }
+mio-signals = "0.1.5" # mio-signals 0.2.0 exists, but requires mio 0.8.0
 
 serde = { version="1", features=["serde_derive"] }
 serde_json = "1"

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -1,0 +1,238 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+
+use std::time::Duration;
+
+use super::protocol::{
+    GpioRequest, GpioResponse, I2cRequest, I2cResponse, I2cTransferRequest, I2cTransferResponse,
+    Message, Request, Response, SpiRequest, SpiResponse, SpiTransferRequest, SpiTransferResponse,
+    UartRequest, UartResponse,
+};
+use super::CommandHandler;
+use crate::app::TransportWrapper;
+use crate::io::i2c;
+use crate::io::spi;
+use crate::transport::TransportError;
+
+/// Implementation of the handling of each protocol request, by means of an underlying
+/// `Transport` implementation.
+pub struct TransportCommandHandler<'a> {
+    transport: &'a TransportWrapper,
+}
+
+impl<'a> TransportCommandHandler<'a> {
+    pub fn new(transport: &'a TransportWrapper) -> Self {
+        Self { transport }
+    }
+
+    /// This method will perform whatever action on the underlying `Transport` that is requested
+    /// by the given `Request`, and return a response to be sent to the client.  Any `Err`
+    /// return from this method will be propagated to the remote client, without any server-side
+    /// logging.
+    fn do_execute_cmd(&self, req: &Request) -> Result<Response, TransportError> {
+        match req {
+            Request::Gpio { id, command } => {
+                let instance = self.transport.gpio_pin(id)?;
+                match command {
+                    GpioRequest::Read => {
+                        let value = instance.read()?;
+                        Ok(Response::Gpio(GpioResponse::Read { value }))
+                    }
+                    GpioRequest::Write { logic } => {
+                        instance.write(*logic)?;
+                        Ok(Response::Gpio(GpioResponse::Write))
+                    }
+                    GpioRequest::SetMode { mode } => {
+                        instance.set_mode(*mode)?;
+                        Ok(Response::Gpio(GpioResponse::SetMode))
+                    }
+                    GpioRequest::SetPullMode { pull } => {
+                        instance.set_pull_mode(*pull)?;
+                        Ok(Response::Gpio(GpioResponse::SetPullMode))
+                    }
+                }
+            }
+            Request::Uart { id, command } => {
+                let instance = self.transport.uart(id)?;
+                match command {
+                    UartRequest::GetBaudrate => {
+                        let rate = instance.get_baudrate()?;
+                        Ok(Response::Uart(UartResponse::GetBaudrate { rate }))
+                    }
+                    UartRequest::SetBaudrate { rate } => {
+                        instance.set_baudrate(*rate)?;
+                        Ok(Response::Uart(UartResponse::SetBaudrate))
+                    }
+                    UartRequest::Read {
+                        timeout_millis,
+                        len,
+                    } => {
+                        let mut data = vec![0u8; *len as usize];
+                        let count = match timeout_millis {
+                            None => instance.read(&mut data)?,
+                            Some(ms) => instance
+                                .read_timeout(&mut data, Duration::from_millis(*ms as u64))?,
+                        };
+                        data.resize(count, 0);
+                        Ok(Response::Uart(UartResponse::Read { data }))
+                    }
+                    UartRequest::Write { data } => {
+                        instance.write(data)?;
+                        Ok(Response::Uart(UartResponse::Write))
+                    }
+                }
+            }
+            Request::Spi { id, command } => {
+                let instance = self.transport.spi(id)?;
+                match command {
+                    SpiRequest::GetTransferMode => {
+                        let mode = instance.get_transfer_mode()?;
+                        Ok(Response::Spi(SpiResponse::GetTransferMode { mode }))
+                    }
+                    SpiRequest::SetTransferMode { mode } => {
+                        instance.set_transfer_mode(*mode)?;
+                        Ok(Response::Spi(SpiResponse::SetTransferMode))
+                    }
+                    SpiRequest::GetBitsPerWord => {
+                        let bits_per_word = instance.get_bits_per_word()?;
+                        Ok(Response::Spi(SpiResponse::GetBitsPerWord { bits_per_word }))
+                    }
+                    SpiRequest::SetBitsPerWord { bits_per_word } => {
+                        instance.set_bits_per_word(*bits_per_word)?;
+                        Ok(Response::Spi(SpiResponse::SetBitsPerWord))
+                    }
+                    SpiRequest::GetMaxSpeed => {
+                        let speed = instance.get_max_speed()?;
+                        Ok(Response::Spi(SpiResponse::GetMaxSpeed { speed }))
+                    }
+                    SpiRequest::SetMaxSpeed { value } => {
+                        instance.set_max_speed(*value)?;
+                        Ok(Response::Spi(SpiResponse::SetMaxSpeed))
+                    }
+                    SpiRequest::GetMaxTransferCount => {
+                        let number = instance.get_max_transfer_count()?;
+                        Ok(Response::Spi(SpiResponse::GetMaxTransferCount { number }))
+                    }
+                    SpiRequest::GetMaxChunkSize => {
+                        let size = instance.max_chunk_size()?;
+                        Ok(Response::Spi(SpiResponse::GetMaxChunkSize { size }))
+                    }
+                    SpiRequest::SetVoltage { voltage } => {
+                        instance.set_voltage(*voltage)?;
+                        Ok(Response::Spi(SpiResponse::SetVoltage))
+                    }
+                    SpiRequest::RunTransaction { transaction: reqs } => {
+                        // Construct proper response to each transfer in request.
+                        let mut resps: Vec<SpiTransferResponse> = reqs
+                            .iter()
+                            .map(|transfer| match transfer {
+                                SpiTransferRequest::Read { len } => SpiTransferResponse::Read {
+                                    data: vec![0; *len as usize],
+                                },
+                                SpiTransferRequest::Write { .. } => SpiTransferResponse::Write,
+                                SpiTransferRequest::Both { data } => SpiTransferResponse::Both {
+                                    data: vec![0; data.len()],
+                                },
+                            })
+                            .collect();
+                        // Now carefully craft a proper parameter to the
+                        // `spi::Target::run_transactions()` method.  It will have reference
+                        // into elements of both the request vector and mutable reference into
+                        // the response vector.
+                        let mut transaction: Vec<spi::Transfer> = reqs
+                            .iter()
+                            .zip(resps.iter_mut())
+                            .map(|pair| match pair {
+                                (
+                                    SpiTransferRequest::Read { .. },
+                                    SpiTransferResponse::Read { data },
+                                ) => spi::Transfer::Read(data),
+                                (
+                                    SpiTransferRequest::Write { data },
+                                    SpiTransferResponse::Write,
+                                ) => spi::Transfer::Write(&data),
+                                (
+                                    SpiTransferRequest::Both { data: wdata },
+                                    SpiTransferResponse::Both { data },
+                                ) => spi::Transfer::Both(&wdata, data),
+                                _ => {
+                                    // This can only happen if the logic in this method is
+                                    // flawed.  (Never due to network input.)
+                                    panic!("Mismatch");
+                                }
+                            })
+                            .collect();
+                        instance.run_transaction(&mut transaction)?;
+                        Ok(Response::Spi(SpiResponse::RunTransaction {
+                            transaction: resps,
+                        }))
+                    }
+                }
+            }
+            Request::I2c { id, command } => {
+                let instance = self.transport.i2c(id)?;
+                match command {
+                    I2cRequest::RunTransaction {
+                        address,
+                        transaction: reqs,
+                    } => {
+                        // Construct proper response to each transfer in request.
+                        let mut resps: Vec<I2cTransferResponse> = reqs
+                            .iter()
+                            .map(|transfer| match transfer {
+                                I2cTransferRequest::Read { len } => I2cTransferResponse::Read {
+                                    data: vec![0; *len as usize],
+                                },
+                                I2cTransferRequest::Write { .. } => I2cTransferResponse::Write,
+                            })
+                            .collect();
+                        // Now carefully craft a proper parameter to the
+                        // `i2c::Bus::run_transactions()` method.  It will have reference
+                        // into elements of both the request vector and mutable reference into
+                        // the response vector.
+                        let mut transaction: Vec<i2c::Transfer> = reqs
+                            .iter()
+                            .zip(resps.iter_mut())
+                            .map(|pair| match pair {
+                                (
+                                    I2cTransferRequest::Read { .. },
+                                    I2cTransferResponse::Read { data },
+                                ) => i2c::Transfer::Read(data),
+                                (
+                                    I2cTransferRequest::Write { data },
+                                    I2cTransferResponse::Write,
+                                ) => i2c::Transfer::Write(&data),
+                                _ => {
+                                    // This can only happen if the logic in this method is
+                                    // flawed.  (Never due to network input.)
+                                    panic!("Mismatch");
+                                }
+                            })
+                            .collect();
+                        instance.run_transaction(*address, &mut transaction)?;
+                        Ok(Response::I2c(I2cResponse::RunTransaction {
+                            transaction: resps,
+                        }))
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl<'a> CommandHandler<Message> for TransportCommandHandler<'a> {
+    /// This method will perform whatever action on the underlying `Transport` that is requested
+    /// by the given `Message`, and return a response to be sent to the client.  Any `Err`
+    /// return from this method will be treated as an irrecoverable protocol error, causing an
+    /// error message in the server log, and the connection to be terminated.
+    fn execute_cmd(&self, msg: &Message) -> Result<Message> {
+        if let Message::Req(req) = msg {
+            // Package either `Ok()` or `Err()` into a `Message`, to be sent via network.
+            return Ok(Message::Res(self.do_execute_cmd(&req)));
+        }
+        bail!("Client sent non-Request to server!!!");
+    }
+}

--- a/sw/host/opentitanlib/src/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/proxy/mod.rs
@@ -2,4 +2,57 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, Result};
+use handler::TransportCommandHandler;
+use protocol::Message;
+use socket_server::JsonSocketServer;
+
+use crate::app::TransportWrapper;
+
+mod handler;
 pub mod protocol;
+mod socket_server;
+
+/// Interface for handlers of protocol messages, responding to each message with a single
+/// instance of the same protocol message.
+pub trait CommandHandler<Msg> {
+    fn execute_cmd(&self, msg: &Msg) -> Result<Msg>;
+}
+
+/// This is the main entry point for the session proxy.  This struct will either bind on a
+/// specified port, or find an available port from a range, before entering an event loop.
+pub struct SessionHandler<'a> {
+    port: u16,
+    socket_server: JsonSocketServer<Message, TransportCommandHandler<'a>>,
+}
+
+impl<'a> SessionHandler<'a> {
+    pub fn init(transport: &'a TransportWrapper, listen_port: Option<u16>) -> Result<Self> {
+        let mut port = listen_port.unwrap_or(9900);
+        let limit = listen_port.unwrap_or(9999);
+        // Find a suitable port to bind to.
+        loop {
+            match JsonSocketServer::new(TransportCommandHandler::new(&transport), port) {
+                Ok(socket_server) => {
+                    // Configure all GPIO pins to default direction and level, according to
+                    // configuration files provided.
+                    transport.apply_default_pin_configurations()?;
+                    return Ok(Self {
+                        port,
+                        socket_server,
+                    });
+                }
+                Err(e) if port >= limit => bail!(e),
+                Err(_) => port += 1,
+            }
+        }
+    }
+
+    pub fn get_port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn run_loop(&mut self) -> Result<()> {
+        self.socket_server.run_loop()
+    }
+}

--- a/sw/host/opentitanlib/src/proxy/socket_server.rs
+++ b/sw/host/opentitanlib/src/proxy/socket_server.rs
@@ -1,0 +1,293 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use mio::event::Event;
+use mio::net::TcpListener;
+use mio::net::TcpStream;
+use mio::{Events, Interest, Poll, Token};
+use mio_signals::{Signal, SignalSet, Signals};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use std::collections::hash_map::Entry::{Occupied, Vacant};
+use std::collections::HashMap;
+use std::io::{ErrorKind, Read, Write};
+use std::marker::PhantomData;
+use std::net::SocketAddr;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::CommandHandler;
+
+const BUFFER_SIZE: usize = 8192;
+const EOL_CODE: u8 = b'\n';
+
+fn get_next_token() -> Token {
+    static TOCKEN_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    Token(TOCKEN_COUNTER.fetch_add(1, Ordering::Relaxed))
+}
+
+/// This struct listens on a TCP socket, and maintains a number of concurrent connections,
+/// receiving serialized JSON representations of `Msg`, passing them to the given
+/// `CommandHandler` to obtain responses to be sent as socket flow contol permits.  Note that
+/// this implementaion is not specific to (and does not refer to) any particular protocol.
+pub struct JsonSocketServer<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> {
+    command_handler: T,
+    poll: Poll,
+    socket: TcpListener,
+    socket_token: Token,
+    signals: Signals,
+    signal_token: Token,
+    connection_map: HashMap<Token, Connection>,
+    exit_requested: bool,
+    phantom: PhantomData<Msg>,
+}
+
+impl<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> JsonSocketServer<Msg, T> {
+    pub fn new(command_handler: T, port: u16) -> Result<Self> {
+        let poll = Poll::new()?;
+        let socket_token = get_next_token();
+        let addr = SocketAddr::from(([0u8; 4], port));
+        log::info!("Setup JsonSocketServer: {}", &addr);
+        let mut socket = TcpListener::bind(addr)?;
+        poll.registry()
+            .register(&mut socket, socket_token, Interest::READABLE)?;
+        // Create a `Signals` instance that will catch given set of signals for us.
+        let signals: SignalSet = Signal::Terminate | Signal::Interrupt;
+        let mut signals = Signals::new(signals)?;
+        // And register it with our `Poll` instance.
+        let signal_token = get_next_token();
+        poll.registry()
+            .register(&mut signals, signal_token, Interest::READABLE)?;
+        Ok(Self {
+            command_handler,
+            poll,
+            socket,
+            socket_token,
+            signals,
+            signal_token,
+            connection_map: HashMap::new(),
+            exit_requested: false,
+            phantom: PhantomData,
+        })
+    }
+
+    pub fn run_loop(&mut self) -> Result<()> {
+        let mut events = Events::with_capacity(1024);
+        while !self.exit_requested {
+            self.poll.poll(&mut events, None)?;
+            for event in events.iter() {
+                if event.token() == self.socket_token {
+                    self.process_new_connection()?;
+                } else if event.token() == self.signal_token {
+                    self.process_signals()?;
+                } else {
+                    match self.process_connection(event) {
+                        Ok(shutdown) => if shutdown { self.shutdown_connection(event)?; }
+                        Err(e) => {
+                            log::warn!(
+                                "Connection {:#X} error: {}",
+                                event.token().0,
+                                e,
+                            );
+                            self.shutdown_connection(event)?;
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Accept new socket connections, creating new Connection objects.
+    fn process_new_connection(&mut self) -> Result<()> {
+        loop {
+            match self.socket.accept() {
+                Ok((mut conn_socket, _addres)) => {
+                    let token = get_next_token();
+                    log::info!("New connection id:{:#X}", token.0);
+                    match self.connection_map.entry(token) {
+                        Vacant(entry) => {
+                            self.poll.registry().register(
+                                &mut conn_socket,
+                                token,
+                                Interest::READABLE | Interest::WRITABLE,
+                            )?;
+                            entry.insert(Connection::new(conn_socket));
+                        }
+                        Occupied(_) => {
+                            panic!("JsonSocketServer error: token colision");
+                        }
+                    };
+                }
+                Err(err) if err.kind() == ErrorKind::WouldBlock => {
+                    // No more connections ready to accept (or spurious poll event).
+                    return Ok(());
+                }
+                Err(err) => bail!("Error accepting TCP connection: {}", err),
+            }
+        }
+    }
+
+    fn process_signals(&mut self) -> Result<()> {
+        loop {
+            match self.signals.receive()? {
+                Some(Signal::Interrupt) => {
+                    log::info!("Got interrupt signal");
+                    self.exit_requested = true;
+                }
+                Some(Signal::Terminate) => {
+                    log::info!("Got terminate signal");
+                    self.exit_requested = true;
+                }
+                Some(signal) => {
+                    log::info!("Got unexpected signal: {:?}", signal);
+                }
+                None => return Ok(()),
+            }
+        }
+    }
+
+    /// Read and write as much as possible from one particular socket connection.
+    fn process_connection(&mut self, event: &Event) -> Result<bool> {
+        match self.connection_map.get_mut(&event.token()) {
+            Some(conn) => {
+                if event.is_writable() {
+                    conn.write()?;
+                }
+                if event.is_readable() {
+                    conn.read()?;
+                    Self::process_any_requests(conn, &self.command_handler)?;
+                }
+                // Return whether this connection object should be dropped.
+                return Ok((conn.rx_eof && (conn.tx_buf.len() == 0)) || conn.broken);
+            }
+            None => bail!("Connection don't exist token:{:#X}", event.token().0),
+        }
+    }
+
+    /// Close a socket connection and remove it from the poll list.
+    fn shutdown_connection(&mut self, event: &Event) -> Result<()> {
+        log::info!("Closing connection id:{:#X}", event.token().0);
+        let mut conn = self
+            .connection_map
+            .remove(&event.token())
+            .expect("Missing connection this should never happend!!!");
+        self.poll.registry().deregister(&mut conn.socket)?;
+        // As `conn` runs out of scope here, its `drop()` method will close the OS handle, which
+        // in turn causes TCP/IP connection shutdown to be signalled to the remote end.
+        Ok(())
+    }
+
+    /// Check if the buffer contains at least one full JSON request.  If so, remove it from the
+    /// buffer, decode and return it.
+    fn get_complete_request(conn: &mut Connection) -> Result<Option<Msg>> {
+        if let Some(n) = conn.rx_buf.iter().position(|c| *c == EOL_CODE) {
+            let res = serde_json::from_slice::<Msg>(&conn.rx_buf[..n])?;
+            if n + 1 < conn.rx_buf.len() {
+                // Shuffling bytes around in a Vec is expensive, but realistically, as the
+                // clients would be waiting for response to each request before sending the next
+                // request, this code will rarely if ever execute.
+                conn.rx_buf.rotate_left(n + 1);
+            }
+            conn.rx_buf.resize(conn.rx_buf.len() - n - 1, 0);
+            return Ok(Some(res));
+        }
+        Ok(None)
+    }
+
+    // Look for any completely received requests in the rx_buf, and handle them one by one.
+    fn process_any_requests(
+        conn: &mut Connection,
+        command_handler: &T,
+    ) -> Result<()> {
+        while let Some(request) = Self::get_complete_request(conn)? {
+            // One complete request received, execute it.
+            let resp = command_handler.execute_cmd(&request)?;
+            // Encode response into tx_buf.
+            serde_json::to_writer(&mut conn.tx_buf, &resp)?;
+            conn.tx_buf.push(EOL_CODE);
+            // Transmit as much as possible without blocking, leaving any remnant in
+            // tx_buf.  poll() will tell us when more can be written.
+            conn.write()?;
+        }
+        Ok(())
+    }
+}
+
+/// Represents one connection with a remote OpenTitan tool invocation.
+struct Connection {
+    socket: TcpStream,
+    /// Outgoing data waiting to be written when the socket permits.
+    tx_buf: Vec<u8>,
+    /// Data received from the remote end, but not yet decoded into `Msg`.
+    rx_buf: Vec<u8>,
+    /// The remote end indicated end-of-stream.  After processing any remaning data in `rx_buf`,
+    /// this Connection should be gracefully shut down and dropped.
+    rx_eof: bool,
+    /// Some error happened during writing or reading from the socket, we cannot meaningfully
+    /// continue processing, and the connection should be dropped as soon as possible.
+    broken: bool,
+}
+
+impl Connection {
+    fn new(soc: TcpStream) -> Self {
+        Self {
+            socket: soc,
+            tx_buf: Vec::new(),
+            rx_buf: Vec::new(),
+            rx_eof: false,
+            broken: false,
+        }
+    }
+
+    // Fill rx_buf with as much data as is available on the socket.
+    fn read(&mut self) -> Result<()> {
+        let mut rx_buf_len: usize = self.rx_buf.len();
+        loop {
+            self.rx_buf.resize(rx_buf_len + BUFFER_SIZE, 0);
+            match self.socket.read(&mut self.rx_buf[rx_buf_len..]) {
+                Ok(0) => {
+                    self.rx_eof = true;
+                    break;
+                }
+                Ok(n) => {
+                    rx_buf_len += n;
+                }
+                Err(err) => {
+                    if err.kind() != ErrorKind::WouldBlock {
+                        self.broken = true;
+                    }
+                    break; // Break out of loop, also on expected WouldBlock
+                }
+            }
+        }
+        self.rx_buf.resize(rx_buf_len, 0);
+        Ok(())
+    }
+
+    // Transmit as much data out of tx_buf as socket will allow.
+    fn write(&mut self) -> Result<()> {
+        while self.tx_buf.len() > 0 {
+            match self.socket.write(&self.tx_buf) {
+                Ok(n) => {
+                    if n < self.tx_buf.len() {
+                        // Shuffling bytes around in a Vec is expensive, but realistically, as
+                        // the clients would be waiting for response to each request before
+                        // sending the next request, it is unlikely that the OS transmit buffer
+                        // would ever fill up and cause partial writes.
+                        self.tx_buf.rotate_left(n);
+                    }
+                    self.tx_buf.resize(self.tx_buf.len() - n, 0);
+                }
+                Err(err) => {
+                    if err.kind() != ErrorKind::WouldBlock {
+                        self.broken = true;
+                    }
+                    break;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/sw/host/opentitansession/BUILD
+++ b/sw/host/opentitansession/BUILD
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+load("//third_party/cargo:crates.bzl", "all_crate_deps")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "opentitansession",
+    srcs = [
+        "src/main.rs",
+    ],
+    deps = [
+        "//sw/host/opentitanlib",
+    ] + all_crate_deps(),
+)
+
+filegroup(
+    name = "test_resources",
+    srcs = [
+        ":opentitansession",
+    ],
+)

--- a/sw/host/opentitansession/Cargo.toml
+++ b/sw/host/opentitansession/Cargo.toml
@@ -1,0 +1,35 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "opentitansession"
+version = "0.1.0"
+authors = ["lowRISC contributors"]
+edition = "2018"
+
+[[bin]]
+name = "opentitansession"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0"
+hex = "0.4"
+thiserror = "1.0"
+opentitanlib = {path="../opentitanlib"}
+structopt = "0.3"
+log = "0.4"
+env_logger = "0.8.3"
+raw_tty = "0.1.0"
+regex = "1"
+nix = "0.17.0"
+indicatif = "0.16.2"
+directories = "4.0.1"
+shellwords = "1.1.0"
+
+serde = {version="1", features=["serde_derive"]}
+serde_json = "1"
+erased-serde = "0.3.12"
+
+[features]
+demo_commands = []

--- a/sw/host/opentitansession/meson.build
+++ b/sw/host/opentitansession/meson.build
@@ -1,0 +1,63 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+cargo = find_program('cargo', required: false, disabler: true)
+
+build_type = 'release'
+build_dir = meson.current_build_dir()
+manifest_path = meson.current_source_dir() / 'Cargo.toml'
+
+# CARGO FLAGS:
+# These flags will only apply to the final binary, and won't get propogated
+# to the dependency crate builds.
+cargo_flags_array = [
+  'manifest-path=' + manifest_path,
+  'target-dir=' + build_dir,
+   build_type,
+]
+
+cargo_flags = ''
+foreach flag : cargo_flags_array
+  cargo_flags += '--' + flag + ' '
+endforeach
+
+# RUSTFLAGS:
+# These flags will apply to all the dependencies, as well as the final
+# binary. Linker and linker flavor amongst other things can be passed through
+# these flags.
+rust_flags = ''
+
+# The cargo invocation script.
+cargo_invoke_cmd = meson.project_source_root() / 'util/invoke_cargo.sh'
+
+# Note: the opentitansession depends on opentitanlib. This dependency is handled
+# by cargo itself but perhaps should be handled by the build system.
+opentitansession = custom_target(
+  'opentitansession',
+  command: [
+    cargo_invoke_cmd,
+    cargo,
+    cargo_flags,
+    rust_flags,
+    meson.project_source_root(),
+    meson.project_build_root(),
+  ],
+  depend_files: [
+    cargo_invoke_cmd,
+    manifest_path,
+  ],
+  output: '.',
+  console: true,
+  build_always_stale: true,
+  build_by_default: true,
+)
+
+opentitansession_export = custom_target(
+  'opentitansession_export',
+  command: ['cp', '@INPUT@' / build_type / 'opentitansession', '@OUTPUT@'],
+  input: opentitansession,
+  output: 'opentitansession',
+  build_always_stale: true,
+  build_by_default: true,
+)

--- a/sw/host/opentitansession/src/main.rs
+++ b/sw/host/opentitansession/src/main.rs
@@ -1,0 +1,112 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use directories::ProjectDirs;
+use log::LevelFilter;
+use std::env::{args_os, ArgsOs};
+use std::ffi::OsString;
+use std::io::ErrorKind;
+use std::iter::{IntoIterator, Iterator};
+use std::path::PathBuf;
+use structopt::StructOpt;
+
+use opentitanlib::backend;
+use opentitanlib::proxy::SessionHandler;
+
+#[derive(Debug, StructOpt)]
+#[structopt(
+    name = "opentitansession",
+    about = "A tool for interacting with OpenTitan chips."
+)]
+struct Opts {
+    #[structopt(
+        long,
+        default_value = "config",
+        help = "Filename of a default flagsfile.  Relative to $XDG_CONFIG_HOME/opentitantool."
+    )]
+    rcfile: PathBuf,
+
+    #[structopt(long, default_value = "off")]
+    logging: LevelFilter,
+
+    #[structopt(flatten)]
+    backend_opts: backend::BackendOpts,
+
+    #[structopt(long)]
+    listen_port: Option<u16>,
+
+    #[structopt(long, help = "Start session, staying in foreground (do not daemonize)")]
+    debug: bool,
+}
+
+// Given some existing option configuration, maybe re-evaluate command
+// line options by reading an `rcfile`.
+fn parse_command_line(opts: Opts, mut args: ArgsOs) -> Result<Opts> {
+    // Initialize the logger if the user requested the non-defualt option.
+    let logging = opts.logging;
+    if logging != LevelFilter::Off {
+        env_logger::Builder::from_default_env()
+            .filter(None, opts.logging)
+            .init();
+    }
+    if opts.rcfile.as_os_str().is_empty() {
+        // No rcfile to parse.
+        return Ok(opts);
+    }
+
+    // Construct the rcfile path based on the user's config directory
+    // (ie: $HOME/.config/opentitantool/<filename>).
+    let rcfile = if let Some(base) = ProjectDirs::from("org", "opentitan", "opentitantool") {
+        base.config_dir().join(&opts.rcfile)
+    } else {
+        opts.rcfile
+    };
+
+    // argument[0] is the executable name.
+    let mut arguments = vec![args.next().unwrap()];
+
+    // Read in the rcfile and extend the argument list.
+    match std::fs::read_to_string(&rcfile) {
+        Ok(content) => {
+            for line in content.split('\n') {
+                // Strip basic comments as shellwords won't handle comments.
+                let (line, _) = line.split_once('#').unwrap_or((line, ""));
+                arguments.extend(shellwords::split(line)?.iter().map(OsString::from));
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == ErrorKind::NotFound => {
+            log::warn!("Could not read {:?}. Ignoring.", rcfile);
+            Ok(())
+        }
+        Err(e) => Err(anyhow::Error::new(e).context(format!("Reading file {:?}", rcfile))),
+    }?;
+
+    // Extend the argument list with all remaining command line arguments.
+    arguments.extend(args.into_iter());
+    let opts = Opts::from_iter(&arguments);
+    if opts.logging != logging {
+        // Try re-initializing the logger.  Ignore errors.
+        let _ = env_logger::Builder::from_default_env()
+            .filter(None, opts.logging)
+            .try_init();
+    }
+    Ok(opts)
+}
+
+fn main() -> Result<()> {
+    let opts = parse_command_line(Opts::from_args(), args_os())?;
+
+    if opts.debug {
+        // Start session process in foreground (do not daemonize)
+        let transport = backend::create(&opts.backend_opts, "null")?;
+        let mut session = SessionHandler::init(&transport, opts.listen_port)?;
+        println!("Listening on port {}", session.get_port());
+        session.run_loop()?;
+        return Ok(());
+    }
+
+    unimplemented!("Background daemon not implemented");
+}

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -22,6 +22,8 @@ _DEPENDENCIES = {
         "lazy_static": "@raze__lazy_static__1_4_0//:lazy_static",
         "log": "@raze__log__0_4_14//:log",
         "memoffset": "@raze__memoffset__0_6_5//:memoffset",
+        "mio": "@raze__mio__0_7_14//:mio",
+        "mio-signals": "@raze__mio_signals__0_1_5//:mio_signals",
         "nix": "@raze__nix__0_17_0//:nix",
         "num-bigint-dig": "@raze__num_bigint_dig__0_7_0//:num_bigint_dig",
         "num-traits": "@raze__num_traits__0_2_14//:num_traits",
@@ -43,6 +45,23 @@ _DEPENDENCIES = {
         "proc-macro2": "@raze__proc_macro2__1_0_32//:proc_macro2",
         "quote": "@raze__quote__1_0_10//:quote",
         "syn": "@raze__syn__1_0_81//:syn",
+    },
+    "sw/host/opentitansession": {
+        "anyhow": "@raze__anyhow__1_0_46//:anyhow",
+        "directories": "@raze__directories__4_0_1//:directories",
+        "env_logger": "@raze__env_logger__0_8_4//:env_logger",
+        "erased-serde": "@raze__erased_serde__0_3_16//:erased_serde",
+        "hex": "@raze__hex__0_4_3//:hex",
+        "indicatif": "@raze__indicatif__0_16_2//:indicatif",
+        "log": "@raze__log__0_4_14//:log",
+        "nix": "@raze__nix__0_17_0//:nix",
+        "raw_tty": "@raze__raw_tty__0_1_0//:raw_tty",
+        "regex": "@raze__regex__1_5_4//:regex",
+        "serde": "@raze__serde__1_0_130//:serde",
+        "serde_json": "@raze__serde_json__1_0_69//:serde_json",
+        "shellwords": "@raze__shellwords__1_1_0//:shellwords",
+        "structopt": "@raze__structopt__0_3_25//:structopt",
+        "thiserror": "@raze__thiserror__1_0_30//:thiserror",
     },
     "sw/host/opentitantool": {
         "anyhow": "@raze__anyhow__1_0_46//:anyhow",
@@ -94,6 +113,8 @@ _DEV_DEPENDENCIES = {
     },
     "sw/host/opentitanlib/opentitantool_derive": {
     },
+    "sw/host/opentitansession": {
+    },
     "sw/host/opentitantool": {
     },
     "sw/host/rom_ext_image_tools/signer": {
@@ -107,6 +128,8 @@ _DEV_PROC_MACRO_DEPENDENCIES = {
     "sw/host/opentitanlib": {
     },
     "sw/host/opentitanlib/opentitantool_derive": {
+    },
+    "sw/host/opentitansession": {
     },
     "sw/host/opentitantool": {
     },
@@ -761,6 +784,33 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         strip_prefix = "miniz_oxide-0.4.4",
         build_file = Label("//third_party/cargo/remote:BUILD.miniz_oxide-0.4.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__mio__0_7_14",
+        url = "https://crates.io/api/v1/crates/mio/0.7.14/download",
+        type = "tar.gz",
+        strip_prefix = "mio-0.7.14",
+        build_file = Label("//third_party/cargo/remote:BUILD.mio-0.7.14.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__mio_signals__0_1_5",
+        url = "https://crates.io/api/v1/crates/mio-signals/0.1.5/download",
+        type = "tar.gz",
+        strip_prefix = "mio-signals-0.1.5",
+        build_file = Label("//third_party/cargo/remote:BUILD.mio-signals-0.1.5.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__miow__0_3_7",
+        url = "https://crates.io/api/v1/crates/miow/0.3.7/download",
+        type = "tar.gz",
+        strip_prefix = "miow-0.3.7",
+        build_file = Label("//third_party/cargo/remote:BUILD.miow-0.3.7.bazel"),
     )
 
     maybe(

--- a/third_party/cargo/remote/BUILD.mio-0.7.14.bazel
+++ b/third_party/cargo/remote/BUILD.mio-0.7.14.bazel
@@ -1,0 +1,73 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+# Unsupported target "tcp_server" with type "example" omitted
+
+# Unsupported target "udp_server" with type "example" omitted
+
+rust_library(
+    name = "mio",
+    srcs = glob(["**/*.rs"]),
+    aliases = {
+    },
+    crate_features = [
+        "default",
+        "net",
+        "os-ext",
+        "os-poll",
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=mio",
+        "manual",
+    ],
+    version = "0.7.14",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__log__0_4_14//:log",
+    ] + selects.with_or({
+        # cfg(unix)
+        (
+            "@rules_rust//rust/platform:x86_64-unknown-linux-gnu",
+        ): [
+            "@raze__libc__0_2_107//:libc",
+        ],
+        "//conditions:default": [],
+    }),
+)

--- a/third_party/cargo/remote/BUILD.mio-signals-0.1.5.bazel
+++ b/third_party/cargo/remote/BUILD.mio-signals-0.1.5.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "mio_signals",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=mio-signals",
+        "manual",
+    ],
+    version = "0.1.5",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__libc__0_2_107//:libc",
+        "@raze__log__0_4_14//:log",
+        "@raze__mio__0_7_14//:mio",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.miow-0.3.7.bazel
+++ b/third_party/cargo/remote/BUILD.miow-0.3.7.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "miow",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=miow",
+        "manual",
+    ],
+    version = "0.3.7",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__winapi__0_3_9//:winapi",
+    ],
+)


### PR DESCRIPTION
This change introduces a `opentitansession` command.

`opentitansession --conf ... --interface ...` will start a new
persistent session process, which would load the given configuration
files and connect to the given physical interface.

Default transport in absense of `--interface` will be changed to be
"proxy" on `localhost:9900` (PR #11023).

Configuration files are loaded as part of the session process startup,
meaning that aliases can be used in the `gpio read` command above,
without each individual invocation needing `--conf ...`.

Forwarding of GPIO, UART and SPI has been verified with UltraDebug and
Andreiboard: `opentitantool bootstrap` and `opentitantool console`
works.

Simulation transports such as Verilator or Ti50 host emulation would
create a simulation environment as part of the constructor for their
implementation of the `Transport` trait.

Large parts of the asynchronous socket code has been copied from host
emulation code in the Ti50 repository, developed by Semihalf.

This PR is one of the steps outlined in #10889.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Signed-off-by: Michał Mazurek <maz@semihalf.com>
Change-Id: I99241a477f9625e0a7effca4afc20576e4e2c123