### PR TITLE
[dv/entropy_src] Temp remove stress_all_with_rand_reset test

### DIFF
--- a/hw/dv/tools/dvsim/tests/stress_all_test.hjson
+++ b/hw/dv/tools/dvsim/tests/stress_all_test.hjson
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Different from `stress_tests.hjson`, this hjson only include `stress_all` test to serve as a
+// temporary import for IPs that are at V2 stage and does not support `stress_all_with_rand_reset`
+// sequence.
+{
+  tests: [
+    {
+      name: "{name}_stress_all"
+      uvm_test_seq: "{name}_stress_all_vseq"
+      // 10ms
+      run_opts: ["+test_timeout_ns=10000000000"]
+    }
+  ]
+}

--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -32,7 +32,8 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
+                // TODO: import `stress_tests.hjson` once hanging issue is resolved.
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_all_test.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["entropy_src_bind", "entropy_src_cov_bind"]


### PR DESCRIPTION
Because some of the `stress_all_with_rand_reset` tests seem to hang
during nightly regression, we decided to temp remove that test.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>