### PR TITLE
[dv/shadow_reg] Minor update on shadow_reg reset

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -190,7 +190,6 @@ virtual task glitch_shadowed_reset(ref dv_base_reg shadowed_csr[$],
       alert_name = shadowed_csr[i].get_storage_err_alert_name();
       // Set alert_name manually because alert_handler module does not trigger alerts.
       if (alert_name == "") alert_name = "fatal_err";
-      predict_shadow_reg_status(.predict_storage_err(1));
       `uvm_info(`gfn, $sformatf("Expect reset storage error %0s", shadowed_csr[i].get_name()),
                 UVM_HIGH)
       break;
@@ -209,6 +208,10 @@ virtual task glitch_shadowed_reset(ref dv_base_reg shadowed_csr[$],
     // Wait until dut reset is done then allow csr_rw sequence to issue.
     ready_to_trigger_csr_rw = 1;
   end
+
+  // Update shadow reg status after DUT reset is issued, in case the predicted value is cleared by
+  // reset.
+  if (alert_name != "") predict_shadow_reg_status(.predict_storage_err(1));
 
   // Check if shadow reset will trigger fatal storage error.
   // - First check if alert_name exists in alert_agent_cfg because alert_handler IP won't trigger


### PR DESCRIPTION
When we glitch reset in shadowed_regs, we predict error status before
reset is issued, that might cause scb to clear the predicted value.
So in this PR, we moved the error prediction after reset is finished.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>