### PR TITLE
Update pulp_riscv_dbg to pulp-platform/riscv-dbg@b11480c

### DIFF
--- a/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_cfg.sv
@@ -65,9 +65,9 @@ class rv_dm_env_cfg extends cip_base_env_cfg #(.RAL_T(rv_dm_regs_reg_block));
     jtag_dmi_ral.abstractcs.progbufsize.set_reset(dm::ProgBufSize);
     jtag_dmi_ral.dmstatus.authenticated.set_reset(1);  // No authentication performed.
     jtag_dmi_ral.sbcs.sbaccess32.set_reset(1);
+    jtag_dmi_ral.sbcs.sbaccess16.set_reset(1);
+    jtag_dmi_ral.sbcs.sbaccess8.set_reset(1);
     jtag_dmi_ral.sbcs.sbasize.set_reset(32);
-    // TODO(#11095): Sub-word accesses are not implemented.
-    void'(jtag_dmi_ral.sbcs.sbaccess.set_access("RO"));
     apply_jtag_dmi_ral_csr_excl();
   endfunction
 

--- a/hw/vendor/patches/pulp_riscv_dbg/0001-dm_csrs-Correct-reset-value-of-sbcs-register.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0001-dm_csrs-Correct-reset-value-of-sbcs-register.patch
@@ -1,0 +1,29 @@
+From 5df0756fec8aaa40d2a8d15dfd980fcca42e8472 Mon Sep 17 00:00:00 2001
+From: Michael Schaffner <msf@google.com>
+Date: Wed, 9 Mar 2022 15:08:51 -0800
+Subject: [PATCH 1/2] [dm_csrs] Correct reset value of sbcs register
+
+Signed-off-by: Michael Schaffner <msf@google.com>
+
+diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
+index 387e18e..1aa5374 100644
+--- a/src/dm_csrs.sv
++++ b/src/dm_csrs.sv
+@@ -584,7 +584,7 @@ module dm_csrs #(
+       abstractauto_q <= '0;
+       progbuf_q      <= '0;
+       data_q         <= '0;
+-      sbcs_q         <= '0;
++      sbcs_q         <= '{default: '0,  sbaccess: 3'd2};
+       sbaddr_q       <= '0;
+       sbdata_q       <= '0;
+       havereset_q    <= '1;
+@@ -612,7 +612,7 @@ module dm_csrs #(
+         abstractauto_q               <= '0;
+         progbuf_q                    <= '0;
+         data_q                       <= '0;
+-        sbcs_q                       <= '0;
++        sbcs_q                       <= '{default: '0,  sbaccess: 3'd2};
+         sbaddr_q                     <= '0;
+         sbdata_q                     <= '0;
+       end else begin

--- a/hw/vendor/patches/pulp_riscv_dbg/0002-Use-lowrisc-instead-of-PULP-primitives.patch
+++ b/hw/vendor/patches/pulp_riscv_dbg/0002-Use-lowrisc-instead-of-PULP-primitives.patch
@@ -1,12 +1,12 @@
-From 3a39c34f70c7181b58d09f0b5fbcb992f296cd4f Mon Sep 17 00:00:00 2001
+From 2d29f145da5d2c25fadfc37c5d64fa76b8a61cd3 Mon Sep 17 00:00:00 2001
 From: Philipp Wagner <phw@lowrisc.org>
 Date: Fri, 22 Feb 2019 14:48:46 +0000
-Subject: [PATCH] Use lowrisc instead of PULP primitives
+Subject: [PATCH 2/2] Use lowrisc instead of PULP primitives
 
 Signed-off-by: Michael Schaffner <msf@google.com>
 
 diff --git a/src/dm_csrs.sv b/src/dm_csrs.sv
-index 4b0f254..8f12ac4 100644
+index 1aa5374..6dbb5a7 100644
 --- a/src/dm_csrs.sv
 +++ b/src/dm_csrs.sv
 @@ -78,6 +78,7 @@ module dm_csrs #(
@@ -38,7 +38,7 @@ index 4b0f254..8f12ac4 100644
    // SBA
    assign sbautoincrement_o = sbcs_q.sbautoincrement;
    assign sbreadonaddr_o    = sbcs_q.sbreadonaddr;
-@@ -554,27 +548,28 @@ module dm_csrs #(
+@@ -550,27 +544,28 @@ module dm_csrs #(
    assign progbuf_o   = progbuf_q;
    assign data_o      = data_q;
  

--- a/hw/vendor/pulp_riscv_dbg.lock.hjson
+++ b/hw/vendor/pulp_riscv_dbg.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/pulp-platform/riscv-dbg
-    rev: 4befe83b03f43cef72486e0078cca0126e2680a0
+    rev: b11480c4f354118ff4c7da674a2461da12d8ed1e
   }
 }

--- a/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
+++ b/hw/vendor/pulp_riscv_dbg/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 ### Fixed
 
+## [0.4.1] - 2021-05-04
+### Added
+### Changed
+### Fixed
+- Remove superfluous helper variable in dm_csrs.sv
+- Synchronized Bender.yml entries
+- Various Lint warnings
+
 ## [0.4.0] - 2020-11-06
 ### Added
 - Added parameter ReadByteEnable that may be disabled to revert SBA _be_ behavior to 0 on reads

