### PR TITLE
[otp_ctrl] Initialize noce/key regs with RndCnst instead of all-zero

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -78,6 +78,12 @@
       randcount: "40",
       randtype:  "perm", // random permutation for randcount elements
     }
+    { name:      "RndCnstScrmblKeyInit",
+      desc:      "Compile-time random permutation for scrambling key/nonce register reset value",
+      type:      "otp_ctrl_pkg::scrmbl_key_init_t"
+      randcount: "256",
+      randtype:  "data", // random permutation for randcount elements
+    }
     // Normal parameters
     { name: "NumSramKeyReqSlots",
       desc: "Number of key slots",

--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson.tpl
@@ -91,6 +91,12 @@
       randcount: "40",
       randtype:  "perm", // random permutation for randcount elements
     }
+    { name:      "RndCnstScrmblKeyInit",
+      desc:      "Compile-time random permutation for scrambling key/nonce register reset value",
+      type:      "otp_ctrl_pkg::scrmbl_key_init_t"
+      randcount: "256",
+      randtype:  "data", // random permutation for randcount elements
+    }
     // Normal parameters
     { name: "NumSramKeyReqSlots",
       desc: "Number of key slots",

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -17,6 +17,7 @@ module otp_ctrl
   // Compile time random constants, to be overriden by topgen.
   parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
   parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault,
+  parameter scrmbl_key_init_t RndCnstScrmblKeyInit = RndCnstScrmblKeyInitDefault,
   // Hexfile file to initialize the OTP macro.
   // Note that the hexdump needs to account for ECC.
   parameter MemInitFile = ""
@@ -1020,7 +1021,9 @@ module otp_ctrl
   logic [SramKeySeedWidth-1:0] sram_data_key_seed;
   logic [FlashKeySeedWidth-1:0] flash_data_key_seed, flash_addr_key_seed;
 
-  otp_ctrl_kdi u_otp_ctrl_kdi (
+  otp_ctrl_kdi #(
+    .RndCnstScrmblKeyInit(RndCnstScrmblKeyInit)
+  ) u_otp_ctrl_kdi (
     .clk_i,
     .rst_ni,
     .kdi_en_i                ( pwr_otp_o.otp_done      ),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_pkg.sv
@@ -191,6 +191,16 @@ package otp_ctrl_pkg;
   typedef logic [OtbnKeyWidth-1:0]   otbn_key_t;
   typedef logic [OtbnNonceWidth-1:0] otbn_nonce_t;
 
+  localparam int OtbnNonceSel  = OtbnNonceWidth / ScrmblBlockWidth;
+  localparam int FlashNonceSel = FlashKeyWidth / ScrmblBlockWidth;
+  localparam int SramNonceSel  = SramNonceWidth / ScrmblBlockWidth;
+
+  // Get maximum nonce width
+  localparam int NumNonceChunks =
+    (OtbnNonceWidth > FlashKeyWidth) ?
+    ((OtbnNonceWidth > SramNonceSel) ? OtbnNonceSel : SramNonceSel) :
+    ((FlashKeyWidth > SramNonceSel)  ? FlashNonceSel  : SramNonceSel);
+
   typedef struct packed {
     logic valid;
     logic [KeyMgrKeyWidth-1:0] key_share0;
@@ -296,5 +306,12 @@ package otp_ctrl_pkg;
   localparam lfsr_seed_t RndCnstLfsrSeedDefault = 40'h453d28ea98;
   localparam lfsr_perm_t RndCnstLfsrPermDefault =
       240'h4235171482c225f79289b32181a0163a760355d3447063d16661e44c12a5;
+
+  typedef struct packed {
+    sram_key_t   key;
+    sram_nonce_t nonce;
+  } scrmbl_key_init_t;
+  localparam scrmbl_key_init_t RndCnstScrmblKeyInitDefault =
+      256'hcebeb96ffe0eced795f8b2cfe23c1e519e4fa08047a6bcfb811b04f0a479006e;
 
 endpackage : otp_ctrl_pkg

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1446,6 +1446,16 @@
           default: 0x5d294061e29a7c404f4593035a19097666e37072064153623855022d39e0
           randwidth: 240
         }
+        {
+          name: RndCnstScrmblKeyInit
+          desc: Compile-time random permutation for scrambling key/nonce register reset value
+          type: otp_ctrl_pkg::scrmbl_key_init_t
+          randcount: 256
+          randtype: data
+          name_top: RndCnstOtpCtrlScrmblKeyInit
+          default: 0x6faf88f22bccd612d1c09f5c02b2c8d1fdb92558e2d9c5d24440722325a93144
+          randwidth: 256
+        }
       ]
       inter_signal_list:
       [
@@ -1788,7 +1798,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivInvalid
-          default: 0xfdb92558e2d9c5d24440722325a93144
+          default: 0x79ee911ce801484ba8373086f9dd4eee
           randwidth: 128
         }
         {
@@ -1798,7 +1808,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivTestDevRma
-          default: 0x6faf88f22bccd612d1c09f5c02b2c8d1
+          default: 0x3a0b091dc41d062dd10ca2d7b93136f
           randwidth: 128
         }
         {
@@ -1808,7 +1818,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstLcCtrlLcKeymgrDivProduction
-          default: 0x79ee911ce801484ba8373086f9dd4eee
+          default: 0xee2a465fd4dabcbd877afb6bcfeed7e
           randwidth: 128
         }
         {
@@ -1818,7 +1828,7 @@
           randcount: 1024
           randtype: data
           name_top: RndCnstLcCtrlInvalidTokens
-          default: 0xe0f7489a309cbe57b77f07ff3d7297200d5ab25561af49c696466a983e5346826a43628219e5a91389b9fe0d3b818e46ce7d846469a3b8e35a6bd38295bd2fb366b3d62126c75eeaeb93d32f5cbc77463c91917516d51a2fa4400adc2669e2530ee2a465fd4dabcbd877afb6bcfeed7e03a0b091dc41d062dd10ca2d7b93136f
+          default: 0x699679edd5369f11b49bac9198bd1ff344c5da2242d290bede094ca8f1435f85e0f7489a309cbe57b77f07ff3d7297200d5ab25561af49c696466a983e5346826a43628219e5a91389b9fe0d3b818e46ce7d846469a3b8e35a6bd38295bd2fb366b3d62126c75eeaeb93d32f5cbc77463c91917516d51a2fa4400adc2669e253
           randwidth: 1024
         }
       ]
