### PR TITLE
[rom_ctrl,rtl] Obey KMAC interface protocol, even after faults

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_counter.sv
@@ -47,7 +47,6 @@ module rom_ctrl_counter
   output [vbits(RomDepth)-1:0] data_addr_o,
 
   input                        data_rdy_i,
-  output                       data_vld_o,
   output                       data_last_nontop_o
 );
 
@@ -97,8 +96,8 @@ module rom_ctrl_counter
       vld_q <= 1'b0;
     end else begin
       // The first ROM request goes out immediately after reset (once we reach the top of ROM, we
-      // signal done_o, after which data_vld_o is unused). We could clear it again when we are done,
-      // but there's no need: the mux will switch away from us anyway.
+      // signal done_o, after which the request signal is unused). We could clear it again when we
+      // are done, but there's no need: the mux will switch away from us anyway.
       req_q <= 1'b1;
 
       // ROM data is valid from one cycle after the request goes out.
@@ -106,7 +105,7 @@ module rom_ctrl_counter
     end
   end
 
-  assign go = data_rdy_i & data_vld_o & ~done_d;
+  assign go = data_rdy_i & vld_q & ~done_d;
 
   assign addr_d        = addr_q + {{AW-1{1'b0}}, 1'b1};
   assign last_nontop_d = addr_q == TNTAddr;
@@ -115,7 +114,6 @@ module rom_ctrl_counter
   assign read_addr_o        = go ? addr_d : addr_q;
   assign read_req_o         = req_q;
   assign data_addr_o        = addr_q;
-  assign data_vld_o         = vld_q;
   assign data_last_nontop_o = last_nontop_q;
 
 endmodule

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -6,6 +6,8 @@
 // The ROM checker FSM module
 //
 
+`include "prim_assert.sv"
+
 module rom_ctrl_fsm
   import prim_mubi_pkg::mubi4_t;
   import prim_util_pkg::vbits;
@@ -276,6 +278,10 @@ module rom_ctrl_fsm
   assign counter_data_rdy = kmac_rom_rdy_i | (state_q != ReadingLow);
   assign kmac_rom_vld_o = kmac_rom_vld_q;
   assign kmac_rom_last_o = counter_lnt;
+
+  // The "last" flag is signalled when we're reading the last word in the first part of the ROM. As
+  // a quick consistency check, this should only happen when the "valid" flag is also high.
+  `ASSERT(LastImpliesValid_A, kmac_rom_last_o |-> kmac_rom_vld_o)
 
   // Start the checker when transitioning into the "Checking" state
   always_ff @(posedge clk_i or negedge rst_ni) begin


### PR DESCRIPTION
The previous version of the code would drop the valid signal on the
KMAC interface if it detected a fault. This kind of makes sense, but
it doesn't obey the ready/valid protocol properly and it's easy to get
it right so let's be better "chip citizens" :-)

@prajwalaputtappa: FYI, this fixes the assertion failure that you were seeing with #11110.