### PR TITLE
[ipgen] Mark the --config-file argument as required

### DIFF
--- a/util/ipgen.py
+++ b/util/ipgen.py
@@ -120,7 +120,7 @@ def main() -> int:
     parser_generate.add_argument(
         "--config-file",
         "-c",
-        required=False,
+        required=True,
         type=argparse.FileType('r'),
         help="path to a configuration file",
     )


### PR DESCRIPTION
The script unconditionally reads the configuration file (not
unreasonable: this tells it what to do!), so that argument must be
given.

Fixes #11249: now the command there gives
```
$ util/ipgen.py generate --template-dir hw/ip_templates/rv_plic/ -o test_ip
usage: ipgen.py generate [-h] [--verbose] -C TEMPLATE_DIR -o OUTDIR [--force] --config-file CONFIG_FILE
ipgen.py generate: error: the following arguments are required: --config-file/-c
```