### PR TITLE
[otbn,dv] Clear the "imem is invalidated" flag when loading program

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -31,6 +31,7 @@ class OTBNSim:
 
     def load_program(self, program: List[OTBNInsn]) -> None:
         self.program = program.copy()
+        self.state.clear_imem_invalidation()
 
     def add_loop_warp(self, addr: int, from_cnt: int, to_cnt: int) -> None:
         '''Add a new loop warp to the simulation'''

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -538,6 +538,11 @@ class OTBNState:
     def invalidate_imem(self) -> None:
         self._time_to_imem_invalidation = 2
 
+    def clear_imem_invalidation(self) -> None:
+        '''Clear any effective or pending IMEM invalidation'''
+        self._time_to_imem_invalidation = None
+        self.invalidated_imem = False
+
     def wipe(self) -> None:
         if not self.secure_wipe_enabled:
             return


### PR DESCRIPTION
This hasn't usually mattered because we reset the dut (and also the
ISS) after injecting IMEM errors to clear the locked state. However,
there was a race window where we injected the errors just after OTBN
had finished. In this case, we don't need to reset the DUT, but we do
have to clear the flag when the IMEM contents are replaced.
