### PR TITLE
[fpv/csr] support d_error [part2]

### DIFF
--- a/hw/ip/rstmgr/dv/sva/rstmgr_sva.core
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_sva.core
@@ -24,7 +24,7 @@ generate:
   csr_assert_gen:
     generator: csr_assert_gen
     parameters:
-      spec: ../../data/rstmgr.hjson
+      spec: ../../../../top_earlgrey/ip/rstmgr/data/autogen/rstmgr.hjson
 
 targets:
   default: &default_target


### PR DESCRIPTION
This PR checks if d_error is asserted when the address is OOB.

This PR completes issue https://github.com/lowRISC/opentitan/issues/11243.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>