### PR TITLE
[fpv/pinmux] Add missing V2 assertions

### DIFF
--- a/hw/ip/pinmux/data/pinmux_fpv_testplan.hjson
+++ b/hw/ip/pinmux/data/pinmux_fpv_testplan.hjson
@@ -36,10 +36,26 @@
       milestone: V1
       tests: ["pinmux_assert"]
     }
+
+    // `mio_to_periph_o` backward tests
+    // Symbolic variable `periph_sel_i` is used to select a specific `mio_to_periph_o` pin.
     {
-      name: MioToPeriphO_A
-      desc: '''This assertion checks that any changes from the mio_to_periph_o output are due to
-            the changes from `mio_in_i`, jtag or register `periph_insel`.'''
+      name: MioToPeriph0Backward_A
+      desc: '''`mio_to_periph_o` should output 0 only if one of the following conditions meets:
+            - Register `periph_insel` is set to 0.
+            - The corresponding `mio_in_i` is 0.
+            - Jtag is enabled.
+            '''
+      milestone: V2
+      tests: ["pinmux_assert"]
+    }
+    {
+      name: MioToPeriph1Backward_A
+      desc: '''`mio_to_periph_o` should output 1 only if one of the following conditions meets:
+            - Register `periph_insel` is set to 1.
+            - The corresponding `mio_in_i` is 1.
+            - Jtag is enabled.
+            '''
       milestone: V2
       tests: ["pinmux_assert"]
     }
@@ -92,10 +108,26 @@
       milestone: V1
       tests: ["pinmux_assert"]
     }
+
+    // `mio_out_o` backward tests
+    // Symbolic variable `mio_sel_i` is used to select a specific `mio_out_o` pin.
     {
-      name: MioOutO_A
-      desc: '''This assertion checks that any changes from the mio_out_o output are due to the
-            changes from `periph_to_mio_i`, sleep_mode, jtag or register `mio_outsel`.'''
+      name: MioOut0Backward_A
+      desc: '''`mio_out_o` should output 0 only if one of the following conditions meets:
+            - Register `mio_insel` is set to 0 or 2.
+            - The corresponding `periph_to_mio_i` is 0.
+            - Sleep mode is enabled.
+            '''
+      milestone: V2
+      tests: ["pinmux_assert"]
+    }
+    {
+      name: MioOut1Backward_A
+      desc: '''`mio_out_o` should output 1 only if one of the following conditions meets:
+            - Register `mio_insel` is set to 1.
+            - The corresponding `periph_to_mio_i` is 1.
+            - Sleep mode is enabled.
+            '''
       milestone: V2
       tests: ["pinmux_assert"]
     }
@@ -140,10 +172,26 @@
       milestone: V1
       tests: ["pinmux_assert"]
     }
+
+    // `mio_oe_o` backward tests
+    // Symbolic variable `mio_sel_i` is used to select a specific `mio_oe_o` pin.
     {
-      name: MioOeO_A
-      desc: '''This assertion checks that any changes from the `mio_oe_o` output are due to the
-            changes from `periph_to_mio_oe_i`, sleep_mode, jtag or register `mio_outsel`.'''
+      name: MioOe0Backward_A
+      desc: '''`mio_oe_o` should output 0 only if one of the following conditions meets:
+            - Register `mio_insel` is set to 2.
+            - The corresponding `periph_to_mio_oe_i` is 0.
+            - Sleep mode is enabled.
+            '''
+      milestone: V2
+      tests: ["pinmux_assert"]
+    }
+    {
+      name: MioOe1Backward_A
+      desc: '''`mio_oe_o` should output 1 only if one of the following conditions meets:
+            - Register `mio_insel` is set to 0 or 1.
+            - The corresponding `periph_to_mio_oe_i` is 1.
+            - Sleep mode is enabled.
+            '''
       milestone: V2
       tests: ["pinmux_assert"]
     }
@@ -248,13 +296,11 @@
       tests: ["pinmux_assert"]
     }
 
