### PR TITLE
[dv/rstmgr] Remove first_reset support in tests

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr_pkg.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr_pkg.sv.tpl
@@ -45,7 +45,6 @@ package rstmgr_pkg;
 
   // cpu reset requests and status
   typedef struct packed {
-    logic rst_cpu_n;
     logic ndmreset_req;
   } rstmgr_cpu_t;
 
@@ -62,7 +61,6 @@ package rstmgr_pkg;
 
   // default value for rstmgr_ast_rsp_t (for dangling ports)
   parameter rstmgr_cpu_t RSTMGR_CPU_DEFAULT = '{
-    rst_cpu_n: 1'b1,
     ndmreset_req: '0
   };
 

--- a/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_pkg.sv
@@ -58,13 +58,11 @@ package rstmgr_pkg;
 
   // cpu reset requests and status
   typedef struct packed {
-    logic rst_cpu_n;
     logic ndmreset_req;
   } rstmgr_cpu_t;
 
   // default value for rstmgr_ast_rsp_t (for dangling ports)
   parameter rstmgr_cpu_t RSTMGR_CPU_DEFAULT = '{
-    rst_cpu_n: 1'b1,
     ndmreset_req: '0
   };
 

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_pkg.sv
@@ -90,7 +90,6 @@ package rstmgr_pkg;
 
   // cpu reset requests and status
   typedef struct packed {
-    logic rst_cpu_n;
     logic ndmreset_req;
   } rstmgr_cpu_t;
 
@@ -98,7 +97,6 @@ package rstmgr_pkg;
 
   // default value for rstmgr_ast_rsp_t (for dangling ports)
   parameter rstmgr_cpu_t RSTMGR_CPU_DEFAULT = '{
-    rst_cpu_n: 1'b1,
     ndmreset_req: '0
   };
 


### PR DESCRIPTION
The RTL recently took out the rst_cpu_n input and associated
functionality. Fix the reset test to match.

Signed-off-by: Guillermo Maturana <maturana@google.com>