### PR TITLE
[opentitantool] Bootstrapping efficiently via proxy

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -11,7 +11,7 @@ use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
-use crate::transport::{Result, Transport, TransportError};
+use crate::transport::{ProxyOps, Result, Transport, TransportError};
 
 use erased_serde::Serialize;
 use std::any::Any;
@@ -92,6 +92,11 @@ impl TransportWrapper {
     /// Returns a [`Emulator`] implementation.
     pub fn emulator(&self) -> Result<Rc<dyn Emulator>> {
         self.transport.borrow().emulator()
+    }
+
+    /// Methods available only on Proxy implementation.
+    pub fn proxy_ops(&self) -> Result<Rc<dyn ProxyOps>> {
+        self.transport.borrow().proxy_ops()
     }
 
     /// Invoke non-standard functionality of some Transport implementations.

--- a/sw/host/opentitanlib/src/bootstrap/.history_*shell*
+++ b/sw/host/opentitanlib/src/bootstrap/.history_*shell*
@@ -1,0 +1,500 @@
+git status
+git restore opentitanlib/
+git status
+git add opentitansession/
+git commit --amend
+git fetch lowrisc
+git rebase
+git push -f jesultra HEAD
+git diff
+find -name \*.rs | xargs grep trim
+git status
+git add opentitansession/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git add opentitansession/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git add opentitansession/
+git status
+git commit --amend
+git push -f jesultra HEAD
+git status
+git add opentitansession/src/main.rs 
+git commit --amend
+git push -f jesultra HEAD
+git status
+git branch -l
+git checkout session_demo
+git status
+git log
+git reset --hard session
+git status
+git branch -l
+git reset --hard daemon
+git status
+git fetch lowrisc
+git status
+git log
+git status
+git add opentitanlib/ opentitansession/ ../../third_party/cargo/
+git commit -m"WIP: Refactoring"
+git checkout daemon
+git status
+git rebase
+git push -f jesultra HEAD
+git status
+rustfmt opentitansession/src/main.rs 
+git status
+git diff
+git commit --amend
+git status
+git add opentitansession/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git checkout session_demo
+git diff HEAD~1
+git status
+git add opentitanlib/ opentitansession/
+git status
+git diff HEAD~1
+git branch -l
+git checkout lowrisc/master
+git status
+git add opentitanlib/ opentitansession/ ../../third_party/cargo/crates.bzl 
+git commit --amend
+git status
+git checkout lowrisc/master
+git checkout -b def_empty_interface
+git status
+git add opentitanlib/ opentitantool/ opentitansession/
+git status
+gti branch -u lowrisc/master
+git branch -u lowrisc/master
+git status
+git commit
+git push jesultra HEAD
+git commit --amend
+git push -f jesultra HEAD
+git status
+git checkout lowrisc/master
+git checkout -b better_errors
+git status
+git add opentitanlib/
+git diff --staged
+git commit
+git status
+git push jesultra HEAD
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git checkout lowrisc/master
+git status
+git stash -m"Bootstrap to use TransportError"
+git status
+git stash show
+ 
+git stash list
+git status
+git checkout -b capabilities
+git diff
+git status
+git diff
+git status
+git add opentitanlib/ opentitantool/
+git commit
+git push jesultra HEAD
+rustfmt opentitanlib/src/app/mod.rs opentitanlib/src/bootstrap/legacy.rs opentitanlib/src/bootstrap/primitive.rs opentitanlib/src/bootstrap/rescue.rs opentitanlib/src/proxy/handler.rs opentitanlib/src/proxy/protocol.rs opentitanlib/src/transport/cw310/mod.rs opentitanlib/src/transport/hyperdebug/mod.rs opentitanlib/src/transport/mod.rs opentitanlib/src/transport/proxy/mod.rs opentitanlib/src/transport/ultradebug/mod.rs opentitanlib/src/transport/verilator/transport.rs opentitantool/src/command/console.rs opentitantool/src/command/gpio.rs opentitantool/src/command/i2c.rs opentitantool/src/command/spi.rs
+git status
+git diff
+git status
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git commit --amend
+git push -f jesultra HEAD
+git status
+git branch -l
+git checkout def_empty_interface
+git fetch lowrisc
+git rebase
+i
+git status
+git add opentitansession/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git branch -l
+git checkout result
+git status
+git log
+git rebase
+git status
+git branch -l
+git checkout fw_update
+git branch -d result
+git status
+git log
+git status
+git branch -l
+git checkout errors
+git status
+git log
+git rebase
+git status
+git branch -l
+git branch -d daemon
+git branch -D daemon
+git checkout compiler_warnings
+git status
+git log
+git rebase
+git status
+git branch -l
+git checkout ccd
+git branch -d compiler_warnings
+git status
+ 
+git branch -u lowrisc/master
+git status
+git rebase
+git status
+git rebase --abort
+git log
+git diff HEAD~1
+git status
+git branch -l
+git checkout better_errors
+git branch -D ccd
+git status
+git branch -u lowrisc/master
+git status
+git log 
+git status
+git rebase
+git status
+git branch -l
+git checkout errors
+git status
+git log
+git checkout better_errors
+git branch -d errors
+git branch -l
+git checkout session_demo
+git status
+git log 
+git rebase
+git status
+git rebase --skip
+git status
+git log
+ git diff HEAD~1
+git status
+git branch --help
+git status
+git branch -m signals
+git status
+git push jesultra HEAD
+git status
+git checkout -b port
+git branch -u lowrisc/main
+git branch -u lowrisc/master
+git status
+git reset --soft HEAD~1
+git status
+git restore --staged
+git status
+git restore --staged ../..
+git status
+git restore ../../third_party/
+git diff opentitansession/
+git restore opentitansession/
+git status
+cd opentitanlib/src/proxy/
+git diff mod.rs 
+git status
+git diff socket_server.rs 
+git status
+git restore socket_server.rs 
+git status
+git diff
+git status
+git add .
+git status
+git commit
+git push jesultra HEAD
+git status
+git branch -l
+git checkout signals
+git rebase --onto port
+git status
+git rebase --continue
+git diff HEAD~1
+git status
+git add mod.rs socket_server.rs 
+git commit --amend
+git branch -l
+git checkout port
+git status
+rustfmt *.rs
+git status
+git diff mod.rs 
+git add mod.rs 
+git commit --amend
+git push -f jesultra HEAD
+git branch -l
+git checkout signals
+git diff HEAD~1
+git diff --name-only HEAD~1
+cd ../../../..
+cd ..
+rustfmt $(git diff --name-only HEAD~1)
+git status
+cd sw/host/opentitanlib/src/proxy/
+git diff
+git status
+git add .
+git commit --amend
+git status
+git add mod.rs ../../../opentitansession/
+git log
+git commit --amend
+git branch -l
+git status
+cd ../../..
+git status
+git add opentitansession/
+git commit --amend
+git branch -l
+git status
+git checkout better_errors
+git rebase
+git status
+git fetch lowrisc
+git rebase
+git status
+git checkout signals
+git branch -d better_errors
+git log
+git stash list
+git status
+git checkout lowrisc/master
+git checkout -b remote_bootstrap
+git stash pop
+git status
+git add opentitanlib/
+git commit
+git commit --amend
+git branch -l
+git checkout capabilities
+git status
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git branch -l
+git checkout remote_bootstrap
+git log
+git rebase HEAD~1 --onto capabilities
+git log
+git status
+git branch -u lowrisc/master
+git status
+git log 
+git status
+git add opentitanlib/
+git commit --amend
+git branch -l
+it
+git checkout capabilities
+git status
+git log --name-only
+rustfmt opentitanlib/src/transport/mod.rs
+git status
+git diff
+git commit --amend
+git push -f jesultra HEAD
+git branch -l
+git checkout remote_bootstrap
+git status
+git checkout capabilities
+git status
+git add opentitan
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git checkout remote_bootstrap
+git log 
+git rebase HEAD~1 --onlo capabilities
+git rebase HEAD~1 --onto capabilities
+git log 
+git fetch
+git fetch lowrisc
+git status
+git add opentitanlib/
+git commit --amend
+git rebase
+git status
+git add opentitanlib/
+git commit --amend
+git statu
+git status
+git checkout lowrisc/master
+git checkout -b signal
+git branch -u lowrisc/master
+git status
+git add opentitanlib/
+git diff --staged
+git checkout -b interrupted
+git branch -u lowrisc/master
+git branch -d signal
+git status
+git commit
+git push jesultra HEAD
+rustfmt opentitanlib/src/proxy/socket_server.rs 
+git status
+git diff
+git status
+git branch -l
+ 
+git checkout remote_bootstrap
+git stash
+git checkout remote_bootstrap
+git stash pop
+git status
+git log
+git status
+git commit --amend
+git push jesultra HEAD
+git status
+git branch -l
+git checkout capabilities
+git status
+git branch -l
+git diff
+git status
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git branch -l
+git fetch lowrisc
+git rebase
+git status
+git branch -u lowrisc/master
+git statu
+git status
+git rebase
+git status
+git branch -l
+git checkout remote_bootstrap
+git branch -d capabilities
+git rebase HEAD~1 --onto lowrisc/master
+git push jesultra HEAD
+git push -f jesultra HEAD
+git commit --amend
+git status
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git branch -D interrupted
+git branch -D port
+git branch -l
+git branch -D def_empty_interface
+git status
+git checkout signals
+git log 
+git rebase
+git rebase --abort
+git rebase HEAD~1 --onto lowrisc/master
+git status
+git add opentitansession/
+git rebase --continue
+git status
+git branch -l
+git checkout remote_bootstrap
+git diff HEAD~1 --name-only
+cd ../..
+rustfmt $(git diff HEAD~1 --name-only)
+git status
+git diff
+git status
+cd sw/host
+git status
+git add opentitanlib/
+git commit --amend
+git push -f jesultra HEAD
+git status
+git checkout lowrisc/master
+git checkout -b legacy
+git branch -u lowrisc/master
+git status
+git diff
+git commit
+git add opentitanlib/
+git commit
+git push
+git push jesultra HEAD
+ls
+grep log *.rs
+ls
+cd ..
+find -name \*.rs | xargs grep utils
+find -name \*.rs | xargs grep macro_use
+cd ../..
+cd ..
+git status
+git add ports/dauntless/src/
+git add ports/dauntless/config.mk 
+git status
+git rebase --continue
+git fetch https://chrome-internal.googlesource.com/ti50/common/ti50 refs/changes/71/4597371/1 && git cherry-pick FETCH_HEAD
+git log
+cd ..
+find -name spiflash
+cd ../..
+find -name \*.rs | xargs grep asm
+repo status
+git status
+git log
+git status
+git add ports/dauntless/build.mk 
+git add ports/dauntless/config.mk 
+git add ports/dauntless/software/tools/andreiboard_ultradebug.json
+git commit --amend
+git fetch
+git rebase
+git log
+c d..
+cd ..
+find -name kernel
+cd third_party/tock/tock/kernel
+find -name \*.rs | xargs grep ErrorCode
+find -name \*.rs | xargs grep "enum ErrorCode"
+./disabled.xsession &
+exit
+git status
+git log
+q
+git status
+git add legacy.rs 
+git commit --amend
+git push -f jesultra HEAD
+git status
+git status
+git add legacy.rs 
+git commit --amend
+git log
+q
+git push -f jesultra HEAD

--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use mundane::hash::{Digest, Hasher, Sha256};
 use std::time::Duration;
 use thiserror::Error;
@@ -11,7 +10,7 @@ use zerocopy::AsBytes;
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, BootstrapOptions, UpdateProtocol};
 use crate::io::spi::Transfer;
