### PR TITLE
[opentitanlib] Fix of rust code formatting

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -138,7 +138,9 @@ impl TransportWrapper {
         if let Some(strapping_conf_map) = self.strapping_conf_map.get(strapping_name) {
             self.apply_pin_configurations(&strapping_conf_map)
         } else {
-            Err(TransportError::InvalidStrappingName(strapping_name.to_string()))
+            Err(TransportError::InvalidStrappingName(
+                strapping_name.to_string(),
+            ))
         }
     }
 
@@ -154,7 +156,9 @@ impl TransportWrapper {
             }
             Ok(())
         } else {
-            Err(TransportError::InvalidStrappingName(strapping_name.to_string()))
+            Err(TransportError::InvalidStrappingName(
+                strapping_name.to_string(),
+            ))
         }
     }
 

--- a/sw/host/opentitanlib/src/backend/cw310.rs
+++ b/sw/host/opentitanlib/src/backend/cw310.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use crate::transport::cw310::CW310;
 use crate::transport::Transport;
+use anyhow::Result;
 
 use crate::backend::BackendOpts;
 

--- a/sw/host/opentitanlib/src/backend/hyperdebug.rs
+++ b/sw/host/opentitanlib/src/backend/hyperdebug.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use crate::transport::hyperdebug::{Flavor, Hyperdebug};
 use crate::transport::Transport;
+use anyhow::Result;
 
 use crate::backend::BackendOpts;
 

--- a/sw/host/opentitanlib/src/backend/ultradebug.rs
+++ b/sw/host/opentitanlib/src/backend/ultradebug.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use crate::transport::ultradebug::Ultradebug;
 use crate::transport::Transport;
+use anyhow::Result;
 
 use crate::backend::BackendOpts;
 

--- a/sw/host/opentitanlib/src/backend/verilator.rs
+++ b/sw/host/opentitanlib/src/backend/verilator.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use crate::transport::verilator::{Options, Verilator};
 use crate::transport::Transport;
+use anyhow::Result;
 use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]

--- a/sw/host/opentitanlib/src/image/manifest_def.rs
+++ b/sw/host/opentitanlib/src/image/manifest_def.rs
@@ -167,11 +167,8 @@ mod tests {
 
     #[test]
     fn test_manifest_from_hjson() {
-        let def: ManifestDef = from_str(
-            &std::fs::read_to_string(testdata!("manifest.hjson"))
-                .unwrap(),
-        )
-        .unwrap();
+        let def: ManifestDef =
+            from_str(&std::fs::read_to_string(testdata!("manifest.hjson")).unwrap()).unwrap();
 
         let _: Manifest = def.unpack("").unwrap();
     }

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -71,4 +71,3 @@ pub enum UartError {
     #[error("{0}")]
     GenericError(String),
 }
-

--- a/sw/host/opentitanlib/src/otp/otp_mmap.rs
+++ b/sw/host/opentitanlib/src/otp/otp_mmap.rs
@@ -2,9 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::util::num_de::{self, DeferredValue};
 use crate::otp::otp_img::OtpImg;
 use crate::otp::vmem_serialize::*;
+use crate::util::num_de::{self, DeferredValue};
 
 use anyhow::{anyhow, bail, Result};
 use serde::Deserialize;

--- a/sw/host/opentitanlib/src/proxy/socket_server.rs
+++ b/sw/host/opentitanlib/src/proxy/socket_server.rs
@@ -83,13 +83,13 @@ impl<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> JsonSocketServer
                     self.process_signals()?;
                 } else {
                     match self.process_connection(event) {
-                        Ok(shutdown) => if shutdown { self.shutdown_connection(event)?; }
+                        Ok(shutdown) => {
+                            if shutdown {
+                                self.shutdown_connection(event)?;
+                            }
+                        }
                         Err(e) => {
-                            log::warn!(
-                                "Connection {:#X} error: {}",
-                                event.token().0,
-                                e,
-                            );
+                            log::warn!("Connection {:#X} error: {}", event.token().0, e,);
                             self.shutdown_connection(event)?;
                         }
                     }
@@ -197,10 +197,7 @@ impl<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> JsonSocketServer
     }
 
     // Look for any completely received requests in the rx_buf, and handle them one by one.
