### PR TITLE
[dif] Update DIF checklists and development stages - pt5

### DIFF
--- a/hw/ip/spi_host/data/spi_host.prj.hjson
+++ b/hw/ip/spi_host/data/spi_host.prj.hjson
@@ -7,6 +7,7 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_spi_host",
     revisions: [
       {
         version:            "1.0",

--- a/hw/ip/sram_ctrl/data/sram_ctrl.prj.hjson
+++ b/hw/ip/sram_ctrl/data/sram_ctrl.prj.hjson
@@ -7,10 +7,11 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
-    sw_checklist:       "",
+    sw_checklist:       "/sw/device/lib/dif/dif_sram_ctrl"
     version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V2S",
+    dif_stage:          "S1",
     notes:              "",
 }

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.prj.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.prj.hjson
@@ -7,9 +7,11 @@
     design_spec:        "../doc",
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
+    sw_checklist:       "/sw/device/lib/dif/dif_sysrst_ctrl",
     version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V1",
+    dif_stage:          "S0",
     notes:              "DV resource allocation pending.",
 }

--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -22,7 +22,7 @@
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",
-        dif_stage:          "S1",
+        dif_stage:          "S2",
         notes:              "Rolled back to D2 as the register module is updated"
       }
     ]

--- a/hw/ip/usbdev/data/usbdev.prj.hjson
+++ b/hw/ip/usbdev/data/usbdev.prj.hjson
@@ -12,6 +12,6 @@
     life_stage:         "L1",
     design_stage:       "D1",
     verification_stage: "V0",
-    dif_stage:          "S0",
+    dif_stage:          "S1",
     notes:              "DV resource allocation pending.",
 }

--- a/sw/device/lib/dif/dif_spi_device.md
+++ b/sw/device/lib/dif/dif_spi_device.md
@@ -5,63 +5,48 @@ title: "SPI Device DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [SPI Device DIF]({{< relref "hw/ip/spi_device/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
 Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | In Progress |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_spi_host.md
+++ b/sw/device/lib/dif/dif_spi_host.md
@@ -1,0 +1,52 @@
+---
+title: "SPI Host DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [SPI Host DIF]({{< relref "hw/ip/spi_host/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+<h2>DIF Checklist</h2>
+
+<h3>S1</h3>
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | In Progress |
+Implementation | [DIF_USED_IN_TREE][] | In Progress |
+Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+
+<h3>S2</h3>
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+
+<h3>S3</h3>
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}

--- a/sw/device/lib/dif/dif_sram_ctrl.md
+++ b/sw/device/lib/dif/dif_sram_ctrl.md
@@ -2,66 +2,51 @@
 title: "SRAM Controller DIF Checklist"
 ---
 
-
-
-<!--
-NOTE: This is a template checklist document that is required to be copied over
-to `sw/device/lib/dif/dif_sram_ctrl.md` for a new DIF that transitions
-from L0 (Specification) to L1 (Development) stage, and updated as needed.
-Once done, please remove this comment before checking it in.
--->
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [SRAM Controller DIF]({{< relref "hw/ip/sram_ctrl/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
+<h2>DIF Checklist</h2>
 
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Done        | Header only.
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
 
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | In Progress |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}

--- a/sw/device/lib/dif/dif_sysrst_ctrl.md
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.md
@@ -1,0 +1,52 @@
+---
+title: "System Reset Controller DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [System Reset Controller DIF]({{< relref "hw/ip/sysrst_ctrl/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+<h2>DIF Checklist</h2>
+
+<h3>S1</h3>
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | In Progress |
+Implementation | [DIF_USED_IN_TREE][] | In Progress |
+Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+
+<h3>S2</h3>
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+
+<h3>S3</h3>
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | In Progress |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}

--- a/sw/device/lib/dif/dif_uart.md
+++ b/sw/device/lib/dif/dif_uart.md
@@ -5,63 +5,48 @@ title: "UART DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [UART DIF]({{< relref "hw/ip/uart/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
 Implementation | [DIF_EXISTS][]       | Done        |
 Implementation | [DIF_USED_IN_TREE][] | Done        |
-Tests          | [DIF_TEST_UNIT][]    | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Done        |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started | @eunchan
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}

--- a/sw/device/lib/dif/dif_usbdev.md
+++ b/sw/device/lib/dif/dif_usbdev.md
@@ -5,63 +5,48 @@ title: "USB Device DIF Checklist"
 This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [USB Device DIF]({{< relref "hw/ip/usbdev/doc" >}}).
 All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
 
-## DIF Checklist
+<h2>DIF Checklist</h2>
 
-### S1
+<h3>S1</h3>
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | Not Started |
-Implementation | [DIF_USED_IN_TREE][] | Not Started |
-Tests          | [DIF_TEST_UNIT][]    | Not Started |
-Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
-[DIF_TEST_UNIT]:    {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
 
-### S2
+<h3>S2</h3>
 
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
-Implementation | [DIF_FEATURES][]            | Not Started |
-Coordination   | [DIF_HW_USAGE_REVIEWED][]   | Not Started |
-Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_HW_PARAMS][]           | Not Started |
-Documentation  | [DIF_DOC_HW][]              | Not Started |
-Documentation  | [DIF_DOC_API][]             | Not Started |
-Code Quality   | [DIF_CODE_STYLE][]          | Not Started |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
-Implementation | [DIF_USED_TOCK][]           | Not Started |
-Review         | HW IP Usage Reviewer(s)     | Not Started |
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | In Progress | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
-[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
-[DIF_HW_USAGE_REVIEWED]:   {{< relref "/doc/project/checklist.md#dif_hw_usage_reviewed" >}}
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
-[DIF_HW_PARAMS]:           {{< relref "/doc/project/checklist.md#dif_hw_params" >}}
-[DIF_DOC_HW]:              {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
-[DIF_DOC_API]:             {{< relref "/doc/project/checklist.md#dif_doc_api" >}}
-[DIF_CODE_STYLE]:          {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
 [DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
-[DIF_USED_TOCK]:           {{< relref "/doc/project/checklist.md#dif_used_tock" >}}
 
-### S3
+<h3>S3</h3>
 
 Type           | Item                             | Resolution  | Note/Collaterals
 ---------------|----------------------------------|-------------|------------------
 Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
-Review         | [DIF_REVIEW_C_STABLE][]          | Not Started |
-Tests          | [DIF_TEST_UNIT_COMPLETE][]       | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | In Progress |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
-Review         | [DIF_REVIEW_TOCK_STABLE][]       | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |
 
 [DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
 [DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
-[DIF_REVIEW_C_STABLE]:          {{< relref "/doc/project/checklist.md#dif_review_c_stable" >}}
-[DIF_TEST_UNIT_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_test_unit_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
 [DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}
-[DIF_REVIEW_TOCK_STABLE]:       {{< relref "/doc/project/checklist.md#dif_review_tock_stable" >}}


### PR DESCRIPTION
This PR updates the DIF checklists and development stages for the following IPs, to match the updated DIF milestone checklist merged in #10777:
- spi_device
- spi_host
- sram_ctrl
- sysrst_ctrl
- uart
- usbdev

This partially addresses #10504.