### PR TITLE
[usbdev] Power on the diff receiver before using it

### DIFF
--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -76,7 +76,7 @@ module usb_fs_nb_pe #(
   output logic [10:0]            frame_index_o,
 
   // RX line status
-  output logic                   rx_jjj_det_o,
+  output logic                   rx_idle_det_o,
   output logic                   rx_j_det_o,
 
   // RX errors
@@ -248,7 +248,7 @@ module usb_fs_nb_pe #(
     .rx_data_put_o          (rx_data_put),
     .rx_data_o              (rx_data),
     .valid_packet_o         (rx_pkt_valid),
-    .rx_jjj_det_o           (rx_jjj_det_o),
+    .rx_idle_det_o          (rx_idle_det_o),
     .rx_j_det_o             (rx_j_det_o),
     .crc_error_o            (rx_crc_err_o),
     .pid_error_o            (rx_pid_err_o),

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -34,6 +34,10 @@ module usb_fs_nb_pe #(
   input  logic                   cfg_use_diff_rcvr_i, // 1: use usb_d_i from a differential receiver
   input  logic                   tx_osc_test_mode_i, // Oscillator test mode (constantly output JK)
   input  logic [NumOutEps-1:0]   data_toggle_clear_i, // Clear the data toggles for an EP
+  input  logic                   diff_rx_ok_i, // 1: received differential data symbols are valid.
+                                               // Set low if K and J symbols might be invalid, such
+                                               // as when an external differential receiver is
+                                               // powering on.
 
   ////////////////////////////
   // USB Endpoint Interface //
@@ -234,6 +238,7 @@ module usb_fs_nb_pe #(
     .link_reset_i           (link_reset_i),
     .cfg_eop_single_bit_i   (cfg_eop_single_bit_i),
     .cfg_use_diff_rcvr_i    (cfg_use_diff_rcvr_i),
+    .diff_rx_ok_i           (diff_rx_ok_i),
     .usb_d_i                (usb_d_i),
     .usb_dp_i               (usb_dp_i),
     .usb_dn_i               (usb_dn_i),

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -150,6 +150,13 @@
       default: "12",
       desc:    "Number of endpoints",
       local:   "true"
+    },
+    { name:    "RcvrWakeTimeUs",
+      type:    "int",
+      default: "1",
+      desc:    "Maximum number of microseconds for the differential receiver to become operational",
+      local:   "false",
+      expose:  "true"
     }
   ],
   interrupt_list: [

--- a/hw/ip/usbdev/rtl/usbdev_linkstate.sv
+++ b/hw/ip/usbdev/rtl/usbdev_linkstate.sv
@@ -16,7 +16,7 @@ module usbdev_linkstate (
   input  logic usb_dn_i,
   input  logic usb_oe_i,
   input  logic usb_pullup_en_i,
-  input  logic rx_jjj_det_i,
+  input  logic rx_idle_det_i,
   input  logic rx_j_det_i,
   input  logic sof_valid_i,
   input  logic resume_link_active_i, // pulse
@@ -130,7 +130,7 @@ module usbdev_linkstate (
   );
 
   // Simple events
-  assign ev_bus_active = !rx_jjj_det_i;
+  assign ev_bus_active = !rx_idle_det_i;
 
   assign monitor_inac = see_pwr_sense ? ((link_state_q == LinkPowered) | link_active_o) :
                         1'b0;

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -263,7 +263,7 @@ module usbdev_usbif  #(
   assign set_sent_o = in_ep_xact_end;
 
   logic [10:0]     frame_index_raw;
-  logic            rx_jjj_det;
+  logic            rx_idle_det;
   logic            rx_j_det;
 
   usb_fs_nb_pe #(
@@ -320,7 +320,7 @@ module usbdev_usbif  #(
     .in_ep_iso_i           (in_ep_iso_i),
 
     // rx status
-    .rx_jjj_det_o          (rx_jjj_det),
+    .rx_idle_det_o         (rx_idle_det),
     .rx_j_det_o            (rx_j_det),
 
     // error signals
@@ -384,7 +384,7 @@ module usbdev_usbif  #(
     .usb_dn_i              (usb_dn_i),
     .usb_oe_i              (usb_oe_o),
     .usb_pullup_en_i       (enable_i),
-    .rx_jjj_det_i          (rx_jjj_det),
+    .rx_idle_det_i         (rx_idle_det),
     .rx_j_det_i            (rx_j_det),
     .sof_valid_i           (sof_valid_o),
     .resume_link_active_i  (resume_link_active_i),

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1101,6 +1101,10 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        RcvrWakeTimeUs: "100"
+      }
       clock_connections:
       {
         clk_i: clkmgr_aon_clocks.clk_io_div4_peri
@@ -1111,7 +1115,6 @@
       [
         "0"
       ]
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -1119,7 +1122,7 @@
           name: RcvrWakeTimeUs
           desc: Maximum number of microseconds for the differential receiver to become operational
           type: int
-          default: "1"
+          default: "100"
           expose: "true"
           name_top: UsbdevRcvrWakeTimeUs
         }

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1112,7 +1112,18 @@
         "0"
       ]
       param_decl: {}
