### PR TITLE
[otp_ctrl] Change error assignment priorities

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -411,13 +411,14 @@ module otp_ctrl
 
   // Status and error reporting CSRs, error interrupt generation and alerts.
   otp_err_e [NumPart+1:0] part_error;
+  logic [NumAgents-1:0] part_fsm_err;
   logic [NumPart+1:0] part_errors_reduced;
   logic otp_operation_done, otp_error;
   logic fatal_macro_error_d, fatal_macro_error_q;
   logic fatal_check_error_d, fatal_check_error_q;
   logic fatal_bus_integ_error_d, fatal_bus_integ_error_q;
   logic chk_pending, chk_timeout;
-  logic lfsr_fsm_err, key_deriv_fsm_err, scrmbl_fsm_err;
+  logic lfsr_fsm_err, scrmbl_fsm_err;
   always_comb begin : p_errors_alerts
     hw2reg.err_code = part_error;
     // Note: since these are all fatal alert events, we latch them and keep on sending
@@ -469,7 +470,7 @@ module otp_ctrl
     fatal_check_error_d |= chk_timeout       |
                            lfsr_fsm_err      |
                            scrmbl_fsm_err    |
-                           key_deriv_fsm_err;
+                           |part_fsm_err;
   end
 
   // Assign these to the status register.
@@ -477,7 +478,7 @@ module otp_ctrl
                           chk_timeout,
                           lfsr_fsm_err,
                           scrmbl_fsm_err,
-                          key_deriv_fsm_err,
+                          part_fsm_err[KdiIdx],
                           fatal_bus_integ_error_q,
                           dai_idle,
                           chk_pending};
@@ -491,7 +492,7 @@ module otp_ctrl
     chk_timeout,
     lfsr_fsm_err,
     scrmbl_fsm_err,
-    key_deriv_fsm_err
+    |part_fsm_err
   };
 
   assign otp_error = |(interrupt_triggers_d & ~interrupt_triggers_q);
@@ -939,6 +940,7 @@ module otp_ctrl
     .part_init_done_i ( part_init_done                        ),
     .escalate_en_i    ( lc_escalate_en[DaiIdx]                ),
     .error_o          ( part_error[DaiIdx]                    ),
+    .fsm_err_o        ( part_fsm_err[DaiIdx]                  ),
     .part_access_i    ( part_access_dai                       ),
     .dai_addr_i       ( dai_addr                              ),
     .dai_cmd_i        ( dai_cmd                               ),
@@ -987,6 +989,7 @@ module otp_ctrl
     .lci_en_i         ( pwr_otp_o.otp_done                ),
     .escalate_en_i    ( lc_escalate_en[LciIdx]            ),
     .error_o          ( part_error[LciIdx]                ),
+    .fsm_err_o        ( part_fsm_err[LciIdx]              ),
     .lci_prog_idle_o  ( lci_prog_idle                     ),
     .lc_req_i         ( lc_otp_program_i.req              ),
     .lc_data_i        ( lc_otp_program_data               ),
@@ -1028,7 +1031,7 @@ module otp_ctrl
     .rst_ni,
     .kdi_en_i                ( pwr_otp_o.otp_done      ),
     .escalate_en_i           ( lc_escalate_en[KdiIdx]  ),
-    .fsm_err_o               ( key_deriv_fsm_err       ),
+    .fsm_err_o               ( part_fsm_err[KdiIdx]    ),
     .scrmbl_key_seed_valid_i ( scrmbl_key_seed_valid   ),
     .flash_data_key_seed_i   ( flash_data_key_seed     ),
     .flash_addr_key_seed_i   ( flash_addr_key_seed     ),
@@ -1081,6 +1084,7 @@ module otp_ctrl
         .init_done_o   ( part_init_done[k]            ),
         .escalate_en_i ( lc_escalate_en[k]            ),
         .error_o       ( part_error[k]                ),
+        .fsm_err_o     ( part_fsm_err[k]              ),
         .access_i      ( part_access[k]               ),
         .access_o      ( part_access_dai[k]           ),
         .digest_o      ( part_digest[k]               ),
@@ -1141,6 +1145,7 @@ module otp_ctrl
         // Only supported by life cycle partition (see further below).
         .check_byp_en_i    ( lc_ctrl_pkg::Off                ),
         .error_o           ( part_error[k]                   ),
+        .fsm_err_o         ( part_fsm_err[k]                 ),
         .access_i          ( part_access[k]                  ),
         .access_o          ( part_access_dai[k]              ),
         .digest_o          ( part_digest[k]                  ),
@@ -1199,6 +1204,7 @@ module otp_ctrl
         // consistent with the values in the buffer regs anymore).
         .check_byp_en_i    ( lc_check_byp_en                 ),
         .error_o           ( part_error[k]                   ),
