### PR TITLE
[clkmgr] Address d2s clock idle handling

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -150,8 +150,8 @@
     { name:    "idle",
       type:    "uni",
       act:     "req",
-      package: "",
-      struct:  "logic",
+      package: "prim_mubi_pkg",
+      struct:  "mubi4",
       width:   "1"
     },
     { struct:  "lc_tx"

--- a/hw/ip/aes/dv/sva/aes_idle_check.sv
+++ b/hw/ip/aes/dv/sva/aes_idle_check.sv
@@ -10,7 +10,7 @@ module aes_idle_check
  input logic               clk_i,
  input logic               rst_ni,
  input aes_reg2hw_t        reg2hw,
- input logic               idle_i
+ input prim_mubi_pkg::mubi4_t idle_i
  );
 
 
@@ -20,5 +20,5 @@ module aes_idle_check
   assign idle = (reg2hw.status.idle.q == 1'b1);
 
   // make sure idle_i always matched the register idle state
-  `ASSERT(IdleNotIdle_A, idle == idle_i);
+  `ASSERT(IdleNotIdle_A, prim_mubi_pkg::mubi4_bool_to_mubi(idle) == idle_i);
 endmodule

--- a/hw/ip/aes/rtl/aes.sv
+++ b/hw/ip/aes/rtl/aes.sv
@@ -41,7 +41,7 @@ module aes
   input  logic                                      rst_shadowed_ni,
 
   // Idle indicator for clock manager
-  output logic                                      idle_o,
+  output prim_mubi_pkg::mubi4_t                     idle_o,
 
   // Life cycle
   input  lc_ctrl_pkg::lc_tx_t                       lc_escalate_en_i,
@@ -205,7 +205,7 @@ module aes
     .hw2reg                 ( hw2reg               )
   );
 
-  assign idle_o = reg2hw.status.idle.q;
+  assign idle_o = prim_mubi_pkg::mubi4_bool_to_mubi(reg2hw.status.idle.q);
 
   ////////////
   // Alerts //

--- a/hw/ip/clkmgr/clkmgr_components.core
+++ b/hw/ip/clkmgr/clkmgr_components.core
@@ -16,6 +16,7 @@ filesets:
       - rtl/clkmgr_byp.sv
       - rtl/clkmgr_clk_status.sv
       - rtl/clkmgr_root_ctrl.sv
+      - rtl/clkmgr_trans.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -147,11 +147,11 @@
       act:     "rsp",
     },
 
-    { struct:  "logic",
+    { struct:  "mubi4",
       type:    "uni",
       name:    "idle",
       act:     "rcv",
-      package: "",
+      package: "prim_mubi_pkg",
       width:   "${len(hint_names)}"
     },
   ],
@@ -492,9 +492,16 @@
             Register file has experienced a fatal integrity error.
           '''
         },
+        { bits: "1",
+          name: "IDLE_CNT",
+          resval: 0
+          desc: '''
+            One of the idle counts encountered a duplicate error.
+          '''
+        },
 % for src in typed_clocks.rg_srcs:
         {
-          bits: "${loop.index + 1}",
+          bits: "${loop.index + 2}",
           name: "${src.upper()}_STORAGE_ERR",
           resval: 0,
           desc: '''

--- a/hw/ip/clkmgr/doc/_index.md
+++ b/hw/ip/clkmgr/doc/_index.md
@@ -65,6 +65,9 @@ The `Idle` signal must be sourced from the transactional modules and sent to the
 For this group software can only express its intent to shut-off, and does not have full control over the final state.
 This intent is indicated with a register in the clock manager register file, see {{< regref "CLK_HINTS" >}}.
 
+Even when the hint is set, the `Idle` does not directly manipulate the clock.  When an idle indicaiton is received, the `clkmgr` counts for a period of 10 local clocks to ensure
+the idle was not an accidental or malicious glitch.
+
 Wait-for-interrupt based control is already a software hint, it can thus be applied to this group with the same `Idle` requirement.
 
 For modules in this group, each module can be individually influenced, and thus each has its own dedicated clock gating logic.

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -30,10 +30,11 @@ package clkmgr_env_pkg;
 
   // parameters
   parameter int NUM_PERI = 4;
-  parameter int NUM_TRANS = 5;
+  parameter int NUM_TRANS = 4;
 
   typedef logic [NUM_PERI-1:0] peri_enables_t;
-  typedef logic [NUM_TRANS-1:0] hintables_t;
+  typedef mubi4_t [NUM_TRANS-1:0] hintables_t;
+  parameter mubi4_t [NUM_TRANS-1:0] IdleAllBusy = {NUM_TRANS{prim_mubi_pkg::MuBi4False}};
 
   parameter int MainClkHz = 100_000_000;
   parameter int IoClkHz = 96_000_000;
@@ -68,12 +69,10 @@ package clkmgr_env_pkg;
     TransAes,
     TransHmac,
     TransKmac,
-    TransOtbnIoDiv4,
     TransOtbnMain
   } trans_e;
   typedef struct packed {
     logic otbn_main;
-    logic otbn_io_div4;
     logic kmac;
     logic hmac;
     logic aes;

--- a/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_scoreboard.sv
@@ -162,19 +162,11 @@ class clkmgr_scoreboard extends cip_base_scoreboard #(
     logic hint, clk_en, idle, src_rst_en;
     trans_e trans = trans_e'(trans_index);
     forever begin
-      if (trans == TransOtbnIoDiv4) begin
-        @cfg.clkmgr_vif.peri_div4_cb;
-        hint = cfg.clkmgr_vif.peri_div4_cb.clk_hint_otbn;
-        idle = cfg.clkmgr_vif.peri_div4_cb.otbn_idle;
-        clk_en = cfg.clkmgr_vif.peri_div4_cb.ip_clk_en;
-        src_rst_en = cfg.io_clk_rst_vif.rst_n;
-      end else begin
-        @cfg.clkmgr_vif.trans_cb;
-        hint = cfg.clkmgr_vif.trans_cb.clk_hints[trans_index];
-        idle = cfg.clkmgr_vif.trans_cb.idle_i[trans_index];
-        clk_en = cfg.clkmgr_vif.trans_cb.ip_clk_en;
-        src_rst_en = cfg.main_clk_rst_vif.rst_n;
-      end
+      @cfg.clkmgr_vif.trans_cb;
+      hint = cfg.clkmgr_vif.trans_cb.clk_hints[trans_index];
+      idle = cfg.clkmgr_vif.trans_cb.idle_i[trans_index];
+      clk_en = cfg.clkmgr_vif.trans_cb.ip_clk_en;
+      src_rst_en = cfg.main_clk_rst_vif.rst_n;
       if (src_rst_en && cfg.en_cov) begin
         logic scan_en = cfg.clkmgr_vif.scanmode_i == prim_mubi_pkg::MuBi4True;
         cov.trans_cg_wrap[trans].sample(hint, clk_en, scan_en, idle);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_base_vseq.sv
@@ -51,7 +51,7 @@ class clkmgr_base_vseq extends cip_base_vseq #(
 
   task initialize_on_start();
     `uvm_info(`gfn, "In clkmgr_if initialize_on_start", UVM_MEDIUM)
