### PR TITLE
[fpv/rom_ctrl] Check connectivity for alerts in rom_ctrl

### DIFF
--- a/hw/ip/prim/rtl/prim_assert_sec_cm.svh
+++ b/hw/ip/prim/rtl/prim_assert_sec_cm.svh
@@ -13,7 +13,8 @@
   `ifdef INC_ASSERT \
   assign PRIM_HIER_.unused_assert_connected = 1'b1; \
   `endif \
-  `ASSUME_FPV(ErrTriggerAfterAlertInit_S, $stable(rst_ni) == 0 |-> PRIM_HIER_.ERR_NAME_ == 0 [*10])
+  `ASSUME_FPV(``NAME_``TriggerAfterAlertInit_S, $stable(rst_ni) == 0 |-> \
+              PRIM_HIER_.ERR_NAME_ == 0 [*10])
 
 // macros for security countermeasures
 `define ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, MAX_CYCLES_ = 7) \

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -554,12 +554,13 @@
                ]
              }
              {
-               name: rom_ctrl
+               name: rom_ctrl_sec_cm
                dut: rom_ctrl
                fusesoc_core: lowrisc:dv:rom_ctrl_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/rom_ctrl/{sub_flow}/{tool}"
                cov: false
+               task: "FpvSecCm"
              }
              {
                name: rv_dm
@@ -586,7 +587,7 @@
                cov: false
              }
              {
-               name: sram_ctrl
+               name: sram_ctrl_sec_cm
                dut: sram_ctrl
                fusesoc_core: lowrisc:dv:sram_ctrl_sva
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]


### PR DESCRIPTION
This PR checks connectivity for sparse fsm alerts in rom_ctrl.
This PR only brings up the script for rom_ctrl, but formal does not accept "$cast" function,
so still need some work to make this property passing.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>