### PR TITLE
[pinmux] Reset wakeup counter upon reconfiguration

### DIFF
--- a/hw/ip/pinmux/data/pinmux.hjson.tpl
+++ b/hw/ip/pinmux/data/pinmux.hjson.tpl
@@ -775,6 +775,9 @@
                                 Note that these registers are synced to the always-on clock.
                                 The first write access always completes immediately.
                                 However, read/write accesses following a write will block until that write has completed.
+
+                                Note that the wkup detector should be disabled by setting !!WKUP_DETECTOR_EN_0 before changing the detection mode.
+                                The reason for that is that the pulse width counter is NOT cleared upon a mode change while the detector is enabled.
                                 '''
                   count:        "NWkupDetect",
                   compact:      "false",
@@ -788,7 +791,7 @@
                     { bits: "2:0",
                       name: "MODE",
                       resval: 0,
-                      desc: "Wakeup detection mode."
+                      desc: "Wakeup detection mode. Out of range values default to Posedge."
                       enum: [
                         { value: "0",
                           name: "Posedge",

--- a/hw/ip/pinmux/doc/_index.md
+++ b/hw/ip/pinmux/doc/_index.md
@@ -184,6 +184,9 @@ This means that the input signal needs to remain stable for at least one AON clo
 
 If a pattern is detected, the wakeup detector will send a wakeup request to the power manager, and the cause bit corresponding to that detector will be set in the {{< regref "WKUP_CAUSE" >}} register.
 
+Note that the wkup detector should be disabled by setting {{< regref "WKUP_DETECTOR_EN_0" >}} before changing the detection mode.
+The reason for that is that the pulse width counter is NOT cleared upon a mode change while the detector is enabled.
+
 ## Strap Sampling and TAP Isolation
 
 The `pinmux` contains a set of dedicated HW "straps", which are essentially signals that are multiplexed onto fixed MIO pad locations.

--- a/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
+++ b/hw/top_earlgrey/ip/pinmux/data/autogen/pinmux.hjson
@@ -771,6 +771,9 @@
                                 Note that these registers are synced to the always-on clock.
                                 The first write access always completes immediately.
                                 However, read/write accesses following a write will block until that write has completed.
+
+                                Note that the wkup detector should be disabled by setting !!WKUP_DETECTOR_EN_0 before changing the detection mode.
+                                The reason for that is that the pulse width counter is NOT cleared upon a mode change while the detector is enabled.
                                 '''
                   count:        "NWkupDetect",
                   compact:      "false",
@@ -784,7 +787,7 @@
                     { bits: "2:0",
                       name: "MODE",
                       resval: 0,
-                      desc: "Wakeup detection mode."
+                      desc: "Wakeup detection mode. Out of range values default to Posedge."
                       enum: [
                         { value: "0",
                           name: "Posedge",


### PR DESCRIPTION
Addresses #11194.

The other way we could deal with this would be to document that SW needs to disable the wkup detector first, before changing modes.

That would save us the extra 2-3 flops per wakeup detector.

LMKWYT