### PR TITLE
[otbn,dv] Extend window at end of IMEM error sequence

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -44,9 +44,11 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     cfg.model_agent_cfg.vif.invalidate_imem();
 
     // If we were unlucky, we might have injected the errors while OTBN was executing an instruction
-    // that was already causing it to stop. To allow for this specific case, we wait exactly one
-    // cycle.
-    @(cfg.clk_rst_vif.cbn);
+    // that was already causing it to stop. To allow for this specific case, we wait three cycles to
+    // let that instruction flush through. We need this much time to handle things like branches
+    // that might take until the second cycle before realising that something failed and then one
+    // more cycle to clean up.
+    repeat (3) @(cfg.clk_rst_vif.cbn);
     // If OTBN is now idle, we hit this exact window and the test didn't do anything useful. Ho
     // hum... Note that we don't need to apply a reset in this case.
     if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle) begin


### PR DESCRIPTION
This is all about an awkward situation where we happen to inject an
IMEM error just after we've fetched the last instruction that we were
going to execute. In this case, there will be no error, which is fine,
but I'd mis-calculated how long you need to wait to figure out whether
it's happened. Fix that.
