### PR TITLE
[dif/alert_handler] Fix DIF doxygen comments

### DIFF
--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -36,8 +36,8 @@ extern "C" {
 
 /**
  * Helper macro for defining a `dif_alert_handler_class_t` enumeration constant.
- * @name_ Name of the enumeration constant.
- * @value Value of the enumeration constant.
+ * @class_ Alert class of the enumeration constant.
+ * @value_ Value of the enumeration constant.
  */
 #define ALERT_CLASS_ENUM_INIT_(class_, value_) \
   kDifAlertHandlerClass##class_ = value_,
@@ -433,7 +433,7 @@ dif_result_t dif_alert_handler_lock_alert(
  *
  * @param alert_handler An alert handler handle.
  * @param alert The alert to check is locked.
- * @param is_locked Out-param for the locked state.
+ * @param[out] is_locked Out-param for the locked state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -464,7 +464,7 @@ dif_result_t dif_alert_handler_lock_local_alert(
  *
  * @param alert_handler An alert handler handle.
  * @param local_alert The local alert to check is locked.
- * @param is_locked Out-param for the locked state.
+ * @param[out] is_locked Out-param for the locked state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -495,7 +495,7 @@ dif_result_t dif_alert_handler_lock_class(
  *
  * @param alert_handler An alert handler handle.
  * @param alert_class The alert class to check is locked.
- * @param is_locked Out-param for the locked state.
+ * @param[out] is_locked Out-param for the locked state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -523,7 +523,7 @@ dif_result_t dif_alert_handler_lock_ping_timer(
  * Checks whether alert handler's ping timer is locked.
  *
  * @param alert_handler An alert handler handle.
- * @param is_locked Out-param for the locked state.
+ * @param[out] is_locked Out-param for the locked state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -537,7 +537,7 @@ dif_result_t dif_alert_handler_is_ping_timer_locked(
  *
  * @param alert_handler An alert handler handle.
  * @param alert The alert to check.
- * @param is_cause Out-param for whether this alert is a cause.
+ * @param[out] is_cause Out-param for whether this alert is a cause.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -563,7 +563,7 @@ dif_result_t dif_alert_handler_alert_acknowledge(
  *
  * @param alert_handler An alert handler handle.
  * @param local_alert The local alert to check.
- * @param is_cause Out-param for whether this alert is a cause.
+ * @param[out] is_cause Out-param for whether this alert is a cause.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -593,7 +593,7 @@ dif_result_t dif_alert_handler_local_alert_acknowledge(
  *
  * @param alert_handler An alert handler handle.
  * @param alert_class The class to check.
- * @param can_clear Out-param for the clear enablement state.
+ * @param[out] can_clear Out-param for the clear enablement state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -643,7 +643,8 @@ dif_result_t dif_alert_handler_escalation_clear(
  *
  * @param alert_handler An alert handler handle.
  * @param alert_class The class to get the accumulator for.
- * @param num_alerts Out-param for the number of alerts that have accumulated.
+ * @param[out] num_alerts Out-param for the number of alerts that have
+ * accumulated.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -662,7 +663,7 @@ dif_result_t dif_alert_handler_get_accumulator(
  *
  * @param alert_handler An alert handler handle.
  * @param alert_class The class to set the counter for.
- * @param cycles Out-param for the counter.
+ * @param[out] cycles Out-param for the counter.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -677,7 +678,7 @@ dif_result_t dif_alert_handler_get_escalation_counter(
  *
  * @param alert_handler An alert handler handle.
  * @param alert_class The class to get the state of
- * @param state Out-param for the class state.
+ * @param[out] state Out-param for the class state.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT


### PR DESCRIPTION
This fixes some typos in a handful of alert_handler DIF comments that
get rendered as API documentation via doxygen.

Signed-off-by: Timothy Trippel <ttrippel@google.com>