### PR TITLE
[fpv/pinmux] Pinmux FPV tb fix

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -32,6 +32,11 @@ if {$env(TASK) == "FpvSecCm"} {
     -bbox_m prim_count \
     -bbox_m prim_double_lfsr \
     -f [glob *.scr]
+} elseif {$env(DUT_TOP) == "pinmux_tb"} {
+  analyze -sv09 \
+    +define+FPV_ON \
+    -bbox_m usbdev_aon_wake \
+    -f [glob *.scr]
 } else {
   analyze -sv09 \
     +define+FPV_ON \
@@ -120,6 +125,13 @@ if {$env(DUT_TOP) == "rv_dm"} {
   reset -expr {!rst_ni}
   clock -rate -default clk_i
 }
+
+#-------------------------------------------------------------------------
+# disable assertions
+#-------------------------------------------------------------------------
+assert -disable {*SyncCheckTransients_A}
+assert -disable {*SyncCheckTransients0_A}
+assert -disable {*SyncCheckTransients1_A}
 
 # Use counter abstractions to reduce the run time.
 if {$env(DUT_TOP) == "alert_handler"} {

--- a/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -462,49 +462,49 @@ module pinmux_assert_fpv
   // Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.
   `ASSERT(RvJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
           !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          $past(prim_mubi_pkg::mubi4_test_true_strict(lc_hw_debug_en_i), 2) |->
+          $past(lc_hw_debug_en_i, 2) == lc_ctrl_pkg::On |->
           rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
                         mio_in_i[TargetCfg.tms_idx],
                         mio_in_i[TargetCfg.trst_idx],
                         mio_in_i[TargetCfg.tdi_idx]})
   `ASSERT(RvJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
           prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          $past(prim_mubi_pkg::mubi4_test_true_strict(lc_hw_debug_en_i), 2) |->
+          $past(lc_hw_debug_en_i, 2) == lc_ctrl_pkg::On |->
           rv_jtag_o == {mio_in_i[TargetCfg.tck_idx],
                         mio_in_i[TargetCfg.tms_idx],
                         rst_ni,
                         mio_in_i[TargetCfg.tdi_idx]})
   `ASSERT(RvJtagOStable_A, (u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel &&
           $past(u_pinmux_strap_sampling.tap_strap) != pinmux_pkg::RvTapSel) ||
-          (!$past(prim_mubi_pkg::mubi4_test_true_strict(lc_hw_debug_en_i), 2) &&
-           !$past(prim_mubi_pkg::mubi4_test_true_strict(lc_hw_debug_en_i), 3)) |->
+          ($past(lc_hw_debug_en_i, 2) != lc_ctrl_pkg::On &&
+           $past(lc_hw_debug_en_i, 3) != lc_ctrl_pkg::On) |->
           $stable(rv_jtag_o))
   `ASSERT(RvJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::RvTapSel ||
-          !$past(prim_mubi_pkg::mubi4_test_true_strict(lc_hw_debug_en_i), 2) |->
+          $past(lc_hw_debug_en_i, 2) != lc_ctrl_pkg::On |->
           rv_jtag_o == '0)
 
   // Lc_dft_en_i signal goes through a two clock cycle synchronizer.
   `ASSERT(DftJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
           !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          $past(prim_mubi_pkg::mubi4_test_true_strict(lc_dft_en_i), 2) |->
+          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
           dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
                          mio_in_i[TargetCfg.tms_idx],
                          mio_in_i[TargetCfg.trst_idx],
                          mio_in_i[TargetCfg.tdi_idx]})
   `ASSERT(DftJtagOWScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
           prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
-          $past(prim_mubi_pkg::mubi4_test_true_strict(lc_dft_en_i), 2) |->
+          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
           dft_jtag_o == {mio_in_i[TargetCfg.tck_idx],
                          mio_in_i[TargetCfg.tms_idx],
                          rst_ni,
                          mio_in_i[TargetCfg.tdi_idx]})
   `ASSERT(DftJtagOStable_A, (u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel &&
           $past(u_pinmux_strap_sampling.tap_strap) != pinmux_pkg::DftTapSel) ||
-          (!$past(prim_mubi_pkg::mubi4_test_true_strict(lc_dft_en_i), 2) &&
-           !$past(prim_mubi_pkg::mubi4_test_true_strict(lc_dft_en_i), 3)) |->
+          ($past(lc_dft_en_i, 2) != lc_ctrl_pkg::On &&
+           $past(lc_dft_en_i, 3) != lc_ctrl_pkg::On) |->
           $stable(dft_jtag_o))
   `ASSERT(DftJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
-          !$past(prim_mubi_pkg::mubi4_test_true_strict(lc_dft_en_i), 2) |->
+          $past(lc_dft_en_i, 2) != lc_ctrl_pkg::On |->
           dft_jtag_o == '0)
 
   `ASSERT(TapStrap_A, ##2 ((!dft_hold_tap_sel_i && $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) ||
@@ -524,17 +524,17 @@ module pinmux_assert_fpv
           lc_jtag_i == {mio_out_o[TargetCfg.tdo_idx],
                         mio_oe_o[TargetCfg.tdo_idx]})
   `ASSERT(RvJtagI_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
-          $past(prim_mubi_pkg::mubi4_test_true_strict(lc_hw_debug_en_i), 2) |->
+          $past(lc_hw_debug_en_i, 2) == lc_ctrl_pkg::On |->
           rv_jtag_i == {mio_out_o[TargetCfg.tdo_idx],
                         mio_oe_o[TargetCfg.tdo_idx]})
   `ASSERT(DftJtagI_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
-          $past(prim_mubi_pkg::mubi4_test_true_strict(lc_dft_en_i), 2) |->
+          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |->
           dft_jtag_i == {mio_out_o[TargetCfg.tdo_idx],
                         mio_oe_o[TargetCfg.tdo_idx]})
 
   // ------ DFT strap_test_o assertions ------
   `ASSERT(DftStrapTestO_A, ##2 strap_en_i &&
-          $past(prim_mubi_pkg::mubi4_test_true_strict(lc_dft_en_i), 2) |=>
+          $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On |=>
           dft_strap_test_o.valid &&
           dft_strap_test_o.straps == $past({mio_in_i[TargetCfg.dft_strap1_idx],
                                             mio_in_i[TargetCfg.dft_strap0_idx]}))

--- a/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
+++ b/hw/ip/pinmux/rtl/pinmux_strap_sampling.sv
@@ -298,8 +298,8 @@ module pinmux_strap_sampling
   `ASSERT(PwrMgrStrapSampleOnce_A, strap_en_i |=> ##0 !strap_en_i [*])
 
   `ASSERT(RvTapOff0_A,  lc_hw_debug_en_i == lc_ctrl_pkg::Off |-> ##2 rv_jtag_o == '0)
-  `ASSERT(RvTapOff1_A,  lc_hw_debug_en_i == lc_ctrl_pkg::Off |-> ##2 rv_jtag_i == '0)
+  `ASSUME(RvTapOff1_A,  lc_hw_debug_en_i == lc_ctrl_pkg::Off |-> ##2 rv_jtag_i == '0)
   `ASSERT(DftTapOff0_A, lc_dft_en_i == lc_ctrl_pkg::Off |-> ##2 dft_jtag_o == '0)
-  `ASSERT(DftTapOff1_A, lc_dft_en_i == lc_ctrl_pkg::Off |-> ##2 dft_jtag_i == '0)
+  `ASSUME(DftTapOff1_A, lc_dft_en_i == lc_ctrl_pkg::Off |-> ##2 dft_jtag_i == '0)
 
 endmodule : pinmux_strap_sampling


### PR DESCRIPTION
This PR fixes pinmux FPV:

1). Blackbox usb module because we only check connectivity here.
2). Disable assertions for `SyncCheckTransients*` because in formal we
  do not constraint inputs.
3). Updated lc_ctrl_pkg::On/Off to not use `mubi4_test_true_strict`
  function.
4). Update a few design input related assertions to use assumptions.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>