@@ -2278,7 +2288,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstAlertHandlerLfsrSeed
-          default: 0xf1435f85
+          default: 0xe10023ec
           randwidth: 32
         }
         {
@@ -2288,7 +2298,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstAlertHandlerLfsrPerm
-          default: 0x8a9e933b2126cbfc2e87af8121b39db89bab4d10
+          default: 0x74449a374b5678ffc0a1c18fb47bb50486cb4ee4
           randwidth: 160
         }
       ]
@@ -4183,7 +4193,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramKey
-          default: 0x3af5fa0aaf8c6a6b90f868a3f2590e4a
+          default: 0x3635d1f47c8f05affc85f7d889ecd94b
           randwidth: 128
         }
         {
@@ -4193,7 +4203,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstSramCtrlRetAonSramNonce
-          default: 0x67eb674bbdf38d62d362249384b1a5a6
+          default: 0xc87b69111a24d5e4442bcfb7032949cc
           randwidth: 128
         }
         {
@@ -4203,7 +4213,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstSramCtrlRetAonLfsrSeed
-          default: 0x89ecd94b
+          default: 0x48bae844
           randwidth: 32
         }
         {
@@ -4213,7 +4223,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstSramCtrlRetAonLfsrPerm
-          default: 0x3d96ced1f5b89d2e422a2b71b9fb440a723400df
+          default: 0x46b0e5d9f9e80fcf3212fc76a2b6a11d2f332482
           randwidth: 160
         }
         {
@@ -4390,7 +4400,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlAddrKey
-          default: 0x8440934dcb834f93689fe9e88ebd5340
+          default: 0xaf06b42350bb6b68440934dcb834f93
           randwidth: 128
         }
         {
@@ -4400,7 +4410,7 @@
           randcount: 128
           randtype: data
           name_top: RndCnstFlashCtrlDataKey
-          default: 0x192aadbb7c918acb0af06b42350bb6b6
+          default: 0xed204633871cb178192aadbb7c918acb
           randwidth: 128
         }
         {
@@ -4410,7 +4420,7 @@
           randcount: 32
           randtype: data
           name_top: RndCnstFlashCtrlLfsrSeed
-          default: 0x871cb178
+          default: 0x33a4ac96
           randwidth: 32
         }
         {
@@ -4420,7 +4430,7 @@
           randcount: 32
           randtype: perm
           name_top: RndCnstFlashCtrlLfsrPerm
-          default: 0x3580d1897f7cb7dc51419f8b7d5630e65c441d2c
+          default: 0x3480d1896c7ff9ed5941bd125c6eb18772e220f3
           randwidth: 160
         }
       ]

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -1439,7 +1439,8 @@ module top_earlgrey #(
     .AlertAsyncOn(alert_handler_reg_pkg::AsyncOn[14:12]),
     .MemInitFile(OtpCtrlMemInitFile),
     .RndCnstLfsrSeed(RndCnstOtpCtrlLfsrSeed),
