### PR TITLE
[usbdev] Move pinflip and dp_o/dn_o to usb_fs_nb_pe

### DIFF
--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_nb_pe.sv
@@ -32,6 +32,8 @@ module usb_fs_nb_pe #(
 
   input  logic                   cfg_eop_single_bit_i, // 1: detect a single SE0 bit as EOP
   input  logic                   cfg_use_diff_rcvr_i, // 1: use usb_d_i from a differential receiver
+  input  logic                   cfg_pinflip_i, // 1: USB-side D+ and D- pins are flipped.
+                                                // Change values in logic to accommodate.
   input  logic                   tx_osc_test_mode_i, // Oscillator test mode (constantly output JK)
   input  logic [NumOutEps-1:0]   data_toggle_clear_i, // Clear the data toggles for an EP
   input  logic                   diff_rx_ok_i, // 1: received differential data symbols are valid.
@@ -100,6 +102,8 @@ module usb_fs_nb_pe #(
   ///////////////////////////////////////
   output logic                   usb_d_o,
   output logic                   usb_se0_o,
+  output logic                   usb_dp_o,
+  output logic                   usb_dn_o,
   output logic                   usb_oe_o
 );
 
@@ -238,6 +242,7 @@ module usb_fs_nb_pe #(
     .link_reset_i           (link_reset_i),
     .cfg_eop_single_bit_i   (cfg_eop_single_bit_i),
     .cfg_use_diff_rcvr_i    (cfg_use_diff_rcvr_i),
+    .cfg_pinflip_i          (cfg_pinflip_i),
     .diff_rx_ok_i           (diff_rx_ok_i),
     .usb_d_i                (usb_d_i),
     .usb_dp_i               (usb_dp_i),
@@ -278,10 +283,13 @@ module usb_fs_nb_pe #(
     .clk_i                  (clk_48mhz_i),
     .rst_ni                 (rst_ni),
     .link_reset_i           (link_reset_i),
+    .cfg_pinflip_i          (cfg_pinflip_i),
     .tx_osc_test_mode_i     (tx_osc_test_mode_i),
     .bit_strobe_i           (bit_strobe),
     .usb_d_o                (usb_d_o),
     .usb_se0_o              (usb_se0_o),
+    .usb_dp_o               (usb_dp_o),
+    .usb_dn_o               (usb_dn_o),
     .usb_oe_o               (usb_oe),
     .pkt_start_i            (tx_pkt_start),
     .pkt_end_o              (tx_pkt_end),

