### PR TITLE
[rom_ctrl, dv] Added testcase for verifying sparse FSM

### DIFF
--- a/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
+++ b/hw/ip/rom_ctrl/data/rom_ctrl_testplan.hjson
@@ -8,6 +8,7 @@
                      "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/passthru_mem_intg_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
                      "rom_ctrl_sec_cm_testplan.hjson"]
   testpoints: [
     {

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -62,6 +62,7 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
 
     // Tell the CIP base code what bit gets set if we see a TL fault.
     tl_intg_alert_fields[ral.fatal_alert_cause.integrity_error] = 1;
+    sec_cm_alert_name = "fatal";
   endfunction
 
 endclass

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_pkg.sv
@@ -17,6 +17,7 @@ package rom_ctrl_env_pkg;
   import kmac_app_agent_pkg::*;
   import mem_bkdr_util_pkg::*;
   import prim_mubi_pkg::*;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_common_vseq.sv
@@ -31,4 +31,9 @@ class rom_ctrl_common_vseq extends rom_ctrl_base_vseq;
     cfg.mem_bkdr_util_h.rom_encrypt_write32_integ(addr, rdata, RND_CNST_SCR_KEY, RND_CNST_SCR_NONCE,
                                                   1'b1, flip_bits);
   endfunction
+
+  virtual function void sec_cm_fi_ctrl_svas(sec_cm_base_if_proxy if_proxy, bit enable);
+    $assertoff(0, "tb.dut.KeymgrValidChk_A");
+    $assertoff(0, "tb.kmac_app_if.req_data_if.ValidHighUntilReady_A");
+  endfunction: sec_cm_fi_ctrl_svas
 endclass

--- a/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
+++ b/hw/ip/rom_ctrl/dv/rom_ctrl_sim_cfg.hjson
@@ -34,13 +34,14 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson"
+                "{proj_root}/hw/dv/tools/dvsim/tests/passthru_mem_intg_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
   // Add additional tops for simulation.
-  sim_tops: ["rom_ctrl_bind", "rom_ctrl_cov_bind"]
+  sim_tops: ["rom_ctrl_bind", "rom_ctrl_cov_bind", "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
Testcase required to test the sparse FSMs inside rom_ctrl module is
enabled in this commit.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>