### PR TITLE
[dif/pwm] Make X macro names consistent across DIF libs

### DIFF
--- a/sw/device/lib/dif/dif_pwm.c
+++ b/sw/device/lib/dif/dif_pwm.c
@@ -130,7 +130,7 @@ dif_result_t dif_pwm_configure_channel(const dif_pwm_t *pwm,
     return kDifBadArg;
   }
 
-#define PWM_CHANNEL_CONFIG_CASE_(channel_)                                     \
+#define DIF_PWM_CHANNEL_CONFIG_CASE_(channel_)                                 \
   case kDifPwmChannel##channel_:                                               \
     invert_reg = bitfield_bit32_write(                                         \
         invert_reg, PWM_INVERT_INVERT_##channel_##_BIT, config.polarity);      \
@@ -148,11 +148,11 @@ dif_result_t dif_pwm_configure_channel(const dif_pwm_t *pwm,
     break;
 
   switch (channel) {
-    LIST_OF_CHANNELS(PWM_CHANNEL_CONFIG_CASE_)
+    DIF_PWM_CHANNEL_LIST(DIF_PWM_CHANNEL_CONFIG_CASE_)
     default:
       return kDifBadArg;
   }
-#undef PWM_CHANNEL_CONFIG_CASE_
+#undef DIF_PWM_CHANNEL_CONFIG_CASE_
 
   mmio_region_write32(pwm->base_addr, PWM_INVERT_REG_OFFSET, invert_reg);
 

--- a/sw/device/lib/dif/dif_pwm.h
+++ b/sw/device/lib/dif/dif_pwm.h
@@ -43,12 +43,12 @@ extern "C" {
  * channels. If an additional channel is ever added to the hardware, this list
  * can be updated.
  */
-#define LIST_OF_CHANNELS(X) \
-  X(0)                      \
-  X(1)                      \
-  X(2)                      \
-  X(3)                      \
-  X(4)                      \
+#define DIF_PWM_CHANNEL_LIST(X) \
+  X(0)                          \
+  X(1)                          \
+  X(2)                          \
+  X(3)                          \
+  X(4)                          \
   X(5)
 
 /**
@@ -62,7 +62,7 @@ extern "C" {
  * A PWM channel.
  */
 typedef enum dif_pwm_channel {
-  LIST_OF_CHANNELS(PWM_CHANNEL_ENUM_INIT_)
+  DIF_PWM_CHANNEL_LIST(PWM_CHANNEL_ENUM_INIT_)
 } dif_pwm_channel_t;
 
 #undef PWM_CHANNEL_ENUM_INIT_


### PR DESCRIPTION
This commit aims to make then names of X macros (used for code gen)
consistent across DIF libraries. X macros simplify maintenance of DIF
libraries that rely on a specific number of resources (e.g., pins,
channels, alerts, etc.) to be available in the HW.

Signed-off-by: Timothy Trippel <ttrippel@google.com>