### PR TITLE
[lc_ctrl,dv] Add an explicit "static" to a block-local variable

### DIFF
--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -178,9 +178,9 @@ module tb;
 
 
   initial begin
-    lc_ctrl_parameters_cfg parameters_cfg = lc_ctrl_parameters_cfg::type_id::create(
-        "parameters_cfg"
-    );
+    static lc_ctrl_parameters_cfg parameters_cfg =
+        lc_ctrl_parameters_cfg::type_id::create("parameters_cfg");
+
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);


### PR DESCRIPTION
It seems that Xcelium doesn't like processes to have local variables
that aren't explicitly marked as "static". Honestly, I'm not sure what
this achieves, but we may as well do so to shut up the warning.
