### PR TITLE
Add constant-power-hardened `mem*()` function equivalents

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -97,6 +97,13 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "random_order",
+    srcs = ["random_order.c"],
+    hdrs = ["random_order.h"],
+    deps = [":bitfield"],
+)
+
 # TODO: Until Meson is removed, these files need to stay in a different
 # directory, but eventually they will be hoisted to live alongside the
 # targets they mock.

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -72,6 +72,7 @@ cc_library(
     # This library defines memcpy(), so we can't have LLVM rewriting memcpy
     # into a call to itself.
     copts = ["-fno-builtin"],
+    deps = [":macros"],
 )
 
 cc_library(
@@ -103,6 +104,29 @@ cc_library(
     hdrs = ["random_order.h"],
     deps = [":bitfield"],
 )
+
+cc_library(
+    name = "hardened_memory",
+    srcs = ["hardened_memory.c"],
+    hdrs = ["hardened_memory.h"],
+    deps = [
+        ":hardened",
+        ":macros",
+        ":memory",
+        ":random_order",
+    ],
+)
+
+cc_test(
+    name = "hardened_memory_unittest",
+    srcs = ["hardened_memory_unittest.cc"],
+    deps = [
+        ":hardened_memory",
+        ":random_order",
+        "@googletest//:gtest_main",
+    ],
+)
+
 
 # TODO: Until Meson is removed, these files need to stay in a different
 # directory, but eventually they will be hoisted to live alongside the

--- a/sw/device/lib/base/hardened_memory.c
+++ b/sw/device/lib/base/hardened_memory.c
@@ -1,0 +1,176 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened_memory.h"
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/random_order.h"
+
+// NOTE: The three hardened_mem* functions have similar contents, but the parts
+// that are shared between them are commented only in `memcpy()`.
+void hardened_memcpy(uint32_t *restrict dest, const uint32_t *restrict src,
+                     size_t word_len) {
+  random_order_t order;
+  random_order_init(&order, word_len);
+
+  size_t count = 0;
+  size_t expected_count = random_order_len(&order);
+
+  // Immediately convert `src` and `dest` to addresses, which erases their
+  // provenance and causes their addresses to be exposed (in the provenance
+  // sense).
+  uintptr_t src_addr = (uintptr_t)src;
+  uintptr_t dest_addr = (uintptr_t)dest;
+
+  // `decoys` is a small stack array that is filled with uninitialized memory.
+  // It is scratch space for us to do "extra" operations, when the number of
+  // iteration indices the chosen random order is different from `word_len`.
+  //
+  // These extra operations also introduce noise that an attacker must do work
+  // to filter, such as by applying side-channel analysis to obtain an address
+  // trace.
+  uint32_t decoys[8];
+  uintptr_t decoy_addr = (uintptr_t)&decoys;
+
+  // We need to launder `count`, so that the SW.LOOP-COMPLETION check is not
+  // deleted by the compiler.
+  for (; launderw(count) < expected_count; count = launderw(count) + 1) {
+    // The order values themselves are in units of words, but we need `idx` to
+    // be in units of bytes.
+    //
+    // The value obtained from `advance()` is laundered, to prevent
+    // implementation details from leaking across procedures.
+    size_t idx = launderw(random_order_advance(&order)) * sizeof(uint32_t);
+
+    // Prevent the compiler from reordering the loop; this ensures a
+    // happens-before among indices consistent with `order`.
+    barrierw(idx);
+
+    // Compute putative offsets into `src`, `dest`, and `decoys`. Some of these
+    // may go off the end of `src` and `dest`, but they will not be cast to
+    // pointers in that case. (Note that casting out-of-range addresses to
+    // pointers is UB.)
+    uintptr_t srcp = src_addr + idx;
+    uintptr_t destp = dest_addr + idx;
+    uintptr_t decoy1 = decoy_addr + (idx % sizeof(decoys));
+    uintptr_t decoy2 =
+        decoy_addr + ((idx + sizeof(decoys) / 2) % sizeof(decoys));
+
+    // Branchlessly select whether to do a "real" copy or a decoy copy,
+    // depending on whether we've gone off the end of the array or not.
+    //
+    // Pretty much everything needs to be laundered: we need to launder `idx`
+    // for obvious reasons, and we need to launder the result of the select, so
+    // that the compiler cannot delete the resulting loads and stores. This is
+    // similar to having used `volatile uint32_t *`.
+    void *src = (void *)launderw(
+        ct_cmovw(ct_sltuw(launderw(idx), word_len), srcp, decoy1));
+    void *dest = (void *)launderw(
+        ct_cmovw(ct_sltuw(launderw(idx), word_len), destp, decoy2));
+
+    // Perform the copy, without performing a typed dereference operation.
+    write_32(read_32(src), dest);
+  }
+
+  HARDENED_CHECK_EQ(count, expected_count);
+}
+
+// The source of randomness for shred, which may be replaced at link-time.
+OT_WEAK
+uint32_t hardened_memshred_random_word(void) { return 0xcaffe17e; }
+
+void hardened_memshred(uint32_t *dest, size_t word_len) {
+  random_order_t order;
+  random_order_init(&order, word_len);
+
+  size_t count = 0;
+  size_t expected_count = random_order_len(&order);
+
+  uintptr_t data_addr = (uintptr_t)dest;
+
+  uint32_t decoys[8];
+  uintptr_t decoy_addr = (uintptr_t)&decoys;
+
+  for (; count < expected_count; count = launderw(count) + 1) {
+    size_t idx = launderw(random_order_advance(&order)) * sizeof(uint32_t);
+    barrierw(idx);
+
+    uintptr_t datap = data_addr + idx;
+    uintptr_t decoy = decoy_addr + (idx % sizeof(decoys));
+
+    void *data = (void *)launderw(
+        ct_cmovw(ct_sltuw(launderw(idx), word_len), datap, decoy));
+
+    // Write a freshly-generated random word to `*data`.
+    write_32(hardened_memshred_random_word(), data);
+  }
+
+  HARDENED_CHECK_EQ(count, expected_count);
+}
+
+hardened_bool_t hardened_memeq(const uint32_t *lhs, const uint32_t *rhs,
+                               size_t word_len) {
+  random_order_t order;
+  random_order_init(&order, word_len);
+
+  size_t count = 0;
+  size_t expected_count = random_order_len(&order);
+
+  uintptr_t lhs_addr = (uintptr_t)lhs;
+  uintptr_t rhs_addr = (uintptr_t)rhs;
+
+  // `decoys` needs to be filled with equal values this time around. It
+  // should be filled with values with a Hamming weight of around 16, which is
+  // the most common hamming weight among 32-bit words.
+  uint32_t decoys[8] = {
+      0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa,
+      0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa, 0xaaaaaaaa,
+  };
+  uintptr_t decoy_addr = (uintptr_t)&decoys;
+
+  uint32_t zeros = 0;
+  uint32_t ones = UINT32_MAX;
+
+  // The loop is almost token-for-token the one above, but the copy is
+  // replaced with something else.
+  for (; count < expected_count; count = launderw(count) + 1) {
+    size_t idx = launderw(random_order_advance(&order)) * sizeof(uint32_t);
+    barrierw(idx);
+
+    uintptr_t ap = lhs_addr + idx;
+    uintptr_t bp = rhs_addr + idx;
+    uintptr_t decoy1 = decoy_addr + (idx % sizeof(decoys));
+    uintptr_t decoy2 =
+        decoy_addr + ((idx + sizeof(decoys) / 2) % sizeof(decoys));
+
+    void *av = (void *)launderw(
+        ct_cmovw(ct_sltuw(launderw(idx), word_len), ap, decoy1));
+    void *bv = (void *)launderw(
+        ct_cmovw(ct_sltuw(launderw(idx), word_len), bp, decoy2));
+
+    uint32_t a = read_32(av);
+    uint32_t b = read_32(bv);
+
+    // Launder one of the operands, so that the compiler cannot cache the result
+    // of the xor for use in the next operation.
+    //
+    // We launder `zeroes` so that compiler cannot learn that `zeroes` has
+    // strictly more bits set at the end of the loop.
+    zeros = launder32(zeros) | (launder32(a) ^ b);
+
+    // Same as above. The compiler can cache the value of `a[offset]`, but it
+    // has no chance to strength-reduce this operation.
+    ones = launder32(ones) & (launder32(a) ^ ~b);
+  }
+
+  HARDENED_CHECK_EQ(count, expected_count);
+  if (launder32(zeros) == 0) {
+    HARDENED_CHECK_EQ(ones, UINT32_MAX);
+    return kHardenedBoolTrue;
+  }
+
+  HARDENED_CHECK_NE(ones, UINT32_MAX);
+  return kHardenedBoolFalse;
+}

--- a/sw/device/lib/base/hardened_memory.h
+++ b/sw/device/lib/base/hardened_memory.h
@@ -1,0 +1,89 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_HARDENED_MEMORY_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_HARDENED_MEMORY_H_
+
+/**
+ * @file
+ * @brief Hardened memory operations for constant power buffer manipulation.
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/base/macros.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Copies 32-bit words between non-overlapping regions.
+ *
+ * Unlike `memcpy()`, this function has important differences:
+ * - It is significantly slower, since it mitigates power-analysis attacks.
+ * - It performs operations on 32-bit words, rather than bytes.
+ * - It returns void.
+ *
+ * Input pointers *MUST* be 32-bit aligned, although they do not need to
+ * actually point to memory declared as `uint32_t` per the C aliasing rules.
+ * Internally, this function is careful to not dereference its operands
+ * directly, and instead uses dedicated load/store intrinsics.
+ *
+ * @param dest The destination of the copy.
+ * @param src The source of the copy.
+ * @param word_len The number of words to copy.
+ */
+void hardened_memcpy(uint32_t *OT_RESTRICT dest,
+                     const uint32_t *OT_RESTRICT src, size_t word_len);
+
+/**
+ * Fills a 32-bit aligned region of memory with random data.
+ *
+ * Unlike `memset()`, this function has important differences:
+ * - It is significantly slower, since it mitigates power-analysis attacks.
+ * - It performs operations on 32-bit words, rather than bytes.
+ * - A fill value cannot be specified.
+ * - It returns void.
+ *
+ * Input pointers *MUST* be 32-bit aligned, although they do not need to
+ * actually point to memory declared as `uint32_t` per the C aliasing rules.
+ * Internally, this function is careful to not dereference its operands
+ * directly, and instead uses dedicated load/store intrinsics.
+ *
+ * @param dest The destination of the set.
+ * @param word_len The number of words to write.
+ */
+void hardened_memshred(uint32_t *dest, size_t word_len);
+
+/**
+ * Compare two potentially-overlapping 32-bit aligned regions of memory for
+ * equality.
+ *
+ * Unlike `memcmp()`, this function has important differences:
+ * - It is significantly slower, since it mitigates power-analysis attacks.
+ * - It performs operations on 32-bit words, rather than bytes.
+ * - It only computes equality, not lexicographic ordering, which would be even
+ *   slower.
+ * - It returns a `hardened_bool_t`.
+ *
+ * Input pointers *MUST* be 32-bit aligned, although they do not need to
+ * actually point to memory declared as `uint32_t` per the C aliasing rules.
+ * Internally, this function is careful to not dereference its operands
+ * directly, and instead uses dedicated load/store intrinsics.
+ *
+ * @param lhs The first buffer to compare.
+ * @param rhs The second buffer to compare.
+ * @param word_len The number of words to write.
+ */
+hardened_bool_t hardened_memeq(const uint32_t *lhs, const uint32_t *rhs,
+                               size_t word_len);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_HARDENED_MEMORY_H_

--- a/sw/device/lib/base/hardened_memory_unittest.cc
+++ b/sw/device/lib/base/hardened_memory_unittest.cc
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/hardened_memory.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+// NOTE: This test does not verify hardening measures; it only checks that the
+// "normal" contract of the functions is upheld.
+
+namespace hardened_memory_unittest {
+namespace {
+
+using ::testing::Each;
+using ::testing::ElementsAre;
+
+TEST(HardenedMemory, Memcpy) {
+  std::vector<uint32_t> xs = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<uint32_t> ys(8);
+
+  hardened_memcpy(ys.data(), xs.data(), 0);
+  EXPECT_THAT(ys, Each(0));
+
+  hardened_memcpy(ys.data() + 1, xs.data(), 7);
+  EXPECT_THAT(ys, ElementsAre(0, 1, 2, 3, 4, 5, 6, 7));
+}
+
+constexpr uint32_t kRandomWord = 0xdeadbeef;
+
+// Override whatever the default randomness source is so we can verify it
+// actually gets used.
+extern "C" size_t hardened_memshred_random_word() { return kRandomWord; }
+
+TEST(HardenedMemory, MemShred) {
+  std::vector<uint32_t> xs = {1, 2, 3, 4, 5, 6, 7, 8};
+  hardened_memshred(xs.data(), xs.size());
+
+  EXPECT_THAT(xs, Each(kRandomWord));
+}
+
+TEST(HardenedMemory, MemEq) {
+  std::vector<uint32_t> xs = {1, 2, 3, 4, 5, 6, 7, 8};
+  std::vector<uint32_t> ys = xs;
+
+  EXPECT_EQ(hardened_memeq(ys.data(), xs.data(), xs.size()), kHardenedBoolTrue);
+
+  ++ys[5];
+  EXPECT_EQ(hardened_memeq(ys.data(), xs.data(), xs.size()),
+            kHardenedBoolFalse);
+}
+
+}  // namespace
+}  // namespace hardened_memory_unittest

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -43,6 +43,14 @@
 #define OT_ALWAYS_INLINE __attribute__((always_inline)) inline
 
 /**
+ * The `restrict` keyword is C specific, so we provide a C++-portable wrapper
+ * that uses the GCC name.
+ *
+ * It only needs to be used in headers; .c files can use `restrict` directly.
+ */
+#define OT_RESTRICT __restrict__
+
+/**
  * A variable-argument macro that expands to the number of arguments passed into
  * it, between 0 and 31 arguments.
  *

--- a/sw/device/lib/base/memory.h
+++ b/sw/device/lib/base/memory.h
@@ -17,6 +17,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/lib/base/macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -157,7 +159,7 @@ inline void write_64(uint64_t value, void *ptr) {
  * @param len the number of bytes to copy.
  * @return the value of `dest`.
  */
-void *memcpy(void *restrict dest, const void *restrict src, size_t len);
+void *memcpy(void *OT_RESTRICT dest, const void *OT_RESTRICT src, size_t len);
 
 /**
  * Set a region of memory to a particular byte value.

--- a/sw/device/lib/base/meson.build
+++ b/sw/device/lib/base/meson.build
@@ -85,3 +85,11 @@ test('base_hardened_unittest', executable(
   ),
   suite: 'base',
 )
+
+sw_lib_random_order = declare_dependency(
+  link_with: static_library(
+    'random_order_ot',
+    sources: ['random_order.c'],
+    dependencies: [sw_lib_bitfield],
+  )
+)

--- a/sw/device/lib/base/meson.build
+++ b/sw/device/lib/base/meson.build
@@ -93,3 +93,15 @@ sw_lib_random_order = declare_dependency(
     dependencies: [sw_lib_bitfield],
   )
 )
+
+sw_lib_hardened_memory = declare_dependency(
+  link_with: static_library(
+    'hardened_memory_ot',
+    sources: ['hardened_memory.c'],
+    dependencies: [
+      sw_lib_hardened,
+      sw_lib_random_order,
+      sw_lib_mem,
+    ],
+  )
+)

--- a/sw/device/lib/base/random_order.c
+++ b/sw/device/lib/base/random_order.c
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/random_order.h"
+
+#include "sw/device/lib/base/bitfield.h"
+
+// TODO: The current implementation is just a skeleton, and currently just
+// traverses from 0 to `min_len * 2`.
+
+void random_order_init(random_order_t *ctx, size_t min_len) {
+  ctx->state = 0;
+  ctx->max = min_len * 2;
+}
+
+size_t random_order_len(const random_order_t *ctx) { return ctx->max; }
+
+size_t random_order_advance(random_order_t *ctx) { return ctx->state++; }

--- a/sw/device/lib/base/random_order.h
+++ b/sw/device/lib/base/random_order.h
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_BASE_RANDOM_ORDER_H_
+#define OPENTITAN_SW_DEVICE_LIB_BASE_RANDOM_ORDER_H_
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * @file
+ * @brief Functions for generating random traversal orders.
+ */
+
+/**
+ * Context for a random traversal order.
+ *
+ * A "random traversal order" specifies a random order to walk through some
+ * buffer of length `n`, which is an important building block for
+ * constant-power code. Given `n`, the random order emits integers in the
+ * range `0..m`, where `m` is an implementation-defined, per-random-order
+ * value greater than `n`. The order is guaranteed to visit each integer in
+ * `0..n` at least once, but with some caveats:
+ * - Values greater than `n` may be returned.
+ * - The same value may be returned multiple times.
+ *
+ * Users must be mindful of these constraints when using `random_order_t`.
+ * These caveats are intended to allow for implementation flexibility, such as
+ * intentionally adding decoys to the sequence.
+ */
+typedef struct random_order {
+  size_t state;
+  size_t max;
+} random_order_t;
+
+/**
+ * Constructs a new, randomly-seeded traversal order,
+ * running from `0` to at least `min_len`.
+ *
+ * This function does not take a seed as input; instead, the seed is
+ * extracted, in some manner or another, from the hardware by this function.
+ *
+ * @param ctx The context to initialize.
+ * @param min_len The minimum length this traversal order must visit.
+ */
+void random_order_init(random_order_t *ctx, size_t min_len);
+
+/**
+ * Returns the length of the sequence represented by `ctx`.
+ *
+ * This value may be greater than `min_len` specified in
+ * `random_order_init()`, but the sequence is guaranteed to contain every
+ * integer in `0..min_len`.
+ *
+ * This value represents the number of times `random_order_advance()` may be
+ * called.
+ *
+ * @param ctx The context to query.
+ * @return The length of the sequence.
+ */
+size_t random_order_len(const random_order_t *ctx);
+
+/**
+ * Returns the next element in the sequence represented by `ctx`.
+ *
+ * See `random_order_len()` for discovering how many times this function can
+ * be called.
+ *
+ * @param ctx The context to advance.
+ * @return The next value in the sequence.
+ */
+size_t random_order_advance(random_order_t *ctx);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_BASE_RANDOM_ORDER_H_


### PR DESCRIPTION
These functions are carefully crafted to traverse buffers in random
order to thwart traditional power-analysis attacks, making the aggregate
behavior of calls to this function appear as if their power usage has
minimal dependency on the input.

The implementation of these functions makes use of all of the hardening primitives I've built up in the base libraries; it is the culmination of much of that work.