### PR TITLE
[tlul] adjust tlul_sram_byte enable condition

### DIFF
--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -160,7 +160,7 @@ module tlul_adapter_sram
 
   // byte handling for integrity
   tlul_sram_byte #(
-    .EnableIntg(ByteAccess & CmdIntgCheck & !ErrOnWrite),
+    .EnableIntg(ByteAccess & EnableDataIntgPt & !ErrOnWrite),
     .Outstanding(Outstanding)
   ) u_sram_byte (
     .clk_i,


### PR DESCRIPTION
Previously, the tlul_sram_byte module was enabled whenever an adapter sram
allowed both byte access and checked for integrity.

This is not the correct enable condition. The tlul_sram_byte is meant to
generate correct integrity when the downstream memory actually stores
full word integrity and requires a read modified write for byte accesses.

If a module simply checks for integrity, it does not say anything about
whether the downstream module stores integrity and whether byte writes require
a read modified write.

Instead, change the condition to byte access AND data integrity passthrough are
enabled. Data integrity passthrough implies the downstream memory will make use of
extra integrity in some way and thus requires correct read modified write handling
on byte accesses.

Signed-off-by: Timothy Chen <timothytim@google.com>