### PR TITLE
[bazel] Fix bug in opentitan_functest

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -476,7 +476,7 @@ def opentitan_functest(
         cargs = _format_list("args", args, cw310, test_bin = test_bin)
         cdata = _format_list("data", data, cw310, test_bin = test_bin)
 
-        if "manual" not in verilator.get("tags", []):
+        if "manual" not in cw310.get("tags", []):
             all_tests.append(test_name)
 
         native.sh_test(


### PR DESCRIPTION
There was a bug in the opentitan_functest macro that checked the wrong
parameter dictionary (named "verilator", instead of "cw310"). This made
CW310 functest targets fail to build/run. This commit fixes this.

Signed-off-by: Timothy Trippel <ttrippel@google.com>