### PR TITLE
[lc_ctrl,dv] Add a couple of missing "void" return types

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -133,7 +133,7 @@ interface lc_ctrl_if (
     flash_rma_ack_i = val;
   endtask
 
-  function automatic clear_static_signals();
+  function automatic void clear_static_signals();
     otp_device_id_i = 0;
     otp_manuf_state_i = 0;
     otp_vendor_test_status_i = 0;
@@ -229,7 +229,7 @@ interface lc_ctrl_if (
     return `LC_CTRL_COUNT_PATH;
   endfunction
 
-  function automatic set_test_sequence_typename(string name);
+  function automatic void set_test_sequence_typename(string name);
     test_sequence_typename = name;
   endfunction
 


### PR DESCRIPTION
The implicit return type in SystemVerilog is 'logic' and Xcelium warns
about the call sites not using the result of calling the functions.
These functions are supposed to be void, so mark them as such.
