### PR TITLE
[entropy_src/rtl] Manage observe FIFO overflow

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1161,6 +1161,26 @@
         }
       ]
     },
+    { name:     "FW_OV_RD_FIFO_OVERFLOW",
+      desc:     "Firmware override Observe FIFO overflow status",
+      swaccess: "rw0c",
+      hwaccess: "hwo",
+      hwext: "false",
+      tags: [// Internal HW can modify status register
+             "excl:CsrAllTests:CsrExclCheck"]
+      fields: [
+        { bits: "0",
+          name: "FW_OV_DR_FIFO_OVERFLOW",
+          desc: '''
+                This bit is set by hardware whenever RNG data is lost due to an overflow condition
+                in the Observe FIFO. The RNG data rate is slow enough that firmware should always
+                be able to keep up. This register meanwhile provides an additional check to confirm
+                that bytes read from the !!FW_OV_RD_DATA register represent contiguous RNG samples.
+                If an overflow event occurs, this bit must be cleared by software.
+                '''
+        }
+      ]
+    },
     { name: "FW_OV_RD_DATA",
       desc: "Firmware override Observe FIFO read register",
       swaccess: "ro",

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_pkg.sv
@@ -533,6 +533,11 @@ package entropy_src_reg_pkg;
   } entropy_src_hw2reg_fw_ov_wr_fifo_full_reg_t;
 
   typedef struct packed {
+    logic        d;
+    logic        de;
+  } entropy_src_hw2reg_fw_ov_rd_fifo_overflow_reg_t;
+
+  typedef struct packed {
     logic [31:0] d;
   } entropy_src_hw2reg_fw_ov_rd_data_reg_t;
 
