### PR TITLE
[sw] Replace uses of _Static_assert with the macro in assert.h

### DIFF
--- a/sw/device/lib/base/csr.h
+++ b/sw/device/lib/base/csr.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_BASE_CSR_H_
 #define OPENTITAN_SW_DEVICE_LIB_BASE_CSR_H_
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -24,17 +25,6 @@ extern "C" {
  * will result in the CSR operations being replaced with a mocked
  * implementation.
  */
-
-/**
- * Portable (C and C++) static assertion.
- *
- * TODO: replace with static_assert macro in C (assert.h does this)?
- */
-#ifdef __cplusplus
-#define CSR_STATIC_ASSERT static_assert
-#else  // __cplusplus
-#define CSR_STATIC_ASSERT _Static_assert
-#endif  // __cplusplus
 
 /**
  * Define the implementation macros.
@@ -59,71 +49,71 @@ extern "C" {
 
 uint32_t mock_csr_read(uint32_t addr);
 
-#define CSR_READ_IMPL(csr, dest)                               \
-  do {                                                         \
-    CSR_STATIC_ASSERT(sizeof(*dest) == sizeof(uint32_t),       \
-                      "dest must point to a 4-byte variable"); \
-    CSR_FORCE_CONST_EXPR(csr);                                 \
-    *dest = mock_csr_read(csr);                                \
+#define CSR_READ_IMPL(csr, dest)                           \
+  do {                                                     \
+    static_assert(sizeof(*dest) == sizeof(uint32_t),       \
+                  "dest must point to a 4-byte variable"); \
+    CSR_FORCE_CONST_EXPR(csr);                             \
+    *dest = mock_csr_read(csr);                            \
   } while (false)
 
 void mock_csr_write(uint32_t addr, uint32_t value);
 
-#define CSR_WRITE_IMPL(csr, val)                       \
-  do {                                                 \
-    CSR_STATIC_ASSERT(sizeof(val) == sizeof(uint32_t), \
-                      "val must be a 4-byte value");   \
-    CSR_FORCE_CONST_EXPR(csr);                         \
-    mock_csr_write(csr, val);                          \
+#define CSR_WRITE_IMPL(csr, val)                   \
+  do {                                             \
+    static_assert(sizeof(val) == sizeof(uint32_t), \
+                  "val must be a 4-byte value");   \
+    CSR_FORCE_CONST_EXPR(csr);                     \
+    mock_csr_write(csr, val);                      \
   } while (false)
 
 void mock_csr_set_bits(uint32_t addr, uint32_t mask);
 
-#define CSR_SET_BITS_IMPL(csr, mask)                    \
-  do {                                                  \
-    CSR_STATIC_ASSERT(sizeof(mask) == sizeof(uint32_t), \
-                      "mask must be a 4-byte value");   \
-    CSR_FORCE_CONST_EXPR(csr);                          \
-    mock_csr_set_bits(csr, mask);                       \
+#define CSR_SET_BITS_IMPL(csr, mask)                \
+  do {                                              \
+    static_assert(sizeof(mask) == sizeof(uint32_t), \
+                  "mask must be a 4-byte value");   \
+    CSR_FORCE_CONST_EXPR(csr);                      \
+    mock_csr_set_bits(csr, mask);                   \
   } while (false)
 
 void mock_csr_clear_bits(uint32_t addr, uint32_t mask);
 
-#define CSR_CLEAR_BITS_IMPL(csr, mask)                  \
-  do {                                                  \
-    CSR_STATIC_ASSERT(sizeof(mask) == sizeof(uint32_t), \
-                      "mask must be a 4-byte value");   \
-    CSR_FORCE_CONST_EXPR(csr);                          \
-    mock_csr_clear_bits(csr, mask);                     \
+#define CSR_CLEAR_BITS_IMPL(csr, mask)              \
+  do {                                              \
+    static_assert(sizeof(mask) == sizeof(uint32_t), \
+                  "mask must be a 4-byte value");   \
+    CSR_FORCE_CONST_EXPR(csr);                      \
+    mock_csr_clear_bits(csr, mask);                 \
   } while (false)
 
 #else  // MOCK_CSR
 
-#define CSR_READ_IMPL(csr, dest)                               \
-  do {                                                         \
-    CSR_STATIC_ASSERT(sizeof(*dest) == sizeof(uint32_t),       \
-                      "dest must point to a 4-byte variable"); \
-    asm volatile("csrr %0, %1;" : "=r"(*dest) : "i"(csr));     \
+#define CSR_READ_IMPL(csr, dest)                           \
+  do {                                                     \
+    static_assert(sizeof(*dest) == sizeof(uint32_t),       \
+                  "dest must point to a 4-byte variable"); \
+    asm volatile("csrr %0, %1;" : "=r"(*dest) : "i"(csr)); \
   } while (false)
 
 #define CSR_WRITE_IMPL(csr, val)                       \
   do {                                                 \
-    CSR_STATIC_ASSERT(sizeof(val) == sizeof(uint32_t), \
-                      "val must be a 4-byte value");   \
+    static_assert(sizeof(val) == sizeof(uint32_t),     \
+                  "val must be a 4-byte value");       \
     asm volatile("csrw %0, %1;" ::"i"(csr), "r"(val)); \
   } while (false)
 
 #define CSR_SET_BITS_IMPL(csr, mask)                    \
   do {                                                  \
-    CSR_STATIC_ASSERT(sizeof(mask) == sizeof(uint32_t), \
-                      "mask must be a 4-byte value");   \
+    static_assert(sizeof(mask) == sizeof(uint32_t),     \
+                  "mask must be a 4-byte value");       \
     asm volatile("csrs %0, %1;" ::"i"(csr), "r"(mask)); \
   } while (false)
 
 #define CSR_CLEAR_BITS_IMPL(csr, mask)                  \
   do {                                                  \
-    CSR_STATIC_ASSERT(sizeof(mask) == sizeof(uint32_t), \
-                      "mask must be a 4-byte value");   \
+    static_assert(sizeof(mask) == sizeof(uint32_t),     \
+                  "mask must be a 4-byte value");       \
     asm volatile("csrc %0, %1;" ::"i"(csr), "r"(mask)); \
   } while (false)
 

--- a/sw/device/lib/testing/test_rom/spiflash_frame.h
+++ b/sw/device/lib/testing/test_rom/spiflash_frame.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_ROM_SPIFLASH_FRAME_H_
 #define OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_ROM_SPIFLASH_FRAME_H_
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "sw/device/lib/dif/dif_hmac.h"
@@ -71,7 +72,7 @@ typedef struct spiflash_frame {
   uint32_t data[SPIFLASH_FRAME_DATA_WORDS];
 } spiflash_frame_t;
 
-_Static_assert(sizeof(spiflash_frame_t) == SPIFLASH_RAW_BUFFER_SIZE,
-               "spiflash_frame_t is the wrong size!");
+static_assert(sizeof(spiflash_frame_t) == SPIFLASH_RAW_BUFFER_SIZE,
+              "spiflash_frame_t is the wrong size!");
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_TEST_ROM_SPIFLASH_FRAME_H_


### PR DESCRIPTION
Not sure how these escaped me when I last salted the earth when removing `_Static_assert`s.