### PR TITLE
[reggen] Add special handling for printing 32-bit unsigned parameters

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -380,7 +380,7 @@
     // hex value of 0xa26a38f7
     { name:      "ExecEn",
       desc:      "Constant value that enables flash execution",
-      type:      "int"
+      type:      "int unsigned"
       default:   "2724870391",
       local:     "true"
     },

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -377,7 +377,7 @@
     // hex value of 0xa26a38f7
     { name:      "ExecEn",
       desc:      "Constant value that enables flash execution",
-      type:      "int"
+      type:      "int unsigned"
       default:   "${int("0xa26a38f7", 16)}",
       local:     "true"
     },

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -21,7 +21,7 @@ package flash_ctrl_reg_pkg;
   parameter int BytesPerWord = 8;
   parameter int BytesPerPage = 2048;
   parameter int BytesPerBank = 524288;
-  parameter int ExecEn = 2724870391;
+  parameter int unsigned ExecEn = 32'ha26a38f7;
   parameter int NumAlerts = 2;
 
   // Address widths within the block

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -386,7 +386,7 @@
     // hex value of 0xa26a38f7
     { name:      "ExecEn",
       desc:      "Constant value that enables flash execution",
-      type:      "int"
+      type:      "int unsigned"
       default:   "2724870391",
       local:     "true"
     },

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -21,7 +21,7 @@ package flash_ctrl_reg_pkg;
   parameter int BytesPerWord = 8;
   parameter int BytesPerPage = 2048;
   parameter int BytesPerBank = 524288;
-  parameter int ExecEn = 2724870391;
+  parameter int unsigned ExecEn = 32'ha26a38f7;
   parameter int NumAlerts = 2;
 
   // Address widths within the block

--- a/util/reggen/reg_pkg.sv.tpl
+++ b/util/reggen/reg_pkg.sv.tpl
@@ -363,7 +363,7 @@ package ${lblock}_reg_pkg;
 
   // Param list
 % for param in localparams:
-  parameter ${param.param_type} ${param.name} = ${param.value};
+  parameter ${param.param_type} ${param.name} = ${gen_rtl.render_param(param.param_type, param.value)};
 % endfor
 % endif
 


### PR DESCRIPTION
This allows us to define flash_ctrl's `ExecEn` parameter without triggering a warning from the simulator.