### PR TITLE
Aes mal inject

### DIFF
--- a/hw/ip/aes/dv/env/aes_env.sv
+++ b/hw/ip/aes/dv/env/aes_env.sv
@@ -25,6 +25,10 @@ class aes_env extends cip_base_env #(
          get(this, "", "lc_escalate_vif", cfg.lc_escalate_vif)) begin
       `uvm_fatal(`gfn, "failed to get lc_escalate_vif from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual pins_if #(1))::
+         get(this, "", "idle_vif", cfg.idle_vif)) begin
+      `uvm_fatal(`gfn, "failed to get idle_vif from uvm_config_db")
+    end
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -9,6 +9,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   `uvm_object_new
 
   virtual pins_if #($bits(lc_ctrl_pkg::lc_tx_t) + 1) lc_escalate_vif;
+  virtual pins_if #(1) idle_vif;
 
   rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;
   // test environment constraints //

--- a/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
+++ b/hw/ip/aes/dv/tests/aes_alert_reset_test.sv
@@ -15,7 +15,7 @@ class aes_alert_reset_test extends aes_base_test;
 
   function void configure_env();
     super.configure_env();
-    cfg.error_types              = 4'b1000; // inject errors in regs and fsm errors
+    cfg.error_types              = 4'b1110; // inject errors in regs and fsm errors
     cfg.num_messages_min         = 3;
     cfg.num_messages_max         = 6;
     cfg.unbalanced               = 0;

--- a/hw/ip/aes/dv/tests/aes_config_error_test.sv
+++ b/hw/ip/aes/dv/tests/aes_config_error_test.sv
@@ -16,9 +16,7 @@ class aes_config_error_test extends aes_base_test;
   function void configure_env();
     super.configure_env();
 
-//    the feature below is waiting in anther PR
-//    cfg.zero_delay_pct           = 100;
-    cfg.error_types              = 3'b001;
+    cfg.error_types              = 4'b0001;
     cfg.config_error_pct         = 75;
     cfg.num_messages_min         = 3;
     cfg.num_messages_max         = 10;

--- a/hw/ip/aes/dv/tests/aes_manual_config_err_test.sv
+++ b/hw/ip/aes/dv/tests/aes_manual_config_err_test.sv
@@ -17,7 +17,7 @@ class aes_manual_config_err_test extends aes_base_test;
     super.configure_env();
     // disable scoreboard for this test
     cfg.en_scb                   = 0;
-    cfg.error_types              = 3'b001;
+    cfg.error_types              = 4'b0001;
     // all should have error
     cfg.config_error_pct         = 100;
     // only allow mode errors

--- a/hw/ip/aes/dv/tests/aes_stress_test.sv
+++ b/hw/ip/aes/dv/tests/aes_stress_test.sv
@@ -21,6 +21,8 @@ class aes_stress_test extends aes_base_test;
     cfg.read_prob                = 60;
     cfg.write_prob               = 80;
     cfg.error_types              = 0;
+    cfg.error_types.cfg          = 1;
+    cfg.error_types.mal_inject   = 1;
     cfg.num_messages_min         = 1;
     cfg.num_messages_max         = 50;
     // message related knobs


### PR DESCRIPTION
This PR updates the prediction to actively use idle as an indicator for when registers can be written and when writes should be ignored.
it also adds a knob to enable Writes to a random register when DUT is busy.
this should bring the functional coverage above the required V2 threshold.