### PR TITLE
[keymgr,dv] Fix some enum casting problems

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -654,7 +654,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
             // advance OP completes
             if (current_op_status == keymgr_pkg::OpWip &&
                 item.d_data inside {keymgr_pkg::OpDoneSuccess, keymgr_pkg::OpDoneFail}) begin
-              current_op_status = item.d_data;
+              current_op_status = keymgr_pkg::keymgr_op_status_e'(item.d_data);
 
               if (cfg.en_cov) begin
                 keymgr_pkg::keymgr_key_dest_e dest = keymgr_pkg::keymgr_key_dest_e'(
@@ -1168,7 +1168,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
   virtual function void wipe_hw_keys();
     fork
       begin
-        keymgr_pkg::keymgr_working_state_e current_design_state;
+        uvm_reg_data_t current_design_state;
         cfg.clk_rst_vif.wait_n_clks(1);
         // When LC disables keymgr across with an operation, will have InvalidOp error.
         // If no operation at that time, no error.

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_base_vseq.sv
@@ -141,7 +141,8 @@ class keymgr_base_vseq extends cip_base_vseq #(
     keymgr_pkg::keymgr_op_status_e exp_status;
     bit is_good_op = 1;
     int key_verion = `gmv(ral.key_version[0]);
-    keymgr_pkg::keymgr_ops_e operation = `gmv(ral.control_shadowed.operation);
+    logic [2:0] operation = `gmv(ral.control_shadowed.operation);
+    keymgr_pkg::keymgr_ops_e cast_operation = keymgr_pkg::keymgr_ops_e'(operation);
     bit[TL_DW-1:0] rd_val;
 
     if (operation inside {keymgr_pkg::OpGenSwOut, keymgr_pkg::OpGenHwOut}) begin
@@ -167,7 +168,7 @@ class keymgr_base_vseq extends cip_base_vseq #(
       is_good_op = !(current_state inside {keymgr_pkg::StReset, keymgr_pkg::StDisabled});
     end
     `uvm_info(`gfn, $sformatf("Wait for operation done in state %0s, operation %0s, good_op %0d",
-                              current_state.name, operation.name, is_good_op), UVM_MEDIUM)
+                              current_state.name, cast_operation.name, is_good_op), UVM_MEDIUM)
 
     // wait for status to get out of OpWip and check
     csr_spinwait(.ptr(ral.op_status.status), .exp_data(keymgr_pkg::OpWip), .timeout_ns(1000_000),


### PR DESCRIPTION
The cast that we add in keymgr_scoreboard.sv to current_op_status is
to silence warnings from Xcelium where you have to be explicit about
converting from an integral type to an enum. Here, we know that the
conversion is safe because we've just checked that the value equals
OpDoneSuccess or OpDoneFail.

The other two changes also fix Xcelium warnings, but possibly change
the meaning of the code (for the better!). For example, in
keymgr_base_vseq, we are reading a 3-bit register. We were then
forcing it to be of type keymgr_ops_e, but that enum doesn't actually
have an item for the bit pattern 3'b111. Fortunately, we only ever use
the result to compare it with enum values so we can just store the
integral value instead, avoiding the cast. The only need for the
"cast_operation" variable is now to generate a debug message.

The same argument applies to current_design_state (which is used as an
output parameter to csr_rd).

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>