-    // `mio_out_o` backward tests
+    // `mio_out_o` sleep mode related backward tests
     // Symbolic variable `mio_sel_i` is used to select a specific `mio_out_o` pin.
     {
-      name: Mio0Backward_A
+      name: MioSleep0Backward_A
       desc: '''`mio_out_o` should output 0 only if one of the following conditions meets:
-            - Register `mio_outsel` is set to 0 or 2.
-            - The corresponding `periph_to_mio_i` is 0.
             - In sleep mode, register `mio_pad_sleep_mode` is set to 0 or 2.
             - In sleep mode, previous `mio_out_o` is 0 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_out_o` is 0 and input `sleep_en_i` is not at posedge.
@@ -263,10 +309,8 @@
       tests: ["pinmux_assert"]
     }
     {
-      name: Mio1Backward_A
+      name: MioSleep1Backward_A
       desc: '''`mio_out_o` should output 1 only if one of the following conditions meets:
-            - Register `mio_outsel` is set to 1.
-            - The corresponding `periph_to_dio_i` is 1.
             - In sleep mode, register `mio_pad_sleep_mode` is set to 1.
             - In sleep mode, previous `mio_out_o` is 1 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_out_o` is 1 and input `sleep_en_i` is not at posedge.
@@ -275,13 +319,11 @@
       tests: ["pinmux_assert"]
     }
 
-    // `mio_oe_o` backward tests
+    // `mio_oe_o` sleep mode related backward tests
     // Symbolic variable `mio_sel_i` is used to select a specific `mio_oe_o` pin.
     {
-      name: MioOe0Backward_A
+      name: MioOeSleep0Backward_A
       desc: '''`mio_oe_o` should output 0 only if one of the following conditions meets:
-            - Register `mio_outsel` is set to 2.
-            - The corresponding `periph_to_dio_i` is 0.
             - In sleep mode, register `mio_pad_sleep_mode` is set to 2.
             - In sleep mode, previous `mio_oe_o` is 0 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_oe_o` is 0 and input `sleep_en_i` is not at posedge.
@@ -290,10 +332,8 @@
       tests: ["pinmux_assert"]
     }
     {
-      name: MioOe1Backward_A
+      name: MioOeSleep1Backward_A
       desc: '''`mio_oe_o` should output 1 only if one of the following conditions meets:
-            - Register `mio_outsel` is set to 0 or 1.
-            - The corresponding `periph_to_mio_i` is 1.
             - In sleep mode, register `mio_pad_sleep_mode` is set to 0 or 1.
             - In sleep mode, previous `mio_oe_o` is 1 and `mio_pad_sleep_mode` is set to 3.
             - In sleep mode, previous `mio_oe_o` is 1 and input `sleep_en_i` is not at posedge.
@@ -588,18 +628,11 @@
       tests: ["pinmux_assert"]
     }
     {
-      name: LcJtagO0Backward_A
-      desc: '''`lc_jtag_o` pins are zero if one of the following conditions are met:
-            - Lc Jtag is enabled and the corresponding pins are 0.
-            - Lc Jtag is disabled.
-            '''
-      milestone: V2
-      tests: ["pinmux_assert"]
-    }
-    {
-      name: LcJtagO1Backward_A
-      desc: '''`lc_jtag_o` pins are ones if one of the following conditions are met:
-            - Lc Jtag is enabled and the corresponding pins are 1.
+      name: LcJtagOBackward_A
+      desc: '''`lc_jtag_o` pins are equal to the corresponding `mio_in_i` inputs if one of the
+            following conditions are met:
+            - Lc Jtag is disabled and the corresponding pins are 0.
+            - Lc Jtag is enabled.
             '''
       milestone: V2
       tests: ["pinmux_assert"]
@@ -632,18 +665,11 @@
       tests: ["pinmux_assert"]
     }
     {
-      name: RvJtagO0Backward_A
-      desc: '''`rv_jtag_o` pins are zero if one of the following conditions are met:
-            - Rv Jtag is enabled and the corresponding pins are 0.
-            - Rv Jtag is disabled.
-            '''
-      milestone: V2
-      tests: ["pinmux_assert"]
-    }
-    {
-      name: RvJtagO1Backward_A
-      desc: '''`rv_jtag_o` pins are ones if one of the following conditions are met:
-            - Rv Jtag is enabled and the corresponding pins are 1.
+      name: RvJtagOBackward_A
+      desc: '''`rv_jtag_o` pins are equal to the corresponding `mio_in_i` inputs if one of the
+            following conditions are met:
+            - Rv Jtag is disabled and the corresponding pins are 0.
+            - Rv Jtag is enabled.
             '''
       milestone: V2
       tests: ["pinmux_assert"]
@@ -675,10 +701,11 @@
       tests: ["pinmux_assert"]
     }
     {
-      name: DftJtagO0Backward_A
-      desc: '''`dft_jtag_o` pins are zero if one of the following conditions are met:
-            - Dft Jtag is enabled and the corresponding pins are 0.
-            - Dft Jtag is disabled.
+      name: DftJtagOBackward_A
+      desc: '''`dft_jtag_o` pins are equal to the corresponding `mio_in_i` inputs if one of the
+            following conditions are met:
+            - Dft Jtag is disabled and the corresponding pins are 0.
+            - Dft Jtag is enabled.
             '''
       milestone: V2
       tests: ["pinmux_assert"]

--- a/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -103,11 +103,19 @@ module pinmux_assert_fpv
           !((periph_insel.q - 2) inside {TargetCfg.tck_idx, TargetCfg.tms_idx, TargetCfg.trst_idx,
                                          TargetCfg.tdi_idx, TargetCfg.tdo_idx}) |->
           mio_to_periph_o[periph_sel_i] == mio_in_i[periph_insel.q - 2])