-use crate::transport::Capability;
+use crate::transport::{Capability, Result};
 
 #[derive(AsBytes, Debug, Default)]
 #[repr(C)]
@@ -140,7 +139,7 @@ impl Legacy {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, serde::Serialize, serde::Deserialize)]
 pub enum LegacyBootstrapError {
     #[error("Boot rom not ready")]
     NotReady,

--- a/sw/host/opentitanlib/src/bootstrap/primitive.rs
+++ b/sw/host/opentitanlib/src/bootstrap/primitive.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
 use mundane::hash::{Digest, Hasher, Sha256};
 use std::time::Duration;
 use zerocopy::AsBytes;
@@ -10,7 +9,7 @@ use zerocopy::AsBytes;
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, BootstrapOptions, UpdateProtocol};
 use crate::io::spi::Transfer;
-use crate::transport::Capability;
+use crate::transport::{Capability, Result};
 
 #[derive(AsBytes, Debug, Default)]
 #[repr(C)]

--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -2,7 +2,6 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{bail, ensure, Result};
 use mundane::hash::{Digest, Hasher, Sha256};
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -11,7 +10,8 @@ use zerocopy::AsBytes;
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, BootstrapOptions, UpdateProtocol};
 use crate::io::uart::Uart;
-use crate::transport::Capability;
+use crate::transport::{Capability, Result};
+use crate::{bail, ensure};
 
 #[derive(AsBytes, Debug, Default)]
 #[repr(C)]
