### PR TITLE
[flash_ctrl/dv] Move callback to apply_reset from dut_init

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -64,12 +64,6 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     super.pre_start();
   endtask : pre_start
 
-  // After finishing basic dut_init do some additional required actions with callback_vseq
-  virtual task dut_init(string reset_kind = "HARD");
-    super.dut_init(reset_kind);
-    callback_vseq.dut_init_callback();
-  endtask : dut_init
-
   virtual task dut_shutdown();
     // check for pending flash_ctrl operations and wait for them to complete
     // TODO
@@ -89,7 +83,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     csr_spinwait(.ptr(ral.status.init_wip), .exp_data(1'b0));
   endtask : reset_flash
 
-  // Apply a Reset to the DUT
+  // Apply a Reset to the DUT, then do some additional required actions with callback_vseq
   virtual task apply_reset(string kind = "HARD");
     uvm_reg_data_t data;
 
@@ -106,6 +100,9 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     if (cfg.seq_cfg.en_init_keys_seeds == 1) begin
       csr_wr(.ptr(ral.init), .value(1));  // Enable Secret Seed Output during INIT
     end
+
+    // Do some additional required actions
+    callback_vseq.apply_reset_callback();
 
   endtask : apply_reset
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_callback_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_callback_vseq.sv
@@ -12,7 +12,7 @@ class flash_ctrl_callback_vseq extends cip_base_vseq #(
   `uvm_object_utils(flash_ctrl_callback_vseq)
   `uvm_object_new
 
-  virtual task dut_init_callback();
+  virtual task apply_reset_callback();
     // Do nothing but can be overridden in closed source environment.
   endtask
 


### PR DESCRIPTION
Hi,
This PR move the call of **flash_ctrl_callback** **dut_init_callback** method in **flash_ctrl_base_vseq** from **dut_init** to **apply_reset**.
The reason for this, is that this method should be called after every reset.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>