### PR TITLE
[AST] Change clk_src_io_48m_o to mubi

### DIFF
--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -83,7 +83,7 @@ module ast #(
   input clk_src_io_en_i,                      // IO Source Clock Enable
   output logic clk_src_io_o,                  // IO Source Clock
   output logic clk_src_io_val_o,              // IO Source Clock Valid
-  output logic clk_src_io_48m_o,              // IO Source Clock is 48MHz
+  output prim_mubi_pkg::mubi4_t clk_src_io_48m_o,  // IO Source Clock is 48MHz
 
   // usb source clock
   input usb_ref_pulse_i,                      // USB Reference Pulse


### PR DESCRIPTION
Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>

* IO source clock is 48MHz is indicated with mubi