### PR TITLE
[rv_dm dv] Add SBA TL access test

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -531,6 +531,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // check if csr write size greater or equal to csr width
   virtual function bit is_tl_csr_write_size_gte_csr_width(tl_seq_item item, string ral_name);
     if (!is_tl_access_mapped_addr(item, ral_name) || is_mem_addr(item, ral_name)) return 1;
+    if (cfg.ral_models[ral_name].get_supports_sub_word_csr_writes()) return 1;
     if (item.is_write()) begin
       dv_base_reg    csr;
       uvm_reg_addr_t addr = cfg.ral_models[ral_name].get_normalized_addr(item.a_addr);

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -506,7 +506,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
   // (third party 'vendored-in' code). The end result is - the TL adapter prevents non-word writes
   // to the entire region. See issue #10765 for more details.
   virtual function bit is_tl_access_unsupported_byte_wr(tl_seq_item item, string ral_name);
-    // TODO: We should infer byte enable support from TL reg adapter attached to the interface (i.e.
+    // TODO: We should infer byte enable support from the adapter attached to the interface (i.e.
     // the map) instead. To do that, more extensive changes may be needed, because we do not know
     // which map to pick - we only know the ral_name of the interface. For now,
     // dv_base_reg_block::supports_byte_enable serves this need.

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -135,10 +135,10 @@ class cip_tl_seq_item extends tl_seq_item;
       bit [DataIntgWidth + $bits(tl_d2h_rsp_intg_t) - 1 : 0] rsp_and_intg_err_mask;
       // Pre-populate str with format specifiers for the updated values that will be set later.
       string str = {"TL data or integrity bits have been flipped, see the changes as below:\n",
-                   $sformatf("\t d_opcode: 0x%0x\n", d_opcode), " -> 0x%0x",
-                   $sformatf("\t d_size: 0x%0x\n", d_size), " -> 0x%0x",
-                   $sformatf("\t d_error: 0x%0x\n", d_error), " -> 0x%0x",
-                   $sformatf("\t rsp_intg: 0x%0x\n", l_d_user.rsp_intg), " -> 0x%0x"};
+                   $sformatf("\td_opcode: 0x%0x", d_opcode), " -> 0x%0x\n",
+                   $sformatf("\td_size: 0x%0x", d_size), " -> 0x%0x\n",
+                   $sformatf("\td_error: 0x%0x", d_error), " -> 0x%0x\n",
+                   $sformatf("\trsp_intg: 0x%0x", l_d_user.rsp_intg), " -> 0x%0x\n"};
 
     // Flip cmd or intg ecc
     `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(rsp_and_intg_err_mask,

--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -53,6 +53,9 @@ class dv_base_reg_block extends uvm_reg_block;
   // This is added for ease of rv_dm testbench development.
   protected bit supports_byte_enable = 1'b1;
 
+  // Custom RAL models may support sub-word CSR writes smaller than CSR width.
+  protected bit supports_sub_word_csr_writes = 1'b0;
+
   bit has_unmapped_addrs;
   addr_range_t unmapped_addr_ranges[$];
 
@@ -84,12 +87,20 @@ class dv_base_reg_block extends uvm_reg_block;
     return unmapped_access_ok;
   endfunction
 
-  function void set_support_byte_enable(bit enable);
+  function void set_supports_byte_enable(bit enable);
     supports_byte_enable = enable;
   endfunction
 
   function bit get_supports_byte_enable();
     return supports_byte_enable;
+  endfunction
+
+  function void set_supports_sub_word_csr_writes(bit enable);
+    supports_sub_word_csr_writes = enable;
+  endfunction
+
+  function bit get_supports_sub_word_csr_writes();
+    return supports_sub_word_csr_writes;
   endfunction
 
   // provide build function to supply base addr

--- a/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
+++ b/hw/dv/sv/jtag_agent/jtag_agent_cfg.sv
@@ -22,7 +22,7 @@ class jtag_agent_cfg extends dv_base_agent_cfg;
     // Create the JTAG DTM RAL.
     jtag_dtm_ral = jtag_dtm_reg_block::type_id::create("jtag_dtm_ral");
     jtag_dtm_ral.build(.base_addr(0), .csr_excl(null));
-    jtag_dtm_ral.set_support_byte_enable(1'b0);
+    jtag_dtm_ral.set_supports_byte_enable(1'b0);
     jtag_dtm_ral.lock_model();
     jtag_dtm_ral.compute_mapped_addr_ranges();
     jtag_dtm_ral.compute_unmapped_addr_ranges();

--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -67,6 +67,8 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     if (req.ir_len) begin
       if (!(req.skip_reselected_ir && req.ir == selected_ir && req.ir_len == selected_ir_len)) begin
         drive_jtag_ir(req.ir_len, req.ir);
+      end else begin
+        `uvm_info(`gfn, $sformatf("UpdateIR for 0x%0h skipped", selected_ir), UVM_HIGH)
       end
     end
     if (req.dr_len) begin

--- a/hw/dv/sv/jtag_agent/jtag_dtm_reg_block.sv
+++ b/hw/dv/sv/jtag_agent/jtag_dtm_reg_block.sv
@@ -300,8 +300,10 @@ class jtag_dtm_reg_dmi extends jtag_dtm_base_reg;
       .individually_accessible(0));
 
     op.set_original_access("RW");
-    // op is modified by the HW.
-    csr_excl.add_excl(op.get_full_name(), CsrExclCheck, CsrAllTests);
+    // Writing to op can affect the DM hardware, and result in unintended consequences.
+    // Reading op may not result in expected value to be returned, since read op value always
+    // differs from the written op value.
+    csr_excl.add_excl(op.get_full_name(), CsrExclAll, CsrAllTests);
 
     data = (dv_base_reg_field::type_id::create("data"));
     data.configure(

--- a/hw/dv/sv/jtag_dmi_agent/README.md
+++ b/hw/dv/sv/jtag_dmi_agent/README.md
@@ -67,3 +67,16 @@ It uses an externally created semaphore `jtag_dtm_ral_sem_h` to atomicize
 accesses to the DTM `dmi` register, since accesses to all DMI registers go
 through this shared resource. This semaphore is also created and set by the
 convenience function `jtag_dmi_agent_pkg::create_jtag_dmi_reg_block()`.
+
+## sba_access_utils_pkg
+
+The JTAG DMI register space has registers to initiate and manage accesses into
+the system through an exernal system bus (whatever that may be). Please see the
+RISCV debug specification for more details. These registers are already
+a part of the `jtag_dmi_reg_block` model.
+
+This package provides some convenience tasks to initiate and manage accesses
+into the system bus access interface (SBA) using these SBA registers, including
+starting an access, waiting for completion and clearing the error bits. These
+tasks take the handle to the `jtag_dmi_reg_block` model as one of the
+arguments.

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent.core
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent.core
@@ -12,12 +12,14 @@ filesets:
       - lowrisc:dv:csr_utils
       - lowrisc:dv:dv_lib
       - lowrisc:dv:jtag_agent
+      - lowrisc:opentitan:bus_params_pkg
     files:
       - jtag_dmi_agent_pkg.sv
       - jtag_dmi_reg_block.sv: {is_include_file: true}
       - jtag_dmi_reg_frontdoor.sv: {is_include_file: true}
       - jtag_dmi_item.sv: {is_include_file: true}
       - jtag_dmi_monitor.sv: {is_include_file: true}
+      - sba_access_utils_pkg.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/jtag_dmi_agent_pkg.sv
@@ -46,7 +46,7 @@ package jtag_dmi_agent_pkg;
   function automatic jtag_dmi_reg_block create_jtag_dmi_reg_block(jtag_agent_cfg cfg);
     jtag_dmi_reg_block jtag_dmi_ral = jtag_dmi_reg_block::type_id::create("jtag_dmi_ral");
     jtag_dmi_ral.build(.base_addr(0), .csr_excl(null));
-    jtag_dmi_ral.set_support_byte_enable(1'b0);
+    jtag_dmi_ral.set_supports_byte_enable(1'b0);
     jtag_dmi_ral.lock_model();
     jtag_dmi_ral.compute_mapped_addr_ranges();
     jtag_dmi_ral.compute_unmapped_addr_ranges();

--- a/hw/dv/sv/jtag_dmi_agent/sba_access_utils_pkg.sv
+++ b/hw/dv/sv/jtag_dmi_agent/sba_access_utils_pkg.sv
@@ -1,0 +1,158 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A package that provides common SBA access utilities from JTAG.
+package sba_access_utils_pkg;
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import bus_params_pkg::*;
+  import dv_base_reg_pkg::*;
+  import csr_utils_pkg::*;
+  import jtag_agent_pkg::*;
+  import jtag_dmi_agent_pkg::*;
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  typedef enum logic [2:0] {
+    SbaAccessSize8b,
+    SbaAccessSize16b,
+    SbaAccessSize32b,
+    SbaAccessSize64b,
+    SbaAccessSize128b
+  } sba_access_size_e;
+
+  typedef enum logic [2:0] {
+    SbaErrNone = 0,
+    SbaErrTimeout = 1,
+    SbaErrBadAddr = 2,
+    SbaErrBadAlignment = 3,
+    SbaErrBadSize = 4,
+    SbaErrOther = 7
+  } sba_access_err_e;
+
+  localparam string MsgId = "sba_access_utils";
+
+  // Initiates a single SBA access through JTAG (-> DTM -> DMI -> SBA).
+  //
+  // It writes DMI SBA registers to create a read or write access on the system bus, poll for its
+  // completion and return the response (on reads).
+  // jtag_dmi_ral: A handle to the DMI RAL block that has the SBA registers.
+  // cfg: A handle to the jtag_agent_cfg.
+  // bus_op: read or a write request.
+  // size: transfer size in bytes (0: 1 byte, 1: 2 bytes ...).
+  // addr: External system address.
+  // data: data written or read. TODO: Needs to be a queue if autoincrement is set.
+  // readonaddr: Trigger SBA read automatically on writing address.
+  // readondata: Trigger SBA read automatically on reading data.
+  // autoincrement: Automatically increment address by size bytes and trigger new access. TODO: TBD
+  task automatic sba_access(input jtag_dmi_reg_block jtag_dmi_ral,
+                            input jtag_agent_cfg cfg,
+                            input bus_op_e bus_op,
+                            input sba_access_size_e size,
+                            input logic [BUS_AW-1:0] addr,
+                            inout logic [BUS_DW-1:0] data,
+                            input logic readonaddr = 1'b1,
+                            input logic readondata = 1'b0,
+                            input logic autoincrement = 1'b0);
+
+    uvm_reg_data_t rdata, wdata;
+    logic is_busy, is_busy_err;
+    sba_access_err_e is_err;
+
+    // Update sbcs for the new transaction.
+    wdata = jtag_dmi_ral.sbcs.get_mirrored_value();
+    wdata = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbaccess, wdata, size);
+    wdata = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbreadonaddr, wdata, readonaddr);
+    wdata = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbreadondata, wdata, readondata);
+    wdata = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbautoincrement, wdata, autoincrement);
+    if (wdata != jtag_dmi_ral.sbcs.sbaccess.get_mirrored_value()) begin
+      csr_wr(.ptr(jtag_dmi_ral.sbcs), .value(wdata));
+    end
+
+    // Initiate the request.
+    csr_wr(.ptr(jtag_dmi_ral.sbaddress0), .value(addr));
+    if (bus_op == BusOpRead) begin
+      if (readonaddr) begin
+        // Do nothing.
+      end else if (readondata) begin
+        // Read the data to trigger the read accesss.
+        csr_rd(.ptr(jtag_dmi_ral.sbdata0), .value(rdata));
+      end else begin
+        `uvm_info(MsgId, {"readonaddr and readondata are not set. ",
+                          "Read request will not be triggered. Returning."}, UVM_MEDIUM)
+        return;
+      end
+    end else begin
+      csr_wr(.ptr(jtag_dmi_ral.sbdata0), .value(data));
+    end
+
+    // Wait for access to complete.
+    sba_access_busy_wait(jtag_dmi_ral, cfg, is_busy, is_busy_err, is_err);
+
+    // Return the data on reads.
+    if (!is_busy && !is_busy_err && !is_err && bus_op == BusOpRead && !cfg.in_reset) begin
+      csr_rd(.ptr(jtag_dmi_ral.sbdata0), .value(data));
+    end
+  endtask
+
+  // Read the SBA access status.
+  task automatic sba_access_status(input jtag_dmi_reg_block jtag_dmi_ral,
+                                   output logic is_busy,
+                                   output logic is_busy_err,
+                                   output sba_access_err_e is_err);
+    uvm_reg_data_t rdata;
+    csr_rd(.ptr(jtag_dmi_ral.sbcs), .value(rdata));
+    is_busy = get_field_val(jtag_dmi_ral.sbcs.sbbusy, rdata);
+    is_busy_err = get_field_val(jtag_dmi_ral.sbcs.sbbusyerror, rdata);
+    is_err = sba_access_err_e'(get_field_val(jtag_dmi_ral.sbcs.sberror, rdata));
+    `uvm_info(MsgId, $sformatf("SBA req status: is_busy: %0b, is_busy_err: %0b, is_err: %0s",
+                               is_busy, is_busy_err, is_err.name()), UVM_HIGH)
+  endtask
+
+  // Reads sbcs register to poll and wait for access to complete.
+  task automatic sba_access_busy_wait(input jtag_dmi_reg_block jtag_dmi_ral,
+                                      input jtag_agent_cfg cfg,
+                                      output logic is_busy,
+                                      output logic is_busy_err,
+                                      output sba_access_err_e is_err);
+    `DV_SPINWAIT_EXIT(
+      do begin
+        sba_access_status(jtag_dmi_ral, is_busy, is_busy_err, is_err);
+        `DV_CHECK_EQ(is_busy_err, 0, "sbbusyerror is not expected to be set", , MsgId)
+        // TODO: Make this optional.
+        sba_access_error_clear(jtag_dmi_ral, is_busy_err, is_err);
+        if (is_err != SbaErrNone) `DV_CHECK_EQ(is_busy, 0, , , MsgId)
+      end while (is_busy);,
+      begin
+        fork
+          // TODO: Provide callbacks to support waiting for custom exit events.
+          wait(cfg.in_reset);
+          // TODO: Make this timeout more configurable.
+          dv_utils_pkg::wait_timeout(cfg.vif.tck_period_ns * 10000);
+        join_any
+      end,
+      , MsgId
+    )
+  endtask
+
+  // Clear SBA access busy error and access error sticky bits if they are set.
+  task automatic sba_access_error_clear(jtag_dmi_reg_block jtag_dmi_ral,
+                                        logic is_busy_err,
+                                        sba_access_err_e is_err);
+    uvm_reg_data_t data;
+    if (!is_busy_err && is_err == SbaErrNone) return;
+    `uvm_info(MsgId, $sformatf("Clearing SBA access errors: is_busy_err: %0b, is_err: %0s",
+                               is_busy_err, is_err.name()), UVM_MEDIUM)
+
+    data = jtag_dmi_ral.sbcs.get_mirrored_value();
+    if (is_busy_err) begin
+      data = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sbbusyerror, data, 1);
+    end
+    if (is_err != SbaErrNone) begin
+      data = get_csr_val_with_updated_field(jtag_dmi_ral.sbcs.sberror, data, 1);
+    end
+    csr_wr(.ptr(jtag_dmi_ral.sbcs), .value(data));
+  endtask
+
+endpackage

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.core
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.core
@@ -12,6 +12,7 @@ filesets:
       - lowrisc:dv:dv_base_reg
       - lowrisc:dv:jtag_agent
       - lowrisc:dv:jtag_dmi_agent
+      - lowrisc:opentitan:bus_params_pkg
       # TODO: we only depend on dm_pkg, which should be separated into its own core file.
       - pulp-platform:riscv-dbg:0.1
     files:
@@ -28,6 +29,7 @@ filesets:
       - seq_lib/rv_dm_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dtm_csr_vseq.sv: {is_include_file: true}
       - seq_lib/rv_dm_jtag_dmi_csr_vseq.sv: {is_include_file: true}
+      - seq_lib/rv_dm_sba_tl_access_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.sv
@@ -18,10 +18,6 @@ class rv_dm_env extends cip_base_env #(
 
   function void build_phase(uvm_phase phase);
     super.build_phase(phase);
-
-    // TODO(#10765): The debug mem RAL space does not support byte access at this time.
-    m_tl_reg_adapters[cfg.rom_ral_name].supports_byte_enable = 1'b0;
-
     // set knobs
     if (cfg.zero_delays) begin
       cfg.m_tl_sba_agent_cfg.a_valid_delay_min = 0;

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -87,10 +87,14 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
       // ROM within the debug mem is RO - it ignores writes instead of throwing an error response.
       `downcast(debug_mem_ral, ral)
       debug_mem_ral.rom.set_write_to_ro_mem_ok(1);
+      debug_mem_ral.rom.set_mem_partial_write_support(1);
 
       // TODO(#10837): Accesses to unmapped regions of debug mem RAL space does not return an error
       // response. Fix this if design is updated.
       debug_mem_ral.set_unmapped_access_ok(1);
+
+      // Debug mem does not error on any type of sub-word writes.
+      debug_mem_ral.set_supports_sub_word_csr_writes(1);
     end
   endfunction
 

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -84,20 +84,13 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
         regs[i].clear_hdl_path("ALL");
       end
 
-      // ROM within debug mem supports partial accesses, but strangely, the TL adapter does not
-      // allow byte accesses. See #10765.
-      `downcast(debug_mem_ral, ral)
-      debug_mem_ral.rom.set_mem_partial_write_support(1);
-
       // ROM within the debug mem is RO - it ignores writes instead of throwing an error response.
+      `downcast(debug_mem_ral, ral)
       debug_mem_ral.rom.set_write_to_ro_mem_ok(1);
 
       // TODO(#10837): Accesses to unmapped regions of debug mem RAL space does not return an error
       // response. Fix this if design is updated.
       debug_mem_ral.set_unmapped_access_ok(1);
-
-      //TODO(#10765): We don't support byte writes at this time.
-      debug_mem_ral.set_support_byte_enable(1'b0);
     end
   endfunction
 

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
@@ -7,6 +7,7 @@ package rv_dm_env_pkg;
   import uvm_pkg::*;
   import top_pkg::*;
   import dv_utils_pkg::*;
+  import bus_params_pkg::*;
   import jtag_agent_pkg::*;
   import jtag_dmi_agent_pkg::*;
   import dv_lib_pkg::*;
@@ -18,6 +19,7 @@ package rv_dm_env_pkg;
   import rv_dm_debug_mem_ral_pkg::*;
   import rv_dm_reg_pkg::NrHarts;
   import rv_dm_reg_pkg::NumAlerts;
+  import sba_access_utils_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -40,10 +42,6 @@ package rv_dm_env_pkg;
   // See hw/ip/rm_dm/data/rv_dm.hjson for alert names.
   parameter uint NUM_ALERTS = rv_dm_reg_pkg::NumAlerts;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
-
-  // types
-
-  // functions
 
   // package sources
   `include "rv_dm_env_cfg.sv"

--- a/hw/ip/rv_dm/dv/env/rv_dm_if.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_if.sv
@@ -17,6 +17,9 @@ interface rv_dm_if(input logic clk, input logic rst_n);
   logic dmactive;
   logic [NUM_HARTS-1:0] debug_req;
 
+  // Disable TLUL host SBA assertions when injecting intg errors on the response channel.
+  bit disable_tlul_assert_host_sba_resp_svas;
+
   // TODO: add clocking blocks.
 
 endinterface

--- a/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_scoreboard.sv
@@ -66,7 +66,8 @@ class rv_dm_scoreboard extends cip_base_scoreboard #(
       tl_sba_d_chan_fifo.get(item);
       `uvm_info(`gfn, $sformatf("Received SBA TL d_chan item:\n%0s", item.sprint()), UVM_HIGH)
       // check tl packet integrity
-      void'(item.is_ok());
+      // TODO: deal with item not being ok.
+      void'(item.is_ok(.throw_error(0)));
       process_tl_sba_access(item, DataChannel);
     end
   endtask

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_csr_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_csr_vseq.sv
@@ -3,25 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Run the JTAG DMT CSRs through our standard CSR suite via JTAG.
-class rv_dm_jtag_dmi_csr_vseq extends rv_dm_base_vseq;
+class rv_dm_jtag_dmi_csr_vseq extends rv_dm_common_vseq;
   `uvm_object_utils(rv_dm_jtag_dmi_csr_vseq)
   `uvm_object_new
-
-  constraint num_trans_c {
-    num_trans inside {[1:2]};
-  }
-
-  // We set these initial inputs to known values to prevent side effects that may affect these
-  // common tests.
-  constraint lc_hw_debug_en_c {
-    lc_hw_debug_en == lc_ctrl_pkg::On;
-  }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
-  constraint unavailable_c {
-    unavailable == 0;
-  }
 
   virtual task body();
     // If writes to DMI SBA registers triggers an access, then ensure the response is sent.

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_csr_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dmi_csr_vseq.sv
@@ -8,8 +8,6 @@ class rv_dm_jtag_dmi_csr_vseq extends rv_dm_common_vseq;
   `uvm_object_new
 
   virtual task body();
-    // If writes to DMI SBA registers triggers an access, then ensure the response is sent.
-    launch_tl_sba_device_seq();
     run_csr_vseq_wrapper(.num_times(num_trans), .models({jtag_dmi_ral}));
   endtask : body
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
@@ -8,8 +8,6 @@ class rv_dm_jtag_dtm_csr_vseq extends rv_dm_common_vseq;
   `uvm_object_new
 
   virtual task body();
-    // If writes to DMI SBA registers triggers an access, then ensure the response is sent.
-    launch_tl_sba_device_seq();
     run_csr_vseq_wrapper(.num_times(num_trans), .models({jtag_dtm_ral}));
   endtask : body
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
@@ -3,25 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Run the JTAG DMT CSRs through our standard CSR suite via JTAG.
-class rv_dm_jtag_dtm_csr_vseq extends rv_dm_base_vseq;
+class rv_dm_jtag_dtm_csr_vseq extends rv_dm_common_vseq;
   `uvm_object_utils(rv_dm_jtag_dtm_csr_vseq)
   `uvm_object_new
-
-  constraint num_trans_c {
-    num_trans inside {[1:2]};
-  }
-
-  // We set these initial inputs to known values to prevent side effects that may affect these
-  // common tests.
-  constraint lc_hw_debug_en_c {
-    lc_hw_debug_en == lc_ctrl_pkg::On;
-  }
-  constraint scanmode_c {
-    scanmode == prim_mubi_pkg::MuBi4False;
-  }
-  constraint unavailable_c {
-    unavailable == 0;
-  }
 
   virtual task body();
     run_csr_vseq_wrapper(.num_times(num_trans), .models({jtag_dtm_ral}));

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_jtag_dtm_csr_vseq.sv
@@ -8,6 +8,8 @@ class rv_dm_jtag_dtm_csr_vseq extends rv_dm_common_vseq;
   `uvm_object_new
 
   virtual task body();
+    // If writes to DMI SBA registers triggers an access, then ensure the response is sent.
+    launch_tl_sba_device_seq();
     run_csr_vseq_wrapper(.num_times(num_trans), .models({jtag_dtm_ral}));
   endtask : body
 

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_tl_access_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_sba_tl_access_vseq.sv
@@ -1,0 +1,129 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Drive random traffic out the SBA TL interface. Scoreboard checks the packet integrity.
+class rv_dm_sba_tl_access_vseq extends rv_dm_base_vseq;
+  `uvm_object_utils(rv_dm_sba_tl_access_vseq)
+  `uvm_object_new
+
+  rand int min_rsp_delay;
+  rand int max_rsp_delay;
+  rand int d_error_pct;
+  rand int d_chan_intg_err_pct;
+
+  rand int num_times;
+  rand bus_op_e bus_op;
+  rand bit [2:0] size;
+  rand bit [BUS_AW-1:0] addr;
+  rand bit [BUS_DW-1:0] data;
+  rand bit readonaddr;
+  rand bit readondata;
+  rand bit autoincrement;
+
+  // To generate reads to the same addr followed by previous writes.
+  rand bit read_addr_after_write;
+  bus_op_e bus_op_prev;
+  bit [BUS_AW-1:0] addr_prev;
+
+  constraint min_rsp_delay_c {
+    cfg.zero_delays -> min_rsp_delay == 0;
+    min_rsp_delay inside {[0:10]};
+  }
+
+  constraint max_rsp_delay_c {
+    solve min_rsp_delay before max_rsp_delay;
+    cfg.zero_delays -> max_rsp_delay == 0;
+    max_rsp_delay >= min_rsp_delay;
+    max_rsp_delay inside {[min_rsp_delay:min_rsp_delay+100]};
+  }
+
+  constraint d_error_pct_c {
+    d_error_pct inside {[0:100]};
+    d_error_pct dist { 0 :/ 6, [1:99] :/ 2, 100 :/ 2};
+  }
+
+  constraint d_chan_intg_err_pct_c {
+    d_chan_intg_err_pct inside {[0:100]};
+    d_chan_intg_err_pct dist { 0 :/ 6, [1:99] :/ 2, 100 :/ 2};
+  }
+
+  // TODO: Randomize these controls every num_times iteration.
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+  constraint unavailable_c {
+    unavailable == 0;
+  }
+
+  // TODO: The design only supports 32b accesses at the moment.
+  constraint size_c {
+    size == 2;
+  }
+
+  // TODO: Save for later.
+  constraint autoincrement_c {
+    autoincrement == 0;
+  }
+
+  constraint num_trans_c {
+    num_trans inside {[20:50]};
+  }
+
+  constraint num_times_c {
+    num_times inside {[1:5]};
+  }
+
+  constraint read_addr_after_write_c {
+    read_addr_after_write dist {0 :/ 7, 1 :/ 3};
+  }
+
+  function void post_randomize();
+    if (read_addr_after_write && bus_op_prev == BusOpWrite) begin
+      bus_op = BusOpRead;
+      addr = addr_prev;
+    end
+    bus_op_prev = bus_op;
+    addr_prev = addr;
+  endfunction
+
+  task body();
+    num_times.rand_mode(0);
+
+    // TODO: Fix and invoke sba_tl_device_seq_disable_tlul_assert_host_sba_resp_svas() instead.
+    cfg.rv_dm_vif.disable_tlul_assert_host_sba_resp_svas = 1'b1;
+
+    sba_tl_device_seq_stop();
+    for (int i = 1; i <= num_times; i++) begin
+      `uvm_info(`gfn, $sformatf("Starting iteration %0d/%0d", i, num_times), UVM_LOW)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(num_trans)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(min_rsp_delay)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(max_rsp_delay)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(d_error_pct)
+      `DV_CHECK_MEMBER_RANDOMIZE_FATAL(d_chan_intg_err_pct)
+      sba_tl_device_seq_start(.min_rsp_delay(min_rsp_delay),
+                              .max_rsp_delay(max_rsp_delay),
+                              .d_error_pct(d_error_pct),
+                              .d_chan_intg_err_pct(d_chan_intg_err_pct));
+      num_trans.rand_mode(0);
+      for (int j = 1; j <= num_trans; j++) begin
+        `DV_CHECK_RANDOMIZE_FATAL(this)
+        `uvm_info(`gfn, $sformatf("Starting transaction %0d/%0d", j, num_trans), UVM_LOW)
+        sba_access(.jtag_dmi_ral(jtag_dmi_ral),
+                   .cfg(cfg.m_jtag_agent_cfg),
+                   .bus_op(bus_op),
+                   .size(size),
+                   .addr(addr),
+                   .data(data),
+                   .readonaddr(readonaddr),
+                   .readondata(readondata),
+                   .autoincrement(autoincrement));
+      end
+      sba_tl_device_seq_stop();
+    end
+  endtask : body
+
+endclass

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_vseq_list.sv
@@ -7,3 +7,4 @@
 `include "rv_dm_common_vseq.sv"
 `include "rv_dm_jtag_dtm_csr_vseq.sv"
 `include "rv_dm_jtag_dmi_csr_vseq.sv"
+`include "rv_dm_sba_tl_access_vseq.sv"

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -127,6 +127,12 @@
       run_opts: ["+en_scb=0", "+csr_aliasing"]
       reseed: 5
     }
