### PR TITLE
[fpv/csr] Enable checking CSRs with regwen

### DIFF
--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -8,7 +8,11 @@ module clkmgr_bind;
     .EndpointType("Device")
   ) tlul_assert_device (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
 
+
+  // In top-level testbench, do not bind the csr_assert_fpv to reduce simulation time.
+  `ifndef TOP_LEVEL_DV
   bind clkmgr clkmgr_csr_assert_fpv clkmgr_csr_assert (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
+  `endif
 
   bind clkmgr clkmgr_pwrmgr_sva_if clkmgr_pwrmgr_sva_if (
     .clk_i,

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -8,7 +8,10 @@ module pwrmgr_bind;
     .EndpointType("Device")
   ) tlul_assert_device (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
 
+  // In top-level testbench, do not bind the csr_assert_fpv to reduce simulation time.
+  `ifndef TOP_LEVEL_DV
   bind pwrmgr pwrmgr_csr_assert_fpv pwrmgr_csr_assert (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
+  `endif
 
   // Clock control assertions.
   bind pwrmgr pwrmgr_clock_enables_sva_if pwrmgr_clock_enables_sva_if (

--- a/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_bind.sv
@@ -8,7 +8,10 @@ module rstmgr_bind;
     .EndpointType("Device")
   ) tlul_assert_device (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
 
+  // In top-level testbench, do not bind the csr_assert_fpv to reduce simulation time.
+  `ifndef TOP_LEVEL_DV
   bind rstmgr rstmgr_csr_assert_fpv rstmgr_csr_assert (.clk_i, .rst_ni, .h2d(tl_i), .d2h(tl_o));
+  `endif
 
   bind rstmgr pwrmgr_rstmgr_sva_if pwrmgr_rstmgr_sva_if (
     .clk_i(clk_i),

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -103,6 +103,9 @@
   uvm_test_seq: chip_sw_base_vseq
   sw_build_device: sim_dv
 
+  // Add a default build option to indicate it is a top-level DV testbench.
+  build_opts: ["+define+TOP_LEVEL_DV"]
+
   // Add build modes.
   build_modes: [
     {

--- a/util/reggen/gen_fpv.py
+++ b/util/reggen/gen_fpv.py
@@ -32,11 +32,11 @@ def gen_fpv(block: IpBlock, outdir: str) -> int:
             # No registers to check!
             continue
 
-        if if_name is None:
-            mod_base = lblock
-        else:
-            mod_base = lblock + '_' + if_name.lower()
+        hier_path = 'u_reg' if block.hier_path is None else block.hier_path
+        if_suffix = '' if if_name is None else '_' + if_name.lower()
+        reg_block_path = hier_path + if_suffix
 
+        mod_base = lblock + if_suffix
         mod_name = mod_base + '_csr_assert_fpv'
         filename = mod_name + '.sv'
         generated.append(filename)
@@ -44,6 +44,7 @@ def gen_fpv(block: IpBlock, outdir: str) -> int:
         with open(reg_top_path, 'w', encoding='UTF-8') as fout:
             try:
                 fout.write(fpv_csr_tpl.render(block=block,
+                                              reg_block_path=reg_block_path,
                                               mod_base=mod_base,
                                               if_name=if_name,
                                               rb=rb))


### PR DESCRIPTION
This PR enables formal to check CSRs regs which could be gated by
regwen.
The regwen can be HRO or HRW, so we need to probe to see the regwen
value. Because DV and FPV testbench has a slightly different path, we
use `FPV_ON` macro to distinguish which path to use.

Another commit is related to binding the CSR assertions to top-level.
We do not want to bind CSR assertions to top-level to avoid creating long
simulation/compile time. So I added a macro define.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>