-    idle = '1;
+    idle = {NUM_TRANS{prim_mubi_pkg::MuBi4True}};
     scanmode = prim_mubi_pkg::MuBi4False;
     cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode), .lc_debug_en(Off));
     io_ip_clk_en   = 1'b1;
@@ -73,7 +73,8 @@ class clkmgr_base_vseq extends cip_base_vseq #(
   endfunction
 
   task pre_start();
-    cfg.clkmgr_vif.init(.idle('1), .scanmode(scanmode), .lc_debug_en(Off));
+    cfg.clkmgr_vif.init(.idle({NUM_TRANS{prim_mubi_pkg::MuBi4True}}),
+      .scanmode(scanmode), .lc_debug_en(Off));
     cfg.clkmgr_vif.update_io_ip_clk_en(1'b0);
     cfg.clkmgr_vif.update_main_ip_clk_en(1'b0);
     cfg.clkmgr_vif.update_usb_ip_clk_en(1'b0);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -8,10 +8,11 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
+
   constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
   constraint main_ip_clk_en_on_c {main_ip_clk_en == 1'b1;}
   constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
-  constraint all_busy {idle == '0;}
+  constraint all_busy_c {idle == IdleAllBusy;}
 
   task body();
     cfg.clk_rst_vif.wait_clks(10);
@@ -70,7 +71,6 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
         '{TransAes, ral.clk_hints.clk_main_aes_hint, ral.clk_hints_status.clk_main_aes_val},
         '{TransHmac, ral.clk_hints.clk_main_hmac_hint, ral.clk_hints_status.clk_main_hmac_val},
         '{TransKmac, ral.clk_hints.clk_main_kmac_hint, ral.clk_hints_status.clk_main_kmac_val},
-        '{TransOtbnIoDiv4, ral.clk_hints.clk_io_div4_otbn_hint, ral.clk_hints_status.clk_io_div4_otbn_val},
         '{TransOtbnMain, ral.clk_hints.clk_main_otbn_hint, ral.clk_hints_status.clk_main_otbn_val}
     };
     idle = 0;
@@ -89,10 +89,11 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
       end
       `uvm_info(`gfn, $sformatf("Setting %s idle bit", descriptor.unit.name), UVM_MEDIUM)
       cfg.clk_rst_vif.wait_clks(1);
-      idle[trans] = 1'b1;
+      idle[trans] = prim_mubi_pkg::MuBi4True;
       cfg.clkmgr_vif.update_idle(idle);
       // Some cycles for the logic to settle.
-      cfg.clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES);
+      // TODO: Temporary update to account for idle counts
+      cfg.clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES*2);
       csr_rd(.ptr(descriptor.value_bit), .value(bit_value));
       if (!cfg.under_reset) begin
         `DV_CHECK_EQ(bit_value, 1'b0, $sformatf(

--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -84,15 +84,6 @@ module clkmgr_bind;
     .gated_clk(clocks_o.clk_main_kmac)
   );
 
-  bind clkmgr clkmgr_gated_clock_sva_if clkmgr_io_div4_otbn_hintable_sva_if (
-    .clk(clocks_o.clk_io_div4_powerup),
-    .rst_n(rst_io_div4_ni),
-    .ip_clk_en(pwr_i.io_ip_clk_en),
-    .sw_clk_en(reg2hw.clk_hints.clk_io_div4_otbn_hint.q || !idle_i[3]),
-    .scanmode(scanmode_i == prim_mubi_pkg::MuBi4True),
-    .gated_clk(clocks_o.clk_io_div4_otbn)
-  );
-
   bind clkmgr clkmgr_gated_clock_sva_if clkmgr_otbn_hintable_sva_if (
     .clk(clocks_o.clk_main_powerup),
     .rst_n(rst_main_ni),
@@ -289,20 +280,12 @@ module clkmgr_bind;
     .cg_en(cg_en_o.usb_peri == prim_mubi_pkg::MuBi4True)
   );
 
-  bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_io_div4_otbn (
-    .clk(clk_io_div4_i),
-    .rst_n(rst_io_div4_ni),
-    .ip_clk_en(clk_io_div4_en),
-    .sw_clk_en(clk_io_div4_otbn_hint || !idle_i[HintIoDiv4Otbn]),
-    .scanmode(prim_mubi_pkg::MuBi4False),
-    .cg_en(cg_en_o.io_div4_otbn == prim_mubi_pkg::MuBi4True)
-  );
-
   bind clkmgr clkmgr_cg_en_sva_if clkmgr_cg_main_aes (
     .clk(clk_main_i),
     .rst_n(rst_main_ni),
     .ip_clk_en(clk_main_en),
-    .sw_clk_en(clk_main_aes_hint || !idle_i[HintMainAes]),
+    .sw_clk_en(u_clk_main_aes_trans.sw_hint_synced ||
+               !u_clk_main_aes_trans.idle_valid),
     .scanmode(prim_mubi_pkg::MuBi4False),
     .cg_en(cg_en_o.main_aes == prim_mubi_pkg::MuBi4True)
   );
@@ -311,7 +294,8 @@ module clkmgr_bind;
     .clk(clk_main_i),
     .rst_n(rst_main_ni),
     .ip_clk_en(clk_main_en),
-    .sw_clk_en(clk_main_hmac_hint || !idle_i[HintMainHmac]),
+    .sw_clk_en(u_clk_main_hmac_trans.sw_hint_synced ||
+               !u_clk_main_hmac_trans.idle_valid),
     .scanmode(prim_mubi_pkg::MuBi4False),
     .cg_en(cg_en_o.main_hmac == prim_mubi_pkg::MuBi4True)
   );
@@ -320,7 +304,8 @@ module clkmgr_bind;
     .clk(clk_main_i),
     .rst_n(rst_main_ni),
     .ip_clk_en(clk_main_en),
-    .sw_clk_en(clk_main_kmac_hint || !idle_i[HintMainKmac]),
+    .sw_clk_en(u_clk_main_kmac_trans.sw_hint_synced ||
+               !u_clk_main_kmac_trans.idle_valid),
     .scanmode(prim_mubi_pkg::MuBi4False),
     .cg_en(cg_en_o.main_kmac == prim_mubi_pkg::MuBi4True)
   );
@@ -329,7 +314,8 @@ module clkmgr_bind;
     .clk(clk_main_i),
     .rst_n(rst_main_ni),
     .ip_clk_en(clk_main_en),
-    .sw_clk_en(clk_main_otbn_hint || !idle_i[HintMainOtbn]),
+    .sw_clk_en(u_clk_main_otbn_trans.sw_hint_synced ||
+               !u_clk_main_otbn_trans.idle_valid),
     .scanmode(prim_mubi_pkg::MuBi4False),
     .cg_en(cg_en_o.main_otbn == prim_mubi_pkg::MuBi4True)
   );

--- a/hw/ip/clkmgr/rtl/clkmgr_trans.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_trans.sv
@@ -1,0 +1,105 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Handle clock manager transactional clocks
+
+module clkmgr_trans
+  import clkmgr_pkg::*;
+  import prim_mubi_pkg::mubi4_t;
+# (
+  parameter bit FpgaBufGlobal = 1
+) (
+  input clk_i,
+  input rst_ni,
+  input clk_root_i,
+  input clk_root_en_i,
+  input mubi4_t idle_i,
+  input sw_hint_i,
+  input mubi4_t scanmode_i,
+  output mubi4_t alert_cg_en_o,
+  output logic clk_o,
+  output logic clk_en_o,
+  output logic cnt_err_o
+);
+
+  import prim_mubi_pkg::MuBi4False;
+  import prim_mubi_pkg::MuBi4True;
+  import prim_mubi_pkg::mubi4_test_true_strict;
+  import prim_mubi_pkg::mubi4_test_false_loose;
+
+  localparam int TransIdleCnt = int'(MuBi4True);
+  localparam int IdleCntWidth = $clog2(TransIdleCnt + 1);
+
+  logic [IdleCntWidth-1:0] idle_cnt;
+  logic idle_valid;
+  logic sw_hint_synced;
+  assign idle_valid = (idle_cnt == MuBi4True);
+  assign clk_en_o = sw_hint_synced | ~idle_valid;
+
+  prim_flop_2sync #(
+    .Width(1)
+  ) u_hint_sync (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(sw_hint_i),
+    .q_o(sw_hint_synced)
+  );
+
+  prim_count #(
+    .Width(IdleCntWidth),
+    .OutSelDnCnt('0),
+    .CntStyle(prim_count_pkg::DupCnt)
+  ) u_idle_cnt (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    // the default condition is to keep the clock enabled
+    .clr_i(mubi4_test_false_loose(idle_i)),
+    .set_i('0),
+    .set_cnt_i('0),
+    .en_i(mubi4_test_true_strict(idle_i) & ~idle_valid),
+    .step_i(IdleCntWidth'(1'b1)),
+    .cnt_o(idle_cnt),
+    .err_o(cnt_err_o)
+  );
+
+  // Declared as size 1 packed array to avoid FPV warning.
+  prim_mubi_pkg::mubi4_t [0:0] scanmode;
+  prim_mubi4_sync #(
+    .NumCopies(1),
+    .AsyncOn(0)
+  ) u_scanmode_sync (
+    .clk_i,
+    .rst_ni,
+    .mubi_i(scanmode_i),
+    .mubi_o(scanmode)
+  );
+
+  // Add a prim buf here to make sure the CG and the lc sender inputs
+  // are derived from the same physical signal.
+  logic clk_combined_en;
+  prim_buf u_prim_buf_en (
+    .in_i(clk_en_o & clk_root_en_i),
+    .out_o(clk_combined_en)
+  );
+
+  prim_clock_gating #(
+    .FpgaBufGlobal(FpgaBufGlobal)
+  ) u_cg (
+    .clk_i(clk_root_i),
+    .en_i(clk_combined_en),
+    .test_en_i(mubi4_test_true_strict(scanmode[0])),
+    .clk_o(clk_o)
+  );
+
+  // clock gated indication for alert handler
+  prim_mubi4_sender #(
+    .ResetValue(MuBi4True)
+  ) u_prim_mubi4_sender (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .mubi_i(clk_combined_en ? MuBi4False : MuBi4True),
+    .mubi_o(alert_cg_en_o)
+  );
+
+endmodule

--- a/hw/ip/hmac/data/hmac.hjson
+++ b/hw/ip/hmac/data/hmac.hjson
@@ -28,8 +28,8 @@
     { name:    "idle",
       type:    "uni",
       act:     "req",
-      package: "",
-      struct:  "logic",
+      package: "prim_mubi_pkg",
+      struct:  "mubi4",
       width:   "1"
     }
   ],

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -25,7 +25,7 @@ module hmac
   output logic intr_fifo_empty_o,
   output logic intr_hmac_err_o,
 
-  output logic idle_o
+  output prim_mubi_pkg::mubi4_t idle_o
 );
 
 
@@ -560,9 +560,9 @@ module hmac
               && hmac_core_idle && sha_core_idle;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      idle_o <= 1'b 1;
+      idle_o <= prim_mubi_pkg::MuBi4False;
     end else begin
-      idle_o <= idle;
+      idle_o <= prim_mubi_pkg::mubi4_bool_to_mubi(idle);
     end
   end
 

--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -157,8 +157,8 @@
     { name:    "idle",
       type:    "uni",
       act:     "req",
-      package: "",
-      struct:  "logic",
+      package: "prim_mubi_pkg",
+      struct:  "mubi4",
       width:   "1"
     }
     { struct:  "logic"

--- a/hw/ip/kmac/dv/env/kmac_if.sv
+++ b/hw/ip/kmac/dv/env/kmac_if.sv
@@ -6,7 +6,7 @@ interface kmac_if(input clk_i, input rst_ni);
 
   lc_ctrl_pkg::lc_tx_t lc_escalate_en_i;
 
-  logic idle_o;
+  prim_mubi_pkg::mubi4_t idle_o;
   logic en_masking_o;
   logic [kmac_pkg::NumAppIntf-1:0] app_err_o;
 

--- a/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
+++ b/hw/ip/kmac/dv/env/seq_lib/kmac_base_vseq.sv
@@ -280,7 +280,7 @@ class kmac_base_vseq extends cip_base_vseq #(
   virtual task kmac_init(bit wait_init = 1);
     // Wait for KMAC to reach idle state
     if (wait_init) begin
-      wait (cfg.kmac_vif.idle_o == 1);
+      wait (cfg.kmac_vif.idle_o == prim_mubi_pkg::MuBi4True);
       `uvm_info(`gfn, "reached idle state", UVM_HIGH)
     end
 

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -75,7 +75,7 @@ module kmac
   output logic en_masking_o,
 
   // Idle signal
-  output logic idle_o
+  output prim_mubi_pkg::mubi4_t idle_o
 );
 
   ////////////////
@@ -534,11 +534,11 @@ module kmac
   // The logic checks idle of SHA3 engine, MSG_FIFO, KMAC_CORE, KEYMGR interface
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      idle_o <= 1'b 1;
+      idle_o <= prim_mubi_pkg::MuBi4True;
     end else if ((sha3_fsm == sha3_pkg::StIdle) && (msgfifo_empty || SecIdleAcceptSwMsg)) begin
-      idle_o <= 1'b 1;
+      idle_o <= prim_mubi_pkg::MuBi4True;
     end else begin
-      idle_o <= 1'b 0;
+      idle_o <= prim_mubi_pkg::MuBi4False;
     end
   end
 

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -89,19 +89,13 @@
       package: "edn_pkg"
     },
 
-    // OTBN is not performing any operation and can be clock/power-gated. One
-    // idle for each clock domain (see assignments in "clocking" dictionary above).
+    // OTBN is not performing any operation and can be clock/power-gated. 
     { name:    "idle",
       type:    "uni",
-      struct:  "logic",
+      struct:  "mubi4", 
       width:   "1",
       act:     "req",
-    },
-    { name:    "idle_otp",
-      type:    "uni",
-      struct:  "logic",
-      width:   "1",
-      act:     "req",
+      package: "prim_mubi_pkg"
     },
 
     // ram configuration

--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -14,7 +14,7 @@ module otbn_idle_checker
   input otbn_hw2reg_t hw2reg,
   input logic         done_i,
 
-  input logic         idle_o_i
+  input prim_mubi_pkg::mubi4_t idle_o_i
 );
 
   // Detect writes of CmdExecute to CMD. They only take effect if we are in state IDLE
@@ -41,6 +41,6 @@ module otbn_idle_checker
 
   // Check that we've modelled the running/not-running logic correctly. The idle_o pin from OTBN
   // should be true iff running is false
-  `ASSERT(IdleIfNotRunning_A, idle_o_i ^ running_q)
+  `ASSERT(IdleIfNotRunning_A, (idle_o_i == prim_mubi_pkg::MuBi4True) ^ running_q)
 
 endmodule

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -127,8 +127,6 @@ module tb;
     .tl_o(tl_if.d2h),
 
     .idle_o(idle),
-    // TODO: Once this signal's behaviour is specified, check that it behaves as we expect.
-    .idle_otp_o (),
 
     .intr_done_o(intr_done),
 

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -33,8 +33,7 @@ module otbn
   output tlul_pkg::tl_d2h_t tl_o,
 
   // Inter-module signals
-  output logic idle_o,
-  output logic idle_otp_o,
+  output prim_mubi_pkg::mubi4_t idle_o,
 
   // Interrupts
   output logic intr_done_o,
@@ -135,11 +134,7 @@ module otbn
 
   // Note: This is not the same thing as STATUS == IDLE. For example, we want to allow clock gating
   // when locked.
-  assign idle_o = is_not_running;
-
-  // TODO: These two signals aren't technically in the same clock domain. Sort out how we do the
-  // signalling properly.
-  assign idle_otp_o = idle_o;
+  assign idle_o = prim_mubi_pkg::mubi4_bool_to_mubi(is_not_running);
 
   // Lifecycle ==================================================================
 
@@ -1127,7 +1122,6 @@ module otbn
   `ASSERT_KNOWN(TlODValidKnown_A, tl_o.d_valid)
   `ASSERT_KNOWN(TlOAReadyKnown_A, tl_o.a_ready)
   `ASSERT_KNOWN(IdleOKnown_A, idle_o)
-  `ASSERT_KNOWN(IdleOtpOKnown_A, idle_otp_o, clk_otp_i, !rst_otp_ni)
   `ASSERT_KNOWN(IntrDoneOKnown_A, intr_done_o)
   `ASSERT_KNOWN(AlertTxOKnown_A, alert_tx_o)
   `ASSERT_KNOWN(EdnRndOKnown_A, edn_rnd_o, clk_edn_i, !rst_edn_ni)

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -118,7 +118,6 @@
           clk_main_hmac: main
           clk_main_kmac: main
           clk_main_otbn: main
-          clk_io_div4_otbn: io_div4
         }
       }
       {
@@ -3223,13 +3222,13 @@
         }
         {
           name: idle
-          struct: logic
+          struct: mubi4
+          package: prim_mubi_pkg
           type: uni
           act: rcv
-          width: 5
+          width: 4
           inst_name: clkmgr_aon
           default: ""
-          package: ""
           end_idx: -1
           top_type: one-to-N
           top_signame: clkmgr_aon_idle
@@ -5148,13 +5147,13 @@
       [
         {
           name: idle
-          struct: logic
+          struct: mubi4
+          package: prim_mubi_pkg
           type: uni
           act: req
           width: 1
           inst_name: aes
           default: ""
-          package: ""
           top_signame: clkmgr_aon_idle
           index: 0
         }
@@ -5243,13 +5242,13 @@
       [
         {
           name: idle
-          struct: logic
+          struct: mubi4
+          package: prim_mubi_pkg
           type: uni
           act: req
           width: 1
           inst_name: hmac
           default: ""
-          package: ""
           top_signame: clkmgr_aon_idle
           index: 1
         }
@@ -5450,13 +5449,13 @@
         }
         {
           name: idle
-          struct: logic
+          struct: mubi4
+          package: prim_mubi_pkg
           type: uni
           act: req
           width: 1
           inst_name: kmac
           default: ""
-          package: ""
           top_signame: clkmgr_aon_idle
           index: 2
         }
@@ -5510,9 +5509,21 @@
       type: otbn
       clock_srcs:
       {
-        clk_i: main
-        clk_edn_i: main
-        clk_otp_i: io_div4
+        clk_i:
+        {
+          clock: main
+          group: trans
+        }
+        clk_edn_i:
+        {
+          clock: main
+          group: secure
+        }
+        clk_otp_i:
+        {
+          clock: io_div4
+          group: secure
+        }
       }
       clock_group: trans
       reset_connections:
@@ -5536,8 +5547,8 @@
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_main_otbn
-        clk_edn_i: clkmgr_aon_clocks.clk_main_otbn
-        clk_otp_i: clkmgr_aon_clocks.clk_io_div4_otbn
+        clk_edn_i: clkmgr_aon_clocks.clk_main_secure
+        clk_otp_i: clkmgr_aon_clocks.clk_io_div4_secure
       }
       domain:
       [
@@ -5634,25 +5645,13 @@
         }
         {
           name: idle
-          struct: logic
+          struct: mubi4
+          package: prim_mubi_pkg
           type: uni
           act: req
           width: 1
           inst_name: otbn
           default: ""
-          package: ""
-          top_signame: clkmgr_aon_idle
-          index: 4
-        }
-        {
-          name: idle_otp
-          struct: logic
-          type: uni
-          act: req
-          width: 1
-          inst_name: otbn
-          default: ""
-          package: ""
           top_signame: clkmgr_aon_idle
           index: 3
         }
@@ -7705,7 +7704,6 @@
         aes.idle
         hmac.idle
         kmac.idle
-        otbn.idle_otp
         otbn.idle
       ]
       pinmux_aon.lc_jtag:
@@ -16101,13 +16099,13 @@
       }
       {
         name: idle
-        struct: logic
+        struct: mubi4
+        package: prim_mubi_pkg
         type: uni
         act: rcv
-        width: 5
+        width: 4
         inst_name: clkmgr_aon
         default: ""
-        package: ""
         end_idx: -1
         top_type: one-to-N
         top_signame: clkmgr_aon_idle
@@ -17230,13 +17228,13 @@
       }
       {
         name: idle
-        struct: logic
+        struct: mubi4
+        package: prim_mubi_pkg
         type: uni
         act: req
         width: 1
         inst_name: aes
         default: ""
-        package: ""
         top_signame: clkmgr_aon_idle
         index: 0
       }
@@ -17291,13 +17289,13 @@
       }
       {
         name: idle
-        struct: logic
+        struct: mubi4
+        package: prim_mubi_pkg
         type: uni
         act: req
         width: 1
         inst_name: hmac
         default: ""
-        package: ""
         top_signame: clkmgr_aon_idle
         index: 1
       }
