### PR TITLE
[ci] Disable the verible format job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,10 +79,6 @@ jobs:
   - bash: ci/scripts/include-guard.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check formatting on header guards
-  - bash: ci/scripts/verible-format.sh
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Check formatting of files on allow list with Verible
-    continueOnError: true
   - bash: ci/scripts/verible-lint.sh rtl
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Style-Lint RTL Verilog source files with Verible

--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -56,10 +56,6 @@ ci/scripts/clang-format.sh $tgt_branch
 echo -e "\n### Check formatting on header guards"
 ci/scripts/include-guard.sh $tgt_branch
 
-echo -e "\n### Check formatting of files on allow list with Verible"
-# This script is allowed to fail for now
-ci/scripts/verible-format.sh || true
-
 echo -e "\n### Style-Lint RTL Verilog source files with Verible"
 ci/scripts/verible-lint.sh rtl
 


### PR DESCRIPTION
This has been broken (but ignored) for ages and keeps confusing
contributors who see the failure in CI and aren't sure why their
change has caused it. Let's stop running it until it's more stable.
