### PR TITLE
[sw, lib] Add more print specifiers to printf

### DIFF
--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -73,7 +73,7 @@ void demo_spi_to_log_echo(const dif_spi_device_t *spi,
     CHECK_DIF_OK(dif_spi_device_send(spi, spi_config, &echo_word,
                                      sizeof(uint32_t),
                                      /*bytes_sent=*/NULL));
-    LOG_INFO("SPI: %z", spi_len, spi_buf);
+    LOG_INFO("SPI: %!s", spi_len, spi_buf);
   }
 }
 

--- a/sw/device/examples/hello_usbdev/hello_usbdev.c
+++ b/sw/device/examples/hello_usbdev/hello_usbdev.c
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
         uint32_t usb_irq_state =
             REG32(USBDEV_BASE_ADDR + USBDEV_INTR_STATE_REG_OFFSET);
         uint32_t usb_stat = REG32(USBDEV_BASE_ADDR + USBDEV_USBSTAT_REG_OFFSET);
-        LOG_INFO("I%4x-%8x", usb_irq_state, usb_stat);
+        LOG_INFO("I%04x-%08x", usb_irq_state, usb_stat);
       } else {
         usb_simpleserial_send_byte(&simple_serial0, rcv_char);
         usb_simpleserial_send_byte(&simple_serial1, rcv_char + 1);

--- a/sw/device/lib/runtime/log.c
+++ b/sw/device/lib/runtime/log.c
@@ -59,7 +59,7 @@ void base_log_internal_core(log_fields_t log, ...) {
   // nothing was printed for some time.
   static uint16_t global_log_counter = 0;
 
-  base_printf("%s%5d %s:%d] ", stringify_severity(log.severity),
+  base_printf("%s%05d %s:%d] ", stringify_severity(log.severity),
               global_log_counter, base_name, log.line);
   ++global_log_counter;
 

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -73,8 +73,9 @@ typedef struct buffer_sink {
  * garbage, and are, as such, unsupported.
  *
  * This function furthermore supports width modifiers for integer specifiers,
- * such as `%10d`. It does not support dynamic widths like `%*d`, and will also
- * always pad with zeroes, rather than spaces.
+ * such as `%010d`. It does not support dynamic widths like `%*d`. If the width
+ * specifier starts with a `0`, it is padded with zeroes; otherwise, it is
+ * padded with spaces, consistent with the standard C behavior.
  *
  * Of course, providing arguments for formatting which are incompatible with a
  * given format specifier is Undefined Behavior.

--- a/sw/device/lib/runtime/print.h
+++ b/sw/device/lib/runtime/print.h
@@ -64,13 +64,18 @@ typedef struct buffer_sink {
  * - %h and %H, which are aliases for %x and %X, respectively.
  * - %b, which prints an unsigned binary uint32_t.
  *
- * Finally, an additional nonstandard format specifier is supported:
- * - %z, which takes a size_t followed by a pointer to a buffer, and prints
+ * Finally, additional nonstandard format specifiers is supported:
+ * - %!s, which takes a size_t followed by a pointer to a buffer, and prints
  *   out that many characters from the buffer.
+ * - %!x, %!X, %!y, and %!Y, which are like %!s but print out a hex dump
+ *   instead; casing is as with %x, and %!x will print in big-endian order
+ *   (i.e., last byte printed first) while %!y will print in little-endian
+ *   order (i.e., first byte printed first). This makes sure %!x is consistent
+ *   with %x.
  *
  * When compiled for a DV testbench, this function will not read any pointers,
- * and as such the specifiers %s and %z will behave as if they were printing
- * garbage, and are, as such, unsupported.
+ * and as such the specifiers %s, %!s, %!x, %!X, %!y, and %!Y will behave as if
+ * they were printing garbage, and are, as such, unsupported.
  *
  * This function furthermore supports width modifiers for integer specifiers,
  * such as `%010d`. It does not support dynamic widths like `%*d`. If the width
@@ -83,7 +88,7 @@ typedef struct buffer_sink {
  * Note that for logging in DV, the following script updates the format
  * specifiers supported in C above and changes them to match the SystemVerilog
  * language semantics: util/device_sw_utils/extract_sw_logs.py
- * It also makes fixes as needed for custom speficiers such as %z.
+ * It also makes fixes as needed for custom speficiers such as %!s.
  *
  * @param format the format spec.
  * @param ... values to interpolate in the format spec.

--- a/sw/device/lib/runtime/print_unittest.cc
+++ b/sw/device/lib/runtime/print_unittest.cc
@@ -30,11 +30,14 @@ using ::testing::StartsWith;
 class PrintfTest : public testing::Test {
  protected:
   void SetUp() override {
-    base_set_stdout({/*data=*/static_cast<void *>(&buf_),
-                     /*sink=*/+[](void *data, const char *buf, size_t len) {
-                       static_cast<std::string *>(data)->append(buf, len);
-                       return len;
-                     }});
+    base_set_stdout({
+        .data = static_cast<void *>(&buf_),
+        .sink =
+            +[](void *data, const char *buf, size_t len) {
+              static_cast<std::string *>(data)->append(buf, len);
+              return len;
+            },
+    });
   }
 
   std::string buf_;
@@ -73,18 +76,66 @@ TEST_F(PrintfTest, StringWithNul) {
 }
 
 TEST_F(PrintfTest, StringWithLen) {
-  EXPECT_EQ(base_printf("Hello, %z!\n", 6, "abcxyz"), 15);
+  EXPECT_EQ(base_printf("Hello, %!s!\n", 6, "abcxyz"), 15);
   EXPECT_EQ(buf_, "Hello, abcxyz!\n");
 }
 
 TEST_F(PrintfTest, StringWithLenPrefix) {
-  EXPECT_EQ(base_printf("Hello, %z!\n", 3, "abcxyz"), 12);
+  EXPECT_EQ(base_printf("Hello, %!s!\n", 3, "abcxyz"), 12);
   EXPECT_EQ(buf_, "Hello, abc!\n");
 }
 
 TEST_F(PrintfTest, StringWithLenZeroLen) {
-  EXPECT_EQ(base_printf("Hello, %z!\n", 0, "abcxyz"), 9);
+  EXPECT_EQ(base_printf("Hello, %!s!\n", 0, "abcxyz"), 9);
   EXPECT_EQ(buf_, "Hello, !\n");
+}
+
+TEST_F(PrintfTest, HexStringWithLen) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!x!\n", 4, &val), 17);
+  EXPECT_EQ(buf_, "Hello, deadbeef!\n");
+}
+
+TEST_F(PrintfTest, HexStringWithLenPrefix) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!x!\n", 1, &val), 11);
+  EXPECT_EQ(buf_, "Hello, ef!\n");
+}
+
+TEST_F(PrintfTest, HexStringWithLenZeroLen) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!x!\n", 0, &val), 9);
+  EXPECT_EQ(buf_, "Hello, !\n");
+}
+
+TEST_F(PrintfTest, UpperHexStringWithLen) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!X!\n", 4, &val), 17);
+  EXPECT_EQ(buf_, "Hello, DEADBEEF!\n");
+}
+
+TEST_F(PrintfTest, UpperHexStringWithLenPrefix) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!X!\n", 1, &val), 11);
+  EXPECT_EQ(buf_, "Hello, EF!\n");
+}
+
+TEST_F(PrintfTest, UpperHexStringWithLenZeroLen) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!X!\n", 0, &val), 9);
+  EXPECT_EQ(buf_, "Hello, !\n");
+}
+
+TEST_F(PrintfTest, LeHexStringWithLen) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!y!\n", 4, &val), 17);
+  EXPECT_EQ(buf_, "Hello, efbeadde!\n");
+}
+
+TEST_F(PrintfTest, UpperLeHexStringWithLen) {
+  uint32_t val = 0xdeadbeef;
+  EXPECT_EQ(base_printf("Hello, %!Y!\n", 4, &val), 17);
+  EXPECT_EQ(buf_, "Hello, EFBEADDE!\n");
 }
 
 TEST_F(PrintfTest, SignedInt) {

--- a/sw/device/lib/runtime/print_unittest.cc
+++ b/sw/device/lib/runtime/print_unittest.cc
@@ -104,11 +104,21 @@ TEST_F(PrintfTest, SignedIntNegative) {
 
 TEST_F(PrintfTest, SignedIntWithWidth) {
   EXPECT_EQ(base_printf("Hello, %3i!\n", 42), 12);
-  EXPECT_EQ(buf_, "Hello, 042!\n");
+  EXPECT_EQ(buf_, "Hello,  42!\n");
 }
 
 TEST_F(PrintfTest, SignedIntWithWidthTooShort) {
   EXPECT_EQ(base_printf("Hello, %3i!\n", 9001), 13);
+  EXPECT_EQ(buf_, "Hello, 9001!\n");
+}
+
+TEST_F(PrintfTest, SignedIntWithZeros) {
+  EXPECT_EQ(base_printf("Hello, %03i!\n", 42), 12);
+  EXPECT_EQ(buf_, "Hello, 042!\n");
+}
+
+TEST_F(PrintfTest, SignedIntWithZerosTooShort) {
+  EXPECT_EQ(base_printf("Hello, %03i!\n", 9001), 13);
   EXPECT_EQ(buf_, "Hello, 9001!\n");
 }
 
@@ -128,7 +138,7 @@ TEST_F(PrintfTest, HexFromDec) {
 }
 
 TEST_F(PrintfTest, HexFromDecWithWidth) {
-  EXPECT_EQ(base_printf("Hello, %8x!\n", 1024), 17);
+  EXPECT_EQ(base_printf("Hello, %08x!\n", 1024), 17);
   EXPECT_EQ(buf_, "Hello, 00000400!\n");
 }
 
@@ -199,7 +209,7 @@ TEST_F(PrintfTest, Binary) {
 }
 
 TEST_F(PrintfTest, BinaryWithWidth) {
-  EXPECT_EQ(base_printf("Hello, %32b!\n", 0b1010'1010), 41);
+  EXPECT_EQ(base_printf("Hello, %032b!\n", 0b1010'1010), 41);
   EXPECT_EQ(buf_, "Hello, 00000000000000000000000010101010!\n");
 }
 

--- a/sw/device/lib/testing/test_framework/test_coverage_llvm.c
+++ b/sw/device/lib/testing/test_framework/test_coverage_llvm.c
@@ -49,7 +49,7 @@ static uint32_t crc32(uint8_t *buf, size_t len) {
  */
 static void send_buffer(uint8_t *buf, size_t len) {
   for (uint32_t i = 0; i < len; ++i) {
-    base_printf("%2X", buf[i]);
+    base_printf("%02X", buf[i]);
   }
 }
 

--- a/sw/device/sca/lib/simple_serial.c
+++ b/sw/device/sca/lib/simple_serial.c
@@ -222,7 +222,7 @@ void simple_serial_send_status(uint8_t res) {
 void simple_serial_print_hex(const uint8_t *data, size_t data_len) {
   char buf[2];
   for (size_t i = 0; i < data_len; ++i) {
-    base_snprintf(&buf[0], 2, "%2x", data[i]);
+    base_snprintf(&buf[0], 2, "%02x", data[i]);
     IGNORE_RESULT(dif_uart_byte_send_polled(uart, buf[0]));
     IGNORE_RESULT(dif_uart_byte_send_polled(uart, buf[1]));
   }

--- a/sw/device/tests/otp_ctrl_smoketest.c
+++ b/sw/device/tests/otp_ctrl_smoketest.c
@@ -46,7 +46,7 @@ bool test_main(void) {
     otp_ctrl_testutils_wait_for_dai(&otp);
     CHECK_DIF_OK(dif_otp_ctrl_dai_program32(
                      &otp, kDifOtpCtrlPartitionVendorTest, 0x10 + i, word),
-                 "Failed to program word kTestData[%d] = 0x%8x.", i, word);
+                 "Failed to program word kTestData[%d] = 0x%08x.", i, word);
   }
 
   uint32_t readout[ARRAYSIZE(kTestData) / sizeof(uint32_t)] = {0};

--- a/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
+++ b/sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest.c
@@ -57,7 +57,7 @@ bool test_main(void) {
     low_power_exit = true;
     LOG_INFO("USB wakeup detected");
   } else {
-    LOG_ERROR("Unexpected wakeup reason (types: %2x, sources: %8x)",
+    LOG_ERROR("Unexpected wakeup reason (types: %02x, sources: %08x)",
               wakeup_reason.types, wakeup_reason.request_sources);
     return false;
   }

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -528,7 +528,7 @@ const test_config_t kTestConfig;
 bool test_main(void) {
   update_uart_base_addr_and_irq_id();
 
-  LOG_INFO("Test UART%d with base_addr: %8x", kUartIdx, uart_base_addr);
+  LOG_INFO("Test UART%d with base_addr: %08x", kUartIdx, uart_base_addr);
 
   // TODO, remove thse once pinout configuration is provided
   pinmux_connect_uart_to_pads(

--- a/sw/device/tests/sram_ctrl_smoketest.c
+++ b/sw/device/tests/sram_ctrl_smoketest.c
@@ -42,8 +42,8 @@ static void write_read_check(mmio_region_t base_addr_region,
     mmio_region_write32(base_addr_region, i * sizeof(uint32_t), kRandomData[i]);
     rw_data_32 = mmio_region_read32(base_addr_region, i * sizeof(uint32_t));
     CHECK(rw_data_32 == kRandomData[i],
-          "Memory Write/Read Mismatch for %s, index %d, data read = %8x "
-          "data_expected = %8x.",
+          "Memory Write/Read Mismatch for %s, index %d, data read = %08x "
+          "data_expected = %08x.",
           sram_name, i, rw_data_32, kRandomData[i]);
   }
 }
@@ -67,9 +67,9 @@ bool test_main() {
   CHECK_DIF_OK(dif_sram_ctrl_get_status(&sram_ctrl_main, &status_main));
 
   CHECK((status_main & kStatusRegMask) == 0x0,
-        "SRAM main status error bits set, status = %8x.", status_main);
+        "SRAM main status error bits set, status = %08x.", status_main);
   CHECK((status_ret & kStatusRegMask) == 0x0,
-        "SRAM ret status error bits set, status = %8x.", status_ret);
+        "SRAM ret status error bits set, status = %08x.", status_ret);
 
   // Read and Write to/from SRAMs. Main SRAM will use the address of the
   // buffer that has been allocated. Ret SRAM can start at the base address.

--- a/util/device_sw_utils/extract_sw_logs.py
+++ b/util/device_sw_utils/extract_sw_logs.py
@@ -52,20 +52,24 @@ def cleanup_newlines(string):
 def cleanup_format(_format):
     '''Converts C style format specifiers to SV style.
 
-    It makes the folllowing substitutions:
+    It makes the following substitutions:
     - Change %[N]?i, %[N]?u --> %[N]?d
     - Change %[N]?x, %[N]?p --> %[N]?h
     - Change %[N]?X         --> %[N]?H
 
     The below is a non-standard format specifier added in OpenTitan
-    (see sw/device/lib/base/print.c for more details). A single %z specifier
+    (see sw/device/lib/base/print.c for more details). A single %!s specifier
     consumes 2 arguments instead of 1 and hence has to converted as such to
     prevent the log monitor in SystemVerilog from throwing an error at runtime.
-    - Change %[N]?z         --> %[N]?s[%d].'''
-    _format = re.sub(r"(%-?\d*)[iu]", r"\1d", _format)
-    _format = re.sub(r"(%-?\d*)[xp]", r"\1h", _format)
-    _format = re.sub(r"(%-?\d*)X", r"\1H", _format)
-    _format = re.sub(r"(%-?\d*)z", r"\1s[%d]", _format)
+    The %!{x, X, y, Y} specifiers have the same property, but can print garbage,
+    so they're converted to pointers instead.
+    - Change %![N]?s        --> %[N]?s[%d].
+    - Change %![N]?[xXyY]   --> %[N]?h.'''
+    _format = re.sub(r"%(-?\d*)[iu]", r"%\1d", _format)
+    _format = re.sub(r"%(-?\d*)[xp]", r"%\1h", _format)
+    _format = re.sub(r"%(-?\d*)X", r"%\1H", _format)
+    _format = re.sub(r"%!(-?\d*)s", r"%\1s[%d]", _format)
+    _format = re.sub(r"%!(-?\d*)[xXyY]", r"%\1h[%d]", _format)
     _format = re.sub(r"%([bcodhHs])", r"%0\1", _format)
     return cleanup_newlines(_format)
 


### PR DESCRIPTION
This PR makes two changes:
- Require `0` in the width of a format specifier to be compliant with C (most people were already adding it anyways).
- Add `%y` and `%Y` for hex-dumping buffers.

I'm wondering whether we should add a version of `%y` which prints in big-endian order like `%x`. There's a few places where this could be useful, such as when printing OTBN wide registers. Not sure what the right character for that would be. I was thinking of maybe picking another pair of unused specifiers, like `v` and `w`, instead. (e.g. `%v` would be lower-case big-endian, `%W` would be upper-case little-endian).