@@ -17354,13 +17352,13 @@
       }
       {
         name: idle
-        struct: logic
+        struct: mubi4
+        package: prim_mubi_pkg
         type: uni
         act: req
         width: 1
         inst_name: kmac
         default: ""
-        package: ""
         top_signame: clkmgr_aon_idle
         index: 2
       }
@@ -17441,25 +17439,13 @@
       }
       {
         name: idle
-        struct: logic
+        struct: mubi4
+        package: prim_mubi_pkg
         type: uni
         act: req
         width: 1
         inst_name: otbn
         default: ""
-        package: ""
-        top_signame: clkmgr_aon_idle
-        index: 4
-      }
-      {
-        name: idle_otp
-        struct: logic
-        type: uni
-        act: req
-        width: 1
-        inst_name: otbn
-        default: ""
-        package: ""
         top_signame: clkmgr_aon_idle
         index: 3
       }
@@ -20392,15 +20378,15 @@
         default: "'0"
       }
       {
-        package: ""
-        struct: logic
+        package: prim_mubi_pkg
+        struct: mubi4
         signame: clkmgr_aon_idle
-        width: 5
+        width: 4
         type: uni
         end_idx: -1
         act: rcv
         suffix: ""
-        default: "'0"
+        default: prim_mubi_pkg::MUBI4_DEFAULT
       }
       {
         package: jtag_pkg

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -593,7 +593,20 @@
     },
     { name: "otbn",
       type: "otbn",
-      clock_srcs: {clk_i: "main", clk_edn_i: "main", clk_otp_i: "io_div4"},
+      clock_srcs: {
+        clk_i: {
+	  clock: "main", 
+	  group: "trans"
+	},
+	clk_edn_i: {
+          clock: "main", 
+          group: "secure"
+        },
+        clk_otp_i: {
+          clock: "io_div4",
+          group: "secure"
+        },
+      },
       clock_group: "trans",
       reset_connections: {rst_ni: "sys", rst_edn_ni: "sys", rst_otp_ni: "lc_io_div4"},
       base_addr: "0x41130000",

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -54,7 +54,7 @@
     { name: "NumHintableClocks",
       desc: "Number of hintable clocks",
       type: "int",
-      default: "5",
+      default: "4",
       local: "true"
     },
   ],