+        .fsm_err_o         ( part_fsm_err[k]                 ),
         .access_i          ( part_access[k]                  ),
         .access_o          ( part_access_dai[k]              ),
         .digest_o          ( part_digest[k]                  ),

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -551,6 +551,7 @@ module otp_ctrl_kdi
       // error state, where an alert will be triggered.
       default: begin
         state_d = ErrorSt;
+        fsm_err_o = 1'b1;
       end
       ///////////////////////////////////////////////////////////////////
     endcase // state_q

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -343,6 +343,7 @@ module otp_ctrl_lfsr_timer
       // error state, where an alert will be triggered.
       default: begin
         state_d = ErrorSt;
+        fsm_err_o = 1'b1;
       end
       ///////////////////////////////////////////////////////////////////
     endcase // state_q

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -37,6 +37,13 @@ module otp_ctrl_part_buf
   // Note that most errors are not recoverable and move the partition FSM into
   // a terminal error state.
   output otp_err_e                    error_o,
+  // This error signal is pulsed high if the FSM has been glitched into an invalid state.
+  // Although it is somewhat redundant with the error code in error_o above, it is
+  // meant to cover cases where we already latched an error code while the FSM is
+  // glitched into an invalid state (since in that case, the error code will not be
+  // overridden with the FSM error code so that the original error code is still
+  // discoverable).
+  output logic                        fsm_err_o,
   // Access/lock status
   // SEC_CM: ACCESS.CTRL.MUBI
   input  part_access_t                access_i, // runtime lock from CSRs
@@ -208,6 +215,7 @@ module otp_ctrl_part_buf
 
     // Error Register
     error_d = error_q;
+    fsm_err_o = 1'b0;
 
     // Integrity/Consistency check responses
     cnsty_chk_ack_o = 1'b0;
@@ -572,6 +580,7 @@ module otp_ctrl_part_buf
       // glitch), error out immediately.
       default: begin
         state_d = ErrorSt;
+        fsm_err_o = 1'b1;
       end
       ///////////////////////////////////////////////////////////////////
     endcase // state_q
@@ -589,6 +598,7 @@ module otp_ctrl_part_buf
     // SEC_CM: PART.FSM.LOCAL_ESC, PART.FSM.GLOBAL_ESC
     if (escalate_en_i != lc_ctrl_pkg::Off || cnt_err) begin
       state_d = ErrorSt;
+      fsm_err_o = 1'b1;
       if (state_q != ErrorSt) begin
         error_d = FsmStateError;
       end

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -27,6 +27,13 @@ module otp_ctrl_part_unbuf
   // Note that most errors are not recoverable and move the partition FSM into
   // a terminal error state.
   output otp_err_e                    error_o,
+  // This error signal is pulsed high if the FSM has been glitched into an invalid state.
+  // Although it is somewhat redundant with the error code in error_o above, it is
+  // meant to cover cases where we already latched an error code while the FSM is
+  // glitched into an invalid state (since in that case, the error code will not be
+  // overridden with the FSM error code so that the original error code is still
+  // discoverable).
+  output logic                        fsm_err_o,
   // Access/lock status
   // SEC_CM: ACCESS.CTRL.MUBI
   input  part_access_t                access_i, // runtime lock from CSRs
@@ -157,6 +164,7 @@ module otp_ctrl_part_unbuf
     // Error Register
     error_d = error_q;
     pending_tlul_error_d = 1'b0;
+    fsm_err_o = 1'b0;
 
     unique case (state_q)
       ///////////////////////////////////////////////////////////////////
@@ -289,6 +297,7 @@ module otp_ctrl_part_unbuf
       // glitch), error out immediately.
       default: begin
         state_d = ErrorSt;
+        fsm_err_o = 1'b1;
       end
       ///////////////////////////////////////////////////////////////////
     endcase // state_q
@@ -305,6 +314,7 @@ module otp_ctrl_part_unbuf
     // SEC_CM: PART.FSM.GLOBAL_ESC
     if (escalate_en_i != lc_ctrl_pkg::Off) begin
       state_d = ErrorSt;
+      fsm_err_o = 1'b1;
       if (state_q != ErrorSt) begin
         error_d = FsmStateError;
       end

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -419,6 +419,7 @@ module otp_ctrl_scrmbl
       // error state, where an alert will be triggered.
       default: begin
         state_d = ErrorSt;
+        fsm_err_o = 1'b1;
       end
       ///////////////////////////////////////////////////////////////////
     endcase // state_q


### PR DESCRIPTION
This changes the error code assignment priorities so that a glitched FSM always outputs an `FsmStateError`.

Fix #11266

Signed-off-by: Michael Schaffner <msf@opentitan.org>