### PR TITLE
[sysrst_ctrl,dv] Add sysrst_ctrl auto-block-key-output test

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_auto_blk_key_output_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_auto_blk_key_output_vseq.sv
@@ -1,0 +1,100 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence will enable the auto block feature and override
+// the key output with their override values set in auto_block_out_ctl reg
+class sysrst_ctrl_auto_blk_key_output_vseq extends sysrst_ctrl_base_vseq;
+  `uvm_object_utils(sysrst_ctrl_auto_blk_key_output_vseq)
+
+  `uvm_object_new
+
+   rand uvm_reg_data_t override_value;
+   rand uint16_t set_timer;
+   rand int cycles;
+
+   constraint cycles_c {cycles dist {
+     [set_timer-10 : set_timer] :/5,
+     [set_timer : set_timer+10] :/95
+     };
+   }
+
+   constraint set_timer_c {
+    set_timer dist {
+      [10:100] :/ 95,
+      [101:$]   :/ 5
+    };
+   }
+
+   constraint num_trans_c {num_trans == 3;}
+
+   task drive_pwrb();
+    cfg.vif.pwrb_in = 1;
+    cfg.clk_aon_rst_vif.wait_clks($urandom_range(1,20));
+    cfg.vif.pwrb_in = 0;
+    cfg.clk_aon_rst_vif.wait_clks(cycles+3);
+    cfg.vif.pwrb_in = 1;
+   endtask
+
+   task body();
+
+    bit enable_key0_out_sel, enable_key1_out_sel, enable_key2_out_sel;
+    bit override_key0_out_value, override_key1_out_value, override_key2_out_value;
+
+    `uvm_info(`gfn, "Starting the body from auto_blk_key_output_vseq", UVM_LOW)
+
+    // Enable the auto block key feature
+    ral.auto_block_debounce_ctl.auto_block_enable.set(1);
+    csr_update(ral.auto_block_debounce_ctl);
+
+    repeat (num_trans) begin
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+
+      // Set the auto block debounce timer value
+      csr_wr(ral.auto_block_debounce_ctl.debounce_timer, set_timer);
+      `uvm_info(`gfn, $sformatf("Debounce timer set for: %0h",set_timer), UVM_LOW)
+
+      // Set the key outputs to auto override with their values
+      `DV_CHECK_RANDOMIZE_FATAL(ral.auto_block_out_ctl)
+      csr_update(ral.auto_block_out_ctl);
+
+      // It takes 2-3 clock cycles to sync the register values
+      cfg.clk_aon_rst_vif.wait_clks(3);
+
+      // Press the pwrb_in input key
+      drive_pwrb();
+
+      `uvm_info(`gfn, $sformatf("Value of cycles:%0d", cycles), UVM_LOW)
+
+      enable_key0_out_sel = `gmv(ral.auto_block_out_ctl.key0_out_sel);
+      enable_key1_out_sel = `gmv(ral.auto_block_out_ctl.key1_out_sel);
+      enable_key2_out_sel = `gmv(ral.auto_block_out_ctl.key2_out_sel);
+
+      override_key0_out_value = `gmv(ral.auto_block_out_ctl.key0_out_value);
+      override_key1_out_value = `gmv(ral.auto_block_out_ctl.key1_out_value);
+      override_key2_out_value = `gmv(ral.auto_block_out_ctl.key2_out_value);
+
+      if (cycles >= set_timer) begin
+        cfg.clk_aon_rst_vif.wait_clks(1);
+        if(enable_key0_out_sel == 1) begin
+         `DV_CHECK_EQ(override_key0_out_value, cfg.vif.key0_out);
+        end
+        if(enable_key1_out_sel == 1) begin
+         `DV_CHECK_EQ(override_key1_out_value, cfg.vif.key1_out);
+        end
+        if(enable_key2_out_sel == 1) begin
+         `DV_CHECK_EQ(override_key2_out_value, cfg.vif.key2_out);
+        end
+      end else begin
+        `DV_CHECK_EQ(cfg.vif.key0_out, 0);
+        `DV_CHECK_EQ(cfg.vif.key1_out, 0);
+        `DV_CHECK_EQ(cfg.vif.key2_out, 0);
+      end
+
+      cfg.clk_aon_rst_vif.wait_clks(20);
+    end
+   endtask : body
+
+endclass : sysrst_ctrl_auto_blk_key_output_vseq
+

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_ec_rst_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_combo_detect_ec_rst_vseq.sv
@@ -2,66 +2,87 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-// This sequence will assert the ec_rst_out_l and raise an interrupt when certain combos are detected.
+// This sequence will assert the ec_rst_out_l and raise an interrupt
+// when certain combos are detected.
 class sysrst_ctrl_combo_detect_ec_rst_vseq extends sysrst_ctrl_base_vseq;
   `uvm_object_utils(sysrst_ctrl_combo_detect_ec_rst_vseq)
 
   `uvm_object_new
 
-   task body();
-    uvm_reg_data_t rdata, rdata1;
+  rand int wait_cycles;
+  rand uvm_reg_data_t detect_timer, debounce_timer;
+
+  constraint wait_cycles_c {wait_cycles dist {
+    [15 : 25] :/5,
+    25 :/95
+    };
+  }
+
+  constraint detect_timer_c {detect_timer == 'h5;}
+  constraint debounce_timer_c {debounce_timer == 'h20;}
+
+  task drive_input();
+    // Trigger the input pins
+    cfg.vif.key0_in = 1;
+    cfg.vif.key1_in = 1;
+    cfg.vif.key2_in = 1;
+    cfg.clk_aon_rst_vif.wait_clks($urandom_range(1,10));
+    cfg.vif.key0_in = 0;
+    cfg.vif.key1_in = 0;
+    cfg.vif.key2_in = 0;
+    cfg.clk_aon_rst_vif.wait_clks(wait_cycles);
+    cfg.vif.key0_in = 1;
+    cfg.vif.key1_in = 1;
+    cfg.vif.key2_in = 1;
+  endtask
+
+  task body();
+    uvm_reg_data_t rdata = 0;
 
     `uvm_info(`gfn, "Starting the body from combo detect ec_rst", UVM_LOW)
 
     // Enable the override function and set the override value for ec_rst_l pin
-    ral.pin_out_ctl.ec_rst_l.set(1);
+    ral.pin_out_ctl.ec_rst_l.set(0);
     csr_update(ral.pin_out_ctl);
-
-    ral.pin_out_value.ec_rst_l.set(1);
-    csr_update(ral.pin_out_value);
-
-    ral.pin_allowed_ctl.ec_rst_l_0.set(1);
-    ral.pin_allowed_ctl.ec_rst_l_1.set(1);
-    csr_update(ral.pin_allowed_ctl);
 
     // Enabled key0_in, key1_in, key2_in to trigger the combo
     csr_wr(ral.com_sel_ctl[0], 'h7);
 
     // Set the duration for combo to pressed
-    csr_wr(ral.com_det_ctl[0],'h5) ;
+    csr_wr(ral.com_det_ctl[0], detect_timer);
 
     // Enabled ec_rst_0 action
     csr_wr(ral.com_out_ctl[0], 'h6);
 
     // Set the ec_rst_0 pulse width
-    csr_wr(ral.ec_rst_ctl, 'h5);
+    csr_wr(ral.ec_rst_ctl, 'h10);
 
-    repeat ($urandom_range(1,3)) begin
-      // Trigger the input pins
-      cfg.vif.key0_in = 1;
-      cfg.vif.key1_in = 1;
-      cfg.vif.key2_in = 1;
-      #50us;
-      cfg.vif.key0_in = 0;
-      cfg.vif.key1_in = 0;
-      cfg.vif.key2_in = 0;
-      #50us;
+    // Set the key triggered debounce timer
+    csr_wr(ral.key_intr_debounce_ctl, debounce_timer);
+
+    // It takes 2-3 clock cycles to sync the register values
+    cfg.clk_aon_rst_vif.wait_clks(2);
+
+    drive_input();
+
+    `uvm_info(`gfn, $sformatf("Value of wait_cycles:%0d", wait_cycles), UVM_LOW)
+    if (wait_cycles >= (debounce_timer + detect_timer)) begin
+      // It takes 2-3 clock cycles to sync the interrupt value
+      // Read the combo status register
+      cfg.clk_aon_rst_vif.wait_clks(2);
+      csr_rd_check(.ptr(ral.combo_intr_status), .compare_value(1));
+
+      // Write to clear the interrupt
+      csr_wr(ral.combo_intr_status, 'h1);
+
+      cfg.clk_aon_rst_vif.wait_clks(20);
+      // check if the interrupt is cleared
+      csr_rd_check(.ptr(ral.combo_intr_status), .compare_value(0));
+    end else begin
+      // check there is no interrupt
+      csr_rd_check(.ptr(ral.combo_intr_status), .compare_value(0));
     end
-
-    // Wait for interrupt to raise
-    #100us;
-
-    csr_rd_check(.ptr(ral.combo_intr_status), .compare_value(1));
-    `uvm_info(`gfn, ral.combo_intr_status.sprint(), UVM_MEDIUM)
-
-    // Write to clear the interrupt
-    csr_wr(ral.combo_intr_status, 'h1);
-
-    #100us;
-    // check if the interrupt is cleared
-    csr_rd_check(.ptr(ral.combo_intr_status), .compare_value(0));
-
-    #100us;
+    cfg.clk_aon_rst_vif.wait_clks(20);
   endtask : body
 
 endclass : sysrst_ctrl_combo_detect_ec_rst_vseq

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_vseq_list.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_vseq_list.sv
@@ -11,5 +11,6 @@
 `include "sysrst_ctrl_pin_override_vseq.sv"
 `include "sysrst_ctrl_flash_wr_prot_vseq.sv"
 `include "sysrst_ctrl_ec_pwr_on_rst_vseq.sv"
+`include "sysrst_ctrl_auto_blk_key_output_vseq.sv"
 
 

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_env.core
@@ -27,6 +27,7 @@ filesets:
       - seq_lib/sysrst_ctrl_pin_override_vseq.sv: {is_include_file: true}
       - seq_lib/sysrst_ctrl_flash_wr_prot_vseq.sv: {is_include_file: true}
       - seq_lib/sysrst_ctrl_ec_pwr_on_rst_vseq.sv: {is_include_file: true}
+      - seq_lib/sysrst_ctrl_auto_blk_key_output_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/sysrst_ctrl_scoreboard.sv
@@ -89,8 +89,6 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
       end
       "auto_block_debounce_ctl", "auto_block_out_ctl": begin
       end
-      "wkup_status": begin
-      end
       "pin_in_value": begin
         do_read_check = 1'b0;  //This check is done in sequence
       end
@@ -98,7 +96,7 @@ class sysrst_ctrl_scoreboard extends cip_base_scoreboard #(
         do_read_check = 1'b0;  //This check is done in sequence
       end
       default: begin
-        `uvm_error(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
+       `uvm_error(`gfn, $sformatf("invalid csr: %0s", csr.get_full_name()))
       end
     endcase
 

--- a/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
+++ b/hw/ip/sysrst_ctrl/dv/sysrst_ctrl_sim_cfg.hjson
@@ -74,6 +74,10 @@
       name: sysrst_ctrl_ec_pwr_on_rst
       uvm_test_seq: sysrst_ctrl_ec_pwr_on_rst_vseq
     }
+    {
+      name: sysrst_ctrl_auto_blk_key_output
+      uvm_test_seq: sysrst_ctrl_auto_blk_key_output_vseq
+    }
 
   ]
 


### PR DESCRIPTION
This PR contains:
1. The test to verify the sysrst_ctrl auto block key output feature.
2. A minor updates to sysrst_ctrl_combo_detect_ec_rst test to align with the new debounce logic.



Signed-off-by: Madhuri Patel <madhuri.patel@ensilica.com>