### PR TITLE
[dv/uart] Fix uart timescale issue

### DIFF
--- a/hw/dv/sv/uart_agent/uart_driver.sv
+++ b/hw/dv/sv/uart_agent/uart_driver.sv
@@ -19,7 +19,8 @@ class uart_driver extends dv_base_driver #(uart_item, uart_agent_cfg);
 
   // Sets the value of rx after randomly glitching for 10% of uart clk
   task set_rx(input bit val);
-    uint glitch_ns = uint'(cfg.vif.uart_clk_period_ns * cfg.get_uart_period_glitch_pct() / 100);
+    uint glitch_ns = uint'(cfg.vif.uart_clk_period_ns * cfg.get_uart_period_glitch_pct() / 100
+                           / 1ns);
     repeat (glitch_ns) begin
       if (!cfg.under_reset) begin
         cfg.vif.uart_rx <= $urandom_range(0, 1);


### PR DESCRIPTION
The timescale change affects this calculation
```
  realtime a = 1 * 1ns;
  int i = int'(a); // when timeunit is 1ns, i = 1;
                   // when timeunit is 1ps, i = 1000
```
this is the correct solution, which is the fix in this PR.
`  int i = int'(a/1ns);`

Signed-off-by: Weicai Yang <weicai@google.com>