### PR TITLE
[opentitantool] Tolerate being interrupted in epoll()

### DIFF
--- a/sw/host/opentitanlib/src/proxy/socket_server.rs
+++ b/sw/host/opentitanlib/src/proxy/socket_server.rs
@@ -75,7 +75,13 @@ impl<Msg: DeserializeOwned + Serialize, T: CommandHandler<Msg>> JsonSocketServer
     pub fn run_loop(&mut self) -> Result<()> {
         let mut events = Events::with_capacity(1024);
         while !self.exit_requested {
-            self.poll.poll(&mut events, None)?;
+            match self.poll.poll(&mut events, None) {
+                Ok(()) => (),
+                Err(err) if err.kind() == ErrorKind::Interrupted => {
+                    continue;
+                }
+                Err(err) => bail!("poll: {}", err),
+            }
             for event in events.iter() {
                 if event.token() == self.socket_token {
                     self.process_new_connection()?;


### PR DESCRIPTION
If a benign signal is handled, while a system call is in progress, it
may cause the system call to return EINTR.  Some rust library
functions, such as write_all() will no doubt loop and make another
system call, until the full buffer has been processed.  Others, such
as epoll() apparently, will return Err(ErrorKind::Interrupted).

This change makes it such that the main event loop of the
opentitansession deamon will not terminate in case of
e.g. SIGSTOP/SIGCONT or other harmless signals being handled.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I792ec2981daeafb7403cef02fca06d72aed98338