### PR TITLE
[keymgr,dv] Work around Xcelium ICE in scoreboard

### DIFF
--- a/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_scoreboard.sv
@@ -1057,7 +1057,7 @@ class keymgr_scoreboard extends cip_base_scoreboard #(
     end
     foreach (cfg.keymgr_vif.keys_a_array[state, cdi, dest]) begin
       `DV_CHECK_NE(act, cfg.keymgr_vif.keys_a_array[state][cdi][dest],
-                   $sformatf("key at state %0s for %s %s", state.name, cdi.name, dest))
+                   $sformatf("key at state %0d for %s %s", state, cdi.name, dest))
     end
   endfunction
 


### PR DESCRIPTION
It turns out that using state.name here causes an internal error in
Xcelium at the elaboration stage. This happens for at least versions
20.03-s001 and 21.09-s006.

I don't *think* there's anything suspect in the code that was there.
Weirdly, to trigger the error you need the \`dv_error() function call
that the \`DV_CHECK_NE macro expands into. In particular, just using
$display() to print out the message doesn't cause a compilation
failure.
