### PR TITLE
[sw,crypto] Adjust cryptolib drivers to use abs_mmio.

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -143,7 +143,6 @@ cc_library(
     name = "abs_mmio",
     srcs = ["abs_mmio.c"],
     hdrs = ["abs_mmio.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":mmio",
         ":macros",

--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -16,7 +16,7 @@ cc_library(
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
-        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/base:abs_mmio",
     ],
 )
 
@@ -28,6 +28,6 @@ cc_library(
         "//hw/ip/otbn/data:otbn_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
-        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/base:abs_mmio",
     ],
 )

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -4,22 +4,21 @@
 
 #include "sw/device/lib/crypto/drivers/hmac.h"
 
+#include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
-#include "sw/device/lib/base/mmio.h"
 
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
 void hmac_sha256_init(void) {
-  mmio_region_t hmac_base = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
-
   // Clear the config, stopping the SHA engine.
-  mmio_region_write32(hmac_base, HMAC_CFG_REG_OFFSET, 0);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, 0);
 
   // Disable and clear interrupts. INTR_STATE register is rw1c.
-  mmio_region_write32(hmac_base, HMAC_INTR_ENABLE_REG_OFFSET, 0);
-  mmio_region_write32(hmac_base, HMAC_INTR_STATE_REG_OFFSET, 0);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_ENABLE_REG_OFFSET,
+                   0);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET, 0);
 
   uint32_t reg = 0;
   // Digest is little-endian by default.
@@ -28,34 +27,36 @@ void hmac_sha256_init(void) {
   reg = bitfield_bit32_write(reg, HMAC_CFG_ENDIAN_SWAP_BIT, true);
   reg = bitfield_bit32_write(reg, HMAC_CFG_SHA_EN_BIT, true);
   reg = bitfield_bit32_write(reg, HMAC_CFG_HMAC_EN_BIT, false);
-  mmio_region_write32(hmac_base, HMAC_CFG_REG_OFFSET, reg);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CFG_REG_OFFSET, reg);
 
   reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_START_BIT, true);
-  mmio_region_write32(hmac_base, HMAC_CMD_REG_OFFSET, reg);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
 }
 
 hmac_error_t hmac_sha256_update(const void *data, size_t len) {
   if (data == NULL) {
     return kHmacErrorBadArg;
   }
-  mmio_region_t hmac_base = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
   const uint8_t *data_sent = (const uint8_t *)data;
 
   // Individual byte writes are needed if the buffer isn't word aligned.
   for (; len != 0 && (uintptr_t)data_sent & 3; --len) {
-    mmio_region_write8(hmac_base, HMAC_MSG_FIFO_REG_OFFSET, *data_sent++);
+    abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
+                    *data_sent++);
   }
 
   for (; len >= sizeof(uint32_t); len -= sizeof(uint32_t)) {
     uint32_t data_aligned = read_32(data_sent);
-    mmio_region_write32(hmac_base, HMAC_MSG_FIFO_REG_OFFSET, data_aligned);
+    abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
+                     data_aligned);
     data_sent += sizeof(uint32_t);
   }
 
   // Handle non-32bit aligned bytes at the end of the buffer.
   for (; len != 0; --len) {
-    mmio_region_write8(hmac_base, HMAC_MSG_FIFO_REG_OFFSET, *data_sent++);
+    abs_mmio_write8(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_MSG_FIFO_REG_OFFSET,
+                    *data_sent++);
   }
   return kHmacOk;
 }
@@ -68,12 +69,13 @@ hmac_error_t hmac_sha256_final(hmac_digest_t *digest) {
 
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_PROCESS_BIT, true);
-  mmio_region_write32(hmac_base, HMAC_CMD_REG_OFFSET, reg);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
 
   do {
     reg = mmio_region_read32(hmac_base, HMAC_INTR_STATE_REG_OFFSET);
   } while (!bitfield_bit32_read(reg, HMAC_INTR_STATE_HMAC_DONE_BIT));
-  mmio_region_write32(hmac_base, HMAC_INTR_STATE_REG_OFFSET, reg);
+  abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
+                   reg);
 
   // Read the digest in reverse to preserve the numerical value.
   // The least significant word is at HMAC_DIGEST_7_REG_OFFSET.

--- a/sw/device/lib/crypto/drivers/meson.build
+++ b/sw/device/lib/crypto/drivers/meson.build
@@ -11,7 +11,7 @@ sw_lib_crypto_hmac = declare_dependency(
       'hmac.c',
     ],
     dependencies: [
-      sw_lib_mmio,
+      sw_lib_abs_mmio,
       sw_lib_bitfield,
       top_earlgrey,
     ]
@@ -27,7 +27,7 @@ sw_lib_crypto_otbn = declare_dependency(
       'otbn.c',
     ],
     dependencies: [
-      sw_lib_mmio,
+      sw_lib_abs_mmio,
       sw_lib_bitfield,
       top_earlgrey,
     ]


### PR DESCRIPTION
Resolves #10249, more detail in the discussion [here](https://github.com/lowRISC/opentitan/pull/9764#discussion_r774021317)

More detail on the issue and the discussion linked there, but the gist is that I got feedback on #9764 that the cryptolib drivers should use `abs_mmio`, but it wasn't possible at the time because `abs_mmio` was in `silicon_creator`. As of #10402 and #10919 that's no longer the case, so I am now able to make the change.