### PR TITLE
[sw/test_rom] Re-enable SW-gateable clocks after reset

### DIFF
--- a/hw/ip/clkmgr/data/BUILD
+++ b/hw/ip/clkmgr/data/BUILD
@@ -2,7 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:autogen.bzl", "autogen_hjson_header")
+
 package(default_visibility = ["//visibility:public"])
+
+autogen_hjson_header(
+    name = "clkmgr_regs",
+    srcs = [
+        "clkmgr.hjson",
+    ],
+)
 
 filegroup(
     name = "all_files",

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -1,5 +1,5 @@
 diff --git a/sw/device/lib/pinmux.c b/sw/device/lib/pinmux.c
-index 3561ef52f..879c4502c 100644
+index 643e44b49..a07e286e1 100644
 --- a/sw/device/lib/pinmux.c
 +++ b/sw/device/lib/pinmux.c
 @@ -61,26 +61,6 @@ void pinmux_init(void) {
@@ -30,12 +30,12 @@ index 3561ef52f..879c4502c 100644
    reg32 =
        mmio_region_from_addr(PINMUX0_BASE_ADDR + PINMUX_MIO_OUTSEL_0_REG_OFFSET);
 diff --git a/sw/device/lib/testing/test_rom/test_rom_start.S b/sw/device/lib/testing/test_rom/test_rom_start.S
-index ea9f7e7ba..cf1c931f9 100644
+index 7092c858a..101d3bc7e 100644
 --- a/sw/device/lib/testing/test_rom/test_rom_start.S
 +++ b/sw/device/lib/testing/test_rom/test_rom_start.S
-@@ -138,47 +138,6 @@ _reset_start:
- _start:
-   .globl _start
+@@ -146,47 +146,6 @@ _start:
+   li   t0, CLKMGR_CLK_HINTS_REG_RESVAL
+   sw   t0, CLKMGR_CLK_HINTS_REG_OFFSET(a0)
 
 -  // Check if AST initialization should be skipped.
 -  li   t0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
@@ -82,7 +82,7 @@ index ea9f7e7ba..cf1c931f9 100644
    // read-write-execute for the entire address space and then clearing
    // all other entries.
 diff --git a/sw/device/sca/aes_serial.c b/sw/device/sca/aes_serial.c
-index a4d57e1c7..d12c776b7 100644
+index aee8a61f3..b910e1c34 100644
 --- a/sw/device/sca/aes_serial.c
 +++ b/sw/device/sca/aes_serial.c
 @@ -199,18 +199,13 @@ int main(void) {
@@ -235,7 +235,7 @@ index 3c0c86f26..7354aa9cb 100644
  }
 
 diff --git a/sw/device/tests/aes_smoketest.c b/sw/device/tests/aes_smoketest.c
-index 26c7a270d..8b464a137 100644
+index 4667a550a..bea5d3bf5 100644
 --- a/sw/device/tests/aes_smoketest.c
 +++ b/sw/device/tests/aes_smoketest.c
 @@ -7,7 +7,6 @@
@@ -257,10 +257,10 @@ index 26c7a270d..8b464a137 100644
    CHECK_DIF_OK(
        dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
-index 529f26e38..e638f25e1 100644
+index 2e822c5f3..2da8fc3be 100644
 --- a/sw/device/tests/meson.build
 +++ b/sw/device/tests/meson.build
-@@ -254,7 +254,6 @@ aes_smoketest_lib = declare_dependency(
+@@ -248,7 +248,6 @@ aes_smoketest_lib = declare_dependency(
        sw_lib_dif_aes,
        sw_lib_mmio,
        sw_lib_runtime_log,

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -34,6 +34,7 @@ cc_library(
     deps = [
         ":bootstrap",
         ":chip_info",
+        "//hw/ip/clkmgr/data:clkmgr_regs",
         "//hw/ip/csrng/data:csrng_regs",
         "//hw/ip/edn/data:edn_regs",
         "//hw/ip/entropy_src/data:entropy_src_regs",

--- a/sw/device/lib/testing/test_rom/meson.build
+++ b/sw/device/lib/testing/test_rom/meson.build
@@ -36,6 +36,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
     'test_rom_' + device_name,
     sources: [
       hw_ip_ast_reg_h,
+      hw_ip_clkmgr_reg_h,
       hw_ip_csrng_reg_h,
       hw_ip_edn_reg_h,
       hw_ip_entropy_src_reg_h,

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -5,6 +5,7 @@
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey_memory.h"
 #include "sw/device/lib/base/multibits_asm.h"
 #include "ast_regs.h"
+#include "clkmgr_regs.h"
 #include "csrng_regs.h"
 #include "edn_regs.h"
 #include "entropy_src_regs.h"
@@ -137,6 +138,13 @@ _reset_start:
  */
 _start:
   .globl _start
+
+  // Re-enable all SW gateable clocks in case the clkmgr was not reset.
+  li   a0, TOP_EARLGREY_CLKMGR_AON_BASE_ADDR
+  li   t0, CLKMGR_CLK_ENABLES_REG_RESVAL
+  sw   t0, CLKMGR_CLK_ENABLES_REG_OFFSET(a0)
+  li   t0, CLKMGR_CLK_HINTS_REG_RESVAL
+  sw   t0, CLKMGR_CLK_HINTS_REG_OFFSET(a0)
 
   // Check if AST initialization should be skipped.
   li   t0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \


### PR DESCRIPTION
As #11081 points out, if a SW-gateable clock is gated, and the chip is
only partially reset (i.e., reset is NOT a POR), peripherals that the
test ROM uses (i.e., UART for logging and HMAC for bootstrap) could be
rendered in-operable.

This commit partially addresses #11081 (w.r.t. to the test ROM) by
resetting all SW-gateable clocks to their default POR values.

Signed-off-by: Timothy Trippel <ttrippel@google.com>