### PR TITLE
[aes] Clear START trigger when ignoring it

### DIFF
--- a/hw/ip/aes/data/aes.hjson
+++ b/hw/ip/aes/data/aes.hjson
@@ -737,7 +737,7 @@
         resval: "0"
         desc:  '''
           Keep AES unit paused (0) or trigger the encryption/decryption of one data block (1).
-          This trigger is ignored if MANUAL_OPERATION=0 (see Control Register).
+          This trigger is cleared to `0` if MANUAL_OPERATION=0 or if MODE=AES_NONE (see Control Register).
         '''
         tags: ["excl:CsrNonInitTests:CsrExclWriteCheck"]
       }

--- a/hw/ip/aes/rtl/aes_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm.sv
@@ -353,6 +353,10 @@ module aes_control_fsm
         idle    = ~(start_core | (prng_reseed_o & prng_reseed_we_o));
         idle_we = 1'b1;
 
+        // Clear the start trigger when seeing invalid configurations or performing automatic
+        // operation.
+        start_we = start_i & ((mode_i == AES_NONE) | ~manual_operation_i);
+
         if (!start_core) begin
           // Initial key and IV updates are ignored if the core is about to start. If key sideload
           // is enabled, software writes to the initial key registers are ignored.


### PR DESCRIPTION
The START trigger is ignored by the AES unit when the current configuration is invalid (MODE = AES_NONE) or when performing automatic operation (MANUAL_OPERATION = 0). When ignoring it, it's better to clear this trigger bit back to 0 to avoid the unintentional operations to start once a valid configuration is written or manual operation is enabled.

This resolves lowRISC/OpenTitan#11166.