@@ -145,12 +145,12 @@
       act:     "rsp",
     },
 
-    { struct:  "logic",
+    { struct:  "mubi4",
       type:    "uni",
       name:    "idle",
       act:     "rcv",
-      package: "",
-      width:   "5"
+      package: "prim_mubi_pkg",
+      width:   "4"
     },
   ],
 
@@ -384,15 +384,6 @@
         }
         {
           bits: "3",
-          name: "CLK_IO_DIV4_OTBN_HINT",
-          resval: 1,
-          desc: '''
-            0 CLK_IO_DIV4_OTBN can be disabled.
-            1 CLK_IO_DIV4_OTBN is enabled.
-          '''
-        }
-        {
-          bits: "4",
           name: "CLK_MAIN_OTBN_HINT",
           resval: 1,
           desc: '''
@@ -445,15 +436,6 @@
         }
         {
           bits: "3",
-          name: "CLK_IO_DIV4_OTBN_VAL",
-          resval: 1,
-          desc: '''
-            0 CLK_IO_DIV4_OTBN is disabled.
-            1 CLK_IO_DIV4_OTBN is enabled.
-          '''
-        }
-        {
-          bits: "4",
           name: "CLK_MAIN_OTBN_VAL",
           resval: 1,
           desc: '''
@@ -835,8 +817,15 @@
             Register file has experienced a fatal integrity error.
           '''
         },
+        { bits: "1",
+          name: "IDLE_CNT",
+          resval: 0
+          desc: '''
+            One of the idle counts encountered a duplicate error.
+          '''
+        },
         {
-          bits: "1",
+          bits: "2",
           name: "IO_STORAGE_ERR",
           resval: 0,
           desc: '''
@@ -844,7 +833,7 @@
           '''
         },
         {
-          bits: "2",
+          bits: "3",
           name: "IO_DIV2_STORAGE_ERR",
           resval: 0,
           desc: '''
@@ -852,7 +841,7 @@
           '''
         },
         {
-          bits: "3",
+          bits: "4",
           name: "IO_DIV4_STORAGE_ERR",
           resval: 0,
           desc: '''
@@ -860,7 +849,7 @@
           '''
         },
         {
-          bits: "4",
+          bits: "5",
           name: "MAIN_STORAGE_ERR",
           resval: 0,
           desc: '''
@@ -868,7 +857,7 @@
           '''
         },
         {
-          bits: "5",
+          bits: "6",
           name: "USB_STORAGE_ERR",
           resval: 0,
           desc: '''

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_pkg.sv
@@ -16,8 +16,7 @@ package clkmgr_pkg;
     HintMainAes = 0,
     HintMainHmac = 1,
     HintMainKmac = 2,
-    HintIoDiv4Otbn = 3,
-    HintMainOtbn = 4
+    HintMainOtbn = 3
   } hint_names_e;
 
   // clocks generated and broadcast
