### PR TITLE
[clkmgr] Exclude jitter enable from csr tests

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -244,6 +244,9 @@
           resval: false
         }
       ]
+      // avoid writing random values to this register as it could trigger transient checks
+      // in mubi sync
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "JITTER_REGWEN",
@@ -279,6 +282,9 @@
             while all other values enable jittery clock.
           ''',
           resval: false
+          // avoid writing random values to this register as it could trigger transient checks
+          // in mubi sync
+          tags: ["excl:CsrAllTests:CsrExclWrite"]
         }
       ]
     },

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -242,6 +242,9 @@
           resval: false
         }
       ]
+      // avoid writing random values to this register as it could trigger transient checks
+      // in mubi sync
+      tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
     { name: "JITTER_REGWEN",
@@ -277,6 +280,9 @@
             while all other values enable jittery clock.
           ''',
           resval: false
+          // avoid writing random values to this register as it could trigger transient checks
+          // in mubi sync
+          tags: ["excl:CsrAllTests:CsrExclWrite"]
         }
       ]
     },


### PR DESCRIPTION
- If jitter enable is written with a random value, it may cause a prim_mubi4_sync failures.

- This is because the prim_mubi4_sync expect any non-false/true values are a one cycle transient.  A write to a different value clearly violates this and will need to be excluded.

Signed-off-by: Timothy Chen <timothytim@google.com>