### PR TITLE
[dv] Add options to improve VCS runtime

### DIFF
--- a/hw/dv/tools/dvsim/common_modes.hjson
+++ b/hw/dv/tools/dvsim/common_modes.hjson
@@ -18,6 +18,11 @@
       en_build_modes: ["{tool}_waves"]
     }
     {
+      name: waves_off
+      is_sim_mode: 1
+      en_build_modes: ["{tool}_waves_off"]
+    }
+    {
       name: cov
       is_sim_mode: 1
       en_build_modes: ["{tool}_cov"]

--- a/hw/dv/tools/dvsim/dsim.hjson
+++ b/hw/dv/tools/dvsim/dsim.hjson
@@ -113,6 +113,11 @@
                    // Dump unpacked structs and arrays.
                    "-dump-agg"]
     }
+    {
+      name: dsim_waves_off
+      is_sim_mode: 1
+      build_opts: []
+    }
     // TODO: support coverage mode
     // Note: no specific build or run options are required for dsim to produce functional
     // coverage. Code coverage support is evolving.

--- a/hw/dv/tools/dvsim/riviera.hjson
+++ b/hw/dv/tools/dvsim/riviera.hjson
@@ -73,6 +73,11 @@
       name: riviera_waves
       is_sim_mode: 1
     }
+    {
+      name: riviera_waves_off
+      is_sim_mode: 1
+      build_opts: []
+    }
     // TODO support coverage for riviera
     {
       name: riviera_cov

--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -254,6 +254,12 @@
                    "-debug_access"]
     }
     {
+      name: vcs_waves_off
+      is_sim_mode: 1
+      build_opts: [// disable dumping assertion failures to improve runtime performance
+                   "-assert novpi+dbgopt"]
+    }
+    {
       name: vcs_cov
       is_sim_mode: 1
       build_opts: [// Enable the required cov metrics
@@ -274,7 +280,10 @@
                    // Ignore warnings about not applying cm_glitch to path and FSM
                    "+warn=noVCM-OPTIGN",
                    // Coverage database output location
-                   "-cm_dir {cov_db_dir}"]
+                   "-cm_dir {cov_db_dir}",
+                   // The following option is to improve runtime performance
+                   "-Xkeyopt=rtopt"
+                   ]
 
       run_opts:   [// Enable the required cov metrics
                    "-cm {cov_metrics}",
@@ -288,7 +297,9 @@
     {
       name: vcs_xprop
       is_sim_mode: 1
-      build_opts: ["-xprop={dv_root}/tools/vcs/xprop.cfg"]
+      build_opts: ["-xprop={dv_root}/tools/vcs/xprop.cfg",
+                   // Enable xmerge mode specific performance optimization
+                   "-xprop=mmsopt"]
     }
     {
       name: vcs_profile

--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -180,6 +180,11 @@
       build_opts: ["-access +c"]
     }
     {
+      name: xcelium_waves_off
+      is_sim_mode: 1
+      build_opts: []
+    }
+    {
       name: xcelium_cov
       is_sim_mode: 1
       build_opts: [// Enable the required cov metrics.

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -97,6 +97,8 @@ class SimCfg(FlowCfg):
             self.en_build_modes.append("gui")
         if args.waves is not None:
             self.en_build_modes.append("waves")
+        else:
+            self.en_build_modes.append("waves_off")
         if self.cov is True:
             self.en_build_modes.append("cov")
         if args.profile is not None:


### PR DESCRIPTION
1. Add `waves_off` build options to supply options when waves is
   disabled
2. Add 3 VCS options to improve runtime perf. Stats:
Test `flash_ctrl_hw_rma` runtime: 5hr -> 14min (95%+ improvement)
 related to #10857 
Test `chip_sw_uart_tx_rx` runtime: 489s -> 405s (17% improvement)

Signed-off-by: Weicai Yang <weicai@google.com>