### PR TITLE
[dv] Fix testplan references to mask ROM tests

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -10,7 +10,7 @@
                      // "hw/dv/tools/dvsim/testplans/mem_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/ip/tlul/data/tlul_testplan.hjson",
-                     "sw/device/silicon_creator/mask_rom/e2e_tests/mask_rom_e2e_testplan.hjson"]
+                     "sw/device/silicon_creator/mask_rom/data/mask_rom_testplan.hjson"]
 
   testpoints: [
     ///////////////////////////////////////////////////////////////////////////

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2650,11 +2650,9 @@
       tests: []
    }
 
-
     ////////////////////////////
     // System level scenarios //
     ////////////////////////////
-
     {
       name: chip_sw_smoketest
       desc: '''Run smoke tests developed for each IP.
@@ -2683,6 +2681,18 @@
               "chip_sw_sram_ctrl_smoketest",
               "chip_sw_uart_smoketest",
             ]
+    }
+    {
+      name: chip_sw_signed
+      desc: '''Run some chip-level tests with mask ROM.
+
+            In addition to mask ROM E2E tests, we select at least one (or a few)
+            tests defined in this file to sign, and run via mask ROM instead of
+            test ROM. We need to ensure our test infrastructure and mask ROM can
+            boot and run one (or a few) of the same tests our test ROM can.
+            '''
+      milestone: V2
+      tests: ["chip_sw_uart_smoketest_signed"]
     }
     {
       name: chip_sw_coremark

--- a/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
@@ -7,29 +7,28 @@
 
   # Note: Please maintain alphabetical order.
   tests: [
+    // Signed chip-level tests to be run with mask ROM, instead of test ROM.
+    {
+      name: chip_sw_uart_smoketest_signed
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/uart_smoketest:1:signed"]
+      en_run_modes: ["sw_test_mode_mask_rom"]
+    }
+
     // Mask ROM func tests to be run with test ROM.
     {
-      name: chip_sw_mask_rom_keymgr_functest
+      name: mask_rom_keymgr_functest
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/silicon_creator/testing/sw_silicon_creator_lib_driver_keymgr_functest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=5000000"]
     }
-
-    // Chip-level tests to be run with mask ROM, i.e., ROM_EXT tests.
-    // Note, these tests will be signed with test keys, prior to loading.
-    {
-      name: chip_sw_mask_rom_uart_smoketest_signed
-      uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/rom_ext_uart_smoketest:1:signed"]
-      en_run_modes: ["sw_test_mode_mask_rom"]
-    }
   ]
 
   regressions: [
     {
-      name: mask_rom_functest
-      tests: ["chip_sw_mask_rom_keymgr_functest"]
+      name: mask_rom_functests
+      tests: ["mask_rom_keymgr_functest"]
     }
   ]
 }

--- a/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
@@ -30,5 +30,9 @@
       name: mask_rom_functests
       tests: ["mask_rom_keymgr_functest"]
     }
+    {
+      name: signed
+      tests: ["chip_sw_uart_smoketest_signed"]
+    }
   ]
 }

--- a/sw/device/silicon_creator/mask_rom/data/mask_rom_testplan.hjson
+++ b/sw/device/silicon_creator/mask_rom/data/mask_rom_testplan.hjson
@@ -10,7 +10,7 @@
 //   - Bringup keys for manufacturing and RMA
 
 {
-  name: "mask_rom_e2e"
+  name: "mask_rom"
 
   testpoints: [
     // Functests

--- a/sw/device/silicon_creator/mask_rom/e2e_tests/mask_rom_e2e_testplan.hjson
+++ b/sw/device/silicon_creator/mask_rom/e2e_tests/mask_rom_e2e_testplan.hjson
@@ -13,6 +13,22 @@
   name: "mask_rom_e2e"
 
   testpoints: [
+    // Functests
+    {
+      name: mask_rom_functests
+      desc: '''Run functests developed for mask ROM.
+
+            Functests test mask ROM components (e.g., drivers, libraries, etc.)
+            work as intended on-chip. However, unlike when these components are
+            embedded in the mask ROM, functests are linked with the OTTF, and
+            run out of flash. Additionally, unlike the mask ROM E2E tests,
+            functests are booted by the test ROM.
+            '''
+      tags: ["verilator", "dv", "fpga", "silicon"]
+      milestone: V2
+      tests: ["mask_rom_keymgr_functest"]
+    }
+
     // Bootup without ROM_EXT
     {
       name: mask_rom_e2e_bootup_no_rom_ext


### PR DESCRIPTION
Some chip-level tests were missing corresponding references in the test
plan so the regression results table had "unmapped tests". This adds
these tests to a testplan entry so the regression results are fixed,
see: https://reports.opentitan.org/hw/top_earlgrey/dv/latest/results.html

Signed-off-by: Timothy Trippel <ttrippel@google.com>