### PR TITLE
[dif/pwm] Implement remaining DIFs

### DIFF
--- a/hw/ip/pwm/data/pwm.hjson
+++ b/hw/ip/pwm/data/pwm.hjson
@@ -44,7 +44,7 @@
         { bits: "0",
           desc: ''' When true, all writable registers can be modified.
                     When false, they become read-only. Defaults true, write
-                    one to clear. This can be cleared after initial
+                    zero to clear. This can be cleared after initial
                     configuration at boot in order to lock in the listed
                     register settings.'''
           resval: 1

--- a/sw/device/lib/dif/dif_pwm.h
+++ b/sw/device/lib/dif/dif_pwm.h
@@ -289,7 +289,7 @@ dif_result_t dif_pwm_channel_set_enabled(const dif_pwm_t *pwm,
                                          dif_toggle_t enabled);
 
 /**
- * Gets the enablement state of a PWM channel.
+ * Gets the enablement state of one PWM channel.
  *
  * @param pwm A PWM handle.
  * @param channel The PWM channel to get the enablement state of.

--- a/sw/device/lib/dif/dif_pwm.md
+++ b/sw/device/lib/dif/dif_pwm.md
@@ -11,8 +11,8 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | In Progress |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
@@ -24,8 +24,8 @@ Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
@@ -39,7 +39,7 @@ Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
 Documentation  | [DIF_DOC_HW][]                   | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
-Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -1090,6 +1090,7 @@ test('dif_pwm_unittest', executable(
     sources: [
       'dif_pwm_unittest.cc',
       'autogen/dif_pwm_autogen_unittest.cc',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_base.c',
       meson.project_source_root() / 'sw/device/lib/dif/dif_pwm.c',
       meson.project_source_root() / 'sw/device/lib/dif/autogen/dif_pwm_autogen.c',
       hw_ip_pwm_reg_h,


### PR DESCRIPTION
This commit implements all remaining DIFs for the PWM IP, including all get/set enablement DIFs and lock(ing) DIFs. Additionally this commit updates the DIF checklist to reflect these changes.

**_Note: this depends on PR #11183, and contains a duplicate commit that will be removed when the dependency merges._**