### PR TITLE
[dv/aes] Update AES script to support masking and unmasking variant

### DIFF
--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -42,6 +42,18 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
+  // Need to override the default output directory
+  overrides: [
+    {
+      name: scratch_path
+      value: "{scratch_base_path}/{variant}-{flow}-{tool}"
+    }
+    {
+      name: rel_path
+      value: "hw/ip/{variant}/dv"
+    }
+  ]
+
   build_modes: [
     {
       name: aes_no_masking


### PR DESCRIPTION
This PR updates the aes_base_cfg.hjson to support adding a variant:
1). Override the rel_path and scratch_path so masking and unmasking
  version can be in two differet folders.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>