@@ -149,7 +149,7 @@ impl Frame {
     }
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, serde::Serialize, serde::Deserialize)]
 pub enum RescueError {
     #[error("Unrecognized image file format")]
     ImageFormatError,

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -12,7 +12,7 @@ use crate::app::TransportWrapper;
 use crate::transport::Result;
 use crate::util::voltage::Voltage;
 
-#[derive(Debug, StructOpt)]
+#[derive(Clone, Debug, StructOpt, Serialize, Deserialize)]
 pub struct SpiParams {
     #[structopt(long, help = "SPI instance", default_value = "0")]
     pub bus: String,

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -11,7 +11,7 @@ use thiserror::Error;
 use crate::app::TransportWrapper;
 use crate::transport::Result;
 
-#[derive(Debug, StructOpt)]
+#[derive(Clone, Debug, StructOpt, Serialize, Deserialize)]
 pub struct UartParams {
     #[structopt(long, help = "UART instance", default_value = "CONSOLE")]
     uart: String,

--- a/sw/host/opentitanlib/src/proxy/handler.rs
+++ b/sw/host/opentitanlib/src/proxy/handler.rs
@@ -8,11 +8,13 @@ use std::time::Duration;
 
 use super::protocol::{
     EmuRequest, EmuResponse, GpioRequest, GpioResponse, I2cRequest, I2cResponse,
-    I2cTransferRequest, I2cTransferResponse, Message, Request, Response, SpiRequest, SpiResponse,
-    SpiTransferRequest, SpiTransferResponse, UartRequest, UartResponse,
+    I2cTransferRequest, I2cTransferResponse, Message, ProxyRequest, ProxyResponse, Request,
+    Response, SpiRequest, SpiResponse, SpiTransferRequest, SpiTransferResponse, UartRequest,
+    UartResponse,
 };
 use super::CommandHandler;
 use crate::app::TransportWrapper;
+use crate::bootstrap::Bootstrap;
 use crate::io::i2c;
 use crate::io::spi;
 use crate::transport::TransportError;
@@ -241,6 +243,12 @@ impl<'a> TransportCommandHandler<'a> {
                     }
                 }
             }
+            Request::Proxy(command) => match command {
+                ProxyRequest::Bootstrap { options, payload } => {
+                    Bootstrap::update(self.transport, options, payload)?;
+                    Ok(Response::Proxy(ProxyResponse::Bootstrap))
+                }
+            },
         }
     }
 }

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -5,6 +5,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+use crate::bootstrap::BootstrapOptions;
 use crate::io::emu::{EmuState, EmuValue};
 use crate::io::gpio::{PinMode, PullMode};
 use crate::io::spi::TransferMode;
