### PR TITLE
[flash_ctrl/dv] Some fixes in flash rand_ops sequences

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -53,6 +53,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
   uint mp_info_page_read_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
   uint mp_info_page_program_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
   uint mp_info_page_erase_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_scramble_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
+  uint mp_info_page_ecc_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
   uint mp_info_page_he_en_pc[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes];
 
   // Control the number of flash ops.
@@ -159,6 +161,8 @@ class flash_ctrl_seq_cfg extends uvm_object;
       mp_info_page_read_en_pc[i][j] = 50;
       mp_info_page_program_en_pc[i][j] = 50;
       mp_info_page_erase_en_pc[i][j] = 50;
+      mp_info_page_scramble_en_pc[i][j] = 0;
+      mp_info_page_ecc_en_pc[i][j] = 0;
       mp_info_page_he_en_pc[i][j] = 0;
     end
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -204,6 +204,16 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
           1 :/ cfg.seq_cfg.mp_info_page_erase_en_pc[i][j]
         };
 
+        mp_info_pages[i][j][k].scramble_en dist {
+          0 :/ (100 - cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]),
+          1 :/ cfg.seq_cfg.mp_info_page_scramble_en_pc[i][j]
+        };
+
+        mp_info_pages[i][j][k].ecc_en dist {
+          0 :/ (100 - cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]),
+          1 :/ cfg.seq_cfg.mp_info_page_ecc_en_pc[i][j]
+        };
+
         mp_info_pages[i][j][k].he_en dist {
           0 :/ (100 - cfg.seq_cfg.mp_info_page_he_en_pc[i][j]),
           1 :/ cfg.seq_cfg.mp_info_page_he_en_pc[i][j]

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv
@@ -20,6 +20,10 @@ class flash_ctrl_rand_ops_vseq extends flash_ctrl_rand_ops_base_vseq;
     // Don't enable any memory protection.
     cfg.seq_cfg.num_en_mp_regions = 0;
 
+    cfg.seq_cfg.set_partition_pc(.sel_data_part_pc(50),
+                                 .sel_info_part_pc(35),
+                                 .sel_info1_part_pc(15));
+
     // Enable access to all information partitions.
     foreach (cfg.seq_cfg.mp_info_page_en_pc[i, j]) begin
       cfg.seq_cfg.mp_info_page_en_pc[i][j] = 100;


### PR DESCRIPTION
Hi,
In this PR:
* Adding the info partitions to the partition randomization in [flash_ctrl_rand_ops_vseq](https://github.com/lowRISC/opentitan/blob/cc975ae1c05f4c06796d90444d7aaaf9b308d3e8/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_vseq.sv), a fix suggestion to issue #10646.
* Adding the handling of the scramble and ecc enable of the info pages cfg to [flash_ctrl_rand_ops_base_vseq](https://github.com/lowRISC/opentitan/blob/cc975ae1c05f4c06796d90444d7aaaf9b308d3e8/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv), while setting their default values to 0.
At the moment those bits are fully randomized, without any constraints.

Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>