### PR TITLE
[rv_dm dv] Set coverage hier file for CSR tests

### DIFF
--- a/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
+++ b/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
++node tb.dut *_tl_*
++node tb.dut jtag_*
+
+// The JTAG DTM is functionally verified, even in CSR tests.
+begin line+cond+fsm+branch+assert
+  +moduletree dmi_jtag
+end

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -56,6 +56,10 @@
       name: tl_dbw
       value: 8
     }
+    {
+      name: cover_reg_top_vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover_reg_top.cfg+{proj_root}/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg"
+    }
   ]
 
   // Default UVM test and seq class name.


### PR DESCRIPTION
This enables some JTAG components for coverage collection
in CSR tests.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>