### PR TITLE
[entropy_src/dif] Disable flaky smoke test

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.prj.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.prj.hjson
@@ -12,5 +12,5 @@
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V1",
-    dif_stage:          "S1",
+    dif_stage:          "S0",
 }

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2669,7 +2669,8 @@
               "chip_sw_clkmgr_smoketest",
               // TODO(lowrisc/opentitan#7505): Debug CSRNG generate bits mismatch.
               // "chip_sw_csrng_smoketest",
-              "chip_sw_entropy_src_smoketest",
+              // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
+              // "chip_sw_entropy_src_smoketest",
               "chip_sw_gpio_smoketest",
               "chip_sw_hmac_smoketest",
               "chip_sw_kmac_smoketest",

--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -32,6 +32,7 @@
     //  sw_images: ["sw/device/tests/csrng_smoketest:1"]
     //  en_run_modes: ["sw_test_mode_test_rom"]
     // }
+    // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
     {
       name: chip_sw_entropy_src_smoketest
       uvm_test_seq: chip_sw_base_vseq
@@ -118,6 +119,7 @@
               "chip_sw_clkmgr_smoketest",
               // TODO(lowrisc/opentitan#7505): Debug CSRNG generate bits mismatch.
               // "chip_sw_csrng_smoketest",
+              // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
               "chip_sw_entropy_src_smoketest",
               "chip_sw_gpio_smoketest",
               "chip_sw_hmac_smoketest",

--- a/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/verilator/verilator_sim_cfg.hjson
@@ -114,6 +114,7 @@
     //  name: csrng_smoketest
     //  sw_images: ["sw/device/tests/csrng_smoketest:1"]
     // }
+    // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
     {
       name: entropy_src_smoketest
       sw_images: ["sw/device/tests/entropy_src_smoketest:1"]

--- a/sw/device/lib/dif/dif_entropy_src.md
+++ b/sw/device/lib/dif/dif_entropy_src.md
@@ -13,7 +13,7 @@ Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Done        |
-Tests          | [DIF_TEST_SMOKE][]   | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | In Progress |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}

--- a/test/systemtest/earlgrey/config.py
+++ b/test/systemtest/earlgrey/config.py
@@ -98,10 +98,12 @@ TEST_APPS_SELFCHECKING = [
     #    "name": "csrng_smoketest",
     #   "targets": ["sim_verilator", "fpga_cw310"],
     # },
-    {
-        "name": "entropy_src_smoketest",
-        "targets": ["sim_verilator", "fpga_cw310"],
-    },
+    # TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled
+    # environment.
+    # {
+    #     "name": "entropy_src_smoketest",
+    #     "targets": ["sim_verilator", "fpga_cw310"],
+    # },
     {
         "name": "kmac_smoketest",
         "targets": ["sim_verilator", "fpga_cw310"],


### PR DESCRIPTION
entropy_src_smoketest performs an invalid check against a hard-coded
constant. It reads the data from entropy_src, but it does not control
the environment that generates that data. Consequently, various factors
can cause CI to break from this test spuriously failing.

Disable the test and downgrade the DIF to S0 until a replacement
strategy is implemented.

Signed-off-by: Alexander Williams <awill@google.com>