--- a/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
+++ b/hw/ip/usb_fs_nb_pe/rtl/usb_fs_rx.sv
@@ -13,6 +13,7 @@ module usb_fs_rx (
   // configuration
   input  logic cfg_eop_single_bit_i,
   input  logic cfg_use_diff_rcvr_i,
+  input  logic cfg_pinflip_i,
   input  logic diff_rx_ok_i,
 
   // USB data+ and data- lines (synchronous)
@@ -63,7 +64,11 @@ module usb_fs_rx (
   //////////////////////
   // usb receive path //
   //////////////////////
-
+  // Adjust inputs when D+/D- are flipped on the USB side
+  logic usb_dp_flipped, usb_dn_flipped, usb_d_flipped;
+  assign usb_dp_flipped = usb_dp_i ^ cfg_pinflip_i;
+  assign usb_dn_flipped = usb_dn_i ^ cfg_pinflip_i;
+  assign usb_d_flipped = usb_d_i ^ cfg_pinflip_i;
 
   ///////////////////////////////////////
   // line state recovery state machine //
@@ -117,8 +122,8 @@ module usb_fs_rx (
       dpair = DJ[1:0]; // J
       ddiff = DJ[1:0]; // J
     end else begin
-      dpair = {usb_dp_i, usb_dn_i};
-      ddiff = usb_d_i ? DJ[1:0] : DK[1:0]; // equiv to {usb_d_i, ~usb_d_i}
+      dpair = {usb_dp_flipped, usb_dn_flipped};
+      ddiff = usb_d_flipped ? DJ[1:0] : DK[1:0]; // equiv to {usb_d_i, ~usb_d_i}
     end
   end
 

--- a/hw/ip/usbdev/data/usbdev.hjson
+++ b/hw/ip/usbdev/data/usbdev.hjson
@@ -859,8 +859,8 @@
         }
         {
           bits: "5",
-          name: "tx_use_d_se0_o",
-          desc: "USB TX mode, intended to enable a variety of transceivers. 0: use dp/dn interface, 1: use d/se0 interface"
+          name: "rx_enable_o",
+          desc: "Enable differential receiver."
         }
         {
           bits: "6",

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -174,12 +174,16 @@ module usbdev
   /////////////////////////////////
   logic usb_tx_d;
   logic usb_tx_se0;
+  logic usb_tx_dp;
+  logic usb_tx_dn;
   logic usb_tx_oe;
   /////////////////////////////////
   // USB contol pins after CDC   //
   /////////////////////////////////
   logic usb_pwr_sense;
   logic usb_pullup_en;
+  logic usb_dp_pullup_en;
+  logic usb_dn_pullup_en;
 
   //////////////////////////////////
   // Microsecond timing reference //
@@ -561,6 +565,10 @@ module usbdev
   ////////////////////////////////////////////////////////
   // USB interface -- everything is in USB clock domain //
   ////////////////////////////////////////////////////////
+  wire cfg_pinflip = reg2hw.phy_config.pinflip.q; // cdc ok: quasi-static
+  assign usb_dp_pullup_en = cfg_pinflip ? 1'b0 : usb_pullup_en;
+  assign usb_dn_pullup_en = !cfg_pinflip ? 1'b0 : usb_pullup_en;
+
 
   usbdev_usbif #(
     .NEndpoints     (NEndpoints),
@@ -580,6 +588,8 @@ module usbdev
     .usb_oe_o             (usb_tx_oe),
     .usb_d_o              (usb_tx_d),
     .usb_se0_o            (usb_tx_se0),
+    .usb_dp_o             (usb_tx_dp),
+    .usb_dn_o             (usb_tx_dn),
     .usb_sense_i          (usb_pwr_sense),
     .usb_pullup_en_o      (usb_pullup_en),
 
@@ -630,7 +640,8 @@ module usbdev
     .diff_rx_ok_i         (usb_diff_rx_ok),
     .cfg_eop_single_bit_i (reg2hw.phy_config.eop_single_bit.q), // cdc ok: quasi-static
     .tx_osc_test_mode_i   (reg2hw.phy_config.tx_osc_test_mode.q), // cdc ok: quasi-static
-    .cfg_use_diff_rcvr_i  (reg2hw.phy_config.use_diff_rcvr.q), // cdc ok: quasi-static
+    .cfg_use_diff_rcvr_i  (usb_rx_enable_o),
+    .cfg_pinflip_i        (cfg_pinflip),
     .data_toggle_clear_i  (usb_data_toggle_clear),
     .resume_link_active_i (usb_resume_link_active),
 
@@ -1068,7 +1079,11 @@ module usbdev
   /////////////////////////////////
   // USB IO Muxing               //
   /////////////////////////////////
-  assign cio_usb_dn_en_o = cio_usb_dp_en_o;
+  logic cio_usb_oe;
+  logic usb_rx_enable;
+  assign cio_usb_dp_en_o = cio_usb_oe;
+  assign cio_usb_dn_en_o = cio_usb_oe;
+  assign usb_tx_use_d_se0_o = reg2hw.phy_config.tx_use_d_se0.q; // cdc ok: quasi-static
 
   usbdev_iomux i_usbdev_iomux (
     .clk_i                  (clk_i),
@@ -1079,7 +1094,6 @@ module usbdev
     // Register interface
     .sys_hw2reg_sense_o     (hw2reg.phy_pins_sense),
     .sys_reg2hw_drive_i     (reg2hw.phy_pins_drive),
-    .sys_reg2hw_config_i    (reg2hw.phy_config),
     .sys_usb_sense_o        (hw2reg.usbstat.sense.d),
 
     // Chip IO
@@ -1090,12 +1104,12 @@ module usbdev
     .usb_tx_se0_o           (usb_tx_se0_o),
     .usb_tx_dp_o            (cio_usb_dp_o),
     .usb_tx_dn_o            (cio_usb_dn_o),
-    .usb_tx_oe_o            (cio_usb_dp_en_o),
-    .usb_tx_use_d_se0_o     (usb_tx_use_d_se0_o),
+    .usb_tx_oe_o            (cio_usb_oe),
     .cio_usb_sense_i        (cio_sense_i),
     .usb_dp_pullup_en_o     (usb_dp_pullup_o),
     .usb_dn_pullup_en_o     (usb_dn_pullup_o),
     .usb_suspend_o          (usb_suspend_o),
+    .usb_rx_enable_o        (usb_rx_enable_o),
 
     // Internal interface
     .usb_rx_d_o             (usb_rx_d),
@@ -1103,10 +1117,14 @@ module usbdev
     .usb_rx_dn_o            (usb_rx_dn),
     .usb_tx_d_i             (usb_tx_d),
     .usb_tx_se0_i           (usb_tx_se0),
+    .usb_tx_dp_i            (usb_tx_dp),
+    .usb_tx_dn_i            (usb_tx_dn),
     .usb_tx_oe_i            (usb_tx_oe),
     .usb_pwr_sense_o        (usb_pwr_sense),
-    .usb_pullup_en_i        (usb_pullup_en),
-    .usb_suspend_i          (usb_event_link_suspend)
+    .usb_dp_pullup_en_i     (usb_dp_pullup_en),
+    .usb_dn_pullup_en_i     (usb_dn_pullup_en),
+    .usb_suspend_i          (usb_event_link_suspend),
+    .usb_rx_enable_i        (usb_rx_enable)
   );
 
   // Differential receiver enable
@@ -1119,8 +1137,8 @@ module usbdev
     .q_o    (usb_use_diff_rcvr)
   );
   // enable rx only when the single-ended input is enabled and the device is
-  // not suspended.
-  assign usb_rx_enable_o = usb_use_diff_rcvr & ~usb_suspend_o;
+  // not suspended (unless it is forced on in the I/O mux).
+  assign usb_rx_enable = usb_use_diff_rcvr & ~usb_suspend_o;
 
   // Symbols from the differential receiver are invalid until it has finished
   // waking up / powering on

--- a/hw/ip/usbdev/rtl/usbdev_iomux.sv
+++ b/hw/ip/usbdev/rtl/usbdev_iomux.sv
@@ -5,9 +5,8 @@
 //
 // USB IO Mux
 //
-// Muxes the USB IO signals from register access, differential signaling, single-ended signaling
-// and swaps D+/D- if configured. The incomming signals are also muxed and synchronized to the
-// corresponding clock domain.
+// Muxes the USB IO signals between the override CSRs and the USB engine. The
+// incoming signals are also synchronized to the corresponding clock domain.
 
 module usbdev_iomux
   import usbdev_reg_pkg::*;
@@ -20,7 +19,6 @@ module usbdev_iomux
   // Register interface (system clk)
   output usbdev_hw2reg_phy_pins_sense_reg_t sys_hw2reg_sense_o,
   input  usbdev_reg2hw_phy_pins_drive_reg_t sys_reg2hw_drive_i,
-  input  usbdev_reg2hw_phy_config_reg_t     sys_reg2hw_config_i,
   output logic                              sys_usb_sense_o,
 
   // External USB Interface(s) (async)
@@ -33,12 +31,12 @@ module usbdev_iomux
   output logic                          usb_tx_dp_o,
   output logic                          usb_tx_dn_o,
   output logic                          usb_tx_oe_o,
-  output logic                          usb_tx_use_d_se0_o,
 
   input  logic                          cio_usb_sense_i,
   output logic                          usb_dp_pullup_en_o,
   output logic                          usb_dn_pullup_en_o,
   output logic                          usb_suspend_o,
+  output logic                          usb_rx_enable_o,
 
   // Internal USB Interface (usb clk)
   output logic                          usb_rx_d_o,
@@ -46,28 +44,17 @@ module usbdev_iomux
   output logic                          usb_rx_dn_o,
   input  logic                          usb_tx_d_i,
   input  logic                          usb_tx_se0_i,
+  input  logic                          usb_tx_dp_i,
+  input  logic                          usb_tx_dn_i,
   input  logic                          usb_tx_oe_i,
-  output logic                          usb_pwr_sense_o,
-  input  logic                          usb_pullup_en_i,
-  input  logic                          usb_suspend_i
+  input  logic                          usb_dp_pullup_en_i,
+  input  logic                          usb_dn_pullup_en_i,
+  input  logic                          usb_suspend_i,
+  input  logic                          usb_rx_enable_i,
+  output logic                          usb_pwr_sense_o
 );
 
-  logic usb_tx_d_flipped;
-  logic usb_dp_pullup_en, usb_dn_pullup_en;
-
   logic sys_usb_sense;
-  logic usb_rx_dp, usb_rx_dn, usb_rx_d;
-  logic pinflip;
-  logic unused_eop_single_bit;
-  logic unused_use_diff_rcvr;
-  logic unused_usb_ref_disable;
-  logic unused_tx_osc_test_mode;
-
-  assign unused_eop_single_bit       = sys_reg2hw_config_i.eop_single_bit.q;
-  assign unused_usb_ref_disable      = sys_reg2hw_config_i.usb_ref_disable.q;
-  assign unused_tx_osc_test_mode     = sys_reg2hw_config_i.tx_osc_test_mode.q;
-  assign unused_use_diff_rcvr        = sys_reg2hw_config_i.use_diff_rcvr.q;
-
   //////////
   // CDCs //
   //////////
@@ -81,8 +68,8 @@ module usbdev_iomux
     .d_i    ({usb_rx_dp_i,
               usb_rx_dn_i,
               usb_rx_d_i,
-              usb_tx_dp_o,
-              usb_tx_dn_o,
+              usb_tx_dp_i,
+              usb_tx_dn_i,
               usb_tx_d_i,
               usb_tx_se0_i,
               usb_tx_oe_i,
@@ -113,79 +100,28 @@ module usbdev_iomux
               usb_rx_dn_i,
               usb_rx_d_i,
               cio_usb_sense_i}),
-    .q_o    ({usb_rx_dp,
-              usb_rx_dn,
-              usb_rx_d,
+    .q_o    ({usb_rx_dp_o,
+              usb_rx_dn_o,
+              usb_rx_d_o,
               usb_pwr_sense_o})
   );
 
   ////////////////////////
   // USB output pin mux //
   ////////////////////////
-
-  // D+/D- can be swapped based on a config register.
-  assign pinflip = sys_reg2hw_config_i.pinflip.q;
-
-  prim_clock_mux2 #(
-    .NoFpgaBufG(1)
-  ) i_mux_tx_d_flip (
-    .clk0_i (usb_tx_d_i),
-    .clk1_i (~usb_tx_d_i),
-    .sel_i  (pinflip),
-    .clk_o  (usb_tx_d_flipped)
-  );
-  prim_clock_mux2 #(
-    .NoFpgaBufG(1)
-  ) i_mux_dp_pull_flip (
-    .clk0_i (usb_pullup_en_i),
-    .clk1_i (1'b0),
-    .sel_i  (pinflip),
-    .clk_o  (usb_dp_pullup_en)
-  );
-  prim_clock_mux2 #(
-    .NoFpgaBufG(1)
-  ) i_mux_dn_pull_flip (
-    .clk0_i (1'b0),
-    .clk1_i (usb_pullup_en_i),
-    .sel_i  (pinflip),
-    .clk_o  (usb_dn_pullup_en)
-  );
-
   always_comb begin : proc_drive_out
-    // Defaults
-    usb_tx_dn_o           = 1'b0;
-    usb_tx_dp_o           = 1'b0;
-
     if (sys_reg2hw_drive_i.en.q) begin
       // Override from registers
-      usb_tx_dp_o       = sys_reg2hw_drive_i.dp_o.q;
-      usb_tx_dn_o       = sys_reg2hw_drive_i.dn_o.q;
       usb_dp_pullup_en_o = sys_reg2hw_drive_i.dp_pullup_en_o.q;
       usb_dn_pullup_en_o = sys_reg2hw_drive_i.dn_pullup_en_o.q;
-      usb_tx_use_d_se0_o = sys_reg2hw_drive_i.tx_use_d_se0_o.q;
       usb_suspend_o      = sys_reg2hw_drive_i.suspend_o.q;
-
+      usb_rx_enable_o    = sys_reg2hw_drive_i.rx_enable_o.q;
     end else begin
       // Signals from the peripheral core
-      usb_dp_pullup_en_o = usb_dp_pullup_en;
-      usb_dn_pullup_en_o = usb_dn_pullup_en;
+      usb_dp_pullup_en_o = usb_dp_pullup_en_i;
+      usb_dn_pullup_en_o = usb_dn_pullup_en_i;
       usb_suspend_o      = usb_suspend_i;
-
-      if(sys_reg2hw_config_i.tx_use_d_se0.q) begin
-        // Single-ended TX interface (physical IO takes d and se0)
-        usb_tx_use_d_se0_o = 1'b1;
-      end else begin
-        // Differential TX interface (physical IO takes dp and dn)
-        // i.e. expect the "else" logic to be in the physical interface
-        usb_tx_use_d_se0_o = 1'b0;
-        if (usb_tx_se0_i) begin
-          usb_tx_dp_o = 1'b0;
-          usb_tx_dn_o = 1'b0;
-        end else begin
-          usb_tx_dp_o = usb_tx_d_flipped;
-          usb_tx_dn_o = ~usb_tx_d_flipped;
-        end
-      end
+      usb_rx_enable_o    = usb_rx_enable_i;
     end
   end
 
@@ -196,8 +132,24 @@ module usbdev_iomux
   // degrades performance in the JK-KJ jitter test.
   prim_clock_mux2 #(
     .NoFpgaBufG(1)
+  ) i_mux_tx_dp (
+    .clk0_i (usb_tx_dp_i),
+    .clk1_i (sys_reg2hw_drive_i.dp_o.q),
+    .sel_i  (sys_reg2hw_drive_i.en.q),
+    .clk_o  (usb_tx_dp_o)
+  );
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1)
+  ) i_mux_tx_dn (
+    .clk0_i (usb_tx_dn_i),
+    .clk1_i (sys_reg2hw_drive_i.dn_o.q),
+    .sel_i  (sys_reg2hw_drive_i.en.q),
+    .clk_o  (usb_tx_dn_o)
+  );
+  prim_clock_mux2 #(
+    .NoFpgaBufG(1)
   ) i_mux_tx_d (
-    .clk0_i (usb_tx_d_flipped),
+    .clk0_i (usb_tx_d_i),
     .clk1_i (sys_reg2hw_drive_i.d_o.q),
     .sel_i  (sys_reg2hw_drive_i.en.q),
     .clk_o  (usb_tx_d_o)
@@ -218,14 +170,5 @@ module usbdev_iomux
     .sel_i  (sys_reg2hw_drive_i.en.q),
     .clk_o  (usb_tx_oe_o)
   );
