### PR TITLE
[dv/rstmgr] Remove mem tests from hjson config

### DIFF
--- a/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
+++ b/hw/ip/rstmgr/dv/rstmgr_sim_cfg.hjson
@@ -29,7 +29,6 @@
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 // Disable until the stress_all sequence is created.


### PR DESCRIPTION
The rstmgr has no memories so these tests are unmapped and cause
noise in the reports.

Signed-off-by: Guillermo Maturana <maturana@google.com>