-   `ASSERT(InSelOOB_A, periph_insel.q >= (pinmux_reg_pkg::NMioPads + 2) |->
+  `ASSERT(InSelOOB_A, periph_insel.q >= (pinmux_reg_pkg::NMioPads + 2) |->
           mio_to_periph_o[periph_sel_i] == 0)
-  // TODO: fix and uncomment the assertion below
-  //`ASSERT(MioToPeriphO_A, ##1 !$stable(mio_to_periph_o[periph_sel_i]) |->
-  //        !$stable(mio_in_i[periph_insel.q - 2]) || !$stable(periph_insel.q))
+
+  `ASSERT(MioToPeriph0Backward_A, mio_to_periph_o[periph_sel_i] == 0 |->
+          (periph_insel.q == 0) ||
+          ((periph_insel.q > 1 && periph_insel.q < (pinmux_reg_pkg::NMioPads + 2) &&
+           (pinmux.u_pinmux_strap_sampling.jtag_en || mio_in_i[periph_insel.q - 2] == 0)) ||
+           periph_insel.q >= (pinmux_reg_pkg::NMioPads + 2)))
+
+  `ASSERT(MioToPeriph1Backward_A, mio_to_periph_o[periph_sel_i] == 1 |->
+          (periph_insel.q == 1) ||
+          (periph_insel.q > 1 && periph_insel.q < (pinmux_reg_pkg::NMioPads + 2) &&
+          (mio_in_i[periph_insel.q - 2] == 1 || pinmux.u_pinmux_strap_sampling.jtag_en)))
 
   `ASSERT(DioInSelN_A, dio_to_periph_o == dio_in_i)
 
@@ -126,9 +134,20 @@ module pinmux_assert_fpv
           !mio_pad_sleep_status.q |-> mio_out_o[mio_sel_i] == periph_to_mio_i[mio_outsel.q - 3])
   `ASSERT(OutSelOOB_A, mio_outsel.q >= (pinmux_reg_pkg::NMioPeriphOut + 3) &&
           !mio_pad_sleep_status.q |-> mio_out_o[mio_sel_i] == 0)
-  // TODO: fix and uncomment the assertion below
-  //`ASSERT(MioOutO_A, ##1 !$stable(mio_out_o[mio_sel_i]) |->
-  //        !$stable(mio_outsel.q) || !$stable(periph_to_mio_i[mio_outsel.q - 3]))
+
+  `ASSERT(MioOut0Backward_A, mio_out_o[mio_sel_i] == 0 |->
+          mio_pad_sleep_status.q ||
+          mio_outsel.q inside {0, 2} ||
+          mio_outsel.q >= (pinmux_reg_pkg::NMioPeriphOut + 3) ||
+          (mio_outsel.q > 2 && mio_outsel.q < (pinmux_reg_pkg::NMioPeriphOut + 3) &&
+           periph_to_mio_i[mio_outsel.q - 3] == 0))
+
+  `ASSERT(MioOut1Backward_A, mio_out_o[mio_sel_i] == 1 |->
+          mio_pad_sleep_status.q ||
+          mio_outsel.q == 1 ||
+          mio_outsel.q > (pinmux_reg_pkg::NMioPeriphOut + 3) ||
+          (mio_outsel.q > 2 && mio_outsel.q < (pinmux_reg_pkg::NMioPeriphOut + 3) &&
+           periph_to_mio_i[mio_outsel.q - 3] == 1))
 
   `ASSERT(OutSelOe0_A, mio_outsel.q == 0 && !mio_pad_sleep_status.q |->
           mio_oe_o[mio_sel_i] == 1'b1)
@@ -140,9 +159,20 @@ module pinmux_assert_fpv
           !mio_pad_sleep_status.q |-> mio_oe_o[mio_sel_i] == periph_to_mio_oe_i[mio_outsel.q - 3])
   `ASSERT(OutSelOeOOB_A, mio_outsel.q >= (pinmux_reg_pkg::NMioPeriphOut + 3) &&
           !mio_pad_sleep_status.q |-> mio_oe_o[mio_sel_i] == 0)
