### PR TITLE
[otbn,dv] Remove support for the model in the OTBN module

### DIFF
--- a/hw/ip/otbn/README.md
+++ b/hw/ip/otbn/README.md
@@ -99,37 +99,6 @@ hw/ip/otbn/dv/smoke/run_smoke.sh
 This will build the standalone simulation, build the smoke test binary, run it
 and check the results are as expected.
 
-### Run OT earlgrey simulation with the OTBN model, rather than the RTL design
-
-For simulation targets, the OTBN block can be built with both the RTL
-implementation and the Python-based instruction set simulator (hereafter called
-the ISS) compiled in. When running the simulation the plusarg `OTBN_USE_MODEL`
-can be used to switch between the RTL implementation and the model, without
-recompiling the simulation.
-
-The Verilator simulation of Earl Grey (`lowrisc:systems:chip_earlgrey_verilator`)
-builds the model by default when compiling the simulation and nothing else needs
-to be done. For other simulation targets, set the `OTBN_BUILD_MODEL` define,
-e.g. by passing `--OTBN_BUILD_MODEL` to fusesoc.
-
-To run the simulation against the OTBN ISS pass `+OTBN_USE_MODEL=1` to the
-simulation run, e.g.
-
-```sh
-build/lowrisc_systems_chip_earlgrey_verilator_0.1/sim-verilator/Vchip_earlgrey_verilator \
-  --meminit=rom,build-bin/sw/device/lib/testing/test_rom/test_rom_sim_verilator.scr.39.vmem \
-  --meminit=flash,build-bin/sw/device/tests/otbn_smoketest_sim_verilator.elf \
-  --meminit=otp,build-bin/sw/device/otp_img/otp_img_sim_verilator.vmem \
-  +UARTDPI_LOG_uart0=- \
-  +OTBN_USE_MODEL=1
-```
-
-The simulation communicates with the model by creating a directory in
-the temporary directory (/tmp or TMPDIR) and filling it with files.
-Normally, it cleans up after itself. If something goes wrong and you'd
-like to look at these files, set the `OTBN_MODEL_KEEP_TMP` environment
-variable to `1`.
-
 ### Run the ISS on its own
 
 There are currently two versions of the ISS and they can be found in

--- a/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/ext_regs.py
@@ -223,8 +223,8 @@ class OTBNExtRegs:
         # where they expected to finish.
         self.regs['STOP_PC'] = make_flag_reg('STOP_PC', True)
 
-        # Add a fake "RND_REQ" register to pass it through otbn_core_model
-        # when OTBN_USE_MODEL parameter is enabled in system level tests.
+        # Add a fake "RND_REQ" register to allow us to tell otbn_core_model to
+        # generate an EDN request.
         self.regs['RND_REQ'] = make_flag_reg('RND_REQ', True)
 
         # Add a fake "WIPE_START" register. We set this for a single cycle when

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -82,17 +82,6 @@ parameters:
   SYNTHESIS:
     datatype: bool
     paramtype: vlogdefine
-  OTBN_BUILD_MODEL:
-    datatype: bool
-    paramtype: vlogdefine
-    description: |
-      Build the simulation with the ISS as well as with the RTL implementation
-      (development only). Use the OTBN_USE_MODEL plusarg to switch at runtime.
-  OTBN_USE_MODEL:
-    datatype: bool
-    description: Use the OTBN model instead of the RTL implementation (development only)
-    paramtype: plusarg
-    default: false
 
 targets:
   default: &default_target
@@ -102,9 +91,6 @@ targets:
       - files_rtl_core
       - files_rtl_top
     toplevel: otbn
-    parameters:
-      - OTBN_USE_MODEL
-      - OTBN_BUILD_MODEL
 
   lint:
     <<: *default_target

--- a/hw/top_earlgrey/dv/verilator/chip_sim.core
+++ b/hw/top_earlgrey/dv/verilator/chip_sim.core
@@ -83,9 +83,6 @@ targets:
       - rominit
       - otpinit
       - DMIDirectTAP
-      # Always build OTBN with model and RTL. Switch between the two at runtime
-      # by passing "+OTBN_USE_MODEL=1" to the simulation.
-      - OTBN_BUILD_MODEL=true
       - RV_CORE_IBEX_SIM_SRAM=true
     default_tool: verilator
     filesets:

--- a/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
@@ -145,14 +145,7 @@
     {
       name: otbn_smoketest_rtl
       sw_images: ["sw/device/tests/otbn_smoketest:1"]
-      run_opts: ["+OTBN_USE_MODEL=0"]
     }
-    // TODO: Needs to be debugged.
-    // {
-    //   name: otbn_smoketest_model
-    //   sw_images: ["sw/device/tests/otbn_smoketest:1"]
-    //   run_opts: ["+OTBN_USE_MODEL=1"]
-    // }
     {
       name: otp_ctrl_smoketest
       sw_images: ["sw/device/tests/otp_ctrl_smoketest:1"]

--- a/test/systemtest/earlgrey/config.py
+++ b/test/systemtest/earlgrey/config.py
@@ -24,13 +24,6 @@ TEST_APPS_SELFCHECKING = [
     {
         "name": "otbn_smoketest_rtl",
         "binary_name": "otbn_smoketest",
-        "verilator_extra_args": ['+OTBN_USE_MODEL=0'],
-        "targets": ["sim_verilator"],
-    },
-    {
-        "name": "otbn_smoketest_model",
-        "binary_name": "otbn_smoketest",
-        "verilator_extra_args": ['+OTBN_USE_MODEL=1'],
         "targets": ["sim_verilator"],
     },
     {


### PR DESCRIPTION
This was originally put in so that we could do system-level testing of
OTBN before the implementation was complete. Since then, it has been
used once or twice for performance tests where we needed to model the
Ibex side as well. But it's really rather difficult to maintain, and
leaves a bit of "DV-ish" code in the design folder.

If we need to do something like this in future, it shouldn't be too
hard to knock together another frontend to the simulator (like
stepped.sv) and to build a testbench in Python.