@@ -694,40 +699,41 @@ package entropy_src_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1056:1049]
-    entropy_src_hw2reg_regwen_reg_t regwen; // [1048:1047]
-    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1046:1015]
-    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1014:983]
-    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [982:951]
-    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [950:919]
-    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [918:887]
-    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [886:855]
-    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [854:823]
-    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [822:791]
-    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [790:759]
-    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [758:727]
-    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [726:695]
-    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [694:663]
-    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [662:631]
-    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [630:599]
-    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [598:567]
-    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [566:535]
-    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [534:503]
-    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [502:471]
-    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [470:439]
-    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [438:407]
-    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [406:375]
-    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [374:343]
-    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [342:311]
-    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [310:279]
-    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [278:247]
-    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [246:215]
-    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [214:183]
-    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [182:151]
-    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [150:135]
-    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [134:107]
-    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [106:99]
-    entropy_src_hw2reg_fw_ov_wr_fifo_full_reg_t fw_ov_wr_fifo_full; // [98:98]
+    entropy_src_hw2reg_intr_state_reg_t intr_state; // [1058:1051]
+    entropy_src_hw2reg_regwen_reg_t regwen; // [1050:1049]
+    entropy_src_hw2reg_entropy_data_reg_t entropy_data; // [1048:1017]
+    entropy_src_hw2reg_repcnt_thresholds_reg_t repcnt_thresholds; // [1016:985]
+    entropy_src_hw2reg_repcnts_thresholds_reg_t repcnts_thresholds; // [984:953]
+    entropy_src_hw2reg_adaptp_hi_thresholds_reg_t adaptp_hi_thresholds; // [952:921]
+    entropy_src_hw2reg_adaptp_lo_thresholds_reg_t adaptp_lo_thresholds; // [920:889]
+    entropy_src_hw2reg_bucket_thresholds_reg_t bucket_thresholds; // [888:857]
+    entropy_src_hw2reg_markov_hi_thresholds_reg_t markov_hi_thresholds; // [856:825]
+    entropy_src_hw2reg_markov_lo_thresholds_reg_t markov_lo_thresholds; // [824:793]
+    entropy_src_hw2reg_extht_hi_thresholds_reg_t extht_hi_thresholds; // [792:761]
+    entropy_src_hw2reg_extht_lo_thresholds_reg_t extht_lo_thresholds; // [760:729]
+    entropy_src_hw2reg_repcnt_hi_watermarks_reg_t repcnt_hi_watermarks; // [728:697]
+    entropy_src_hw2reg_repcnts_hi_watermarks_reg_t repcnts_hi_watermarks; // [696:665]
+    entropy_src_hw2reg_adaptp_hi_watermarks_reg_t adaptp_hi_watermarks; // [664:633]
+    entropy_src_hw2reg_adaptp_lo_watermarks_reg_t adaptp_lo_watermarks; // [632:601]
+    entropy_src_hw2reg_extht_hi_watermarks_reg_t extht_hi_watermarks; // [600:569]
+    entropy_src_hw2reg_extht_lo_watermarks_reg_t extht_lo_watermarks; // [568:537]
+    entropy_src_hw2reg_bucket_hi_watermarks_reg_t bucket_hi_watermarks; // [536:505]
+    entropy_src_hw2reg_markov_hi_watermarks_reg_t markov_hi_watermarks; // [504:473]
+    entropy_src_hw2reg_markov_lo_watermarks_reg_t markov_lo_watermarks; // [472:441]
+    entropy_src_hw2reg_repcnt_total_fails_reg_t repcnt_total_fails; // [440:409]
+    entropy_src_hw2reg_repcnts_total_fails_reg_t repcnts_total_fails; // [408:377]
+    entropy_src_hw2reg_adaptp_hi_total_fails_reg_t adaptp_hi_total_fails; // [376:345]
+    entropy_src_hw2reg_adaptp_lo_total_fails_reg_t adaptp_lo_total_fails; // [344:313]
+    entropy_src_hw2reg_bucket_total_fails_reg_t bucket_total_fails; // [312:281]
+    entropy_src_hw2reg_markov_hi_total_fails_reg_t markov_hi_total_fails; // [280:249]
+    entropy_src_hw2reg_markov_lo_total_fails_reg_t markov_lo_total_fails; // [248:217]
+    entropy_src_hw2reg_extht_hi_total_fails_reg_t extht_hi_total_fails; // [216:185]
+    entropy_src_hw2reg_extht_lo_total_fails_reg_t extht_lo_total_fails; // [184:153]
+    entropy_src_hw2reg_alert_summary_fail_counts_reg_t alert_summary_fail_counts; // [152:137]
+    entropy_src_hw2reg_alert_fail_counts_reg_t alert_fail_counts; // [136:109]
+    entropy_src_hw2reg_extht_fail_counts_reg_t extht_fail_counts; // [108:101]
+    entropy_src_hw2reg_fw_ov_wr_fifo_full_reg_t fw_ov_wr_fifo_full; // [100:100]
+    entropy_src_hw2reg_fw_ov_rd_fifo_overflow_reg_t fw_ov_rd_fifo_overflow; // [99:98]
     entropy_src_hw2reg_fw_ov_rd_data_reg_t fw_ov_rd_data; // [97:66]
     entropy_src_hw2reg_debug_status_reg_t debug_status; // [65:54]
     entropy_src_hw2reg_recov_alert_sts_reg_t recov_alert_sts; // [53:28]
@@ -783,14 +789,15 @@ package entropy_src_reg_pkg;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_CONTROL_OFFSET = 8'h b0;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_SHA3_START_OFFSET = 8'h b4;
   parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET = 8'h b8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h bc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h c0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h c4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h c8;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h cc;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h d0;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h d4;