-  // TODO: fix and uncomment the assertion below
-  //`ASSERT(MioOeO_A, ##1 !$stable(mio_oe_o[mio_sel_i]) |->
-  //    !$stable(mio_outsel.q) || !$stable(periph_to_mio_oe_i[mio_outsel.q - 3]))
+
+  `ASSERT(MioOe0Backward_A, mio_oe_o[mio_sel_i] == 0 |->
+          mio_pad_sleep_status.q ||
+          mio_outsel.q == 2 ||
+          mio_outsel.q >= (pinmux_reg_pkg::NMioPeriphOut + 3) ||
+          (mio_outsel.q > 2 && mio_outsel.q < (pinmux_reg_pkg::NMioPeriphOut + 3) &&
+           periph_to_mio_oe_i[mio_outsel.q - 3] == 0))
+
+  `ASSERT(MioOe1Backward_A, mio_oe_o[mio_sel_i] == 1 |->
+          mio_pad_sleep_status.q ||
+          mio_outsel.q inside {0, 1} ||
+          mio_outsel.q > (pinmux_reg_pkg::NMioPeriphOut + 3) ||
+          (mio_outsel.q > 2 && mio_outsel.q < (pinmux_reg_pkg::NMioPeriphOut + 3) &&
+           periph_to_mio_oe_i[mio_outsel.q - 3] == 1))
 
   // ------ Mio sleep behavior assertions ------
   pinmux_reg_pkg::pinmux_reg2hw_mio_pad_sleep_en_mreg_t mio_pad_sleep_en;
@@ -199,6 +229,51 @@ module pinmux_assert_fpv
           // Ensure SW does not write to sleep status register to clear sleep status.
           ##1 mio_pad_sleep_status.q |->
           $stable(mio_oe_o[mio_sel_i]))
+
+  // ------Mio sleep enabled backward assertions ------
+  `ASSERT(MioSleep0Backward_A, mio_out_o[mio_sel_i] == 0 |->
+          mio_pad_sleep_status.q == 0 ||
+          // Sleep mode set to 0 and 2.
+          $past(mio_pad_sleep_mode.q) inside {0, 2} ||
+          // Previous value is 0 and sleep mode is set to 3.
+          ($past(mio_out_o[mio_sel_i]) == 0) &&
+           ($past(mio_pad_sleep_mode.q) == 3 ||
+            // Previous value is 0 and sleep mode selection is disabled either by sleep_en_i input
+            // or sleep_en CSR.
+            ($past(!$rose(sleep_en_i) || !mio_pad_sleep_en.q) && mio_pad_sleep_status.q)))
+
+  `ASSERT(MioSleep1Backward_A, mio_out_o[mio_sel_i] == 1 |->
+          mio_pad_sleep_status.q == 0 ||
+          // Sleep mode set to 1.
+          $past(mio_pad_sleep_mode.q) == 1 ||
+          // Previous value is 1 and sleep mode is set to 3.
+          ($past(mio_out_o[mio_sel_i]) == 1) &&
+           ($past(mio_pad_sleep_mode.q) == 3 ||
+            // Previous value is 1 and sleep mode selection is disabled either by sleep_en_i input
+            // or sleep_en CSR.
+            ($past(!$rose(sleep_en_i) || !mio_pad_sleep_en.q) && mio_pad_sleep_status.q)))
+
+  `ASSERT(MioOeSleep0Backward_A, mio_oe_o[mio_sel_i] == 0 |->
+          mio_pad_sleep_status.q == 0 ||
+          // Sleep mode set to 2.
+          $past(mio_pad_sleep_mode.q) == 2 ||
+          // Previous value is 0 and sleep mode is set to 3.
+          ($past(mio_oe_o[mio_sel_i]) == 0) &&
+           ($past(mio_pad_sleep_mode.q) == 3 ||
+            // Previous value is 0 and sleep mode selection is disabled either by sleep_en_i input
+            // or sleep_en CSR.
+            ($past(!$rose(sleep_en_i) || !mio_pad_sleep_en.q) && mio_pad_sleep_status.q)))
+
+  `ASSERT(MioOeSleep1Backward_A, mio_oe_o[mio_sel_i] == 1 |->
+          mio_pad_sleep_status.q == 0 ||
+          // Sleep mode set to 0 or 1.
+          $past(mio_pad_sleep_mode.q) inside {0, 1} ||
+          // Previous value is 1 and sleep mode is set to 3.
+          ($past(mio_oe_o[mio_sel_i]) == 1) &&
+           ($past(mio_pad_sleep_mode.q) == 3 ||
+            // Previous value is 1 and sleep mode selection is disabled either by sleep_en_i input
+            // or sleep_en CSR.
+            ($past(!$rose(sleep_en_i) || !mio_pad_sleep_en.q) && mio_pad_sleep_status.q)))
 
   // ------ Mio_attr_o ------
   pinmux_reg_pkg::pinmux_reg2hw_mio_pad_attr_mreg_t mio_pad_attr;