-    .RndCnstLfsrPerm(RndCnstOtpCtrlLfsrPerm)
+    .RndCnstLfsrPerm(RndCnstOtpCtrlLfsrPerm),
+    .RndCnstScrmblKeyInit(RndCnstOtpCtrlScrmblKeyInit)
   ) u_otp_ctrl (
 
       // Output

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
@@ -25,30 +25,35 @@ package top_earlgrey_rnd_cnst_pkg;
     240'h5D294061E29A7C404F4593035A19097666E37072064153623855022D39E0
   };
 
+  // Compile-time random permutation for scrambling key/nonce register reset value
+  parameter otp_ctrl_pkg::scrmbl_key_init_t RndCnstOtpCtrlScrmblKeyInit = {
+    256'h6FAF88F22BCCD612D1C09F5C02B2C8D1FDB92558E2D9C5D24440722325A93144
+  };
+
   ////////////////////////////////////////////
   // lc_ctrl
   ////////////////////////////////////////////
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivInvalid = {
-    128'hFDB92558E2D9C5D24440722325A93144
+    128'h79EE911CE801484BA8373086F9DD4EEE
   };
 
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivTestDevRma = {
-    128'h6FAF88F22BCCD612D1C09F5C02B2C8D1
+    128'h03A0B091DC41D062DD10CA2D7B93136F
   };
 
   // Compile-time random bits for lc state group diversification value
   parameter lc_ctrl_pkg::lc_keymgr_div_t RndCnstLcCtrlLcKeymgrDivProduction = {
-    128'h79EE911CE801484BA8373086F9DD4EEE
+    128'h0EE2A465FD4DABCBD877AFB6BCFEED7E
   };
 
   // Compile-time random bits used for invalid tokens in the token mux
   parameter lc_ctrl_pkg::lc_token_mux_t RndCnstLcCtrlInvalidTokens = {
+    256'h699679EDD5369F11B49BAC9198BD1FF344C5DA2242D290BEDE094CA8F1435F85,
     256'hE0F7489A309CBE57B77F07FF3D7297200D5AB25561AF49C696466A983E534682,
     256'h6A43628219E5A91389B9FE0D3B818E46CE7D846469A3B8E35A6BD38295BD2FB3,
-    256'h66B3D62126C75EEAEB93D32F5CBC77463C91917516D51A2FA4400ADC2669E253,
-    256'h0EE2A465FD4DABCBD877AFB6BCFEED7E03A0B091DC41D062DD10CA2D7B93136F
+    256'h66B3D62126C75EEAEB93D32F5CBC77463C91917516D51A2FA4400ADC2669E253
   };
 
   ////////////////////////////////////////////