-      param_list: []
+      memory: {}
+      param_list:
+      [
+        {
+          name: RcvrWakeTimeUs
+          desc: Maximum number of microseconds for the differential receiver to become operational
+          type: int
+          default: "1"
+          expose: "true"
+          name_top: UsbdevRcvrWakeTimeUs
+        }
+      ]
       inter_signal_list:
       [
         {

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -294,6 +294,9 @@
       clock_group: "peri",
       reset_connections: {rst_ni: "usb", rst_aon_ni: "sys_aon", rst_usb_48mhz_ni: "usbif"},
       base_addr: "0x40110000",
+      param_decl: {
+        RcvrWakeTimeUs: "100"
+      },
     },
     { name: "otp_ctrl",
       type: "otp_ctrl",

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -965,6 +965,7 @@ module chip_earlgrey_cw310 #(
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
+    .UsbdevRcvrWakeTimeUs(10000),
     .RomCtrlBootRomInitFile(BootRomInitFile),
     .RvCoreIbexRegFile(ibex_pkg::RegFileFPGA),
     .RvCoreIbexPipeLine(1),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -26,7 +26,7 @@ module top_earlgrey #(
   // parameters for pattgen
   // parameters for rv_timer
   // parameters for usbdev
-  parameter int UsbdevRcvrWakeTimeUs = 1,
+  parameter int UsbdevRcvrWakeTimeUs = 100,
   // parameters for otp_ctrl
   parameter OtpCtrlMemInitFile = "",
   // parameters for lc_ctrl

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -26,6 +26,7 @@ module top_earlgrey #(
   // parameters for pattgen
   // parameters for rv_timer
   // parameters for usbdev
+  parameter int UsbdevRcvrWakeTimeUs = 1,
   // parameters for otp_ctrl
   parameter OtpCtrlMemInitFile = "",
   // parameters for lc_ctrl
@@ -1368,7 +1369,8 @@ module top_earlgrey #(
       .rst_ni (rstmgr_aon_resets.rst_sys_io_div4_n[rstmgr_pkg::Domain0Sel])
   );
   usbdev #(
-    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[11:11])
+    .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[11:11]),
+    .RcvrWakeTimeUs(UsbdevRcvrWakeTimeUs)
   ) u_usbdev (
 
       // Input

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -1156,6 +1156,7 @@ module chip_${top["name"]}_${target["name"]} (
     .CsrngSBoxImpl(aes_pkg::SBoxImplLut),
     .OtbnRegFile(otbn_pkg::RegFileFPGA),
     .OtpCtrlMemInitFile(OtpCtrlMemInitFile),
+    .UsbdevRcvrWakeTimeUs(10000),
 % elif target["name"] == "cw305":
     .SecAesMasking(1'b1),
     .SecAesSBoxImpl(aes_pkg::SBoxImplDom),


### PR DESCRIPTION
Add a parameter to usbdev to count time until a differential receiver
should be operational. If the device is configured to use a differential
receiver, reject detected K and J symbols for the power-on time after
enabling the receiver.

Resolves #10901 