### PR TITLE
[dif/pwm] Add autogen, header, and checklist

### DIFF
--- a/sw/device/lib/dif/autogen/dif_pwm_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_pwm_autogen.c
@@ -1,0 +1,43 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
+// util/make_new_dif.py --mode=regen --only=autogen
+
+#include "sw/device/lib/dif/autogen/dif_pwm_autogen.h"
+#include <stdint.h>
+
+#include "pwm_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_init(mmio_region_t base_addr, dif_pwm_t *pwm) {
+  if (pwm == NULL) {
+    return kDifBadArg;
+  }
+
+  pwm->base_addr = base_addr;
+
+  return kDifOk;
+}
+
+dif_result_t dif_pwm_alert_force(const dif_pwm_t *pwm, dif_pwm_alert_t alert) {
+  if (pwm == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifPwmAlertFatalFault:
+      alert_idx = PWM_ALERT_TEST_FATAL_FAULT_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(pwm->base_addr, PWM_ALERT_TEST_REG_OFFSET,
+                      alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_pwm_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_pwm_autogen.h
@@ -1,0 +1,77 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_PWM_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_PWM_AUTOGEN_H_
+
+// THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
+// util/make_new_dif.py --mode=regen --only=autogen
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/pwm/doc/">PWM</a> Device Interface Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to pwm.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_pwm {
+  /**
+   * The base address for the pwm hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_pwm_t;
+
+/**
+ * Creates a new handle for a(n) pwm peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the pwm peripheral.
+ * @param[out] pwm Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_init(mmio_region_t base_addr, dif_pwm_t *pwm);
+
+/**
+ * A pwm alert type.
+ */
+typedef enum dif_pwm_alert {
+  /**
+   * This fatal alert is triggered when a fatal TL-UL bus integrity fault is
+   * detected.
+   */
+  kDifPwmAlertFatalFault = 0,
+} dif_pwm_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param pwm A pwm handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_alert_force(const dif_pwm_t *pwm, dif_pwm_alert_t alert);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_PWM_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_pwm_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwm_autogen_unittest.cc
@@ -1,0 +1,57 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
+// util/make_new_dif.py --mode=regen --only=autogen
+
+#include "sw/device/lib/dif/autogen/dif_pwm_autogen.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+
+#include "pwm_regs.h"  // Generated.
+
+namespace dif_pwm_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Eq;
+using ::testing::Test;
+
+class PwmTest : public Test, public MmioTest {
+ protected:
+  dif_pwm_t pwm_ = {.base_addr = dev().region()};
+};
+
+class InitTest : public PwmTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_EQ(dif_pwm_init(dev().region(), nullptr), kDifBadArg);
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_EQ(dif_pwm_init(dev().region(), &pwm_), kDifOk);
+}
+
+class AlertForceTest : public PwmTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_EQ(dif_pwm_alert_force(nullptr, kDifPwmAlertFatalFault), kDifBadArg);
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_EQ(dif_pwm_alert_force(nullptr, static_cast<dif_pwm_alert_t>(32)),
+            kDifBadArg);
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(PWM_ALERT_TEST_REG_OFFSET,
+                 {{PWM_ALERT_TEST_FATAL_FAULT_BIT, true}});
+  EXPECT_EQ(dif_pwm_alert_force(&pwm_, kDifPwmAlertFatalFault), kDifOk);
+}
+
+}  // namespace
+}  // namespace dif_pwm_autogen_unittest

