### PR TITLE
[fpga, clkmgr] Use global clock buffer for KMAC

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -493,7 +493,11 @@
   );
 
   prim_clock_gating #(
+% if clk == "clk_main_kmac":
+    .FpgaBufGlobal(1'b1) // KMAC is getting too big for a single clock region.
+% else:
     .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
+% endif
   ) u_${clk}_cg (
     .clk_i(clk_${sig.src.name}_root),
     .en_i(${clk}_combined_en),

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -1216,7 +1216,7 @@
   );
 
   prim_clock_gating #(
-    .FpgaBufGlobal(1'b0) // This clock is used primarily locally.
+    .FpgaBufGlobal(1'b1) // KMAC is getting too big for a single clock region.
   ) u_clk_main_kmac_cg (
     .clk_i(clk_main_root),
     .en_i(clk_main_kmac_combined_en),


### PR DESCRIPTION
KMAC keeps growing in size, especially with masking turned on it barely fits a single clock region. For this reason, this PR uses a global clock buffer for KMAC to give Vivado more freedom in placing and routing KMAC.
