### PR TITLE
[opentitantool] Revert default interface to "empty"

### DIFF
--- a/sw/host/opentitanlib/src/backend/mod.rs
+++ b/sw/host/opentitanlib/src/backend/mod.rs
@@ -22,8 +22,8 @@ mod verilator;
 
 #[derive(Debug, StructOpt)]
 pub struct BackendOpts {
-    #[structopt(long, help = "Name of the debug interface")]
-    interface: Option<String>,
+    #[structopt(long, default_value = "", help = "Name of the debug interface")]
+    interface: String,
 
     #[structopt(long, parse(try_from_str = u16::from_str),
                 help="USB Vendor ID of the interface")]
@@ -51,10 +51,10 @@ pub enum Error {
 }
 
 /// Creates the requested backend interface according to [`BackendOpts`].
-pub fn create(args: &BackendOpts, default_interface: &str) -> Result<TransportWrapper> {
-    let interface = args.interface.as_deref().unwrap_or(default_interface);
+pub fn create(args: &BackendOpts) -> Result<TransportWrapper> {
+    let interface = args.interface.as_str();
     let mut env = TransportWrapper::new(match interface {
-        "null" => create_empty_transport(),
+        "" => create_empty_transport(),
         "proxy" => proxy::create(&args.proxy_opts),
         "verilator" => verilator::create(&args.verilator_opts),
         "ultradebug" => ultradebug::create(args),

--- a/sw/host/opentitansession/src/main.rs
+++ b/sw/host/opentitansession/src/main.rs
@@ -157,7 +157,7 @@ fn start_session(run_file_fn: impl FnOnce(u16) -> PathBuf) -> Result<Box<dyn Ser
 // `SessionStartResult` sent through the stdout anonymous pipe, and finally enter an infnite
 // loop, processing connections on that socket
 fn session_child(listen_port: Option<u16>, backend_opts: &backend::BackendOpts) -> Result<()> {
-    let transport = backend::create(backend_opts, "null")?;
+    let transport = backend::create(backend_opts)?;
     let mut session = SessionHandler::init(&transport, listen_port)?;
     // Instantiation of Transport backend, and binding to a socket was successful, now go
     // through the process of making this process a daemon, disconnected from the
@@ -226,7 +226,7 @@ fn main() -> Result<()> {
 
     if opts.debug {
         // Start session process in foreground (do not daemonize)
-        let transport = backend::create(&opts.backend_opts, "null")?;
+        let transport = backend::create(&opts.backend_opts)?;
         let mut session = SessionHandler::init(&transport, opts.listen_port)?;
         println!("Listening on port {}", session.get_port());
         session.run_loop()?;

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -141,7 +141,7 @@ where
 fn main() -> Result<()> {
     let opts = parse_command_line(Opts::from_args(), args_os())?;
 
-    let transport = backend::create(&opts.backend_opts, "proxy")?;
+    let transport = backend::create(&opts.backend_opts)?;
 
     for command in &opts.exec {
         execute(


### PR DESCRIPTION
In order to support the opentitantool subcommands that do not operate
on any debugger backend, the default backend should be one that can be
instantiated without any hardware, but does not support any features.

I previously changed that default as part of adding session support,
without realizing the usefulness of an "empty" transport.  This CL
reverts the default.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I56874bba81552cf440387d8bb110d9162946f4ce