@@ -36,7 +35,6 @@ package clkmgr_pkg;
     logic clk_main_hmac;
     logic clk_main_kmac;
     logic clk_main_otbn;
-    logic clk_io_div4_otbn;
     logic clk_io_div4_infra;
     logic clk_main_infra;
     logic clk_io_infra;
@@ -67,7 +65,6 @@ package clkmgr_pkg;
     prim_mubi_pkg::mubi4_t main_hmac;
     prim_mubi_pkg::mubi4_t main_kmac;
     prim_mubi_pkg::mubi4_t main_otbn;
-    prim_mubi_pkg::mubi4_t io_div4_otbn;
     prim_mubi_pkg::mubi4_t io_div4_infra;
     prim_mubi_pkg::mubi4_t main_infra;
     prim_mubi_pkg::mubi4_t io_infra;
@@ -82,15 +79,15 @@ package clkmgr_pkg;
     prim_mubi_pkg::mubi4_t io_peri;
   } clkmgr_cg_en_t;
 
-  parameter int NumOutputClk = 27;
+  parameter int NumOutputClk = 26;
 
 
   typedef struct packed {
-    logic [5-1:0] idle;
+    logic [4-1:0] idle;
   } clk_hint_status_t;
 
   parameter clk_hint_status_t CLK_HINT_STATUS_DEFAULT = '{