--- a/hw/vendor/pulp_riscv_dbg/doc/debug-system.md
+++ b/hw/vendor/pulp_riscv_dbg/doc/debug-system.md
@@ -54,24 +54,24 @@ Our implementation only provides a single Debug Module on the DMI bus mapped to 
 0x11        | Debug Module Status (dmstatus)               | see table below
 0x12        | Hart Info (hartinfo)
 0x13        | Halt Summary 1 (haltsum1)
-0x14        | Hart Array Window Select (hawindowsel)
-0x15        | Hart Array Window (hawindow)
+0x14        | Hart Array Window Select (hawindowsel)       | Not implemented
+0x15        | Hart Array Window (hawindow)                 | Not implemented
 0x16        | Abstract Control and Status (abstractcs)
 0x17        | Abstract Command (command)
 0x18        | Abstract Command Autoexec (abstractauto)
-0x19        | Configuration String Pointer 0 (confstrptr0)
-0x1a        | Configuration String Pointer 1 (confstrptr1)
-0x1b        | Configuration String Pointer 2 (confstrptr2)
-0x1c        | Configuration String Pointer 3 (confstrptr3)
-0x1d        | Next Debug Module (nextdm)
-0x1f        | Custom Features (custom)
+0x19        | Configuration String Pointer 0 (confstrptr0) | Not implemented
+0x1a        | Configuration String Pointer 1 (confstrptr1) | Not implemented
+0x1b        | Configuration String Pointer 2 (confstrptr2) | Not implemented
+0x1c        | Configuration String Pointer 3 (confstrptr3) | Not implemented
+0x1d        | Next Debug Module (nextdm)                   | Not implemented
+0x1f        | Custom Features (custom)                     | Not implemented
 0x20        | Program Buffer 0 (progbuf0)
 0x2f        | Program Buffer 15 (progbuf15)
-0x30        | Authentication Data (authdata)
-0x32        | Debug Module Control and Status 2 (dmcs2)
+0x30        | Authentication Data (authdata)               | Not implemented
+0x32        | Debug Module Control and Status 2 (dmcs2)    | Not implemented
 0x34        | Halt Summary 2 (haltsum2)
 0x35        | Halt Summary 3 (haltsum3)
-0x37        | System Bus Address 127:96 (sbaddress3)
+0x37        | System Bus Address 127:96 (sbaddress3).      | Not implemented
 0x38        | System Bus Access Control and Status (sbcs)
 0x39        | System Bus Address 31:0 (sbaddress0)
 0x3a        | System Bus Address 63:32 (sbaddress1)
@@ -79,8 +79,10 @@ Our implementation only provides a single Debug Module on the DMI bus mapped to 
 0x3c        | System Bus Data 31:0 (sbdata0)
 0x3d        | System Bus Data 63:32 (sbdata1)
 0x3e        | System Bus Data 95:64 (sbdata2)
-0x3f        | System Bus Data 127:96 (sbdata3)
+0x3f        | System Bus Data 127:96 (sbdata3).            | Not implemented
 0x40        | Halt Summary 0 (haltsum0)
+
+Accessing a non-implemented register will return `0`.
 
 ### dmcontrol (0x10)
 

--- a/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
+++ b/hw/vendor/pulp_riscv_dbg/src/dm_csrs.sv
@@ -519,12 +519,11 @@ module dm_csrs #(
     sbcs_d.sbversion            = 3'd1;
     sbcs_d.sbbusy               = sbbusy_i;
     sbcs_d.sbasize              = $bits(sbcs_d.sbasize)'(BusWidth);
-    sbcs_d.sbaccess128          = 1'b0;
-    sbcs_d.sbaccess64           = logic'(BusWidth == 32'd64);
-    sbcs_d.sbaccess32           = logic'(BusWidth == 32'd32);
-    sbcs_d.sbaccess16           = 1'b0;
-    sbcs_d.sbaccess8            = 1'b0;
-    sbcs_d.sbaccess             = (BusWidth == 32'd64) ? 3'd3 : 3'd2;
+    sbcs_d.sbaccess128          = logic'(BusWidth >= 32'd128);
+    sbcs_d.sbaccess64           = logic'(BusWidth >= 32'd64);
+    sbcs_d.sbaccess32           = logic'(BusWidth >= 32'd32);
+    sbcs_d.sbaccess16           = logic'(BusWidth >= 32'd16);
+    sbcs_d.sbaccess8            = logic'(BusWidth >= 32'd8);
   end
 
   // output multiplexer
@@ -580,7 +579,7 @@ module dm_csrs #(
       abstractauto_q <= '0;
       progbuf_q      <= '0;
       data_q         <= '0;
-      sbcs_q         <= '0;
+      sbcs_q         <= '{default: '0,  sbaccess: 3'd2};
       sbaddr_q       <= '0;
       sbdata_q       <= '0;
       havereset_q    <= '1;
@@ -608,7 +607,7 @@ module dm_csrs #(
         abstractauto_q               <= '0;
         progbuf_q                    <= '0;
         data_q                       <= '0;
-        sbcs_q                       <= '0;
+        sbcs_q                       <= '{default: '0,  sbaccess: 3'd2};
         sbaddr_q                     <= '0;
         sbdata_q                     <= '0;
       end else begin


### PR DESCRIPTION
This re-vendors the `rv_dm` in order to address https://github.com/lowRISC/opentitan/issues/11095.

It looks like the register contents have slightly changed, so I still need to patch the corresponding hjson.