### PR TITLE
[opentitantool] Pass capabilities via proxy protocol

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -56,7 +56,7 @@ impl TransportWrapper {
 
     /// Returns a `Capabilities` object to check the capabilities of this
     /// transport object.
-    pub fn capabilities(&self) -> crate::transport::Capabilities {
+    pub fn capabilities(&self) -> Result<crate::transport::Capabilities> {
         self.transport.borrow().capabilities()
     }
 

--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -213,7 +213,7 @@ impl UpdateProtocol for Legacy {
         transport: &TransportWrapper,
     ) -> Result<()> {
         transport
-            .capabilities()
+            .capabilities()?
             .request(Capability::GPIO | Capability::SPI)
             .ok()?;
         Ok(())

--- a/sw/host/opentitanlib/src/bootstrap/primitive.rs
+++ b/sw/host/opentitanlib/src/bootstrap/primitive.rs
@@ -113,7 +113,7 @@ impl UpdateProtocol for Primitive {
         transport: &TransportWrapper,
     ) -> Result<()> {
         transport
-            .capabilities()
+            .capabilities()?
             .request(Capability::GPIO | Capability::SPI)
             .ok()?;
         Ok(())

--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -283,7 +283,7 @@ impl UpdateProtocol for Rescue {
         transport: &TransportWrapper,
     ) -> Result<()> {
         transport
-            .capabilities()
+            .capabilities()?
             .request(Capability::GPIO | Capability::UART)
             .ok()?;
         Ok(())

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -34,6 +34,9 @@ impl<'a> TransportCommandHandler<'a> {
     /// logging.
     fn do_execute_cmd(&self, req: &Request) -> Result<Response, TransportError> {
         match req {
+            Request::GetCapabilities => {
+                Ok(Response::GetCapabilities(self.transport.capabilities()?))
+            }
             Request::Gpio { id, command } => {
                 let instance = self.transport.gpio_pin(id)?;
                 match command {

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::io::gpio::{PinMode, PullMode};
 use crate::io::spi::TransferMode;
-use crate::transport::TransportError;
+use crate::transport::{Capabilities, TransportError};
 use crate::util::voltage::Voltage;
 
 #[derive(Serialize, Deserialize)]
@@ -17,6 +17,7 @@ pub enum Message {
 
 #[derive(Serialize, Deserialize)]
 pub enum Request {
+    GetCapabilities,
     Gpio { id: String, command: GpioRequest },
     Uart { id: String, command: UartRequest },
     Spi { id: String, command: SpiRequest },
@@ -25,6 +26,7 @@ pub enum Request {
 
 #[derive(Serialize, Deserialize)]
 pub enum Response {
+    GetCapabilities(Capabilities),
     Gpio(GpioResponse),
     Uart(UartResponse),
     Spi(SpiResponse),

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -97,8 +97,10 @@ impl CW310 {
 }
 
 impl Transport for CW310 {
-    fn capabilities(&self) -> Capabilities {
-        Capabilities::new(Capability::SPI | Capability::GPIO | Capability::UART)
+    fn capabilities(&self) -> Result<Capabilities> {
+        Ok(Capabilities::new(
+            Capability::SPI | Capability::GPIO | Capability::UART,
+        ))
     }
 
     fn uart(&self, instance: &str) -> Result<Rc<dyn Uart>> {

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -5,6 +5,8 @@
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use super::Capability;
+
 /// Contains all the errors that any method on the `Transport` trait could generate.  This
 /// struct is serializable, such that it can be transmitted across a network for instance as
 /// part of the session proxy functionality.
@@ -46,6 +48,8 @@ pub enum TransportError {
     ProxyConnectError(String, String),
     #[error("Proxy communication error: {0}")]
     ProxyCommunicationError(#[from] crate::transport::proxy::ProxyError),
+    #[error("Requested capabilities {0:?}, but capabilities {1:?} are supplied")]
+    MissingCapabilities(Capability, Capability),
 
     // Include sub-enums for the various sub-traits of Tranport.
     #[error("GPIO error: {0}")]

--- a/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/mod.rs
@@ -381,8 +381,10 @@ impl Inner {
 }
 
 impl<T: Flavor> Transport for Hyperdebug<T> {
-    fn capabilities(&self) -> Capabilities {
-        Capabilities::new(Capability::UART | Capability::GPIO | Capability::SPI | Capability::I2C)
+    fn capabilities(&self) -> Result<Capabilities> {
+        Ok(Capabilities::new(
+            Capability::UART | Capability::GPIO | Capability::SPI | Capability::I2C,
+        ))
     }
 
     // Crate SPI Target instance, or return one from a cache of previously created instances.

--- a/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/mod.rs
@@ -115,8 +115,10 @@ impl Ultradebug {
 }
 
 impl Transport for Ultradebug {
-    fn capabilities(&self) -> Capabilities {
-        Capabilities::new(Capability::UART | Capability::GPIO | Capability::SPI)
+    fn capabilities(&self) -> Result<Capabilities> {
+        Ok(Capabilities::new(
+            Capability::UART | Capability::GPIO | Capability::SPI,
+        ))
     }
 
     fn uart(&self, instance: &str) -> Result<Rc<dyn Uart>> {

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use lazy_static::lazy_static;
 use log::info;
 use regex::Regex;
@@ -15,7 +14,7 @@ use crate::io::uart::Uart;
 use crate::transport::verilator::subprocess::{Options, Subprocess};
 use crate::transport::verilator::uart::VerilatorUart;
 use crate::transport::{
-    Capabilities, Capability, Transport, TransportError, TransportInterfaceType,
+    Capabilities, Capability, Result, Transport, TransportError, TransportInterfaceType,
 };
 
 #[derive(Default)]
@@ -36,7 +35,7 @@ pub struct Verilator {
 
 impl Verilator {
     /// Creates a verilator subprocess-hosting transport from [`options`].
-    pub fn from_options(options: Options) -> Result<Self> {
+    pub fn from_options(options: Options) -> anyhow::Result<Self> {
         lazy_static! {
             static ref UART: Regex = Regex::new("UART: Created ([^ ]+) for uart0").unwrap();
             static ref SPI: Regex = Regex::new("SPI: Created ([^ ]+) for spi0").unwrap();
@@ -68,7 +67,7 @@ impl Verilator {
     }
 
     /// Shuts down the verilator subprocess.
-    pub fn shutdown(&mut self) -> Result<()> {
+    pub fn shutdown(&mut self) -> anyhow::Result<()> {
         if let Some(mut subprocess) = self.subprocess.take() {
             subprocess.kill()
         } else {
@@ -84,11 +83,11 @@ impl Drop for Verilator {
 }
 
 impl Transport for Verilator {
-    fn capabilities(&self) -> Capabilities {
-        Capabilities::new(Capability::UART)
+    fn capabilities(&self) -> Result<Capabilities> {
+        Ok(Capabilities::new(Capability::UART))
     }
 
-    fn uart(&self, instance: &str) -> Result<Rc<dyn Uart>, TransportError> {
+    fn uart(&self, instance: &str) -> Result<Rc<dyn Uart>> {
         ensure!(
             instance == "0",
             TransportError::InvalidInstance(TransportInterfaceType::Uart, instance.to_string())

--- a/sw/host/opentitantool/src/command/console.rs
+++ b/sw/host/opentitantool/src/command/console.rs
@@ -48,7 +48,7 @@ impl CommandDispatch for Console {
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
         // We need the UART for the console command to operate.
-        transport.capabilities().request(Capability::UART).ok()?;
+        transport.capabilities()?.request(Capability::UART).ok()?;
         let mut stdout = std::io::stdout();
         let mut stdin = std::io::stdin();
 

--- a/sw/host/opentitantool/src/command/gpio.rs
+++ b/sw/host/opentitantool/src/command/gpio.rs
@@ -31,7 +31,7 @@ impl CommandDispatch for GpioRead {
         _context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::GPIO).ok()?;
+        transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         let value = gpio_pin.read()?;
         Ok(Some(Box::new(GpioReadResult {
@@ -60,7 +60,7 @@ impl CommandDispatch for GpioWrite {
         _context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::GPIO).ok()?;
+        transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
 
         gpio_pin.write(self.value)?;
@@ -88,7 +88,7 @@ impl CommandDispatch for GpioSetMode {
         _context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::GPIO).ok()?;
+        transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         gpio_pin.set_mode(self.mode)?;
         Ok(None)
@@ -115,7 +115,7 @@ impl CommandDispatch for GpioSetPullMode {
         _context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::GPIO).ok()?;
+        transport.capabilities()?.request(Capability::GPIO).ok()?;
         let gpio_pin = transport.gpio_pin(&self.pin)?;
         gpio_pin.set_pull_mode(self.pull_mode)?;
         Ok(None)

--- a/sw/host/opentitantool/src/command/i2c.rs
+++ b/sw/host/opentitantool/src/command/i2c.rs
@@ -30,7 +30,7 @@ impl CommandDispatch for I2cRawRead {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::I2C).ok()?;
+        transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport)?;
         let mut v = vec![0u8; self.length];
@@ -54,7 +54,7 @@ impl CommandDispatch for I2cRawWrite {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::I2C).ok()?;
+        transport.capabilities()?.request(Capability::I2C).ok()?;
         let context = context.downcast_ref::<I2cCommand>().unwrap();
         let i2c_bus = context.params.create(transport)?;
         i2c_bus.run_transaction(

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -76,7 +76,7 @@ impl CommandDispatch for SpiSfdp {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::SPI).ok()?;
+        transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
 
@@ -118,7 +118,7 @@ impl CommandDispatch for SpiReadId {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::SPI).ok()?;
+        transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
         let jedec_id = SpiFlash::read_jedec_id(&*spi, self.length)?;
@@ -167,7 +167,7 @@ impl CommandDispatch for SpiRead {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::SPI).ok()?;
+        transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
         let mut flash = SpiFlash::from_spi(&*spi)?;
@@ -217,7 +217,7 @@ impl CommandDispatch for SpiErase {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::SPI).ok()?;
+        transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
         let mut flash = SpiFlash::from_spi(&*spi)?;
@@ -259,7 +259,7 @@ impl CommandDispatch for SpiProgram {
         context: &dyn Any,
         transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        transport.capabilities().request(Capability::SPI).ok()?;
+        transport.capabilities()?.request(Capability::SPI).ok()?;
         let context = context.downcast_ref::<SpiCommand>().unwrap();
         let spi = context.params.create(transport)?;
         let mut flash = SpiFlash::from_spi(&*spi)?;


### PR DESCRIPTION
Until now, the Proxy implementation of Transport has claimed to
support all of GPIO, SPI, I2C, etc.  And if a user attempted to get
e.g. an SPI instance and the remote session process had an underlying
Transport which did not support SPI, a TransportError would be
returned.

This change adds a GetCapabilities request/response to the protocol, so
that the Proxy object can properly advertise what the caller can
expect to be able to use it for.

Longer term, I plan on adding one more sub-trait to Transport, which is
to be implemented by the Proxy struct only.  This sub-trait should have
for instance a bootstrap() method, and the Bootstrap::update() would
be modified, such that if it detects the PROXY capability of the transport,
then rather than doing a sequence of spi transactions, it makes a single call
to a new transport.proxy().bootstrap(...), which results in an RPC call with
the entire binary image are one of the parameters.  On the server side,
the RPC is handled by invoking Bootstrap::update(), which this time will
perform a sequence of spi operations.  This dance will avoid the pitfall
of having network overhead on each individual SPI request/response.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I3391f4dfb739c0ec45dbcb7754a3494d18dc2138