-    idle: {5{1'b1}}
+    idle: {4{1'b1}}
   };
 
 endpackage // clkmgr_pkg

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -9,7 +9,7 @@ package clkmgr_reg_pkg;
   // Param list
   parameter int NumGroups = 7;
   parameter int NumSwGateableClocks = 4;
-  parameter int NumHintableClocks = 5;
+  parameter int NumHintableClocks = 4;
   parameter int NumAlerts = 2;
 
   // Address widths within the block
@@ -68,9 +68,6 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        q;
     } clk_main_kmac_hint;
-    struct packed {
-      logic        q;
-    } clk_io_div4_otbn_hint;
     struct packed {
       logic        q;
     } clk_main_otbn_hint;
@@ -172,6 +169,9 @@ package clkmgr_reg_pkg;
     } reg_intg;
     struct packed {
       logic        q;
+    } idle_cnt;
+    struct packed {
+      logic        q;
     } io_storage_err;
     struct packed {
       logic        q;
@@ -200,10 +200,6 @@ package clkmgr_reg_pkg;
       logic        d;
       logic        de;
     } clk_main_kmac_val;
-    struct packed {
-      logic        d;
-      logic        de;
-    } clk_io_div4_otbn_val;
     struct packed {
       logic        d;
       logic        de;
@@ -281,6 +277,10 @@ package clkmgr_reg_pkg;
     struct packed {
       logic        d;
       logic        de;
+    } idle_cnt;
+    struct packed {
+      logic        d;
+      logic        de;
     } io_storage_err;
     struct packed {
       logic        d;
@@ -306,20 +306,20 @@ package clkmgr_reg_pkg;
     clkmgr_reg2hw_extclk_ctrl_reg_t extclk_ctrl; // [123:116]
     clkmgr_reg2hw_jitter_enable_reg_t jitter_enable; // [115:112]
     clkmgr_reg2hw_clk_enables_reg_t clk_enables; // [111:108]
-    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [107:103]
-    clkmgr_reg2hw_io_meas_ctrl_shadowed_reg_t io_meas_ctrl_shadowed; // [102:82]
-    clkmgr_reg2hw_io_div2_meas_ctrl_shadowed_reg_t io_div2_meas_ctrl_shadowed; // [81:63]
-    clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t io_div4_meas_ctrl_shadowed; // [62:46]
-    clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t main_meas_ctrl_shadowed; // [45:25]
-    clkmgr_reg2hw_usb_meas_ctrl_shadowed_reg_t usb_meas_ctrl_shadowed; // [24:6]
-    clkmgr_reg2hw_fatal_err_code_reg_t fatal_err_code; // [5:0]
+    clkmgr_reg2hw_clk_hints_reg_t clk_hints; // [107:104]
+    clkmgr_reg2hw_io_meas_ctrl_shadowed_reg_t io_meas_ctrl_shadowed; // [103:83]
+    clkmgr_reg2hw_io_div2_meas_ctrl_shadowed_reg_t io_div2_meas_ctrl_shadowed; // [82:64]
+    clkmgr_reg2hw_io_div4_meas_ctrl_shadowed_reg_t io_div4_meas_ctrl_shadowed; // [63:47]
+    clkmgr_reg2hw_main_meas_ctrl_shadowed_reg_t main_meas_ctrl_shadowed; // [46:26]
+    clkmgr_reg2hw_usb_meas_ctrl_shadowed_reg_t usb_meas_ctrl_shadowed; // [25:7]
+    clkmgr_reg2hw_fatal_err_code_reg_t fatal_err_code; // [6:0]
   } clkmgr_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [51:42]
-    clkmgr_hw2reg_recov_err_code_reg_t recov_err_code; // [41:12]
-    clkmgr_hw2reg_fatal_err_code_reg_t fatal_err_code; // [11:0]
+    clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [51:44]
+    clkmgr_hw2reg_recov_err_code_reg_t recov_err_code; // [43:14]
+    clkmgr_hw2reg_fatal_err_code_reg_t fatal_err_code; // [13:0]
   } clkmgr_hw2reg_t;
 
   // Register offsets

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -212,14 +212,11 @@ module clkmgr_reg_top (
   logic clk_hints_clk_main_hmac_hint_wd;
   logic clk_hints_clk_main_kmac_hint_qs;
   logic clk_hints_clk_main_kmac_hint_wd;
-  logic clk_hints_clk_io_div4_otbn_hint_qs;
-  logic clk_hints_clk_io_div4_otbn_hint_wd;
   logic clk_hints_clk_main_otbn_hint_qs;
   logic clk_hints_clk_main_otbn_hint_wd;
   logic clk_hints_status_clk_main_aes_val_qs;
   logic clk_hints_status_clk_main_hmac_val_qs;
   logic clk_hints_status_clk_main_kmac_val_qs;
-  logic clk_hints_status_clk_io_div4_otbn_val_qs;
   logic clk_hints_status_clk_main_otbn_val_qs;
   logic measure_ctrl_regwen_we;
   logic measure_ctrl_regwen_qs;
@@ -276,6 +273,7 @@ module clkmgr_reg_top (
   logic recov_err_code_usb_update_err_qs;
   logic recov_err_code_usb_update_err_wd;
   logic fatal_err_code_reg_intg_qs;
+  logic fatal_err_code_idle_cnt_qs;
   logic fatal_err_code_io_storage_err_qs;
   logic fatal_err_code_io_div2_storage_err_qs;
   logic fatal_err_code_io_div4_storage_err_qs;
@@ -833,32 +831,7 @@ module clkmgr_reg_top (
     .qs     (clk_hints_clk_main_kmac_hint_qs)
   );
 
-  //   F[clk_io_div4_otbn_hint]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (1'h1)
-  ) u_clk_hints_clk_io_div4_otbn_hint (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (clk_hints_we),
-    .wd     (clk_hints_clk_io_div4_otbn_hint_wd),
-
-    // from internal hardware
-    .de     (1'b0),
-    .d      ('0),
-
-    // to internal hardware
-    .qe     (),
-    .q      (reg2hw.clk_hints.clk_io_div4_otbn_hint.q),
-
-    // to register interface (read)
-    .qs     (clk_hints_clk_io_div4_otbn_hint_qs)
-  );
-
-  //   F[clk_main_otbn_hint]: 4:4
+  //   F[clk_main_otbn_hint]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -960,32 +933,7 @@ module clkmgr_reg_top (
     .qs     (clk_hints_status_clk_main_kmac_val_qs)
   );
 
-  //   F[clk_io_div4_otbn_val]: 3:3
-  prim_subreg #(
-    .DW      (1),
-    .SwAccess(prim_subreg_pkg::SwAccessRO),
-    .RESVAL  (1'h1)
-  ) u_clk_hints_status_clk_io_div4_otbn_val (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-
-    // from register interface
-    .we     (1'b0),
-    .wd     ('0),
-
-    // from internal hardware
-    .de     (hw2reg.clk_hints_status.clk_io_div4_otbn_val.de),
-    .d      (hw2reg.clk_hints_status.clk_io_div4_otbn_val.d),
-
-    // to internal hardware
-    .qe     (),
-    .q      (),
-
-    // to register interface (read)
-    .qs     (clk_hints_status_clk_io_div4_otbn_val_qs)
-  );
-
-  //   F[clk_main_otbn_val]: 4:4
+  //   F[clk_main_otbn_val]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2320,7 +2268,32 @@ module clkmgr_reg_top (
     .qs     (fatal_err_code_reg_intg_qs)
   );
 
-  //   F[io_storage_err]: 1:1
+  //   F[idle_cnt]: 1:1
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fatal_err_code_idle_cnt (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fatal_err_code.idle_cnt.de),
+    .d      (hw2reg.fatal_err_code.idle_cnt.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fatal_err_code.idle_cnt.q),
+
+    // to register interface (read)
+    .qs     (fatal_err_code_idle_cnt_qs)
+  );
+
+  //   F[io_storage_err]: 2:2
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2345,7 +2318,7 @@ module clkmgr_reg_top (
     .qs     (fatal_err_code_io_storage_err_qs)
   );
 
-  //   F[io_div2_storage_err]: 2:2
+  //   F[io_div2_storage_err]: 3:3
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2370,7 +2343,7 @@ module clkmgr_reg_top (
     .qs     (fatal_err_code_io_div2_storage_err_qs)
   );
 
-  //   F[io_div4_storage_err]: 3:3
+  //   F[io_div4_storage_err]: 4:4
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2395,7 +2368,7 @@ module clkmgr_reg_top (
     .qs     (fatal_err_code_io_div4_storage_err_qs)
   );
 
-  //   F[main_storage_err]: 4:4
+  //   F[main_storage_err]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2420,7 +2393,7 @@ module clkmgr_reg_top (
     .qs     (fatal_err_code_main_storage_err_qs)
   );
 
-  //   F[usb_storage_err]: 5:5
+  //   F[usb_storage_err]: 6:6
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
@@ -2526,9 +2499,7 @@ module clkmgr_reg_top (
 
   assign clk_hints_clk_main_kmac_hint_wd = reg_wdata[2];
 
-  assign clk_hints_clk_io_div4_otbn_hint_wd = reg_wdata[3];
-
-  assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[4];
+  assign clk_hints_clk_main_otbn_hint_wd = reg_wdata[3];
   assign measure_ctrl_regwen_we = addr_hit[8] & reg_we & !reg_error;
 
   assign measure_ctrl_regwen_wd = reg_wdata[0];
@@ -2626,16 +2597,14 @@ module clkmgr_reg_top (
         reg_rdata_next[0] = clk_hints_clk_main_aes_hint_qs;
         reg_rdata_next[1] = clk_hints_clk_main_hmac_hint_qs;
         reg_rdata_next[2] = clk_hints_clk_main_kmac_hint_qs;
-        reg_rdata_next[3] = clk_hints_clk_io_div4_otbn_hint_qs;
-        reg_rdata_next[4] = clk_hints_clk_main_otbn_hint_qs;
+        reg_rdata_next[3] = clk_hints_clk_main_otbn_hint_qs;
       end
 
       addr_hit[7]: begin
         reg_rdata_next[0] = clk_hints_status_clk_main_aes_val_qs;
         reg_rdata_next[1] = clk_hints_status_clk_main_hmac_val_qs;
         reg_rdata_next[2] = clk_hints_status_clk_main_kmac_val_qs;
-        reg_rdata_next[3] = clk_hints_status_clk_io_div4_otbn_val_qs;
-        reg_rdata_next[4] = clk_hints_status_clk_main_otbn_val_qs;
+        reg_rdata_next[3] = clk_hints_status_clk_main_otbn_val_qs;
       end
 
       addr_hit[8]: begin
@@ -2677,11 +2646,12 @@ module clkmgr_reg_top (
 
       addr_hit[15]: begin
         reg_rdata_next[0] = fatal_err_code_reg_intg_qs;
-        reg_rdata_next[1] = fatal_err_code_io_storage_err_qs;
-        reg_rdata_next[2] = fatal_err_code_io_div2_storage_err_qs;
-        reg_rdata_next[3] = fatal_err_code_io_div4_storage_err_qs;
-        reg_rdata_next[4] = fatal_err_code_main_storage_err_qs;
-        reg_rdata_next[5] = fatal_err_code_usb_storage_err_qs;
+        reg_rdata_next[1] = fatal_err_code_idle_cnt_qs;
+        reg_rdata_next[2] = fatal_err_code_io_storage_err_qs;
+        reg_rdata_next[3] = fatal_err_code_io_div2_storage_err_qs;
+        reg_rdata_next[4] = fatal_err_code_io_div4_storage_err_qs;
+        reg_rdata_next[5] = fatal_err_code_main_storage_err_qs;
+        reg_rdata_next[6] = fatal_err_code_usb_storage_err_qs;
       end
 
       default: begin

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -1087,7 +1087,6 @@ module chip_earlgrey_cw310 #(
       3'b000:  trigger_sel = clkmgr_pkg::HintMainAes;
       3'b001:  trigger_sel = clkmgr_pkg::HintMainHmac;
       3'b010:  trigger_sel = clkmgr_pkg::HintMainKmac;
-      3'b011:  trigger_sel = clkmgr_pkg::HintIoDiv4Otbn;
       3'b100:  trigger_sel = clkmgr_pkg::HintMainOtbn;
       default: trigger_sel = clkmgr_pkg::HintMainAes;
     endcase;

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -580,7 +580,7 @@ module top_earlgrey #(
   kmac_pkg::app_req_t [2:0] kmac_app_req;
   kmac_pkg::app_rsp_t [2:0] kmac_app_rsp;
   logic       kmac_en_masking;
-  logic [4:0] clkmgr_aon_idle;
+  prim_mubi_pkg::mubi4_t [3:0] clkmgr_aon_idle;
   jtag_pkg::jtag_req_t       pinmux_aon_lc_jtag_req;
   jtag_pkg::jtag_rsp_t       pinmux_aon_lc_jtag_rsp;
   jtag_pkg::jtag_req_t       pinmux_aon_rv_jtag_req;
@@ -912,15 +912,13 @@ module top_earlgrey #(
     prim_mubi_pkg::mubi4_t unused_cg_en_11;
     assign unused_cg_en_11 = clkmgr_aon_cg_en.main_otbn;
     prim_mubi_pkg::mubi4_t unused_cg_en_12;
-    assign unused_cg_en_12 = clkmgr_aon_cg_en.io_div4_otbn;
+    assign unused_cg_en_12 = clkmgr_aon_cg_en.io_infra;
     prim_mubi_pkg::mubi4_t unused_cg_en_13;
-    assign unused_cg_en_13 = clkmgr_aon_cg_en.io_infra;
+    assign unused_cg_en_13 = clkmgr_aon_cg_en.io_div2_infra;
     prim_mubi_pkg::mubi4_t unused_cg_en_14;
-    assign unused_cg_en_14 = clkmgr_aon_cg_en.io_div2_infra;
+    assign unused_cg_en_14 = clkmgr_aon_cg_en.usb_secure;
     prim_mubi_pkg::mubi4_t unused_cg_en_15;
-    assign unused_cg_en_15 = clkmgr_aon_cg_en.usb_secure;
-    prim_mubi_pkg::mubi4_t unused_cg_en_16;
-    assign unused_cg_en_16 = clkmgr_aon_cg_en.usb_peri;
+    assign unused_cg_en_15 = clkmgr_aon_cg_en.usb_peri;
     prim_mubi_pkg::mubi4_t unused_rst_en_0;
     assign unused_rst_en_0 = rstmgr_aon_rst_en.por_aon[rstmgr_pkg::DomainAonSel];
     prim_mubi_pkg::mubi4_t unused_rst_en_1;
@@ -2258,8 +2256,7 @@ module top_earlgrey #(
       .edn_rnd_i(edn1_edn_rsp[0]),
       .edn_urnd_o(edn0_edn_req[6]),
       .edn_urnd_i(edn0_edn_rsp[6]),
-      .idle_o(clkmgr_aon_idle[4]),
-      .idle_otp_o(clkmgr_aon_idle[3]),
+      .idle_o(clkmgr_aon_idle[3]),
       .ram_cfg_i(ast_ram_1p_cfg),
       .lc_escalate_en_i(lc_ctrl_lc_escalate_en),
       .keymgr_key_i(keymgr_otbn_key),
@@ -2268,8 +2265,8 @@ module top_earlgrey #(
 
       // Clock and reset connections
       .clk_i (clkmgr_aon_clocks.clk_main_otbn),
-      .clk_edn_i (clkmgr_aon_clocks.clk_main_otbn),
-      .clk_otp_i (clkmgr_aon_clocks.clk_io_div4_otbn),
+      .clk_edn_i (clkmgr_aon_clocks.clk_main_secure),
+      .clk_otp_i (clkmgr_aon_clocks.clk_io_div4_secure),
       .rst_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
       .rst_edn_ni (rstmgr_aon_resets.rst_sys_n[rstmgr_pkg::Domain0Sel]),
       .rst_otp_ni (rstmgr_aon_resets.rst_lc_io_div4_n[rstmgr_pkg::Domain0Sel])

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey.h
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey.h
@@ -1681,8 +1681,7 @@ typedef enum top_earlgrey_hintable_clocks {
   kTopEarlgreyHintableClocksMainHmac = 1, /**< Clock clk_main_hmac in group trans */
   kTopEarlgreyHintableClocksMainKmac = 2, /**< Clock clk_main_kmac in group trans */
   kTopEarlgreyHintableClocksMainOtbn = 3, /**< Clock clk_main_otbn in group trans */
-  kTopEarlgreyHintableClocksIoDiv4Otbn = 4, /**< Clock clk_io_div4_otbn in group trans */
-  kTopEarlgreyHintableClocksLast = 4, /**< \internal Last Valid Hintable Clock */
+  kTopEarlgreyHintableClocksLast = 3, /**< \internal Last Valid Hintable Clock */
 } top_earlgrey_hintable_clocks_t;
 
 // Header Extern Guard

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -207,7 +207,7 @@ index 3c0c86f26..7354aa9cb 100644
    // Disable HMAC, KMAC, OTBN and USB clocks through CLKMGR DIF.
    dif_clkmgr_t clkmgr;
    IGNORE_RESULT(dif_clkmgr_init(
-@@ -199,17 +156,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
+@@ -199,14 +156,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
      IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
          &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_HMAC_HINT_BIT, kDifToggleDisabled));
    }
@@ -216,9 +216,6 @@ index 3c0c86f26..7354aa9cb 100644
 -        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_KMAC_HINT_BIT, kDifToggleDisabled));
 -  }
 -  if (disable & kScaPeripheralOtbn) {
--    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
--        &clkmgr, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
--        kDifToggleDisabled));
 -    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
 -        &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT, kDifToggleDisabled));
 -  }

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -205,9 +205,6 @@ void sca_disable_peripherals(sca_peripherals_t disable) {
   }
   if (disable & kScaPeripheralOtbn) {
     IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
-        &clkmgr, CLKMGR_CLK_HINTS_CLK_IO_DIV4_OTBN_HINT_BIT,
-        kDifToggleDisabled));
-    IGNORE_RESULT(dif_clkmgr_hintable_clock_set_hint(
         &clkmgr, CLKMGR_CLK_HINTS_CLK_MAIN_OTBN_HINT_BIT, kDifToggleDisabled));
   }
   if (disable & kScaPeripheralUsb) {

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1317,7 +1317,6 @@ module chip_${top["name"]}_${target["name"]} (
       3'b000:  trigger_sel = clkmgr_pkg::HintMainAes;
       3'b001:  trigger_sel = clkmgr_pkg::HintMainHmac;
       3'b010:  trigger_sel = clkmgr_pkg::HintMainKmac;
-      3'b011:  trigger_sel = clkmgr_pkg::HintIoDiv4Otbn;
       3'b100:  trigger_sel = clkmgr_pkg::HintMainOtbn;
       default: trigger_sel = clkmgr_pkg::HintMainAes;
     endcase;


### PR DESCRIPTION
The first major change in this PR converts clock idles to mubi signal types:
- update idle interface to use mubi directly
- also do an idle count to ensure idle is really idle.
- addresses the clock idle point in https://github.com/lowRISC/opentitan/issues/10926

The second change defines independent clock groups for the `otbn` clocks.
- Previously, all otbn clocks were placed into the trasnactional group.
- As a result of this, an idle was generated for each clock.
- In reality, this is not the intent.  Only the core otbn clock was meant
  to be transactional.  The others were meant to be part of a separate secure
  clock network.
- Define each clock to a specific group, this removes the need for unnecessary
  clock idles/hints in clkmgr