### PR TITLE
[sw/runtime] Fix ibex_timeout_check

### DIFF
--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -149,7 +149,7 @@ inline ibex_timeout_t ibex_timeout_init(uint32_t timeout_usec) {
  * @return Boolean indicating the timeout expired.
  */
 inline bool ibex_timeout_check(const ibex_timeout_t *timeout) {
-  return ibex_mcycle_read() - timeout->start < timeout->cycles;
+  return ibex_mcycle_read() - timeout->start > timeout->cycles;
 }
 
 /**
@@ -173,7 +173,7 @@ inline uint64_t ibex_timeout_elapsed(const ibex_timeout_t *timeout) {
   do {                                                                    \
     const ibex_timeout_t timeout_ = ibex_timeout_init(timeout_usec);      \
     while (!(expr)) {                                                     \
-      CHECK(!ibex_timeout_check(&timeout_),                               \
+      CHECK(ibex_timeout_check(&timeout_),                                \
             "Timed out after %d usec (%d CPU cycles) waiting for " #expr, \
             timeout_usec, (uint32_t)timeout_.cycles);                     \
     }                                                                     \


### PR DESCRIPTION
The return value should match the function documentation.
Fix the IBEX_SPIN_FOR macro to match.

Signed-off-by: Guillermo Maturana <maturana@google.com>