### PR TITLE
[tlul/otp_ctrl/rv_dm] improve LC gating of security critical TL-UL ports

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -724,16 +724,25 @@ module otp_ctrl
 
   // Life cycle qualification of TL-UL test interface.
   // SEC_CM: TEST.BUS.LC_GATED
-  assign prim_tl_h2d_gated = (lc_dft_en[0] == lc_ctrl_pkg::On) ?
-                             prim_tl_i : '0;
-  assign prim_tl_o         = (lc_dft_en[1] == lc_ctrl_pkg::On) ?
-                             prim_tl_d2h_gated : '0;
+  tlul_lc_gate #(
+    .NumGatesPerDirection(2)
+  ) u_tlul_lc_gate (
+    .clk_i,
+    .rst_ni,
+    .tl_h2d_i(prim_tl_i),
+    .tl_d2h_o(prim_tl_o),
+    .tl_h2d_o(prim_tl_h2d_gated),
+    .tl_d2h_i(prim_tl_d2h_gated),
+    .lc_en_i (lc_dft_en[0])
+  );
 
   // Test-related GPIOs.
   // SEC_CM: TEST.BUS.LC_GATED
   logic [OtpTestVectWidth-1:0] otp_test_vect;
-  assign cio_test_o = (lc_dft_en[2] == lc_ctrl_pkg::On) ? otp_test_vect : '0;
-  assign cio_test_en_o = (lc_dft_en[2] == lc_ctrl_pkg::On) ? {OtpTestVectWidth{1'b1}} : '0;
+  assign cio_test_o    = (lc_ctrl_pkg::lc_tx_test_true_strict(lc_dft_en[1])) ?
+                         otp_test_vect            : '0;
+  assign cio_test_en_o = (lc_ctrl_pkg::lc_tx_test_true_strict(lc_dft_en[2])) ?
+                         {OtpTestVectWidth{1'b1}} : '0;
 
   // SEC_CM: MACRO.MEM.CM, MACRO.MEM.INTEGRITY
   prim_otp #(

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -31,12 +31,6 @@ module tlul_adapter_sram
   parameter bit EnableRspIntgGen  = 0,  // 1: Generate response integrity
   parameter bit EnableDataIntgGen = 0,  // 1: Generate response data integrity
   parameter bit EnableDataIntgPt  = 0,  // 1: Passthrough command/response data integrity
-  // Data that is returned upon an a TL-UL error belonging to an instruction fetch.
-  // Note that this data will be returned with the correct bus integrity value.
-  parameter logic [top_pkg::TL_DW-1:0] DataWhenInstrError = '0,
-  // Data that is returned upon an a TL-UL error not belonging to an instruction fetch.
-  // Note that this data will be returned with the correct bus integrity value.
-  parameter logic [top_pkg::TL_DW-1:0] DataWhenError      = {top_pkg::TL_DW{1'b1}},
   localparam int WidthMult        = SramDw / top_pkg::TL_DW,
   localparam int IntgWidth        = tlul_pkg::DataIntgWidth * WidthMult,
   localparam int DataOutW         = EnableDataIntgPt ? SramDw + IntgWidth : SramDw

--- a/hw/ip/tlul/rtl/tlul_err_resp.sv
+++ b/hw/ip/tlul/rtl/tlul_err_resp.sv
@@ -13,11 +13,13 @@ module tlul_err_resp (
   output tlul_pkg::tl_d2h_t tl_h_o
 );
   import tlul_pkg::*;
+  import prim_mubi_pkg::*;
 
   tl_a_op_e                          err_opcode;
   logic [$bits(tl_h_i.a_source)-1:0] err_source;
   logic [$bits(tl_h_i.a_size)-1:0]   err_size;
   logic                              err_req_pending, err_rsp_pending;
+  mubi4_t                            err_instr_type;
   tlul_pkg::tl_d2h_t                 tl_h_o_int;
 
   tlul_rsp_intg_gen #(
@@ -34,11 +36,13 @@ module tlul_err_resp (
       err_source      <= {top_pkg::TL_AIW{1'b0}};
       err_opcode      <= Get;
       err_size        <= '0;
+      err_instr_type  <= MuBi4False;
     end else if (tl_h_i.a_valid && tl_h_o_int.a_ready) begin
       err_req_pending <= 1'b1;
       err_source      <= tl_h_i.a_source;
       err_opcode      <= tl_h_i.a_opcode;
       err_size        <= tl_h_i.a_size;
+      err_instr_type  <= tl_h_i.a_user.instr_type;
     end else if (!err_rsp_pending) begin
       err_req_pending <= 1'b0;
     end
@@ -46,7 +50,8 @@ module tlul_err_resp (
 
   assign tl_h_o_int.a_ready  = ~err_rsp_pending & ~(err_req_pending & ~tl_h_i.d_ready);
   assign tl_h_o_int.d_valid  = err_req_pending | err_rsp_pending;
-  assign tl_h_o_int.d_data   = '1; // Return all F
+  assign tl_h_o_int.d_data   = (mubi4_test_true_strict(err_instr_type)) ? DataWhenInstrError :
+                                                                          DataWhenError;
   assign tl_h_o_int.d_source = err_source;
   assign tl_h_o_int.d_sink   = '0;
   assign tl_h_o_int.d_param  = '0;

--- a/hw/ip/tlul/rtl/tlul_lc_gate.sv
+++ b/hw/ip/tlul/rtl/tlul_lc_gate.sv
@@ -1,0 +1,115 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Life cycle gating module for TL-UL protocol.
+// Transactions are passed through when lc_en_i == ON.
+// In all other cases (lc_en_i != ON) incoming transactions return a bus error.
+//
+// Note that the lc_en_i should be synchronized and buffered outside of this module using
+// an instance of prim_lc_sync.
+
+module tlul_lc_gate
+  import tlul_pkg::*;
+  import lc_ctrl_pkg::*;
+#(
+  // Number of LC gating muxes in each direction.
+  // It is recommended to set this parameter to 2, which results
+  // in a total of 4 gating muxes.
+  parameter int NumGatesPerDirection = 2
+) (
+  input clk_i,
+  input rst_ni,
+
+  // To host
+  input  tl_h2d_t tl_h2d_i,
+  output tl_d2h_t tl_d2h_o,
+
+  // To device
+  output tl_h2d_t tl_h2d_o,
+  input  tl_d2h_t tl_d2h_i,
+
+  // LC control signal
+  input  lc_tx_t  lc_en_i
+);
+
+  //////////////////
+  // Access Gates //
+  //////////////////
+
+  // Make a separate MUBI copy for each gating mux.
+  lc_ctrl_pkg::lc_tx_t [2*NumGatesPerDirection:0] lc_en_buf;
+  prim_lc_sync #(
+    .NumCopies(2*NumGatesPerDirection+1),
+    .AsyncOn(0)
+  ) u_prim_lc_sync (
+    .clk_i,
+    .rst_ni,
+    .lc_en_i(lc_en_i),
+    .lc_en_o(lc_en_buf)
+  );
+
+  tl_h2d_t tl_h2d_int [NumGatesPerDirection+1];
+  tl_d2h_t tl_d2h_int [NumGatesPerDirection+1];
+  for (genvar k = 0; k < NumGatesPerDirection; k++) begin : gen_lc_gating_muxes
+    // H -> D path.
+    tl_h2d_t tl_h2d_unbuf;
+    assign tl_h2d_unbuf = (lc_tx_test_true_strict(lc_en_buf[2*k]))   ? tl_h2d_int[k]   : '0;
+    // We do not want the tool to get smart about restructuring the muxes, hence we insert an
+    // optimization barrier between them.
+    prim_buf #(
+      .Width($bits(tl_h2d_t))
+    ) u_prim_buf_h2d (
+      .in_i(tl_h2d_unbuf),
+      .out_o(tl_h2d_int[k+1])
+    );
+
+    // D -> H path.
+    tl_d2h_t tl_d2h_unbuf;
+    assign tl_d2h_unbuf = (lc_tx_test_true_strict(lc_en_buf[2*k+1])) ? tl_d2h_int[k+1] : '0;
+    // We do not want the tool to get smart about restructuring the muxes, hence we insert an
+    // optimization barrier between them.
+    prim_buf #(
+      .Width($bits(tl_d2h_t))
+    ) u_prim_buf_d2h (
+      .in_i(tl_d2h_unbuf),
+      .out_o(tl_d2h_int[k])
+    );
+  end
+
+  // Assign signals on the device side.
+  assign tl_h2d_o = tl_h2d_int[NumGatesPerDirection];
+  assign tl_d2h_int[NumGatesPerDirection] = tl_d2h_i;
+
+  ///////////////////////////
+  // Host Side Interposing //
+  ///////////////////////////
+
+  // At the host side, we interpose the ready / valid signals so that we can return a bus error
+  // in case the lc signal is not set to ON. Note that this logic does not have to be duplicated
+  // since erroring back is considered a convenience feature so that the bus does not lock up.
+  tl_h2d_t tl_h2d_error;
+  tl_d2h_t tl_d2h_error;
+  always_comb begin
+    tl_h2d_int[0] = '0;
+    tl_d2h_o      = '0;
+    tl_h2d_error  = '0;
+
+    if (lc_tx_test_true_strict(lc_en_buf[2*NumGatesPerDirection]) || !tl_d2h_error.d_valid) begin
+      tl_h2d_int[0] = tl_h2d_i;
+      tl_d2h_o      = tl_d2h_int[0];
+    end else begin
+      // In this case we route the incoming transactions through the error responder submodule.
+      tl_h2d_error  = tl_h2d_i;
+      tl_d2h_o      = tl_d2h_error;
+    end
+  end
+
+  tlul_err_resp u_tlul_err_resp (
+    .clk_i,
+    .rst_ni,
+    .tl_h_i(tl_h2d_error),
+    .tl_h_o(tl_d2h_error)
+  );
+
+endmodule : tlul_lc_gate

--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -34,6 +34,13 @@ package tlul_pkg;
   parameter int DataIntgWidth   = 7;
   parameter int DataFullWidth   = DataMaxWidth + DataIntgWidth;
 
+  // Data that is returned upon an a TL-UL error belonging to an instruction fetch.
+  // Note that this data will be returned with the correct bus integrity value.
+  parameter logic [top_pkg::TL_DW-1:0] DataWhenInstrError = '0;
+  // Data that is returned upon an a TL-UL error not belonging to an instruction fetch.
+  // Note that this data will be returned with the correct bus integrity value.
+  parameter logic [top_pkg::TL_DW-1:0] DataWhenError      = {top_pkg::TL_DW{1'b1}};
+
   typedef struct packed {
     logic [4:0]                 rsvd;
     prim_mubi_pkg::mubi4_t      instr_type;

--- a/hw/ip/tlul/tlul.core
+++ b/hw/ip/tlul/tlul.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:tlul:adapter_sram
       - lowrisc:tlul:adapter_reg
       - lowrisc:tlul:sram2tlul
+      - lowrisc:tlul:lc_gate
 
 targets:
   default:

--- a/hw/ip/tlul/tlul_lc_gate.core
+++ b/hw/ip/tlul/tlul_lc_gate.core
@@ -1,0 +1,63 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:tlul:lc_gate:0.1"
+description: "TL-UL Lifecycle Gate"
+
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:assert
+      - lowrisc:tlul:common
+      - lowrisc:ip:lc_ctrl_pkg
+    files:
+      - rtl/tlul_lc_gate.sv
+    file_type: systemVerilogSource
+
+  files_verilator_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/tlul_lc_gate.vlt
+    file_type: vlt
+
+  files_ascentlint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+    files:
+      #- lint/tlul_lc_gate.waiver
+    file_type: waiver
+
+  files_veriblelint_waiver:
+    depend:
+      # common waivers
+      - lowrisc:lint:common
+
+parameters:
+  SYNTHESIS:
+    datatype: bool
+    paramtype: vlogdefine
+
+
+targets:
+  default: &default_target
+    filesets:
+      - tool_verilator   ? (files_verilator_waiver)
+      - tool_ascentlint  ? (files_ascentlint_waiver)
+      - tool_veriblelint ? (files_veriblelint_waiver)
+      - files_rtl
+    toplevel: tlul_lc_gate
+
+  lint:
+    <<: *default_target
+    default_tool: verilator
+    parameters:
+      - SYNTHESIS=true
+    tools:
+      verilator:
+        mode: lint-only
+        verilator_options:
+          - "-Wall"


### PR DESCRIPTION
This adds a life cycle TL-UL gating module with parameterizable number of gating muxes in each direction.
If the gate is disabled, all incoming transactions will be immediately returned with a bus error.

The gating module is then instantiated inside `otp_ctrl` to guard the prim port, and inside `rv_dm` to guard the ROM and SBA ports.

This addressed https://github.com/lowRISC/opentitan/issues/10453 and https://github.com/lowRISC/opentitan/issues/11296.