### PR TITLE
[dvsim] Fix pass/fail status for synthesis regression

### DIFF
--- a/hw/syn/tools/dc/parse-syn-report.py
+++ b/hw/syn/tools/dc/parse-syn-report.py
@@ -593,12 +593,16 @@ def main():
                    for_json=True,
                    use_decimal=True)
 
+    # helper function
+    def _getlen(x):
+        return len(x) if x is not None else 0
+
     # return nonzero status if any warnings or errors are present
     # lint infos do not count as failures
-    nr_errors = (len(results["messages"]["flow_errors"]) +
-                 len(results["messages"]["analyze_errors"]) +
-                 len(results["messages"]["elab_errors"]) +
-                 len(results["messages"]["compile_errors"]))
+    nr_errors = (_getlen(results["messages"]["flow_errors"]) +
+                 _getlen(results["messages"]["analyze_errors"]) +
+                 _getlen(results["messages"]["elab_errors"]) +
+                 _getlen(results["messages"]["compile_errors"]))
 
     print("""------------- Summary -------------
 Flow Warnings:      %s
@@ -610,14 +614,14 @@ Elab Errors:        %s
 Compile Warnings:   %s
 Compile Errors:     %s
 -----------------------------------""" %
-          (len(results["messages"]["flow_warnings"]),
-           len(results["messages"]["flow_errors"]),
-           len(results["messages"]["analyze_warnings"]),
-           len(results["messages"]["analyze_errors"]),
-           len(results["messages"]["elab_warnings"]),
-           len(results["messages"]["elab_errors"]),
-           len(results["messages"]["compile_warnings"]),
-           len(results["messages"]["compile_errors"])))
+          (_getlen(results["messages"]["flow_warnings"]),
+           _getlen(results["messages"]["flow_errors"]),
+           _getlen(results["messages"]["analyze_warnings"]),
+           _getlen(results["messages"]["analyze_errors"]),
+           _getlen(results["messages"]["elab_warnings"]),
+           _getlen(results["messages"]["elab_errors"]),
+           _getlen(results["messages"]["compile_warnings"]),
+           _getlen(results["messages"]["compile_errors"])))
 
     if nr_errors > 0:
         print("Synthesis not successful.")

--- a/util/dvsim/SynCfg.py
+++ b/util/dvsim/SynCfg.py
@@ -12,7 +12,7 @@ import hjson
 from tabulate import tabulate
 
 from OneShotCfg import OneShotCfg
-from utils import VERBOSE, print_msg_list, subst_wildcards
+from utils import print_msg_list, subst_wildcards
 
 
 class SynCfg(OneShotCfg):
@@ -253,11 +253,10 @@ class SynCfg(OneShotCfg):
 
                         for field in ["comb", "buf", "reg", "logic", "macro", "total"]:
                             entry = _create_entry(
-                                        self.result["area"]["instances"][name]
-                                        [field], kge)
+                                self.result["area"]["instances"][name]
+                                [field], kge)
                             entry = "**" + entry + "**" if is_top else entry
                             row.append(entry)
-
 
                         for k, field in enumerate(["logic", "macro", "total"]):
                             if is_top:
@@ -372,17 +371,21 @@ class SynCfg(OneShotCfg):
                              ("Compile Warnings", "compile_warnings", False),
                              ("Compile Errors", "compile_errors", True)]
 
+            # helper function
+            def _getlen(x):
+                return len(x) if x is not None else 0
+
             # Synthesis fails if any error messages have occurred
-            self.errors_seen = False
-            msgs_seen = False
+            self.errors_seen = 0
+            msgs_seen = 0
             fail_msgs = ""
             for _, key, fail in hdr_key_pairs:
                 if key in self.result['messages']:
-                    if self.result['messages'].get(key):
-                        self.errors_seen = fail or self.errors_seen
-                        msgs_seen = True
+                    num_msgs = _getlen(self.result['messages'][key])
+                    msgs_seen += num_msgs
+                    self.errors_seen += num_msgs if fail else 0
 
-            if msgs_seen:
+            if msgs_seen > 0:
                 fail_msgs += "\n### Errors and Warnings for Build Mode `'" + mode.name + "'`\n"
                 for hdr, key, _ in hdr_key_pairs:
                     msgs = self.result['messages'].get(key)


### PR DESCRIPTION
Recent updates to the synthesis report parser output caused the pass/fail status reporting of dvsim to incorrectly report failures when there where none.
This was due to the fact that in some cases, `len()` would be invoked on a variable that was `None`, hence leading to an error in the Python script.
This patch corrects that.

Signed-off-by: Michael Schaffner <msf@opentitan.org>