--- a/sw/device/lib/dif/dif_pwm.h
+++ b/sw/device/lib/dif/dif_pwm.h
@@ -1,0 +1,327 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PWM_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PWM_H_
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/pwm/doc/">PWM</a> Device Interface Functions
+ *
+ * The PWM block contains a 16-bit "phase counter" that controls each channel's
+ * output signal. The "phase counter" acts as a point of reference for a single
+ * PWM "pulse cycle", that is further broken into "beats", depending on the
+ * `beats_per_cycle` parameter. Specifically, a "pulse cycle" may contain [2,
+ * 2^16] "beats". Within a "pulse cycle", users can configure the duty cycle in
+ * number of "beats". Additionally, the duration of a single "beat", is computed
+ * by dividing the core clock frequency by `clock_divisor + 1`.
+ *
+ *       PWM "pulse cycle" defined by 16-bit phase counter
+ *  ___________________________________________________________
+ *  |                                                         |
+ *  v                                                         v
+ * |-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-| ... |-|-|-|-|
+ *
+ * |-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-|-| ... |-|-|-|-|
+ * min beat size = 1 phase counter ticks --> 2^16 "beats" / "pulse cycle"
+ *
+ * |---------------------------------------------- ... | ... --|
+ *    max beat size = 2^15 phase counter ticks --> 2 "beats" / "pulse cycle"
+ */
+
+#include <stdint.h>
+
+#include "sw/device/lib/dif/autogen/dif_pwm_autogen.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Helper X macro for defining enums and case statements related to PWM
+ * channels. If an additional channel is ever added to the hardware, this list
+ * can be updated.
+ */
+#define LIST_OF_CHANNELS(X) \
+  X(0)                      \
+  X(1)                      \
+  X(2)                      \
+  X(3)                      \
+  X(4)                      \
+  X(5)
+
+/**
+ * Helper macro for defining a `dif_pwm_channel_t` enumeration constant.
+ * @channel_ PWM channel of the enumeration constant.
+ */
+#define PWM_CHANNEL_ENUM_INIT_(channel_) \
+  kDifPwmChannel##channel_ = 1U << channel_,
+
+/**
+ * A PWM channel.
+ */
+typedef enum dif_pwm_channel {
+  LIST_OF_CHANNELS(PWM_CHANNEL_ENUM_INIT_)
+} dif_pwm_channel_t;
+
+#undef PWM_CHANNEL_ENUM_INIT_
+
+/**
+ * Runtime configuration for PWM.
+ *
+ * This struct describes runtime configuration for one-time configuration of the
+ * PWM "pulse cycle" and "beat" durations that impact all PWM channels.
+ */
+typedef struct dif_pwm_config {
+  /**
+   * The core clock frequency divisor that determines the period of a single
+   * "beat" within a PWM "pulse cycle".
+   *
+   * Valid range: [0, 2^26)
+   *
+   * A value of zero, configures the "beat" period to the core clock period.
+   */
+  uint32_t clock_divisor;
+  /**
+   * The total number of "beats" in a "pulse cycle", including both "on" and
+   * "off" beats in a "pulse cycle".
+   *
+   * Valid range: [2, 2^16]
+   *
+   * Note: while any value in the range is acceptable, values will be rounded
+   * down to closest power-of-two.
+   *
+   * A "beat" represents a unit of time of the PWM output signal. Higher values
+   * provide higher duty cycle resolutions, at the expense of longer "pulse
+   * cycles", while lower values provide shorter "pulse cycles", at the expense
+   * of lower duty cycle resolutions (since duty cycles are configured in
+   * "beats" / "pulse cycle").
+   */
+  uint32_t beats_per_pulse_cycle;
+} dif_pwm_config_t;
+
+/**
+ * A PWM channel mode.
+ */
+typedef enum dif_pwm_mode {
+  /**
+   * The PWM duty cycle is set by the firmware and remains constant.
+   */
+  kDifPwmModeFirmware = 0,
+  /**
+   * The PWM duty cycle linearly sweeps between both primary and secondary
+   * firmware-configured values, based on a firmware-configured step size.
+   */
+  kDifPwmModeHeartbeat = 1,
+  /**
+   * The PWM duty cycle alternates between both primary and secondary
+   * firmware-configured values, based on two firmware-configured durations.
+   */
+  kDifPwmModeBlink = 2,
+} dif_pwm_mode_t;
+
+/**
+ * A PWM channel polarity.
+ */
+typedef enum dif_pwm_polarity {
+  /**
+   * A PWM signal is active-high.
+   */
+  kDifPwmActiveHigh = 0,
+  /**
+   * A PWM signal is active-low.
+   */
+  kDifPwmActiveLow = 1,
+} dif_pwm_polarity_t;
+
+/**
+ * Runtime configuration for a specific PWM channel.
+ *
+ * This struct describes runtime configuration for one-time configuration of a
+ * specific PWM channel.
+ */
+typedef struct dif_pwm_channel_config {
+  /**
+   * Phase delay at the beginning of a "pulse cycle" to delay the active
+   * duty cycle "beats" for.
+   */
+  uint16_t phase_delay;
+  /**
+   * Primary duty cycle, in number of "beats" / "pulse cycle".
+   *
+   * Valid range: [0, beats_per_cycle)
+   *
+   * Note: the raw value written to the `A_*` bitfield in each PWM channel's
+   *       `DUTY_CYCLE_*` CSR is in units of "phase counter ticks", not "beats".
+   *       However, the hardware only takes into account the first `DC_RESN` + 1
+   *       MSBs of the raw duty cycle value to determine the number of "beats"
+   *       for a given duty cycle. To make this configuration easier, the
+   *       software manages the conversion from "beats_per_cycle" to
+   *       "phase_counter_ticks". under the hood.
+   */
+  uint16_t duty_cycle_a;
+  /**
+   * Secondary duty cycle, in number of "beats" / "pulse cycle", that is only
+   * relevant in heartbeat and blink modes.
+   *
+   * Valid range: [0, beats_per_cycle)
+   *
+   * Note: above note for `duty_cycle_a` applies here too.
+   */
+  uint16_t duty_cycle_b;
+  /**
+   * The operation mode to configure the channel in, see `dif_pwm_mode_t`.
+   */
+  dif_pwm_mode_t mode;
+  /**
+   * The polarity to configure the channel in, see `dif_pwm_polarity_t`.
+   */
+  dif_pwm_polarity_t polarity;
+  /**
+   * One of two blink parameters that only impact the "Heartbeat" and "Blink"
+   * operation modes.
+   *
+   * The meaning of this parameter is different based on the operation mode:
+   *     - Heartbeat mode: determines the number of "pulse cycles" between
+   *                       increments/decrements to the duty cycle.
+   *
+   *     - Blink mode: determines the number of "pulse cycles" to pulse at duty
+   *                   cycle A, before switching to duty cycle B.
+   */
+  uint16_t blink_parameter_x;
+  /**
+   * One of two blink parameters that only impact the "Heartbeat" and "Blink"
+   * operation modes.
+   *
+   * The meaning of this parameter is different based on the operation mode:
+   *     - Heartbeat mode: determines the increment/decrement amount in number
+   *                       of duty cycle "beats".
+   *
+   *     - Blink mode: determines the number of "pulse cycles" to pulse at duty
+   *                   cycle B, before switching to duty cycle A.
+   *
+   * Note: the raw value written to the `blink_parameter_x` bitfield in each PWM
+   * channel's `BLINK_PARAM_*` CSR is in units of "phase counter ticks", not
+   * "beats". However, for ease of configuration, the software manages this
+   * conversion under the hood.
+   */
+  uint16_t blink_parameter_y;
+} dif_pwm_channel_config_t;
+
+/**
+ * Configures "phase cycle" and "beat" durations of all PWM channels.
+ *
+ * Since changes to `CLK_DIV` and `DC_RESN` are only allowed when the PWM is
+ * disabled, this function has the side effect of temporarily disabling all PWM
+ * channels while configurations are updated, before restoring the original
+ * enablement state.
+ *
+ * This function should only need to be called once for the lifetime of
+ * `handle`.
+ *
+ * @param pwm A PWM handle.
+ * @param config Runtime configuration parameters.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_configure(const dif_pwm_t *pwm, dif_pwm_config_t config);
+
+/**
+ * Configures a single PWM channel.
+ *
+ * Since changes to `CLK_DIV` and `DC_RESN` are only allowed when the PWM is
+ * disabled, this function has the side effect of temporarily disabling the
+ * PWM while configurations are updated, before returning the block to its
+ * original enablement state.
+ *
+ * This function should only need to be called once for each PWM channel that
+ * will be used.
+ *
+ * @param pwm A PWM handle.
+ * @param channel A PWM channel to configure.
+ * @param config Runtime configuration parameters for the channel.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT dif_result_t
+dif_pwm_channel_configure(const dif_pwm_t *pwm, dif_pwm_channel_t channel,
+                          dif_pwm_channel_config_t config);
+
+/**
+ * Sets the enablement state of the PWM phase counter, which controls the
+ * enablement of all PWM channels.
+ *
+ * @param pwm A PWM handle.
+ * @param enabled The enablement state to configure the PWM phase counter in.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_phase_cntr_set_enabled(const dif_pwm_t *pwm,
+                                            dif_toggle_t enabled);
+
+/**
+ * Gets the enablement state of the PWM phase counter, which controls the
+ * enablement of all PWM channels.
+ *
+ * @param pwm A PWM handle.
+ * @param[out] is_enabled The enablement state of the PWM phase counter.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_phase_cntr_get_enabled(const dif_pwm_t *pwm,
+                                            dif_toggle_t *is_enabled);
+
+/**
+ * Sets the enablement states of one or more PWM channels.
+ *
+ * @param pwm A PWM handle.
+ * @param channels The channels to enable (one or more `dif_pmw_channel_t`s
+ *                 ORed together.)
+ * @param enabled The enablement state to set.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_channel_set_enabled(const dif_pwm_t *pwm,
+                                         uint32_t channels,
+                                         dif_toggle_t enabled);
+
+/**
+ * Gets the enablement state of a PWM channel.
+ *
+ * @param pwm A PWM handle.
+ * @param channel The PWM channel to get the enablement state of.
+ * @param[out] is_enabled The enablement state of the PWM channel.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_channel_get_enabled(const dif_pwm_t *pwm,
+                                         dif_pwm_channel_t channel,
+                                         dif_toggle_t *is_enabled);
+
+/**
+ * Locks PWM configurations.
+ *
+ * This function is reentrant: calling it while locked will have no effect and
+ * return `kDifOk`.
+ *
+ * @param pwm A PWM handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_lock(const dif_pwm_t *pwm);
+
+/**
+ * Checks whether PWM configurations are locked.
+ *
+ * @param pwm A PWM handle.
+ * @param[out] is_locked Out-param for the locked state.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_pwm_is_locked(const dif_pwm_t *pwm, bool *is_locked);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_PWM_H_

--- a/sw/device/lib/dif/dif_pwm.md
+++ b/sw/device/lib/dif/dif_pwm.md
@@ -1,0 +1,52 @@
+---
+title: "PWM DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [PWM DIF]({{< relref "hw/ip/pwm/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+<h2>DIF Checklist</h2>
+
+<h3>S1</h3>
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | In Progress |
+Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+
+<h3>S2</h3>
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+
+<h3>S3</h3>
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}


### PR DESCRIPTION
This adds part of the DIF library for the PWM, including:
1. all autogenerated DIFs,
2. a header with a suggested API,
3. a checklist.

Signed-off-by: Timothy Trippel <ttrippel@google.com>