-  parameter logic [BlockAw-1:0] ENTROPY_SRC_MAIN_SM_STATE_OFFSET = 8'h d8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_OFFSET = 8'h bc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_RD_DATA_OFFSET = 8'h c0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_FW_OV_WR_DATA_OFFSET = 8'h c4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET = 8'h c8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_DEBUG_STATUS_OFFSET = 8'h cc;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_RECOV_ALERT_STS_OFFSET = 8'h d0;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_OFFSET = 8'h d4;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_ERR_CODE_TEST_OFFSET = 8'h d8;
+  parameter logic [BlockAw-1:0] ENTROPY_SRC_MAIN_SM_STATE_OFFSET = 8'h dc;
 
   // Reset values for hwext registers and their fields
   parameter logic [3:0] ENTROPY_SRC_INTR_TEST_RESVAL = 4'h 0;
@@ -910,6 +917,7 @@ package entropy_src_reg_pkg;
     ENTROPY_SRC_FW_OV_CONTROL,
     ENTROPY_SRC_FW_OV_SHA3_START,
     ENTROPY_SRC_FW_OV_WR_FIFO_FULL,
+    ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW,
     ENTROPY_SRC_FW_OV_RD_DATA,
     ENTROPY_SRC_FW_OV_WR_DATA,
     ENTROPY_SRC_OBSERVE_FIFO_THRESH,
@@ -921,7 +929,7 @@ package entropy_src_reg_pkg;
   } entropy_src_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] ENTROPY_SRC_PERMIT [55] = '{
+  parameter logic [3:0] ENTROPY_SRC_PERMIT [56] = '{
     4'b 0001, // index[ 0] ENTROPY_SRC_INTR_STATE
     4'b 0001, // index[ 1] ENTROPY_SRC_INTR_ENABLE
     4'b 0001, // index[ 2] ENTROPY_SRC_INTR_TEST
@@ -969,14 +977,15 @@ package entropy_src_reg_pkg;
     4'b 0001, // index[44] ENTROPY_SRC_FW_OV_CONTROL
     4'b 0001, // index[45] ENTROPY_SRC_FW_OV_SHA3_START
     4'b 0001, // index[46] ENTROPY_SRC_FW_OV_WR_FIFO_FULL
