### PR TITLE
[opentitantool] Refactor TCP port search

### DIFF
--- a/sw/host/opentitanlib/src/proxy/socket_server.rs
+++ b/sw/host/opentitanlib/src/proxy/socket_server.rs
@@ -14,7 +14,6 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::HashMap;
 use std::io::{ErrorKind, Read, Write};
 use std::marker::PhantomData;
-use std::net::SocketAddr;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::CommandHandler;
@@ -44,12 +43,9 @@ pub struct JsonSocketServer<Msg: DeserializeOwned + Serialize, T: CommandHandler
 }
 
 impl<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> JsonSocketServer<Msg, T> {
-    pub fn new(command_handler: T, port: u16) -> Result<Self> {
+    pub fn new(command_handler: T, mut socket: TcpListener) -> Result<Self> {
         let poll = Poll::new()?;
         let socket_token = get_next_token();
-        let addr = SocketAddr::from(([0u8; 4], port));
-        log::info!("Setup JsonSocketServer: {}", &addr);
-        let mut socket = TcpListener::bind(addr)?;
         poll.registry()
             .register(&mut socket, socket_token, Interest::READABLE)?;
         // Create a `Signals` instance that will catch given set of signals for us.


### PR DESCRIPTION
When attempting to find an available TCP port to bind to, the current
code catches any error from the JsonSocketServer constructor and
handles it by calling the constructor again with the next candidate
port.

This change makes sure that unrelated errors to not get handled as
above.  The constructor is changed to take a ready TcpListener, and
the loop over available ports can then happen before the constructor
is called, and any Err() return from the constructor is now treated as
a fatal exception.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I765ba8897c2e7d20004056de92e260ef274144fd