### PR TITLE
[conn] Fix conn compile error

### DIFF
--- a/hw/formal/tools/jaspergold/conn.tcl
+++ b/hw/formal/tools/jaspergold/conn.tcl
@@ -24,8 +24,8 @@ if {$conn_csvs eq ""} {
 
 # only one scr file exists in this folder
 # Blackbox ast related modules to avoid compile errors.
-analyze -sv09     \
-  +define+FPV_ON  \
+analyze -sv09 \
+  +define+SYNTHESIS \
   -f [glob *.scr] \
   -bbox_m aon_osc \
   -bbox_m io_osc  \


### PR DESCRIPTION
This PR fixes the conn compile error because the `prim_sparse_fsm` has
too many loops inside `INC_ASSERT`.
Because conn test only compile design and does not need any assertions
or assumptions, I used `+define+SYNTHESIS` instead of `+define+FPV_ON`.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>