### PR TITLE
[otbn,rtl] Remove (unused) part of decoder supporting AUIPC

### DIFF
--- a/hw/ip/otbn/rtl/otbn_decoder.sv
+++ b/hw/ip/otbn/rtl/otbn_decoder.sv
@@ -706,13 +706,6 @@ module otbn_decoder
         alu_operator_base     = AluOpBaseAdd;
       end
 
-      InsnOpcodeBaseAuipc: begin  // Add Upper Immediate to PC
-        alu_op_a_mux_sel_base = OpASelCurrPc;
-        alu_op_b_mux_sel_base = OpBSelImmediate;
-        imm_b_mux_sel_base    = ImmBaseBU;
-        alu_operator_base     = AluOpBaseAdd;
-      end
-
       InsnOpcodeBaseOpImm: begin  // Register-Immediate ALU Operations
         alu_op_a_mux_sel_base = OpASelRegister;
         alu_op_b_mux_sel_base = OpBSelImmediate;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -101,7 +101,6 @@ package otbn_pkg;
     InsnOpcodeBaseLoad       = 7'h03,
     InsnOpcodeBaseMemMisc    = 7'h0f,
     InsnOpcodeBaseOpImm      = 7'h13,
-    InsnOpcodeBaseAuipc      = 7'h17,
     InsnOpcodeBaseStore      = 7'h23,
     InsnOpcodeBaseOp         = 7'h33,
     InsnOpcodeBaseLui        = 7'h37,


### PR DESCRIPTION
We don't actually have that instruction! Spotted by a coverage hole.
