### PR TITLE
[sw, base] Clean up macros.h

### DIFF
--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -125,7 +125,7 @@
 /**
  * Attribute for weak functions that can be overridden, e.g., ISRs.
  */
-#define OT_ATTR_WEAK __attribute__((weak))
+#define OT_WEAK __attribute__((weak))
 
 /**
  * Attribute to construct functions without prologue/epilogue sequences.
@@ -135,7 +135,7 @@
  * See https://gcc.gnu.org/onlinedocs/gcc/RISC-V-Function-Attributes.html
  * #RISC-V-Function-Attributes
  */
-#define OT_ATTR_NAKED __attribute__((naked))
+#define OT_NAKED __attribute__((naked))
 
 /**
  * Attribute to place symbols into particular sections.
@@ -143,7 +143,7 @@
  * See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html
  * #Common-Function-Attributes
  */
-#define OT_ATTR_SECTION(name) __attribute__((section(name)))
+#define OT_SECTION(name) __attribute__((section(name)))
 
 /**
  * Returns the address of the current function stack frame.

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -28,17 +28,19 @@
  * @param array The array expression to measure.
  * @return The number of elements in the array, as a `size_t`.
  */
+// This is a sufficiently well-known macro that we don't really need to bother
+// with a prefix like the others, and a rename will cause churn.
 #define ARRAYSIZE(array) (sizeof(array) / sizeof(array[0]))
 
 /**
  * An annotation that a switch/case fallthrough is the intended behavior.
  */
-#define FALLTHROUGH_INTENDED __attribute__((fallthrough))
+#define OT_FALLTHROUGH_INTENDED __attribute__((fallthrough))
 
 /**
  * A directive to force the compiler to inline a function.
  */
-#define ALWAYS_INLINE __attribute__((always_inline)) inline
+#define OT_ALWAYS_INLINE __attribute__((always_inline)) inline
 
 /**
  * A variable-argument macro that expands to the number of arguments passed into
@@ -53,17 +55,17 @@
  *              to work correctly.
  * @param ... the variable args list.
  */
+#define OT_VA_ARGS_COUNT(dummy, ...)                                          \
+  OT_SHIFT_N_VARIABLE_ARGS_(dummy, ##__VA_ARGS__, 31, 30, 29, 28, 27, 26, 25, \
+                            24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13,   \
+                            12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
 
-// Implementation details for `GET_NUM_VARIABLE_ARGS()`.
-#define GET_NUM_VARIABLE_ARGS(dummy, ...)                                      \
-  SHIFT_N_VARIABLE_ARGS_(dummy, ##__VA_ARGS__, 31, 30, 29, 28, 27, 26, 25, 24, \
-                         23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11,   \
-                         10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
-#define SHIFT_N_VARIABLE_ARGS_(...) GET_NTH_VARIABLE_ARG_(__VA_ARGS__)
-#define GET_NTH_VARIABLE_ARG_(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, \
-                              x11, x12, x13, x14, x15, x16, x17, x18, x19, \
-                              x20, x21, x22, x23, x24, x25, x26, x27, x28, \
-                              x29, x30, x31, n, ...)                       \
+// Implementation details for `OT_VA_ARGS_COUNT()`.
+#define OT_SHIFT_N_VARIABLE_ARGS_(...) OT_GET_NTH_VARIABLE_ARG_(__VA_ARGS__)
+#define OT_GET_NTH_VARIABLE_ARG_(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, \
+                                 x11, x12, x13, x14, x15, x16, x17, x18, x19, \
+                                 x20, x21, x22, x23, x24, x25, x26, x27, x28, \
+                                 x29, x30, x31, n, ...)                       \
   n
 
 /**

--- a/sw/device/lib/dif/dif_alert_handler.h
+++ b/sw/device/lib/dif/dif_alert_handler.h
@@ -390,7 +390,8 @@ dif_result_t dif_alert_handler_configure_class(
  * @param locked The locked state to configure ping timer in.
  * @return The result of the operation.
  */