-    4'b 1111, // index[47] ENTROPY_SRC_FW_OV_RD_DATA
-    4'b 1111, // index[48] ENTROPY_SRC_FW_OV_WR_DATA
-    4'b 0001, // index[49] ENTROPY_SRC_OBSERVE_FIFO_THRESH
-    4'b 0111, // index[50] ENTROPY_SRC_DEBUG_STATUS
-    4'b 0011, // index[51] ENTROPY_SRC_RECOV_ALERT_STS
-    4'b 1111, // index[52] ENTROPY_SRC_ERR_CODE
-    4'b 0001, // index[53] ENTROPY_SRC_ERR_CODE_TEST
-    4'b 0011  // index[54] ENTROPY_SRC_MAIN_SM_STATE
+    4'b 0001, // index[47] ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW
+    4'b 1111, // index[48] ENTROPY_SRC_FW_OV_RD_DATA
+    4'b 1111, // index[49] ENTROPY_SRC_FW_OV_WR_DATA
+    4'b 0001, // index[50] ENTROPY_SRC_OBSERVE_FIFO_THRESH
+    4'b 0111, // index[51] ENTROPY_SRC_DEBUG_STATUS
+    4'b 0011, // index[52] ENTROPY_SRC_RECOV_ALERT_STS
+    4'b 1111, // index[53] ENTROPY_SRC_ERR_CODE
+    4'b 0001, // index[54] ENTROPY_SRC_ERR_CODE_TEST
+    4'b 0011  // index[55] ENTROPY_SRC_MAIN_SM_STATE
   };
 
 endpackage

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -297,6 +297,9 @@ module entropy_src_reg_top (
   logic [3:0] fw_ov_sha3_start_wd;
   logic fw_ov_wr_fifo_full_re;
   logic fw_ov_wr_fifo_full_qs;
+  logic fw_ov_rd_fifo_overflow_we;
+  logic fw_ov_rd_fifo_overflow_qs;
+  logic fw_ov_rd_fifo_overflow_wd;
   logic fw_ov_rd_data_re;
   logic [31:0] fw_ov_rd_data_qs;
   logic fw_ov_wr_data_we;
@@ -1976,6 +1979,32 @@ module entropy_src_reg_top (
   );
 
 
+  // R[fw_ov_rd_fifo_overflow]: V(False)
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessW0C),
+    .RESVAL  (1'h0)
+  ) u_fw_ov_rd_fifo_overflow (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (fw_ov_rd_fifo_overflow_we),
+    .wd     (fw_ov_rd_fifo_overflow_wd),
+
+    // from internal hardware
+    .de     (hw2reg.fw_ov_rd_fifo_overflow.de),
+    .d      (hw2reg.fw_ov_rd_fifo_overflow.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (fw_ov_rd_fifo_overflow_qs)
+  );
+
+
   // R[fw_ov_rd_data]: V(True)
   prim_subreg_ext #(
     .DW    (32)
@@ -2753,7 +2782,7 @@ module entropy_src_reg_top (
 
 
 
-  logic [54:0] addr_hit;
+  logic [55:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == ENTROPY_SRC_INTR_STATE_OFFSET);
@@ -2803,14 +2832,15 @@ module entropy_src_reg_top (
     addr_hit[44] = (reg_addr == ENTROPY_SRC_FW_OV_CONTROL_OFFSET);
     addr_hit[45] = (reg_addr == ENTROPY_SRC_FW_OV_SHA3_START_OFFSET);
     addr_hit[46] = (reg_addr == ENTROPY_SRC_FW_OV_WR_FIFO_FULL_OFFSET);
-    addr_hit[47] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
-    addr_hit[48] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
-    addr_hit[49] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
-    addr_hit[50] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
-    addr_hit[51] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
-    addr_hit[52] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
-    addr_hit[53] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
-    addr_hit[54] = (reg_addr == ENTROPY_SRC_MAIN_SM_STATE_OFFSET);
+    addr_hit[47] = (reg_addr == ENTROPY_SRC_FW_OV_RD_FIFO_OVERFLOW_OFFSET);
+    addr_hit[48] = (reg_addr == ENTROPY_SRC_FW_OV_RD_DATA_OFFSET);
+    addr_hit[49] = (reg_addr == ENTROPY_SRC_FW_OV_WR_DATA_OFFSET);
+    addr_hit[50] = (reg_addr == ENTROPY_SRC_OBSERVE_FIFO_THRESH_OFFSET);
+    addr_hit[51] = (reg_addr == ENTROPY_SRC_DEBUG_STATUS_OFFSET);
+    addr_hit[52] = (reg_addr == ENTROPY_SRC_RECOV_ALERT_STS_OFFSET);
+    addr_hit[53] = (reg_addr == ENTROPY_SRC_ERR_CODE_OFFSET);
+    addr_hit[54] = (reg_addr == ENTROPY_SRC_ERR_CODE_TEST_OFFSET);
+    addr_hit[55] = (reg_addr == ENTROPY_SRC_MAIN_SM_STATE_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -2872,7 +2902,8 @@ module entropy_src_reg_top (
                (addr_hit[51] & (|(ENTROPY_SRC_PERMIT[51] & ~reg_be))) |
                (addr_hit[52] & (|(ENTROPY_SRC_PERMIT[52] & ~reg_be))) |
                (addr_hit[53] & (|(ENTROPY_SRC_PERMIT[53] & ~reg_be))) |
-               (addr_hit[54] & (|(ENTROPY_SRC_PERMIT[54] & ~reg_be)))));
+               (addr_hit[54] & (|(ENTROPY_SRC_PERMIT[54] & ~reg_be))) |
+               (addr_hit[55] & (|(ENTROPY_SRC_PERMIT[55] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -3026,15 +3057,18 @@ module entropy_src_reg_top (
 
   assign fw_ov_sha3_start_wd = reg_wdata[3:0];
   assign fw_ov_wr_fifo_full_re = addr_hit[46] & reg_re & !reg_error;
-  assign fw_ov_rd_data_re = addr_hit[47] & reg_re & !reg_error;
-  assign fw_ov_wr_data_we = addr_hit[48] & reg_we & !reg_error;
+  assign fw_ov_rd_fifo_overflow_we = addr_hit[47] & reg_we & !reg_error;
+
+  assign fw_ov_rd_fifo_overflow_wd = reg_wdata[0];
+  assign fw_ov_rd_data_re = addr_hit[48] & reg_re & !reg_error;
+  assign fw_ov_wr_data_we = addr_hit[49] & reg_we & !reg_error;
 
   assign fw_ov_wr_data_wd = reg_wdata[31:0];
-  assign observe_fifo_thresh_we = addr_hit[49] & reg_we & !reg_error;
+  assign observe_fifo_thresh_we = addr_hit[50] & reg_we & !reg_error;
 
   assign observe_fifo_thresh_wd = reg_wdata[6:0];
-  assign debug_status_re = addr_hit[50] & reg_re & !reg_error;
-  assign recov_alert_sts_we = addr_hit[51] & reg_we & !reg_error;
+  assign debug_status_re = addr_hit[51] & reg_re & !reg_error;
+  assign recov_alert_sts_we = addr_hit[52] & reg_we & !reg_error;
 
   assign recov_alert_sts_fips_enable_field_alert_wd = reg_wdata[0];
 
@@ -3061,7 +3095,7 @@ module entropy_src_reg_top (
   assign recov_alert_sts_es_bus_cmp_alert_wd = reg_wdata[13];
 
   assign recov_alert_sts_es_thresh_cfg_alert_wd = reg_wdata[14];
-  assign err_code_test_we = addr_hit[53] & reg_we & !reg_error;
+  assign err_code_test_we = addr_hit[54] & reg_we & !reg_error;
 
   assign err_code_test_wd = reg_wdata[4:0];
 
@@ -3303,18 +3337,22 @@ module entropy_src_reg_top (
       end
 
       addr_hit[47]: begin
-        reg_rdata_next[31:0] = fw_ov_rd_data_qs;
+        reg_rdata_next[0] = fw_ov_rd_fifo_overflow_qs;
       end
 
       addr_hit[48]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[31:0] = fw_ov_rd_data_qs;
       end
 
       addr_hit[49]: begin
-        reg_rdata_next[6:0] = observe_fifo_thresh_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[50]: begin
+        reg_rdata_next[6:0] = observe_fifo_thresh_qs;
+      end
+
+      addr_hit[51]: begin
         reg_rdata_next[2:0] = debug_status_entropy_fifo_depth_qs;
         reg_rdata_next[5:3] = debug_status_sha3_fsm_qs;
         reg_rdata_next[6] = debug_status_sha3_block_pr_qs;
@@ -3325,7 +3363,7 @@ module entropy_src_reg_top (
         reg_rdata_next[17] = debug_status_main_sm_boot_done_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[0] = recov_alert_sts_fips_enable_field_alert_qs;
         reg_rdata_next[1] = recov_alert_sts_entropy_data_reg_en_field_alert_qs;
         reg_rdata_next[2] = recov_alert_sts_module_enable_field_alert_qs;
@@ -3341,7 +3379,7 @@ module entropy_src_reg_top (
         reg_rdata_next[14] = recov_alert_sts_es_thresh_cfg_alert_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[0] = err_code_sfifo_esrng_err_qs;
         reg_rdata_next[1] = err_code_sfifo_observe_err_qs;
         reg_rdata_next[2] = err_code_sfifo_esfinal_err_qs;
@@ -3353,11 +3391,11 @@ module entropy_src_reg_top (
         reg_rdata_next[30] = err_code_fifo_state_err_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[4:0] = err_code_test_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[8:0] = main_sm_state_qs;
       end
 


### PR DESCRIPTION
Prevents the observe FIFO from overflowing and at the same time
ensures that at any given time, the data in the FIFO is always contiguous.

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>