-    fn process_any_requests(
-        conn: &mut Connection,
-        command_handler: &T,
-    ) -> Result<()> {
+    fn process_any_requests(conn: &mut Connection, command_handler: &T) -> Result<()> {
         while let Some(request) = Self::get_complete_request(conn)? {
             // One complete request received, execute it.
             let resp = command_handler.execute_cmd(&request)?;

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -26,7 +26,9 @@ impl SerialPortUart {
     pub fn open(port_name: &str) -> Result<Self> {
         Ok(SerialPortUart {
             port: RefCell::new(
-                serialport::new(port_name, 115200).open().wrap(UartError::OpenError)?,
+                serialport::new(port_name, 115200)
+                    .open()
+                    .wrap(UartError::OpenError)?,
             ),
         })
     }
@@ -50,7 +52,11 @@ impl Uart for SerialPortUart {
     /// Reads UART receive data into `buf`, returning the number of bytes read.
     /// This function _may_ block.
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        Ok(self.port.borrow_mut().read(buf).wrap(UartError::ReadError)?)
+        Ok(self
+            .port
+            .borrow_mut()
+            .read(buf)
+            .wrap(UartError::ReadError)?)
     }
 
     /// Reads UART receive data into `buf`, returning the number of bytes read.
@@ -66,7 +72,11 @@ impl Uart for SerialPortUart {
     /// Writes data from `buf` to the UART.
     fn write(&self, mut buf: &[u8]) -> Result<()> {
         while buf.len() > 0 {
-            let written = self.port.borrow_mut().write(buf).wrap(UartError::WriteError)?;
+            let written = self
+                .port
+                .borrow_mut()
+                .write(buf)
+                .wrap(UartError::WriteError)?;
             buf = &buf[written..];
         }
         Ok(())

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -14,11 +14,11 @@ use crate::ensure;
 use crate::io::gpio::GpioPin;
 use crate::io::spi::Target;
 use crate::io::uart::{Uart, UartError};
+use crate::transport::common::uart::SerialPortUart;
 use crate::transport::{
     Capabilities, Capability, Result, Transport, TransportError, TransportInterfaceType,
     WrapInTransportError,
 };
-use crate::transport::common::uart::SerialPortUart;
 use crate::util::parse_int::ParseInt;
 
 pub mod gpio;
@@ -108,9 +108,7 @@ impl Transport for CW310 {
         })?;
         let uart = match inner.uart.entry(instance) {
             Entry::Vacant(v) => {
-                let u = v.insert(Rc::new(self.open_uart(
-                    instance,
-                )?));
+                let u = v.insert(Rc::new(self.open_uart(instance)?));
                 Rc::clone(u)
             }
             Entry::Occupied(o) => Rc::clone(o.get()),

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -6,10 +6,10 @@ use std::cmp;
 use std::rc::Rc;
 use zerocopy::{AsBytes, FromBytes};
 
-use crate::{bail, ensure};
 use crate::io::i2c::{Bus, I2cError, Transfer};
 use crate::transport::hyperdebug::{BulkInterface, Inner};
 use crate::transport::{Result, TransportError};
+use crate::{bail, ensure};
 
 pub struct HyperdebugI2cBus {
     inner: Rc<Inner>,
@@ -138,7 +138,10 @@ impl HyperdebugI2cBus {
             0 => (),
             1 => bail!(I2cError::Timeout),
             2 => bail!(I2cError::Busy),
-            n => bail!(TransportError::CommunicationError(format!("I2C error: {}", n))),
+            n => bail!(TransportError::CommunicationError(format!(
+                "I2C error: {}",
+                n
+            ))),
         }
         let databytes = bytecount - 4;
         rbuf[..databytes].clone_from_slice(&resp.data[..databytes]);

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -80,19 +80,27 @@ pub trait Transport {
 
     /// Returns a SPI [`Target`] implementation.
     fn spi(&self, _instance: &str) -> Result<Rc<dyn Target>> {
-        Err(TransportError::InvalidInterface(TransportInterfaceType::Spi))
+        Err(TransportError::InvalidInterface(
+            TransportInterfaceType::Spi,
+        ))
     }
     /// Returns a I2C [`Bus`] implementation.
     fn i2c(&self, _instance: &str) -> Result<Rc<dyn Bus>> {
-        Err(TransportError::InvalidInterface(TransportInterfaceType::I2c))
+        Err(TransportError::InvalidInterface(
+            TransportInterfaceType::I2c,
+        ))
     }
     /// Returns a [`Uart`] implementation.
     fn uart(&self, _instance: &str) -> Result<Rc<dyn Uart>> {
-        Err(TransportError::InvalidInterface(TransportInterfaceType::Uart))
+        Err(TransportError::InvalidInterface(
+            TransportInterfaceType::Uart,
+        ))
     }
     /// Returns a [`GpioPin`] implementation.
     fn gpio_pin(&self, _instance: &str) -> Result<Rc<dyn GpioPin>> {
-        Err(TransportError::InvalidInterface(TransportInterfaceType::Gpio))
+        Err(TransportError::InvalidInterface(
+            TransportInterfaceType::Gpio,
+        ))
     }
     /// Invoke non-standard functionality of some Transport implementations.
     fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn Serialize>>> {

--- a/sw/host/opentitanlib/src/transport/proxy/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/gpio.rs
@@ -4,11 +4,11 @@
 
 use std::rc::Rc;
 
+use super::ProxyError;
 use crate::bail;
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::proxy::protocol::{GpioRequest, GpioResponse, Request, Response};
 use crate::transport::proxy::{Inner, Proxy, Result};
-use super::ProxyError;
 
 pub struct ProxyGpioPin {
     inner: Rc<Inner>,
@@ -24,7 +24,7 @@ impl ProxyGpioPin {
         Ok(result)
     }
 
-    // Convenience method for issuing GPIO commands via proxy protocol. 
+    // Convenience method for issuing GPIO commands via proxy protocol.
     fn execute_command(&self, command: GpioRequest) -> Result<GpioResponse> {
         match self.inner.execute_command(Request::Gpio {
             id: self.pinname.clone(),

--- a/sw/host/opentitanlib/src/transport/proxy/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/i2c.rs
@@ -4,13 +4,13 @@
 
 use std::rc::Rc;
 
-use crate::{bail, ensure};
+use super::ProxyError;
 use crate::io::i2c::{Bus, Transfer};
 use crate::proxy::protocol::{
     I2cRequest, I2cResponse, I2cTransferRequest, I2cTransferResponse, Request, Response,
 };
 use crate::transport::proxy::{Inner, Proxy, Result};
-use super::ProxyError;
+use crate::{bail, ensure};
 
 pub struct ProxyI2c {
     inner: Rc<Inner>,
@@ -26,7 +26,7 @@ impl ProxyI2c {
         Ok(result)
     }
 
-    // Convenience method for issuing I2C commands via proxy protocol. 
+    // Convenience method for issuing I2C commands via proxy protocol.
     fn execute_command(&self, command: I2cRequest) -> Result<I2cResponse> {
         match self.inner.execute_command(Request::I2c {
             id: self.instance.clone(),
@@ -41,7 +41,8 @@ impl ProxyI2c {
 impl Bus for ProxyI2c {
     fn run_transaction(&self, address: u8, transaction: &mut [Transfer]) -> Result<()> {
         let mut req: Vec<I2cTransferRequest> = Vec::new();
-        for transfer in &*transaction { // &* to treat as non-mutable in this loop
+        for transfer in &*transaction {
+            // &* to treat as non-mutable in this loop
             match transfer {
                 Transfer::Read(rbuf) => req.push(I2cTransferRequest::Read {
                     len: rbuf.len() as u32,

--- a/sw/host/opentitanlib/src/transport/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/mod.rs
@@ -50,13 +50,12 @@ impl Proxy {
             .map_err(|e| TransportError::ProxyLookupError(host.to_string(), e.to_string()))?
             .next()
             .unwrap();
-        let conn = TcpStream::connect(addr).map_err(|e| {
-            TransportError::ProxyConnectError(addr.to_string(), e.to_string())
-        })?;
+        let conn = TcpStream::connect(addr)
+            .map_err(|e| TransportError::ProxyConnectError(addr.to_string(), e.to_string()))?;
         Ok(Self {
             inner: Rc::new(Inner {
                 reader: RefCell::new(BufReader::new(conn.try_clone()?)),
-                writer: RefCell::new(BufWriter::new(conn))
+                writer: RefCell::new(BufWriter::new(conn)),
             }),
         })
     }

--- a/sw/host/opentitanlib/src/transport/proxy/spi.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/spi.rs
@@ -4,14 +4,14 @@
 
 use std::rc::Rc;
 
-use crate::{bail, ensure};
+use super::ProxyError;
 use crate::io::spi::{SpiError, Target, Transfer, TransferMode};
 use crate::proxy::protocol::{
     Request, Response, SpiRequest, SpiResponse, SpiTransferRequest, SpiTransferResponse,
 };
 use crate::transport::proxy::{Inner, Proxy, Result};
 use crate::util::voltage::Voltage;
-use super::ProxyError;
+use crate::{bail, ensure};
 
 pub struct ProxySpi {
     inner: Rc<Inner>,
@@ -27,7 +27,7 @@ impl ProxySpi {
         Ok(result)
     }
 
-    // Convenience method for issuing SPI commands via proxy protocol. 
+    // Convenience method for issuing SPI commands via proxy protocol.
     fn execute_command(&self, command: SpiRequest) -> Result<SpiResponse> {
         match self.inner.execute_command(Request::Spi {
             id: self.instance.clone(),

--- a/sw/host/opentitanlib/src/transport/proxy/uart.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/uart.rs
@@ -5,11 +5,11 @@
 use std::rc::Rc;
 use std::time::Duration;
 
+use super::ProxyError;
 use crate::bail;
 use crate::io::uart::Uart;
 use crate::proxy::protocol::{Request, Response, UartRequest, UartResponse};
 use crate::transport::proxy::{Inner, Proxy, Result};
-use super::ProxyError;
 
 pub struct ProxyUart {
     inner: Rc<Inner>,
@@ -25,7 +25,7 @@ impl ProxyUart {
         Ok(result)
     }
 
-    // Convenience method for issuing UART commands via proxy protocol. 
+    // Convenience method for issuing UART commands via proxy protocol.
     fn execute_command(&self, command: UartRequest) -> Result<UartResponse> {
         match self.inner.execute_command(Request::Uart {
             id: self.instance.clone(),

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -73,13 +73,20 @@ pub struct UltradebugGpioPin {
 impl GpioPin for UltradebugGpioPin {
     /// Reads the value of the the GPIO pin `id`.
     fn read(&self) -> Result<bool> {
-        let bits = self.device.borrow_mut().gpio_get().wrap(TransportError::FtdiError)?;
+        let bits = self
+            .device
+            .borrow_mut()
+            .gpio_get()
+            .wrap(TransportError::FtdiError)?;
         Ok(bits & (1 << self.pin_id) != 0)
     }
 
     /// Sets the value of the GPIO pin `id` to `value`.
     fn write(&self, value: bool) -> Result<()> {
-        self.device.borrow_mut().gpio_set(self.pin_id, value).wrap(TransportError::FtdiError)?;
+        self.device
+            .borrow_mut()
+            .gpio_set(self.pin_id, value)
+            .wrap(TransportError::FtdiError)?;
         Ok(())
     }
 

--- a/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
@@ -126,9 +126,7 @@ impl Transport for Ultradebug {
         );
         let mut inner = self.inner.borrow_mut();
         if inner.uart.is_none() {
-            inner.uart = Some(Rc::new(
-                uart::UltradebugUart::open(self)?,
-            ));
+            inner.uart = Some(Rc::new(uart::UltradebugUart::open(self)?));
         }
         Ok(Rc::clone(inner.uart.as_ref().unwrap()))
     }

--- a/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/spi.rs
@@ -36,7 +36,8 @@ impl UltradebugSpi {
         log::debug!("Setting SPI_ZB");
         mpsse
             .borrow_mut()
-            .gpio_set(UltradebugSpi::PIN_SPI_ZB, false).wrap(TransportError::FtdiError)?;
+            .gpio_set(UltradebugSpi::PIN_SPI_ZB, false)
+            .wrap(TransportError::FtdiError)?;
 
         Ok(UltradebugSpi {
             device: mpsse,
@@ -71,7 +72,9 @@ impl Target for UltradebugSpi {
     }
     fn set_max_speed(&self, frequency: u32) -> Result<()> {
         let mut device = self.device.borrow_mut();
-        device.set_clock_frequency(frequency).wrap(TransportError::FtdiError)?;
+        device
+            .set_clock_frequency(frequency)
+            .wrap(TransportError::FtdiError)?;
         Ok(())
     }
 
@@ -140,7 +143,9 @@ impl Target for UltradebugSpi {
             device.gpio_direction,
             device.gpio_value | chip_select,
         ));
-        device.execute(&mut command).wrap(TransportError::FtdiError)?;
+        device
+            .execute(&mut command)
+            .wrap(TransportError::FtdiError)?;
         Ok(())
     }
 }

--- a/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
@@ -24,9 +24,15 @@ pub struct UltradebugUart {
 
 impl UltradebugUart {
     pub fn open(ultradebug: &Ultradebug) -> Result<Self> {
-        let device = ultradebug.from_interface(ftdi::Interface::C).wrap(TransportError::FtdiError)?;
-        device.set_bitmode(0, ftdi::BitMode::Reset).wrap(TransportError::FtdiError)?;
-        device.set_baudrate(115200).wrap(TransportError::FtdiError)?;
+        let device = ultradebug
+            .from_interface(ftdi::Interface::C)
+            .wrap(TransportError::FtdiError)?;
+        device
+            .set_bitmode(0, ftdi::BitMode::Reset)
+            .wrap(TransportError::FtdiError)?;
+        device
+            .set_baudrate(115200)
+            .wrap(TransportError::FtdiError)?;
         // Read and write timeouts:
         device.set_timeouts(5000, 5000);
         Ok(UltradebugUart {
@@ -45,7 +51,10 @@ impl Uart for UltradebugUart {
 
     fn set_baudrate(&self, baudrate: u32) -> Result<()> {
         let mut inner = self.inner.borrow_mut();
-        inner.device.set_baudrate(baudrate).wrap(TransportError::FtdiError)?;
+        inner
+            .device
+            .set_baudrate(baudrate)
+            .wrap(TransportError::FtdiError)?;
         inner.baudrate = baudrate;
         Ok(())
     }
@@ -68,7 +77,12 @@ impl Uart for UltradebugUart {
     }
 
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        let n = self.inner.borrow().device.read_data(buf).wrap(UartError::ReadError)?;
+        let n = self
+            .inner
+            .borrow()
+            .device
+            .read_data(buf)
+            .wrap(UartError::ReadError)?;
         Ok(n as usize)
     }
 

--- a/sw/host/opentitanlib/src/transport/verilator/uart.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/uart.rs
@@ -21,8 +21,13 @@ pub struct VerilatorUart {
 impl VerilatorUart {
     pub fn open(path: &str) -> Result<Self> {
         Ok(VerilatorUart {
-            file: RefCell::new(OpenOptions::new().read(true).write(true).open(path)
-                               .wrap(|e| TransportError::OpenError(path.to_string(), e))?),
+            file: RefCell::new(
+                OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(path)
+                    .wrap(|e| TransportError::OpenError(path.to_string(), e))?,
+            ),
         })
     }
 }
@@ -57,10 +62,18 @@ impl Uart for VerilatorUart {
     }
 
     fn read(&self, buf: &mut [u8]) -> Result<usize> {
-        Ok(self.file.borrow_mut().read(buf).wrap(UartError::ReadError)?)
+        Ok(self
+            .file
+            .borrow_mut()
+            .read(buf)
+            .wrap(UartError::ReadError)?)
     }
 
     fn write(&self, buf: &[u8]) -> Result<()> {
-        Ok(self.file.borrow_mut().write_all(buf).wrap(UartError::WriteError)?)
+        Ok(self
+            .file
+            .borrow_mut()
+            .write_all(buf)
+            .wrap(UartError::WriteError)?)
     }
 }

--- a/sw/host/opentitanlib/src/util/usb.rs
+++ b/sw/host/opentitanlib/src/util/usb.rs
@@ -25,7 +25,10 @@ impl UsbBackend {
         usb_serial: Option<&str>,
     ) -> Result<Vec<(rusb::Device<rusb::GlobalContext>, String)>> {
         let mut devices = Vec::new();
-        for device in rusb::devices().wrap(TransportError::UsbGenericError)?.iter() {
+        for device in rusb::devices()
+            .wrap(TransportError::UsbGenericError)?
+            .iter()
+        {
             let descriptor = match device.device_descriptor() {
                 Ok(desc) => desc,
                 _ => {
@@ -102,11 +105,17 @@ impl UsbBackend {
     //
 
     pub fn claim_interface(&mut self, iface: u8) -> Result<()> {
-        Ok(self.handle.claim_interface(iface).wrap(TransportError::UsbGenericError)?)
+        Ok(self
+            .handle
+            .claim_interface(iface)
+            .wrap(TransportError::UsbGenericError)?)
     }
 
     pub fn active_config_descriptor(&self) -> Result<rusb::ConfigDescriptor> {
-        Ok(self.device.active_config_descriptor().wrap(TransportError::UsbGenericError)?)
+        Ok(self
+            .device
+            .active_config_descriptor()
+            .wrap(TransportError::UsbGenericError)?)
     }
 
     pub fn bus_number(&self) -> u8 {
@@ -114,11 +123,17 @@ impl UsbBackend {
     }
 
     pub fn port_numbers(&self) -> Result<Vec<u8>> {
-        Ok(self.device.port_numbers().wrap(TransportError::UsbGenericError)?)
+        Ok(self
+            .device
+            .port_numbers()
+            .wrap(TransportError::UsbGenericError)?)
     }
 
     pub fn read_string_descriptor_ascii(&self, idx: u8) -> Result<String> {
-        Ok(self.handle.read_string_descriptor_ascii(idx).wrap(TransportError::UsbGenericError)?)
+        Ok(self
+            .handle
+            .read_string_descriptor_ascii(idx)
+            .wrap(TransportError::UsbGenericError)?)
     }
 
     //

--- a/sw/host/opentitansession/meson.build
+++ b/sw/host/opentitansession/meson.build
@@ -22,6 +22,20 @@ foreach flag : cargo_flags_array
   cargo_flags += '--' + flag + ' '
 endforeach
 
+# CARGO FMT FLAGS:
+# These flags will only be used for checking code formatting
+cargo_fmt_flags_array = [
+  'verbose',
+  'all',
+  'manifest-path=' + manifest_path,
+  'check',
+]
+
+cargo_fmt_flag = ''
+foreach flag : cargo_fmt_flags_array
+  cargo_fmt_flag += '--' + flag + ' '
+endforeach
+
 # RUSTFLAGS:
 # These flags will apply to all the dependencies, as well as the final
 # binary. Linker and linker flavor amongst other things can be passed through
@@ -39,6 +53,7 @@ opentitansession = custom_target(
     cargo_invoke_cmd,
     cargo,
     cargo_flags,
+    cargo_fmt_flag,
     rust_flags,
     meson.project_source_root(),
     meson.project_build_root(),

--- a/sw/host/opentitantool/meson.build
+++ b/sw/host/opentitantool/meson.build
@@ -22,6 +22,20 @@ foreach flag : cargo_flags_array
   cargo_flags += '--' + flag + ' '
 endforeach
 
+# CARGO FMT FLAGS:
+# These flags will only be used for checking code formatting
+cargo_fmt_flags_array = [
+  'verbose',
+  'all',
+  'manifest-path=' + manifest_path,
+  'check',
+]
+
+cargo_fmt_flag = ''
+foreach flag : cargo_fmt_flags_array
+  cargo_fmt_flag += '--' + flag + ' '
+endforeach
+
 # RUSTFLAGS:
 # These flags will apply to all the dependencies, as well as the final
 # binary. Linker and linker flavor amongst other things can be passed through
@@ -39,6 +53,7 @@ opentitantool = custom_target(
     cargo_invoke_cmd,
     cargo,
     cargo_flags,
+    cargo_fmt_flag,
     rust_flags,
     meson.project_source_root(),
     meson.project_build_root(),

--- a/sw/host/opentitantool/src/command/bootstrap.rs
+++ b/sw/host/opentitantool/src/command/bootstrap.rs
@@ -11,8 +11,8 @@ use structopt::StructOpt;
 use opentitanlib::app::command::CommandDispatch;
 use opentitanlib::app::TransportWrapper;
 use opentitanlib::bootstrap::{Bootstrap, BootstrapOptions, BootstrapProtocol};
-use opentitanlib::transport;
 use opentitanlib::image::image::ImageAssembler;
+use opentitanlib::transport;
 use opentitanlib::util::parse_int::ParseInt;
 
 /// Bootstrap the target device.

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -15,11 +15,7 @@ use opentitanlib::transport::Capability;
 /// Read plain data bytes from a I2C device.
 #[derive(Debug, StructOpt)]
 pub struct I2cRawRead {
-    #[structopt(
-        short = "n",
-        long,
-        help = "Number of bytes to read."
-    )]
+    #[structopt(short = "n", long, help = "Number of bytes to read.")]
     length: usize,
 }
 
@@ -61,11 +57,13 @@ impl CommandDispatch for I2cRawWrite {
         transport.capabilities().request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport)?;
-        i2c_bus.run_transaction(context.addr, &mut [Transfer::Write(&hex::decode(&self.hexdata)?)])?;
+        i2c_bus.run_transaction(
+            context.addr,
+            &mut [Transfer::Write(&hex::decode(&self.hexdata)?)],
+        )?;
         Ok(None)
     }
 }
-
 
 /// Commands for interacting with a generic I2C bus.
 #[derive(Debug, StructOpt, CommandDispatch)]

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -5,8 +5,8 @@
 pub mod bootstrap;
 pub mod console;
 pub mod gpio;
-pub mod i2c;
 pub mod hello;
+pub mod i2c;
 pub mod image;
 pub mod load_bitstream;
 pub mod spi;

--- a/sw/host/rom_ext_image_tools/signer/meson.build
+++ b/sw/host/rom_ext_image_tools/signer/meson.build
@@ -22,6 +22,20 @@ foreach flag : cargo_flags_array
   cargo_flags += '--' + flag + ' '
 endforeach
 
+# CARGO FMT FLAGS:
+# These flags will only be used for checking code formatting
+cargo_fmt_flags_array = [
+  'verbose',
+  'all',
+  'manifest-path=' + manifest_path,
+  'check',
+]
+
+cargo_fmt_flag = ''
+foreach flag : cargo_fmt_flags_array
+  cargo_fmt_flag += '--' + flag + ' '
+endforeach
+
 # RUSTFLAGS:
 # These flags will apply to all the dependencies, as well as the final
 # binary. Linker and linker flavor amongst other things can be passed through
@@ -48,6 +62,7 @@ rom_ext_signer = custom_target(
     cargo_invoke_cmd,
     cargo,
     cargo_flags,
+    cargo_fmt_flag,
     rust_flags,
     '',
     meson.project_source_root(),

--- a/util/invoke_cargo.sh
+++ b/util/invoke_cargo.sh
@@ -11,20 +11,23 @@ set -e
 
 CARGO="${1}"
 CARGO_FLAGS="${2}"
-export RUSTFLAGS="${3}"
+CARGO_FMT_FLAG="${3}"
+export RUSTFLAGS="${4}"
 
-TOOLCHAIN_FILE="${4}"
+TOOLCHAIN_FILE="${5}"
 if [[ -f $TOOLCHAIN_FILE ]]; then
     TOOLCHAIN="$(cat ${TOOLCHAIN_FILE})"
 fi
 
-export MESON_SOURCE_ROOT="${5}"
-export MESON_BUILD_ROOT="${6}"
+export MESON_SOURCE_ROOT="${6}"
+export MESON_BUILD_ROOT="${7}"
 
 if [ "${CARGO_TEST}" == 1 ]; then
     echo "CARGO TEST BUILD!"
+    "${CARGO}" fmt ${CARGO_FMT_FLAG}
     "${CARGO}" +"${TOOLCHAIN}" test ${CARGO_FLAGS} --workspace
     "${CARGO}" +"${TOOLCHAIN}" build ${CARGO_FLAGS}
 else
+    "${CARGO}" fmt ${CARGO_FMT_FLAG}
     "${CARGO}" +"${TOOLCHAIN}" build ${CARGO_FLAGS}  
 fi


### PR DESCRIPTION
Fix code formatting by applying cargo fmt over opentitantools.
Add cargo fmt invocation to meson build script.

Signed-off-by: Michał Mazurek <maz@semihalf.com>