-OT_WARN_UNUSED_RESULT dif_result_t dif_alert_handler_configure_ping_timer(
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_configure_ping_timer(
     const dif_alert_handler_t *alert_handler, uint32_t ping_timeout,
     dif_toggle_t enabled, dif_toggle_t locked);
 
@@ -408,7 +409,8 @@ OT_WARN_UNUSED_RESULT dif_result_t dif_alert_handler_configure_ping_timer(
  * @param locked The locked state to configure ping timer in after enabling it.
  * @return The result of the operation.
  */
-OT_WARN_UNUSED_RESULT dif_result_t dif_alert_handler_ping_timer_set_enabled(
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_alert_handler_ping_timer_set_enabled(
     const dif_alert_handler_t *alert_handler, dif_toggle_t locked);
 
 /**

--- a/sw/device/lib/runtime/log.h
+++ b/sw/device/lib/runtime/log.h
@@ -120,7 +120,7 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
       static const log_fields_t kLogFields =                     \
           LOG_MAKE_FIELDS_(severity, format, ##__VA_ARGS__);     \
       base_log_internal_dv(&kLogFields,                          \
-                           GET_NUM_VARIABLE_ARGS(format, ##__VA_ARGS__), \
+                           OT_VA_ARGS_COUNT(format, ##__VA_ARGS__), \
                            ##__VA_ARGS__); /* clang-format on */ \
     } else {                                                     \
       log_fields_t log_fields =                                  \
@@ -135,7 +135,7 @@ void base_log_internal_dv(const log_fields_t *log, uint32_t nargs, ...);
 #define LOG_MAKE_FIELDS_(_severity, _format, ...)                         \
   {                                                                       \
     .severity = _severity, .file_name = "" __FILE__ "", .line = __LINE__, \
-    .nargs = GET_NUM_VARIABLE_ARGS(_format, ##__VA_ARGS__),               \
+    .nargs = OT_VA_ARGS_COUNT(_format, ##__VA_ARGS__),                    \
     .format = "" _format "",                                              \
   }
 

--- a/sw/device/lib/testing/check.h
+++ b/sw/device/lib/testing/check.h
@@ -26,25 +26,25 @@
  * @param ... Arguments to a LOG_* macro, which are evaluated if the check
  * fails.
  */
-#define CHECK(condition, ...)                             \
-  do {                                                    \
-    if (!(condition)) {                                   \
-      /* NOTE: because the condition in this if           \
-         statement can be statically determined,          \
-         only one of the below string constants           \
-         will be included in the final binary.*/          \
-      if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("CHECK-fail: " #condition);             \
-      } else {                                            \
-        LOG_ERROR("CHECK-fail: " __VA_ARGS__);            \
-      }                                                   \
-      /* Currently, this macro will call into             \
-         the test failure code, which logs                \
-         "FAIL" and aborts. In the future,                \
-         we will try to condition on whether              \
-         or not this is a test.*/                         \
-      test_status_set(kTestStatusFailed);                 \
-    }                                                     \
+#define CHECK(condition, ...)                        \
+  do {                                               \
+    if (!(condition)) {                              \
+      /* NOTE: because the condition in this if      \
+         statement can be statically determined,     \
+         only one of the below string constants      \
+         will be included in the final binary.*/     \
+      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) { \
+        LOG_ERROR("CHECK-fail: " #condition);        \
+      } else {                                       \
+        LOG_ERROR("CHECK-fail: " __VA_ARGS__);       \
+      }                                              \
+      /* Currently, this macro will call into        \
+         the test failure code, which logs           \
+         "FAIL" and aborts. In the future,           \
+         we will try to condition on whether         \
+         or not this is a test.*/                    \
+      test_status_set(kTestStatusFailed);            \
+    }                                                \
   } while (false)
 
 /**
@@ -69,7 +69,7 @@
         LOG_INFO("[%d] actual = 0x%x; expected = 0x%x", i, actual_[i],         \
                  expected_[i]);                                                \
       }                                                                        \
-      if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) {                      \
+      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) {                           \
         LOG_ERROR("CHECK-BUFFER-fail: " #actual_ "does not match" #expected_); \
       } else {                                                                 \
         LOG_ERROR("CHECK-BUFFER-fail: " __VA_ARGS__);                          \
@@ -92,25 +92,25 @@
  * @param ... Arguments to a LOG_* macro, which are evaluated if the check
  * fails.
  */
-#define CHECK_DIF_OK(dif_call, ...)                       \
-  do {                                                    \
-    if (dif_call != kDifOk) {                             \
-      /* NOTE: because the condition in this if           \
-         statement can be statically determined,          \
-         only one of the below string constants           \
-         will be included in the final binary.*/          \
-      if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("DIF-fail: " #dif_call);                \
-      } else {                                            \
-        LOG_ERROR("DIF-fail: " __VA_ARGS__);              \
-      }                                                   \
-      /* Currently, this macro will call into             \
-         the test failure code, which logs                \
-         "FAIL" and aborts. In the future,                \
-         we will try to condition on whether              \
-         or not this is a test.*/                         \
-      test_status_set(kTestStatusFailed);                 \
-    }                                                     \
+#define CHECK_DIF_OK(dif_call, ...)                  \
+  do {                                               \
+    if (dif_call != kDifOk) {                        \
+      /* NOTE: because the condition in this if      \
+         statement can be statically determined,     \
+         only one of the below string constants      \
+         will be included in the final binary.*/     \
+      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) { \
+        LOG_ERROR("DIF-fail: " #dif_call);           \
+      } else {                                       \
+        LOG_ERROR("DIF-fail: " __VA_ARGS__);         \
+      }                                              \
+      /* Currently, this macro will call into        \
+         the test failure code, which logs           \
+         "FAIL" and aborts. In the future,           \
+         we will try to condition on whether         \
+         or not this is a test.*/                    \
+      test_status_set(kTestStatusFailed);            \
+    }                                                \
   } while (false)
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CHECK_H_

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -16,12 +16,12 @@
  * ISRs for testing, while also enabling writing tests that do not make use of
  * the OTTF. See the `crt_test` in `sw/device/tests/crt_test.c` for an example.
  */
-OT_ATTR_WEAK
+OT_WEAK
 void *pxCurrentTCB = NULL;
-OT_ATTR_WEAK
+OT_WEAK
 void *kTestConfig = NULL;
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_exception_handler(void) {
   uint32_t mcause = ibex_mcause_read();
 
@@ -56,66 +56,66 @@ void ottf_exception_handler(void) {
   }
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_instr_misaligned_fault_handler(void) {
   LOG_INFO("Misaligned instruction, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_instr_access_fault_handler(void) {
   LOG_INFO("Instruction access fault, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_illegal_instr_fault_handler(void) {
   LOG_INFO("Illegal instruction fault, mtval shows the faulting instruction.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_breakpoint_handler(void) {
   LOG_INFO("Breakpoint triggered, mtval holds the breakpoint address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_load_store_fault_handler(void) {
   LOG_INFO("Load/Store fault, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_machine_ecall_handler(void) {
   LOG_INFO("Machine-mode environment call (syscall).");
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_user_ecall_handler(void) {
   LOG_INFO("User-mode environment call (syscall).");
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_software_isr(void) {
   LOG_INFO("Software IRQ triggered!");
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_timer_isr(void) {
   LOG_INFO("Timer IRQ triggered!");
   abort();
 }
 
-OT_ATTR_WEAK
+OT_WEAK
 void ottf_external_isr(void) {
   LOG_INFO("External IRQ triggered!");
   abort();

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -16,10 +16,13 @@
  * ISRs for testing, while also enabling writing tests that do not make use of
  * the OTTF. See the `crt_test` in `sw/device/tests/crt_test.c` for an example.
  */
-OT_ATTR_WEAK void *pxCurrentTCB = NULL;
-OT_ATTR_WEAK void *kTestConfig = NULL;
+OT_ATTR_WEAK
+void *pxCurrentTCB = NULL;
+OT_ATTR_WEAK
+void *kTestConfig = NULL;
 
-OT_ATTR_WEAK void ottf_exception_handler(void) {
+OT_ATTR_WEAK
+void ottf_exception_handler(void) {
   uint32_t mcause = ibex_mcause_read();
 
   switch ((ottf_exc_id_t)(mcause & kIdMax)) {
@@ -53,57 +56,67 @@ OT_ATTR_WEAK void ottf_exception_handler(void) {
   }
 }
 
-OT_ATTR_WEAK void ottf_instr_misaligned_fault_handler(void) {
+OT_ATTR_WEAK
+void ottf_instr_misaligned_fault_handler(void) {
   LOG_INFO("Misaligned instruction, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_instr_access_fault_handler(void) {
+OT_ATTR_WEAK
+void ottf_instr_access_fault_handler(void) {
   LOG_INFO("Instruction access fault, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_illegal_instr_fault_handler(void) {
+OT_ATTR_WEAK
+void ottf_illegal_instr_fault_handler(void) {
   LOG_INFO("Illegal instruction fault, mtval shows the faulting instruction.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_breakpoint_handler(void) {
+OT_ATTR_WEAK
+void ottf_breakpoint_handler(void) {
   LOG_INFO("Breakpoint triggered, mtval holds the breakpoint address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_load_store_fault_handler(void) {
+OT_ATTR_WEAK
+void ottf_load_store_fault_handler(void) {
   LOG_INFO("Load/Store fault, mtval holds the fault address.");
   LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
   abort();
 }
 
-OT_ATTR_WEAK void ottf_machine_ecall_handler(void) {
+OT_ATTR_WEAK
+void ottf_machine_ecall_handler(void) {
   LOG_INFO("Machine-mode environment call (syscall).");
   abort();
 }
 
-OT_ATTR_WEAK void ottf_user_ecall_handler(void) {
+OT_ATTR_WEAK
+void ottf_user_ecall_handler(void) {
   LOG_INFO("User-mode environment call (syscall).");
   abort();
 }
 
-OT_ATTR_WEAK void ottf_software_isr(void) {
+OT_ATTR_WEAK
+void ottf_software_isr(void) {
   LOG_INFO("Software IRQ triggered!");
   abort();
 }
 
-OT_ATTR_WEAK void ottf_timer_isr(void) {
+OT_ATTR_WEAK
+void ottf_timer_isr(void) {
   LOG_INFO("Timer IRQ triggered!");
   abort();
 }
 
-OT_ATTR_WEAK void ottf_external_isr(void) {
+OT_ATTR_WEAK
+void ottf_external_isr(void) {
   LOG_INFO("External IRQ triggered!");
   abort();
 }

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -153,18 +153,18 @@ void sca_call_and_sleep(sca_callee callee, uint32_t sleep_cycles);
  * TODO: Remove once there is a CHECK_DIF_OK version that does not require test
  * library dependencies.
  */
-#define CHECK_DIF_OK(dif_call, ...)                       \
-  do {                                                    \
-    if (dif_call != kDifOk) {                             \
-      /* NOTE: because the condition in this if           \
-         statement can be statically determined,          \
-         only one of the below string constants           \
-         will be included in the final binary.*/          \
-      if (GET_NUM_VARIABLE_ARGS(_, ##__VA_ARGS__) == 0) { \
-        LOG_ERROR("DIF-fail: " #dif_call);                \
-      } else {                                            \
-        LOG_ERROR("DIF-fail: " __VA_ARGS__);              \
-      }                                                   \
-    }                                                     \
+#define CHECK_DIF_OK(dif_call, ...)                  \
+  do {                                               \
+    if (dif_call != kDifOk) {                        \
+      /* NOTE: because the condition in this if      \
+         statement can be statically determined,     \
+         only one of the below string constants      \
+         will be included in the final binary.*/     \
+      if (OT_VA_ARGS_COUNT(_, ##__VA_ARGS__) == 0) { \
+        LOG_ERROR("DIF-fail: " #dif_call);           \
+      } else {                                       \
+        LOG_ERROR("DIF-fail: " __VA_ARGS__);         \
+      }                                              \
+    }                                                \
   } while (false)
 #endif  // OPENTITAN_SW_DEVICE_SCA_LIB_SCA_H_

--- a/sw/device/silicon_creator/lib/drivers/alert.c
+++ b/sw/device/silicon_creator/lib/drivers/alert.c
@@ -184,11 +184,11 @@ rom_error_t alert_class_configure(alert_class_t cls,
     case kAlertEnableLocked:
       reg = bitfield_bit32_write(
           reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_LOCK_BIT, true);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kAlertEnableEnabled:
       reg = bitfield_bit32_write(reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_EN_BIT,
                                  true);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kAlertEnableNone:
       break;
     default:
@@ -198,19 +198,19 @@ rom_error_t alert_class_configure(alert_class_t cls,
     case kAlertEscalatePhase3:
       reg = bitfield_bit32_write(
           reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_EN_E3_BIT, true);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kAlertEscalatePhase2:
       reg = bitfield_bit32_write(
           reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_EN_E2_BIT, true);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kAlertEscalatePhase1:
       reg = bitfield_bit32_write(
           reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_EN_E1_BIT, true);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kAlertEscalatePhase0:
       reg = bitfield_bit32_write(
           reg, ALERT_HANDLER_CLASSA_CTRL_SHADOWED_EN_E0_BIT, true);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kAlertEscalateNone:
       break;
     default:

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -51,7 +51,7 @@ static_assert(ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT <=
   void unmocked_##name_
 #else
 #define SHUTDOWN_FUNC(modifiers_, name_) \
-  static ALWAYS_INLINE modifiers_ void name_
+  static OT_ALWAYS_INLINE modifiers_ void name_
 #endif
 
 // Convert the alert class to an index.
@@ -224,7 +224,7 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
  *
  * This function must be inlined because it is called from `shutdown_finalize`.
  */
-static ALWAYS_INLINE uint32_t
+static OT_ALWAYS_INLINE uint32_t
 shutdown_redact_inline(rom_error_t reason, shutdown_error_redact_t severity) {
   uint32_t redacted = (uint32_t)reason;
   if (reason == kErrorOk) {
@@ -233,14 +233,14 @@ shutdown_redact_inline(rom_error_t reason, shutdown_error_redact_t severity) {
   switch (severity) {
     case kShutdownErrorRedactModule:
       redacted = bitfield_field32_write(redacted, ROM_ERROR_FIELD_MODULE, 0);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kShutdownErrorRedactError:
       redacted = bitfield_field32_write(redacted, ROM_ERROR_FIELD_ERROR, 0);
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     case kShutdownErrorRedactNone:
       break;
     case kShutdownErrorRedactAll:
-      FALLTHROUGH_INTENDED;
+      OT_FALLTHROUGH_INTENDED;
     default:
       redacted = kErrorUnknown;
   }
@@ -256,7 +256,7 @@ uint32_t shutdown_redact(rom_error_t reason, shutdown_error_redact_t severity) {
  *
  * This function must be inlined because it is called from `shutdown_finalize`.
  */
-static ALWAYS_INLINE shutdown_error_redact_t
+static OT_ALWAYS_INLINE shutdown_error_redact_t
 shutdown_redact_policy_inline(uint32_t raw_state) {
   switch (raw_state) {
     case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0:
@@ -328,8 +328,8 @@ enum {
  * @param prefix Prefix encoded as a 32-bit value.
  * @param val Integer to print.
  */
-static ALWAYS_INLINE void shutdown_print(shutdown_log_prefix_t prefix,
-                                         uint32_t val) {
+static OT_ALWAYS_INLINE void shutdown_print(shutdown_log_prefix_t prefix,
+                                            uint32_t val) {
   // Print the 4 character `prefix`.
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, prefix);
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, prefix >> 8);

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -51,7 +51,8 @@ static_assert(ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT <=
   void unmocked_##name_
 #else
 #define SHUTDOWN_FUNC(modifiers_, name_) \
-  static OT_ALWAYS_INLINE modifiers_ void name_
+  OT_ALWAYS_INLINE                       \
+  static modifiers_ void name_
 #endif
 
 // Convert the alert class to an index.
@@ -224,8 +225,9 @@ rom_error_t shutdown_init(lifecycle_state_t lc_state) {
  *
  * This function must be inlined because it is called from `shutdown_finalize`.
  */
-static OT_ALWAYS_INLINE uint32_t
-shutdown_redact_inline(rom_error_t reason, shutdown_error_redact_t severity) {
+OT_ALWAYS_INLINE
+static uint32_t shutdown_redact_inline(rom_error_t reason,
+                                       shutdown_error_redact_t severity) {
   uint32_t redacted = (uint32_t)reason;
   if (reason == kErrorOk) {
     return 0;
@@ -256,8 +258,9 @@ uint32_t shutdown_redact(rom_error_t reason, shutdown_error_redact_t severity) {
  *
  * This function must be inlined because it is called from `shutdown_finalize`.
  */
-static OT_ALWAYS_INLINE shutdown_error_redact_t
-shutdown_redact_policy_inline(uint32_t raw_state) {
+OT_ALWAYS_INLINE
+static shutdown_error_redact_t shutdown_redact_policy_inline(
+    uint32_t raw_state) {
   switch (raw_state) {
     case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED0:
     case LC_CTRL_LC_STATE_STATE_VALUE_TEST_UNLOCKED1:
@@ -328,8 +331,8 @@ enum {
  * @param prefix Prefix encoded as a 32-bit value.
  * @param val Integer to print.
  */
-static OT_ALWAYS_INLINE void shutdown_print(shutdown_log_prefix_t prefix,
-                                            uint32_t val) {
+OT_ALWAYS_INLINE
+static void shutdown_print(shutdown_log_prefix_t prefix, uint32_t val) {
   // Print the 4 character `prefix`.
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, prefix);
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, prefix >> 8);

--- a/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
+++ b/sw/device/tests/sim_dv/sram_ctrl_execution_test_main.c
@@ -58,8 +58,8 @@ static const uint32_t kOtpIfetchHwRelativeOffset =
  * This function will return on success, or cause an exception if the
  * execution is disabled.
  */
-OT_ATTR_NAKED
-OT_ATTR_SECTION(".data")
+OT_NAKED
+OT_SECTION(".data")
 void execute_code_in_sram(void) { asm volatile("jalr zero, 0(ra)"); }
 
 static bool otp_ifetch_enabled(void) {

--- a/sw/device/tests/sram_ctrl_smoketest.c
+++ b/sw/device/tests/sram_ctrl_smoketest.c
@@ -30,7 +30,7 @@ static const uint32_t kRandomData[SRAM_CTRL_TEST_DATA_SIZE_WORDS] = {
 // Buffer to allow the compiler to allocate a safe area in Main SRAM where
 // we can do the write/read test without the risk of clobbering data
 // used by the program.
-OT_ATTR_SECTION(".data")
+OT_SECTION(".data")
 static volatile uint32_t sram_main_buffer[SRAM_CTRL_TEST_DATA_SIZE_WORDS];
 
 // Write / Read small chunks of data to SRAM to test


### PR DESCRIPTION
This CL:
- Makes sure ~all macros start with `OT_`.
- Makes sure we consistently put attribute macros on their own line; compare Rust attributes like `#[must_use]`. We *mostly* already do this, but this actually makes it consistent.
- This drops `_ATTR_` from the attribute macros that had it (not all of them did).