@@ -56,12 +61,12 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for initial LFSR seed
   parameter alert_pkg::lfsr_seed_t RndCnstAlertHandlerLfsrSeed = {
-    32'hF1435F85
+    32'hE10023EC
   };
 
   // Compile-time random permutation for LFSR output
   parameter alert_pkg::lfsr_perm_t RndCnstAlertHandlerLfsrPerm = {
-    160'h8A9E933B2126CBFC2E87AF8121B39DB89BAB4D10
+    160'h74449A374B5678FFC0A1C18FB47BB50486CB4EE4
   };
 
   ////////////////////////////////////////////
@@ -69,22 +74,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random reset value for SRAM scrambling key.
   parameter otp_ctrl_pkg::sram_key_t RndCnstSramCtrlRetAonSramKey = {
-    128'h3AF5FA0AAF8C6A6B90F868A3F2590E4A
+    128'h3635D1F47C8F05AFFC85F7D889ECD94B
   };
 
   // Compile-time random reset value for SRAM scrambling nonce.
   parameter otp_ctrl_pkg::sram_nonce_t RndCnstSramCtrlRetAonSramNonce = {
-    128'h67EB674BBDF38D62D362249384B1A5A6
+    128'hC87B69111A24D5E4442BCFB7032949CC
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter sram_ctrl_pkg::lfsr_seed_t RndCnstSramCtrlRetAonLfsrSeed = {
-    32'h89ECD94B
+    32'h48BAE844
   };
 
   // Compile-time random permutation for LFSR output
   parameter sram_ctrl_pkg::lfsr_perm_t RndCnstSramCtrlRetAonLfsrPerm = {
-    160'h3D96CED1F5B89D2E422A2B71B9FB440A723400DF
+    160'h46B0E5D9F9E80FCF3212FC76A2B6A11D2F332482
   };
 
   ////////////////////////////////////////////
@@ -92,22 +97,22 @@ package top_earlgrey_rnd_cnst_pkg;
   ////////////////////////////////////////////
   // Compile-time random bits for default address key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlAddrKey = {
-    128'h8440934DCB834F93689FE9E88EBD5340
+    128'h0AF06B42350BB6B68440934DCB834F93
   };
 
   // Compile-time random bits for default data key
   parameter flash_ctrl_pkg::flash_key_t RndCnstFlashCtrlDataKey = {
-    128'h192AADBB7C918ACB0AF06B42350BB6B6
+    128'hED204633871CB178192AADBB7C918ACB
   };
 
   // Compile-time random bits for initial LFSR seed
   parameter flash_ctrl_pkg::lfsr_seed_t RndCnstFlashCtrlLfsrSeed = {
-    32'h871CB178
+    32'h33A4AC96
   };
 
   // Compile-time random permutation for LFSR output
   parameter flash_ctrl_pkg::lfsr_perm_t RndCnstFlashCtrlLfsrPerm = {
-    160'h3580D1897F7CB7DC51419F8B7D5630E65C441D2C
+    160'h3480D1896C7FF9ED5941BD125C6EB18772E220F3
   };
 
   ////////////////////////////////////////////


### PR DESCRIPTION
This improvement has been identified in the OTBN D2S review #11019 and essentially changes the reset value of the nonce/key output registers in `otp_ctrl_kdi` to a `RndCnst` instead of resetting this to all zero.
The motivation is to make sure that the data on the scrambling key request interface never has an all-zero value.

@cindychip does this significantly alter the coverage? It is not a functional feature that needs to be tested I believe.

Signed-off-by: Michael Schaffner <msf@opentitan.org>