-
-  ///////////////////////
-  // USB input pin mux //
-  ///////////////////////
-
-  // D+/D- can be swapped based on a config register.
-  assign usb_rx_dp_o = pinflip ?  usb_rx_dn : usb_rx_dp;
-  assign usb_rx_dn_o = pinflip ?  usb_rx_dp : usb_rx_dn;
-  assign usb_rx_d_o  = pinflip ? ~usb_rx_d  : usb_rx_d;
 
 endmodule

--- a/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_pkg.sv
@@ -312,7 +312,7 @@ package usbdev_reg_pkg;
     } oe_o;
     struct packed {
       logic        q;
-    } tx_use_d_se0_o;
+    } rx_enable_o;
     struct packed {
       logic        q;
     } dp_pullup_en_o;

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -670,8 +670,8 @@ module usbdev_reg_top (
   logic phy_pins_drive_se0_o_wd;
   logic phy_pins_drive_oe_o_qs;
   logic phy_pins_drive_oe_o_wd;
-  logic phy_pins_drive_tx_use_d_se0_o_qs;
-  logic phy_pins_drive_tx_use_d_se0_o_wd;
+  logic phy_pins_drive_rx_enable_o_qs;
+  logic phy_pins_drive_rx_enable_o_wd;
   logic phy_pins_drive_dp_pullup_en_o_qs;
   logic phy_pins_drive_dp_pullup_en_o_wd;
   logic phy_pins_drive_dn_pullup_en_o_qs;
@@ -7090,18 +7090,18 @@ module usbdev_reg_top (
     .qs     (phy_pins_drive_oe_o_qs)
   );
 
-  //   F[tx_use_d_se0_o]: 5:5
+  //   F[rx_enable_o]: 5:5
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
     .RESVAL  (1'h0)
-  ) u_phy_pins_drive_tx_use_d_se0_o (
+  ) u_phy_pins_drive_rx_enable_o (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
     .we     (phy_pins_drive_we),
-    .wd     (phy_pins_drive_tx_use_d_se0_o_wd),
+    .wd     (phy_pins_drive_rx_enable_o_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -7109,10 +7109,10 @@ module usbdev_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.phy_pins_drive.tx_use_d_se0_o.q),
+    .q      (reg2hw.phy_pins_drive.rx_enable_o.q),
 
     // to register interface (read)
-    .qs     (phy_pins_drive_tx_use_d_se0_o_qs)
+    .qs     (phy_pins_drive_rx_enable_o_qs)
   );
 
   //   F[dp_pullup_en_o]: 6:6
@@ -8082,7 +8082,7 @@ module usbdev_reg_top (
 
   assign phy_pins_drive_oe_o_wd = reg_wdata[4];
 
-  assign phy_pins_drive_tx_use_d_se0_o_wd = reg_wdata[5];
+  assign phy_pins_drive_rx_enable_o_wd = reg_wdata[5];
 
   assign phy_pins_drive_dp_pullup_en_o_wd = reg_wdata[6];
 
@@ -8457,7 +8457,7 @@ module usbdev_reg_top (
         reg_rdata_next[2] = phy_pins_drive_d_o_qs;
         reg_rdata_next[3] = phy_pins_drive_se0_o_qs;
         reg_rdata_next[4] = phy_pins_drive_oe_o_qs;
-        reg_rdata_next[5] = phy_pins_drive_tx_use_d_se0_o_qs;
+        reg_rdata_next[5] = phy_pins_drive_rx_enable_o_qs;
         reg_rdata_next[6] = phy_pins_drive_dp_pullup_en_o_qs;
         reg_rdata_next[7] = phy_pins_drive_dn_pullup_en_o_qs;
         reg_rdata_next[8] = phy_pins_drive_suspend_o_qs;

--- a/hw/ip/usbdev/rtl/usbdev_usbif.sv
+++ b/hw/ip/usbdev/rtl/usbdev_usbif.sv
@@ -29,6 +29,8 @@ module usbdev_usbif  #(
 
   output logic                     usb_d_o,
   output logic                     usb_se0_o,
+  output logic                     usb_dp_o,
+  output logic                     usb_dn_o,
   output logic                     usb_oe_o,
 
   output logic                     usb_pullup_en_o,
@@ -81,6 +83,8 @@ module usbdev_usbif  #(
   input  logic                     diff_rx_ok_i, // 1: differential symbols (K/J) are valid
   input  logic                     cfg_eop_single_bit_i, // 1: detect a single SE0 bit as EOP
   input  logic                     cfg_use_diff_rcvr_i, // 1: use single-ended rx data on usb_d_i
+  input  logic                     cfg_pinflip_i, // 1: Treat outputs and inputs as though D+/D-
+                                                  // are flipped
   input  logic                     tx_osc_test_mode_i, // Oscillator test mode: constant JK output
   input  logic [NEndpoints-1:0]    data_toggle_clear_i, // Clear the data toggles for an EP
   input  logic                     resume_link_active_i, // Jump from LinkPowered to LinkResuming
@@ -282,6 +286,7 @@ module usbdev_usbif  #(
 
     .cfg_eop_single_bit_i  (cfg_eop_single_bit_i),
     .cfg_use_diff_rcvr_i   (cfg_use_diff_rcvr_i),
+    .cfg_pinflip_i         (cfg_pinflip_i),
     .tx_osc_test_mode_i    (tx_osc_test_mode_i),
     .data_toggle_clear_i   (data_toggle_clear_i),
     .diff_rx_ok_i          (diff_rx_ok_i),
@@ -291,6 +296,8 @@ module usbdev_usbif  #(
     .usb_dn_i              (usb_dn_i),
     .usb_d_o               (usb_d_o),
     .usb_se0_o             (usb_se0_o),
+    .usb_dp_o              (usb_dp_o),
+    .usb_dn_o              (usb_dn_o),
     .usb_oe_o              (usb_oe_o),
 
     .dev_addr_i            (devaddr_i),


### PR DESCRIPTION
Handle the interface changes and alternate TX interface in logic, before
the final register. Prior to this change, the pinflip was sometimes
handled in clock muxes, on the I/O side of the first/final registers,
and the dp_o/dn_o interface was only done in behavioral logic. Move this
all inside the USB clock domain, and perform only the pin overrides with
clock muxes.

Add override for rx_enable and remove the redundant one for
tx_use_d_se0.