### PR TITLE
[otbn,dv] (Almost) get OTBN tests working with Xcelium

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -199,7 +199,9 @@ module otbn_core_model
     end
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
+  // Note: This can't be an always_ff block because we write to model_state here and also in an
+  // initial block (see declaration of the variable above)
+  always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       otbn_model_reset(model_handle);
       model_state <= 0;

--- a/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_loop_if.sv
@@ -111,7 +111,7 @@ interface otbn_loop_if (
       lengths.delete();
     end else begin
       if (current_loop_finish && lengths.size()) begin
-        lengths.pop_front();
+        void'(lengths.pop_front());
       end
       if (loop_start_req_i && loop_start_commit_i) begin
         lengths.push_front(loop_iterations_i);

--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -539,8 +539,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
   endtask
 
   // Overridden from cip_base_scoreboard. Called when an alert happens.
-  protected function void on_alert(string alert_name,
-                                   alert_esc_agent_pkg::alert_esc_seq_item item);
+  function void on_alert(string alert_name, alert_esc_agent_pkg::alert_esc_seq_item item);
 
     `uvm_info(`gfn, $sformatf("on_alert(%0s)", alert_name), UVM_HIGH)
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -67,36 +67,42 @@ class otbn_common_vseq extends otbn_base_vseq;
 
   virtual function void inject_intg_fault_in_passthru_mem(dv_base_mem mem,
                                                           bit [bus_params_pkg::BUS_AW-1:0] addr);
-    bit [38:0]       rdata_imem;
-    bit [311:0]      rdata_dmem;
-    bit [38:0]       flip_bits_imem;
-    bit [311:0]      flip_bits_dmem;
-    bit [38:0]       flip_bits_dmem_arr [8];
+    logic [127:0] key;
+    logic [63:0]  nonce;
+    bit [38:0]    flip_bits;
 
-    logic [127:0]    key;
-    logic [63:0]     nonce;
+    `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(
+        flip_bits,
+        $countones(flip_bits) inside {[1:cip_base_pkg::MAX_TL_ECC_ERRORS]};)
 
     if(mem.get_name() == "imem") begin
+      bit [38:0] rdata;
+
       key   = cfg.get_imem_key();
       nonce = cfg.get_imem_nonce();
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bits_imem,
-          $countones(flip_bits_imem) inside {[1:cip_base_pkg::MAX_TL_ECC_ERRORS]};)
-      rdata_imem = cfg.read_imem_word(addr / 4, key, nonce);
-      `uvm_info(`gfn, $sformatf("Backdoor change mem (addr 0x%0h) value 0x%0h by flipping bits %0h",
-                              addr, rdata_imem, flip_bits_imem), UVM_LOW)
-      cfg.write_imem_word(addr / 4, rdata_imem, key, nonce, flip_bits_imem);
+      rdata = cfg.read_imem_word(addr / 4, key, nonce);
+      `uvm_info(`gfn,
+                $sformatf("Backdoor change IMEM (addr 0x%0h) value 0x%0h by flipping bits %0h",
+                          addr, rdata, flip_bits),
+                UVM_LOW)
+      cfg.write_imem_word(addr / 4, rdata, key, nonce, flip_bits);
     end
     else begin
+      bit [311:0] rdata;
+      bit [311:0] rep_flip_bits;
+
+      rep_flip_bits = {8{flip_bits}};
+
       key   = cfg.get_dmem_key();
       nonce = cfg.get_dmem_nonce();
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(flip_bits_dmem_arr[addr[7:0] / 4],
-          $countones(flip_bits_dmem_arr[addr[7:0] / 4])
-          inside {[1:cip_base_pkg::MAX_TL_ECC_ERRORS]};)
-      flip_bits_dmem = {<<{flip_bits_dmem_arr}};
-      rdata_dmem = cfg.read_dmem_word(addr / 32, key, nonce);
-      `uvm_info(`gfn, $sformatf("Backdoor change mem (addr 0x%0h) value 0x%0h by flipping bits %0h",
-                                addr, rdata_dmem, flip_bits_dmem), UVM_LOW)
-      cfg.write_dmem_word(addr / 32, rdata_dmem, key, nonce, flip_bits_dmem);
+      rdata = cfg.read_dmem_word(addr / 32, key, nonce);
+
+      `uvm_info(`gfn,
+                $sformatf("Backdoor change DMEM (addr 0x%0h) value 0x%0h by flipping bits %0h",
+                          addr, rdata, rep_flip_bits),
+                UVM_LOW)
+
+      cfg.write_dmem_word(addr / 32, rdata, key, nonce, flip_bits);
     end
 
   endfunction

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -39,14 +39,6 @@ interface otbn_model_if
     end
   endtask
 
-  // Start model by setting start for a cycle. Waits until not in reset.
-  task automatic start_model();
-    wait(rst_ni);
-    start = 1'b1;
-    @(posedge clk_i or negedge rst_ni);
-    start = 1'b0;
-  endtask
-
   // Mark the entirety of IMEM as invalid
   //
   // Call this on a negedge of clk_i to ensure sequencing with the otbn_model_step on the following

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -150,7 +150,7 @@ module otbn
     .clk_i,
     .rst_ni,
     .lc_en_i(lc_escalate_en_i),
-    .lc_en_o(lc_escalate_en)
+    .lc_en_o({lc_escalate_en})
   );
 
   // Reduce the life cycle escalation signal to a single bit to be used within this cycle.


### PR DESCRIPTION
The "almost" in the title is because the approach we're using for getting scrambling keys/nonces over DPI won't work with the runtime ELF loading approach that Xcelium uses, but I'll handle that in a separate PR.

Other than that, this commit should get everything working properly with Xcelium as well as VCS.