### PR TITLE
[kmac] Unsupported Mode Strength

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -426,6 +426,20 @@
                 '''
           tags: ["shadowed_reg_path:u_cfg_reg_shadowed.u_cfg_reg_shadowed_err_processed"]
         } // f: err_processed
+        { bits: "26"
+          name: en_unsupported_modestrength
+          desc: '''Enable Unsupported Mode and Strength configs.
+
+            SW may set this field for KMAC to move forward with unsupported
+            Keccak Mode and Strength configurations, such as cSHAKE512.
+
+            If not set, KMAC won't propagate the SW command (CmdStart) to the
+            rest of the blocks (AppIntf, KMAC Core, SHA3).
+            '''
+          tags: [// Randomly write mem will cause this reg updated by design
+                 "excl:CsrAllTests:CsrExclWrite",
+                 "shadowed_reg_path:u_cfg_reg_shadowed.u_cfg_reg_shadowed_en_unsupported_modestrength"]
+        } // f: en_unsupported_modestrength
       ]
       tags: ["shadowed_reg_path:u_cfg_reg_shadowed"]
     } // R: CFG

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -259,7 +259,7 @@ module kmac
   sha3_pkg::keccak_strength_e reg_keccak_strength, app_keccak_strength;
 
   // RegIF of enabling unsupported mode & strength
-  logic cfg_en_unsupported_mode_strength;
+  logic cfg_en_unsupported_modestrength;
 
   // Indicating AppIntf is active. This signal is used to check SW error
   logic app_active;
@@ -525,7 +525,8 @@ module kmac
   assign msg_mask_en = cfg_msg_mask & msg_valid & msg_ready;
 
   // Enable unsupported mode & strength combination
-  assign cfg_en_unsupported_mode_strength = 1'b 1;
+  assign cfg_en_unsupported_modestrength =
+    reg2hw.cfg_shadowed.en_unsupported_modestrength.q;
 
   `ASSERT(EntropyReadyLatched_A, $rose(entropy_ready) |=> !entropy_ready)
 
@@ -1092,7 +1093,7 @@ module kmac
     .kmac_en_i      (reg_kmac_en        ),
     .cfg_prefix_6B_i(reg_ns_prefix[47:0]), // first 6B of PREFIX
 
-    .cfg_en_unsupported_modestrength_i (cfg_en_unsupported_mode_strength),
+    .cfg_en_unsupported_modestrength_i (cfg_en_unsupported_modestrength),
 
     // SW commands
     .sw_cmd_i(sw_cmd),
@@ -1259,44 +1260,47 @@ module kmac
 
   // SEC_CM: CFG_SHADOWED.CONFIG.SHADOW
   assign shadowed_storage_err = |{
-      reg2hw.cfg_shadowed.kmac_en.err_storage             ,
-      reg2hw.cfg_shadowed.kstrength.err_storage           ,
-      reg2hw.cfg_shadowed.mode.err_storage                ,
-      reg2hw.cfg_shadowed.msg_endianness.err_storage      ,
-      reg2hw.cfg_shadowed.state_endianness.err_storage    ,
-      reg2hw.cfg_shadowed.sideload.err_storage            ,
-      reg2hw.cfg_shadowed.entropy_mode.err_storage        ,
-      reg2hw.cfg_shadowed.entropy_fast_process.err_storage,
-      reg2hw.cfg_shadowed.msg_mask.err_storage            ,
-      reg2hw.cfg_shadowed.entropy_ready.err_storage       ,
-      reg2hw.cfg_shadowed.err_processed.err_storage
+      reg2hw.cfg_shadowed.kmac_en.err_storage                     ,
+      reg2hw.cfg_shadowed.kstrength.err_storage                   ,
+      reg2hw.cfg_shadowed.mode.err_storage                        ,
+      reg2hw.cfg_shadowed.msg_endianness.err_storage              ,
+      reg2hw.cfg_shadowed.state_endianness.err_storage            ,
+      reg2hw.cfg_shadowed.sideload.err_storage                    ,
+      reg2hw.cfg_shadowed.entropy_mode.err_storage                ,
+      reg2hw.cfg_shadowed.entropy_fast_process.err_storage        ,
+      reg2hw.cfg_shadowed.msg_mask.err_storage                    ,
+      reg2hw.cfg_shadowed.entropy_ready.err_storage               ,
+      reg2hw.cfg_shadowed.err_processed.err_storage               ,
+      reg2hw.cfg_shadowed.en_unsupported_modestrength.err_storage
     };
 
   assign shadowed_update_err  = |{
-      reg2hw.cfg_shadowed.kmac_en.err_update              ,
-      reg2hw.cfg_shadowed.kstrength.err_update            ,
-      reg2hw.cfg_shadowed.mode.err_update                 ,
-      reg2hw.cfg_shadowed.msg_endianness.err_update       ,
-      reg2hw.cfg_shadowed.state_endianness.err_update     ,
-      reg2hw.cfg_shadowed.sideload.err_update             ,
-      reg2hw.cfg_shadowed.entropy_mode.err_update         ,
-      reg2hw.cfg_shadowed.entropy_fast_process.err_update ,
-      reg2hw.cfg_shadowed.msg_mask.err_update             ,
-      reg2hw.cfg_shadowed.entropy_ready.err_update        ,
-      reg2hw.cfg_shadowed.err_processed.err_update
+      reg2hw.cfg_shadowed.kmac_en.err_update                     ,
+      reg2hw.cfg_shadowed.kstrength.err_update                   ,
+      reg2hw.cfg_shadowed.mode.err_update                        ,
+      reg2hw.cfg_shadowed.msg_endianness.err_update              ,
+      reg2hw.cfg_shadowed.state_endianness.err_update            ,
+      reg2hw.cfg_shadowed.sideload.err_update                    ,
+      reg2hw.cfg_shadowed.entropy_mode.err_update                ,
+      reg2hw.cfg_shadowed.entropy_fast_process.err_update        ,
+      reg2hw.cfg_shadowed.msg_mask.err_update                    ,
+      reg2hw.cfg_shadowed.entropy_ready.err_update               ,
+      reg2hw.cfg_shadowed.err_processed.err_update               ,
+      reg2hw.cfg_shadowed.en_unsupported_modestrength.err_update
     };
 
   logic unused_cfg_shadowed_qe;
   assign unused_cfg_shadowed_qe = ^{
-    reg2hw.cfg_shadowed.kmac_en.qe              ,
-    reg2hw.cfg_shadowed.kstrength.qe            ,
-    reg2hw.cfg_shadowed.mode.qe                 ,
-    reg2hw.cfg_shadowed.msg_endianness.qe       ,
-    reg2hw.cfg_shadowed.state_endianness.qe     ,
-    reg2hw.cfg_shadowed.sideload.qe             ,
-    reg2hw.cfg_shadowed.entropy_mode.qe         ,
-    reg2hw.cfg_shadowed.entropy_fast_process.qe ,
-    reg2hw.cfg_shadowed.msg_mask.qe
+    reg2hw.cfg_shadowed.kmac_en.qe                     ,
+    reg2hw.cfg_shadowed.kstrength.qe                   ,
+    reg2hw.cfg_shadowed.mode.qe                        ,
+    reg2hw.cfg_shadowed.msg_endianness.qe              ,
+    reg2hw.cfg_shadowed.state_endianness.qe            ,
+    reg2hw.cfg_shadowed.sideload.qe                    ,
+    reg2hw.cfg_shadowed.entropy_mode.qe                ,
+    reg2hw.cfg_shadowed.entropy_fast_process.qe        ,
+    reg2hw.cfg_shadowed.msg_mask.qe                    ,
+    reg2hw.cfg_shadowed.en_unsupported_modestrength.qe
     };
 
   // Alerts

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -258,6 +258,9 @@ module kmac
   sha3_pkg::sha3_mode_e       reg_sha3_mode,       app_sha3_mode;
   sha3_pkg::keccak_strength_e reg_keccak_strength, app_keccak_strength;
 
+  // RegIF of enabling unsupported mode & strength
+  logic cfg_en_unsupported_mode_strength;
+
   // Indicating AppIntf is active. This signal is used to check SW error
   logic app_active;
 
@@ -520,6 +523,9 @@ module kmac
   // msg_mask_en turns on the message LFSR when KMAC is enabled.
   assign cfg_msg_mask = reg2hw.cfg_shadowed.msg_mask.q;
   assign msg_mask_en = cfg_msg_mask & msg_valid & msg_ready;
+
+  // Enable unsupported mode & strength combination
+  assign cfg_en_unsupported_mode_strength = 1'b 1;
 
   `ASSERT(EntropyReadyLatched_A, $rose(entropy_ready) |=> !entropy_ready)
 
@@ -1085,6 +1091,8 @@ module kmac
 
     .kmac_en_i      (reg_kmac_en        ),
     .cfg_prefix_6B_i(reg_ns_prefix[47:0]), // first 6B of PREFIX
+
+    .cfg_en_unsupported_modestrength_i (cfg_en_unsupported_mode_strength),
 
     // SW commands
     .sw_cmd_i(sw_cmd),

--- a/hw/ip/kmac/rtl/kmac_reg_pkg.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_pkg.sv
@@ -136,6 +136,12 @@ package kmac_reg_pkg;
       logic        err_update;
       logic        err_storage;
     } err_processed;
+    struct packed {
+      logic        q;
+      logic        qe;
+      logic        err_update;
+      logic        err_storage;
+    } en_unsupported_modestrength;
   } kmac_reg2hw_cfg_shadowed_reg_t;
 
   typedef struct packed {
@@ -256,11 +262,11 @@ package kmac_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    kmac_reg2hw_intr_state_reg_t intr_state; // [1563:1561]
-    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1560:1558]
-    kmac_reg2hw_intr_test_reg_t intr_test; // [1557:1552]
-    kmac_reg2hw_alert_test_reg_t alert_test; // [1551:1548]
-    kmac_reg2hw_cfg_shadowed_reg_t cfg_shadowed; // [1547:1522]
+    kmac_reg2hw_intr_state_reg_t intr_state; // [1565:1563]
+    kmac_reg2hw_intr_enable_reg_t intr_enable; // [1562:1560]
+    kmac_reg2hw_intr_test_reg_t intr_test; // [1559:1554]
+    kmac_reg2hw_alert_test_reg_t alert_test; // [1553:1550]
+    kmac_reg2hw_cfg_shadowed_reg_t cfg_shadowed; // [1549:1522]
     kmac_reg2hw_cmd_reg_t cmd; // [1521:1513]
     kmac_reg2hw_entropy_period_reg_t entropy_period; // [1512:1487]
     kmac_reg2hw_entropy_refresh_reg_t entropy_refresh; // [1486:1477]

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -215,6 +215,8 @@ module kmac_reg_top (
   logic cfg_shadowed_entropy_ready_wd;
   logic cfg_shadowed_err_processed_qs;
   logic cfg_shadowed_err_processed_wd;
+  logic cfg_shadowed_en_unsupported_modestrength_qs;
+  logic cfg_shadowed_en_unsupported_modestrength_wd;
   logic cmd_we;
   logic [3:0] cmd_cmd_wd;
   logic cmd_entropy_req_wd;
@@ -961,6 +963,40 @@ module kmac_reg_top (
     // Shadow register error conditions
     .err_update  (reg2hw.cfg_shadowed.err_processed.err_update),
     .err_storage (reg2hw.cfg_shadowed.err_processed.err_storage)
+  );
+
+  //   F[en_unsupported_modestrength]: 26:26
+  prim_subreg_shadow #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cfg_shadowed_en_unsupported_modestrength (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+    .rst_shadowed_ni (rst_shadowed_ni),
+
+    // from register interface
+    .re     (cfg_shadowed_re),
+    .we     (cfg_shadowed_we & cfg_regwen_qs),
+    .wd     (cfg_shadowed_en_unsupported_modestrength_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (reg2hw.cfg_shadowed.en_unsupported_modestrength.qe),
+    .q      (reg2hw.cfg_shadowed.en_unsupported_modestrength.q),
+
+    // to register interface (read)
+    .qs     (cfg_shadowed_en_unsupported_modestrength_qs),
+
+    // Shadow register phase. Relevant for hwext only.
+    .phase  (),
+
+    // Shadow register error conditions
+    .err_update  (reg2hw.cfg_shadowed.en_unsupported_modestrength.err_update),
+    .err_storage (reg2hw.cfg_shadowed.en_unsupported_modestrength.err_storage)
   );
 
 
@@ -2316,6 +2352,8 @@ module kmac_reg_top (
   assign cfg_shadowed_entropy_ready_wd = reg_wdata[24];
 
   assign cfg_shadowed_err_processed_wd = reg_wdata[25];
+
+  assign cfg_shadowed_en_unsupported_modestrength_wd = reg_wdata[26];
   assign cmd_we = addr_hit[6] & reg_we & !reg_error;
 
   assign cmd_cmd_wd = reg_wdata[3:0];
@@ -2514,6 +2552,7 @@ module kmac_reg_top (
         reg_rdata_next[20] = cfg_shadowed_msg_mask_qs;
         reg_rdata_next[24] = cfg_shadowed_entropy_ready_qs;
         reg_rdata_next[25] = cfg_shadowed_err_processed_qs;
+        reg_rdata_next[26] = cfg_shadowed_en_unsupported_modestrength_qs;
       end
 
       addr_hit[6]: begin


### PR DESCRIPTION
This commit adds a control knob to enable/ disable further process on
ModeStrength error. In previous design, KMAC always proceeded with the
error to support the KMAC512, cSHAKE512.

Now, the error check module won't hand over the SW issued command if
`en_unsupported_mode_strength` is cleared and unsupported mode and
strength combination has been configured.

Addresses one A.I. in #10823 