### PR TITLE
[reggen] Make field 'qe' behavior consistent

### DIFF
--- a/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
+++ b/hw/ip/adc_ctrl/rtl/adc_ctrl_reg_top.sv
@@ -1288,6 +1288,9 @@ module adc_ctrl_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [0:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -1296,13 +1299,17 @@ module adc_ctrl_reg_top (
     .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1311,10 +1318,11 @@ module adc_ctrl_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[adc_en_ctl]: V(False)

--- a/hw/ip/aes/rtl/aes_reg_top.sv
+++ b/hw/ip/aes/rtl/aes_reg_top.sv
@@ -214,6 +214,9 @@ module aes_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_ctrl_update_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -223,10 +226,11 @@ module aes_reg_top (
     .wd     (alert_test_recov_ctrl_update_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_ctrl_update_err.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_ctrl_update_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_ctrl_update_err.qe = alert_test_qe;
 
   //   F[fatal_fault]: 1:1
   prim_subreg_ext #(
@@ -237,14 +241,18 @@ module aes_reg_top (
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_fault.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_fault.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
 
 
   // Subregister 0 of Multireg key_share0
   // R[key_share0_0]: V(True)
+  logic key_share0_0_qe;
+  logic [0:0] key_share0_0_flds_we;
+  assign key_share0_0_qe = &key_share0_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_0 (
@@ -253,14 +261,18 @@ module aes_reg_top (
     .wd     (key_share0_0_wd),
     .d      (hw2reg.key_share0[0].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[0].qe),
+    .qe     (key_share0_0_flds_we[0]),
     .q      (reg2hw.key_share0[0].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[0].qe = key_share0_0_qe;
 
 
   // Subregister 1 of Multireg key_share0
   // R[key_share0_1]: V(True)
+  logic key_share0_1_qe;
+  logic [0:0] key_share0_1_flds_we;
+  assign key_share0_1_qe = &key_share0_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_1 (
@@ -269,14 +281,18 @@ module aes_reg_top (
     .wd     (key_share0_1_wd),
     .d      (hw2reg.key_share0[1].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[1].qe),
+    .qe     (key_share0_1_flds_we[0]),
     .q      (reg2hw.key_share0[1].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[1].qe = key_share0_1_qe;
 
 
   // Subregister 2 of Multireg key_share0
   // R[key_share0_2]: V(True)
+  logic key_share0_2_qe;
+  logic [0:0] key_share0_2_flds_we;
+  assign key_share0_2_qe = &key_share0_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_2 (
@@ -285,14 +301,18 @@ module aes_reg_top (
     .wd     (key_share0_2_wd),
     .d      (hw2reg.key_share0[2].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[2].qe),
+    .qe     (key_share0_2_flds_we[0]),
     .q      (reg2hw.key_share0[2].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[2].qe = key_share0_2_qe;
 
 
   // Subregister 3 of Multireg key_share0
   // R[key_share0_3]: V(True)
+  logic key_share0_3_qe;
+  logic [0:0] key_share0_3_flds_we;
+  assign key_share0_3_qe = &key_share0_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_3 (
@@ -301,14 +321,18 @@ module aes_reg_top (
     .wd     (key_share0_3_wd),
     .d      (hw2reg.key_share0[3].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[3].qe),
+    .qe     (key_share0_3_flds_we[0]),
     .q      (reg2hw.key_share0[3].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[3].qe = key_share0_3_qe;
 
 
   // Subregister 4 of Multireg key_share0
   // R[key_share0_4]: V(True)
+  logic key_share0_4_qe;
+  logic [0:0] key_share0_4_flds_we;
+  assign key_share0_4_qe = &key_share0_4_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_4 (
@@ -317,14 +341,18 @@ module aes_reg_top (
     .wd     (key_share0_4_wd),
     .d      (hw2reg.key_share0[4].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[4].qe),
+    .qe     (key_share0_4_flds_we[0]),
     .q      (reg2hw.key_share0[4].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[4].qe = key_share0_4_qe;
 
 
   // Subregister 5 of Multireg key_share0
   // R[key_share0_5]: V(True)
+  logic key_share0_5_qe;
+  logic [0:0] key_share0_5_flds_we;
+  assign key_share0_5_qe = &key_share0_5_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_5 (
@@ -333,14 +361,18 @@ module aes_reg_top (
     .wd     (key_share0_5_wd),
     .d      (hw2reg.key_share0[5].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[5].qe),
+    .qe     (key_share0_5_flds_we[0]),
     .q      (reg2hw.key_share0[5].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[5].qe = key_share0_5_qe;
 
 
   // Subregister 6 of Multireg key_share0
   // R[key_share0_6]: V(True)
+  logic key_share0_6_qe;
+  logic [0:0] key_share0_6_flds_we;
+  assign key_share0_6_qe = &key_share0_6_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_6 (
@@ -349,14 +381,18 @@ module aes_reg_top (
     .wd     (key_share0_6_wd),
     .d      (hw2reg.key_share0[6].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[6].qe),
+    .qe     (key_share0_6_flds_we[0]),
     .q      (reg2hw.key_share0[6].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[6].qe = key_share0_6_qe;
 
 
   // Subregister 7 of Multireg key_share0
   // R[key_share0_7]: V(True)
+  logic key_share0_7_qe;
+  logic [0:0] key_share0_7_flds_we;
+  assign key_share0_7_qe = &key_share0_7_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_7 (
@@ -365,14 +401,18 @@ module aes_reg_top (
     .wd     (key_share0_7_wd),
     .d      (hw2reg.key_share0[7].d),
     .qre    (),
-    .qe     (reg2hw.key_share0[7].qe),
+    .qe     (key_share0_7_flds_we[0]),
     .q      (reg2hw.key_share0[7].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[7].qe = key_share0_7_qe;
 
 
   // Subregister 0 of Multireg key_share1
   // R[key_share1_0]: V(True)
+  logic key_share1_0_qe;
+  logic [0:0] key_share1_0_flds_we;
+  assign key_share1_0_qe = &key_share1_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_0 (
@@ -381,14 +421,18 @@ module aes_reg_top (
     .wd     (key_share1_0_wd),
     .d      (hw2reg.key_share1[0].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[0].qe),
+    .qe     (key_share1_0_flds_we[0]),
     .q      (reg2hw.key_share1[0].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[0].qe = key_share1_0_qe;
 
 
   // Subregister 1 of Multireg key_share1
   // R[key_share1_1]: V(True)
+  logic key_share1_1_qe;
+  logic [0:0] key_share1_1_flds_we;
+  assign key_share1_1_qe = &key_share1_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_1 (
@@ -397,14 +441,18 @@ module aes_reg_top (
     .wd     (key_share1_1_wd),
     .d      (hw2reg.key_share1[1].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[1].qe),
+    .qe     (key_share1_1_flds_we[0]),
     .q      (reg2hw.key_share1[1].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[1].qe = key_share1_1_qe;
 
 
   // Subregister 2 of Multireg key_share1
   // R[key_share1_2]: V(True)
+  logic key_share1_2_qe;
+  logic [0:0] key_share1_2_flds_we;
+  assign key_share1_2_qe = &key_share1_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_2 (
@@ -413,14 +461,18 @@ module aes_reg_top (
     .wd     (key_share1_2_wd),
     .d      (hw2reg.key_share1[2].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[2].qe),
+    .qe     (key_share1_2_flds_we[0]),
     .q      (reg2hw.key_share1[2].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[2].qe = key_share1_2_qe;
 
 
   // Subregister 3 of Multireg key_share1
   // R[key_share1_3]: V(True)
+  logic key_share1_3_qe;
+  logic [0:0] key_share1_3_flds_we;
+  assign key_share1_3_qe = &key_share1_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_3 (
@@ -429,14 +481,18 @@ module aes_reg_top (
     .wd     (key_share1_3_wd),
     .d      (hw2reg.key_share1[3].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[3].qe),
+    .qe     (key_share1_3_flds_we[0]),
     .q      (reg2hw.key_share1[3].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[3].qe = key_share1_3_qe;
 
 
   // Subregister 4 of Multireg key_share1
   // R[key_share1_4]: V(True)
+  logic key_share1_4_qe;
+  logic [0:0] key_share1_4_flds_we;
+  assign key_share1_4_qe = &key_share1_4_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_4 (
@@ -445,14 +501,18 @@ module aes_reg_top (
     .wd     (key_share1_4_wd),
     .d      (hw2reg.key_share1[4].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[4].qe),
+    .qe     (key_share1_4_flds_we[0]),
     .q      (reg2hw.key_share1[4].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[4].qe = key_share1_4_qe;
 
 
   // Subregister 5 of Multireg key_share1
   // R[key_share1_5]: V(True)
+  logic key_share1_5_qe;
+  logic [0:0] key_share1_5_flds_we;
+  assign key_share1_5_qe = &key_share1_5_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_5 (
@@ -461,14 +521,18 @@ module aes_reg_top (
     .wd     (key_share1_5_wd),
     .d      (hw2reg.key_share1[5].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[5].qe),
+    .qe     (key_share1_5_flds_we[0]),
     .q      (reg2hw.key_share1[5].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[5].qe = key_share1_5_qe;
 
 
   // Subregister 6 of Multireg key_share1
   // R[key_share1_6]: V(True)
+  logic key_share1_6_qe;
+  logic [0:0] key_share1_6_flds_we;
+  assign key_share1_6_qe = &key_share1_6_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_6 (
@@ -477,14 +541,18 @@ module aes_reg_top (
     .wd     (key_share1_6_wd),
     .d      (hw2reg.key_share1[6].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[6].qe),
+    .qe     (key_share1_6_flds_we[0]),
     .q      (reg2hw.key_share1[6].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[6].qe = key_share1_6_qe;
 
 
   // Subregister 7 of Multireg key_share1
   // R[key_share1_7]: V(True)
+  logic key_share1_7_qe;
+  logic [0:0] key_share1_7_flds_we;
+  assign key_share1_7_qe = &key_share1_7_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_7 (
@@ -493,14 +561,18 @@ module aes_reg_top (
     .wd     (key_share1_7_wd),
     .d      (hw2reg.key_share1[7].d),
     .qre    (),
-    .qe     (reg2hw.key_share1[7].qe),
+    .qe     (key_share1_7_flds_we[0]),
     .q      (reg2hw.key_share1[7].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[7].qe = key_share1_7_qe;
 
 
   // Subregister 0 of Multireg iv
   // R[iv_0]: V(True)
+  logic iv_0_qe;
+  logic [0:0] iv_0_flds_we;
+  assign iv_0_qe = &iv_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_0 (
@@ -509,14 +581,18 @@ module aes_reg_top (
     .wd     (iv_0_wd),
     .d      (hw2reg.iv[0].d),
     .qre    (),
-    .qe     (reg2hw.iv[0].qe),
+    .qe     (iv_0_flds_we[0]),
     .q      (reg2hw.iv[0].q),
     .qs     (iv_0_qs)
   );
+  assign reg2hw.iv[0].qe = iv_0_qe;
 
 
   // Subregister 1 of Multireg iv
   // R[iv_1]: V(True)
+  logic iv_1_qe;
+  logic [0:0] iv_1_flds_we;
+  assign iv_1_qe = &iv_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_1 (
@@ -525,14 +601,18 @@ module aes_reg_top (
     .wd     (iv_1_wd),
     .d      (hw2reg.iv[1].d),
     .qre    (),
-    .qe     (reg2hw.iv[1].qe),
+    .qe     (iv_1_flds_we[0]),
     .q      (reg2hw.iv[1].q),
     .qs     (iv_1_qs)
   );
+  assign reg2hw.iv[1].qe = iv_1_qe;
 
 
   // Subregister 2 of Multireg iv
   // R[iv_2]: V(True)
+  logic iv_2_qe;
+  logic [0:0] iv_2_flds_we;
+  assign iv_2_qe = &iv_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_2 (
@@ -541,14 +621,18 @@ module aes_reg_top (
     .wd     (iv_2_wd),
     .d      (hw2reg.iv[2].d),
     .qre    (),
-    .qe     (reg2hw.iv[2].qe),
+    .qe     (iv_2_flds_we[0]),
     .q      (reg2hw.iv[2].q),
     .qs     (iv_2_qs)
   );
+  assign reg2hw.iv[2].qe = iv_2_qe;
 
 
   // Subregister 3 of Multireg iv
   // R[iv_3]: V(True)
+  logic iv_3_qe;
+  logic [0:0] iv_3_flds_we;
+  assign iv_3_qe = &iv_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_iv_3 (
@@ -557,14 +641,26 @@ module aes_reg_top (
     .wd     (iv_3_wd),
     .d      (hw2reg.iv[3].d),
     .qre    (),
-    .qe     (reg2hw.iv[3].qe),
+    .qe     (iv_3_flds_we[0]),
     .q      (reg2hw.iv[3].q),
     .qs     (iv_3_qs)
   );
+  assign reg2hw.iv[3].qe = iv_3_qe;
 
 
   // Subregister 0 of Multireg data_in
   // R[data_in_0]: V(False)
+  logic data_in_0_qe;
+  logic [0:0] data_in_0_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_data_in0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&data_in_0_flds_we),
+    .q_o(data_in_0_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -582,16 +678,28 @@ module aes_reg_top (
     .d      (hw2reg.data_in[0].d),
 
     // to internal hardware
-    .qe     (reg2hw.data_in[0].qe),
+    .qe     (data_in_0_flds_we[0]),
     .q      (reg2hw.data_in[0].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_in[0].qe = data_in_0_qe;
 
 
   // Subregister 1 of Multireg data_in
   // R[data_in_1]: V(False)
+  logic data_in_1_qe;
+  logic [0:0] data_in_1_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_data_in1_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&data_in_1_flds_we),
+    .q_o(data_in_1_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -609,16 +717,28 @@ module aes_reg_top (
     .d      (hw2reg.data_in[1].d),
 
     // to internal hardware
-    .qe     (reg2hw.data_in[1].qe),
+    .qe     (data_in_1_flds_we[0]),
     .q      (reg2hw.data_in[1].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_in[1].qe = data_in_1_qe;
 
 
   // Subregister 2 of Multireg data_in
   // R[data_in_2]: V(False)
+  logic data_in_2_qe;
+  logic [0:0] data_in_2_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_data_in2_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&data_in_2_flds_we),
+    .q_o(data_in_2_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -636,16 +756,28 @@ module aes_reg_top (
     .d      (hw2reg.data_in[2].d),
 
     // to internal hardware
-    .qe     (reg2hw.data_in[2].qe),
+    .qe     (data_in_2_flds_we[0]),
     .q      (reg2hw.data_in[2].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_in[2].qe = data_in_2_qe;
 
 
   // Subregister 3 of Multireg data_in
   // R[data_in_3]: V(False)
+  logic data_in_3_qe;
+  logic [0:0] data_in_3_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_data_in3_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&data_in_3_flds_we),
+    .q_o(data_in_3_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -663,12 +795,13 @@ module aes_reg_top (
     .d      (hw2reg.data_in[3].d),
 
     // to internal hardware
-    .qe     (reg2hw.data_in[3].qe),
+    .qe     (data_in_3_flds_we[0]),
     .q      (reg2hw.data_in[3].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_in[3].qe = data_in_3_qe;
 
 
   // Subregister 0 of Multireg data_out
@@ -736,6 +869,9 @@ module aes_reg_top (
 
 
   // R[ctrl_shadowed]: V(True)
+  logic ctrl_shadowed_qe;
+  logic [6:0] ctrl_shadowed_flds_we;
+  assign ctrl_shadowed_qe = &ctrl_shadowed_flds_we;
   //   F[operation]: 1:0
   prim_subreg_ext #(
     .DW    (2)
@@ -745,10 +881,11 @@ module aes_reg_top (
     .wd     (ctrl_shadowed_operation_wd),
     .d      (hw2reg.ctrl_shadowed.operation.d),
     .qre    (reg2hw.ctrl_shadowed.operation.re),
-    .qe     (reg2hw.ctrl_shadowed.operation.qe),
+    .qe     (ctrl_shadowed_flds_we[0]),
     .q      (reg2hw.ctrl_shadowed.operation.q),
     .qs     (ctrl_shadowed_operation_qs)
   );
+  assign reg2hw.ctrl_shadowed.operation.qe = ctrl_shadowed_qe;
 
   //   F[mode]: 7:2
   prim_subreg_ext #(
@@ -759,10 +896,11 @@ module aes_reg_top (
     .wd     (ctrl_shadowed_mode_wd),
     .d      (hw2reg.ctrl_shadowed.mode.d),
     .qre    (reg2hw.ctrl_shadowed.mode.re),
-    .qe     (reg2hw.ctrl_shadowed.mode.qe),
+    .qe     (ctrl_shadowed_flds_we[1]),
     .q      (reg2hw.ctrl_shadowed.mode.q),
     .qs     (ctrl_shadowed_mode_qs)
   );
+  assign reg2hw.ctrl_shadowed.mode.qe = ctrl_shadowed_qe;
 
   //   F[key_len]: 10:8
   prim_subreg_ext #(
@@ -773,10 +911,11 @@ module aes_reg_top (
     .wd     (ctrl_shadowed_key_len_wd),
     .d      (hw2reg.ctrl_shadowed.key_len.d),
     .qre    (reg2hw.ctrl_shadowed.key_len.re),
-    .qe     (reg2hw.ctrl_shadowed.key_len.qe),
+    .qe     (ctrl_shadowed_flds_we[2]),
     .q      (reg2hw.ctrl_shadowed.key_len.q),
     .qs     (ctrl_shadowed_key_len_qs)
   );
+  assign reg2hw.ctrl_shadowed.key_len.qe = ctrl_shadowed_qe;
 
   //   F[sideload]: 11:11
   prim_subreg_ext #(
@@ -787,10 +926,11 @@ module aes_reg_top (
     .wd     (ctrl_shadowed_sideload_wd),
     .d      (hw2reg.ctrl_shadowed.sideload.d),
     .qre    (reg2hw.ctrl_shadowed.sideload.re),
-    .qe     (reg2hw.ctrl_shadowed.sideload.qe),
+    .qe     (ctrl_shadowed_flds_we[3]),
     .q      (reg2hw.ctrl_shadowed.sideload.q),
     .qs     (ctrl_shadowed_sideload_qs)
   );
+  assign reg2hw.ctrl_shadowed.sideload.qe = ctrl_shadowed_qe;
 
   //   F[prng_reseed_rate]: 14:12
   prim_subreg_ext #(
@@ -801,10 +941,11 @@ module aes_reg_top (
     .wd     (ctrl_shadowed_prng_reseed_rate_wd),
     .d      (hw2reg.ctrl_shadowed.prng_reseed_rate.d),
     .qre    (reg2hw.ctrl_shadowed.prng_reseed_rate.re),
-    .qe     (reg2hw.ctrl_shadowed.prng_reseed_rate.qe),
+    .qe     (ctrl_shadowed_flds_we[4]),
     .q      (reg2hw.ctrl_shadowed.prng_reseed_rate.q),
     .qs     (ctrl_shadowed_prng_reseed_rate_qs)
   );
+  assign reg2hw.ctrl_shadowed.prng_reseed_rate.qe = ctrl_shadowed_qe;
 
   //   F[manual_operation]: 15:15
   prim_subreg_ext #(
@@ -815,10 +956,11 @@ module aes_reg_top (
     .wd     (ctrl_shadowed_manual_operation_wd),
     .d      (hw2reg.ctrl_shadowed.manual_operation.d),
     .qre    (reg2hw.ctrl_shadowed.manual_operation.re),
-    .qe     (reg2hw.ctrl_shadowed.manual_operation.qe),
+    .qe     (ctrl_shadowed_flds_we[5]),
     .q      (reg2hw.ctrl_shadowed.manual_operation.q),
     .qs     (ctrl_shadowed_manual_operation_qs)
   );
+  assign reg2hw.ctrl_shadowed.manual_operation.qe = ctrl_shadowed_qe;
 
   //   F[force_zero_masks]: 16:16
   prim_subreg_ext #(
@@ -829,10 +971,11 @@ module aes_reg_top (
     .wd     (ctrl_shadowed_force_zero_masks_wd),
     .d      (hw2reg.ctrl_shadowed.force_zero_masks.d),
     .qre    (reg2hw.ctrl_shadowed.force_zero_masks.re),
-    .qe     (reg2hw.ctrl_shadowed.force_zero_masks.qe),
+    .qe     (ctrl_shadowed_flds_we[6]),
     .q      (reg2hw.ctrl_shadowed.force_zero_masks.q),
     .qs     (ctrl_shadowed_force_zero_masks_qs)
   );
+  assign reg2hw.ctrl_shadowed.force_zero_masks.qe = ctrl_shadowed_qe;
 
 
   // R[ctrl_aux_shadowed]: V(False)

--- a/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
+++ b/hw/ip/aon_timer/rtl/aon_timer_reg_top.sv
@@ -459,6 +459,9 @@ module aon_timer_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -467,10 +470,11 @@ module aon_timer_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[wkup_ctrl]: V(False)
@@ -786,6 +790,9 @@ module aon_timer_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [1:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[wkup_timer_expired]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -795,10 +802,11 @@ module aon_timer_reg_top (
     .wd     (intr_test_wkup_timer_expired_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.wkup_timer_expired.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.wkup_timer_expired.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.wkup_timer_expired.qe = intr_test_qe;
 
   //   F[wdog_timer_bark]: 1:1
   prim_subreg_ext #(
@@ -809,10 +817,11 @@ module aon_timer_reg_top (
     .wd     (intr_test_wdog_timer_bark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.wdog_timer_bark.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.wdog_timer_bark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.wdog_timer_bark.qe = intr_test_qe;
 
 
   // R[wkup_cause]: V(False)

--- a/hw/ip/csrng/rtl/csrng_reg_top.sv
+++ b/hw/ip/csrng/rtl/csrng_reg_top.sv
@@ -407,6 +407,9 @@ module csrng_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [3:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[cs_cmd_req_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -416,10 +419,11 @@ module csrng_reg_top (
     .wd     (intr_test_cs_cmd_req_done_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.cs_cmd_req_done.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.cs_cmd_req_done.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.cs_cmd_req_done.qe = intr_test_qe;
 
   //   F[cs_entropy_req]: 1:1
   prim_subreg_ext #(
@@ -430,10 +434,11 @@ module csrng_reg_top (
     .wd     (intr_test_cs_entropy_req_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.cs_entropy_req.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.cs_entropy_req.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.cs_entropy_req.qe = intr_test_qe;
 
   //   F[cs_hw_inst_exc]: 2:2
   prim_subreg_ext #(
@@ -444,10 +449,11 @@ module csrng_reg_top (
     .wd     (intr_test_cs_hw_inst_exc_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.cs_hw_inst_exc.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.cs_hw_inst_exc.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.cs_hw_inst_exc.qe = intr_test_qe;
 
   //   F[cs_fatal_err]: 3:3
   prim_subreg_ext #(
@@ -458,13 +464,17 @@ module csrng_reg_top (
     .wd     (intr_test_cs_fatal_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.cs_fatal_err.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.cs_fatal_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.cs_fatal_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -474,10 +484,11 @@ module csrng_reg_top (
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_alert.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
 
   //   F[fatal_alert]: 1:1
   prim_subreg_ext #(
@@ -488,10 +499,11 @@ module csrng_reg_top (
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_alert.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
 
 
   // R[regwen]: V(False)
@@ -598,6 +610,17 @@ module csrng_reg_top (
 
 
   // R[cmd_req]: V(False)
+  logic cmd_req_qe;
+  logic [0:0] cmd_req_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_cmd_req0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&cmd_req_flds_we),
+    .q_o(cmd_req_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -615,12 +638,13 @@ module csrng_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cmd_req.qe),
+    .qe     (cmd_req_flds_we[0]),
     .q      (reg2hw.cmd_req.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.cmd_req.qe = cmd_req_qe;
 
 
   // R[sw_cmd_sts]: V(False)
@@ -721,6 +745,17 @@ module csrng_reg_top (
 
 
   // R[int_state_num]: V(False)
+  logic int_state_num_qe;
+  logic [0:0] int_state_num_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_int_state_num0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&int_state_num_flds_we),
+    .q_o(int_state_num_qe)
+  );
   prim_subreg #(
     .DW      (4),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -738,12 +773,13 @@ module csrng_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.int_state_num.qe),
+    .qe     (int_state_num_flds_we[0]),
     .q      (reg2hw.int_state_num.q),
 
     // to register interface (read)
     .qs     (int_state_num_qs)
   );
+  assign reg2hw.int_state_num.qe = int_state_num_qe;
 
 
   // R[int_state_val]: V(True)
@@ -1542,6 +1578,17 @@ module csrng_reg_top (
 
 
   // R[err_code_test]: V(False)
+  logic err_code_test_qe;
+  logic [0:0] err_code_test_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_err_code_test0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&err_code_test_flds_we),
+    .q_o(err_code_test_qe)
+  );
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1559,12 +1606,13 @@ module csrng_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.err_code_test.qe),
+    .qe     (err_code_test_flds_we[0]),
     .q      (reg2hw.err_code_test.q),
 
     // to register interface (read)
     .qs     (err_code_test_qs)
   );
+  assign reg2hw.err_code_test.qe = err_code_test_qe;
 
 
   // R[main_sm_state]: V(False)

--- a/hw/ip/edn/rtl/edn_reg_top.sv
+++ b/hw/ip/edn/rtl/edn_reg_top.sv
@@ -283,6 +283,9 @@ module edn_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [1:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[edn_cmd_req_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -292,10 +295,11 @@ module edn_reg_top (
     .wd     (intr_test_edn_cmd_req_done_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.edn_cmd_req_done.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.edn_cmd_req_done.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.edn_cmd_req_done.qe = intr_test_qe;
 
   //   F[edn_fatal_err]: 1:1
   prim_subreg_ext #(
@@ -306,13 +310,17 @@ module edn_reg_top (
     .wd     (intr_test_edn_fatal_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.edn_fatal_err.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.edn_fatal_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.edn_fatal_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -322,10 +330,11 @@ module edn_reg_top (
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_alert.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
 
   //   F[fatal_alert]: 1:1
   prim_subreg_ext #(
@@ -336,10 +345,11 @@ module edn_reg_top (
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_alert.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
 
 
   // R[regwen]: V(False)
@@ -523,6 +533,9 @@ module edn_reg_top (
 
 
   // R[sw_cmd_req]: V(True)
+  logic sw_cmd_req_qe;
+  logic [0:0] sw_cmd_req_flds_we;
+  assign sw_cmd_req_qe = &sw_cmd_req_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_sw_cmd_req (
@@ -531,10 +544,11 @@ module edn_reg_top (
     .wd     (sw_cmd_req_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.sw_cmd_req.qe),
+    .qe     (sw_cmd_req_flds_we[0]),
     .q      (reg2hw.sw_cmd_req.q),
     .qs     ()
   );
+  assign reg2hw.sw_cmd_req.qe = sw_cmd_req_qe;
 
 
   // R[sw_cmd_sts]: V(False)
@@ -590,6 +604,9 @@ module edn_reg_top (
 
 
   // R[reseed_cmd]: V(True)
+  logic reseed_cmd_qe;
+  logic [0:0] reseed_cmd_flds_we;
+  assign reseed_cmd_qe = &reseed_cmd_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_reseed_cmd (
@@ -598,13 +615,17 @@ module edn_reg_top (
     .wd     (reseed_cmd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.reseed_cmd.qe),
+    .qe     (reseed_cmd_flds_we[0]),
     .q      (reg2hw.reseed_cmd.q),
     .qs     ()
   );
+  assign reg2hw.reseed_cmd.qe = reseed_cmd_qe;
 
 
   // R[generate_cmd]: V(True)
+  logic generate_cmd_qe;
+  logic [0:0] generate_cmd_flds_we;
+  assign generate_cmd_qe = &generate_cmd_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_generate_cmd (
@@ -613,13 +634,25 @@ module edn_reg_top (
     .wd     (generate_cmd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.generate_cmd.qe),
+    .qe     (generate_cmd_flds_we[0]),
     .q      (reg2hw.generate_cmd.q),
     .qs     ()
   );
+  assign reg2hw.generate_cmd.qe = generate_cmd_qe;
 
 
   // R[max_num_reqs_between_reseeds]: V(False)
+  logic max_num_reqs_between_reseeds_qe;
+  logic [0:0] max_num_reqs_between_reseeds_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_max_num_reqs_between_reseeds0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&max_num_reqs_between_reseeds_flds_we),
+    .q_o(max_num_reqs_between_reseeds_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -637,12 +670,13 @@ module edn_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.max_num_reqs_between_reseeds.qe),
+    .qe     (max_num_reqs_between_reseeds_flds_we[0]),
     .q      (reg2hw.max_num_reqs_between_reseeds.q),
 
     // to register interface (read)
     .qs     (max_num_reqs_between_reseeds_qs)
   );
+  assign reg2hw.max_num_reqs_between_reseeds.qe = max_num_reqs_between_reseeds_qe;
 
 
   // R[recov_alert_sts]: V(False)
@@ -975,6 +1009,17 @@ module edn_reg_top (
 
 
   // R[err_code_test]: V(False)
+  logic err_code_test_qe;
+  logic [0:0] err_code_test_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_err_code_test0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&err_code_test_flds_we),
+    .q_o(err_code_test_qe)
+  );
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -992,12 +1037,13 @@ module edn_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.err_code_test.qe),
+    .qe     (err_code_test_flds_we[0]),
     .q      (reg2hw.err_code_test.q),
 
     // to register interface (read)
     .qs     (err_code_test_qs)
   );
+  assign reg2hw.err_code_test.qe = err_code_test_qe;
 
 
   // R[main_sm_state]: V(False)

--- a/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_reg_top.sv
@@ -565,6 +565,9 @@ module entropy_src_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [3:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[es_entropy_valid]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -574,10 +577,11 @@ module entropy_src_reg_top (
     .wd     (intr_test_es_entropy_valid_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.es_entropy_valid.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.es_entropy_valid.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.es_entropy_valid.qe = intr_test_qe;
 
   //   F[es_health_test_failed]: 1:1
   prim_subreg_ext #(
@@ -588,10 +592,11 @@ module entropy_src_reg_top (
     .wd     (intr_test_es_health_test_failed_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.es_health_test_failed.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.es_health_test_failed.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.es_health_test_failed.qe = intr_test_qe;
 
   //   F[es_observe_fifo_ready]: 2:2
   prim_subreg_ext #(
@@ -602,10 +607,11 @@ module entropy_src_reg_top (
     .wd     (intr_test_es_observe_fifo_ready_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.es_observe_fifo_ready.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.es_observe_fifo_ready.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.es_observe_fifo_ready.qe = intr_test_qe;
 
   //   F[es_fatal_err]: 3:3
   prim_subreg_ext #(
@@ -616,13 +622,17 @@ module entropy_src_reg_top (
     .wd     (intr_test_es_fatal_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.es_fatal_err.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.es_fatal_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.es_fatal_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -632,10 +642,11 @@ module entropy_src_reg_top (
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_alert.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
 
   //   F[fatal_alert]: 1:1
   prim_subreg_ext #(
@@ -646,10 +657,11 @@ module entropy_src_reg_top (
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_alert.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
 
 
   // R[me_regwen]: V(False)
@@ -1017,6 +1029,9 @@ module entropy_src_reg_top (
 
 
   // R[repcnt_thresholds]: V(True)
+  logic repcnt_thresholds_qe;
+  logic [1:0] repcnt_thresholds_flds_we;
+  assign repcnt_thresholds_qe = &repcnt_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1026,10 +1041,11 @@ module entropy_src_reg_top (
     .wd     (repcnt_thresholds_fips_thresh_wd),
     .d      (hw2reg.repcnt_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.repcnt_thresholds.fips_thresh.qe),
+    .qe     (repcnt_thresholds_flds_we[0]),
     .q      (reg2hw.repcnt_thresholds.fips_thresh.q),
     .qs     (repcnt_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.repcnt_thresholds.fips_thresh.qe = repcnt_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1040,13 +1056,17 @@ module entropy_src_reg_top (
     .wd     (repcnt_thresholds_bypass_thresh_wd),
     .d      (hw2reg.repcnt_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.repcnt_thresholds.bypass_thresh.qe),
+    .qe     (repcnt_thresholds_flds_we[1]),
     .q      (reg2hw.repcnt_thresholds.bypass_thresh.q),
     .qs     (repcnt_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.repcnt_thresholds.bypass_thresh.qe = repcnt_thresholds_qe;
 
 
   // R[repcnts_thresholds]: V(True)
+  logic repcnts_thresholds_qe;
+  logic [1:0] repcnts_thresholds_flds_we;
+  assign repcnts_thresholds_qe = &repcnts_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1056,10 +1076,11 @@ module entropy_src_reg_top (
     .wd     (repcnts_thresholds_fips_thresh_wd),
     .d      (hw2reg.repcnts_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.repcnts_thresholds.fips_thresh.qe),
+    .qe     (repcnts_thresholds_flds_we[0]),
     .q      (reg2hw.repcnts_thresholds.fips_thresh.q),
     .qs     (repcnts_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.repcnts_thresholds.fips_thresh.qe = repcnts_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1070,13 +1091,17 @@ module entropy_src_reg_top (
     .wd     (repcnts_thresholds_bypass_thresh_wd),
     .d      (hw2reg.repcnts_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.repcnts_thresholds.bypass_thresh.qe),
+    .qe     (repcnts_thresholds_flds_we[1]),
     .q      (reg2hw.repcnts_thresholds.bypass_thresh.q),
     .qs     (repcnts_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.repcnts_thresholds.bypass_thresh.qe = repcnts_thresholds_qe;
 
 
   // R[adaptp_hi_thresholds]: V(True)
+  logic adaptp_hi_thresholds_qe;
+  logic [1:0] adaptp_hi_thresholds_flds_we;
+  assign adaptp_hi_thresholds_qe = &adaptp_hi_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1086,10 +1111,11 @@ module entropy_src_reg_top (
     .wd     (adaptp_hi_thresholds_fips_thresh_wd),
     .d      (hw2reg.adaptp_hi_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.adaptp_hi_thresholds.fips_thresh.qe),
+    .qe     (adaptp_hi_thresholds_flds_we[0]),
     .q      (reg2hw.adaptp_hi_thresholds.fips_thresh.q),
     .qs     (adaptp_hi_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.adaptp_hi_thresholds.fips_thresh.qe = adaptp_hi_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1100,13 +1126,17 @@ module entropy_src_reg_top (
     .wd     (adaptp_hi_thresholds_bypass_thresh_wd),
     .d      (hw2reg.adaptp_hi_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.adaptp_hi_thresholds.bypass_thresh.qe),
+    .qe     (adaptp_hi_thresholds_flds_we[1]),
     .q      (reg2hw.adaptp_hi_thresholds.bypass_thresh.q),
     .qs     (adaptp_hi_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.adaptp_hi_thresholds.bypass_thresh.qe = adaptp_hi_thresholds_qe;
 
 
   // R[adaptp_lo_thresholds]: V(True)
+  logic adaptp_lo_thresholds_qe;
+  logic [1:0] adaptp_lo_thresholds_flds_we;
+  assign adaptp_lo_thresholds_qe = &adaptp_lo_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1116,10 +1146,11 @@ module entropy_src_reg_top (
     .wd     (adaptp_lo_thresholds_fips_thresh_wd),
     .d      (hw2reg.adaptp_lo_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.adaptp_lo_thresholds.fips_thresh.qe),
+    .qe     (adaptp_lo_thresholds_flds_we[0]),
     .q      (reg2hw.adaptp_lo_thresholds.fips_thresh.q),
     .qs     (adaptp_lo_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.adaptp_lo_thresholds.fips_thresh.qe = adaptp_lo_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1130,13 +1161,17 @@ module entropy_src_reg_top (
     .wd     (adaptp_lo_thresholds_bypass_thresh_wd),
     .d      (hw2reg.adaptp_lo_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.adaptp_lo_thresholds.bypass_thresh.qe),
+    .qe     (adaptp_lo_thresholds_flds_we[1]),
     .q      (reg2hw.adaptp_lo_thresholds.bypass_thresh.q),
     .qs     (adaptp_lo_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.adaptp_lo_thresholds.bypass_thresh.qe = adaptp_lo_thresholds_qe;
 
 
   // R[bucket_thresholds]: V(True)
+  logic bucket_thresholds_qe;
+  logic [1:0] bucket_thresholds_flds_we;
+  assign bucket_thresholds_qe = &bucket_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1146,10 +1181,11 @@ module entropy_src_reg_top (
     .wd     (bucket_thresholds_fips_thresh_wd),
     .d      (hw2reg.bucket_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.bucket_thresholds.fips_thresh.qe),
+    .qe     (bucket_thresholds_flds_we[0]),
     .q      (reg2hw.bucket_thresholds.fips_thresh.q),
     .qs     (bucket_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.bucket_thresholds.fips_thresh.qe = bucket_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1160,13 +1196,17 @@ module entropy_src_reg_top (
     .wd     (bucket_thresholds_bypass_thresh_wd),
     .d      (hw2reg.bucket_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.bucket_thresholds.bypass_thresh.qe),
+    .qe     (bucket_thresholds_flds_we[1]),
     .q      (reg2hw.bucket_thresholds.bypass_thresh.q),
     .qs     (bucket_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.bucket_thresholds.bypass_thresh.qe = bucket_thresholds_qe;
 
 
   // R[markov_hi_thresholds]: V(True)
+  logic markov_hi_thresholds_qe;
+  logic [1:0] markov_hi_thresholds_flds_we;
+  assign markov_hi_thresholds_qe = &markov_hi_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1176,10 +1216,11 @@ module entropy_src_reg_top (
     .wd     (markov_hi_thresholds_fips_thresh_wd),
     .d      (hw2reg.markov_hi_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.markov_hi_thresholds.fips_thresh.qe),
+    .qe     (markov_hi_thresholds_flds_we[0]),
     .q      (reg2hw.markov_hi_thresholds.fips_thresh.q),
     .qs     (markov_hi_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.markov_hi_thresholds.fips_thresh.qe = markov_hi_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1190,13 +1231,17 @@ module entropy_src_reg_top (
     .wd     (markov_hi_thresholds_bypass_thresh_wd),
     .d      (hw2reg.markov_hi_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.markov_hi_thresholds.bypass_thresh.qe),
+    .qe     (markov_hi_thresholds_flds_we[1]),
     .q      (reg2hw.markov_hi_thresholds.bypass_thresh.q),
     .qs     (markov_hi_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.markov_hi_thresholds.bypass_thresh.qe = markov_hi_thresholds_qe;
 
 
   // R[markov_lo_thresholds]: V(True)
+  logic markov_lo_thresholds_qe;
+  logic [1:0] markov_lo_thresholds_flds_we;
+  assign markov_lo_thresholds_qe = &markov_lo_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1206,10 +1251,11 @@ module entropy_src_reg_top (
     .wd     (markov_lo_thresholds_fips_thresh_wd),
     .d      (hw2reg.markov_lo_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.markov_lo_thresholds.fips_thresh.qe),
+    .qe     (markov_lo_thresholds_flds_we[0]),
     .q      (reg2hw.markov_lo_thresholds.fips_thresh.q),
     .qs     (markov_lo_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.markov_lo_thresholds.fips_thresh.qe = markov_lo_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1220,13 +1266,17 @@ module entropy_src_reg_top (
     .wd     (markov_lo_thresholds_bypass_thresh_wd),
     .d      (hw2reg.markov_lo_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.markov_lo_thresholds.bypass_thresh.qe),
+    .qe     (markov_lo_thresholds_flds_we[1]),
     .q      (reg2hw.markov_lo_thresholds.bypass_thresh.q),
     .qs     (markov_lo_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.markov_lo_thresholds.bypass_thresh.qe = markov_lo_thresholds_qe;
 
 
   // R[extht_hi_thresholds]: V(True)
+  logic extht_hi_thresholds_qe;
+  logic [1:0] extht_hi_thresholds_flds_we;
+  assign extht_hi_thresholds_qe = &extht_hi_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1236,10 +1286,11 @@ module entropy_src_reg_top (
     .wd     (extht_hi_thresholds_fips_thresh_wd),
     .d      (hw2reg.extht_hi_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.extht_hi_thresholds.fips_thresh.qe),
+    .qe     (extht_hi_thresholds_flds_we[0]),
     .q      (reg2hw.extht_hi_thresholds.fips_thresh.q),
     .qs     (extht_hi_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.extht_hi_thresholds.fips_thresh.qe = extht_hi_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1250,13 +1301,17 @@ module entropy_src_reg_top (
     .wd     (extht_hi_thresholds_bypass_thresh_wd),
     .d      (hw2reg.extht_hi_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.extht_hi_thresholds.bypass_thresh.qe),
+    .qe     (extht_hi_thresholds_flds_we[1]),
     .q      (reg2hw.extht_hi_thresholds.bypass_thresh.q),
     .qs     (extht_hi_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.extht_hi_thresholds.bypass_thresh.qe = extht_hi_thresholds_qe;
 
 
   // R[extht_lo_thresholds]: V(True)
+  logic extht_lo_thresholds_qe;
+  logic [1:0] extht_lo_thresholds_flds_we;
+  assign extht_lo_thresholds_qe = &extht_lo_thresholds_flds_we;
   //   F[fips_thresh]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -1266,10 +1321,11 @@ module entropy_src_reg_top (
     .wd     (extht_lo_thresholds_fips_thresh_wd),
     .d      (hw2reg.extht_lo_thresholds.fips_thresh.d),
     .qre    (),
-    .qe     (reg2hw.extht_lo_thresholds.fips_thresh.qe),
+    .qe     (extht_lo_thresholds_flds_we[0]),
     .q      (reg2hw.extht_lo_thresholds.fips_thresh.q),
     .qs     (extht_lo_thresholds_fips_thresh_qs)
   );
+  assign reg2hw.extht_lo_thresholds.fips_thresh.qe = extht_lo_thresholds_qe;
 
   //   F[bypass_thresh]: 31:16
   prim_subreg_ext #(
@@ -1280,10 +1336,11 @@ module entropy_src_reg_top (
     .wd     (extht_lo_thresholds_bypass_thresh_wd),
     .d      (hw2reg.extht_lo_thresholds.bypass_thresh.d),
     .qre    (),
-    .qe     (reg2hw.extht_lo_thresholds.bypass_thresh.qe),
+    .qe     (extht_lo_thresholds_flds_we[1]),
     .q      (reg2hw.extht_lo_thresholds.bypass_thresh.q),
     .qs     (extht_lo_thresholds_bypass_thresh_qs)
   );
+  assign reg2hw.extht_lo_thresholds.bypass_thresh.qe = extht_lo_thresholds_qe;
 
 
   // R[repcnt_hi_watermarks]: V(True)
@@ -2023,6 +2080,9 @@ module entropy_src_reg_top (
 
 
   // R[fw_ov_wr_data]: V(True)
+  logic fw_ov_wr_data_qe;
+  logic [0:0] fw_ov_wr_data_flds_we;
+  assign fw_ov_wr_data_qe = &fw_ov_wr_data_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_fw_ov_wr_data (
@@ -2031,10 +2091,11 @@ module entropy_src_reg_top (
     .wd     (fw_ov_wr_data_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.fw_ov_wr_data.qe),
+    .qe     (fw_ov_wr_data_flds_we[0]),
     .q      (reg2hw.fw_ov_wr_data.q),
     .qs     ()
   );
+  assign reg2hw.fw_ov_wr_data.qe = fw_ov_wr_data_qe;
 
 
   // R[observe_fifo_thresh]: V(False)
@@ -2747,6 +2808,17 @@ module entropy_src_reg_top (
 
 
   // R[err_code_test]: V(False)
+  logic err_code_test_qe;
+  logic [0:0] err_code_test_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_err_code_test0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&err_code_test_flds_we),
+    .q_o(err_code_test_qe)
+  );
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -2764,12 +2836,13 @@ module entropy_src_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.err_code_test.qe),
+    .qe     (err_code_test_flds_we[0]),
     .q      (reg2hw.err_code_test.q),
 
     // to register interface (read)
     .qs     (err_code_test_qs)
   );
+  assign reg2hw.err_code_test.qe = err_code_test_qe;
 
 
   // R[main_sm_state]: V(False)

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -1310,6 +1310,9 @@ module flash_ctrl_core_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [5:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[prog_empty]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1319,10 +1322,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_prog_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.prog_empty.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.prog_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.prog_empty.qe = intr_test_qe;
 
   //   F[prog_lvl]: 1:1
   prim_subreg_ext #(
@@ -1333,10 +1337,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_prog_lvl_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.prog_lvl.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.prog_lvl.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.prog_lvl.qe = intr_test_qe;
 
   //   F[rd_full]: 2:2
   prim_subreg_ext #(
@@ -1347,10 +1352,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_rd_full_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rd_full.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.rd_full.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rd_full.qe = intr_test_qe;
 
   //   F[rd_lvl]: 3:3
   prim_subreg_ext #(
@@ -1361,10 +1367,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_rd_lvl_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rd_lvl.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rd_lvl.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rd_lvl.qe = intr_test_qe;
 
   //   F[op_done]: 4:4
   prim_subreg_ext #(
@@ -1375,10 +1382,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_op_done_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.op_done.qe),
+    .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.op_done.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.op_done.qe = intr_test_qe;
 
   //   F[corr_err]: 5:5
   prim_subreg_ext #(
@@ -1389,13 +1397,17 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_corr_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.corr_err.qe),
+    .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.corr_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.corr_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1405,10 +1417,11 @@ module flash_ctrl_core_reg_top (
     .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_err.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_err.qe = alert_test_qe;
 
   //   F[fatal_err]: 1:1
   prim_subreg_ext #(
@@ -1419,10 +1432,11 @@ module flash_ctrl_core_reg_top (
     .wd     (alert_test_fatal_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_err.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_err.qe = alert_test_qe;
 
 
   // R[dis]: V(False)

--- a/hw/ip/gpio/rtl/gpio_reg_top.sv
+++ b/hw/ip/gpio/rtl/gpio_reg_top.sv
@@ -219,6 +219,9 @@ module gpio_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [0:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_intr_test (
@@ -227,13 +230,17 @@ module gpio_reg_top (
     .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -242,10 +249,11 @@ module gpio_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[data_in]: V(False)
@@ -275,6 +283,9 @@ module gpio_reg_top (
 
 
   // R[direct_out]: V(True)
+  logic direct_out_qe;
+  logic [0:0] direct_out_flds_we;
+  assign direct_out_qe = &direct_out_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_direct_out (
@@ -283,13 +294,17 @@ module gpio_reg_top (
     .wd     (direct_out_wd),
     .d      (hw2reg.direct_out.d),
     .qre    (),
-    .qe     (reg2hw.direct_out.qe),
+    .qe     (direct_out_flds_we[0]),
     .q      (reg2hw.direct_out.q),
     .qs     (direct_out_qs)
   );
+  assign reg2hw.direct_out.qe = direct_out_qe;
 
 
   // R[masked_out_lower]: V(True)
+  logic masked_out_lower_qe;
+  logic [1:0] masked_out_lower_flds_we;
+  assign masked_out_lower_qe = &masked_out_lower_flds_we;
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -299,10 +314,11 @@ module gpio_reg_top (
     .wd     (masked_out_lower_data_wd),
     .d      (hw2reg.masked_out_lower.data.d),
     .qre    (),
-    .qe     (reg2hw.masked_out_lower.data.qe),
+    .qe     (masked_out_lower_flds_we[0]),
     .q      (reg2hw.masked_out_lower.data.q),
     .qs     (masked_out_lower_data_qs)
   );
+  assign reg2hw.masked_out_lower.data.qe = masked_out_lower_qe;
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -313,13 +329,17 @@ module gpio_reg_top (
     .wd     (masked_out_lower_mask_wd),
     .d      (hw2reg.masked_out_lower.mask.d),
     .qre    (),
-    .qe     (reg2hw.masked_out_lower.mask.qe),
+    .qe     (masked_out_lower_flds_we[1]),
     .q      (reg2hw.masked_out_lower.mask.q),
     .qs     ()
   );
+  assign reg2hw.masked_out_lower.mask.qe = masked_out_lower_qe;
 
 
   // R[masked_out_upper]: V(True)
+  logic masked_out_upper_qe;
+  logic [1:0] masked_out_upper_flds_we;
+  assign masked_out_upper_qe = &masked_out_upper_flds_we;
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -329,10 +349,11 @@ module gpio_reg_top (
     .wd     (masked_out_upper_data_wd),
     .d      (hw2reg.masked_out_upper.data.d),
     .qre    (),
-    .qe     (reg2hw.masked_out_upper.data.qe),
+    .qe     (masked_out_upper_flds_we[0]),
     .q      (reg2hw.masked_out_upper.data.q),
     .qs     (masked_out_upper_data_qs)
   );
+  assign reg2hw.masked_out_upper.data.qe = masked_out_upper_qe;
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -343,13 +364,17 @@ module gpio_reg_top (
     .wd     (masked_out_upper_mask_wd),
     .d      (hw2reg.masked_out_upper.mask.d),
     .qre    (),
-    .qe     (reg2hw.masked_out_upper.mask.qe),
+    .qe     (masked_out_upper_flds_we[1]),
     .q      (reg2hw.masked_out_upper.mask.q),
     .qs     ()
   );
+  assign reg2hw.masked_out_upper.mask.qe = masked_out_upper_qe;
 
 
   // R[direct_oe]: V(True)
+  logic direct_oe_qe;
+  logic [0:0] direct_oe_flds_we;
+  assign direct_oe_qe = &direct_oe_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_direct_oe (
@@ -358,13 +383,17 @@ module gpio_reg_top (
     .wd     (direct_oe_wd),
     .d      (hw2reg.direct_oe.d),
     .qre    (),
-    .qe     (reg2hw.direct_oe.qe),
+    .qe     (direct_oe_flds_we[0]),
     .q      (reg2hw.direct_oe.q),
     .qs     (direct_oe_qs)
   );
+  assign reg2hw.direct_oe.qe = direct_oe_qe;
 
 
   // R[masked_oe_lower]: V(True)
+  logic masked_oe_lower_qe;
+  logic [1:0] masked_oe_lower_flds_we;
+  assign masked_oe_lower_qe = &masked_oe_lower_flds_we;
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -374,10 +403,11 @@ module gpio_reg_top (
     .wd     (masked_oe_lower_data_wd),
     .d      (hw2reg.masked_oe_lower.data.d),
     .qre    (),
-    .qe     (reg2hw.masked_oe_lower.data.qe),
+    .qe     (masked_oe_lower_flds_we[0]),
     .q      (reg2hw.masked_oe_lower.data.q),
     .qs     (masked_oe_lower_data_qs)
   );
+  assign reg2hw.masked_oe_lower.data.qe = masked_oe_lower_qe;
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -388,13 +418,17 @@ module gpio_reg_top (
     .wd     (masked_oe_lower_mask_wd),
     .d      (hw2reg.masked_oe_lower.mask.d),
     .qre    (),
-    .qe     (reg2hw.masked_oe_lower.mask.qe),
+    .qe     (masked_oe_lower_flds_we[1]),
     .q      (reg2hw.masked_oe_lower.mask.q),
     .qs     (masked_oe_lower_mask_qs)
   );
+  assign reg2hw.masked_oe_lower.mask.qe = masked_oe_lower_qe;
 
 
   // R[masked_oe_upper]: V(True)
+  logic masked_oe_upper_qe;
+  logic [1:0] masked_oe_upper_flds_we;
+  assign masked_oe_upper_qe = &masked_oe_upper_flds_we;
   //   F[data]: 15:0
   prim_subreg_ext #(
     .DW    (16)
@@ -404,10 +438,11 @@ module gpio_reg_top (
     .wd     (masked_oe_upper_data_wd),
     .d      (hw2reg.masked_oe_upper.data.d),
     .qre    (),
-    .qe     (reg2hw.masked_oe_upper.data.qe),
+    .qe     (masked_oe_upper_flds_we[0]),
     .q      (reg2hw.masked_oe_upper.data.q),
     .qs     (masked_oe_upper_data_qs)
   );
+  assign reg2hw.masked_oe_upper.data.qe = masked_oe_upper_qe;
 
   //   F[mask]: 31:16
   prim_subreg_ext #(
@@ -418,10 +453,11 @@ module gpio_reg_top (
     .wd     (masked_oe_upper_mask_wd),
     .d      (hw2reg.masked_oe_upper.mask.d),
     .qre    (),
-    .qe     (reg2hw.masked_oe_upper.mask.qe),
+    .qe     (masked_oe_upper_flds_we[1]),
     .q      (reg2hw.masked_oe_upper.mask.q),
     .qs     (masked_oe_upper_mask_qs)
   );
+  assign reg2hw.masked_oe_upper.mask.qe = masked_oe_upper_qe;
 
 
   // R[intr_ctrl_en_rising]: V(False)

--- a/hw/ip/hmac/rtl/hmac_reg_top.sv
+++ b/hw/ip/hmac/rtl/hmac_reg_top.sv
@@ -393,6 +393,9 @@ module hmac_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [2:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[hmac_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -402,10 +405,11 @@ module hmac_reg_top (
     .wd     (intr_test_hmac_done_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.hmac_done.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.hmac_done.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.hmac_done.qe = intr_test_qe;
 
   //   F[fifo_empty]: 1:1
   prim_subreg_ext #(
@@ -416,10 +420,11 @@ module hmac_reg_top (
     .wd     (intr_test_fifo_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.fifo_empty.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.fifo_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.fifo_empty.qe = intr_test_qe;
 
   //   F[hmac_err]: 2:2
   prim_subreg_ext #(
@@ -430,13 +435,17 @@ module hmac_reg_top (
     .wd     (intr_test_hmac_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.hmac_err.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.hmac_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.hmac_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -445,13 +454,17 @@ module hmac_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[cfg]: V(True)
+  logic cfg_qe;
+  logic [3:0] cfg_flds_we;
+  assign cfg_qe = &cfg_flds_we;
   //   F[hmac_en]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -461,10 +474,11 @@ module hmac_reg_top (
     .wd     (cfg_hmac_en_wd),
     .d      (hw2reg.cfg.hmac_en.d),
     .qre    (),
-    .qe     (reg2hw.cfg.hmac_en.qe),
+    .qe     (cfg_flds_we[0]),
     .q      (reg2hw.cfg.hmac_en.q),
     .qs     (cfg_hmac_en_qs)
   );
+  assign reg2hw.cfg.hmac_en.qe = cfg_qe;
 
   //   F[sha_en]: 1:1
   prim_subreg_ext #(
@@ -475,10 +489,11 @@ module hmac_reg_top (
     .wd     (cfg_sha_en_wd),
     .d      (hw2reg.cfg.sha_en.d),
     .qre    (),
-    .qe     (reg2hw.cfg.sha_en.qe),
+    .qe     (cfg_flds_we[1]),
     .q      (reg2hw.cfg.sha_en.q),
     .qs     (cfg_sha_en_qs)
   );
+  assign reg2hw.cfg.sha_en.qe = cfg_qe;
 
   //   F[endian_swap]: 2:2
   prim_subreg_ext #(
@@ -489,10 +504,11 @@ module hmac_reg_top (
     .wd     (cfg_endian_swap_wd),
     .d      (hw2reg.cfg.endian_swap.d),
     .qre    (),
-    .qe     (reg2hw.cfg.endian_swap.qe),
+    .qe     (cfg_flds_we[2]),
     .q      (reg2hw.cfg.endian_swap.q),
     .qs     (cfg_endian_swap_qs)
   );
+  assign reg2hw.cfg.endian_swap.qe = cfg_qe;
 
   //   F[digest_swap]: 3:3
   prim_subreg_ext #(
@@ -503,13 +519,17 @@ module hmac_reg_top (
     .wd     (cfg_digest_swap_wd),
     .d      (hw2reg.cfg.digest_swap.d),
     .qre    (),
-    .qe     (reg2hw.cfg.digest_swap.qe),
+    .qe     (cfg_flds_we[3]),
     .q      (reg2hw.cfg.digest_swap.q),
     .qs     (cfg_digest_swap_qs)
   );
+  assign reg2hw.cfg.digest_swap.qe = cfg_qe;
 
 
   // R[cmd]: V(True)
+  logic cmd_qe;
+  logic [1:0] cmd_flds_we;
+  assign cmd_qe = &cmd_flds_we;
   //   F[hash_start]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -519,10 +539,11 @@ module hmac_reg_top (
     .wd     (cmd_hash_start_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.hash_start.qe),
+    .qe     (cmd_flds_we[0]),
     .q      (reg2hw.cmd.hash_start.q),
     .qs     ()
   );
+  assign reg2hw.cmd.hash_start.qe = cmd_qe;
 
   //   F[hash_process]: 1:1
   prim_subreg_ext #(
@@ -533,10 +554,11 @@ module hmac_reg_top (
     .wd     (cmd_hash_process_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.hash_process.qe),
+    .qe     (cmd_flds_we[1]),
     .q      (reg2hw.cmd.hash_process.q),
     .qs     ()
   );
+  assign reg2hw.cmd.hash_process.qe = cmd_qe;
 
 
   // R[status]: V(True)
@@ -610,6 +632,9 @@ module hmac_reg_top (
 
 
   // R[wipe_secret]: V(True)
+  logic wipe_secret_qe;
+  logic [0:0] wipe_secret_flds_we;
+  assign wipe_secret_qe = &wipe_secret_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_wipe_secret (
@@ -618,14 +643,18 @@ module hmac_reg_top (
     .wd     (wipe_secret_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.wipe_secret.qe),
+    .qe     (wipe_secret_flds_we[0]),
     .q      (reg2hw.wipe_secret.q),
     .qs     ()
   );
+  assign reg2hw.wipe_secret.qe = wipe_secret_qe;
 
 
   // Subregister 0 of Multireg key
   // R[key_0]: V(True)
+  logic key_0_qe;
+  logic [0:0] key_0_flds_we;
+  assign key_0_qe = &key_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_0 (
@@ -634,14 +663,18 @@ module hmac_reg_top (
     .wd     (key_0_wd),
     .d      (hw2reg.key[0].d),
     .qre    (),
-    .qe     (reg2hw.key[0].qe),
+    .qe     (key_0_flds_we[0]),
     .q      (reg2hw.key[0].q),
     .qs     ()
   );
+  assign reg2hw.key[0].qe = key_0_qe;
 
 
   // Subregister 1 of Multireg key
   // R[key_1]: V(True)
+  logic key_1_qe;
+  logic [0:0] key_1_flds_we;
+  assign key_1_qe = &key_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_1 (
@@ -650,14 +683,18 @@ module hmac_reg_top (
     .wd     (key_1_wd),
     .d      (hw2reg.key[1].d),
     .qre    (),
-    .qe     (reg2hw.key[1].qe),
+    .qe     (key_1_flds_we[0]),
     .q      (reg2hw.key[1].q),
     .qs     ()
   );
+  assign reg2hw.key[1].qe = key_1_qe;
 
 
   // Subregister 2 of Multireg key
   // R[key_2]: V(True)
+  logic key_2_qe;
+  logic [0:0] key_2_flds_we;
+  assign key_2_qe = &key_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_2 (
@@ -666,14 +703,18 @@ module hmac_reg_top (
     .wd     (key_2_wd),
     .d      (hw2reg.key[2].d),
     .qre    (),
-    .qe     (reg2hw.key[2].qe),
+    .qe     (key_2_flds_we[0]),
     .q      (reg2hw.key[2].q),
     .qs     ()
   );
+  assign reg2hw.key[2].qe = key_2_qe;
 
 
   // Subregister 3 of Multireg key
   // R[key_3]: V(True)
+  logic key_3_qe;
+  logic [0:0] key_3_flds_we;
+  assign key_3_qe = &key_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_3 (
@@ -682,14 +723,18 @@ module hmac_reg_top (
     .wd     (key_3_wd),
     .d      (hw2reg.key[3].d),
     .qre    (),
-    .qe     (reg2hw.key[3].qe),
+    .qe     (key_3_flds_we[0]),
     .q      (reg2hw.key[3].q),
     .qs     ()
   );
+  assign reg2hw.key[3].qe = key_3_qe;
 
 
   // Subregister 4 of Multireg key
   // R[key_4]: V(True)
+  logic key_4_qe;
+  logic [0:0] key_4_flds_we;
+  assign key_4_qe = &key_4_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_4 (
@@ -698,14 +743,18 @@ module hmac_reg_top (
     .wd     (key_4_wd),
     .d      (hw2reg.key[4].d),
     .qre    (),
-    .qe     (reg2hw.key[4].qe),
+    .qe     (key_4_flds_we[0]),
     .q      (reg2hw.key[4].q),
     .qs     ()
   );
+  assign reg2hw.key[4].qe = key_4_qe;
 
 
   // Subregister 5 of Multireg key
   // R[key_5]: V(True)
+  logic key_5_qe;
+  logic [0:0] key_5_flds_we;
+  assign key_5_qe = &key_5_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_5 (
@@ -714,14 +763,18 @@ module hmac_reg_top (
     .wd     (key_5_wd),
     .d      (hw2reg.key[5].d),
     .qre    (),
-    .qe     (reg2hw.key[5].qe),
+    .qe     (key_5_flds_we[0]),
     .q      (reg2hw.key[5].q),
     .qs     ()
   );
+  assign reg2hw.key[5].qe = key_5_qe;
 
 
   // Subregister 6 of Multireg key
   // R[key_6]: V(True)
+  logic key_6_qe;
+  logic [0:0] key_6_flds_we;
+  assign key_6_qe = &key_6_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_6 (
@@ -730,14 +783,18 @@ module hmac_reg_top (
     .wd     (key_6_wd),
     .d      (hw2reg.key[6].d),
     .qre    (),
-    .qe     (reg2hw.key[6].qe),
+    .qe     (key_6_flds_we[0]),
     .q      (reg2hw.key[6].q),
     .qs     ()
   );
+  assign reg2hw.key[6].qe = key_6_qe;
 
 
   // Subregister 7 of Multireg key
   // R[key_7]: V(True)
+  logic key_7_qe;
+  logic [0:0] key_7_flds_we;
+  assign key_7_qe = &key_7_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_7 (
@@ -746,10 +803,11 @@ module hmac_reg_top (
     .wd     (key_7_wd),
     .d      (hw2reg.key[7].d),
     .qre    (),
-    .qe     (reg2hw.key[7].qe),
+    .qe     (key_7_flds_we[0]),
     .q      (reg2hw.key[7].q),
     .qs     ()
   );
+  assign reg2hw.key[7].qe = key_7_qe;
 
 
   // Subregister 0 of Multireg digest

--- a/hw/ip/i2c/rtl/i2c_reg_top.sv
+++ b/hw/ip/i2c/rtl/i2c_reg_top.sv
@@ -1107,6 +1107,9 @@ module i2c_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [15:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[fmt_watermark]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1116,10 +1119,11 @@ module i2c_reg_top (
     .wd     (intr_test_fmt_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.fmt_watermark.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.fmt_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.fmt_watermark.qe = intr_test_qe;
 
   //   F[rx_watermark]: 1:1
   prim_subreg_ext #(
@@ -1130,10 +1134,11 @@ module i2c_reg_top (
     .wd     (intr_test_rx_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_watermark.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.rx_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_watermark.qe = intr_test_qe;
 
   //   F[fmt_overflow]: 2:2
   prim_subreg_ext #(
@@ -1144,10 +1149,11 @@ module i2c_reg_top (
     .wd     (intr_test_fmt_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.fmt_overflow.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.fmt_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.fmt_overflow.qe = intr_test_qe;
 
   //   F[rx_overflow]: 3:3
   prim_subreg_ext #(
@@ -1158,10 +1164,11 @@ module i2c_reg_top (
     .wd     (intr_test_rx_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_overflow.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rx_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_overflow.qe = intr_test_qe;
 
   //   F[nak]: 4:4
   prim_subreg_ext #(
@@ -1172,10 +1179,11 @@ module i2c_reg_top (
     .wd     (intr_test_nak_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.nak.qe),
+    .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.nak.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.nak.qe = intr_test_qe;
 
   //   F[scl_interference]: 5:5
   prim_subreg_ext #(
@@ -1186,10 +1194,11 @@ module i2c_reg_top (
     .wd     (intr_test_scl_interference_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.scl_interference.qe),
+    .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.scl_interference.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.scl_interference.qe = intr_test_qe;
 
   //   F[sda_interference]: 6:6
   prim_subreg_ext #(
@@ -1200,10 +1209,11 @@ module i2c_reg_top (
     .wd     (intr_test_sda_interference_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.sda_interference.qe),
+    .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.sda_interference.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.sda_interference.qe = intr_test_qe;
 
   //   F[stretch_timeout]: 7:7
   prim_subreg_ext #(
@@ -1214,10 +1224,11 @@ module i2c_reg_top (
     .wd     (intr_test_stretch_timeout_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.stretch_timeout.qe),
+    .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.stretch_timeout.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.stretch_timeout.qe = intr_test_qe;
 
   //   F[sda_unstable]: 8:8
   prim_subreg_ext #(
@@ -1228,10 +1239,11 @@ module i2c_reg_top (
     .wd     (intr_test_sda_unstable_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.sda_unstable.qe),
+    .qe     (intr_test_flds_we[8]),
     .q      (reg2hw.intr_test.sda_unstable.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.sda_unstable.qe = intr_test_qe;
 
   //   F[trans_complete]: 9:9
   prim_subreg_ext #(
@@ -1242,10 +1254,11 @@ module i2c_reg_top (
     .wd     (intr_test_trans_complete_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.trans_complete.qe),
+    .qe     (intr_test_flds_we[9]),
     .q      (reg2hw.intr_test.trans_complete.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.trans_complete.qe = intr_test_qe;
 
   //   F[tx_empty]: 10:10
   prim_subreg_ext #(
@@ -1256,10 +1269,11 @@ module i2c_reg_top (
     .wd     (intr_test_tx_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_empty.qe),
+    .qe     (intr_test_flds_we[10]),
     .q      (reg2hw.intr_test.tx_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tx_empty.qe = intr_test_qe;
 
   //   F[tx_nonempty]: 11:11
   prim_subreg_ext #(
@@ -1270,10 +1284,11 @@ module i2c_reg_top (
     .wd     (intr_test_tx_nonempty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_nonempty.qe),
+    .qe     (intr_test_flds_we[11]),
     .q      (reg2hw.intr_test.tx_nonempty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tx_nonempty.qe = intr_test_qe;
 
   //   F[tx_overflow]: 12:12
   prim_subreg_ext #(
@@ -1284,10 +1299,11 @@ module i2c_reg_top (
     .wd     (intr_test_tx_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_overflow.qe),
+    .qe     (intr_test_flds_we[12]),
     .q      (reg2hw.intr_test.tx_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tx_overflow.qe = intr_test_qe;
 
   //   F[acq_overflow]: 13:13
   prim_subreg_ext #(
@@ -1298,10 +1314,11 @@ module i2c_reg_top (
     .wd     (intr_test_acq_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.acq_overflow.qe),
+    .qe     (intr_test_flds_we[13]),
     .q      (reg2hw.intr_test.acq_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.acq_overflow.qe = intr_test_qe;
 
   //   F[ack_stop]: 14:14
   prim_subreg_ext #(
@@ -1312,10 +1329,11 @@ module i2c_reg_top (
     .wd     (intr_test_ack_stop_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.ack_stop.qe),
+    .qe     (intr_test_flds_we[14]),
     .q      (reg2hw.intr_test.ack_stop.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.ack_stop.qe = intr_test_qe;
 
   //   F[host_timeout]: 15:15
   prim_subreg_ext #(
@@ -1326,13 +1344,17 @@ module i2c_reg_top (
     .wd     (intr_test_host_timeout_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.host_timeout.qe),
+    .qe     (intr_test_flds_we[15]),
     .q      (reg2hw.intr_test.host_timeout.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.host_timeout.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1341,10 +1363,11 @@ module i2c_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[ctrl]: V(False)
@@ -1582,6 +1605,17 @@ module i2c_reg_top (
 
 
   // R[fdata]: V(False)
+  logic fdata_qe;
+  logic [5:0] fdata_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_fdata0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&fdata_flds_we),
+    .q_o(fdata_qe)
+  );
   //   F[fbyte]: 7:0
   prim_subreg #(
     .DW      (8),
@@ -1600,12 +1634,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fdata.fbyte.qe),
+    .qe     (fdata_flds_we[0]),
     .q      (reg2hw.fdata.fbyte.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fdata.fbyte.qe = fdata_qe;
 
   //   F[start]: 8:8
   prim_subreg #(
@@ -1625,12 +1660,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fdata.start.qe),
+    .qe     (fdata_flds_we[1]),
     .q      (reg2hw.fdata.start.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fdata.start.qe = fdata_qe;
 
   //   F[stop]: 9:9
   prim_subreg #(
@@ -1650,12 +1686,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fdata.stop.qe),
+    .qe     (fdata_flds_we[2]),
     .q      (reg2hw.fdata.stop.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fdata.stop.qe = fdata_qe;
 
   //   F[read]: 10:10
   prim_subreg #(
@@ -1675,12 +1712,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fdata.read.qe),
+    .qe     (fdata_flds_we[3]),
     .q      (reg2hw.fdata.read.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fdata.read.qe = fdata_qe;
 
   //   F[rcont]: 11:11
   prim_subreg #(
@@ -1700,12 +1738,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fdata.rcont.qe),
+    .qe     (fdata_flds_we[4]),
     .q      (reg2hw.fdata.rcont.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fdata.rcont.qe = fdata_qe;
 
   //   F[nakok]: 12:12
   prim_subreg #(
@@ -1725,15 +1764,27 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fdata.nakok.qe),
+    .qe     (fdata_flds_we[5]),
     .q      (reg2hw.fdata.nakok.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fdata.nakok.qe = fdata_qe;
 
 
   // R[fifo_ctrl]: V(False)
+  logic fifo_ctrl_qe;
+  logic [5:0] fifo_ctrl_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_fifo_ctrl0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&fifo_ctrl_flds_we),
+    .q_o(fifo_ctrl_qe)
+  );
   //   F[rxrst]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1752,12 +1803,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxrst.qe),
+    .qe     (fifo_ctrl_flds_we[0]),
     .q      (reg2hw.fifo_ctrl.rxrst.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fifo_ctrl.rxrst.qe = fifo_ctrl_qe;
 
   //   F[fmtrst]: 1:1
   prim_subreg #(
@@ -1777,12 +1829,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.fmtrst.qe),
+    .qe     (fifo_ctrl_flds_we[1]),
     .q      (reg2hw.fifo_ctrl.fmtrst.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fifo_ctrl.fmtrst.qe = fifo_ctrl_qe;
 
   //   F[rxilvl]: 4:2
   prim_subreg #(
@@ -1802,12 +1855,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxilvl.qe),
+    .qe     (fifo_ctrl_flds_we[2]),
     .q      (reg2hw.fifo_ctrl.rxilvl.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
   );
+  assign reg2hw.fifo_ctrl.rxilvl.qe = fifo_ctrl_qe;
 
   //   F[fmtilvl]: 6:5
   prim_subreg #(
@@ -1827,12 +1881,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.fmtilvl.qe),
+    .qe     (fifo_ctrl_flds_we[3]),
     .q      (reg2hw.fifo_ctrl.fmtilvl.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_fmtilvl_qs)
   );
+  assign reg2hw.fifo_ctrl.fmtilvl.qe = fifo_ctrl_qe;
 
   //   F[acqrst]: 7:7
   prim_subreg #(
@@ -1852,12 +1907,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.acqrst.qe),
+    .qe     (fifo_ctrl_flds_we[4]),
     .q      (reg2hw.fifo_ctrl.acqrst.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fifo_ctrl.acqrst.qe = fifo_ctrl_qe;
 
   //   F[txrst]: 8:8
   prim_subreg #(
@@ -1877,12 +1933,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.txrst.qe),
+    .qe     (fifo_ctrl_flds_we[5]),
     .q      (reg2hw.fifo_ctrl.txrst.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fifo_ctrl.txrst.qe = fifo_ctrl_qe;
 
 
   // R[fifo_status]: V(True)
@@ -2495,6 +2552,17 @@ module i2c_reg_top (
 
 
   // R[txdata]: V(False)
+  logic txdata_qe;
+  logic [0:0] txdata_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_txdata0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&txdata_flds_we),
+    .q_o(txdata_qe)
+  );
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -2512,12 +2580,13 @@ module i2c_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.txdata.qe),
+    .qe     (txdata_flds_we[0]),
     .q      (reg2hw.txdata.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.txdata.qe = txdata_qe;
 
 
   // R[stretch_ctrl]: V(False)

--- a/hw/ip/keymgr/rtl/keymgr_reg_top.sv
+++ b/hw/ip/keymgr/rtl/keymgr_reg_top.sv
@@ -367,6 +367,9 @@ module keymgr_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [0:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -375,13 +378,17 @@ module keymgr_reg_top (
     .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[fatal_fault_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -391,10 +398,11 @@ module keymgr_reg_top (
     .wd     (alert_test_fatal_fault_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_fault_err.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_fault_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_fault_err.qe = alert_test_qe;
 
   //   F[recov_operation_err]: 1:1
   prim_subreg_ext #(
@@ -405,10 +413,11 @@ module keymgr_reg_top (
     .wd     (alert_test_recov_operation_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_operation_err.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.recov_operation_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_operation_err.qe = alert_test_qe;
 
 
   // R[cfg_regwen]: V(True)
@@ -644,6 +653,9 @@ module keymgr_reg_top (
 
 
   // R[sw_binding_regwen]: V(True)
+  logic sw_binding_regwen_qe;
+  logic [0:0] sw_binding_regwen_flds_we;
+  assign sw_binding_regwen_qe = &sw_binding_regwen_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_sw_binding_regwen (
@@ -652,10 +664,11 @@ module keymgr_reg_top (
     .wd     (sw_binding_regwen_wd),
     .d      (hw2reg.sw_binding_regwen.d),
     .qre    (),
-    .qe     (reg2hw.sw_binding_regwen.qe),
+    .qe     (sw_binding_regwen_flds_we[0]),
     .q      (reg2hw.sw_binding_regwen.q),
     .qs     (sw_binding_regwen_qs)
   );
+  assign reg2hw.sw_binding_regwen.qe = sw_binding_regwen_qe;
 
 
   // Subregister 0 of Multireg sealing_sw_binding

--- a/hw/ip/kmac/rtl/kmac_reg_top.sv
+++ b/hw/ip/kmac/rtl/kmac_reg_top.sv
@@ -503,6 +503,9 @@ module kmac_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [2:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[kmac_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -512,10 +515,11 @@ module kmac_reg_top (
     .wd     (intr_test_kmac_done_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.kmac_done.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.kmac_done.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.kmac_done.qe = intr_test_qe;
 
   //   F[fifo_empty]: 1:1
   prim_subreg_ext #(
@@ -526,10 +530,11 @@ module kmac_reg_top (
     .wd     (intr_test_fifo_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.fifo_empty.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.fifo_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.fifo_empty.qe = intr_test_qe;
 
   //   F[kmac_err]: 2:2
   prim_subreg_ext #(
@@ -540,13 +545,17 @@ module kmac_reg_top (
     .wd     (intr_test_kmac_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.kmac_err.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.kmac_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.kmac_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_operation_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -556,10 +565,11 @@ module kmac_reg_top (
     .wd     (alert_test_recov_operation_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_operation_err.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_operation_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_operation_err.qe = alert_test_qe;
 
   //   F[fatal_fault_err]: 1:1
   prim_subreg_ext #(
@@ -570,10 +580,11 @@ module kmac_reg_top (
     .wd     (alert_test_fatal_fault_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_fault_err.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_fault_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_fault_err.qe = alert_test_qe;
 
 
   // R[cfg_regwen]: V(True)
@@ -592,6 +603,17 @@ module kmac_reg_top (
 
 
   // R[cfg_shadowed]: V(False)
+  logic cfg_shadowed_qe;
+  logic [11:0] cfg_shadowed_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_cfg_shadowed0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&cfg_shadowed_flds_we),
+    .q_o(cfg_shadowed_qe)
+  );
   //   F[kmac_en]: 0:0
   prim_subreg_shadow #(
     .DW      (1),
@@ -612,7 +634,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.kmac_en.qe),
+    .qe     (cfg_shadowed_flds_we[0]),
     .q      (reg2hw.cfg_shadowed.kmac_en.q),
 
     // to register interface (read)
@@ -625,6 +647,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.kmac_en.err_update),
     .err_storage (reg2hw.cfg_shadowed.kmac_en.err_storage)
   );
+  assign reg2hw.cfg_shadowed.kmac_en.qe = cfg_shadowed_qe;
 
   //   F[kstrength]: 3:1
   prim_subreg_shadow #(
@@ -646,7 +669,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.kstrength.qe),
+    .qe     (cfg_shadowed_flds_we[1]),
     .q      (reg2hw.cfg_shadowed.kstrength.q),
 
     // to register interface (read)
@@ -659,6 +682,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.kstrength.err_update),
     .err_storage (reg2hw.cfg_shadowed.kstrength.err_storage)
   );
+  assign reg2hw.cfg_shadowed.kstrength.qe = cfg_shadowed_qe;
 
   //   F[mode]: 5:4
   prim_subreg_shadow #(
@@ -680,7 +704,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.mode.qe),
+    .qe     (cfg_shadowed_flds_we[2]),
     .q      (reg2hw.cfg_shadowed.mode.q),
 
     // to register interface (read)
@@ -693,6 +717,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.mode.err_update),
     .err_storage (reg2hw.cfg_shadowed.mode.err_storage)
   );
+  assign reg2hw.cfg_shadowed.mode.qe = cfg_shadowed_qe;
 
   //   F[msg_endianness]: 8:8
   prim_subreg_shadow #(
@@ -714,7 +739,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.msg_endianness.qe),
+    .qe     (cfg_shadowed_flds_we[3]),
     .q      (reg2hw.cfg_shadowed.msg_endianness.q),
 
     // to register interface (read)
@@ -727,6 +752,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.msg_endianness.err_update),
     .err_storage (reg2hw.cfg_shadowed.msg_endianness.err_storage)
   );
+  assign reg2hw.cfg_shadowed.msg_endianness.qe = cfg_shadowed_qe;
 
   //   F[state_endianness]: 9:9
   prim_subreg_shadow #(
@@ -748,7 +774,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.state_endianness.qe),
+    .qe     (cfg_shadowed_flds_we[4]),
     .q      (reg2hw.cfg_shadowed.state_endianness.q),
 
     // to register interface (read)
@@ -761,6 +787,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.state_endianness.err_update),
     .err_storage (reg2hw.cfg_shadowed.state_endianness.err_storage)
   );
+  assign reg2hw.cfg_shadowed.state_endianness.qe = cfg_shadowed_qe;
 
   //   F[sideload]: 12:12
   prim_subreg_shadow #(
@@ -782,7 +809,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.sideload.qe),
+    .qe     (cfg_shadowed_flds_we[5]),
     .q      (reg2hw.cfg_shadowed.sideload.q),
 
     // to register interface (read)
@@ -795,6 +822,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.sideload.err_update),
     .err_storage (reg2hw.cfg_shadowed.sideload.err_storage)
   );
+  assign reg2hw.cfg_shadowed.sideload.qe = cfg_shadowed_qe;
 
   //   F[entropy_mode]: 17:16
   prim_subreg_shadow #(
@@ -816,7 +844,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.entropy_mode.qe),
+    .qe     (cfg_shadowed_flds_we[6]),
     .q      (reg2hw.cfg_shadowed.entropy_mode.q),
 
     // to register interface (read)
@@ -829,6 +857,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.entropy_mode.err_update),
     .err_storage (reg2hw.cfg_shadowed.entropy_mode.err_storage)
   );
+  assign reg2hw.cfg_shadowed.entropy_mode.qe = cfg_shadowed_qe;
 
   //   F[entropy_fast_process]: 19:19
   prim_subreg_shadow #(
@@ -850,7 +879,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.entropy_fast_process.qe),
+    .qe     (cfg_shadowed_flds_we[7]),
     .q      (reg2hw.cfg_shadowed.entropy_fast_process.q),
 
     // to register interface (read)
@@ -863,6 +892,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.entropy_fast_process.err_update),
     .err_storage (reg2hw.cfg_shadowed.entropy_fast_process.err_storage)
   );
+  assign reg2hw.cfg_shadowed.entropy_fast_process.qe = cfg_shadowed_qe;
 
   //   F[msg_mask]: 20:20
   prim_subreg_shadow #(
@@ -884,7 +914,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.msg_mask.qe),
+    .qe     (cfg_shadowed_flds_we[8]),
     .q      (reg2hw.cfg_shadowed.msg_mask.q),
 
     // to register interface (read)
@@ -897,6 +927,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.msg_mask.err_update),
     .err_storage (reg2hw.cfg_shadowed.msg_mask.err_storage)
   );
+  assign reg2hw.cfg_shadowed.msg_mask.qe = cfg_shadowed_qe;
 
   //   F[entropy_ready]: 24:24
   prim_subreg_shadow #(
@@ -918,7 +949,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.entropy_ready.qe),
+    .qe     (cfg_shadowed_flds_we[9]),
     .q      (reg2hw.cfg_shadowed.entropy_ready.q),
 
     // to register interface (read)
@@ -931,6 +962,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.entropy_ready.err_update),
     .err_storage (reg2hw.cfg_shadowed.entropy_ready.err_storage)
   );
+  assign reg2hw.cfg_shadowed.entropy_ready.qe = cfg_shadowed_qe;
 
   //   F[err_processed]: 25:25
   prim_subreg_shadow #(
@@ -952,7 +984,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.err_processed.qe),
+    .qe     (cfg_shadowed_flds_we[10]),
     .q      (reg2hw.cfg_shadowed.err_processed.q),
 
     // to register interface (read)
@@ -965,6 +997,7 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.err_processed.err_update),
     .err_storage (reg2hw.cfg_shadowed.err_processed.err_storage)
   );
+  assign reg2hw.cfg_shadowed.err_processed.qe = cfg_shadowed_qe;
 
   //   F[en_unsupported_modestrength]: 26:26
   prim_subreg_shadow #(
@@ -986,7 +1019,7 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_shadowed.en_unsupported_modestrength.qe),
+    .qe     (cfg_shadowed_flds_we[11]),
     .q      (reg2hw.cfg_shadowed.en_unsupported_modestrength.q),
 
     // to register interface (read)
@@ -999,9 +1032,13 @@ module kmac_reg_top (
     .err_update  (reg2hw.cfg_shadowed.en_unsupported_modestrength.err_update),
     .err_storage (reg2hw.cfg_shadowed.en_unsupported_modestrength.err_storage)
   );
+  assign reg2hw.cfg_shadowed.en_unsupported_modestrength.qe = cfg_shadowed_qe;
 
 
   // R[cmd]: V(True)
+  logic cmd_qe;
+  logic [2:0] cmd_flds_we;
+  assign cmd_qe = &cmd_flds_we;
   //   F[cmd]: 3:0
   prim_subreg_ext #(
     .DW    (4)
@@ -1011,10 +1048,11 @@ module kmac_reg_top (
     .wd     (cmd_cmd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.cmd.qe),
+    .qe     (cmd_flds_we[0]),
     .q      (reg2hw.cmd.cmd.q),
     .qs     ()
   );
+  assign reg2hw.cmd.cmd.qe = cmd_qe;
 
   //   F[entropy_req]: 8:8
   prim_subreg_ext #(
@@ -1025,10 +1063,11 @@ module kmac_reg_top (
     .wd     (cmd_entropy_req_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.entropy_req.qe),
+    .qe     (cmd_flds_we[1]),
     .q      (reg2hw.cmd.entropy_req.q),
     .qs     ()
   );
+  assign reg2hw.cmd.entropy_req.qe = cmd_qe;
 
   //   F[hash_cnt_clr]: 9:9
   prim_subreg_ext #(
@@ -1039,10 +1078,11 @@ module kmac_reg_top (
     .wd     (cmd_hash_cnt_clr_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.hash_cnt_clr.qe),
+    .qe     (cmd_flds_we[2]),
     .q      (reg2hw.cmd.hash_cnt_clr.q),
     .qs     ()
   );
+  assign reg2hw.cmd.hash_cnt_clr.qe = cmd_qe;
 
 
   // R[status]: V(True)
@@ -1273,6 +1313,17 @@ module kmac_reg_top (
 
 
   // R[entropy_seed_lower]: V(False)
+  logic entropy_seed_lower_qe;
+  logic [0:0] entropy_seed_lower_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_entropy_seed_lower0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&entropy_seed_lower_flds_we),
+    .q_o(entropy_seed_lower_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1290,15 +1341,27 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.entropy_seed_lower.qe),
+    .qe     (entropy_seed_lower_flds_we[0]),
     .q      (reg2hw.entropy_seed_lower.q),
 
     // to register interface (read)
     .qs     (entropy_seed_lower_qs)
   );
+  assign reg2hw.entropy_seed_lower.qe = entropy_seed_lower_qe;
 
 
   // R[entropy_seed_upper]: V(False)
+  logic entropy_seed_upper_qe;
+  logic [0:0] entropy_seed_upper_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_entropy_seed_upper0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&entropy_seed_upper_flds_we),
+    .q_o(entropy_seed_upper_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -1316,16 +1379,20 @@ module kmac_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.entropy_seed_upper.qe),
+    .qe     (entropy_seed_upper_flds_we[0]),
     .q      (reg2hw.entropy_seed_upper.q),
 
     // to register interface (read)
     .qs     (entropy_seed_upper_qs)
   );
+  assign reg2hw.entropy_seed_upper.qe = entropy_seed_upper_qe;
 
 
   // Subregister 0 of Multireg key_share0
   // R[key_share0_0]: V(True)
+  logic key_share0_0_qe;
+  logic [0:0] key_share0_0_flds_we;
+  assign key_share0_0_qe = &key_share0_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_0 (
@@ -1334,14 +1401,18 @@ module kmac_reg_top (
     .wd     (key_share0_0_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[0].qe),
+    .qe     (key_share0_0_flds_we[0]),
     .q      (reg2hw.key_share0[0].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[0].qe = key_share0_0_qe;
 
 
   // Subregister 1 of Multireg key_share0
   // R[key_share0_1]: V(True)
+  logic key_share0_1_qe;
+  logic [0:0] key_share0_1_flds_we;
+  assign key_share0_1_qe = &key_share0_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_1 (
@@ -1350,14 +1421,18 @@ module kmac_reg_top (
     .wd     (key_share0_1_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[1].qe),
+    .qe     (key_share0_1_flds_we[0]),
     .q      (reg2hw.key_share0[1].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[1].qe = key_share0_1_qe;
 
 
   // Subregister 2 of Multireg key_share0
   // R[key_share0_2]: V(True)
+  logic key_share0_2_qe;
+  logic [0:0] key_share0_2_flds_we;
+  assign key_share0_2_qe = &key_share0_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_2 (
@@ -1366,14 +1441,18 @@ module kmac_reg_top (
     .wd     (key_share0_2_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[2].qe),
+    .qe     (key_share0_2_flds_we[0]),
     .q      (reg2hw.key_share0[2].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[2].qe = key_share0_2_qe;
 
 
   // Subregister 3 of Multireg key_share0
   // R[key_share0_3]: V(True)
+  logic key_share0_3_qe;
+  logic [0:0] key_share0_3_flds_we;
+  assign key_share0_3_qe = &key_share0_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_3 (
@@ -1382,14 +1461,18 @@ module kmac_reg_top (
     .wd     (key_share0_3_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[3].qe),
+    .qe     (key_share0_3_flds_we[0]),
     .q      (reg2hw.key_share0[3].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[3].qe = key_share0_3_qe;
 
 
   // Subregister 4 of Multireg key_share0
   // R[key_share0_4]: V(True)
+  logic key_share0_4_qe;
+  logic [0:0] key_share0_4_flds_we;
+  assign key_share0_4_qe = &key_share0_4_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_4 (
@@ -1398,14 +1481,18 @@ module kmac_reg_top (
     .wd     (key_share0_4_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[4].qe),
+    .qe     (key_share0_4_flds_we[0]),
     .q      (reg2hw.key_share0[4].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[4].qe = key_share0_4_qe;
 
 
   // Subregister 5 of Multireg key_share0
   // R[key_share0_5]: V(True)
+  logic key_share0_5_qe;
+  logic [0:0] key_share0_5_flds_we;
+  assign key_share0_5_qe = &key_share0_5_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_5 (
@@ -1414,14 +1501,18 @@ module kmac_reg_top (
     .wd     (key_share0_5_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[5].qe),
+    .qe     (key_share0_5_flds_we[0]),
     .q      (reg2hw.key_share0[5].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[5].qe = key_share0_5_qe;
 
 
   // Subregister 6 of Multireg key_share0
   // R[key_share0_6]: V(True)
+  logic key_share0_6_qe;
+  logic [0:0] key_share0_6_flds_we;
+  assign key_share0_6_qe = &key_share0_6_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_6 (
@@ -1430,14 +1521,18 @@ module kmac_reg_top (
     .wd     (key_share0_6_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[6].qe),
+    .qe     (key_share0_6_flds_we[0]),
     .q      (reg2hw.key_share0[6].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[6].qe = key_share0_6_qe;
 
 
   // Subregister 7 of Multireg key_share0
   // R[key_share0_7]: V(True)
+  logic key_share0_7_qe;
+  logic [0:0] key_share0_7_flds_we;
+  assign key_share0_7_qe = &key_share0_7_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_7 (
@@ -1446,14 +1541,18 @@ module kmac_reg_top (
     .wd     (key_share0_7_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[7].qe),
+    .qe     (key_share0_7_flds_we[0]),
     .q      (reg2hw.key_share0[7].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[7].qe = key_share0_7_qe;
 
 
   // Subregister 8 of Multireg key_share0
   // R[key_share0_8]: V(True)
+  logic key_share0_8_qe;
+  logic [0:0] key_share0_8_flds_we;
+  assign key_share0_8_qe = &key_share0_8_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_8 (
@@ -1462,14 +1561,18 @@ module kmac_reg_top (
     .wd     (key_share0_8_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[8].qe),
+    .qe     (key_share0_8_flds_we[0]),
     .q      (reg2hw.key_share0[8].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[8].qe = key_share0_8_qe;
 
 
   // Subregister 9 of Multireg key_share0
   // R[key_share0_9]: V(True)
+  logic key_share0_9_qe;
+  logic [0:0] key_share0_9_flds_we;
+  assign key_share0_9_qe = &key_share0_9_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_9 (
@@ -1478,14 +1581,18 @@ module kmac_reg_top (
     .wd     (key_share0_9_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[9].qe),
+    .qe     (key_share0_9_flds_we[0]),
     .q      (reg2hw.key_share0[9].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[9].qe = key_share0_9_qe;
 
 
   // Subregister 10 of Multireg key_share0
   // R[key_share0_10]: V(True)
+  logic key_share0_10_qe;
+  logic [0:0] key_share0_10_flds_we;
+  assign key_share0_10_qe = &key_share0_10_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_10 (
@@ -1494,14 +1601,18 @@ module kmac_reg_top (
     .wd     (key_share0_10_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[10].qe),
+    .qe     (key_share0_10_flds_we[0]),
     .q      (reg2hw.key_share0[10].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[10].qe = key_share0_10_qe;
 
 
   // Subregister 11 of Multireg key_share0
   // R[key_share0_11]: V(True)
+  logic key_share0_11_qe;
+  logic [0:0] key_share0_11_flds_we;
+  assign key_share0_11_qe = &key_share0_11_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_11 (
@@ -1510,14 +1621,18 @@ module kmac_reg_top (
     .wd     (key_share0_11_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[11].qe),
+    .qe     (key_share0_11_flds_we[0]),
     .q      (reg2hw.key_share0[11].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[11].qe = key_share0_11_qe;
 
 
   // Subregister 12 of Multireg key_share0
   // R[key_share0_12]: V(True)
+  logic key_share0_12_qe;
+  logic [0:0] key_share0_12_flds_we;
+  assign key_share0_12_qe = &key_share0_12_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_12 (
@@ -1526,14 +1641,18 @@ module kmac_reg_top (
     .wd     (key_share0_12_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[12].qe),
+    .qe     (key_share0_12_flds_we[0]),
     .q      (reg2hw.key_share0[12].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[12].qe = key_share0_12_qe;
 
 
   // Subregister 13 of Multireg key_share0
   // R[key_share0_13]: V(True)
+  logic key_share0_13_qe;
+  logic [0:0] key_share0_13_flds_we;
+  assign key_share0_13_qe = &key_share0_13_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_13 (
@@ -1542,14 +1661,18 @@ module kmac_reg_top (
     .wd     (key_share0_13_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[13].qe),
+    .qe     (key_share0_13_flds_we[0]),
     .q      (reg2hw.key_share0[13].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[13].qe = key_share0_13_qe;
 
 
   // Subregister 14 of Multireg key_share0
   // R[key_share0_14]: V(True)
+  logic key_share0_14_qe;
+  logic [0:0] key_share0_14_flds_we;
+  assign key_share0_14_qe = &key_share0_14_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_14 (
@@ -1558,14 +1681,18 @@ module kmac_reg_top (
     .wd     (key_share0_14_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[14].qe),
+    .qe     (key_share0_14_flds_we[0]),
     .q      (reg2hw.key_share0[14].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[14].qe = key_share0_14_qe;
 
 
   // Subregister 15 of Multireg key_share0
   // R[key_share0_15]: V(True)
+  logic key_share0_15_qe;
+  logic [0:0] key_share0_15_flds_we;
+  assign key_share0_15_qe = &key_share0_15_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share0_15 (
@@ -1574,14 +1701,18 @@ module kmac_reg_top (
     .wd     (key_share0_15_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share0[15].qe),
+    .qe     (key_share0_15_flds_we[0]),
     .q      (reg2hw.key_share0[15].q),
     .qs     ()
   );
+  assign reg2hw.key_share0[15].qe = key_share0_15_qe;
 
 
   // Subregister 0 of Multireg key_share1
   // R[key_share1_0]: V(True)
+  logic key_share1_0_qe;
+  logic [0:0] key_share1_0_flds_we;
+  assign key_share1_0_qe = &key_share1_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_0 (
@@ -1590,14 +1721,18 @@ module kmac_reg_top (
     .wd     (key_share1_0_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[0].qe),
+    .qe     (key_share1_0_flds_we[0]),
     .q      (reg2hw.key_share1[0].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[0].qe = key_share1_0_qe;
 
 
   // Subregister 1 of Multireg key_share1
   // R[key_share1_1]: V(True)
+  logic key_share1_1_qe;
+  logic [0:0] key_share1_1_flds_we;
+  assign key_share1_1_qe = &key_share1_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_1 (
@@ -1606,14 +1741,18 @@ module kmac_reg_top (
     .wd     (key_share1_1_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[1].qe),
+    .qe     (key_share1_1_flds_we[0]),
     .q      (reg2hw.key_share1[1].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[1].qe = key_share1_1_qe;
 
 
   // Subregister 2 of Multireg key_share1
   // R[key_share1_2]: V(True)
+  logic key_share1_2_qe;
+  logic [0:0] key_share1_2_flds_we;
+  assign key_share1_2_qe = &key_share1_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_2 (
@@ -1622,14 +1761,18 @@ module kmac_reg_top (
     .wd     (key_share1_2_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[2].qe),
+    .qe     (key_share1_2_flds_we[0]),
     .q      (reg2hw.key_share1[2].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[2].qe = key_share1_2_qe;
 
 
   // Subregister 3 of Multireg key_share1
   // R[key_share1_3]: V(True)
+  logic key_share1_3_qe;
+  logic [0:0] key_share1_3_flds_we;
+  assign key_share1_3_qe = &key_share1_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_3 (
@@ -1638,14 +1781,18 @@ module kmac_reg_top (
     .wd     (key_share1_3_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[3].qe),
+    .qe     (key_share1_3_flds_we[0]),
     .q      (reg2hw.key_share1[3].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[3].qe = key_share1_3_qe;
 
 
   // Subregister 4 of Multireg key_share1
   // R[key_share1_4]: V(True)
+  logic key_share1_4_qe;
+  logic [0:0] key_share1_4_flds_we;
+  assign key_share1_4_qe = &key_share1_4_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_4 (
@@ -1654,14 +1801,18 @@ module kmac_reg_top (
     .wd     (key_share1_4_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[4].qe),
+    .qe     (key_share1_4_flds_we[0]),
     .q      (reg2hw.key_share1[4].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[4].qe = key_share1_4_qe;
 
 
   // Subregister 5 of Multireg key_share1
   // R[key_share1_5]: V(True)
+  logic key_share1_5_qe;
+  logic [0:0] key_share1_5_flds_we;
+  assign key_share1_5_qe = &key_share1_5_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_5 (
@@ -1670,14 +1821,18 @@ module kmac_reg_top (
     .wd     (key_share1_5_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[5].qe),
+    .qe     (key_share1_5_flds_we[0]),
     .q      (reg2hw.key_share1[5].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[5].qe = key_share1_5_qe;
 
 
   // Subregister 6 of Multireg key_share1
   // R[key_share1_6]: V(True)
+  logic key_share1_6_qe;
+  logic [0:0] key_share1_6_flds_we;
+  assign key_share1_6_qe = &key_share1_6_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_6 (
@@ -1686,14 +1841,18 @@ module kmac_reg_top (
     .wd     (key_share1_6_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[6].qe),
+    .qe     (key_share1_6_flds_we[0]),
     .q      (reg2hw.key_share1[6].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[6].qe = key_share1_6_qe;
 
 
   // Subregister 7 of Multireg key_share1
   // R[key_share1_7]: V(True)
+  logic key_share1_7_qe;
+  logic [0:0] key_share1_7_flds_we;
+  assign key_share1_7_qe = &key_share1_7_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_7 (
@@ -1702,14 +1861,18 @@ module kmac_reg_top (
     .wd     (key_share1_7_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[7].qe),
+    .qe     (key_share1_7_flds_we[0]),
     .q      (reg2hw.key_share1[7].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[7].qe = key_share1_7_qe;
 
 
   // Subregister 8 of Multireg key_share1
   // R[key_share1_8]: V(True)
+  logic key_share1_8_qe;
+  logic [0:0] key_share1_8_flds_we;
+  assign key_share1_8_qe = &key_share1_8_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_8 (
@@ -1718,14 +1881,18 @@ module kmac_reg_top (
     .wd     (key_share1_8_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[8].qe),
+    .qe     (key_share1_8_flds_we[0]),
     .q      (reg2hw.key_share1[8].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[8].qe = key_share1_8_qe;
 
 
   // Subregister 9 of Multireg key_share1
   // R[key_share1_9]: V(True)
+  logic key_share1_9_qe;
+  logic [0:0] key_share1_9_flds_we;
+  assign key_share1_9_qe = &key_share1_9_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_9 (
@@ -1734,14 +1901,18 @@ module kmac_reg_top (
     .wd     (key_share1_9_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[9].qe),
+    .qe     (key_share1_9_flds_we[0]),
     .q      (reg2hw.key_share1[9].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[9].qe = key_share1_9_qe;
 
 
   // Subregister 10 of Multireg key_share1
   // R[key_share1_10]: V(True)
+  logic key_share1_10_qe;
+  logic [0:0] key_share1_10_flds_we;
+  assign key_share1_10_qe = &key_share1_10_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_10 (
@@ -1750,14 +1921,18 @@ module kmac_reg_top (
     .wd     (key_share1_10_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[10].qe),
+    .qe     (key_share1_10_flds_we[0]),
     .q      (reg2hw.key_share1[10].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[10].qe = key_share1_10_qe;
 
 
   // Subregister 11 of Multireg key_share1
   // R[key_share1_11]: V(True)
+  logic key_share1_11_qe;
+  logic [0:0] key_share1_11_flds_we;
+  assign key_share1_11_qe = &key_share1_11_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_11 (
@@ -1766,14 +1941,18 @@ module kmac_reg_top (
     .wd     (key_share1_11_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[11].qe),
+    .qe     (key_share1_11_flds_we[0]),
     .q      (reg2hw.key_share1[11].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[11].qe = key_share1_11_qe;
 
 
   // Subregister 12 of Multireg key_share1
   // R[key_share1_12]: V(True)
+  logic key_share1_12_qe;
+  logic [0:0] key_share1_12_flds_we;
+  assign key_share1_12_qe = &key_share1_12_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_12 (
@@ -1782,14 +1961,18 @@ module kmac_reg_top (
     .wd     (key_share1_12_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[12].qe),
+    .qe     (key_share1_12_flds_we[0]),
     .q      (reg2hw.key_share1[12].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[12].qe = key_share1_12_qe;
 
 
   // Subregister 13 of Multireg key_share1
   // R[key_share1_13]: V(True)
+  logic key_share1_13_qe;
+  logic [0:0] key_share1_13_flds_we;
+  assign key_share1_13_qe = &key_share1_13_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_13 (
@@ -1798,14 +1981,18 @@ module kmac_reg_top (
     .wd     (key_share1_13_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[13].qe),
+    .qe     (key_share1_13_flds_we[0]),
     .q      (reg2hw.key_share1[13].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[13].qe = key_share1_13_qe;
 
 
   // Subregister 14 of Multireg key_share1
   // R[key_share1_14]: V(True)
+  logic key_share1_14_qe;
+  logic [0:0] key_share1_14_flds_we;
+  assign key_share1_14_qe = &key_share1_14_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_14 (
@@ -1814,14 +2001,18 @@ module kmac_reg_top (
     .wd     (key_share1_14_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[14].qe),
+    .qe     (key_share1_14_flds_we[0]),
     .q      (reg2hw.key_share1[14].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[14].qe = key_share1_14_qe;
 
 
   // Subregister 15 of Multireg key_share1
   // R[key_share1_15]: V(True)
+  logic key_share1_15_qe;
+  logic [0:0] key_share1_15_flds_we;
+  assign key_share1_15_qe = &key_share1_15_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_key_share1_15 (
@@ -1830,10 +2021,11 @@ module kmac_reg_top (
     .wd     (key_share1_15_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.key_share1[15].qe),
+    .qe     (key_share1_15_flds_we[0]),
     .q      (reg2hw.key_share1[15].q),
     .qs     ()
   );
+  assign reg2hw.key_share1[15].qe = key_share1_15_qe;
 
 
   // R[key_len]: V(False)

--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -808,7 +808,6 @@
                 ''',
       swaccess: "ro",
       hwaccess: "hwo",
-      hwqe:     "true",
       hwext:    "true",
       regwen:   "TRANSITION_REGWEN",
       tags: [ // To update this register, SW needs to claim the associated hardware mutex via

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_reg_top.sv
@@ -202,6 +202,9 @@ module lc_ctrl_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [2:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[fatal_prog_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -211,10 +214,11 @@ module lc_ctrl_reg_top (
     .wd     (alert_test_fatal_prog_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_prog_error.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_prog_error.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_prog_error.qe = alert_test_qe;
 
   //   F[fatal_state_error]: 1:1
   prim_subreg_ext #(
@@ -225,10 +229,11 @@ module lc_ctrl_reg_top (
     .wd     (alert_test_fatal_state_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_state_error.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_state_error.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_state_error.qe = alert_test_qe;
 
   //   F[fatal_bus_integ_error]: 2:2
   prim_subreg_ext #(
@@ -239,10 +244,11 @@ module lc_ctrl_reg_top (
     .wd     (alert_test_fatal_bus_integ_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_bus_integ_error.qe),
+    .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_bus_integ_error.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_bus_integ_error.qe = alert_test_qe;
 
 
   // R[status]: V(True)
@@ -388,6 +394,9 @@ module lc_ctrl_reg_top (
 
 
   // R[claim_transition_if]: V(True)
+  logic claim_transition_if_qe;
+  logic [0:0] claim_transition_if_flds_we;
+  assign claim_transition_if_qe = &claim_transition_if_flds_we;
   prim_subreg_ext #(
     .DW    (8)
   ) u_claim_transition_if (
@@ -396,10 +405,11 @@ module lc_ctrl_reg_top (
     .wd     (claim_transition_if_wd),
     .d      (hw2reg.claim_transition_if.d),
     .qre    (),
-    .qe     (reg2hw.claim_transition_if.qe),
+    .qe     (claim_transition_if_flds_we[0]),
     .q      (reg2hw.claim_transition_if.q),
     .qs     (claim_transition_if_qs)
   );
+  assign reg2hw.claim_transition_if.qe = claim_transition_if_qe;
 
 
   // R[transition_regwen]: V(True)
@@ -418,6 +428,9 @@ module lc_ctrl_reg_top (
 
 
   // R[transition_cmd]: V(True)
+  logic transition_cmd_qe;
+  logic [0:0] transition_cmd_flds_we;
+  assign transition_cmd_qe = &transition_cmd_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_transition_cmd (
@@ -426,13 +439,17 @@ module lc_ctrl_reg_top (
     .wd     (transition_cmd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.transition_cmd.qe),
+    .qe     (transition_cmd_flds_we[0]),
     .q      (reg2hw.transition_cmd.q),
     .qs     ()
   );
+  assign reg2hw.transition_cmd.qe = transition_cmd_qe;
 
 
   // R[transition_ctrl]: V(True)
+  logic transition_ctrl_qe;
+  logic [0:0] transition_ctrl_flds_we;
+  assign transition_ctrl_qe = &transition_ctrl_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_transition_ctrl (
@@ -441,14 +458,18 @@ module lc_ctrl_reg_top (
     .wd     (transition_ctrl_wd),
     .d      (hw2reg.transition_ctrl.d),
     .qre    (),
-    .qe     (reg2hw.transition_ctrl.qe),
+    .qe     (transition_ctrl_flds_we[0]),
     .q      (reg2hw.transition_ctrl.q),
     .qs     (transition_ctrl_qs)
   );
+  assign reg2hw.transition_ctrl.qe = transition_ctrl_qe;
 
 
   // Subregister 0 of Multireg transition_token
   // R[transition_token_0]: V(True)
+  logic transition_token_0_qe;
+  logic [0:0] transition_token_0_flds_we;
+  assign transition_token_0_qe = &transition_token_0_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_0 (
@@ -457,14 +478,18 @@ module lc_ctrl_reg_top (
     .wd     (transition_token_0_wd),
     .d      (hw2reg.transition_token[0].d),
     .qre    (),
-    .qe     (reg2hw.transition_token[0].qe),
+    .qe     (transition_token_0_flds_we[0]),
     .q      (reg2hw.transition_token[0].q),
     .qs     (transition_token_0_qs)
   );
+  assign reg2hw.transition_token[0].qe = transition_token_0_qe;
 
 
   // Subregister 1 of Multireg transition_token
   // R[transition_token_1]: V(True)
+  logic transition_token_1_qe;
+  logic [0:0] transition_token_1_flds_we;
+  assign transition_token_1_qe = &transition_token_1_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_1 (
@@ -473,14 +498,18 @@ module lc_ctrl_reg_top (
     .wd     (transition_token_1_wd),
     .d      (hw2reg.transition_token[1].d),
     .qre    (),
-    .qe     (reg2hw.transition_token[1].qe),
+    .qe     (transition_token_1_flds_we[0]),
     .q      (reg2hw.transition_token[1].q),
     .qs     (transition_token_1_qs)
   );
+  assign reg2hw.transition_token[1].qe = transition_token_1_qe;
 
 
   // Subregister 2 of Multireg transition_token
   // R[transition_token_2]: V(True)
+  logic transition_token_2_qe;
+  logic [0:0] transition_token_2_flds_we;
+  assign transition_token_2_qe = &transition_token_2_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_2 (
@@ -489,14 +518,18 @@ module lc_ctrl_reg_top (
     .wd     (transition_token_2_wd),
     .d      (hw2reg.transition_token[2].d),
     .qre    (),
-    .qe     (reg2hw.transition_token[2].qe),
+    .qe     (transition_token_2_flds_we[0]),
     .q      (reg2hw.transition_token[2].q),
     .qs     (transition_token_2_qs)
   );
+  assign reg2hw.transition_token[2].qe = transition_token_2_qe;
 
 
   // Subregister 3 of Multireg transition_token
   // R[transition_token_3]: V(True)
+  logic transition_token_3_qe;
+  logic [0:0] transition_token_3_flds_we;
+  assign transition_token_3_qe = &transition_token_3_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_transition_token_3 (
@@ -505,13 +538,17 @@ module lc_ctrl_reg_top (
     .wd     (transition_token_3_wd),
     .d      (hw2reg.transition_token[3].d),
     .qre    (),
-    .qe     (reg2hw.transition_token[3].qe),
+    .qe     (transition_token_3_flds_we[0]),
     .q      (reg2hw.transition_token[3].q),
     .qs     (transition_token_3_qs)
   );
+  assign reg2hw.transition_token[3].qe = transition_token_3_qe;
 
 
   // R[transition_target]: V(True)
+  logic transition_target_qe;
+  logic [0:0] transition_target_flds_we;
+  assign transition_target_qe = &transition_target_flds_we;
   prim_subreg_ext #(
     .DW    (30)
   ) u_transition_target (
@@ -520,13 +557,17 @@ module lc_ctrl_reg_top (
     .wd     (transition_target_wd),
     .d      (hw2reg.transition_target.d),
     .qre    (),
-    .qe     (reg2hw.transition_target.qe),
+    .qe     (transition_target_flds_we[0]),
     .q      (reg2hw.transition_target.q),
     .qs     (transition_target_qs)
   );
+  assign reg2hw.transition_target.qe = transition_target_qe;
 
 
   // R[otp_vendor_test_ctrl]: V(True)
+  logic otp_vendor_test_ctrl_qe;
+  logic [0:0] otp_vendor_test_ctrl_flds_we;
+  assign otp_vendor_test_ctrl_qe = &otp_vendor_test_ctrl_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_otp_vendor_test_ctrl (
@@ -535,10 +576,11 @@ module lc_ctrl_reg_top (
     .wd     (otp_vendor_test_ctrl_wd),
     .d      (hw2reg.otp_vendor_test_ctrl.d),
     .qre    (),
-    .qe     (reg2hw.otp_vendor_test_ctrl.qe),
+    .qe     (otp_vendor_test_ctrl_flds_we[0]),
     .q      (reg2hw.otp_vendor_test_ctrl.q),
     .qs     (otp_vendor_test_ctrl_qs)
   );
+  assign reg2hw.otp_vendor_test_ctrl.qe = otp_vendor_test_ctrl_qe;
 
 
   // R[otp_vendor_test_status]: V(True)

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -286,6 +286,9 @@ module otbn_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [0:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -294,13 +297,17 @@ module otbn_reg_top (
     .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[fatal]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -310,10 +317,11 @@ module otbn_reg_top (
     .wd     (alert_test_fatal_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal.qe = alert_test_qe;
 
   //   F[recov]: 1:1
   prim_subreg_ext #(
@@ -324,13 +332,17 @@ module otbn_reg_top (
     .wd     (alert_test_recov_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.recov.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov.qe = alert_test_qe;
 
 
   // R[cmd]: V(True)
+  logic cmd_qe;
+  logic [0:0] cmd_flds_we;
+  assign cmd_qe = &cmd_flds_we;
   prim_subreg_ext #(
     .DW    (8)
   ) u_cmd (
@@ -339,13 +351,17 @@ module otbn_reg_top (
     .wd     (cmd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.cmd.qe),
+    .qe     (cmd_flds_we[0]),
     .q      (reg2hw.cmd.q),
     .qs     ()
   );
+  assign reg2hw.cmd.qe = cmd_qe;
 
 
   // R[ctrl]: V(True)
+  logic ctrl_qe;
+  logic [0:0] ctrl_flds_we;
+  assign ctrl_qe = &ctrl_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_ctrl (
@@ -354,10 +370,11 @@ module otbn_reg_top (
     .wd     (ctrl_wd),
     .d      (hw2reg.ctrl.d),
     .qre    (),
-    .qe     (reg2hw.ctrl.qe),
+    .qe     (ctrl_flds_we[0]),
     .q      (reg2hw.ctrl.q),
     .qs     (ctrl_qs)
   );
+  assign reg2hw.ctrl.qe = ctrl_qe;
 
 
   // R[status]: V(False)
@@ -387,6 +404,9 @@ module otbn_reg_top (
 
 
   // R[err_bits]: V(True)
+  logic err_bits_qe;
+  logic [13:0] err_bits_flds_we;
+  assign err_bits_qe = &err_bits_flds_we;
   //   F[bad_data_addr]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -396,10 +416,11 @@ module otbn_reg_top (
     .wd     (err_bits_bad_data_addr_wd),
     .d      (hw2reg.err_bits.bad_data_addr.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.bad_data_addr.qe),
+    .qe     (err_bits_flds_we[0]),
     .q      (reg2hw.err_bits.bad_data_addr.q),
     .qs     (err_bits_bad_data_addr_qs)
   );
+  assign reg2hw.err_bits.bad_data_addr.qe = err_bits_qe;
 
   //   F[bad_insn_addr]: 1:1
   prim_subreg_ext #(
@@ -410,10 +431,11 @@ module otbn_reg_top (
     .wd     (err_bits_bad_insn_addr_wd),
     .d      (hw2reg.err_bits.bad_insn_addr.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.bad_insn_addr.qe),
+    .qe     (err_bits_flds_we[1]),
     .q      (reg2hw.err_bits.bad_insn_addr.q),
     .qs     (err_bits_bad_insn_addr_qs)
   );
+  assign reg2hw.err_bits.bad_insn_addr.qe = err_bits_qe;
 
   //   F[call_stack]: 2:2
   prim_subreg_ext #(
@@ -424,10 +446,11 @@ module otbn_reg_top (
     .wd     (err_bits_call_stack_wd),
     .d      (hw2reg.err_bits.call_stack.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.call_stack.qe),
+    .qe     (err_bits_flds_we[2]),
     .q      (reg2hw.err_bits.call_stack.q),
     .qs     (err_bits_call_stack_qs)
   );
+  assign reg2hw.err_bits.call_stack.qe = err_bits_qe;
 
   //   F[illegal_insn]: 3:3
   prim_subreg_ext #(
@@ -438,10 +461,11 @@ module otbn_reg_top (
     .wd     (err_bits_illegal_insn_wd),
     .d      (hw2reg.err_bits.illegal_insn.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.illegal_insn.qe),
+    .qe     (err_bits_flds_we[3]),
     .q      (reg2hw.err_bits.illegal_insn.q),
     .qs     (err_bits_illegal_insn_qs)
   );
+  assign reg2hw.err_bits.illegal_insn.qe = err_bits_qe;
 
   //   F[loop]: 4:4
   prim_subreg_ext #(
@@ -452,10 +476,11 @@ module otbn_reg_top (
     .wd     (err_bits_loop_wd),
     .d      (hw2reg.err_bits.loop.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.loop.qe),
+    .qe     (err_bits_flds_we[4]),
     .q      (reg2hw.err_bits.loop.q),
     .qs     (err_bits_loop_qs)
   );
+  assign reg2hw.err_bits.loop.qe = err_bits_qe;
 
   //   F[key_invalid]: 5:5
   prim_subreg_ext #(
@@ -466,10 +491,11 @@ module otbn_reg_top (
     .wd     (err_bits_key_invalid_wd),
     .d      (hw2reg.err_bits.key_invalid.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.key_invalid.qe),
+    .qe     (err_bits_flds_we[5]),
     .q      (reg2hw.err_bits.key_invalid.q),
     .qs     (err_bits_key_invalid_qs)
   );
+  assign reg2hw.err_bits.key_invalid.qe = err_bits_qe;
 
   //   F[imem_intg_violation]: 16:16
   prim_subreg_ext #(
@@ -480,10 +506,11 @@ module otbn_reg_top (
     .wd     (err_bits_imem_intg_violation_wd),
     .d      (hw2reg.err_bits.imem_intg_violation.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.imem_intg_violation.qe),
+    .qe     (err_bits_flds_we[6]),
     .q      (reg2hw.err_bits.imem_intg_violation.q),
     .qs     (err_bits_imem_intg_violation_qs)
   );
+  assign reg2hw.err_bits.imem_intg_violation.qe = err_bits_qe;
 
   //   F[dmem_intg_violation]: 17:17
   prim_subreg_ext #(
@@ -494,10 +521,11 @@ module otbn_reg_top (
     .wd     (err_bits_dmem_intg_violation_wd),
     .d      (hw2reg.err_bits.dmem_intg_violation.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.dmem_intg_violation.qe),
+    .qe     (err_bits_flds_we[7]),
     .q      (reg2hw.err_bits.dmem_intg_violation.q),
     .qs     (err_bits_dmem_intg_violation_qs)
   );
+  assign reg2hw.err_bits.dmem_intg_violation.qe = err_bits_qe;
 
   //   F[reg_intg_violation]: 18:18
   prim_subreg_ext #(
@@ -508,10 +536,11 @@ module otbn_reg_top (
     .wd     (err_bits_reg_intg_violation_wd),
     .d      (hw2reg.err_bits.reg_intg_violation.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.reg_intg_violation.qe),
+    .qe     (err_bits_flds_we[8]),
     .q      (reg2hw.err_bits.reg_intg_violation.q),
     .qs     (err_bits_reg_intg_violation_qs)
   );
+  assign reg2hw.err_bits.reg_intg_violation.qe = err_bits_qe;
 
   //   F[bus_intg_violation]: 19:19
   prim_subreg_ext #(
@@ -522,10 +551,11 @@ module otbn_reg_top (
     .wd     (err_bits_bus_intg_violation_wd),
     .d      (hw2reg.err_bits.bus_intg_violation.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.bus_intg_violation.qe),
+    .qe     (err_bits_flds_we[9]),
     .q      (reg2hw.err_bits.bus_intg_violation.q),
     .qs     (err_bits_bus_intg_violation_qs)
   );
+  assign reg2hw.err_bits.bus_intg_violation.qe = err_bits_qe;
 
   //   F[bad_internal_state]: 20:20
   prim_subreg_ext #(
@@ -536,10 +566,11 @@ module otbn_reg_top (
     .wd     (err_bits_bad_internal_state_wd),
     .d      (hw2reg.err_bits.bad_internal_state.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.bad_internal_state.qe),
+    .qe     (err_bits_flds_we[10]),
     .q      (reg2hw.err_bits.bad_internal_state.q),
     .qs     (err_bits_bad_internal_state_qs)
   );
+  assign reg2hw.err_bits.bad_internal_state.qe = err_bits_qe;
 
   //   F[illegal_bus_access]: 21:21
   prim_subreg_ext #(
@@ -550,10 +581,11 @@ module otbn_reg_top (
     .wd     (err_bits_illegal_bus_access_wd),
     .d      (hw2reg.err_bits.illegal_bus_access.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.illegal_bus_access.qe),
+    .qe     (err_bits_flds_we[11]),
     .q      (reg2hw.err_bits.illegal_bus_access.q),
     .qs     (err_bits_illegal_bus_access_qs)
   );
+  assign reg2hw.err_bits.illegal_bus_access.qe = err_bits_qe;
 
   //   F[lifecycle_escalation]: 22:22
   prim_subreg_ext #(
@@ -564,10 +596,11 @@ module otbn_reg_top (
     .wd     (err_bits_lifecycle_escalation_wd),
     .d      (hw2reg.err_bits.lifecycle_escalation.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.lifecycle_escalation.qe),
+    .qe     (err_bits_flds_we[12]),
     .q      (reg2hw.err_bits.lifecycle_escalation.q),
     .qs     (err_bits_lifecycle_escalation_qs)
   );
+  assign reg2hw.err_bits.lifecycle_escalation.qe = err_bits_qe;
 
   //   F[fatal_software]: 23:23
   prim_subreg_ext #(
@@ -578,10 +611,11 @@ module otbn_reg_top (
     .wd     (err_bits_fatal_software_wd),
     .d      (hw2reg.err_bits.fatal_software.d),
     .qre    (),
-    .qe     (reg2hw.err_bits.fatal_software.qe),
+    .qe     (err_bits_flds_we[13]),
     .q      (reg2hw.err_bits.fatal_software.q),
     .qs     (err_bits_fatal_software_qs)
   );
+  assign reg2hw.err_bits.fatal_software.qe = err_bits_qe;
 
 
   // R[fatal_alert_cause]: V(False)
@@ -787,6 +821,9 @@ module otbn_reg_top (
 
 
   // R[insn_cnt]: V(True)
+  logic insn_cnt_qe;
+  logic [0:0] insn_cnt_flds_we;
+  assign insn_cnt_qe = &insn_cnt_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_insn_cnt (
@@ -795,13 +832,17 @@ module otbn_reg_top (
     .wd     (insn_cnt_wd),
     .d      (hw2reg.insn_cnt.d),
     .qre    (),
-    .qe     (reg2hw.insn_cnt.qe),
+    .qe     (insn_cnt_flds_we[0]),
     .q      (reg2hw.insn_cnt.q),
     .qs     (insn_cnt_qs)
   );
+  assign reg2hw.insn_cnt.qe = insn_cnt_qe;
 
 
   // R[load_checksum]: V(True)
+  logic load_checksum_qe;
+  logic [0:0] load_checksum_flds_we;
+  assign load_checksum_qe = &load_checksum_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_load_checksum (
@@ -810,10 +851,11 @@ module otbn_reg_top (
     .wd     (load_checksum_wd),
     .d      (hw2reg.load_checksum.d),
     .qre    (),
-    .qe     (reg2hw.load_checksum.qe),
+    .qe     (load_checksum_flds_we[0]),
     .q      (reg2hw.load_checksum.q),
     .qs     (load_checksum_qs)
   );
+  assign reg2hw.load_checksum.qe = load_checksum_qe;
 
 
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_core_reg_top.sv
@@ -389,6 +389,9 @@ module otp_ctrl_core_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [1:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[otp_operation_done]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -398,10 +401,11 @@ module otp_ctrl_core_reg_top (
     .wd     (intr_test_otp_operation_done_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.otp_operation_done.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.otp_operation_done.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.otp_operation_done.qe = intr_test_qe;
 
   //   F[otp_error]: 1:1
   prim_subreg_ext #(
@@ -412,13 +416,17 @@ module otp_ctrl_core_reg_top (
     .wd     (intr_test_otp_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.otp_error.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.otp_error.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.otp_error.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [2:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[fatal_macro_error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -428,10 +436,11 @@ module otp_ctrl_core_reg_top (
     .wd     (alert_test_fatal_macro_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_macro_error.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_macro_error.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_macro_error.qe = alert_test_qe;
 
   //   F[fatal_check_error]: 1:1
   prim_subreg_ext #(
@@ -442,10 +451,11 @@ module otp_ctrl_core_reg_top (
     .wd     (alert_test_fatal_check_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_check_error.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_check_error.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_check_error.qe = alert_test_qe;
 
   //   F[fatal_bus_integ_error]: 2:2
   prim_subreg_ext #(
@@ -456,10 +466,11 @@ module otp_ctrl_core_reg_top (
     .wd     (alert_test_fatal_bus_integ_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_bus_integ_error.qe),
+    .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_bus_integ_error.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_bus_integ_error.qe = alert_test_qe;
 
 
   // R[status]: V(True)
@@ -861,6 +872,9 @@ module otp_ctrl_core_reg_top (
 
 
   // R[direct_access_cmd]: V(True)
+  logic direct_access_cmd_qe;
+  logic [2:0] direct_access_cmd_flds_we;
+  assign direct_access_cmd_qe = &direct_access_cmd_flds_we;
   //   F[rd]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -870,10 +884,11 @@ module otp_ctrl_core_reg_top (
     .wd     (direct_access_cmd_rd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.direct_access_cmd.rd.qe),
+    .qe     (direct_access_cmd_flds_we[0]),
     .q      (reg2hw.direct_access_cmd.rd.q),
     .qs     ()
   );
+  assign reg2hw.direct_access_cmd.rd.qe = direct_access_cmd_qe;
 
   //   F[wr]: 1:1
   prim_subreg_ext #(
@@ -884,10 +899,11 @@ module otp_ctrl_core_reg_top (
     .wd     (direct_access_cmd_wr_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.direct_access_cmd.wr.qe),
+    .qe     (direct_access_cmd_flds_we[1]),
     .q      (reg2hw.direct_access_cmd.wr.q),
     .qs     ()
   );
+  assign reg2hw.direct_access_cmd.wr.qe = direct_access_cmd_qe;
 
   //   F[digest]: 2:2
   prim_subreg_ext #(
@@ -898,10 +914,11 @@ module otp_ctrl_core_reg_top (
     .wd     (direct_access_cmd_digest_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.direct_access_cmd.digest.qe),
+    .qe     (direct_access_cmd_flds_we[2]),
     .q      (reg2hw.direct_access_cmd.digest.q),
     .qs     ()
   );
+  assign reg2hw.direct_access_cmd.digest.qe = direct_access_cmd_qe;
 
 
   // R[direct_access_address]: V(False)
@@ -1043,6 +1060,9 @@ module otp_ctrl_core_reg_top (
 
 
   // R[check_trigger]: V(True)
+  logic check_trigger_qe;
+  logic [1:0] check_trigger_flds_we;
+  assign check_trigger_qe = &check_trigger_flds_we;
   //   F[integrity]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1052,10 +1072,11 @@ module otp_ctrl_core_reg_top (
     .wd     (check_trigger_integrity_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.check_trigger.integrity.qe),
+    .qe     (check_trigger_flds_we[0]),
     .q      (reg2hw.check_trigger.integrity.q),
     .qs     ()
   );
+  assign reg2hw.check_trigger.integrity.qe = check_trigger_qe;
 
   //   F[consistency]: 1:1
   prim_subreg_ext #(
@@ -1066,10 +1087,11 @@ module otp_ctrl_core_reg_top (
     .wd     (check_trigger_consistency_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.check_trigger.consistency.qe),
+    .qe     (check_trigger_flds_we[1]),
     .q      (reg2hw.check_trigger.consistency.q),
     .qs     ()
   );
+  assign reg2hw.check_trigger.consistency.qe = check_trigger_qe;
 
 
   // R[check_regwen]: V(False)

--- a/hw/ip/pattgen/rtl/pattgen_reg_top.sv
+++ b/hw/ip/pattgen/rtl/pattgen_reg_top.sv
@@ -266,6 +266,9 @@ module pattgen_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [1:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[done_ch0]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -275,10 +278,11 @@ module pattgen_reg_top (
     .wd     (intr_test_done_ch0_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.done_ch0.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.done_ch0.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.done_ch0.qe = intr_test_qe;
 
   //   F[done_ch1]: 1:1
   prim_subreg_ext #(
@@ -289,13 +293,17 @@ module pattgen_reg_top (
     .wd     (intr_test_done_ch1_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.done_ch1.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.done_ch1.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.done_ch1.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -304,10 +312,11 @@ module pattgen_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[ctrl]: V(False)

--- a/hw/ip/pinmux/rtl/pinmux_reg_top.sv
+++ b/hw/ip/pinmux/rtl/pinmux_reg_top.sv
@@ -2478,6 +2478,9 @@ module pinmux_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -2486,10 +2489,11 @@ module pinmux_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // Subregister 0 of Multireg mio_periph_insel_regwen
@@ -6868,6 +6872,9 @@ module pinmux_reg_top (
 
   // Subregister 0 of Multireg mio_pad_attr
   // R[mio_pad_attr_0]: V(True)
+  logic mio_pad_attr_0_qe;
+  logic [0:0] mio_pad_attr_0_flds_we;
+  assign mio_pad_attr_0_qe = &mio_pad_attr_0_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_0 (
@@ -6876,14 +6883,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_0_wd),
     .d      (hw2reg.mio_pad_attr[0].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[0].qe),
+    .qe     (mio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[0].q),
     .qs     (mio_pad_attr_0_qs)
   );
+  assign reg2hw.mio_pad_attr[0].qe = mio_pad_attr_0_qe;
 
 
   // Subregister 1 of Multireg mio_pad_attr
   // R[mio_pad_attr_1]: V(True)
+  logic mio_pad_attr_1_qe;
+  logic [0:0] mio_pad_attr_1_flds_we;
+  assign mio_pad_attr_1_qe = &mio_pad_attr_1_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_1 (
@@ -6892,14 +6903,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_1_wd),
     .d      (hw2reg.mio_pad_attr[1].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[1].qe),
+    .qe     (mio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[1].q),
     .qs     (mio_pad_attr_1_qs)
   );
+  assign reg2hw.mio_pad_attr[1].qe = mio_pad_attr_1_qe;
 
 
   // Subregister 2 of Multireg mio_pad_attr
   // R[mio_pad_attr_2]: V(True)
+  logic mio_pad_attr_2_qe;
+  logic [0:0] mio_pad_attr_2_flds_we;
+  assign mio_pad_attr_2_qe = &mio_pad_attr_2_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_2 (
@@ -6908,14 +6923,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_2_wd),
     .d      (hw2reg.mio_pad_attr[2].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[2].qe),
+    .qe     (mio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[2].q),
     .qs     (mio_pad_attr_2_qs)
   );
+  assign reg2hw.mio_pad_attr[2].qe = mio_pad_attr_2_qe;
 
 
   // Subregister 3 of Multireg mio_pad_attr
   // R[mio_pad_attr_3]: V(True)
+  logic mio_pad_attr_3_qe;
+  logic [0:0] mio_pad_attr_3_flds_we;
+  assign mio_pad_attr_3_qe = &mio_pad_attr_3_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_3 (
@@ -6924,14 +6943,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_3_wd),
     .d      (hw2reg.mio_pad_attr[3].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[3].qe),
+    .qe     (mio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[3].q),
     .qs     (mio_pad_attr_3_qs)
   );
+  assign reg2hw.mio_pad_attr[3].qe = mio_pad_attr_3_qe;
 
 
   // Subregister 4 of Multireg mio_pad_attr
   // R[mio_pad_attr_4]: V(True)
+  logic mio_pad_attr_4_qe;
+  logic [0:0] mio_pad_attr_4_flds_we;
+  assign mio_pad_attr_4_qe = &mio_pad_attr_4_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_4 (
@@ -6940,14 +6963,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_4_wd),
     .d      (hw2reg.mio_pad_attr[4].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[4].qe),
+    .qe     (mio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[4].q),
     .qs     (mio_pad_attr_4_qs)
   );
+  assign reg2hw.mio_pad_attr[4].qe = mio_pad_attr_4_qe;
 
 
   // Subregister 5 of Multireg mio_pad_attr
   // R[mio_pad_attr_5]: V(True)
+  logic mio_pad_attr_5_qe;
+  logic [0:0] mio_pad_attr_5_flds_we;
+  assign mio_pad_attr_5_qe = &mio_pad_attr_5_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_5 (
@@ -6956,14 +6983,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_5_wd),
     .d      (hw2reg.mio_pad_attr[5].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[5].qe),
+    .qe     (mio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[5].q),
     .qs     (mio_pad_attr_5_qs)
   );
+  assign reg2hw.mio_pad_attr[5].qe = mio_pad_attr_5_qe;
 
 
   // Subregister 6 of Multireg mio_pad_attr
   // R[mio_pad_attr_6]: V(True)
+  logic mio_pad_attr_6_qe;
+  logic [0:0] mio_pad_attr_6_flds_we;
+  assign mio_pad_attr_6_qe = &mio_pad_attr_6_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_6 (
@@ -6972,14 +7003,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_6_wd),
     .d      (hw2reg.mio_pad_attr[6].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[6].qe),
+    .qe     (mio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[6].q),
     .qs     (mio_pad_attr_6_qs)
   );
+  assign reg2hw.mio_pad_attr[6].qe = mio_pad_attr_6_qe;
 
 
   // Subregister 7 of Multireg mio_pad_attr
   // R[mio_pad_attr_7]: V(True)
+  logic mio_pad_attr_7_qe;
+  logic [0:0] mio_pad_attr_7_flds_we;
+  assign mio_pad_attr_7_qe = &mio_pad_attr_7_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_7 (
@@ -6988,14 +7023,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_7_wd),
     .d      (hw2reg.mio_pad_attr[7].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[7].qe),
+    .qe     (mio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[7].q),
     .qs     (mio_pad_attr_7_qs)
   );
+  assign reg2hw.mio_pad_attr[7].qe = mio_pad_attr_7_qe;
 
 
   // Subregister 8 of Multireg mio_pad_attr
   // R[mio_pad_attr_8]: V(True)
+  logic mio_pad_attr_8_qe;
+  logic [0:0] mio_pad_attr_8_flds_we;
+  assign mio_pad_attr_8_qe = &mio_pad_attr_8_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_8 (
@@ -7004,14 +7043,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_8_wd),
     .d      (hw2reg.mio_pad_attr[8].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[8].qe),
+    .qe     (mio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[8].q),
     .qs     (mio_pad_attr_8_qs)
   );
+  assign reg2hw.mio_pad_attr[8].qe = mio_pad_attr_8_qe;
 
 
   // Subregister 9 of Multireg mio_pad_attr
   // R[mio_pad_attr_9]: V(True)
+  logic mio_pad_attr_9_qe;
+  logic [0:0] mio_pad_attr_9_flds_we;
+  assign mio_pad_attr_9_qe = &mio_pad_attr_9_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_9 (
@@ -7020,14 +7063,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_9_wd),
     .d      (hw2reg.mio_pad_attr[9].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[9].qe),
+    .qe     (mio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[9].q),
     .qs     (mio_pad_attr_9_qs)
   );
+  assign reg2hw.mio_pad_attr[9].qe = mio_pad_attr_9_qe;
 
 
   // Subregister 10 of Multireg mio_pad_attr
   // R[mio_pad_attr_10]: V(True)
+  logic mio_pad_attr_10_qe;
+  logic [0:0] mio_pad_attr_10_flds_we;
+  assign mio_pad_attr_10_qe = &mio_pad_attr_10_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_10 (
@@ -7036,14 +7083,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_10_wd),
     .d      (hw2reg.mio_pad_attr[10].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[10].qe),
+    .qe     (mio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[10].q),
     .qs     (mio_pad_attr_10_qs)
   );
+  assign reg2hw.mio_pad_attr[10].qe = mio_pad_attr_10_qe;
 
 
   // Subregister 11 of Multireg mio_pad_attr
   // R[mio_pad_attr_11]: V(True)
+  logic mio_pad_attr_11_qe;
+  logic [0:0] mio_pad_attr_11_flds_we;
+  assign mio_pad_attr_11_qe = &mio_pad_attr_11_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_11 (
@@ -7052,14 +7103,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_11_wd),
     .d      (hw2reg.mio_pad_attr[11].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[11].qe),
+    .qe     (mio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[11].q),
     .qs     (mio_pad_attr_11_qs)
   );
+  assign reg2hw.mio_pad_attr[11].qe = mio_pad_attr_11_qe;
 
 
   // Subregister 12 of Multireg mio_pad_attr
   // R[mio_pad_attr_12]: V(True)
+  logic mio_pad_attr_12_qe;
+  logic [0:0] mio_pad_attr_12_flds_we;
+  assign mio_pad_attr_12_qe = &mio_pad_attr_12_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_12 (
@@ -7068,14 +7123,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_12_wd),
     .d      (hw2reg.mio_pad_attr[12].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[12].qe),
+    .qe     (mio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[12].q),
     .qs     (mio_pad_attr_12_qs)
   );
+  assign reg2hw.mio_pad_attr[12].qe = mio_pad_attr_12_qe;
 
 
   // Subregister 13 of Multireg mio_pad_attr
   // R[mio_pad_attr_13]: V(True)
+  logic mio_pad_attr_13_qe;
+  logic [0:0] mio_pad_attr_13_flds_we;
+  assign mio_pad_attr_13_qe = &mio_pad_attr_13_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_13 (
@@ -7084,14 +7143,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_13_wd),
     .d      (hw2reg.mio_pad_attr[13].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[13].qe),
+    .qe     (mio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[13].q),
     .qs     (mio_pad_attr_13_qs)
   );
+  assign reg2hw.mio_pad_attr[13].qe = mio_pad_attr_13_qe;
 
 
   // Subregister 14 of Multireg mio_pad_attr
   // R[mio_pad_attr_14]: V(True)
+  logic mio_pad_attr_14_qe;
+  logic [0:0] mio_pad_attr_14_flds_we;
+  assign mio_pad_attr_14_qe = &mio_pad_attr_14_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_14 (
@@ -7100,14 +7163,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_14_wd),
     .d      (hw2reg.mio_pad_attr[14].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[14].qe),
+    .qe     (mio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[14].q),
     .qs     (mio_pad_attr_14_qs)
   );
+  assign reg2hw.mio_pad_attr[14].qe = mio_pad_attr_14_qe;
 
 
   // Subregister 15 of Multireg mio_pad_attr
   // R[mio_pad_attr_15]: V(True)
+  logic mio_pad_attr_15_qe;
+  logic [0:0] mio_pad_attr_15_flds_we;
+  assign mio_pad_attr_15_qe = &mio_pad_attr_15_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_15 (
@@ -7116,14 +7183,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_15_wd),
     .d      (hw2reg.mio_pad_attr[15].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[15].qe),
+    .qe     (mio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[15].q),
     .qs     (mio_pad_attr_15_qs)
   );
+  assign reg2hw.mio_pad_attr[15].qe = mio_pad_attr_15_qe;
 
 
   // Subregister 16 of Multireg mio_pad_attr
   // R[mio_pad_attr_16]: V(True)
+  logic mio_pad_attr_16_qe;
+  logic [0:0] mio_pad_attr_16_flds_we;
+  assign mio_pad_attr_16_qe = &mio_pad_attr_16_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_16 (
@@ -7132,14 +7203,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_16_wd),
     .d      (hw2reg.mio_pad_attr[16].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[16].qe),
+    .qe     (mio_pad_attr_16_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[16].q),
     .qs     (mio_pad_attr_16_qs)
   );
+  assign reg2hw.mio_pad_attr[16].qe = mio_pad_attr_16_qe;
 
 
   // Subregister 17 of Multireg mio_pad_attr
   // R[mio_pad_attr_17]: V(True)
+  logic mio_pad_attr_17_qe;
+  logic [0:0] mio_pad_attr_17_flds_we;
+  assign mio_pad_attr_17_qe = &mio_pad_attr_17_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_17 (
@@ -7148,14 +7223,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_17_wd),
     .d      (hw2reg.mio_pad_attr[17].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[17].qe),
+    .qe     (mio_pad_attr_17_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[17].q),
     .qs     (mio_pad_attr_17_qs)
   );
+  assign reg2hw.mio_pad_attr[17].qe = mio_pad_attr_17_qe;
 
 
   // Subregister 18 of Multireg mio_pad_attr
   // R[mio_pad_attr_18]: V(True)
+  logic mio_pad_attr_18_qe;
+  logic [0:0] mio_pad_attr_18_flds_we;
+  assign mio_pad_attr_18_qe = &mio_pad_attr_18_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_18 (
@@ -7164,14 +7243,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_18_wd),
     .d      (hw2reg.mio_pad_attr[18].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[18].qe),
+    .qe     (mio_pad_attr_18_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[18].q),
     .qs     (mio_pad_attr_18_qs)
   );
+  assign reg2hw.mio_pad_attr[18].qe = mio_pad_attr_18_qe;
 
 
   // Subregister 19 of Multireg mio_pad_attr
   // R[mio_pad_attr_19]: V(True)
+  logic mio_pad_attr_19_qe;
+  logic [0:0] mio_pad_attr_19_flds_we;
+  assign mio_pad_attr_19_qe = &mio_pad_attr_19_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_19 (
@@ -7180,14 +7263,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_19_wd),
     .d      (hw2reg.mio_pad_attr[19].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[19].qe),
+    .qe     (mio_pad_attr_19_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[19].q),
     .qs     (mio_pad_attr_19_qs)
   );
+  assign reg2hw.mio_pad_attr[19].qe = mio_pad_attr_19_qe;
 
 
   // Subregister 20 of Multireg mio_pad_attr
   // R[mio_pad_attr_20]: V(True)
+  logic mio_pad_attr_20_qe;
+  logic [0:0] mio_pad_attr_20_flds_we;
+  assign mio_pad_attr_20_qe = &mio_pad_attr_20_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_20 (
@@ -7196,14 +7283,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_20_wd),
     .d      (hw2reg.mio_pad_attr[20].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[20].qe),
+    .qe     (mio_pad_attr_20_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[20].q),
     .qs     (mio_pad_attr_20_qs)
   );
+  assign reg2hw.mio_pad_attr[20].qe = mio_pad_attr_20_qe;
 
 
   // Subregister 21 of Multireg mio_pad_attr
   // R[mio_pad_attr_21]: V(True)
+  logic mio_pad_attr_21_qe;
+  logic [0:0] mio_pad_attr_21_flds_we;
+  assign mio_pad_attr_21_qe = &mio_pad_attr_21_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_21 (
@@ -7212,14 +7303,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_21_wd),
     .d      (hw2reg.mio_pad_attr[21].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[21].qe),
+    .qe     (mio_pad_attr_21_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[21].q),
     .qs     (mio_pad_attr_21_qs)
   );
+  assign reg2hw.mio_pad_attr[21].qe = mio_pad_attr_21_qe;
 
 
   // Subregister 22 of Multireg mio_pad_attr
   // R[mio_pad_attr_22]: V(True)
+  logic mio_pad_attr_22_qe;
+  logic [0:0] mio_pad_attr_22_flds_we;
+  assign mio_pad_attr_22_qe = &mio_pad_attr_22_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_22 (
@@ -7228,14 +7323,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_22_wd),
     .d      (hw2reg.mio_pad_attr[22].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[22].qe),
+    .qe     (mio_pad_attr_22_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[22].q),
     .qs     (mio_pad_attr_22_qs)
   );
+  assign reg2hw.mio_pad_attr[22].qe = mio_pad_attr_22_qe;
 
 
   // Subregister 23 of Multireg mio_pad_attr
   // R[mio_pad_attr_23]: V(True)
+  logic mio_pad_attr_23_qe;
+  logic [0:0] mio_pad_attr_23_flds_we;
+  assign mio_pad_attr_23_qe = &mio_pad_attr_23_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_23 (
@@ -7244,14 +7343,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_23_wd),
     .d      (hw2reg.mio_pad_attr[23].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[23].qe),
+    .qe     (mio_pad_attr_23_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[23].q),
     .qs     (mio_pad_attr_23_qs)
   );
+  assign reg2hw.mio_pad_attr[23].qe = mio_pad_attr_23_qe;
 
 
   // Subregister 24 of Multireg mio_pad_attr
   // R[mio_pad_attr_24]: V(True)
+  logic mio_pad_attr_24_qe;
+  logic [0:0] mio_pad_attr_24_flds_we;
+  assign mio_pad_attr_24_qe = &mio_pad_attr_24_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_24 (
@@ -7260,14 +7363,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_24_wd),
     .d      (hw2reg.mio_pad_attr[24].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[24].qe),
+    .qe     (mio_pad_attr_24_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[24].q),
     .qs     (mio_pad_attr_24_qs)
   );
+  assign reg2hw.mio_pad_attr[24].qe = mio_pad_attr_24_qe;
 
 
   // Subregister 25 of Multireg mio_pad_attr
   // R[mio_pad_attr_25]: V(True)
+  logic mio_pad_attr_25_qe;
+  logic [0:0] mio_pad_attr_25_flds_we;
+  assign mio_pad_attr_25_qe = &mio_pad_attr_25_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_25 (
@@ -7276,14 +7383,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_25_wd),
     .d      (hw2reg.mio_pad_attr[25].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[25].qe),
+    .qe     (mio_pad_attr_25_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[25].q),
     .qs     (mio_pad_attr_25_qs)
   );
+  assign reg2hw.mio_pad_attr[25].qe = mio_pad_attr_25_qe;
 
 
   // Subregister 26 of Multireg mio_pad_attr
   // R[mio_pad_attr_26]: V(True)
+  logic mio_pad_attr_26_qe;
+  logic [0:0] mio_pad_attr_26_flds_we;
+  assign mio_pad_attr_26_qe = &mio_pad_attr_26_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_26 (
@@ -7292,14 +7403,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_26_wd),
     .d      (hw2reg.mio_pad_attr[26].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[26].qe),
+    .qe     (mio_pad_attr_26_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[26].q),
     .qs     (mio_pad_attr_26_qs)
   );
+  assign reg2hw.mio_pad_attr[26].qe = mio_pad_attr_26_qe;
 
 
   // Subregister 27 of Multireg mio_pad_attr
   // R[mio_pad_attr_27]: V(True)
+  logic mio_pad_attr_27_qe;
+  logic [0:0] mio_pad_attr_27_flds_we;
+  assign mio_pad_attr_27_qe = &mio_pad_attr_27_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_27 (
@@ -7308,14 +7423,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_27_wd),
     .d      (hw2reg.mio_pad_attr[27].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[27].qe),
+    .qe     (mio_pad_attr_27_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[27].q),
     .qs     (mio_pad_attr_27_qs)
   );
+  assign reg2hw.mio_pad_attr[27].qe = mio_pad_attr_27_qe;
 
 
   // Subregister 28 of Multireg mio_pad_attr
   // R[mio_pad_attr_28]: V(True)
+  logic mio_pad_attr_28_qe;
+  logic [0:0] mio_pad_attr_28_flds_we;
+  assign mio_pad_attr_28_qe = &mio_pad_attr_28_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_28 (
@@ -7324,14 +7443,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_28_wd),
     .d      (hw2reg.mio_pad_attr[28].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[28].qe),
+    .qe     (mio_pad_attr_28_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[28].q),
     .qs     (mio_pad_attr_28_qs)
   );
+  assign reg2hw.mio_pad_attr[28].qe = mio_pad_attr_28_qe;
 
 
   // Subregister 29 of Multireg mio_pad_attr
   // R[mio_pad_attr_29]: V(True)
+  logic mio_pad_attr_29_qe;
+  logic [0:0] mio_pad_attr_29_flds_we;
+  assign mio_pad_attr_29_qe = &mio_pad_attr_29_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_29 (
@@ -7340,14 +7463,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_29_wd),
     .d      (hw2reg.mio_pad_attr[29].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[29].qe),
+    .qe     (mio_pad_attr_29_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[29].q),
     .qs     (mio_pad_attr_29_qs)
   );
+  assign reg2hw.mio_pad_attr[29].qe = mio_pad_attr_29_qe;
 
 
   // Subregister 30 of Multireg mio_pad_attr
   // R[mio_pad_attr_30]: V(True)
+  logic mio_pad_attr_30_qe;
+  logic [0:0] mio_pad_attr_30_flds_we;
+  assign mio_pad_attr_30_qe = &mio_pad_attr_30_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_30 (
@@ -7356,14 +7483,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_30_wd),
     .d      (hw2reg.mio_pad_attr[30].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[30].qe),
+    .qe     (mio_pad_attr_30_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[30].q),
     .qs     (mio_pad_attr_30_qs)
   );
+  assign reg2hw.mio_pad_attr[30].qe = mio_pad_attr_30_qe;
 
 
   // Subregister 31 of Multireg mio_pad_attr
   // R[mio_pad_attr_31]: V(True)
+  logic mio_pad_attr_31_qe;
+  logic [0:0] mio_pad_attr_31_flds_we;
+  assign mio_pad_attr_31_qe = &mio_pad_attr_31_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_31 (
@@ -7372,10 +7503,11 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_31_wd),
     .d      (hw2reg.mio_pad_attr[31].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[31].qe),
+    .qe     (mio_pad_attr_31_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[31].q),
     .qs     (mio_pad_attr_31_qs)
   );
+  assign reg2hw.mio_pad_attr[31].qe = mio_pad_attr_31_qe;
 
 
   // Subregister 0 of Multireg dio_pad_attr_regwen
@@ -7812,6 +7944,9 @@ module pinmux_reg_top (
 
   // Subregister 0 of Multireg dio_pad_attr
   // R[dio_pad_attr_0]: V(True)
+  logic dio_pad_attr_0_qe;
+  logic [0:0] dio_pad_attr_0_flds_we;
+  assign dio_pad_attr_0_qe = &dio_pad_attr_0_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_0 (
@@ -7820,14 +7955,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_0_wd),
     .d      (hw2reg.dio_pad_attr[0].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[0].qe),
+    .qe     (dio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[0].q),
     .qs     (dio_pad_attr_0_qs)
   );
+  assign reg2hw.dio_pad_attr[0].qe = dio_pad_attr_0_qe;
 
 
   // Subregister 1 of Multireg dio_pad_attr
   // R[dio_pad_attr_1]: V(True)
+  logic dio_pad_attr_1_qe;
+  logic [0:0] dio_pad_attr_1_flds_we;
+  assign dio_pad_attr_1_qe = &dio_pad_attr_1_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_1 (
@@ -7836,14 +7975,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_1_wd),
     .d      (hw2reg.dio_pad_attr[1].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[1].qe),
+    .qe     (dio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[1].q),
     .qs     (dio_pad_attr_1_qs)
   );
+  assign reg2hw.dio_pad_attr[1].qe = dio_pad_attr_1_qe;
 
 
   // Subregister 2 of Multireg dio_pad_attr
   // R[dio_pad_attr_2]: V(True)
+  logic dio_pad_attr_2_qe;
+  logic [0:0] dio_pad_attr_2_flds_we;
+  assign dio_pad_attr_2_qe = &dio_pad_attr_2_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_2 (
@@ -7852,14 +7995,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_2_wd),
     .d      (hw2reg.dio_pad_attr[2].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[2].qe),
+    .qe     (dio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[2].q),
     .qs     (dio_pad_attr_2_qs)
   );
+  assign reg2hw.dio_pad_attr[2].qe = dio_pad_attr_2_qe;
 
 
   // Subregister 3 of Multireg dio_pad_attr
   // R[dio_pad_attr_3]: V(True)
+  logic dio_pad_attr_3_qe;
+  logic [0:0] dio_pad_attr_3_flds_we;
+  assign dio_pad_attr_3_qe = &dio_pad_attr_3_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_3 (
@@ -7868,14 +8015,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_3_wd),
     .d      (hw2reg.dio_pad_attr[3].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[3].qe),
+    .qe     (dio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[3].q),
     .qs     (dio_pad_attr_3_qs)
   );
+  assign reg2hw.dio_pad_attr[3].qe = dio_pad_attr_3_qe;
 
 
   // Subregister 4 of Multireg dio_pad_attr
   // R[dio_pad_attr_4]: V(True)
+  logic dio_pad_attr_4_qe;
+  logic [0:0] dio_pad_attr_4_flds_we;
+  assign dio_pad_attr_4_qe = &dio_pad_attr_4_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_4 (
@@ -7884,14 +8035,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_4_wd),
     .d      (hw2reg.dio_pad_attr[4].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[4].qe),
+    .qe     (dio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[4].q),
     .qs     (dio_pad_attr_4_qs)
   );
+  assign reg2hw.dio_pad_attr[4].qe = dio_pad_attr_4_qe;
 
 
   // Subregister 5 of Multireg dio_pad_attr
   // R[dio_pad_attr_5]: V(True)
+  logic dio_pad_attr_5_qe;
+  logic [0:0] dio_pad_attr_5_flds_we;
+  assign dio_pad_attr_5_qe = &dio_pad_attr_5_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_5 (
@@ -7900,14 +8055,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_5_wd),
     .d      (hw2reg.dio_pad_attr[5].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[5].qe),
+    .qe     (dio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[5].q),
     .qs     (dio_pad_attr_5_qs)
   );
+  assign reg2hw.dio_pad_attr[5].qe = dio_pad_attr_5_qe;
 
 
   // Subregister 6 of Multireg dio_pad_attr
   // R[dio_pad_attr_6]: V(True)
+  logic dio_pad_attr_6_qe;
+  logic [0:0] dio_pad_attr_6_flds_we;
+  assign dio_pad_attr_6_qe = &dio_pad_attr_6_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_6 (
@@ -7916,14 +8075,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_6_wd),
     .d      (hw2reg.dio_pad_attr[6].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[6].qe),
+    .qe     (dio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[6].q),
     .qs     (dio_pad_attr_6_qs)
   );
+  assign reg2hw.dio_pad_attr[6].qe = dio_pad_attr_6_qe;
 
 
   // Subregister 7 of Multireg dio_pad_attr
   // R[dio_pad_attr_7]: V(True)
+  logic dio_pad_attr_7_qe;
+  logic [0:0] dio_pad_attr_7_flds_we;
+  assign dio_pad_attr_7_qe = &dio_pad_attr_7_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_7 (
@@ -7932,14 +8095,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_7_wd),
     .d      (hw2reg.dio_pad_attr[7].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[7].qe),
+    .qe     (dio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[7].q),
     .qs     (dio_pad_attr_7_qs)
   );
+  assign reg2hw.dio_pad_attr[7].qe = dio_pad_attr_7_qe;
 
 
   // Subregister 8 of Multireg dio_pad_attr
   // R[dio_pad_attr_8]: V(True)
+  logic dio_pad_attr_8_qe;
+  logic [0:0] dio_pad_attr_8_flds_we;
+  assign dio_pad_attr_8_qe = &dio_pad_attr_8_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_8 (
@@ -7948,14 +8115,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_8_wd),
     .d      (hw2reg.dio_pad_attr[8].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[8].qe),
+    .qe     (dio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[8].q),
     .qs     (dio_pad_attr_8_qs)
   );
+  assign reg2hw.dio_pad_attr[8].qe = dio_pad_attr_8_qe;
 
 
   // Subregister 9 of Multireg dio_pad_attr
   // R[dio_pad_attr_9]: V(True)
+  logic dio_pad_attr_9_qe;
+  logic [0:0] dio_pad_attr_9_flds_we;
+  assign dio_pad_attr_9_qe = &dio_pad_attr_9_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_9 (
@@ -7964,14 +8135,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_9_wd),
     .d      (hw2reg.dio_pad_attr[9].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[9].qe),
+    .qe     (dio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[9].q),
     .qs     (dio_pad_attr_9_qs)
   );
+  assign reg2hw.dio_pad_attr[9].qe = dio_pad_attr_9_qe;
 
 
   // Subregister 10 of Multireg dio_pad_attr
   // R[dio_pad_attr_10]: V(True)
+  logic dio_pad_attr_10_qe;
+  logic [0:0] dio_pad_attr_10_flds_we;
+  assign dio_pad_attr_10_qe = &dio_pad_attr_10_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_10 (
@@ -7980,14 +8155,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_10_wd),
     .d      (hw2reg.dio_pad_attr[10].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[10].qe),
+    .qe     (dio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[10].q),
     .qs     (dio_pad_attr_10_qs)
   );
+  assign reg2hw.dio_pad_attr[10].qe = dio_pad_attr_10_qe;
 
 
   // Subregister 11 of Multireg dio_pad_attr
   // R[dio_pad_attr_11]: V(True)
+  logic dio_pad_attr_11_qe;
+  logic [0:0] dio_pad_attr_11_flds_we;
+  assign dio_pad_attr_11_qe = &dio_pad_attr_11_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_11 (
@@ -7996,14 +8175,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_11_wd),
     .d      (hw2reg.dio_pad_attr[11].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[11].qe),
+    .qe     (dio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[11].q),
     .qs     (dio_pad_attr_11_qs)
   );
+  assign reg2hw.dio_pad_attr[11].qe = dio_pad_attr_11_qe;
 
 
   // Subregister 12 of Multireg dio_pad_attr
   // R[dio_pad_attr_12]: V(True)
+  logic dio_pad_attr_12_qe;
+  logic [0:0] dio_pad_attr_12_flds_we;
+  assign dio_pad_attr_12_qe = &dio_pad_attr_12_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_12 (
@@ -8012,14 +8195,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_12_wd),
     .d      (hw2reg.dio_pad_attr[12].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[12].qe),
+    .qe     (dio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[12].q),
     .qs     (dio_pad_attr_12_qs)
   );
+  assign reg2hw.dio_pad_attr[12].qe = dio_pad_attr_12_qe;
 
 
   // Subregister 13 of Multireg dio_pad_attr
   // R[dio_pad_attr_13]: V(True)
+  logic dio_pad_attr_13_qe;
+  logic [0:0] dio_pad_attr_13_flds_we;
+  assign dio_pad_attr_13_qe = &dio_pad_attr_13_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_13 (
@@ -8028,14 +8215,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_13_wd),
     .d      (hw2reg.dio_pad_attr[13].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[13].qe),
+    .qe     (dio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[13].q),
     .qs     (dio_pad_attr_13_qs)
   );
+  assign reg2hw.dio_pad_attr[13].qe = dio_pad_attr_13_qe;
 
 
   // Subregister 14 of Multireg dio_pad_attr
   // R[dio_pad_attr_14]: V(True)
+  logic dio_pad_attr_14_qe;
+  logic [0:0] dio_pad_attr_14_flds_we;
+  assign dio_pad_attr_14_qe = &dio_pad_attr_14_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_14 (
@@ -8044,14 +8235,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_14_wd),
     .d      (hw2reg.dio_pad_attr[14].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[14].qe),
+    .qe     (dio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[14].q),
     .qs     (dio_pad_attr_14_qs)
   );
+  assign reg2hw.dio_pad_attr[14].qe = dio_pad_attr_14_qe;
 
 
   // Subregister 15 of Multireg dio_pad_attr
   // R[dio_pad_attr_15]: V(True)
+  logic dio_pad_attr_15_qe;
+  logic [0:0] dio_pad_attr_15_flds_we;
+  assign dio_pad_attr_15_qe = &dio_pad_attr_15_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_15 (
@@ -8060,10 +8255,11 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_15_wd),
     .d      (hw2reg.dio_pad_attr[15].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[15].qe),
+    .qe     (dio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[15].q),
     .qs     (dio_pad_attr_15_qs)
   );
+  assign reg2hw.dio_pad_attr[15].qe = dio_pad_attr_15_qe;
 
 
   // Subregister 0 of Multireg mio_pad_sleep_status

--- a/hw/ip/prim/rtl/prim_subreg.sv
+++ b/hw/ip/prim/rtl/prim_subreg.sv
@@ -45,14 +45,6 @@ module prim_subreg
     .wr_data
   );
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      qe <= 1'b0;
-    end else begin
-      qe <= we;
-    end
-  end
-
   logic wr_en_buf;
   prim_buf #(
     .Width(1)
@@ -60,6 +52,9 @@ module prim_subreg
     .in_i(wr_en),
     .out_o(wr_en_buf)
   );
+
+  // feed back out for consolidation
+  assign qe = wr_en_buf;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -179,8 +179,8 @@ module prim_subreg_shadow
   assign err_storage = (~shadow_q != committed_q);
 
   // Remaining output assignments
-  assign qe   = comitted_qe;
-  assign q    = committed_q;
-  assign qs   = committed_qs;
+  assign qe = committed_qe;
+  assign q  = committed_q;
+  assign qs = committed_qs;
 
 endmodule

--- a/hw/ip/prim/rtl/prim_subreg_shadow.sv
+++ b/hw/ip/prim/rtl/prim_subreg_shadow.sv
@@ -179,8 +179,8 @@ module prim_subreg_shadow
   assign err_storage = (~shadow_q != committed_q);
 
   // Remaining output assignments
-  assign qe = committed_qe;
-  assign q  = committed_q;
-  assign qs = committed_qs;
+  assign qe   = comitted_qe;
+  assign q    = committed_q;
+  assign qs   = committed_qs;
 
 endmodule

--- a/hw/ip/pwm/rtl/pwm_reg_top.sv
+++ b/hw/ip/pwm/rtl/pwm_reg_top.sv
@@ -1043,6 +1043,9 @@ module pwm_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1051,10 +1054,11 @@ module pwm_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[regwen]: V(False)
@@ -1084,6 +1088,17 @@ module pwm_reg_top (
 
 
   // R[cfg]: V(False)
+  logic cfg_qe;
+  logic [2:0] cfg_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_cfg0_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&cfg_flds_we),
+    .q_o(cfg_qe)
+  );
   //   F[clk_div]: 26:0
   prim_subreg #(
     .DW      (27),
@@ -1102,12 +1117,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg.clk_div.qe),
+    .qe     (cfg_flds_we[0]),
     .q      (reg2hw.cfg.clk_div.q),
 
     // to register interface (read)
     .qs     (core_cfg_clk_div_qs_int)
   );
+  assign reg2hw.cfg.clk_div.qe = cfg_qe;
 
   //   F[dc_resn]: 30:27
   prim_subreg #(
@@ -1127,12 +1143,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg.dc_resn.qe),
+    .qe     (cfg_flds_we[1]),
     .q      (reg2hw.cfg.dc_resn.q),
 
     // to register interface (read)
     .qs     (core_cfg_dc_resn_qs_int)
   );
+  assign reg2hw.cfg.dc_resn.qe = cfg_qe;
 
   //   F[cntr_en]: 31:31
   prim_subreg #(
@@ -1152,16 +1169,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.cfg.cntr_en.qe),
+    .qe     (cfg_flds_we[2]),
     .q      (reg2hw.cfg.cntr_en.q),
 
     // to register interface (read)
     .qs     (core_cfg_cntr_en_qs_int)
   );
+  assign reg2hw.cfg.cntr_en.qe = cfg_qe;
 
 
   // Subregister 0 of Multireg pwm_en
   // R[pwm_en]: V(False)
+  logic pwm_en_qe;
+  logic [5:0] pwm_en_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_pwm_en0_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&pwm_en_flds_we),
+    .q_o(pwm_en_qe)
+  );
   //   F[en_0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1180,12 +1209,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_en[0].qe),
+    .qe     (pwm_en_flds_we[0]),
     .q      (reg2hw.pwm_en[0].q),
 
     // to register interface (read)
     .qs     (core_pwm_en_en_0_qs_int)
   );
+  assign reg2hw.pwm_en[0].qe = pwm_en_qe;
 
   //   F[en_1]: 1:1
   prim_subreg #(
@@ -1205,12 +1235,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_en[1].qe),
+    .qe     (pwm_en_flds_we[1]),
     .q      (reg2hw.pwm_en[1].q),
 
     // to register interface (read)
     .qs     (core_pwm_en_en_1_qs_int)
   );
+  assign reg2hw.pwm_en[1].qe = pwm_en_qe;
 
   //   F[en_2]: 2:2
   prim_subreg #(
@@ -1230,12 +1261,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_en[2].qe),
+    .qe     (pwm_en_flds_we[2]),
     .q      (reg2hw.pwm_en[2].q),
 
     // to register interface (read)
     .qs     (core_pwm_en_en_2_qs_int)
   );
+  assign reg2hw.pwm_en[2].qe = pwm_en_qe;
 
   //   F[en_3]: 3:3
   prim_subreg #(
@@ -1255,12 +1287,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_en[3].qe),
+    .qe     (pwm_en_flds_we[3]),
     .q      (reg2hw.pwm_en[3].q),
 
     // to register interface (read)
     .qs     (core_pwm_en_en_3_qs_int)
   );
+  assign reg2hw.pwm_en[3].qe = pwm_en_qe;
 
   //   F[en_4]: 4:4
   prim_subreg #(
@@ -1280,12 +1313,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_en[4].qe),
+    .qe     (pwm_en_flds_we[4]),
     .q      (reg2hw.pwm_en[4].q),
 
     // to register interface (read)
     .qs     (core_pwm_en_en_4_qs_int)
   );
+  assign reg2hw.pwm_en[4].qe = pwm_en_qe;
 
   //   F[en_5]: 5:5
   prim_subreg #(
@@ -1305,16 +1339,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_en[5].qe),
+    .qe     (pwm_en_flds_we[5]),
     .q      (reg2hw.pwm_en[5].q),
 
     // to register interface (read)
     .qs     (core_pwm_en_en_5_qs_int)
   );
+  assign reg2hw.pwm_en[5].qe = pwm_en_qe;
 
 
   // Subregister 0 of Multireg invert
   // R[invert]: V(False)
+  logic invert_qe;
+  logic [5:0] invert_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_invert0_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&invert_flds_we),
+    .q_o(invert_qe)
+  );
   //   F[invert_0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1333,12 +1379,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.invert[0].qe),
+    .qe     (invert_flds_we[0]),
     .q      (reg2hw.invert[0].q),
 
     // to register interface (read)
     .qs     (core_invert_invert_0_qs_int)
   );
+  assign reg2hw.invert[0].qe = invert_qe;
 
   //   F[invert_1]: 1:1
   prim_subreg #(
@@ -1358,12 +1405,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.invert[1].qe),
+    .qe     (invert_flds_we[1]),
     .q      (reg2hw.invert[1].q),
 
     // to register interface (read)
     .qs     (core_invert_invert_1_qs_int)
   );
+  assign reg2hw.invert[1].qe = invert_qe;
 
   //   F[invert_2]: 2:2
   prim_subreg #(
@@ -1383,12 +1431,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.invert[2].qe),
+    .qe     (invert_flds_we[2]),
     .q      (reg2hw.invert[2].q),
 
     // to register interface (read)
     .qs     (core_invert_invert_2_qs_int)
   );
+  assign reg2hw.invert[2].qe = invert_qe;
 
   //   F[invert_3]: 3:3
   prim_subreg #(
@@ -1408,12 +1457,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.invert[3].qe),
+    .qe     (invert_flds_we[3]),
     .q      (reg2hw.invert[3].q),
 
     // to register interface (read)
     .qs     (core_invert_invert_3_qs_int)
   );
+  assign reg2hw.invert[3].qe = invert_qe;
 
   //   F[invert_4]: 4:4
   prim_subreg #(
@@ -1433,12 +1483,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.invert[4].qe),
+    .qe     (invert_flds_we[4]),
     .q      (reg2hw.invert[4].q),
 
     // to register interface (read)
     .qs     (core_invert_invert_4_qs_int)
   );
+  assign reg2hw.invert[4].qe = invert_qe;
 
   //   F[invert_5]: 5:5
   prim_subreg #(
@@ -1458,16 +1509,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.invert[5].qe),
+    .qe     (invert_flds_we[5]),
     .q      (reg2hw.invert[5].q),
 
     // to register interface (read)
     .qs     (core_invert_invert_5_qs_int)
   );
+  assign reg2hw.invert[5].qe = invert_qe;
 
 
   // Subregister 0 of Multireg pwm_param
   // R[pwm_param_0]: V(False)
+  logic pwm_param_0_qe;
+  logic [2:0] pwm_param_0_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_pwm_param0_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&pwm_param_0_flds_we),
+    .q_o(pwm_param_0_qe)
+  );
   //   F[phase_delay_0]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1486,12 +1549,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[0].phase_delay.qe),
+    .qe     (pwm_param_0_flds_we[0]),
     .q      (reg2hw.pwm_param[0].phase_delay.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_0_phase_delay_0_qs_int)
   );
+  assign reg2hw.pwm_param[0].phase_delay.qe = pwm_param_0_qe;
 
   //   F[htbt_en_0]: 30:30
   prim_subreg #(
@@ -1511,12 +1575,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[0].htbt_en.qe),
+    .qe     (pwm_param_0_flds_we[1]),
     .q      (reg2hw.pwm_param[0].htbt_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_0_htbt_en_0_qs_int)
   );
+  assign reg2hw.pwm_param[0].htbt_en.qe = pwm_param_0_qe;
 
   //   F[blink_en_0]: 31:31
   prim_subreg #(
@@ -1536,16 +1601,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[0].blink_en.qe),
+    .qe     (pwm_param_0_flds_we[2]),
     .q      (reg2hw.pwm_param[0].blink_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_0_blink_en_0_qs_int)
   );
+  assign reg2hw.pwm_param[0].blink_en.qe = pwm_param_0_qe;
 
 
   // Subregister 1 of Multireg pwm_param
   // R[pwm_param_1]: V(False)
+  logic pwm_param_1_qe;
+  logic [2:0] pwm_param_1_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_pwm_param1_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&pwm_param_1_flds_we),
+    .q_o(pwm_param_1_qe)
+  );
   //   F[phase_delay_1]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1564,12 +1641,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[1].phase_delay.qe),
+    .qe     (pwm_param_1_flds_we[0]),
     .q      (reg2hw.pwm_param[1].phase_delay.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_1_phase_delay_1_qs_int)
   );
+  assign reg2hw.pwm_param[1].phase_delay.qe = pwm_param_1_qe;
 
   //   F[htbt_en_1]: 30:30
   prim_subreg #(
@@ -1589,12 +1667,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[1].htbt_en.qe),
+    .qe     (pwm_param_1_flds_we[1]),
     .q      (reg2hw.pwm_param[1].htbt_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_1_htbt_en_1_qs_int)
   );
+  assign reg2hw.pwm_param[1].htbt_en.qe = pwm_param_1_qe;
 
   //   F[blink_en_1]: 31:31
   prim_subreg #(
@@ -1614,16 +1693,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[1].blink_en.qe),
+    .qe     (pwm_param_1_flds_we[2]),
     .q      (reg2hw.pwm_param[1].blink_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_1_blink_en_1_qs_int)
   );
+  assign reg2hw.pwm_param[1].blink_en.qe = pwm_param_1_qe;
 
 
   // Subregister 2 of Multireg pwm_param
   // R[pwm_param_2]: V(False)
+  logic pwm_param_2_qe;
+  logic [2:0] pwm_param_2_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_pwm_param2_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&pwm_param_2_flds_we),
+    .q_o(pwm_param_2_qe)
+  );
   //   F[phase_delay_2]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1642,12 +1733,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[2].phase_delay.qe),
+    .qe     (pwm_param_2_flds_we[0]),
     .q      (reg2hw.pwm_param[2].phase_delay.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_2_phase_delay_2_qs_int)
   );
+  assign reg2hw.pwm_param[2].phase_delay.qe = pwm_param_2_qe;
 
   //   F[htbt_en_2]: 30:30
   prim_subreg #(
@@ -1667,12 +1759,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[2].htbt_en.qe),
+    .qe     (pwm_param_2_flds_we[1]),
     .q      (reg2hw.pwm_param[2].htbt_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_2_htbt_en_2_qs_int)
   );
+  assign reg2hw.pwm_param[2].htbt_en.qe = pwm_param_2_qe;
 
   //   F[blink_en_2]: 31:31
   prim_subreg #(
@@ -1692,16 +1785,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[2].blink_en.qe),
+    .qe     (pwm_param_2_flds_we[2]),
     .q      (reg2hw.pwm_param[2].blink_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_2_blink_en_2_qs_int)
   );
+  assign reg2hw.pwm_param[2].blink_en.qe = pwm_param_2_qe;
 
 
   // Subregister 3 of Multireg pwm_param
   // R[pwm_param_3]: V(False)
+  logic pwm_param_3_qe;
+  logic [2:0] pwm_param_3_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_pwm_param3_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&pwm_param_3_flds_we),
+    .q_o(pwm_param_3_qe)
+  );
   //   F[phase_delay_3]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1720,12 +1825,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[3].phase_delay.qe),
+    .qe     (pwm_param_3_flds_we[0]),
     .q      (reg2hw.pwm_param[3].phase_delay.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_3_phase_delay_3_qs_int)
   );
+  assign reg2hw.pwm_param[3].phase_delay.qe = pwm_param_3_qe;
 
   //   F[htbt_en_3]: 30:30
   prim_subreg #(
@@ -1745,12 +1851,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[3].htbt_en.qe),
+    .qe     (pwm_param_3_flds_we[1]),
     .q      (reg2hw.pwm_param[3].htbt_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_3_htbt_en_3_qs_int)
   );
+  assign reg2hw.pwm_param[3].htbt_en.qe = pwm_param_3_qe;
 
   //   F[blink_en_3]: 31:31
   prim_subreg #(
@@ -1770,16 +1877,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[3].blink_en.qe),
+    .qe     (pwm_param_3_flds_we[2]),
     .q      (reg2hw.pwm_param[3].blink_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_3_blink_en_3_qs_int)
   );
+  assign reg2hw.pwm_param[3].blink_en.qe = pwm_param_3_qe;
 
 
   // Subregister 4 of Multireg pwm_param
   // R[pwm_param_4]: V(False)
+  logic pwm_param_4_qe;
+  logic [2:0] pwm_param_4_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_pwm_param4_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&pwm_param_4_flds_we),
+    .q_o(pwm_param_4_qe)
+  );
   //   F[phase_delay_4]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1798,12 +1917,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[4].phase_delay.qe),
+    .qe     (pwm_param_4_flds_we[0]),
     .q      (reg2hw.pwm_param[4].phase_delay.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_4_phase_delay_4_qs_int)
   );
+  assign reg2hw.pwm_param[4].phase_delay.qe = pwm_param_4_qe;
 
   //   F[htbt_en_4]: 30:30
   prim_subreg #(
@@ -1823,12 +1943,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[4].htbt_en.qe),
+    .qe     (pwm_param_4_flds_we[1]),
     .q      (reg2hw.pwm_param[4].htbt_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_4_htbt_en_4_qs_int)
   );
+  assign reg2hw.pwm_param[4].htbt_en.qe = pwm_param_4_qe;
 
   //   F[blink_en_4]: 31:31
   prim_subreg #(
@@ -1848,16 +1969,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[4].blink_en.qe),
+    .qe     (pwm_param_4_flds_we[2]),
     .q      (reg2hw.pwm_param[4].blink_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_4_blink_en_4_qs_int)
   );
+  assign reg2hw.pwm_param[4].blink_en.qe = pwm_param_4_qe;
 
 
   // Subregister 5 of Multireg pwm_param
   // R[pwm_param_5]: V(False)
+  logic pwm_param_5_qe;
+  logic [2:0] pwm_param_5_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_pwm_param5_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&pwm_param_5_flds_we),
+    .q_o(pwm_param_5_qe)
+  );
   //   F[phase_delay_5]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1876,12 +2009,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[5].phase_delay.qe),
+    .qe     (pwm_param_5_flds_we[0]),
     .q      (reg2hw.pwm_param[5].phase_delay.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_5_phase_delay_5_qs_int)
   );
+  assign reg2hw.pwm_param[5].phase_delay.qe = pwm_param_5_qe;
 
   //   F[htbt_en_5]: 30:30
   prim_subreg #(
@@ -1901,12 +2035,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[5].htbt_en.qe),
+    .qe     (pwm_param_5_flds_we[1]),
     .q      (reg2hw.pwm_param[5].htbt_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_5_htbt_en_5_qs_int)
   );
+  assign reg2hw.pwm_param[5].htbt_en.qe = pwm_param_5_qe;
 
   //   F[blink_en_5]: 31:31
   prim_subreg #(
@@ -1926,16 +2061,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.pwm_param[5].blink_en.qe),
+    .qe     (pwm_param_5_flds_we[2]),
     .q      (reg2hw.pwm_param[5].blink_en.q),
 
     // to register interface (read)
     .qs     (core_pwm_param_5_blink_en_5_qs_int)
   );
+  assign reg2hw.pwm_param[5].blink_en.qe = pwm_param_5_qe;
 
 
   // Subregister 0 of Multireg duty_cycle
   // R[duty_cycle_0]: V(False)
+  logic duty_cycle_0_qe;
+  logic [1:0] duty_cycle_0_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_duty_cycle0_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&duty_cycle_0_flds_we),
+    .q_o(duty_cycle_0_qe)
+  );
   //   F[a_0]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -1954,12 +2101,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[0].a.qe),
+    .qe     (duty_cycle_0_flds_we[0]),
     .q      (reg2hw.duty_cycle[0].a.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_0_a_0_qs_int)
   );
+  assign reg2hw.duty_cycle[0].a.qe = duty_cycle_0_qe;
 
   //   F[b_0]: 31:16
   prim_subreg #(
@@ -1979,16 +2127,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[0].b.qe),
+    .qe     (duty_cycle_0_flds_we[1]),
     .q      (reg2hw.duty_cycle[0].b.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_0_b_0_qs_int)
   );
+  assign reg2hw.duty_cycle[0].b.qe = duty_cycle_0_qe;
 
 
   // Subregister 1 of Multireg duty_cycle
   // R[duty_cycle_1]: V(False)
+  logic duty_cycle_1_qe;
+  logic [1:0] duty_cycle_1_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_duty_cycle1_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&duty_cycle_1_flds_we),
+    .q_o(duty_cycle_1_qe)
+  );
   //   F[a_1]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2007,12 +2167,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[1].a.qe),
+    .qe     (duty_cycle_1_flds_we[0]),
     .q      (reg2hw.duty_cycle[1].a.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_1_a_1_qs_int)
   );
+  assign reg2hw.duty_cycle[1].a.qe = duty_cycle_1_qe;
 
   //   F[b_1]: 31:16
   prim_subreg #(
@@ -2032,16 +2193,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[1].b.qe),
+    .qe     (duty_cycle_1_flds_we[1]),
     .q      (reg2hw.duty_cycle[1].b.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_1_b_1_qs_int)
   );
+  assign reg2hw.duty_cycle[1].b.qe = duty_cycle_1_qe;
 
 
   // Subregister 2 of Multireg duty_cycle
   // R[duty_cycle_2]: V(False)
+  logic duty_cycle_2_qe;
+  logic [1:0] duty_cycle_2_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_duty_cycle2_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&duty_cycle_2_flds_we),
+    .q_o(duty_cycle_2_qe)
+  );
   //   F[a_2]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2060,12 +2233,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[2].a.qe),
+    .qe     (duty_cycle_2_flds_we[0]),
     .q      (reg2hw.duty_cycle[2].a.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_2_a_2_qs_int)
   );
+  assign reg2hw.duty_cycle[2].a.qe = duty_cycle_2_qe;
 
   //   F[b_2]: 31:16
   prim_subreg #(
@@ -2085,16 +2259,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[2].b.qe),
+    .qe     (duty_cycle_2_flds_we[1]),
     .q      (reg2hw.duty_cycle[2].b.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_2_b_2_qs_int)
   );
+  assign reg2hw.duty_cycle[2].b.qe = duty_cycle_2_qe;
 
 
   // Subregister 3 of Multireg duty_cycle
   // R[duty_cycle_3]: V(False)
+  logic duty_cycle_3_qe;
+  logic [1:0] duty_cycle_3_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_duty_cycle3_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&duty_cycle_3_flds_we),
+    .q_o(duty_cycle_3_qe)
+  );
   //   F[a_3]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2113,12 +2299,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[3].a.qe),
+    .qe     (duty_cycle_3_flds_we[0]),
     .q      (reg2hw.duty_cycle[3].a.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_3_a_3_qs_int)
   );
+  assign reg2hw.duty_cycle[3].a.qe = duty_cycle_3_qe;
 
   //   F[b_3]: 31:16
   prim_subreg #(
@@ -2138,16 +2325,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[3].b.qe),
+    .qe     (duty_cycle_3_flds_we[1]),
     .q      (reg2hw.duty_cycle[3].b.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_3_b_3_qs_int)
   );
+  assign reg2hw.duty_cycle[3].b.qe = duty_cycle_3_qe;
 
 
   // Subregister 4 of Multireg duty_cycle
   // R[duty_cycle_4]: V(False)
+  logic duty_cycle_4_qe;
+  logic [1:0] duty_cycle_4_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_duty_cycle4_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&duty_cycle_4_flds_we),
+    .q_o(duty_cycle_4_qe)
+  );
   //   F[a_4]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2166,12 +2365,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[4].a.qe),
+    .qe     (duty_cycle_4_flds_we[0]),
     .q      (reg2hw.duty_cycle[4].a.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_4_a_4_qs_int)
   );
+  assign reg2hw.duty_cycle[4].a.qe = duty_cycle_4_qe;
 
   //   F[b_4]: 31:16
   prim_subreg #(
@@ -2191,16 +2391,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[4].b.qe),
+    .qe     (duty_cycle_4_flds_we[1]),
     .q      (reg2hw.duty_cycle[4].b.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_4_b_4_qs_int)
   );
+  assign reg2hw.duty_cycle[4].b.qe = duty_cycle_4_qe;
 
 
   // Subregister 5 of Multireg duty_cycle
   // R[duty_cycle_5]: V(False)
+  logic duty_cycle_5_qe;
+  logic [1:0] duty_cycle_5_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_duty_cycle5_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&duty_cycle_5_flds_we),
+    .q_o(duty_cycle_5_qe)
+  );
   //   F[a_5]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2219,12 +2431,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[5].a.qe),
+    .qe     (duty_cycle_5_flds_we[0]),
     .q      (reg2hw.duty_cycle[5].a.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_5_a_5_qs_int)
   );
+  assign reg2hw.duty_cycle[5].a.qe = duty_cycle_5_qe;
 
   //   F[b_5]: 31:16
   prim_subreg #(
@@ -2244,16 +2457,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.duty_cycle[5].b.qe),
+    .qe     (duty_cycle_5_flds_we[1]),
     .q      (reg2hw.duty_cycle[5].b.q),
 
     // to register interface (read)
     .qs     (core_duty_cycle_5_b_5_qs_int)
   );
+  assign reg2hw.duty_cycle[5].b.qe = duty_cycle_5_qe;
 
 
   // Subregister 0 of Multireg blink_param
   // R[blink_param_0]: V(False)
+  logic blink_param_0_qe;
+  logic [1:0] blink_param_0_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_blink_param0_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&blink_param_0_flds_we),
+    .q_o(blink_param_0_qe)
+  );
   //   F[x_0]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2272,12 +2497,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[0].x.qe),
+    .qe     (blink_param_0_flds_we[0]),
     .q      (reg2hw.blink_param[0].x.q),
 
     // to register interface (read)
     .qs     (core_blink_param_0_x_0_qs_int)
   );
+  assign reg2hw.blink_param[0].x.qe = blink_param_0_qe;
 
   //   F[y_0]: 31:16
   prim_subreg #(
@@ -2297,16 +2523,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[0].y.qe),
+    .qe     (blink_param_0_flds_we[1]),
     .q      (reg2hw.blink_param[0].y.q),
 
     // to register interface (read)
     .qs     (core_blink_param_0_y_0_qs_int)
   );
+  assign reg2hw.blink_param[0].y.qe = blink_param_0_qe;
 
 
   // Subregister 1 of Multireg blink_param
   // R[blink_param_1]: V(False)
+  logic blink_param_1_qe;
+  logic [1:0] blink_param_1_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_blink_param1_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&blink_param_1_flds_we),
+    .q_o(blink_param_1_qe)
+  );
   //   F[x_1]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2325,12 +2563,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[1].x.qe),
+    .qe     (blink_param_1_flds_we[0]),
     .q      (reg2hw.blink_param[1].x.q),
 
     // to register interface (read)
     .qs     (core_blink_param_1_x_1_qs_int)
   );
+  assign reg2hw.blink_param[1].x.qe = blink_param_1_qe;
 
   //   F[y_1]: 31:16
   prim_subreg #(
@@ -2350,16 +2589,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[1].y.qe),
+    .qe     (blink_param_1_flds_we[1]),
     .q      (reg2hw.blink_param[1].y.q),
 
     // to register interface (read)
     .qs     (core_blink_param_1_y_1_qs_int)
   );
+  assign reg2hw.blink_param[1].y.qe = blink_param_1_qe;
 
 
   // Subregister 2 of Multireg blink_param
   // R[blink_param_2]: V(False)
+  logic blink_param_2_qe;
+  logic [1:0] blink_param_2_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_blink_param2_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&blink_param_2_flds_we),
+    .q_o(blink_param_2_qe)
+  );
   //   F[x_2]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2378,12 +2629,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[2].x.qe),
+    .qe     (blink_param_2_flds_we[0]),
     .q      (reg2hw.blink_param[2].x.q),
 
     // to register interface (read)
     .qs     (core_blink_param_2_x_2_qs_int)
   );
+  assign reg2hw.blink_param[2].x.qe = blink_param_2_qe;
 
   //   F[y_2]: 31:16
   prim_subreg #(
@@ -2403,16 +2655,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[2].y.qe),
+    .qe     (blink_param_2_flds_we[1]),
     .q      (reg2hw.blink_param[2].y.q),
 
     // to register interface (read)
     .qs     (core_blink_param_2_y_2_qs_int)
   );
+  assign reg2hw.blink_param[2].y.qe = blink_param_2_qe;
 
 
   // Subregister 3 of Multireg blink_param
   // R[blink_param_3]: V(False)
+  logic blink_param_3_qe;
+  logic [1:0] blink_param_3_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_blink_param3_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&blink_param_3_flds_we),
+    .q_o(blink_param_3_qe)
+  );
   //   F[x_3]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2431,12 +2695,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[3].x.qe),
+    .qe     (blink_param_3_flds_we[0]),
     .q      (reg2hw.blink_param[3].x.q),
 
     // to register interface (read)
     .qs     (core_blink_param_3_x_3_qs_int)
   );
+  assign reg2hw.blink_param[3].x.qe = blink_param_3_qe;
 
   //   F[y_3]: 31:16
   prim_subreg #(
@@ -2456,16 +2721,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[3].y.qe),
+    .qe     (blink_param_3_flds_we[1]),
     .q      (reg2hw.blink_param[3].y.q),
 
     // to register interface (read)
     .qs     (core_blink_param_3_y_3_qs_int)
   );
+  assign reg2hw.blink_param[3].y.qe = blink_param_3_qe;
 
 
   // Subregister 4 of Multireg blink_param
   // R[blink_param_4]: V(False)
+  logic blink_param_4_qe;
+  logic [1:0] blink_param_4_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_blink_param4_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&blink_param_4_flds_we),
+    .q_o(blink_param_4_qe)
+  );
   //   F[x_4]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2484,12 +2761,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[4].x.qe),
+    .qe     (blink_param_4_flds_we[0]),
     .q      (reg2hw.blink_param[4].x.q),
 
     // to register interface (read)
     .qs     (core_blink_param_4_x_4_qs_int)
   );
+  assign reg2hw.blink_param[4].x.qe = blink_param_4_qe;
 
   //   F[y_4]: 31:16
   prim_subreg #(
@@ -2509,16 +2787,28 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[4].y.qe),
+    .qe     (blink_param_4_flds_we[1]),
     .q      (reg2hw.blink_param[4].y.q),
 
     // to register interface (read)
     .qs     (core_blink_param_4_y_4_qs_int)
   );
+  assign reg2hw.blink_param[4].y.qe = blink_param_4_qe;
 
 
   // Subregister 5 of Multireg blink_param
   // R[blink_param_5]: V(False)
+  logic blink_param_5_qe;
+  logic [1:0] blink_param_5_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_blink_param5_qe (
+    .clk_i(clk_core_i),
+    .rst_ni(rst_core_ni),
+    .d_i(&blink_param_5_flds_we),
+    .q_o(blink_param_5_qe)
+  );
   //   F[x_5]: 15:0
   prim_subreg #(
     .DW      (16),
@@ -2537,12 +2827,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[5].x.qe),
+    .qe     (blink_param_5_flds_we[0]),
     .q      (reg2hw.blink_param[5].x.q),
 
     // to register interface (read)
     .qs     (core_blink_param_5_x_5_qs_int)
   );
+  assign reg2hw.blink_param[5].x.qe = blink_param_5_qe;
 
   //   F[y_5]: 31:16
   prim_subreg #(
@@ -2562,12 +2853,13 @@ module pwm_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.blink_param[5].y.qe),
+    .qe     (blink_param_5_flds_we[1]),
     .q      (reg2hw.blink_param[5].y.q),
 
     // to register interface (read)
     .qs     (core_blink_param_5_y_5_qs_int)
   );
+  assign reg2hw.blink_param[5].y.qe = blink_param_5_qe;
 
 
 

--- a/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_reg_top.sv
@@ -214,6 +214,9 @@ module pwrmgr_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [0:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -222,10 +225,11 @@ module pwrmgr_reg_top (
     .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.qe = intr_test_qe;
 
 
   // R[ctrl_cfg_regwen]: V(True)
@@ -396,6 +400,17 @@ module pwrmgr_reg_top (
 
 
   // R[cfg_cdc_sync]: V(False)
+  logic cfg_cdc_sync_qe;
+  logic [0:0] cfg_cdc_sync_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_cfg_cdc_sync0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&cfg_cdc_sync_flds_we),
+    .q_o(cfg_cdc_sync_qe)
+  );
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -413,12 +428,13 @@ module pwrmgr_reg_top (
     .d      (hw2reg.cfg_cdc_sync.d),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_cdc_sync.qe),
+    .qe     (cfg_cdc_sync_flds_we[0]),
     .q      (reg2hw.cfg_cdc_sync.q),
 
     // to register interface (read)
     .qs     (cfg_cdc_sync_qs)
   );
+  assign reg2hw.cfg_cdc_sync.qe = cfg_cdc_sync_qe;
 
 
   // R[wakeup_en_regwen]: V(False)
@@ -608,6 +624,9 @@ module pwrmgr_reg_top (
 
 
   // R[wake_info]: V(True)
+  logic wake_info_qe;
+  logic [2:0] wake_info_flds_we;
+  assign wake_info_qe = &wake_info_flds_we;
   //   F[reasons]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -617,10 +636,11 @@ module pwrmgr_reg_top (
     .wd     (wake_info_reasons_wd),
     .d      (hw2reg.wake_info.reasons.d),
     .qre    (),
-    .qe     (reg2hw.wake_info.reasons.qe),
+    .qe     (wake_info_flds_we[0]),
     .q      (reg2hw.wake_info.reasons.q),
     .qs     (wake_info_reasons_qs)
   );
+  assign reg2hw.wake_info.reasons.qe = wake_info_qe;
 
   //   F[fall_through]: 1:1
   prim_subreg_ext #(
@@ -631,10 +651,11 @@ module pwrmgr_reg_top (
     .wd     (wake_info_fall_through_wd),
     .d      (hw2reg.wake_info.fall_through.d),
     .qre    (),
-    .qe     (reg2hw.wake_info.fall_through.qe),
+    .qe     (wake_info_flds_we[1]),
     .q      (reg2hw.wake_info.fall_through.q),
     .qs     (wake_info_fall_through_qs)
   );
+  assign reg2hw.wake_info.fall_through.qe = wake_info_qe;
 
   //   F[abort]: 2:2
   prim_subreg_ext #(
@@ -645,10 +666,11 @@ module pwrmgr_reg_top (
     .wd     (wake_info_abort_wd),
     .d      (hw2reg.wake_info.abort.d),
     .qre    (),
-    .qe     (reg2hw.wake_info.abort.qe),
+    .qe     (wake_info_flds_we[2]),
     .q      (reg2hw.wake_info.abort.q),
     .qs     (wake_info_abort_qs)
   );
+  assign reg2hw.wake_info.abort.qe = wake_info_qe;
 
 
 

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_regs_reg_top.sv
@@ -131,6 +131,9 @@ module rom_ctrl_regs_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -139,10 +142,11 @@ module rom_ctrl_regs_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[fatal_alert_cause]: V(False)

--- a/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_reg_top.sv
@@ -378,6 +378,9 @@ module rstmgr_reg_top (
 
   // Subregister 0 of Multireg sw_rst_ctrl_n
   // R[sw_rst_ctrl_n]: V(True)
+  logic sw_rst_ctrl_n_qe;
+  logic [1:0] sw_rst_ctrl_n_flds_we;
+  assign sw_rst_ctrl_n_qe = &sw_rst_ctrl_n_flds_we;
   //   F[val_0]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -387,10 +390,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_0_wd),
     .d      (hw2reg.sw_rst_ctrl_n[0].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[0].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[0]),
     .q      (reg2hw.sw_rst_ctrl_n[0].q),
     .qs     (sw_rst_ctrl_n_val_0_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[0].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_1]: 1:1
   prim_subreg_ext #(
@@ -401,10 +405,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_1_wd),
     .d      (hw2reg.sw_rst_ctrl_n[1].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[1].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[1]),
     .q      (reg2hw.sw_rst_ctrl_n[1].q),
     .qs     (sw_rst_ctrl_n_val_1_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[1].qe = sw_rst_ctrl_n_qe;
 
 
 

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_cfg_reg_top.sv
@@ -194,6 +194,9 @@ module rv_core_ibex_cfg_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [3:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[fatal_sw_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -203,10 +206,11 @@ module rv_core_ibex_cfg_reg_top (
     .wd     (alert_test_fatal_sw_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_sw_err.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_sw_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_sw_err.qe = alert_test_qe;
 
   //   F[recov_sw_err]: 1:1
   prim_subreg_ext #(
@@ -217,10 +221,11 @@ module rv_core_ibex_cfg_reg_top (
     .wd     (alert_test_recov_sw_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_sw_err.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.recov_sw_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_sw_err.qe = alert_test_qe;
 
   //   F[fatal_hw_err]: 2:2
   prim_subreg_ext #(
@@ -231,10 +236,11 @@ module rv_core_ibex_cfg_reg_top (
     .wd     (alert_test_fatal_hw_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_hw_err.qe),
+    .qe     (alert_test_flds_we[2]),
     .q      (reg2hw.alert_test.fatal_hw_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_hw_err.qe = alert_test_qe;
 
   //   F[recov_hw_err]: 3:3
   prim_subreg_ext #(
@@ -245,10 +251,11 @@ module rv_core_ibex_cfg_reg_top (
     .wd     (alert_test_recov_hw_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_hw_err.qe),
+    .qe     (alert_test_flds_we[3]),
     .q      (reg2hw.alert_test.recov_hw_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_hw_err.qe = alert_test_qe;
 
 
   // R[sw_recov_err]: V(False)

--- a/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
+++ b/hw/ip/rv_dm/rtl/rv_dm_regs_reg_top.sv
@@ -112,6 +112,9 @@ module rv_dm_regs_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -120,10 +123,11 @@ module rv_dm_regs_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
 

--- a/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
+++ b/hw/ip/rv_timer/rtl/rv_timer_reg_top.sv
@@ -141,6 +141,9 @@ module rv_timer_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -149,10 +152,11 @@ module rv_timer_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // Subregister 0 of Multireg ctrl
@@ -287,6 +291,17 @@ module rv_timer_reg_top (
 
 
   // R[compare_lower0_0]: V(False)
+  logic compare_lower0_0_qe;
+  logic [0:0] compare_lower0_0_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_compare_lower0_00_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&compare_lower0_0_flds_we),
+    .q_o(compare_lower0_0_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -304,15 +319,27 @@ module rv_timer_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.compare_lower0_0.qe),
+    .qe     (compare_lower0_0_flds_we[0]),
     .q      (reg2hw.compare_lower0_0.q),
 
     // to register interface (read)
     .qs     (compare_lower0_0_qs)
   );
+  assign reg2hw.compare_lower0_0.qe = compare_lower0_0_qe;
 
 
   // R[compare_upper0_0]: V(False)
+  logic compare_upper0_0_qe;
+  logic [0:0] compare_upper0_0_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_compare_upper0_00_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&compare_upper0_0_flds_we),
+    .q_o(compare_upper0_0_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -330,12 +357,13 @@ module rv_timer_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.compare_upper0_0.qe),
+    .qe     (compare_upper0_0_flds_we[0]),
     .q      (reg2hw.compare_upper0_0.q),
 
     // to register interface (read)
     .qs     (compare_upper0_0_qs)
   );
+  assign reg2hw.compare_upper0_0.qe = compare_upper0_0_qe;
 
 
   // Subregister 0 of Multireg intr_enable0
@@ -394,6 +422,9 @@ module rv_timer_reg_top (
 
   // Subregister 0 of Multireg intr_test0
   // R[intr_test0]: V(True)
+  logic intr_test0_qe;
+  logic [0:0] intr_test0_flds_we;
+  assign intr_test0_qe = &intr_test0_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test0 (
@@ -402,10 +433,11 @@ module rv_timer_reg_top (
     .wd     (intr_test0_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test0[0].qe),
+    .qe     (intr_test0_flds_we[0]),
     .q      (reg2hw.intr_test0[0].q),
     .qs     ()
   );
+  assign reg2hw.intr_test0[0].qe = intr_test0_qe;
 
 
 

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -2082,6 +2082,9 @@ module spi_device_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [10:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[generic_rx_full]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -2091,10 +2094,11 @@ module spi_device_reg_top (
     .wd     (intr_test_generic_rx_full_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.generic_rx_full.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.generic_rx_full.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.generic_rx_full.qe = intr_test_qe;
 
   //   F[generic_rx_watermark]: 1:1
   prim_subreg_ext #(
@@ -2105,10 +2109,11 @@ module spi_device_reg_top (
     .wd     (intr_test_generic_rx_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.generic_rx_watermark.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.generic_rx_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.generic_rx_watermark.qe = intr_test_qe;
 
   //   F[generic_tx_watermark]: 2:2
   prim_subreg_ext #(
@@ -2119,10 +2124,11 @@ module spi_device_reg_top (
     .wd     (intr_test_generic_tx_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.generic_tx_watermark.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.generic_tx_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.generic_tx_watermark.qe = intr_test_qe;
 
   //   F[generic_rx_error]: 3:3
   prim_subreg_ext #(
@@ -2133,10 +2139,11 @@ module spi_device_reg_top (
     .wd     (intr_test_generic_rx_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.generic_rx_error.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.generic_rx_error.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.generic_rx_error.qe = intr_test_qe;
 
   //   F[generic_rx_overflow]: 4:4
   prim_subreg_ext #(
@@ -2147,10 +2154,11 @@ module spi_device_reg_top (
     .wd     (intr_test_generic_rx_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.generic_rx_overflow.qe),
+    .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.generic_rx_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.generic_rx_overflow.qe = intr_test_qe;
 
   //   F[generic_tx_underflow]: 5:5
   prim_subreg_ext #(
@@ -2161,10 +2169,11 @@ module spi_device_reg_top (
     .wd     (intr_test_generic_tx_underflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.generic_tx_underflow.qe),
+    .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.generic_tx_underflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.generic_tx_underflow.qe = intr_test_qe;
 
   //   F[upload_cmdfifo_not_empty]: 6:6
   prim_subreg_ext #(
@@ -2175,10 +2184,11 @@ module spi_device_reg_top (
     .wd     (intr_test_upload_cmdfifo_not_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.upload_cmdfifo_not_empty.qe),
+    .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.upload_cmdfifo_not_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.upload_cmdfifo_not_empty.qe = intr_test_qe;
 
   //   F[upload_payload_not_empty]: 7:7
   prim_subreg_ext #(
@@ -2189,10 +2199,11 @@ module spi_device_reg_top (
     .wd     (intr_test_upload_payload_not_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.upload_payload_not_empty.qe),
+    .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.upload_payload_not_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.upload_payload_not_empty.qe = intr_test_qe;
 
   //   F[readbuf_watermark]: 8:8
   prim_subreg_ext #(
@@ -2203,10 +2214,11 @@ module spi_device_reg_top (
     .wd     (intr_test_readbuf_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.readbuf_watermark.qe),
+    .qe     (intr_test_flds_we[8]),
     .q      (reg2hw.intr_test.readbuf_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.readbuf_watermark.qe = intr_test_qe;
 
   //   F[readbuf_flip]: 9:9
   prim_subreg_ext #(
@@ -2217,10 +2229,11 @@ module spi_device_reg_top (
     .wd     (intr_test_readbuf_flip_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.readbuf_flip.qe),
+    .qe     (intr_test_flds_we[9]),
     .q      (reg2hw.intr_test.readbuf_flip.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.readbuf_flip.qe = intr_test_qe;
 
   //   F[tpm_header_not_empty]: 10:10
   prim_subreg_ext #(
@@ -2231,13 +2244,17 @@ module spi_device_reg_top (
     .wd     (intr_test_tpm_header_not_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tpm_header_not_empty.qe),
+    .qe     (intr_test_flds_we[10]),
     .q      (reg2hw.intr_test.tpm_header_not_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tpm_header_not_empty.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -2246,10 +2263,11 @@ module spi_device_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[control]: V(False)
@@ -3050,6 +3068,9 @@ module spi_device_reg_top (
 
 
   // R[flash_status]: V(True)
+  logic flash_status_qe;
+  logic [1:0] flash_status_flds_we;
+  assign flash_status_qe = &flash_status_flds_we;
   //   F[busy]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -3059,10 +3080,11 @@ module spi_device_reg_top (
     .wd     (flash_status_busy_wd),
     .d      (hw2reg.flash_status.busy.d),
     .qre    (),
-    .qe     (reg2hw.flash_status.busy.qe),
+    .qe     (flash_status_flds_we[0]),
     .q      (reg2hw.flash_status.busy.q),
     .qs     (flash_status_busy_qs)
   );
+  assign reg2hw.flash_status.busy.qe = flash_status_qe;
 
   //   F[status]: 23:1
   prim_subreg_ext #(
@@ -3073,10 +3095,11 @@ module spi_device_reg_top (
     .wd     (flash_status_status_wd),
     .d      (hw2reg.flash_status.status.d),
     .qre    (),
-    .qe     (reg2hw.flash_status.status.qe),
+    .qe     (flash_status_flds_we[1]),
     .q      (reg2hw.flash_status.status.q),
     .qs     (flash_status_status_qs)
   );
+  assign reg2hw.flash_status.status.qe = flash_status_qe;
 
 
   // R[jedec_cc]: V(False)
@@ -17941,6 +17964,9 @@ module spi_device_reg_top (
 
 
   // R[tpm_cmd_addr]: V(True)
+  logic tpm_cmd_addr_qe;
+  logic [1:0] tpm_cmd_addr_flds_we;
+  assign tpm_cmd_addr_qe = &tpm_cmd_addr_flds_we;
   //   F[addr]: 23:0
   prim_subreg_ext #(
     .DW    (24)
@@ -17950,10 +17976,11 @@ module spi_device_reg_top (
     .wd     ('0),
     .d      (hw2reg.tpm_cmd_addr.addr.d),
     .qre    (reg2hw.tpm_cmd_addr.addr.re),
-    .qe     (reg2hw.tpm_cmd_addr.addr.qe),
+    .qe     (tpm_cmd_addr_flds_we[0]),
     .q      (reg2hw.tpm_cmd_addr.addr.q),
     .qs     (tpm_cmd_addr_addr_qs)
   );
+  assign reg2hw.tpm_cmd_addr.addr.qe = tpm_cmd_addr_qe;
 
   //   F[cmd]: 31:24
   prim_subreg_ext #(
@@ -17964,13 +17991,17 @@ module spi_device_reg_top (
     .wd     ('0),
     .d      (hw2reg.tpm_cmd_addr.cmd.d),
     .qre    (reg2hw.tpm_cmd_addr.cmd.re),
-    .qe     (reg2hw.tpm_cmd_addr.cmd.qe),
+    .qe     (tpm_cmd_addr_flds_we[1]),
     .q      (reg2hw.tpm_cmd_addr.cmd.q),
     .qs     (tpm_cmd_addr_cmd_qs)
   );
+  assign reg2hw.tpm_cmd_addr.cmd.qe = tpm_cmd_addr_qe;
 
 
   // R[tpm_read_fifo]: V(True)
+  logic tpm_read_fifo_qe;
+  logic [0:0] tpm_read_fifo_flds_we;
+  assign tpm_read_fifo_qe = &tpm_read_fifo_flds_we;
   prim_subreg_ext #(
     .DW    (8)
   ) u_tpm_read_fifo (
@@ -17979,13 +18010,17 @@ module spi_device_reg_top (
     .wd     (tpm_read_fifo_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.tpm_read_fifo.qe),
+    .qe     (tpm_read_fifo_flds_we[0]),
     .q      (reg2hw.tpm_read_fifo.q),
     .qs     ()
   );
+  assign reg2hw.tpm_read_fifo.qe = tpm_read_fifo_qe;
 
 
   // R[tpm_write_fifo]: V(True)
+  logic tpm_write_fifo_qe;
+  logic [0:0] tpm_write_fifo_flds_we;
+  assign tpm_write_fifo_qe = &tpm_write_fifo_flds_we;
   prim_subreg_ext #(
     .DW    (8)
   ) u_tpm_write_fifo (
@@ -17994,10 +18029,11 @@ module spi_device_reg_top (
     .wd     ('0),
     .d      (hw2reg.tpm_write_fifo.d),
     .qre    (reg2hw.tpm_write_fifo.re),
-    .qe     (reg2hw.tpm_write_fifo.qe),
+    .qe     (tpm_write_fifo_flds_we[0]),
     .q      (reg2hw.tpm_write_fifo.q),
     .qs     (tpm_write_fifo_qs)
   );
+  assign reg2hw.tpm_write_fifo.qe = tpm_write_fifo_qe;
 
 
 

--- a/hw/ip/spi_host/rtl/spi_host_reg_top.sv
+++ b/hw/ip/spi_host/rtl/spi_host_reg_top.sv
@@ -374,6 +374,9 @@ module spi_host_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [1:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[error]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -383,10 +386,11 @@ module spi_host_reg_top (
     .wd     (intr_test_error_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.error.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.error.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.error.qe = intr_test_qe;
 
   //   F[spi_event]: 1:1
   prim_subreg_ext #(
@@ -397,13 +401,17 @@ module spi_host_reg_top (
     .wd     (intr_test_spi_event_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.spi_event.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.spi_event.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.spi_event.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -412,10 +420,11 @@ module spi_host_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[control]: V(False)
@@ -1102,6 +1111,9 @@ module spi_host_reg_top (
 
 
   // R[command]: V(True)
+  logic command_qe;
+  logic [3:0] command_flds_we;
+  assign command_qe = &command_flds_we;
   //   F[len]: 8:0
   prim_subreg_ext #(
     .DW    (9)
@@ -1111,10 +1123,11 @@ module spi_host_reg_top (
     .wd     (command_len_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.command.len.qe),
+    .qe     (command_flds_we[0]),
     .q      (reg2hw.command.len.q),
     .qs     ()
   );
+  assign reg2hw.command.len.qe = command_qe;
 
   //   F[csaat]: 9:9
   prim_subreg_ext #(
@@ -1125,10 +1138,11 @@ module spi_host_reg_top (
     .wd     (command_csaat_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.command.csaat.qe),
+    .qe     (command_flds_we[1]),
     .q      (reg2hw.command.csaat.q),
     .qs     ()
   );
+  assign reg2hw.command.csaat.qe = command_qe;
 
   //   F[speed]: 11:10
   prim_subreg_ext #(
@@ -1139,10 +1153,11 @@ module spi_host_reg_top (
     .wd     (command_speed_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.command.speed.qe),
+    .qe     (command_flds_we[2]),
     .q      (reg2hw.command.speed.q),
     .qs     ()
   );
+  assign reg2hw.command.speed.qe = command_qe;
 
   //   F[direction]: 13:12
   prim_subreg_ext #(
@@ -1153,10 +1168,11 @@ module spi_host_reg_top (
     .wd     (command_direction_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.command.direction.qe),
+    .qe     (command_flds_we[3]),
     .q      (reg2hw.command.direction.q),
     .qs     ()
   );
+  assign reg2hw.command.direction.qe = command_qe;
 
 
   // R[error_enable]: V(False)

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl_regs_reg_top.sv
@@ -131,6 +131,9 @@ module sram_ctrl_regs_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -139,10 +142,11 @@ module sram_ctrl_regs_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[status]: V(False)
@@ -376,6 +380,17 @@ module sram_ctrl_regs_reg_top (
 
 
   // R[ctrl]: V(False)
+  logic ctrl_qe;
+  logic [1:0] ctrl_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_ctrl0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&ctrl_flds_we),
+    .q_o(ctrl_qe)
+  );
   //   F[renew_scr_key]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -394,12 +409,13 @@ module sram_ctrl_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.ctrl.renew_scr_key.qe),
+    .qe     (ctrl_flds_we[0]),
     .q      (reg2hw.ctrl.renew_scr_key.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.ctrl.renew_scr_key.qe = ctrl_qe;
 
   //   F[init]: 1:1
   prim_subreg #(
@@ -419,12 +435,13 @@ module sram_ctrl_regs_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.ctrl.init.qe),
+    .qe     (ctrl_flds_we[1]),
     .q      (reg2hw.ctrl.init.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.ctrl.init.qe = ctrl_qe;
 
 
 

--- a/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
+++ b/hw/ip/sysrst_ctrl/rtl/sysrst_ctrl_reg_top.sv
@@ -1559,6 +1559,9 @@ module sysrst_ctrl_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [0:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -1567,13 +1570,17 @@ module sysrst_ctrl_reg_top (
     .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1582,10 +1589,11 @@ module sysrst_ctrl_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[regwen]: V(False)

--- a/hw/ip/trial1/rtl/trial1_reg_top.sv
+++ b/hw/ip/trial1/rtl/trial1_reg_top.sv
@@ -910,6 +910,17 @@ module trial1_reg_top (
 
 
   // R[rwtype5]: V(False)
+  logic rwtype5_qe;
+  logic [0:0] rwtype5_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_rwtype50_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&rwtype5_flds_we),
+    .q_o(rwtype5_qe)
+  );
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -927,15 +938,19 @@ module trial1_reg_top (
     .d      (hw2reg.rwtype5.d),
 
     // to internal hardware
-    .qe     (reg2hw.rwtype5.qe),
+    .qe     (rwtype5_flds_we[0]),
     .q      (reg2hw.rwtype5.q),
 
     // to register interface (read)
     .qs     (rwtype5_qs)
   );
+  assign reg2hw.rwtype5.qe = rwtype5_qe;
 
 
   // R[rwtype6]: V(True)
+  logic rwtype6_qe;
+  logic [0:0] rwtype6_flds_we;
+  assign rwtype6_qe = &rwtype6_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_rwtype6 (
@@ -944,10 +959,11 @@ module trial1_reg_top (
     .wd     (rwtype6_wd),
     .d      (hw2reg.rwtype6.d),
     .qre    (),
-    .qe     (reg2hw.rwtype6.qe),
+    .qe     (rwtype6_flds_we[0]),
     .q      (reg2hw.rwtype6.q),
     .qs     (rwtype6_qs)
   );
+  assign reg2hw.rwtype6.qe = rwtype6_qe;
 
 
   // R[rotype1]: V(True)

--- a/hw/ip/uart/rtl/uart_reg_top.sv
+++ b/hw/ip/uart/rtl/uart_reg_top.sv
@@ -612,6 +612,9 @@ module uart_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [7:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[tx_watermark]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -621,10 +624,11 @@ module uart_reg_top (
     .wd     (intr_test_tx_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_watermark.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.tx_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tx_watermark.qe = intr_test_qe;
 
   //   F[rx_watermark]: 1:1
   prim_subreg_ext #(
@@ -635,10 +639,11 @@ module uart_reg_top (
     .wd     (intr_test_rx_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_watermark.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.rx_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_watermark.qe = intr_test_qe;
 
   //   F[tx_empty]: 2:2
   prim_subreg_ext #(
@@ -649,10 +654,11 @@ module uart_reg_top (
     .wd     (intr_test_tx_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_empty.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.tx_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tx_empty.qe = intr_test_qe;
 
   //   F[rx_overflow]: 3:3
   prim_subreg_ext #(
@@ -663,10 +669,11 @@ module uart_reg_top (
     .wd     (intr_test_rx_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_overflow.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rx_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_overflow.qe = intr_test_qe;
 
   //   F[rx_frame_err]: 4:4
   prim_subreg_ext #(
@@ -677,10 +684,11 @@ module uart_reg_top (
     .wd     (intr_test_rx_frame_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_frame_err.qe),
+    .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.rx_frame_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_frame_err.qe = intr_test_qe;
 
   //   F[rx_break_err]: 5:5
   prim_subreg_ext #(
@@ -691,10 +699,11 @@ module uart_reg_top (
     .wd     (intr_test_rx_break_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_break_err.qe),
+    .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.rx_break_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_break_err.qe = intr_test_qe;
 
   //   F[rx_timeout]: 6:6
   prim_subreg_ext #(
@@ -705,10 +714,11 @@ module uart_reg_top (
     .wd     (intr_test_rx_timeout_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_timeout.qe),
+    .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.rx_timeout.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_timeout.qe = intr_test_qe;
 
   //   F[rx_parity_err]: 7:7
   prim_subreg_ext #(
@@ -719,13 +729,17 @@ module uart_reg_top (
     .wd     (intr_test_rx_parity_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_parity_err.qe),
+    .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.rx_parity_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_parity_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -734,10 +748,11 @@ module uart_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[ctrl]: V(False)
@@ -1069,6 +1084,17 @@ module uart_reg_top (
 
 
   // R[wdata]: V(False)
+  logic wdata_qe;
+  logic [0:0] wdata_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_wdata0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&wdata_flds_we),
+    .q_o(wdata_qe)
+  );
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -1086,15 +1112,27 @@ module uart_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.wdata.qe),
+    .qe     (wdata_flds_we[0]),
     .q      (reg2hw.wdata.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.wdata.qe = wdata_qe;
 
 
   // R[fifo_ctrl]: V(False)
+  logic fifo_ctrl_qe;
+  logic [3:0] fifo_ctrl_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_fifo_ctrl0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&fifo_ctrl_flds_we),
+    .q_o(fifo_ctrl_qe)
+  );
   //   F[rxrst]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1113,12 +1151,13 @@ module uart_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxrst.qe),
+    .qe     (fifo_ctrl_flds_we[0]),
     .q      (reg2hw.fifo_ctrl.rxrst.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fifo_ctrl.rxrst.qe = fifo_ctrl_qe;
 
   //   F[txrst]: 1:1
   prim_subreg #(
@@ -1138,12 +1177,13 @@ module uart_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.txrst.qe),
+    .qe     (fifo_ctrl_flds_we[1]),
     .q      (reg2hw.fifo_ctrl.txrst.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.fifo_ctrl.txrst.qe = fifo_ctrl_qe;
 
   //   F[rxilvl]: 4:2
   prim_subreg #(
@@ -1163,12 +1203,13 @@ module uart_reg_top (
     .d      (hw2reg.fifo_ctrl.rxilvl.d),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxilvl.qe),
+    .qe     (fifo_ctrl_flds_we[2]),
     .q      (reg2hw.fifo_ctrl.rxilvl.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
   );
+  assign reg2hw.fifo_ctrl.rxilvl.qe = fifo_ctrl_qe;
 
   //   F[txilvl]: 6:5
   prim_subreg #(
@@ -1188,12 +1229,13 @@ module uart_reg_top (
     .d      (hw2reg.fifo_ctrl.txilvl.d),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.txilvl.qe),
+    .qe     (fifo_ctrl_flds_we[3]),
     .q      (reg2hw.fifo_ctrl.txilvl.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_txilvl_qs)
   );
+  assign reg2hw.fifo_ctrl.txilvl.qe = fifo_ctrl_qe;
 
 
   // R[fifo_status]: V(True)

--- a/hw/ip/usbdev/rtl/usbdev_reg_top.sv
+++ b/hw/ip/usbdev/rtl/usbdev_reg_top.sv
@@ -1724,6 +1724,9 @@ module usbdev_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [16:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[pkt_received]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1733,10 +1736,11 @@ module usbdev_reg_top (
     .wd     (intr_test_pkt_received_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.pkt_received.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.pkt_received.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.pkt_received.qe = intr_test_qe;
 
   //   F[pkt_sent]: 1:1
   prim_subreg_ext #(
@@ -1747,10 +1751,11 @@ module usbdev_reg_top (
     .wd     (intr_test_pkt_sent_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.pkt_sent.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.pkt_sent.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.pkt_sent.qe = intr_test_qe;
 
   //   F[disconnected]: 2:2
   prim_subreg_ext #(
@@ -1761,10 +1766,11 @@ module usbdev_reg_top (
     .wd     (intr_test_disconnected_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.disconnected.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.disconnected.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.disconnected.qe = intr_test_qe;
 
   //   F[host_lost]: 3:3
   prim_subreg_ext #(
@@ -1775,10 +1781,11 @@ module usbdev_reg_top (
     .wd     (intr_test_host_lost_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.host_lost.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.host_lost.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.host_lost.qe = intr_test_qe;
 
   //   F[link_reset]: 4:4
   prim_subreg_ext #(
@@ -1789,10 +1796,11 @@ module usbdev_reg_top (
     .wd     (intr_test_link_reset_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.link_reset.qe),
+    .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.link_reset.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.link_reset.qe = intr_test_qe;
 
   //   F[link_suspend]: 5:5
   prim_subreg_ext #(
@@ -1803,10 +1811,11 @@ module usbdev_reg_top (
     .wd     (intr_test_link_suspend_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.link_suspend.qe),
+    .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.link_suspend.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.link_suspend.qe = intr_test_qe;
 
   //   F[link_resume]: 6:6
   prim_subreg_ext #(
@@ -1817,10 +1826,11 @@ module usbdev_reg_top (
     .wd     (intr_test_link_resume_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.link_resume.qe),
+    .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.link_resume.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.link_resume.qe = intr_test_qe;
 
   //   F[av_empty]: 7:7
   prim_subreg_ext #(
@@ -1831,10 +1841,11 @@ module usbdev_reg_top (
     .wd     (intr_test_av_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.av_empty.qe),
+    .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.av_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.av_empty.qe = intr_test_qe;
 
   //   F[rx_full]: 8:8
   prim_subreg_ext #(
@@ -1845,10 +1856,11 @@ module usbdev_reg_top (
     .wd     (intr_test_rx_full_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_full.qe),
+    .qe     (intr_test_flds_we[8]),
     .q      (reg2hw.intr_test.rx_full.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_full.qe = intr_test_qe;
 
   //   F[av_overflow]: 9:9
   prim_subreg_ext #(
@@ -1859,10 +1871,11 @@ module usbdev_reg_top (
     .wd     (intr_test_av_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.av_overflow.qe),
+    .qe     (intr_test_flds_we[9]),
     .q      (reg2hw.intr_test.av_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.av_overflow.qe = intr_test_qe;
 
   //   F[link_in_err]: 10:10
   prim_subreg_ext #(
@@ -1873,10 +1886,11 @@ module usbdev_reg_top (
     .wd     (intr_test_link_in_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.link_in_err.qe),
+    .qe     (intr_test_flds_we[10]),
     .q      (reg2hw.intr_test.link_in_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.link_in_err.qe = intr_test_qe;
 
   //   F[rx_crc_err]: 11:11
   prim_subreg_ext #(
@@ -1887,10 +1901,11 @@ module usbdev_reg_top (
     .wd     (intr_test_rx_crc_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_crc_err.qe),
+    .qe     (intr_test_flds_we[11]),
     .q      (reg2hw.intr_test.rx_crc_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_crc_err.qe = intr_test_qe;
 
   //   F[rx_pid_err]: 12:12
   prim_subreg_ext #(
@@ -1901,10 +1916,11 @@ module usbdev_reg_top (
     .wd     (intr_test_rx_pid_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_pid_err.qe),
+    .qe     (intr_test_flds_we[12]),
     .q      (reg2hw.intr_test.rx_pid_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_pid_err.qe = intr_test_qe;
 
   //   F[rx_bitstuff_err]: 13:13
   prim_subreg_ext #(
@@ -1915,10 +1931,11 @@ module usbdev_reg_top (
     .wd     (intr_test_rx_bitstuff_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_bitstuff_err.qe),
+    .qe     (intr_test_flds_we[13]),
     .q      (reg2hw.intr_test.rx_bitstuff_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_bitstuff_err.qe = intr_test_qe;
 
   //   F[frame]: 14:14
   prim_subreg_ext #(
@@ -1929,10 +1946,11 @@ module usbdev_reg_top (
     .wd     (intr_test_frame_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.frame.qe),
+    .qe     (intr_test_flds_we[14]),
     .q      (reg2hw.intr_test.frame.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.frame.qe = intr_test_qe;
 
   //   F[powered]: 15:15
   prim_subreg_ext #(
@@ -1943,10 +1961,11 @@ module usbdev_reg_top (
     .wd     (intr_test_powered_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.powered.qe),
+    .qe     (intr_test_flds_we[15]),
     .q      (reg2hw.intr_test.powered.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.powered.qe = intr_test_qe;
 
   //   F[link_out_err]: 16:16
   prim_subreg_ext #(
@@ -1957,13 +1976,17 @@ module usbdev_reg_top (
     .wd     (intr_test_link_out_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.link_out_err.qe),
+    .qe     (intr_test_flds_we[16]),
     .q      (reg2hw.intr_test.link_out_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.link_out_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -1972,13 +1995,25 @@ module usbdev_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[usbctrl]: V(False)
+  logic usbctrl_qe;
+  logic [2:0] usbctrl_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_usbctrl0_qe (
+    .clk_i(clk_usb_48mhz_i),
+    .rst_ni(rst_usb_48mhz_ni),
+    .d_i(&usbctrl_flds_we),
+    .q_o(usbctrl_qe)
+  );
   //   F[enable]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1997,7 +2032,7 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (usbctrl_flds_we[0]),
     .q      (reg2hw.usbctrl.enable.q),
 
     // to register interface (read)
@@ -2022,12 +2057,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.usbctrl.resume_link_active.qe),
+    .qe     (usbctrl_flds_we[1]),
     .q      (reg2hw.usbctrl.resume_link_active.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.usbctrl.resume_link_active.qe = usbctrl_qe;
 
   //   F[device_address]: 22:16
   prim_subreg #(
@@ -2047,7 +2083,7 @@ module usbdev_reg_top (
     .d      (hw2reg.usbctrl.device_address.d),
 
     // to internal hardware
-    .qe     (),
+    .qe     (usbctrl_flds_we[2]),
     .q      (reg2hw.usbctrl.device_address.q),
 
     // to register interface (read)
@@ -2776,6 +2812,17 @@ module usbdev_reg_top (
 
 
   // R[avbuffer]: V(False)
+  logic avbuffer_qe;
+  logic [0:0] avbuffer_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_avbuffer0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&avbuffer_flds_we),
+    .q_o(avbuffer_qe)
+  );
   prim_subreg #(
     .DW      (5),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -2793,12 +2840,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.avbuffer.qe),
+    .qe     (avbuffer_flds_we[0]),
     .q      (reg2hw.avbuffer.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.avbuffer.qe = avbuffer_qe;
 
 
   // R[rxfifo]: V(True)
@@ -6521,6 +6569,17 @@ module usbdev_reg_top (
 
   // Subregister 0 of Multireg data_toggle_clear
   // R[data_toggle_clear]: V(False)
+  logic data_toggle_clear_qe;
+  logic [11:0] data_toggle_clear_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_data_toggle_clear0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&data_toggle_clear_flds_we),
+    .q_o(data_toggle_clear_qe)
+  );
   //   F[clear_0]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -6539,12 +6598,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[0].qe),
+    .qe     (data_toggle_clear_flds_we[0]),
     .q      (reg2hw.data_toggle_clear[0].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[0].qe = data_toggle_clear_qe;
 
   //   F[clear_1]: 1:1
   prim_subreg #(
@@ -6564,12 +6624,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[1].qe),
+    .qe     (data_toggle_clear_flds_we[1]),
     .q      (reg2hw.data_toggle_clear[1].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[1].qe = data_toggle_clear_qe;
 
   //   F[clear_2]: 2:2
   prim_subreg #(
@@ -6589,12 +6650,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[2].qe),
+    .qe     (data_toggle_clear_flds_we[2]),
     .q      (reg2hw.data_toggle_clear[2].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[2].qe = data_toggle_clear_qe;
 
   //   F[clear_3]: 3:3
   prim_subreg #(
@@ -6614,12 +6676,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[3].qe),
+    .qe     (data_toggle_clear_flds_we[3]),
     .q      (reg2hw.data_toggle_clear[3].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[3].qe = data_toggle_clear_qe;
 
   //   F[clear_4]: 4:4
   prim_subreg #(
@@ -6639,12 +6702,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[4].qe),
+    .qe     (data_toggle_clear_flds_we[4]),
     .q      (reg2hw.data_toggle_clear[4].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[4].qe = data_toggle_clear_qe;
 
   //   F[clear_5]: 5:5
   prim_subreg #(
@@ -6664,12 +6728,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[5].qe),
+    .qe     (data_toggle_clear_flds_we[5]),
     .q      (reg2hw.data_toggle_clear[5].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[5].qe = data_toggle_clear_qe;
 
   //   F[clear_6]: 6:6
   prim_subreg #(
@@ -6689,12 +6754,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[6].qe),
+    .qe     (data_toggle_clear_flds_we[6]),
     .q      (reg2hw.data_toggle_clear[6].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[6].qe = data_toggle_clear_qe;
 
   //   F[clear_7]: 7:7
   prim_subreg #(
@@ -6714,12 +6780,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[7].qe),
+    .qe     (data_toggle_clear_flds_we[7]),
     .q      (reg2hw.data_toggle_clear[7].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[7].qe = data_toggle_clear_qe;
 
   //   F[clear_8]: 8:8
   prim_subreg #(
@@ -6739,12 +6806,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[8].qe),
+    .qe     (data_toggle_clear_flds_we[8]),
     .q      (reg2hw.data_toggle_clear[8].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[8].qe = data_toggle_clear_qe;
 
   //   F[clear_9]: 9:9
   prim_subreg #(
@@ -6764,12 +6832,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[9].qe),
+    .qe     (data_toggle_clear_flds_we[9]),
     .q      (reg2hw.data_toggle_clear[9].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[9].qe = data_toggle_clear_qe;
 
   //   F[clear_10]: 10:10
   prim_subreg #(
@@ -6789,12 +6858,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[10].qe),
+    .qe     (data_toggle_clear_flds_we[10]),
     .q      (reg2hw.data_toggle_clear[10].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[10].qe = data_toggle_clear_qe;
 
   //   F[clear_11]: 11:11
   prim_subreg #(
@@ -6814,12 +6884,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.data_toggle_clear[11].qe),
+    .qe     (data_toggle_clear_flds_we[11]),
     .q      (reg2hw.data_toggle_clear[11].q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.data_toggle_clear[11].qe = data_toggle_clear_qe;
 
 
   // R[phy_pins_sense]: V(True)
@@ -7369,6 +7440,17 @@ module usbdev_reg_top (
 
 
   // R[wake_config]: V(False)
+  logic wake_config_qe;
+  logic [1:0] wake_config_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_wake_config0_qe (
+    .clk_i(clk_aon_i),
+    .rst_ni(rst_aon_ni),
+    .d_i(&wake_config_flds_we),
+    .q_o(wake_config_qe)
+  );
   //   F[wake_en]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -7387,7 +7469,7 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (),
+    .qe     (wake_config_flds_we[0]),
     .q      (reg2hw.wake_config.wake_en.q),
 
     // to register interface (read)
@@ -7412,12 +7494,13 @@ module usbdev_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.wake_config.wake_ack.qe),
+    .qe     (wake_config_flds_we[1]),
     .q      (reg2hw.wake_config.wake_ack.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.wake_config.wake_ack.qe = wake_config_qe;
 
 
   // R[wake_events]: V(False)

--- a/hw/ip/usbuart/rtl/usbuart_reg_top.sv
+++ b/hw/ip/usbuart/rtl/usbuart_reg_top.sv
@@ -622,6 +622,9 @@ module usbuart_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [7:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[tx_watermark]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -631,10 +634,11 @@ module usbuart_reg_top (
     .wd     (intr_test_tx_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_watermark.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.tx_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tx_watermark.qe = intr_test_qe;
 
   //   F[rx_watermark]: 1:1
   prim_subreg_ext #(
@@ -645,10 +649,11 @@ module usbuart_reg_top (
     .wd     (intr_test_rx_watermark_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_watermark.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.rx_watermark.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_watermark.qe = intr_test_qe;
 
   //   F[tx_overflow]: 2:2
   prim_subreg_ext #(
@@ -659,10 +664,11 @@ module usbuart_reg_top (
     .wd     (intr_test_tx_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.tx_overflow.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.tx_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.tx_overflow.qe = intr_test_qe;
 
   //   F[rx_overflow]: 3:3
   prim_subreg_ext #(
@@ -673,10 +679,11 @@ module usbuart_reg_top (
     .wd     (intr_test_rx_overflow_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_overflow.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rx_overflow.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_overflow.qe = intr_test_qe;
 
   //   F[rx_frame_err]: 4:4
   prim_subreg_ext #(
@@ -687,10 +694,11 @@ module usbuart_reg_top (
     .wd     (intr_test_rx_frame_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_frame_err.qe),
+    .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.rx_frame_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_frame_err.qe = intr_test_qe;
 
   //   F[rx_break_err]: 5:5
   prim_subreg_ext #(
@@ -701,10 +709,11 @@ module usbuart_reg_top (
     .wd     (intr_test_rx_break_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_break_err.qe),
+    .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.rx_break_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_break_err.qe = intr_test_qe;
 
   //   F[rx_timeout]: 6:6
   prim_subreg_ext #(
@@ -715,10 +724,11 @@ module usbuart_reg_top (
     .wd     (intr_test_rx_timeout_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_timeout.qe),
+    .qe     (intr_test_flds_we[6]),
     .q      (reg2hw.intr_test.rx_timeout.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_timeout.qe = intr_test_qe;
 
   //   F[rx_parity_err]: 7:7
   prim_subreg_ext #(
@@ -729,13 +739,17 @@ module usbuart_reg_top (
     .wd     (intr_test_rx_parity_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rx_parity_err.qe),
+    .qe     (intr_test_flds_we[7]),
     .q      (reg2hw.intr_test.rx_parity_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rx_parity_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -744,10 +758,11 @@ module usbuart_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[ctrl]: V(False)
@@ -1079,6 +1094,17 @@ module usbuart_reg_top (
 
 
   // R[wdata]: V(False)
+  logic wdata_qe;
+  logic [0:0] wdata_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_wdata0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&wdata_flds_we),
+    .q_o(wdata_qe)
+  );
   prim_subreg #(
     .DW      (8),
     .SwAccess(prim_subreg_pkg::SwAccessWO),
@@ -1096,15 +1122,27 @@ module usbuart_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.wdata.qe),
+    .qe     (wdata_flds_we[0]),
     .q      (reg2hw.wdata.q),
 
     // to register interface (read)
     .qs     ()
   );
+  assign reg2hw.wdata.qe = wdata_qe;
 
 
   // R[fifo_ctrl]: V(False)
+  logic fifo_ctrl_qe;
+  logic [3:0] fifo_ctrl_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_fifo_ctrl0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&fifo_ctrl_flds_we),
+    .q_o(fifo_ctrl_qe)
+  );
   //   F[rxrst]: 0:0
   prim_subreg #(
     .DW      (1),
@@ -1123,12 +1161,13 @@ module usbuart_reg_top (
     .d      (hw2reg.fifo_ctrl.rxrst.d),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxrst.qe),
+    .qe     (fifo_ctrl_flds_we[0]),
     .q      (reg2hw.fifo_ctrl.rxrst.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_rxrst_qs)
   );
+  assign reg2hw.fifo_ctrl.rxrst.qe = fifo_ctrl_qe;
 
   //   F[txrst]: 1:1
   prim_subreg #(
@@ -1148,12 +1187,13 @@ module usbuart_reg_top (
     .d      (hw2reg.fifo_ctrl.txrst.d),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.txrst.qe),
+    .qe     (fifo_ctrl_flds_we[1]),
     .q      (reg2hw.fifo_ctrl.txrst.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_txrst_qs)
   );
+  assign reg2hw.fifo_ctrl.txrst.qe = fifo_ctrl_qe;
 
   //   F[rxilvl]: 4:2
   prim_subreg #(
@@ -1173,12 +1213,13 @@ module usbuart_reg_top (
     .d      (hw2reg.fifo_ctrl.rxilvl.d),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.rxilvl.qe),
+    .qe     (fifo_ctrl_flds_we[2]),
     .q      (reg2hw.fifo_ctrl.rxilvl.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_rxilvl_qs)
   );
+  assign reg2hw.fifo_ctrl.rxilvl.qe = fifo_ctrl_qe;
 
   //   F[txilvl]: 6:5
   prim_subreg #(
@@ -1198,12 +1239,13 @@ module usbuart_reg_top (
     .d      (hw2reg.fifo_ctrl.txilvl.d),
 
     // to internal hardware
-    .qe     (reg2hw.fifo_ctrl.txilvl.qe),
+    .qe     (fifo_ctrl_flds_we[3]),
     .q      (reg2hw.fifo_ctrl.txilvl.q),
 
     // to register interface (read)
     .qs     (fifo_ctrl_txilvl_qs)
   );
+  assign reg2hw.fifo_ctrl.txilvl.qe = fifo_ctrl_qe;
 
 
   // R[fifo_status]: V(True)

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -1060,6 +1060,9 @@ module ast_reg_top (
 
 
   // R[regal]: V(True)
+  logic regal_qe;
+  logic [0:0] regal_flds_we;
+  assign regal_qe = &regal_flds_we;
   prim_subreg_ext #(
     .DW    (32)
   ) u_regal (
@@ -1068,10 +1071,11 @@ module ast_reg_top (
     .wd     (regal_wd),
     .d      (hw2reg.regal.d),
     .qre    (),
-    .qe     (reg2hw.regal.qe),
+    .qe     (regal_flds_we[0]),
     .q      (reg2hw.regal.q),
     .qs     (regal_qs)
   );
+  assign reg2hw.regal.qe = regal_qe;
 
 
   // Subregister 0 of Multireg regb

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_top.sv
@@ -494,6 +494,9 @@ module clkmgr_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -503,10 +506,11 @@ module clkmgr_reg_top (
     .wd     (alert_test_recov_fault_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_fault.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_fault.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_fault.qe = alert_test_qe;
 
   //   F[fatal_fault]: 1:1
   prim_subreg_ext #(
@@ -517,10 +521,11 @@ module clkmgr_reg_top (
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_fault.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_fault.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
 
 
   // R[extclk_ctrl_regwen]: V(False)

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -1310,6 +1310,9 @@ module flash_ctrl_core_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [5:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[prog_empty]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1319,10 +1322,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_prog_empty_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.prog_empty.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.prog_empty.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.prog_empty.qe = intr_test_qe;
 
   //   F[prog_lvl]: 1:1
   prim_subreg_ext #(
@@ -1333,10 +1337,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_prog_lvl_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.prog_lvl.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.prog_lvl.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.prog_lvl.qe = intr_test_qe;
 
   //   F[rd_full]: 2:2
   prim_subreg_ext #(
@@ -1347,10 +1352,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_rd_full_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rd_full.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.rd_full.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rd_full.qe = intr_test_qe;
 
   //   F[rd_lvl]: 3:3
   prim_subreg_ext #(
@@ -1361,10 +1367,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_rd_lvl_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.rd_lvl.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.rd_lvl.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.rd_lvl.qe = intr_test_qe;
 
   //   F[op_done]: 4:4
   prim_subreg_ext #(
@@ -1375,10 +1382,11 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_op_done_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.op_done.qe),
+    .qe     (intr_test_flds_we[4]),
     .q      (reg2hw.intr_test.op_done.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.op_done.qe = intr_test_qe;
 
   //   F[corr_err]: 5:5
   prim_subreg_ext #(
@@ -1389,13 +1397,17 @@ module flash_ctrl_core_reg_top (
     .wd     (intr_test_corr_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.corr_err.qe),
+    .qe     (intr_test_flds_we[5]),
     .q      (reg2hw.intr_test.corr_err.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.corr_err.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_err]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1405,10 +1417,11 @@ module flash_ctrl_core_reg_top (
     .wd     (alert_test_recov_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_err.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_err.qe = alert_test_qe;
 
   //   F[fatal_err]: 1:1
   prim_subreg_ext #(
@@ -1419,10 +1432,11 @@ module flash_ctrl_core_reg_top (
     .wd     (alert_test_fatal_err_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_err.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_err.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_err.qe = alert_test_qe;
 
 
   // R[dis]: V(False)

--- a/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
+++ b/hw/top_earlgrey/ip/pinmux/rtl/autogen/pinmux_reg_top.sv
@@ -2983,6 +2983,9 @@ module pinmux_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -2991,10 +2994,11 @@ module pinmux_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // Subregister 0 of Multireg mio_periph_insel_regwen
@@ -9884,6 +9888,9 @@ module pinmux_reg_top (
 
   // Subregister 0 of Multireg mio_pad_attr
   // R[mio_pad_attr_0]: V(True)
+  logic mio_pad_attr_0_qe;
+  logic [0:0] mio_pad_attr_0_flds_we;
+  assign mio_pad_attr_0_qe = &mio_pad_attr_0_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_0 (
@@ -9892,14 +9899,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_0_wd),
     .d      (hw2reg.mio_pad_attr[0].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[0].qe),
+    .qe     (mio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[0].q),
     .qs     (mio_pad_attr_0_qs)
   );
+  assign reg2hw.mio_pad_attr[0].qe = mio_pad_attr_0_qe;
 
 
   // Subregister 1 of Multireg mio_pad_attr
   // R[mio_pad_attr_1]: V(True)
+  logic mio_pad_attr_1_qe;
+  logic [0:0] mio_pad_attr_1_flds_we;
+  assign mio_pad_attr_1_qe = &mio_pad_attr_1_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_1 (
@@ -9908,14 +9919,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_1_wd),
     .d      (hw2reg.mio_pad_attr[1].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[1].qe),
+    .qe     (mio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[1].q),
     .qs     (mio_pad_attr_1_qs)
   );
+  assign reg2hw.mio_pad_attr[1].qe = mio_pad_attr_1_qe;
 
 
   // Subregister 2 of Multireg mio_pad_attr
   // R[mio_pad_attr_2]: V(True)
+  logic mio_pad_attr_2_qe;
+  logic [0:0] mio_pad_attr_2_flds_we;
+  assign mio_pad_attr_2_qe = &mio_pad_attr_2_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_2 (
@@ -9924,14 +9939,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_2_wd),
     .d      (hw2reg.mio_pad_attr[2].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[2].qe),
+    .qe     (mio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[2].q),
     .qs     (mio_pad_attr_2_qs)
   );
+  assign reg2hw.mio_pad_attr[2].qe = mio_pad_attr_2_qe;
 
 
   // Subregister 3 of Multireg mio_pad_attr
   // R[mio_pad_attr_3]: V(True)
+  logic mio_pad_attr_3_qe;
+  logic [0:0] mio_pad_attr_3_flds_we;
+  assign mio_pad_attr_3_qe = &mio_pad_attr_3_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_3 (
@@ -9940,14 +9959,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_3_wd),
     .d      (hw2reg.mio_pad_attr[3].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[3].qe),
+    .qe     (mio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[3].q),
     .qs     (mio_pad_attr_3_qs)
   );
+  assign reg2hw.mio_pad_attr[3].qe = mio_pad_attr_3_qe;
 
 
   // Subregister 4 of Multireg mio_pad_attr
   // R[mio_pad_attr_4]: V(True)
+  logic mio_pad_attr_4_qe;
+  logic [0:0] mio_pad_attr_4_flds_we;
+  assign mio_pad_attr_4_qe = &mio_pad_attr_4_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_4 (
@@ -9956,14 +9979,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_4_wd),
     .d      (hw2reg.mio_pad_attr[4].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[4].qe),
+    .qe     (mio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[4].q),
     .qs     (mio_pad_attr_4_qs)
   );
+  assign reg2hw.mio_pad_attr[4].qe = mio_pad_attr_4_qe;
 
 
   // Subregister 5 of Multireg mio_pad_attr
   // R[mio_pad_attr_5]: V(True)
+  logic mio_pad_attr_5_qe;
+  logic [0:0] mio_pad_attr_5_flds_we;
+  assign mio_pad_attr_5_qe = &mio_pad_attr_5_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_5 (
@@ -9972,14 +9999,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_5_wd),
     .d      (hw2reg.mio_pad_attr[5].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[5].qe),
+    .qe     (mio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[5].q),
     .qs     (mio_pad_attr_5_qs)
   );
+  assign reg2hw.mio_pad_attr[5].qe = mio_pad_attr_5_qe;
 
 
   // Subregister 6 of Multireg mio_pad_attr
   // R[mio_pad_attr_6]: V(True)
+  logic mio_pad_attr_6_qe;
+  logic [0:0] mio_pad_attr_6_flds_we;
+  assign mio_pad_attr_6_qe = &mio_pad_attr_6_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_6 (
@@ -9988,14 +10019,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_6_wd),
     .d      (hw2reg.mio_pad_attr[6].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[6].qe),
+    .qe     (mio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[6].q),
     .qs     (mio_pad_attr_6_qs)
   );
+  assign reg2hw.mio_pad_attr[6].qe = mio_pad_attr_6_qe;
 
 
   // Subregister 7 of Multireg mio_pad_attr
   // R[mio_pad_attr_7]: V(True)
+  logic mio_pad_attr_7_qe;
+  logic [0:0] mio_pad_attr_7_flds_we;
+  assign mio_pad_attr_7_qe = &mio_pad_attr_7_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_7 (
@@ -10004,14 +10039,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_7_wd),
     .d      (hw2reg.mio_pad_attr[7].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[7].qe),
+    .qe     (mio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[7].q),
     .qs     (mio_pad_attr_7_qs)
   );
+  assign reg2hw.mio_pad_attr[7].qe = mio_pad_attr_7_qe;
 
 
   // Subregister 8 of Multireg mio_pad_attr
   // R[mio_pad_attr_8]: V(True)
+  logic mio_pad_attr_8_qe;
+  logic [0:0] mio_pad_attr_8_flds_we;
+  assign mio_pad_attr_8_qe = &mio_pad_attr_8_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_8 (
@@ -10020,14 +10059,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_8_wd),
     .d      (hw2reg.mio_pad_attr[8].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[8].qe),
+    .qe     (mio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[8].q),
     .qs     (mio_pad_attr_8_qs)
   );
+  assign reg2hw.mio_pad_attr[8].qe = mio_pad_attr_8_qe;
 
 
   // Subregister 9 of Multireg mio_pad_attr
   // R[mio_pad_attr_9]: V(True)
+  logic mio_pad_attr_9_qe;
+  logic [0:0] mio_pad_attr_9_flds_we;
+  assign mio_pad_attr_9_qe = &mio_pad_attr_9_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_9 (
@@ -10036,14 +10079,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_9_wd),
     .d      (hw2reg.mio_pad_attr[9].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[9].qe),
+    .qe     (mio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[9].q),
     .qs     (mio_pad_attr_9_qs)
   );
+  assign reg2hw.mio_pad_attr[9].qe = mio_pad_attr_9_qe;
 
 
   // Subregister 10 of Multireg mio_pad_attr
   // R[mio_pad_attr_10]: V(True)
+  logic mio_pad_attr_10_qe;
+  logic [0:0] mio_pad_attr_10_flds_we;
+  assign mio_pad_attr_10_qe = &mio_pad_attr_10_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_10 (
@@ -10052,14 +10099,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_10_wd),
     .d      (hw2reg.mio_pad_attr[10].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[10].qe),
+    .qe     (mio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[10].q),
     .qs     (mio_pad_attr_10_qs)
   );
+  assign reg2hw.mio_pad_attr[10].qe = mio_pad_attr_10_qe;
 
 
   // Subregister 11 of Multireg mio_pad_attr
   // R[mio_pad_attr_11]: V(True)
+  logic mio_pad_attr_11_qe;
+  logic [0:0] mio_pad_attr_11_flds_we;
+  assign mio_pad_attr_11_qe = &mio_pad_attr_11_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_11 (
@@ -10068,14 +10119,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_11_wd),
     .d      (hw2reg.mio_pad_attr[11].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[11].qe),
+    .qe     (mio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[11].q),
     .qs     (mio_pad_attr_11_qs)
   );
+  assign reg2hw.mio_pad_attr[11].qe = mio_pad_attr_11_qe;
 
 
   // Subregister 12 of Multireg mio_pad_attr
   // R[mio_pad_attr_12]: V(True)
+  logic mio_pad_attr_12_qe;
+  logic [0:0] mio_pad_attr_12_flds_we;
+  assign mio_pad_attr_12_qe = &mio_pad_attr_12_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_12 (
@@ -10084,14 +10139,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_12_wd),
     .d      (hw2reg.mio_pad_attr[12].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[12].qe),
+    .qe     (mio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[12].q),
     .qs     (mio_pad_attr_12_qs)
   );
+  assign reg2hw.mio_pad_attr[12].qe = mio_pad_attr_12_qe;
 
 
   // Subregister 13 of Multireg mio_pad_attr
   // R[mio_pad_attr_13]: V(True)
+  logic mio_pad_attr_13_qe;
+  logic [0:0] mio_pad_attr_13_flds_we;
+  assign mio_pad_attr_13_qe = &mio_pad_attr_13_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_13 (
@@ -10100,14 +10159,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_13_wd),
     .d      (hw2reg.mio_pad_attr[13].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[13].qe),
+    .qe     (mio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[13].q),
     .qs     (mio_pad_attr_13_qs)
   );
+  assign reg2hw.mio_pad_attr[13].qe = mio_pad_attr_13_qe;
 
 
   // Subregister 14 of Multireg mio_pad_attr
   // R[mio_pad_attr_14]: V(True)
+  logic mio_pad_attr_14_qe;
+  logic [0:0] mio_pad_attr_14_flds_we;
+  assign mio_pad_attr_14_qe = &mio_pad_attr_14_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_14 (
@@ -10116,14 +10179,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_14_wd),
     .d      (hw2reg.mio_pad_attr[14].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[14].qe),
+    .qe     (mio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[14].q),
     .qs     (mio_pad_attr_14_qs)
   );
+  assign reg2hw.mio_pad_attr[14].qe = mio_pad_attr_14_qe;
 
 
   // Subregister 15 of Multireg mio_pad_attr
   // R[mio_pad_attr_15]: V(True)
+  logic mio_pad_attr_15_qe;
+  logic [0:0] mio_pad_attr_15_flds_we;
+  assign mio_pad_attr_15_qe = &mio_pad_attr_15_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_15 (
@@ -10132,14 +10199,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_15_wd),
     .d      (hw2reg.mio_pad_attr[15].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[15].qe),
+    .qe     (mio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[15].q),
     .qs     (mio_pad_attr_15_qs)
   );
+  assign reg2hw.mio_pad_attr[15].qe = mio_pad_attr_15_qe;
 
 
   // Subregister 16 of Multireg mio_pad_attr
   // R[mio_pad_attr_16]: V(True)
+  logic mio_pad_attr_16_qe;
+  logic [0:0] mio_pad_attr_16_flds_we;
+  assign mio_pad_attr_16_qe = &mio_pad_attr_16_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_16 (
@@ -10148,14 +10219,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_16_wd),
     .d      (hw2reg.mio_pad_attr[16].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[16].qe),
+    .qe     (mio_pad_attr_16_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[16].q),
     .qs     (mio_pad_attr_16_qs)
   );
+  assign reg2hw.mio_pad_attr[16].qe = mio_pad_attr_16_qe;
 
 
   // Subregister 17 of Multireg mio_pad_attr
   // R[mio_pad_attr_17]: V(True)
+  logic mio_pad_attr_17_qe;
+  logic [0:0] mio_pad_attr_17_flds_we;
+  assign mio_pad_attr_17_qe = &mio_pad_attr_17_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_17 (
@@ -10164,14 +10239,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_17_wd),
     .d      (hw2reg.mio_pad_attr[17].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[17].qe),
+    .qe     (mio_pad_attr_17_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[17].q),
     .qs     (mio_pad_attr_17_qs)
   );
+  assign reg2hw.mio_pad_attr[17].qe = mio_pad_attr_17_qe;
 
 
   // Subregister 18 of Multireg mio_pad_attr
   // R[mio_pad_attr_18]: V(True)
+  logic mio_pad_attr_18_qe;
+  logic [0:0] mio_pad_attr_18_flds_we;
+  assign mio_pad_attr_18_qe = &mio_pad_attr_18_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_18 (
@@ -10180,14 +10259,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_18_wd),
     .d      (hw2reg.mio_pad_attr[18].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[18].qe),
+    .qe     (mio_pad_attr_18_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[18].q),
     .qs     (mio_pad_attr_18_qs)
   );
+  assign reg2hw.mio_pad_attr[18].qe = mio_pad_attr_18_qe;
 
 
   // Subregister 19 of Multireg mio_pad_attr
   // R[mio_pad_attr_19]: V(True)
+  logic mio_pad_attr_19_qe;
+  logic [0:0] mio_pad_attr_19_flds_we;
+  assign mio_pad_attr_19_qe = &mio_pad_attr_19_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_19 (
@@ -10196,14 +10279,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_19_wd),
     .d      (hw2reg.mio_pad_attr[19].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[19].qe),
+    .qe     (mio_pad_attr_19_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[19].q),
     .qs     (mio_pad_attr_19_qs)
   );
+  assign reg2hw.mio_pad_attr[19].qe = mio_pad_attr_19_qe;
 
 
   // Subregister 20 of Multireg mio_pad_attr
   // R[mio_pad_attr_20]: V(True)
+  logic mio_pad_attr_20_qe;
+  logic [0:0] mio_pad_attr_20_flds_we;
+  assign mio_pad_attr_20_qe = &mio_pad_attr_20_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_20 (
@@ -10212,14 +10299,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_20_wd),
     .d      (hw2reg.mio_pad_attr[20].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[20].qe),
+    .qe     (mio_pad_attr_20_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[20].q),
     .qs     (mio_pad_attr_20_qs)
   );
+  assign reg2hw.mio_pad_attr[20].qe = mio_pad_attr_20_qe;
 
 
   // Subregister 21 of Multireg mio_pad_attr
   // R[mio_pad_attr_21]: V(True)
+  logic mio_pad_attr_21_qe;
+  logic [0:0] mio_pad_attr_21_flds_we;
+  assign mio_pad_attr_21_qe = &mio_pad_attr_21_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_21 (
@@ -10228,14 +10319,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_21_wd),
     .d      (hw2reg.mio_pad_attr[21].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[21].qe),
+    .qe     (mio_pad_attr_21_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[21].q),
     .qs     (mio_pad_attr_21_qs)
   );
+  assign reg2hw.mio_pad_attr[21].qe = mio_pad_attr_21_qe;
 
 
   // Subregister 22 of Multireg mio_pad_attr
   // R[mio_pad_attr_22]: V(True)
+  logic mio_pad_attr_22_qe;
+  logic [0:0] mio_pad_attr_22_flds_we;
+  assign mio_pad_attr_22_qe = &mio_pad_attr_22_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_22 (
@@ -10244,14 +10339,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_22_wd),
     .d      (hw2reg.mio_pad_attr[22].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[22].qe),
+    .qe     (mio_pad_attr_22_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[22].q),
     .qs     (mio_pad_attr_22_qs)
   );
+  assign reg2hw.mio_pad_attr[22].qe = mio_pad_attr_22_qe;
 
 
   // Subregister 23 of Multireg mio_pad_attr
   // R[mio_pad_attr_23]: V(True)
+  logic mio_pad_attr_23_qe;
+  logic [0:0] mio_pad_attr_23_flds_we;
+  assign mio_pad_attr_23_qe = &mio_pad_attr_23_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_23 (
@@ -10260,14 +10359,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_23_wd),
     .d      (hw2reg.mio_pad_attr[23].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[23].qe),
+    .qe     (mio_pad_attr_23_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[23].q),
     .qs     (mio_pad_attr_23_qs)
   );
+  assign reg2hw.mio_pad_attr[23].qe = mio_pad_attr_23_qe;
 
 
   // Subregister 24 of Multireg mio_pad_attr
   // R[mio_pad_attr_24]: V(True)
+  logic mio_pad_attr_24_qe;
+  logic [0:0] mio_pad_attr_24_flds_we;
+  assign mio_pad_attr_24_qe = &mio_pad_attr_24_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_24 (
@@ -10276,14 +10379,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_24_wd),
     .d      (hw2reg.mio_pad_attr[24].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[24].qe),
+    .qe     (mio_pad_attr_24_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[24].q),
     .qs     (mio_pad_attr_24_qs)
   );
+  assign reg2hw.mio_pad_attr[24].qe = mio_pad_attr_24_qe;
 
 
   // Subregister 25 of Multireg mio_pad_attr
   // R[mio_pad_attr_25]: V(True)
+  logic mio_pad_attr_25_qe;
+  logic [0:0] mio_pad_attr_25_flds_we;
+  assign mio_pad_attr_25_qe = &mio_pad_attr_25_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_25 (
@@ -10292,14 +10399,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_25_wd),
     .d      (hw2reg.mio_pad_attr[25].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[25].qe),
+    .qe     (mio_pad_attr_25_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[25].q),
     .qs     (mio_pad_attr_25_qs)
   );
+  assign reg2hw.mio_pad_attr[25].qe = mio_pad_attr_25_qe;
 
 
   // Subregister 26 of Multireg mio_pad_attr
   // R[mio_pad_attr_26]: V(True)
+  logic mio_pad_attr_26_qe;
+  logic [0:0] mio_pad_attr_26_flds_we;
+  assign mio_pad_attr_26_qe = &mio_pad_attr_26_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_26 (
@@ -10308,14 +10419,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_26_wd),
     .d      (hw2reg.mio_pad_attr[26].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[26].qe),
+    .qe     (mio_pad_attr_26_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[26].q),
     .qs     (mio_pad_attr_26_qs)
   );
+  assign reg2hw.mio_pad_attr[26].qe = mio_pad_attr_26_qe;
 
 
   // Subregister 27 of Multireg mio_pad_attr
   // R[mio_pad_attr_27]: V(True)
+  logic mio_pad_attr_27_qe;
+  logic [0:0] mio_pad_attr_27_flds_we;
+  assign mio_pad_attr_27_qe = &mio_pad_attr_27_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_27 (
@@ -10324,14 +10439,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_27_wd),
     .d      (hw2reg.mio_pad_attr[27].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[27].qe),
+    .qe     (mio_pad_attr_27_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[27].q),
     .qs     (mio_pad_attr_27_qs)
   );
+  assign reg2hw.mio_pad_attr[27].qe = mio_pad_attr_27_qe;
 
 
   // Subregister 28 of Multireg mio_pad_attr
   // R[mio_pad_attr_28]: V(True)
+  logic mio_pad_attr_28_qe;
+  logic [0:0] mio_pad_attr_28_flds_we;
+  assign mio_pad_attr_28_qe = &mio_pad_attr_28_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_28 (
@@ -10340,14 +10459,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_28_wd),
     .d      (hw2reg.mio_pad_attr[28].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[28].qe),
+    .qe     (mio_pad_attr_28_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[28].q),
     .qs     (mio_pad_attr_28_qs)
   );
+  assign reg2hw.mio_pad_attr[28].qe = mio_pad_attr_28_qe;
 
 
   // Subregister 29 of Multireg mio_pad_attr
   // R[mio_pad_attr_29]: V(True)
+  logic mio_pad_attr_29_qe;
+  logic [0:0] mio_pad_attr_29_flds_we;
+  assign mio_pad_attr_29_qe = &mio_pad_attr_29_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_29 (
@@ -10356,14 +10479,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_29_wd),
     .d      (hw2reg.mio_pad_attr[29].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[29].qe),
+    .qe     (mio_pad_attr_29_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[29].q),
     .qs     (mio_pad_attr_29_qs)
   );
+  assign reg2hw.mio_pad_attr[29].qe = mio_pad_attr_29_qe;
 
 
   // Subregister 30 of Multireg mio_pad_attr
   // R[mio_pad_attr_30]: V(True)
+  logic mio_pad_attr_30_qe;
+  logic [0:0] mio_pad_attr_30_flds_we;
+  assign mio_pad_attr_30_qe = &mio_pad_attr_30_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_30 (
@@ -10372,14 +10499,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_30_wd),
     .d      (hw2reg.mio_pad_attr[30].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[30].qe),
+    .qe     (mio_pad_attr_30_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[30].q),
     .qs     (mio_pad_attr_30_qs)
   );
+  assign reg2hw.mio_pad_attr[30].qe = mio_pad_attr_30_qe;
 
 
   // Subregister 31 of Multireg mio_pad_attr
   // R[mio_pad_attr_31]: V(True)
+  logic mio_pad_attr_31_qe;
+  logic [0:0] mio_pad_attr_31_flds_we;
+  assign mio_pad_attr_31_qe = &mio_pad_attr_31_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_31 (
@@ -10388,14 +10519,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_31_wd),
     .d      (hw2reg.mio_pad_attr[31].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[31].qe),
+    .qe     (mio_pad_attr_31_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[31].q),
     .qs     (mio_pad_attr_31_qs)
   );
+  assign reg2hw.mio_pad_attr[31].qe = mio_pad_attr_31_qe;
 
 
   // Subregister 32 of Multireg mio_pad_attr
   // R[mio_pad_attr_32]: V(True)
+  logic mio_pad_attr_32_qe;
+  logic [0:0] mio_pad_attr_32_flds_we;
+  assign mio_pad_attr_32_qe = &mio_pad_attr_32_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_32 (
@@ -10404,14 +10539,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_32_wd),
     .d      (hw2reg.mio_pad_attr[32].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[32].qe),
+    .qe     (mio_pad_attr_32_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[32].q),
     .qs     (mio_pad_attr_32_qs)
   );
+  assign reg2hw.mio_pad_attr[32].qe = mio_pad_attr_32_qe;
 
 
   // Subregister 33 of Multireg mio_pad_attr
   // R[mio_pad_attr_33]: V(True)
+  logic mio_pad_attr_33_qe;
+  logic [0:0] mio_pad_attr_33_flds_we;
+  assign mio_pad_attr_33_qe = &mio_pad_attr_33_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_33 (
@@ -10420,14 +10559,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_33_wd),
     .d      (hw2reg.mio_pad_attr[33].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[33].qe),
+    .qe     (mio_pad_attr_33_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[33].q),
     .qs     (mio_pad_attr_33_qs)
   );
+  assign reg2hw.mio_pad_attr[33].qe = mio_pad_attr_33_qe;
 
 
   // Subregister 34 of Multireg mio_pad_attr
   // R[mio_pad_attr_34]: V(True)
+  logic mio_pad_attr_34_qe;
+  logic [0:0] mio_pad_attr_34_flds_we;
+  assign mio_pad_attr_34_qe = &mio_pad_attr_34_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_34 (
@@ -10436,14 +10579,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_34_wd),
     .d      (hw2reg.mio_pad_attr[34].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[34].qe),
+    .qe     (mio_pad_attr_34_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[34].q),
     .qs     (mio_pad_attr_34_qs)
   );
+  assign reg2hw.mio_pad_attr[34].qe = mio_pad_attr_34_qe;
 
 
   // Subregister 35 of Multireg mio_pad_attr
   // R[mio_pad_attr_35]: V(True)
+  logic mio_pad_attr_35_qe;
+  logic [0:0] mio_pad_attr_35_flds_we;
+  assign mio_pad_attr_35_qe = &mio_pad_attr_35_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_35 (
@@ -10452,14 +10599,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_35_wd),
     .d      (hw2reg.mio_pad_attr[35].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[35].qe),
+    .qe     (mio_pad_attr_35_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[35].q),
     .qs     (mio_pad_attr_35_qs)
   );
+  assign reg2hw.mio_pad_attr[35].qe = mio_pad_attr_35_qe;
 
 
   // Subregister 36 of Multireg mio_pad_attr
   // R[mio_pad_attr_36]: V(True)
+  logic mio_pad_attr_36_qe;
+  logic [0:0] mio_pad_attr_36_flds_we;
+  assign mio_pad_attr_36_qe = &mio_pad_attr_36_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_36 (
@@ -10468,14 +10619,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_36_wd),
     .d      (hw2reg.mio_pad_attr[36].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[36].qe),
+    .qe     (mio_pad_attr_36_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[36].q),
     .qs     (mio_pad_attr_36_qs)
   );
+  assign reg2hw.mio_pad_attr[36].qe = mio_pad_attr_36_qe;
 
 
   // Subregister 37 of Multireg mio_pad_attr
   // R[mio_pad_attr_37]: V(True)
+  logic mio_pad_attr_37_qe;
+  logic [0:0] mio_pad_attr_37_flds_we;
+  assign mio_pad_attr_37_qe = &mio_pad_attr_37_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_37 (
@@ -10484,14 +10639,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_37_wd),
     .d      (hw2reg.mio_pad_attr[37].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[37].qe),
+    .qe     (mio_pad_attr_37_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[37].q),
     .qs     (mio_pad_attr_37_qs)
   );
+  assign reg2hw.mio_pad_attr[37].qe = mio_pad_attr_37_qe;
 
 
   // Subregister 38 of Multireg mio_pad_attr
   // R[mio_pad_attr_38]: V(True)
+  logic mio_pad_attr_38_qe;
+  logic [0:0] mio_pad_attr_38_flds_we;
+  assign mio_pad_attr_38_qe = &mio_pad_attr_38_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_38 (
@@ -10500,14 +10659,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_38_wd),
     .d      (hw2reg.mio_pad_attr[38].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[38].qe),
+    .qe     (mio_pad_attr_38_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[38].q),
     .qs     (mio_pad_attr_38_qs)
   );
+  assign reg2hw.mio_pad_attr[38].qe = mio_pad_attr_38_qe;
 
 
   // Subregister 39 of Multireg mio_pad_attr
   // R[mio_pad_attr_39]: V(True)
+  logic mio_pad_attr_39_qe;
+  logic [0:0] mio_pad_attr_39_flds_we;
+  assign mio_pad_attr_39_qe = &mio_pad_attr_39_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_39 (
@@ -10516,14 +10679,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_39_wd),
     .d      (hw2reg.mio_pad_attr[39].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[39].qe),
+    .qe     (mio_pad_attr_39_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[39].q),
     .qs     (mio_pad_attr_39_qs)
   );
+  assign reg2hw.mio_pad_attr[39].qe = mio_pad_attr_39_qe;
 
 
   // Subregister 40 of Multireg mio_pad_attr
   // R[mio_pad_attr_40]: V(True)
+  logic mio_pad_attr_40_qe;
+  logic [0:0] mio_pad_attr_40_flds_we;
+  assign mio_pad_attr_40_qe = &mio_pad_attr_40_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_40 (
@@ -10532,14 +10699,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_40_wd),
     .d      (hw2reg.mio_pad_attr[40].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[40].qe),
+    .qe     (mio_pad_attr_40_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[40].q),
     .qs     (mio_pad_attr_40_qs)
   );
+  assign reg2hw.mio_pad_attr[40].qe = mio_pad_attr_40_qe;
 
 
   // Subregister 41 of Multireg mio_pad_attr
   // R[mio_pad_attr_41]: V(True)
+  logic mio_pad_attr_41_qe;
+  logic [0:0] mio_pad_attr_41_flds_we;
+  assign mio_pad_attr_41_qe = &mio_pad_attr_41_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_41 (
@@ -10548,14 +10719,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_41_wd),
     .d      (hw2reg.mio_pad_attr[41].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[41].qe),
+    .qe     (mio_pad_attr_41_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[41].q),
     .qs     (mio_pad_attr_41_qs)
   );
+  assign reg2hw.mio_pad_attr[41].qe = mio_pad_attr_41_qe;
 
 
   // Subregister 42 of Multireg mio_pad_attr
   // R[mio_pad_attr_42]: V(True)
+  logic mio_pad_attr_42_qe;
+  logic [0:0] mio_pad_attr_42_flds_we;
+  assign mio_pad_attr_42_qe = &mio_pad_attr_42_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_42 (
@@ -10564,14 +10739,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_42_wd),
     .d      (hw2reg.mio_pad_attr[42].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[42].qe),
+    .qe     (mio_pad_attr_42_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[42].q),
     .qs     (mio_pad_attr_42_qs)
   );
+  assign reg2hw.mio_pad_attr[42].qe = mio_pad_attr_42_qe;
 
 
   // Subregister 43 of Multireg mio_pad_attr
   // R[mio_pad_attr_43]: V(True)
+  logic mio_pad_attr_43_qe;
+  logic [0:0] mio_pad_attr_43_flds_we;
+  assign mio_pad_attr_43_qe = &mio_pad_attr_43_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_43 (
@@ -10580,14 +10759,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_43_wd),
     .d      (hw2reg.mio_pad_attr[43].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[43].qe),
+    .qe     (mio_pad_attr_43_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[43].q),
     .qs     (mio_pad_attr_43_qs)
   );
+  assign reg2hw.mio_pad_attr[43].qe = mio_pad_attr_43_qe;
 
 
   // Subregister 44 of Multireg mio_pad_attr
   // R[mio_pad_attr_44]: V(True)
+  logic mio_pad_attr_44_qe;
+  logic [0:0] mio_pad_attr_44_flds_we;
+  assign mio_pad_attr_44_qe = &mio_pad_attr_44_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_44 (
@@ -10596,14 +10779,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_44_wd),
     .d      (hw2reg.mio_pad_attr[44].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[44].qe),
+    .qe     (mio_pad_attr_44_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[44].q),
     .qs     (mio_pad_attr_44_qs)
   );
+  assign reg2hw.mio_pad_attr[44].qe = mio_pad_attr_44_qe;
 
 
   // Subregister 45 of Multireg mio_pad_attr
   // R[mio_pad_attr_45]: V(True)
+  logic mio_pad_attr_45_qe;
+  logic [0:0] mio_pad_attr_45_flds_we;
+  assign mio_pad_attr_45_qe = &mio_pad_attr_45_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_45 (
@@ -10612,14 +10799,18 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_45_wd),
     .d      (hw2reg.mio_pad_attr[45].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[45].qe),
+    .qe     (mio_pad_attr_45_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[45].q),
     .qs     (mio_pad_attr_45_qs)
   );
+  assign reg2hw.mio_pad_attr[45].qe = mio_pad_attr_45_qe;
 
 
   // Subregister 46 of Multireg mio_pad_attr
   // R[mio_pad_attr_46]: V(True)
+  logic mio_pad_attr_46_qe;
+  logic [0:0] mio_pad_attr_46_flds_we;
+  assign mio_pad_attr_46_qe = &mio_pad_attr_46_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_mio_pad_attr_46 (
@@ -10628,10 +10819,11 @@ module pinmux_reg_top (
     .wd     (mio_pad_attr_46_wd),
     .d      (hw2reg.mio_pad_attr[46].d),
     .qre    (),
-    .qe     (reg2hw.mio_pad_attr[46].qe),
+    .qe     (mio_pad_attr_46_flds_we[0]),
     .q      (reg2hw.mio_pad_attr[46].q),
     .qs     (mio_pad_attr_46_qs)
   );
+  assign reg2hw.mio_pad_attr[46].qe = mio_pad_attr_46_qe;
 
 
   // Subregister 0 of Multireg dio_pad_attr_regwen
@@ -11068,6 +11260,9 @@ module pinmux_reg_top (
 
   // Subregister 0 of Multireg dio_pad_attr
   // R[dio_pad_attr_0]: V(True)
+  logic dio_pad_attr_0_qe;
+  logic [0:0] dio_pad_attr_0_flds_we;
+  assign dio_pad_attr_0_qe = &dio_pad_attr_0_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_0 (
@@ -11076,14 +11271,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_0_wd),
     .d      (hw2reg.dio_pad_attr[0].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[0].qe),
+    .qe     (dio_pad_attr_0_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[0].q),
     .qs     (dio_pad_attr_0_qs)
   );
+  assign reg2hw.dio_pad_attr[0].qe = dio_pad_attr_0_qe;
 
 
   // Subregister 1 of Multireg dio_pad_attr
   // R[dio_pad_attr_1]: V(True)
+  logic dio_pad_attr_1_qe;
+  logic [0:0] dio_pad_attr_1_flds_we;
+  assign dio_pad_attr_1_qe = &dio_pad_attr_1_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_1 (
@@ -11092,14 +11291,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_1_wd),
     .d      (hw2reg.dio_pad_attr[1].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[1].qe),
+    .qe     (dio_pad_attr_1_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[1].q),
     .qs     (dio_pad_attr_1_qs)
   );
+  assign reg2hw.dio_pad_attr[1].qe = dio_pad_attr_1_qe;
 
 
   // Subregister 2 of Multireg dio_pad_attr
   // R[dio_pad_attr_2]: V(True)
+  logic dio_pad_attr_2_qe;
+  logic [0:0] dio_pad_attr_2_flds_we;
+  assign dio_pad_attr_2_qe = &dio_pad_attr_2_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_2 (
@@ -11108,14 +11311,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_2_wd),
     .d      (hw2reg.dio_pad_attr[2].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[2].qe),
+    .qe     (dio_pad_attr_2_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[2].q),
     .qs     (dio_pad_attr_2_qs)
   );
+  assign reg2hw.dio_pad_attr[2].qe = dio_pad_attr_2_qe;
 
 
   // Subregister 3 of Multireg dio_pad_attr
   // R[dio_pad_attr_3]: V(True)
+  logic dio_pad_attr_3_qe;
+  logic [0:0] dio_pad_attr_3_flds_we;
+  assign dio_pad_attr_3_qe = &dio_pad_attr_3_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_3 (
@@ -11124,14 +11331,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_3_wd),
     .d      (hw2reg.dio_pad_attr[3].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[3].qe),
+    .qe     (dio_pad_attr_3_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[3].q),
     .qs     (dio_pad_attr_3_qs)
   );
+  assign reg2hw.dio_pad_attr[3].qe = dio_pad_attr_3_qe;
 
 
   // Subregister 4 of Multireg dio_pad_attr
   // R[dio_pad_attr_4]: V(True)
+  logic dio_pad_attr_4_qe;
+  logic [0:0] dio_pad_attr_4_flds_we;
+  assign dio_pad_attr_4_qe = &dio_pad_attr_4_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_4 (
@@ -11140,14 +11351,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_4_wd),
     .d      (hw2reg.dio_pad_attr[4].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[4].qe),
+    .qe     (dio_pad_attr_4_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[4].q),
     .qs     (dio_pad_attr_4_qs)
   );
+  assign reg2hw.dio_pad_attr[4].qe = dio_pad_attr_4_qe;
 
 
   // Subregister 5 of Multireg dio_pad_attr
   // R[dio_pad_attr_5]: V(True)
+  logic dio_pad_attr_5_qe;
+  logic [0:0] dio_pad_attr_5_flds_we;
+  assign dio_pad_attr_5_qe = &dio_pad_attr_5_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_5 (
@@ -11156,14 +11371,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_5_wd),
     .d      (hw2reg.dio_pad_attr[5].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[5].qe),
+    .qe     (dio_pad_attr_5_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[5].q),
     .qs     (dio_pad_attr_5_qs)
   );
+  assign reg2hw.dio_pad_attr[5].qe = dio_pad_attr_5_qe;
 
 
   // Subregister 6 of Multireg dio_pad_attr
   // R[dio_pad_attr_6]: V(True)
+  logic dio_pad_attr_6_qe;
+  logic [0:0] dio_pad_attr_6_flds_we;
+  assign dio_pad_attr_6_qe = &dio_pad_attr_6_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_6 (
@@ -11172,14 +11391,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_6_wd),
     .d      (hw2reg.dio_pad_attr[6].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[6].qe),
+    .qe     (dio_pad_attr_6_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[6].q),
     .qs     (dio_pad_attr_6_qs)
   );
+  assign reg2hw.dio_pad_attr[6].qe = dio_pad_attr_6_qe;
 
 
   // Subregister 7 of Multireg dio_pad_attr
   // R[dio_pad_attr_7]: V(True)
+  logic dio_pad_attr_7_qe;
+  logic [0:0] dio_pad_attr_7_flds_we;
+  assign dio_pad_attr_7_qe = &dio_pad_attr_7_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_7 (
@@ -11188,14 +11411,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_7_wd),
     .d      (hw2reg.dio_pad_attr[7].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[7].qe),
+    .qe     (dio_pad_attr_7_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[7].q),
     .qs     (dio_pad_attr_7_qs)
   );
+  assign reg2hw.dio_pad_attr[7].qe = dio_pad_attr_7_qe;
 
 
   // Subregister 8 of Multireg dio_pad_attr
   // R[dio_pad_attr_8]: V(True)
+  logic dio_pad_attr_8_qe;
+  logic [0:0] dio_pad_attr_8_flds_we;
+  assign dio_pad_attr_8_qe = &dio_pad_attr_8_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_8 (
@@ -11204,14 +11431,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_8_wd),
     .d      (hw2reg.dio_pad_attr[8].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[8].qe),
+    .qe     (dio_pad_attr_8_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[8].q),
     .qs     (dio_pad_attr_8_qs)
   );
+  assign reg2hw.dio_pad_attr[8].qe = dio_pad_attr_8_qe;
 
 
   // Subregister 9 of Multireg dio_pad_attr
   // R[dio_pad_attr_9]: V(True)
+  logic dio_pad_attr_9_qe;
+  logic [0:0] dio_pad_attr_9_flds_we;
+  assign dio_pad_attr_9_qe = &dio_pad_attr_9_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_9 (
@@ -11220,14 +11451,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_9_wd),
     .d      (hw2reg.dio_pad_attr[9].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[9].qe),
+    .qe     (dio_pad_attr_9_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[9].q),
     .qs     (dio_pad_attr_9_qs)
   );
+  assign reg2hw.dio_pad_attr[9].qe = dio_pad_attr_9_qe;
 
 
   // Subregister 10 of Multireg dio_pad_attr
   // R[dio_pad_attr_10]: V(True)
+  logic dio_pad_attr_10_qe;
+  logic [0:0] dio_pad_attr_10_flds_we;
+  assign dio_pad_attr_10_qe = &dio_pad_attr_10_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_10 (
@@ -11236,14 +11471,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_10_wd),
     .d      (hw2reg.dio_pad_attr[10].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[10].qe),
+    .qe     (dio_pad_attr_10_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[10].q),
     .qs     (dio_pad_attr_10_qs)
   );
+  assign reg2hw.dio_pad_attr[10].qe = dio_pad_attr_10_qe;
 
 
   // Subregister 11 of Multireg dio_pad_attr
   // R[dio_pad_attr_11]: V(True)
+  logic dio_pad_attr_11_qe;
+  logic [0:0] dio_pad_attr_11_flds_we;
+  assign dio_pad_attr_11_qe = &dio_pad_attr_11_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_11 (
@@ -11252,14 +11491,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_11_wd),
     .d      (hw2reg.dio_pad_attr[11].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[11].qe),
+    .qe     (dio_pad_attr_11_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[11].q),
     .qs     (dio_pad_attr_11_qs)
   );
+  assign reg2hw.dio_pad_attr[11].qe = dio_pad_attr_11_qe;
 
 
   // Subregister 12 of Multireg dio_pad_attr
   // R[dio_pad_attr_12]: V(True)
+  logic dio_pad_attr_12_qe;
+  logic [0:0] dio_pad_attr_12_flds_we;
+  assign dio_pad_attr_12_qe = &dio_pad_attr_12_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_12 (
@@ -11268,14 +11511,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_12_wd),
     .d      (hw2reg.dio_pad_attr[12].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[12].qe),
+    .qe     (dio_pad_attr_12_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[12].q),
     .qs     (dio_pad_attr_12_qs)
   );
+  assign reg2hw.dio_pad_attr[12].qe = dio_pad_attr_12_qe;
 
 
   // Subregister 13 of Multireg dio_pad_attr
   // R[dio_pad_attr_13]: V(True)
+  logic dio_pad_attr_13_qe;
+  logic [0:0] dio_pad_attr_13_flds_we;
+  assign dio_pad_attr_13_qe = &dio_pad_attr_13_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_13 (
@@ -11284,14 +11531,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_13_wd),
     .d      (hw2reg.dio_pad_attr[13].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[13].qe),
+    .qe     (dio_pad_attr_13_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[13].q),
     .qs     (dio_pad_attr_13_qs)
   );
+  assign reg2hw.dio_pad_attr[13].qe = dio_pad_attr_13_qe;
 
 
   // Subregister 14 of Multireg dio_pad_attr
   // R[dio_pad_attr_14]: V(True)
+  logic dio_pad_attr_14_qe;
+  logic [0:0] dio_pad_attr_14_flds_we;
+  assign dio_pad_attr_14_qe = &dio_pad_attr_14_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_14 (
@@ -11300,14 +11551,18 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_14_wd),
     .d      (hw2reg.dio_pad_attr[14].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[14].qe),
+    .qe     (dio_pad_attr_14_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[14].q),
     .qs     (dio_pad_attr_14_qs)
   );
+  assign reg2hw.dio_pad_attr[14].qe = dio_pad_attr_14_qe;
 
 
   // Subregister 15 of Multireg dio_pad_attr
   // R[dio_pad_attr_15]: V(True)
+  logic dio_pad_attr_15_qe;
+  logic [0:0] dio_pad_attr_15_flds_we;
+  assign dio_pad_attr_15_qe = &dio_pad_attr_15_flds_we;
   prim_subreg_ext #(
     .DW    (13)
   ) u_dio_pad_attr_15 (
@@ -11316,10 +11571,11 @@ module pinmux_reg_top (
     .wd     (dio_pad_attr_15_wd),
     .d      (hw2reg.dio_pad_attr[15].d),
     .qre    (),
-    .qe     (reg2hw.dio_pad_attr[15].qe),
+    .qe     (dio_pad_attr_15_flds_we[0]),
     .q      (reg2hw.dio_pad_attr[15].q),
     .qs     (dio_pad_attr_15_qs)
   );
+  assign reg2hw.dio_pad_attr[15].qe = dio_pad_attr_15_qe;
 
 
   // Subregister 0 of Multireg mio_pad_sleep_status

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -237,6 +237,9 @@ module pwrmgr_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [0:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_intr_test (
@@ -245,13 +248,17 @@ module pwrmgr_reg_top (
     .wd     (intr_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.qe = intr_test_qe;
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -260,10 +267,11 @@ module pwrmgr_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
   // R[ctrl_cfg_regwen]: V(True)
@@ -434,6 +442,17 @@ module pwrmgr_reg_top (
 
 
   // R[cfg_cdc_sync]: V(False)
+  logic cfg_cdc_sync_qe;
+  logic [0:0] cfg_cdc_sync_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_cfg_cdc_sync0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&cfg_cdc_sync_flds_we),
+    .q_o(cfg_cdc_sync_qe)
+  );
   prim_subreg #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -451,12 +470,13 @@ module pwrmgr_reg_top (
     .d      (hw2reg.cfg_cdc_sync.d),
 
     // to internal hardware
-    .qe     (reg2hw.cfg_cdc_sync.qe),
+    .qe     (cfg_cdc_sync_flds_we[0]),
     .q      (reg2hw.cfg_cdc_sync.q),
 
     // to register interface (read)
     .qs     (cfg_cdc_sync_qs)
   );
+  assign reg2hw.cfg_cdc_sync.qe = cfg_cdc_sync_qe;
 
 
   // R[wakeup_en_regwen]: V(False)
@@ -976,6 +996,9 @@ module pwrmgr_reg_top (
 
 
   // R[wake_info]: V(True)
+  logic wake_info_qe;
+  logic [2:0] wake_info_flds_we;
+  assign wake_info_qe = &wake_info_flds_we;
   //   F[reasons]: 5:0
   prim_subreg_ext #(
     .DW    (6)
@@ -985,10 +1008,11 @@ module pwrmgr_reg_top (
     .wd     (wake_info_reasons_wd),
     .d      (hw2reg.wake_info.reasons.d),
     .qre    (),
-    .qe     (reg2hw.wake_info.reasons.qe),
+    .qe     (wake_info_flds_we[0]),
     .q      (reg2hw.wake_info.reasons.q),
     .qs     (wake_info_reasons_qs)
   );
+  assign reg2hw.wake_info.reasons.qe = wake_info_qe;
 
   //   F[fall_through]: 6:6
   prim_subreg_ext #(
@@ -999,10 +1023,11 @@ module pwrmgr_reg_top (
     .wd     (wake_info_fall_through_wd),
     .d      (hw2reg.wake_info.fall_through.d),
     .qre    (),
-    .qe     (reg2hw.wake_info.fall_through.qe),
+    .qe     (wake_info_flds_we[1]),
     .q      (reg2hw.wake_info.fall_through.q),
     .qs     (wake_info_fall_through_qs)
   );
+  assign reg2hw.wake_info.fall_through.qe = wake_info_qe;
 
   //   F[abort]: 7:7
   prim_subreg_ext #(
@@ -1013,10 +1038,11 @@ module pwrmgr_reg_top (
     .wd     (wake_info_abort_wd),
     .d      (hw2reg.wake_info.abort.d),
     .qre    (),
-    .qe     (reg2hw.wake_info.abort.qe),
+    .qe     (wake_info_flds_we[2]),
     .q      (reg2hw.wake_info.abort.q),
     .qs     (wake_info_abort_qs)
   );
+  assign reg2hw.wake_info.abort.qe = wake_info_qe;
 
 
   // R[fault_status]: V(False)

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr_reg_top.sv
@@ -192,6 +192,9 @@ module rstmgr_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[fatal_fault]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -201,10 +204,11 @@ module rstmgr_reg_top (
     .wd     (alert_test_fatal_fault_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_fault.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.fatal_fault.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_fault.qe = alert_test_qe;
 
   //   F[fatal_cnsty_fault]: 1:1
   prim_subreg_ext #(
@@ -215,10 +219,11 @@ module rstmgr_reg_top (
     .wd     (alert_test_fatal_cnsty_fault_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_cnsty_fault.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_cnsty_fault.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_cnsty_fault.qe = alert_test_qe;
 
 
   // R[reset_req]: V(False)
@@ -795,6 +800,9 @@ module rstmgr_reg_top (
 
   // Subregister 0 of Multireg sw_rst_ctrl_n
   // R[sw_rst_ctrl_n]: V(True)
+  logic sw_rst_ctrl_n_qe;
+  logic [7:0] sw_rst_ctrl_n_flds_we;
+  assign sw_rst_ctrl_n_qe = &sw_rst_ctrl_n_flds_we;
   //   F[val_0]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -804,10 +812,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_0_wd),
     .d      (hw2reg.sw_rst_ctrl_n[0].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[0].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[0]),
     .q      (reg2hw.sw_rst_ctrl_n[0].q),
     .qs     (sw_rst_ctrl_n_val_0_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[0].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_1]: 1:1
   prim_subreg_ext #(
@@ -818,10 +827,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_1_wd),
     .d      (hw2reg.sw_rst_ctrl_n[1].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[1].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[1]),
     .q      (reg2hw.sw_rst_ctrl_n[1].q),
     .qs     (sw_rst_ctrl_n_val_1_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[1].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_2]: 2:2
   prim_subreg_ext #(
@@ -832,10 +842,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_2_wd),
     .d      (hw2reg.sw_rst_ctrl_n[2].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[2].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[2]),
     .q      (reg2hw.sw_rst_ctrl_n[2].q),
     .qs     (sw_rst_ctrl_n_val_2_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[2].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_3]: 3:3
   prim_subreg_ext #(
@@ -846,10 +857,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_3_wd),
     .d      (hw2reg.sw_rst_ctrl_n[3].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[3].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[3]),
     .q      (reg2hw.sw_rst_ctrl_n[3].q),
     .qs     (sw_rst_ctrl_n_val_3_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[3].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_4]: 4:4
   prim_subreg_ext #(
@@ -860,10 +872,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_4_wd),
     .d      (hw2reg.sw_rst_ctrl_n[4].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[4].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[4]),
     .q      (reg2hw.sw_rst_ctrl_n[4].q),
     .qs     (sw_rst_ctrl_n_val_4_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[4].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_5]: 5:5
   prim_subreg_ext #(
@@ -874,10 +887,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_5_wd),
     .d      (hw2reg.sw_rst_ctrl_n[5].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[5].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[5]),
     .q      (reg2hw.sw_rst_ctrl_n[5].q),
     .qs     (sw_rst_ctrl_n_val_5_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[5].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_6]: 6:6
   prim_subreg_ext #(
@@ -888,10 +902,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_6_wd),
     .d      (hw2reg.sw_rst_ctrl_n[6].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[6].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[6]),
     .q      (reg2hw.sw_rst_ctrl_n[6].q),
     .qs     (sw_rst_ctrl_n_val_6_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[6].qe = sw_rst_ctrl_n_qe;
 
   //   F[val_7]: 7:7
   prim_subreg_ext #(
@@ -902,10 +917,11 @@ module rstmgr_reg_top (
     .wd     (sw_rst_ctrl_n_val_7_wd),
     .d      (hw2reg.sw_rst_ctrl_n[7].d),
     .qre    (),
-    .qe     (reg2hw.sw_rst_ctrl_n[7].qe),
+    .qe     (sw_rst_ctrl_n_flds_we[7]),
     .q      (reg2hw.sw_rst_ctrl_n[7].q),
     .qs     (sw_rst_ctrl_n_val_7_qs)
   );
+  assign reg2hw.sw_rst_ctrl_n[7].qe = sw_rst_ctrl_n_qe;
 
 
   // R[err_code]: V(False)

--- a/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
+++ b/hw/top_earlgrey/ip/sensor_ctrl/rtl/sensor_ctrl_reg_top.sv
@@ -214,6 +214,9 @@ module sensor_ctrl_reg_top (
 
   // Register instances
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [1:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   //   F[recov_alert]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -223,10 +226,11 @@ module sensor_ctrl_reg_top (
     .wd     (alert_test_recov_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.recov_alert.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.recov_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.recov_alert.qe = alert_test_qe;
 
   //   F[fatal_alert]: 1:1
   prim_subreg_ext #(
@@ -237,10 +241,11 @@ module sensor_ctrl_reg_top (
     .wd     (alert_test_fatal_alert_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.fatal_alert.qe),
+    .qe     (alert_test_flds_we[1]),
     .q      (reg2hw.alert_test.fatal_alert.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.fatal_alert.qe = alert_test_qe;
 
 
   // R[cfg_regwen]: V(False)

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_top.sv
@@ -1552,6 +1552,9 @@ module alert_handler_reg_top (
 
 
   // R[intr_test]: V(True)
+  logic intr_test_qe;
+  logic [3:0] intr_test_flds_we;
+  assign intr_test_qe = &intr_test_flds_we;
   //   F[classa]: 0:0
   prim_subreg_ext #(
     .DW    (1)
@@ -1561,10 +1564,11 @@ module alert_handler_reg_top (
     .wd     (intr_test_classa_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.classa.qe),
+    .qe     (intr_test_flds_we[0]),
     .q      (reg2hw.intr_test.classa.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.classa.qe = intr_test_qe;
 
   //   F[classb]: 1:1
   prim_subreg_ext #(
@@ -1575,10 +1579,11 @@ module alert_handler_reg_top (
     .wd     (intr_test_classb_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.classb.qe),
+    .qe     (intr_test_flds_we[1]),
     .q      (reg2hw.intr_test.classb.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.classb.qe = intr_test_qe;
 
   //   F[classc]: 2:2
   prim_subreg_ext #(
@@ -1589,10 +1594,11 @@ module alert_handler_reg_top (
     .wd     (intr_test_classc_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.classc.qe),
+    .qe     (intr_test_flds_we[2]),
     .q      (reg2hw.intr_test.classc.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.classc.qe = intr_test_qe;
 
   //   F[classd]: 3:3
   prim_subreg_ext #(
@@ -1603,10 +1609,11 @@ module alert_handler_reg_top (
     .wd     (intr_test_classd_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.intr_test.classd.qe),
+    .qe     (intr_test_flds_we[3]),
     .q      (reg2hw.intr_test.classd.q),
     .qs     ()
   );
+  assign reg2hw.intr_test.classd.qe = intr_test_qe;
 
 
   // R[ping_timer_regwen]: V(False)
@@ -10542,6 +10549,17 @@ module alert_handler_reg_top (
 
 
   // R[classa_clr_shadowed]: V(False)
+  logic classa_clr_shadowed_qe;
+  logic [0:0] classa_clr_shadowed_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_classa_clr_shadowed0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&classa_clr_shadowed_flds_we),
+    .q_o(classa_clr_shadowed_qe)
+  );
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -10561,7 +10579,7 @@ module alert_handler_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.classa_clr_shadowed.qe),
+    .qe     (classa_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classa_clr_shadowed.q),
 
     // to register interface (read)
@@ -10574,6 +10592,7 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classa_clr_shadowed.err_update),
     .err_storage (reg2hw.classa_clr_shadowed.err_storage)
   );
+  assign reg2hw.classa_clr_shadowed.qe = classa_clr_shadowed_qe;
 
 
   // R[classa_accum_cnt]: V(True)
@@ -11261,6 +11280,17 @@ module alert_handler_reg_top (
 
 
   // R[classb_clr_shadowed]: V(False)
+  logic classb_clr_shadowed_qe;
+  logic [0:0] classb_clr_shadowed_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_classb_clr_shadowed0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&classb_clr_shadowed_flds_we),
+    .q_o(classb_clr_shadowed_qe)
+  );
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11280,7 +11310,7 @@ module alert_handler_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.classb_clr_shadowed.qe),
+    .qe     (classb_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classb_clr_shadowed.q),
 
     // to register interface (read)
@@ -11293,6 +11323,7 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classb_clr_shadowed.err_update),
     .err_storage (reg2hw.classb_clr_shadowed.err_storage)
   );
+  assign reg2hw.classb_clr_shadowed.qe = classb_clr_shadowed_qe;
 
 
   // R[classb_accum_cnt]: V(True)
@@ -11980,6 +12011,17 @@ module alert_handler_reg_top (
 
 
   // R[classc_clr_shadowed]: V(False)
+  logic classc_clr_shadowed_qe;
+  logic [0:0] classc_clr_shadowed_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_classc_clr_shadowed0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&classc_clr_shadowed_flds_we),
+    .q_o(classc_clr_shadowed_qe)
+  );
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -11999,7 +12041,7 @@ module alert_handler_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.classc_clr_shadowed.qe),
+    .qe     (classc_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classc_clr_shadowed.q),
 
     // to register interface (read)
@@ -12012,6 +12054,7 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classc_clr_shadowed.err_update),
     .err_storage (reg2hw.classc_clr_shadowed.err_storage)
   );
+  assign reg2hw.classc_clr_shadowed.qe = classc_clr_shadowed_qe;
 
 
   // R[classc_accum_cnt]: V(True)
@@ -12699,6 +12742,17 @@ module alert_handler_reg_top (
 
 
   // R[classd_clr_shadowed]: V(False)
+  logic classd_clr_shadowed_qe;
+  logic [0:0] classd_clr_shadowed_flds_we;
+  prim_flop #(
+    .Width(1),
+    .ResetValue(0)
+  ) u_classd_clr_shadowed0_qe (
+    .clk_i(clk_i),
+    .rst_ni(rst_ni),
+    .d_i(&classd_clr_shadowed_flds_we),
+    .q_o(classd_clr_shadowed_qe)
+  );
   prim_subreg_shadow #(
     .DW      (1),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
@@ -12718,7 +12772,7 @@ module alert_handler_reg_top (
     .d      ('0),
 
     // to internal hardware
-    .qe     (reg2hw.classd_clr_shadowed.qe),
+    .qe     (classd_clr_shadowed_flds_we[0]),
     .q      (reg2hw.classd_clr_shadowed.q),
 
     // to register interface (read)
@@ -12731,6 +12785,7 @@ module alert_handler_reg_top (
     .err_update  (reg2hw.classd_clr_shadowed.err_update),
     .err_storage (reg2hw.classd_clr_shadowed.err_storage)
   );
+  assign reg2hw.classd_clr_shadowed.qe = classd_clr_shadowed_qe;
 
 
   // R[classd_accum_cnt]: V(True)

--- a/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
+++ b/hw/top_earlgrey/ip_autogen/rv_plic/rtl/rv_plic_reg_top.sv
@@ -15361,6 +15361,9 @@ module rv_plic_reg_top (
 
 
   // R[cc0]: V(True)
+  logic cc0_qe;
+  logic [0:0] cc0_flds_we;
+  assign cc0_qe = &cc0_flds_we;
   prim_subreg_ext #(
     .DW    (8)
   ) u_cc0 (
@@ -15369,10 +15372,11 @@ module rv_plic_reg_top (
     .wd     (cc0_wd),
     .d      (hw2reg.cc0.d),
     .qre    (reg2hw.cc0.re),
-    .qe     (reg2hw.cc0.qe),
+    .qe     (cc0_flds_we[0]),
     .q      (reg2hw.cc0.q),
     .qs     (cc0_qs)
   );
+  assign reg2hw.cc0.qe = cc0_qe;
 
 
   // R[msip0]: V(False)
@@ -15402,6 +15406,9 @@ module rv_plic_reg_top (
 
 
   // R[alert_test]: V(True)
+  logic alert_test_qe;
+  logic [0:0] alert_test_flds_we;
+  assign alert_test_qe = &alert_test_flds_we;
   prim_subreg_ext #(
     .DW    (1)
   ) u_alert_test (
@@ -15410,10 +15417,11 @@ module rv_plic_reg_top (
     .wd     (alert_test_wd),
     .d      ('0),
     .qre    (),
-    .qe     (reg2hw.alert_test.qe),
+    .qe     (alert_test_flds_we[0]),
     .q      (reg2hw.alert_test.q),
     .qs     ()
   );
+  assign reg2hw.alert_test.qe = alert_test_qe;
 
 
 

--- a/util/reggen/multi_register.py
+++ b/util/reggen/multi_register.py
@@ -158,6 +158,9 @@ class MultiRegister(RegBase):
     def is_homogeneous(self) -> bool:
         return self.reg.is_homogeneous()
 
+    def needs_qe(self) -> bool:
+        return self.reg.needs_qe()
+
     def _asdict(self) -> Dict[str, object]:
         rd = self.reg._asdict()
         rd['count'] = str(self.count)

--- a/util/reggen/register.py
+++ b/util/reggen/register.py
@@ -376,6 +376,15 @@ class Register(RegBase):
                 return True
         return False
 
+    def needs_qe(self) -> bool:
+        '''Return true if the register or at least one field needs a q-enable'''
+        if self.hwqe:
+            return True
+        for fld in self.fields:
+            if fld.hwqe:
+                return True
+        return False
+
     def needs_re(self) -> bool:
         '''Return true if at least one field needs a read-enable
 


### PR DESCRIPTION
[reggen] Make field 'qe' behavior consistent
- if one field does not generate 'qe' for whatever reason (for example
  shadow update error), suppress qe generation for the entire register.

Originally this PR consolidated all the `qe` into one item in the struct instead of having it per field. 
However that turned out to disturb a bunch of ip blocks. 

I can still re-open and do that if people prefer. 