@@ -463,6 +538,13 @@ module pinmux_assert_fpv
   `ASSERT(LcJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::LcTapSel |->
           lc_jtag_o == '0)
 
+  `ASSERT(LcJtagBackward_A,
+          lc_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
+          lc_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
+          lc_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
+          lc_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
+          u_pinmux_strap_sampling.tap_strap == pinmux_pkg::LcTapSel || lc_jtag_o == 0)
+
   // Lc_hw_debug_en_i signal goes through a two clock cycle synchronizer.
   `ASSERT(RvJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
           !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
@@ -487,6 +569,14 @@ module pinmux_assert_fpv
           $past(lc_hw_debug_en_i, 2) != lc_ctrl_pkg::On |->
           rv_jtag_o == '0)
 
+  `ASSERT(RvJtagBackward_A,
+          rv_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
+          rv_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
+          rv_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
+          rv_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
+          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::RvTapSel &&
+           $past(lc_hw_debug_en_i, 2) == lc_ctrl_pkg::On) || rv_jtag_o == 0)
+
   // Lc_dft_en_i signal goes through a two clock cycle synchronizer.
   `ASSERT(DftJtagOWoScanmode_A, u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
           !prim_mubi_pkg::mubi4_test_true_strict(scanmode_i) &&
@@ -510,6 +600,14 @@ module pinmux_assert_fpv
   `ASSERT(DftJtagODefault_A, u_pinmux_strap_sampling.tap_strap != pinmux_pkg::DftTapSel ||
           $past(lc_dft_en_i, 2) != lc_ctrl_pkg::On |->
           dft_jtag_o == '0)
+
+  `ASSERT(DftJtagBackward_A,
+          dft_jtag_o[0] == mio_in_i[TargetCfg.tdi_idx] &&
+          dft_jtag_o[1] inside {mio_in_i[TargetCfg.trst_idx], rst_ni } &&
+          dft_jtag_o[2] == mio_in_i[TargetCfg.tms_idx] &&
+          dft_jtag_o[3] == mio_in_i[TargetCfg.tck_idx] |->
+          (u_pinmux_strap_sampling.tap_strap == pinmux_pkg::DftTapSel &&
+           $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) || dft_jtag_o == 0)
 
   `ASSERT(TapStrap_A, ##2 ((!dft_hold_tap_sel_i && $past(lc_dft_en_i, 2) == lc_ctrl_pkg::On) ||
           strap_en_i) && $past(lc_hw_debug_en_i, 2) == lc_ctrl_pkg::On |=>


### PR DESCRIPTION
This PR adds the missing V2 assertions from the testplan.
Also modify the testplan to combine(JTAG) or breakdown(Mios) backward
assertions so it is easier to write assertions.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>