### PR TITLE
[dv/rstmgr] Fix handling cpu dump info

### DIFF
--- a/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -21,6 +21,9 @@ package rstmgr_env_pkg;
   import rstmgr_reg_pkg::NumHwResets;
   import rstmgr_reg_pkg::NumSwResets;
 
+  import alert_pkg::alert_crashdump_t;
+  import rv_core_ibex_pkg::cpu_crash_dump_t;
+
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
@@ -33,7 +36,7 @@ package rstmgr_env_pkg;
   // types
   typedef logic [NumSwResets-1:0] sw_rst_t;
 
-  typedef logic [$bits(alert_pkg::alert_crashdump_t)-1:0] linearized_alert_dump_t;
+  typedef logic [$bits(alert_crashdump_t)-1:0] linearized_alert_dump_t;
 
   // functions
 

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_reset_vseq.sv
@@ -57,8 +57,8 @@ class rstmgr_reset_vseq extends rstmgr_base_vseq;
     int expected_reset_info_code;
     logic expected_alert_enable;
     logic expected_cpu_enable;
-    alert_pkg::alert_crashdump_t prev_alert_dump = '0;
-    ibex_pkg::crash_dump_t prev_cpu_dump = '0;
+    alert_crashdump_t prev_alert_dump = '0;
+    cpu_crash_dump_t prev_cpu_dump = '0;
     int trans_before_enabling_cpu_rst_response;
     bit capture = 0;
 

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_smoke_vseq.sv
@@ -80,8 +80,8 @@ class rstmgr_smoke_vseq extends rstmgr_base_vseq;
     if (is_standalone) begin : sw_rst
       logic [NumSwResets-1:0] exp_ctrl_n;
       const logic [NumSwResets-1:0] sw_rst_all_ones = '1;
-      alert_pkg::alert_crashdump_t bogus_alert_dump = '1;
-      rv_core_ibex_pkg::cpu_crash_dump_t bogus_cpu_dump = '1;
+      alert_crashdump_t bogus_alert_dump = '1;
+      cpu_crash_dump_t bogus_cpu_dump = '1;
 
       set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
       csr_rd_check(.ptr(ral.sw_rst_ctrl_n[0]), .compare_value(sw_rst_all_ones),

--- a/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
+++ b/hw/ip/rstmgr/dv/env/seq_lib/rstmgr_sw_rst_vseq.sv
@@ -16,8 +16,8 @@ class rstmgr_sw_rst_vseq extends rstmgr_base_vseq;
   task body();
     bit [NumSwResets-1:0] exp_ctrl_n;
     bit [NumSwResets-1:0] sw_rst_regwen = '1;
-    alert_pkg::alert_crashdump_t bogus_alert_dump = '1;
-    ibex_pkg::crash_dump_t bogus_cpu_dump = '1;
+    alert_crashdump_t bogus_alert_dump = '1;
+    cpu_crash_dump_t bogus_cpu_dump = '1;
     set_alert_and_cpu_info_for_capture(bogus_alert_dump, bogus_cpu_dump);
 
     for (int i = 0; i < num_trans; ++i) begin


### PR DESCRIPTION
Enhance the cpu dump info check to go through all words.
Consistently use rv_core_ibex_pkg instead of ibex_pkg for the dump info.

Signed-off-by: Guillermo Maturana <maturana@google.com>