### PR TITLE
[prim] Add prim_and2 primitive

### DIFF
--- a/hw/ip/prim/lint/prim_and2.waiver
+++ b/hw/ip/prim/lint/prim_and2.waiver
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# waiver file for prim_and2
+
+waive -rules {STAR_PORT_CONN_USE} -location {prim_and2.sv} -regexp {.*wild card port connection encountered on instance.*} \
+      -comment "Generated prims may have wildcard connections."

--- a/hw/ip/prim/prim.core
+++ b/hw/ip/prim/prim.core
@@ -26,6 +26,7 @@ filesets:
       - lowrisc:prim:subreg
       - lowrisc:prim:cipher
       - lowrisc:prim:xor2
+      - lowrisc:prim:and2
     files:
       - rtl/prim_clock_gating_sync.sv
       - rtl/prim_sram_arbiter.sv

--- a/hw/ip/prim/prim_and2.core
+++ b/hw/ip/prim/prim_and2.core
@@ -1,0 +1,48 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim:and2"
+description: "Generic 2-input and"
+filesets:
+  primgen_dep:
+    depend:
+      - lowrisc:prim:prim_pkg
+      - lowrisc:prim:primgen
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      - lint/prim_and2.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+generate:
+  impl:
+    generator: primgen
+    parameters:
+      prim_name: and2
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - primgen_dep
+    generate:
+      - impl

--- a/hw/ip/prim_generic/prim_generic_and2.core
+++ b/hw/ip/prim_generic/prim_generic_and2.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_generic:and2"
+description: "Generic 2-input and"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_generic_and2.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_generic/rtl/prim_generic_and2.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_and2.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+module prim_generic_and2 #(
+  parameter int Width = 1
+) (
+  input        [Width-1:0] in0_i,
+  input        [Width-1:0] in1_i,
+  output logic [Width-1:0] out_o
+);
+
+  assign out_o = in0_i & in1_i;
+
+endmodule

--- a/hw/ip/prim_xilinx/prim_xilinx_and2.core
+++ b/hw/ip/prim_xilinx/prim_xilinx_and2.core
@@ -1,0 +1,39 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:prim_xilinx:and2"
+description: "Xilinx 2-input and"
+filesets:
+  files_rtl:
+    files:
+      - rtl/prim_xilinx_and2.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+targets:
+  default:
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl

--- a/hw/ip/prim_xilinx/rtl/prim_xilinx_and2.sv
+++ b/hw/ip/prim_xilinx/rtl/prim_xilinx_and2.sv
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "prim_assert.sv"
+
+// Prevent Vivado from performing optimizations on/across this module.
+(* DONT_TOUCH = "yes" *)
+module prim_xilinx_and2 #(
+  parameter int Width = 1
+) (
+  input [Width-1:0] in0_i,
+  input [Width-1:0] in1_i,
+  output logic [Width-1:0] out_o
+);
+
+  assign out_o = in0_i & in1_i;
+
+endmodule


### PR DESCRIPTION
This PR adds a new prim_and2 primitive onto which tool constraints can be placed. This new primitive will be most useful for the OTBN blanking, in particular inside the one-hot blanking multiplexer primitive.

This is related to #11019.