### PR TITLE
[AST] Start with un-calibrated AST clocks

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/aon_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_clk.sv
@@ -7,17 +7,18 @@
 //############################################################################
 
 module aon_clk (
-  input vcore_pok_h_i,                     // VCORE POK @3.3V (for OSC)
-  input clk_aon_pd_ni,                     // AON Clock Power-down
-  input rst_aon_clk_ni,                    // AON Clock Logic reset
-  input clk_src_aon_en_i,                  // AON Source Clock Enable
-  input scan_mode_i,                       // Scan Mode
-  input scan_reset_ni,                     // Scan Reset
+  input vcore_pok_h_i,             // VCORE POK @3.3V (for OSC)
+  input clk_aon_pd_ni,             // AON Clock Power-down
+  input rst_aon_clk_ni,            // AON Clock Logic reset
+  input clk_src_aon_en_i,          // AON Source Clock Enable
+  input scan_mode_i,               // Scan Mode
+  input scan_reset_ni,             // Scan Reset
+  input aon_osc_cal_i,             // AON Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
-  input clk_aon_ext_i,                     // FPGA/VERILATOR Clock input
+  input clk_aon_ext_i,             // FPGA/VERILATOR Clock input
 `endif
-  output logic clk_src_aon_o,              // AON Source Clock
-  output logic clk_src_aon_val_o           // AON Source Clock Valid
+  output logic clk_src_aon_o,      // AON Source Clock
+  output logic clk_src_aon_val_o   // AON Source Clock Valid
 );
 
 logic clk, osc_en, aon_clk_en;
@@ -30,6 +31,7 @@ assign aon_clk_en = scan_mode_i || osc_en;
 aon_osc u_aon_osc (
   .vcore_pok_h_i ( vcore_pok_h_i ),
   .aon_en_i ( aon_clk_en ),
+  .aon_osc_cal_i ( aon_osc_cal_i ),
 `ifdef AST_BYPASS_CLK
   .clk_aon_ext_i ( clk_aon_ext_i ),
 `endif

--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -9,6 +9,7 @@
 module aon_osc (
   input vcore_pok_h_i,    // VCORE POK @3.3V
   input aon_en_i,         // AON Source Clock Enable
+  input aon_osc_cal_i,    // AON Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
   input clk_aon_ext_i,    // FPGA/VERILATOR Clock input\
 `endif
@@ -22,16 +23,17 @@ module aon_osc (
 timeunit 1ns / 10ps;
 import ast_bhv_pkg::* ;
 
-localparam time AonClkPeriod = 5000ns; // 5000ns (200KHz)
-
-real CLK_PERIOD, ckmul;
 reg init_start = 1'b0;
+real CLK_PERIOD, ckmul, CalAonClkPeriod, UncAonClkPeriod, AonClkPeriod;
+
+assign CalAonClkPeriod = $itor( 5000 );                         // 5000ns (200KHz)
+assign UncAonClkPeriod = $itor( $urandom_range(10000, 5555) );  // 10000-5555ps (100-180KHz)
+assign AonClkPeriod = (aon_osc_cal_i && init_start) ? CalAonClkPeriod : UncAonClkPeriod;
 
 initial begin
   if ( !$value$plusargs("osc200k_freq_multiplier=%f", ckmul) ) begin
     ckmul = 1.0;
   end
-  CLK_PERIOD = $itor(AonClkPeriod)/ckmul;
   #1; init_start = 1'b1;
   $display("\nAON Power-up Base Clock Frequency: %0d Hz", $rtoi(10**9/(CLK_PERIOD*ckmul)));
   $display("AON Power-up Multiplied Clock Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
@@ -44,7 +46,9 @@ assign en_osc_re = en_osc_re_buf && init_start;
 
 // Clock Oscillator
 ////////////////////////////////////////
-reg clk_osc = 1'b1;
+reg clk_osc = 1'b0;
+
+assign CLK_PERIOD = AonClkPeriod/ckmul;
 
 // Free running oscillator
 always begin
@@ -110,5 +114,14 @@ prim_clock_buf #(
   .clk_i ( clk ),
   .clk_o ( aon_clk_o )
 );
+
+
+`ifdef SYNTHESIS
+///////////////////////
+// Unused Signals
+///////////////////////
+logic unused_sigs;
+assign unused_sigs = ^{ aon_osc_cal_i };
+`endif
 
 endmodule : aon_osc

--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -28,8 +28,8 @@ parameter int unsigned Ot3Sel     = 10;
 parameter int unsigned Ot4Sel     = 11;
 parameter int unsigned Ot5Sel     = 12;
 //
-parameter int unsigned Lc2HcTrCyc = 104;  // (100+4)x5 = 520 us
-parameter int unsigned Hc2LcTrCyc = 40;   // (36+4)x5 = 200 us
+parameter int unsigned Lc2HcTrCyc = 102;  // ((99+1)+(3+1))x5 = 520 us
+parameter int unsigned Hc2LcTrCyc = 38;   // ((35+1)+(3+1))x5 = 200 us
 //
 parameter int unsigned EntropyStreams  = 4;
 parameter int unsigned AdcChannels     = 2;

--- a/hw/top_earlgrey/ip/ast/rtl/io_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/io_clk.sv
@@ -7,17 +7,18 @@
 //############################################################################
 
 module io_clk (
-  input vcore_pok_h_i,                     // VCORE POK @3.3V (for OSC)
-  input clk_io_pd_ni,                      // IO Clock Power-down
-  input rst_io_clk_ni,                     // IO Clock Logic reset
-  input clk_src_io_en_i,                   // IO Source Clock Enable
-  input scan_mode_i,                       // Scan Mode
-  input scan_reset_ni,                     // Scan Reset
+  input vcore_pok_h_i,               // VCORE POK @3.3V (for OSC)
+  input clk_io_pd_ni,                // IO Clock Power-down
+  input rst_io_clk_ni,               // IO Clock Logic reset
+  input clk_src_io_en_i,             // IO Source Clock Enable
+  input scan_mode_i,                 // Scan Mode
+  input scan_reset_ni,               // Scan Reset
+  input io_osc_cal_i,                // IO Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
-  input clk_io_ext_i,                      // FPGA/VERILATOR Clock input
+  input clk_io_ext_i,                // FPGA/VERILATOR Clock input
 `endif
-  output logic clk_src_io_o,               // IO Source Clock
-  output logic clk_src_io_val_o            // IO Source Clock Valid
+  output logic clk_src_io_o,         // IO Source Clock
+  output logic clk_src_io_val_o      // IO Source Clock Valid
 );
 
 logic clk, osc_en, io_clk_en;
@@ -30,6 +31,7 @@ assign io_clk_en = scan_mode_i || osc_en;
 io_osc u_io_osc (
   .vcore_pok_h_i ( vcore_pok_h_i ),
   .io_en_i ( io_clk_en ),
+  .io_osc_cal_i ( io_osc_cal_i ),
 `ifdef AST_BYPASS_CLK
   .clk_io_ext_i ( clk_io_ext_i ),
 `endif

--- a/hw/top_earlgrey/ip/ast/rtl/sys_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/sys_clk.sv
@@ -7,18 +7,19 @@
 //############################################################################
 
 module sys_clk (
-  input clk_src_sys_jen_i,                 // System Source Clock Jitter Enable
-  input clk_src_sys_en_i,                  // System Source Clock Enable
-  input clk_sys_pd_ni,                     // System Clock Power-down
-  input rst_sys_clk_ni,                    // System Clock Logic reset
-  input vcore_pok_h_i,                     // VCORE POK @3.3V (for OSC)
-  input scan_mode_i,                       // Scan Mode
-  input scan_reset_ni,                     // Scan Reset
+  input clk_src_sys_jen_i,           // System Source Clock Jitter Enable
+  input clk_src_sys_en_i,            // System Source Clock Enable
+  input clk_sys_pd_ni,               // System Clock Power-down
+  input rst_sys_clk_ni,              // System Clock Logic reset
+  input vcore_pok_h_i,               // VCORE POK @3.3V (for OSC)
+  input scan_mode_i,                 // Scan Mode
+  input scan_reset_ni,               // Scan Reset
+  input sys_osc_cal_i,               // System Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
-  input clk_sys_ext_i,                     // FPGA/VERILATOR Clock input
+  input clk_sys_ext_i,               // FPGA/VERILATOR Clock input
 `endif
-  output logic clk_src_sys_o,              // System Source Clock
-  output logic clk_src_sys_val_o           // System Source Clock Valid
+  output logic clk_src_sys_o,        // System Source Clock
+  output logic clk_src_sys_val_o     // System Source Clock Valid
 );
 
 logic clk, osc_en, sys_clk_en;
@@ -32,6 +33,7 @@ sys_osc u_sys_osc (
   .vcore_pok_h_i ( vcore_pok_h_i ),
   .sys_en_i ( sys_clk_en ),
   .sys_jen_i ( clk_src_sys_jen_i ),
+  .sys_osc_cal_i ( sys_osc_cal_i ),
 `ifdef AST_BYPASS_CLK
   .clk_sys_ext_i ( clk_sys_ext_i ),
 `endif

--- a/hw/top_earlgrey/ip/ast/rtl/usb_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_clk.sv
@@ -7,20 +7,21 @@
 //############################################################################
 
 module usb_clk (
-  input vcore_pok_h_i,                     // VCORE POK @3.3V (for OSC)
-  input clk_usb_pd_ni,                     // USB Clock Power-down
-  input rst_usb_clk_ni,                    // USB Clock Logic reset
-  input clk_src_usb_en_i,                  // USB Source Clock Enable
-  input usb_ref_val_i,                     // USB Reference (Pulse) Valid
-  input usb_ref_pulse_i,                   // USB Reference Pulse
-  input scan_mode_i,                       // Scan Mode
-  input scan_reset_ni,                     // Scan Reset
+  input vcore_pok_h_i,               // VCORE POK @3.3V (for OSC)
+  input clk_usb_pd_ni,               // USB Clock Power-down
+  input rst_usb_clk_ni,              // USB Clock Logic reset
+  input clk_src_usb_en_i,            // USB Source Clock Enable
+  input usb_ref_val_i,               // USB Reference (Pulse) Valid
+  input usb_ref_pulse_i,             // USB Reference Pulse
+  input scan_mode_i,                 // Scan Mode
+  input scan_reset_ni,               // Scan Reset
+  input usb_osc_cal_i,               // USB Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
-  input clk_usb_ext_i,                     // FPGA/VERILATOR Clock input
+  input clk_usb_ext_i,               // FPGA/VERILATOR Clock input
 `endif
   //
-  output logic clk_src_usb_o,              // USB Source Clock
-  output logic clk_src_usb_val_o           // USB Source Clock Valid
+  output logic clk_src_usb_o,        // USB Source Clock
+  output logic clk_src_usb_val_o     // USB Source Clock Valid
 );
 
 logic clk, osc_en, usb_clk_en;
@@ -34,6 +35,7 @@ usb_osc u_usb_osc (
   .vcore_pok_h_i ( vcore_pok_h_i ),
   .usb_en_i (usb_clk_en ),
   .usb_ref_val_i ( usb_ref_val_i ),
+  .usb_osc_cal_i ( usb_osc_cal_i ),
 `ifdef AST_BYPASS_CLK
   .clk_usb_ext_i ( clk_usb_ext_i ),
 `endif


### PR DESCRIPTION
Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>

Start with uncalibrated AST clock according to clock spec.
Once AST init is done the clocks become calibrated.