### PR TITLE
[adc_ctrl] Adjust fsm power-up timing and counter clearing

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.hjson
@@ -97,7 +97,7 @@
           name: "pwrup_time",
           desc: '''
             ADC power up time, measured in always on clock cycles".
-            After power up time is reached, the adc controller needs two more cycles before an ADC channel is selected for access.
+            After power up time is reached, the adc controller needs one additional cycle before an ADC channel is selected for access.
           '''
           resval: "6",
         }


### PR DESCRIPTION
- fixes #11256
- Adjust fsm's such that initial power-up to sample and low power exit
  to sample have the same timing.  The IDLE state is removed as a result.
- Update documentation to reflect change
- Clear counters on adc disable otherwise the old count value carries over
  and affects the next round of detection.

Signed-off-by: Timothy Chen <timothytim@google.com>