+    {
+      name: rv_dm_sba_tl_access
+      uvm_test_seq: rv_dm_sba_tl_access_vseq
+      reseed: 20
+    }
+
   ]
 
   // List of regressions.

--- a/hw/ip/rv_dm/dv/tb.sv
+++ b/hw/ip/rv_dm/dv/tb.sv
@@ -80,4 +80,17 @@ module tb;
     run_test();
   end
 
+  // Disable TLUL host SBA assertions when injecting intg errors on the response channel.
+  initial begin
+    forever @rv_dm_if.disable_tlul_assert_host_sba_resp_svas begin
+      if (rv_dm_if.disable_tlul_assert_host_sba_resp_svas) begin
+        $assertoff(0, dut.tlul_assert_host_sba.gen_host.respOpcode_M);
+        $assertoff(0, dut.tlul_assert_host_sba.gen_host.respSzEqReqSz_M);
+      end else begin
+        $asserton(0, dut.tlul_assert_host_sba.gen_host.respOpcode_M);
+        $asserton(0, dut.tlul_assert_host_sba.gen_host.respSzEqReqSz_M);
+      end
+    end
+  end
+
 endmodule


### PR DESCRIPTION
This commit prepares the JTAG DMI agent and adds a well randomized SBA access test via JTAG -> DTM -> DMI -> SBA. There is no checking at the moment, but the waves look promising. The extensive set of checks in the scoreboard will come in a future PR. 