@@ -25,6 +26,7 @@ pub enum Request {
     Spi { id: String, command: SpiRequest },
     I2c { id: String, command: I2cRequest },
     Emu { command: EmuRequest },
+    Proxy(ProxyRequest),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -35,6 +37,7 @@ pub enum Response {
     Spi(SpiResponse),
     I2c(I2cResponse),
     Emu(EmuResponse),
+    Proxy(ProxyResponse),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -181,4 +184,17 @@ pub enum EmuResponse {
     GetState { state: EmuState },
     Start,
     Stop,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum ProxyRequest {
+    Bootstrap {
+        options: BootstrapOptions,
+        payload: Vec<u8>,
+    },
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum ProxyResponse {
+    Bootstrap,
 }

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -62,6 +62,15 @@ pub enum TransportError {
     I2cError(#[from] crate::io::i2c::I2cError),
     #[error("Emulator error: {0}")]
     EmuError(#[from] crate::io::emu::EmuError),
+
+    // Other sub-enums used by proxy logic (that is, opentitanlib logic running in session daemon
+    // process for efficiency).
+    #[error("Bootstrapping: {0}")]
+    BootstrapError(#[from] crate::bootstrap::BootstrapError),
+    #[error("Bootstrapping: {0}")]
+    LegacyBootstrapError(#[from] crate::bootstrap::LegacyBootstrapError),
+    #[error("Bootstrapping: {0}")]
+    RescueError(#[from] crate::bootstrap::RescueError),
 }
 
 /// Enum value used by `TransportError::InvalidInstance`.
@@ -72,6 +81,7 @@ pub enum TransportInterfaceType {
     Spi,
     I2c,
     Emulator,
+    ProxyOps,
 }
 
 /// Return type to be used in `Transport` methods.
@@ -81,7 +91,7 @@ pub type Result<T> = anyhow::Result<T, TransportError>;
 #[macro_export]
 macro_rules! bail {
     ($err:expr $(,)?) => {
-        return Err($err.into())
+        return Err($err.into());
     };
 }
 

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -8,6 +8,7 @@ use std::any::Any;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use crate::bootstrap::BootstrapOptions;
 use crate::io::emu::Emulator;
 use crate::io::gpio::GpioPin;
 use crate::io::i2c::Bus;
@@ -125,10 +126,22 @@ pub trait Transport {
         ))
     }
 
+    /// Methods available only on Proxy implementation.
+    fn proxy_ops(&self) -> Result<Rc<dyn ProxyOps>> {
+        Err(TransportError::InvalidInterface(
+            TransportInterfaceType::ProxyOps,
+        ))
+    }
+
     /// Invoke non-standard functionality of some Transport implementations.
     fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         Err(TransportError::UnsupportedOperation)
     }
+}
+
+/// Methods available only on the Proxy implementation of the Transport trait.
+pub trait ProxyOps {
+    fn bootstrap(&self, options: &BootstrapOptions, payload: &[u8]) -> Result<()>;
 }
 
 /// Used by Transport implementations dealing with emulated OpenTitan


### PR DESCRIPTION
The proxy potocol allow issuing SPI commands to a USB debugger
connected on a remote machine running opentitansession.  This can be
useful for short interactions (e.g. testing TPM functionality), but
for bootstrapping by writing an entire image into flash, even the
slightest round-trip time will causing excruciatingly slow progress.
The device may even be sensitive to SPI transaction timing, causing
the bootstrapping to fail, if performed with significant latency.

Considering that opentitansession compiles with all the same library
functions for the SPI bootstrapping protocols as the "local"
opentitantool, it would be much more efficient to transfer the image
file to the proxy daemon, and let it break it down into individual SPI
transactions.

This CL does exactly that, by adding code to Bootstrap::update() for
detecting when the Transport implementation happens to be a proxy
stub, and in such case make use of a new "Transport::proxy_ops()"
method call to transfer the entire image file to the proxy daemon,
which in turn will invoke the same Bootstrap::update() which this time
will detect a non-proxy (USB) Transport implementation, and perform
SPI operations using it.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>

Change-Id: Icdc4eaa98368aaa3eaca0ce9edee971b29a4961b