### PR TITLE
[adc_ctrl/dv] Update PwrupTime_A assertion for latest Spec/RTL

### DIFF
--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -241,7 +241,7 @@ module tb;
   `ASSERT(ChannelSelOnehot_A, $onehot0(adc_o.channel_sel), clk_aon, ~rst_aon_n)
   `ASSERT_KNOWN(ChannelSelKnown_A, adc_o.channel_sel, clk_aon, ~rst_aon_n)
   `ASSERT_KNOWN(PdKnown_A, adc_o.pd, clk_aon, ~rst_aon_n)
-  `ASSERT(PwrupTime_A, $rose(pwrup_time_chk) |-> pwrup_time == (cfg_pwrup_time + 2), clk_aon,
+  `ASSERT(PwrupTime_A, $rose(pwrup_time_chk) |-> pwrup_time == (cfg_pwrup_time + 1), clk_aon,
           ~rst_aon_n)
   `ASSERT(WakeupTime_A, $rose(wakeup_time_chk) |-> wakeup_time == cfg_wakeup_time, clk_aon,
           ~rst_aon_n)


### PR DESCRIPTION
- Updated PwrupTime_A to check power up time as pwrup_time value plus one rather
than pwrup_time value plus two (PR #11267)

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>