### PR TITLE
[dv,full_chip,clkmgr] Test access to disabled peripheral

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -803,7 +803,7 @@
             watchdog event results, and verify the rstmgr crash dump info records the CSR address.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_clkmgr_peri_off"]
     }
     {
       name: chip_conn_clk_div
@@ -879,7 +879,7 @@
             wakeup.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_pwrmgr_smoketest"]
     }
     {
       name: chip_sw_pwrmgr_sleep_all_reset_reqs
@@ -892,7 +892,7 @@
             rstmgr's `reset_info` indicates the expected reset.
             '''
       milestone: V2
-      tests: []
+      tests: ["aon_timer_wdog_bite_reset"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_all_wake_ups
@@ -917,7 +917,7 @@
             chip_pwrmgr_sleep_all_reset_reqs, except `control.main_pd_n` is set to 0.
             '''
       milestone: V2
-      tests: []
+      tests: ["aon_timer_wdog_bite_reset"]
     }
     {
       name: chip_sw_pwrmgr_all_reset_reqs

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -440,6 +440,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_clkmgr_peri_off
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/clkmgr_peri_off_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=7000000"]
+    }
+    {
       name: chip_sw_clkmgr_jitter
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/clkmgr_jitter_test:1"]

--- a/sw/device/lib/testing/aon_timer_testutils.c
+++ b/sw/device/lib/testing/aon_timer_testutils.c
@@ -13,6 +13,14 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
+uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds) {
+  uint64_t cycles = (microseconds * kClockFreqAonHz / 1000000);
+  CHECK(cycles < UINT32_MAX,
+        "The value 0x%08x%08x can't fit into the 32 bits timer counter.",
+        (cycles >> 32), (uint32_t)cycles);
+  return (uint32_t)cycles;
+}
+
 void aon_timer_testutils_wakeup_config(const dif_aon_timer_t *aon_timer,
                                        uint32_t cycles) {
   // Make sure that wake-up timer is stopped.

--- a/sw/device/lib/testing/aon_timer_testutils.h
+++ b/sw/device/lib/testing/aon_timer_testutils.h
@@ -10,6 +10,11 @@
 #include "sw/device/lib/dif/dif_aon_timer.h"
 
 /**
+ * Returns the number of AON cycles corresponding to the given microseconds.
+ */
+uint32_t aon_timer_testutils_get_aon_cycles_from_us(uint64_t microseconds);
+
+/**
  * Configure wakeup counter for a number of AON clock cycles.
  * @param cycles The number of AON clock cycles.
  */

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -24,17 +24,6 @@
 #define WKUP_TIME_US 2000
 const test_config_t kTestConfig;
 
-static uint64_t us_to_aon_cycles(uint64_t time_us) {
-  return time_us * kClockFreqAonHz / 1000000;
-}
-
-static uint32_t cycles_to_32_bits(uint64_t cycles, const char *label) {
-  CHECK(cycles < UINT32_MAX,
-        "The %s value 0x%08x%08x can't fit into the 32 bits timer counter",
-        label, (uint32_t)(cycles >> 32), (uint32_t)cycles);
-  return (uint32_t)cycles;
-}
-
 bool test_main(void) {
   // Initialize pwrmgr.
   dif_pwrmgr_t pwrmgr;
@@ -69,11 +58,11 @@ bool test_main(void) {
     CHECK(WKUP_TIME_US > WDOG_BITE_TIME_US);
     CHECK(WDOG_BARK_TIME_US < WDOG_BITE_TIME_US);
     uint32_t wkup_cycles =
-        cycles_to_32_bits(us_to_aon_cycles(WKUP_TIME_US), "wkup_time");
+        aon_timer_testutils_get_aon_cycles_from_us(WKUP_TIME_US);
     uint32_t bark_cycles =
-        cycles_to_32_bits(us_to_aon_cycles(WDOG_BARK_TIME_US), "bark_time");
+        aon_timer_testutils_get_aon_cycles_from_us(WDOG_BARK_TIME_US);
     uint32_t bite_cycles =
-        cycles_to_32_bits(us_to_aon_cycles(WDOG_BITE_TIME_US), "bite_time");
+        aon_timer_testutils_get_aon_cycles_from_us(WDOG_BITE_TIME_US);
     aon_timer_testutils_wakeup_config(&aon_timer, wkup_cycles);
     aon_timer_testutils_watchdog_config(&aon_timer, bark_cycles, bite_cycles,
                                         true);

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -28,14 +28,13 @@ const test_config_t kTestConfig;
 static void config_wdog(const dif_aon_timer_t *aon_timer,
                         const dif_pwrmgr_t *pwrmgr, uint64_t bark_time_us,
                         uint64_t bite_time_us) {
-  uint64_t bark_cycles = (bark_time_us * kClockFreqAonHz / 1000000);
-  uint64_t bite_cycles = (bite_time_us * kClockFreqAonHz / 1000000);
+  uint32_t bark_cycles =
+      aon_timer_testutils_get_aon_cycles_from_us(bark_time_us);
+  uint32_t bite_cycles =
+      aon_timer_testutils_get_aon_cycles_from_us(bite_time_us);
 
-  CHECK(bite_cycles < UINT32_MAX,
-        "The value %u can't fit into the 32 bits timer counter.", bite_cycles);
-
-  LOG_INFO("Wdog will bark after %u us and bite after %u us",
-           (uint32_t)bark_time_us, (uint32_t)bite_time_us);
+  LOG_INFO("Wdog will bark after %u us and bite after %u us", bark_time_us,
+           bite_time_us);
 
   // Set wdog as a reset source.
   CHECK_DIF_OK(dif_pwrmgr_set_request_sources(pwrmgr, kDifPwrmgrReqTypeReset,

--- a/sw/device/tests/clkmgr_peri_off_test.c
+++ b/sw/device/tests/clkmgr_peri_off_test.c
@@ -1,0 +1,107 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/dif/dif_aon_timer.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rstmgr.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/rstmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+ * The peripherals used to test when the peri clocks are disabled are
+ * bit 0: clk_io_div4_peri: uart0
+ * bit 1: clk_io_div2_peri: spi_host1
+ * bit 2: clk_usb_peri: usbdev
+ * bit 3: clk_io_peri: spi_host0
+ */
+
+const test_config_t kTestConfig;
+
+static dif_aon_timer_t aon_timer;
+static dif_uart_t uart0;
+
+static const uint32_t bite_us = 200;
+
+/**
+ * Send CSR access to uart0, expecting to timeout.
+ */
+static void uart0_csr_access(void) {
+  CHECK_DIF_OK(dif_uart_watermark_rx_set(&uart0, kDifUartWatermarkByte1));
+}
+
+/**
+ * Test that disabling a 'gateable' unit's clock causes the unit to become
+ * unresponsive to CSR accesses. Configure a watchdog reset, and if it triggers
+ * the test is successful.
+ */
+static void test_gateable_clocks_off(const dif_clkmgr_t *clkmgr,
+                                     dif_clkmgr_gateable_clock_t clock) {
+  // Make sure the clock for the unit is on.
+  CHECK_DIF_OK(
+      dif_clkmgr_gateable_clock_set_enabled(clkmgr, clock, kDifToggleEnabled));
+
+  // The unit is enabled. Set the aon timer to bite, disable it, and issue a
+  // CSR read.
+  uint32_t bite_cycles = aon_timer_testutils_get_aon_cycles_from_us(bite_us);
+  LOG_INFO("Setting bite reset for %u us (%u cycles)", bite_us, bite_cycles);
+
+  aon_timer_testutils_watchdog_config(&aon_timer, UINT32_MAX, bite_cycles,
+                                      false);
+  CHECK_DIF_OK(
+      dif_clkmgr_gateable_clock_set_enabled(clkmgr, clock, kDifToggleDisabled));
+  uart0_csr_access();
+}
+
+bool test_main() {
+  dif_clkmgr_t clkmgr;
+  dif_pwrmgr_t pwrmgr;
+  dif_rstmgr_t rstmgr;
+
+  CHECK_DIF_OK(dif_rstmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_RSTMGR_AON_BASE_ADDR), &rstmgr));
+
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+
+  // Initialize aon timer.
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
+  // Initialize uart0.
+  CHECK_DIF_OK(dif_uart_init(
+      mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
+
+  if (rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor)) {
+    // Enable watchdog bite reset.
+    CHECK_DIF_OK(dif_pwrmgr_set_request_sources(&pwrmgr, kDifPwrmgrReqTypeReset,
+                                                kDifPwrmgrResetRequestSourceTwo,
+                                                true));
+    rstmgr_testutils_pre_reset(&rstmgr);
+    test_gateable_clocks_off(&clkmgr, 0);
+
+    // This should never be reached.
+    LOG_ERROR("This is unreachable since a reset should have been triggered");
+    return false;
+  } else if (rstmgr_testutils_is_reset_info(&rstmgr,
+                                            kDifRstmgrResetInfoWatchdog)) {
+    return true;
+  } else {
+    dif_rstmgr_reset_info_bitfield_t reset_info;
+    CHECK_DIF_OK(dif_rstmgr_reset_info_get(&rstmgr, &reset_info));
+    LOG_ERROR("Unexpected reset_info 0x%x", reset_info);
+  }
+  return false;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -276,6 +276,31 @@ sw_tests += {
   }
 }
 
+clkmgr_peri_off_test_lib = declare_dependency(
+  link_with: static_library(
+    'clkmgr_peri_off_test_lib',
+    sources: ['clkmgr_peri_off_test.c'],
+    dependencies: [
+      sw_lib_dif_aon_timer,
+      sw_lib_dif_clkmgr,
+      sw_lib_dif_pwrmgr,
+      sw_lib_dif_rstmgr,
+      sw_lib_dif_uart,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+      sw_lib_runtime_ibex,
+      sw_lib_testing_aon_timer_testutils,
+      sw_lib_testing_rstmgr_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'clkmgr_peri_off_test': {
+    'library': clkmgr_peri_off_test_lib,
+  }
+}
+
 clkmgr_jitter_test_lib = declare_dependency(
   link_with: static_library(
     'clkmgr_jitter_test_lib',
@@ -761,7 +786,6 @@ aon_timer_irq_test = declare_dependency(
       sw_lib_dif_rstmgr,
       sw_lib_dif_aon_timer,
       sw_lib_dif_rv_timer,
-      sw_lib_dif_pwrmgr,
       sw_lib_dif_rv_plic,
       sw_lib_runtime_log,
       sw_lib_runtime_ibex,


### PR DESCRIPTION
Configure a watchdog bite.
Disable the clock to some peripheral and perform a CSR access to it.
The access should cause the CPU to freeze, so the watchdog will bite.
Detect if a reset is due to the watchdog, indicating test success.
Introduce a simple aon_timer testutils function.
Minor cleanup of aon_timer_irq_test.
Minor updates to the full chip testplan.

Signed-off-by: Guillermo Maturana <maturana@google.com>