### PR TITLE
[dv/full_chip] Add clkmgr_external_clk_src_for_sw

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -814,9 +814,10 @@
 
             The IP level checks the divided clocks via SVA, and these are also bound at chip level.
             Connectivity tests check peripherals are connected to the clock they expect.
+            Use the clkmgr count measurement feature to verify clock division.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_clkmgr_external_clk_src_for_sw"]
       tags: ["conn"]
     }
     {
@@ -840,7 +841,7 @@
             X-ref with chip_sw_uart_tx_rx_alt_clk_freq, which needs to deal with this as well.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_clkmgr_external_clk_src_for_sw"]
     }
     {
       name: chip_sw_clkmgr_jitter

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -483,6 +483,12 @@
       run_opts: ["+sw_test_timeout_ns=7000000"]
     }
     {
+      name: chip_sw_clkmgr_external_clk_src_for_sw
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_sw_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_clkmgr_jitter
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/clkmgr_jitter_test:1"]

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -10,6 +10,8 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
   );
   `uvm_object_utils(chip_base_vseq)
 
+  typedef enum int {ExtClkFreq48MHz = 48, ExtClkFreq100MHz = 100} ext_clk_freq_e;
+
   // knobs to enable pre_start routines
   bit do_strap_pins_init = 1'b1; // initialize the strap
 
@@ -74,6 +76,8 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
   virtual task pre_start();
     // Do DUT init after some additional settings.
     bit do_dut_init_save = do_dut_init;
+    int extclk_frequency_mhz = ExtClkFreq100MHz;
+    int extclk_frequency_attempted;
     do_dut_init = 1'b0;
     super.pre_start();
     do_dut_init = do_dut_init_save;
@@ -84,6 +88,19 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
       cfg.dft_straps_vif.drive(2'b00);
       cfg.sw_straps_vif.drive({2'b00, cfg.use_spi_load_bootstrap});
     end
+
+    // Set external clock frequency.
+    if ($value$plusargs("extclk_freq_mhz=%d", extclk_frequency_attempted)) begin
+      if (extclk_frequency_attempted == ExtClkFreq100MHz ||
+          extclk_frequency_attempted == ExtClkFreq48MHz) begin
+        extclk_frequency_mhz = extclk_frequency_attempted;
+      end else begin
+        `uvm_error(`gfn, $sformatf(
+                   "Unexpected extclk frequency %0d: valid numbers are 100 and 48",
+                   extclk_frequency_attempted))
+      end
+    end
+    cfg.clk_rst_vif.set_freq_mhz(extclk_frequency_mhz);
 
     // Now safe to do DUT init.
     if (do_dut_init) dut_init();

--- a/sw/device/lib/testing/clkmgr_testutils.c
+++ b/sw/device/lib/testing/clkmgr_testutils.c
@@ -6,6 +6,9 @@
 
 #include "sw/device/lib/dif/dif_clkmgr.h"
 
+const char *measure_clock_names[kDifClkmgrMeasureClockUsb + 1] = {
+    "io_clk", "io_div2_clk", "io_div4_clk", "main_clk", "usb_clk"};
+
 // `extern` declarations to give the inline functions in the
 // corresponding header a link location.
 
@@ -15,3 +18,15 @@ extern bool clkmgr_testutils_get_trans_clock_status(
 extern void clkmgr_testutils_check_trans_clock_gating(
     dif_clkmgr_t *clkmgr, dif_clkmgr_hintable_clock_t clock,
     bool exp_clock_enabled, uint32_t timeout_usec);
+
+extern void clkmgr_testutils_enable_clock_count_measurement(
+    dif_clkmgr_t *clkmgr, dif_clkmgr_measure_clock_t clock,
+    uint32_t lo_threshold, uint32_t hi_threshold);
+
+void clkmgr_testutils_disable_clock_count_measurements(dif_clkmgr_t *clkmgr) {
+  LOG_INFO("Disabling all clock count measurements");
+  for (int i = 0; i <= kDifClkmgrMeasureClockUsb; ++i) {
+    dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
+    CHECK_DIF_OK(dif_clkmgr_disable_measure_counts(clkmgr, clock));
+  }
+}

--- a/sw/device/lib/testing/clkmgr_testutils.h
+++ b/sw/device/lib/testing/clkmgr_testutils.h
@@ -33,7 +33,6 @@ inline bool clkmgr_testutils_get_trans_clock_status(
  * sets the hint back to 1 afterwards. Inlined due to latency-sensitivity.
  *
  * @param clkmgr A clkmgr DIF handle.
- * @param params clkmgr hardware instance parameters.
  * @param clock The transactional clock ID.
  * @param exp_clock_enabled Expected clock status.
  * @param timeout_usec Timeout in microseconds.
@@ -49,5 +48,33 @@ inline void clkmgr_testutils_check_trans_clock_gating(
 
   CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(clkmgr, clock, 0x1));
 }
+
+extern const char *measure_clock_names[kDifClkmgrMeasureClockUsb + 1];
+
+/**
+ * Enables clock measurements.
+ *
+ * This enables measurements with lo and hi count bounds for a given clock.
+ *
+ * @param clkmgr A clkmgr DIF handle.
+ * @param clock The clock to be measured.
+ * @param lo_threshold Expected minimum cycle count.
+ * @param hi_threshold Expected maximum cycle count.
+ */
+inline void clkmgr_testutils_enable_clock_count_measurement(
+    dif_clkmgr_t *clkmgr, dif_clkmgr_measure_clock_t clock,
+    uint32_t lo_threshold, uint32_t hi_threshold) {
+  LOG_INFO("Enabling clock count measurement for %0s lo %0d hi %0d",
+           measure_clock_names[clock], lo_threshold, hi_threshold);
+  CHECK_DIF_OK(dif_clkmgr_enable_measure_counts(clkmgr, clock, lo_threshold,
+                                                hi_threshold));
+}
+
+/**
+ * Disable all clock measurements.
+ *
+ * @param clkmgr A clkmgr DIF handle.
+ */
+void clkmgr_testutils_disable_clock_count_measurements(dif_clkmgr_t *clkmgr);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_CLKMGR_TESTUTILS_H_

--- a/sw/device/tests/clkmgr_external_clk_src_for_sw_test.c
+++ b/sw/device/tests/clkmgr_external_clk_src_for_sw_test.c
@@ -1,0 +1,138 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This test enables the external clock via software and ramps down the
+// clock dividers. It checks the expected frequencies via the clock count
+// measurement feature.
+//
+// The variability for USB is larger because that clock is uncalibrated at
+// power-on.
+// TODO(lowrisc/opentitan:#11264): tighten up the USB measurement once
+// this issue is addressed.
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/clkmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig;
+
+typedef struct expected_count_info {
+  int count;
+  int variability;
+} expected_count_info_t;
+
+expected_count_info_t count_infos[kDifClkmgrMeasureClockUsb + 1] = {
+    {479, 1}, {239, 1}, {119, 1}, {499, 1}, {239, 6}};
+
+const int extclk_settle_delay_us = 30;
+const int measurement_delay_us = 100;
+
+static void clear_recoverable_errors(const dif_clkmgr_t *clkmgr) {
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(clkmgr, ~0u));
+}
+
+static void check_measurement_counts(const dif_clkmgr_t *clkmgr) {
+  dif_clkmgr_recov_err_codes_t err_codes;
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_get_codes(clkmgr, &err_codes));
+  if (err_codes) {
+    LOG_ERROR("Unexpected recoverable error codes 0x%x", err_codes);
+  } else {
+    LOG_INFO("Clock measurements are okay");
+  }
+  clear_recoverable_errors(clkmgr);
+}
+
+bool test_main() {
+  dif_clkmgr_t clkmgr;
+  dif_clkmgr_recov_err_codes_t err_codes;
+
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(&clkmgr, ~0u));
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_get_codes(&clkmgr, &err_codes));
+  LOG_INFO("Recoverable error codes 0x%x", err_codes);
+
+  LOG_INFO("Enabling clock count measurements");
+  // Enable cycle count measurements to confirm the frequencies are correct.
+  for (int i = 0; i <= kDifClkmgrMeasureClockUsb; ++i) {
+    dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
+    expected_count_info_t count_info = count_infos[clock];
+    clkmgr_testutils_enable_clock_count_measurement(
+        &clkmgr, clock, count_info.count - count_info.variability,
+        count_info.count + count_info.variability);
+  }
+
+  busy_spin_micros(measurement_delay_us);
+  check_measurement_counts(&clkmgr);
+  clkmgr_testutils_disable_clock_count_measurements(&clkmgr);
+
+  // Configure external clock and low speed: both main and io clocks counts
+  // are the nominal IoDiv2's.
+  LOG_INFO("Selecting external clock and low speed clocks");
+  CHECK_DIF_OK(dif_clkmgr_external_clock_set_enabled(&clkmgr, true));
+
+  // Wait a few AON cycles for glitches from the transition to external
+  // clock to settle.
+  busy_spin_micros(extclk_settle_delay_us);
+
+  // Enable cycle measurements to confirm the frequencies are correct.
+  for (int i = 0; i <= kDifClkmgrMeasureClockUsb; ++i) {
+    dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
+    expected_count_info_t count_info;
+    if (clock == kDifClkmgrMeasureClockIo ||
+        clock == kDifClkmgrMeasureClockMain) {
+      count_info = count_infos[kDifClkmgrMeasureClockIoDiv2];
+    } else {
+      count_info = count_infos[clock];
+    }
+    clkmgr_testutils_enable_clock_count_measurement(
+        &clkmgr, clock, count_info.count - count_info.variability,
+        count_info.count + count_info.variability);
+  }
+
+  busy_spin_micros(measurement_delay_us);
+  check_measurement_counts(&clkmgr);
+  clkmgr_testutils_disable_clock_count_measurements(&clkmgr);
+
+  // Configure external clock and high speed: io, io_div2, and main expected
+  // at 96 MHz, and io_div4 at 48 MHz.
+  LOG_INFO("Selecting external clock and high speed clocks");
+  CHECK_DIF_OK(dif_clkmgr_external_clock_set_enabled(&clkmgr, false));
+
+  // Wait a few AON cycles for glitches from the transition to external
+  // high speed to settle.
+  busy_spin_micros(10);
+
+  // Enable cycle measurements to confirm the frequencies are correct.
+  for (int i = 0; i <= kDifClkmgrMeasureClockUsb; ++i) {
+    dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
+    expected_count_info_t count_info;
+    if (clock == kDifClkmgrMeasureClockMain ||
+        clock == kDifClkmgrMeasureClockIoDiv2) {
+      count_info = count_infos[kDifClkmgrMeasureClockIo];
+    } else if (clock == kDifClkmgrMeasureClockIoDiv4) {
+      count_info = count_infos[kDifClkmgrMeasureClockIoDiv2];
+    } else {
+      count_info = count_infos[clock];
+    }
+    clkmgr_testutils_enable_clock_count_measurement(
+        &clkmgr, clock, count_info.count - count_info.variability,
+        count_info.count + count_info.variability);
+  }
+
+  busy_spin_micros(measurement_delay_us);
+  check_measurement_counts(&clkmgr);
+  clkmgr_testutils_disable_clock_count_measurements(&clkmgr);
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -302,6 +302,27 @@ sw_tests += {
   }
 }
 
+clkmgr_external_clk_src_for_sw_test_lib = declare_dependency(
+  link_with: static_library(
+    'clkmgr_external_clk_src_for_sw_test_lib',
+    sources: ['clkmgr_external_clk_src_for_sw_test.c'],
+    dependencies: [
+      sw_lib_dif_clkmgr,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+      sw_lib_runtime_ibex,
+      sw_lib_runtime_log,
+      sw_lib_testing_clkmgr_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'clkmgr_external_clk_src_for_sw_test': {
+    'library': clkmgr_external_clk_src_for_sw_test_lib,
+  }
+}
+
 clkmgr_jitter_test_lib = declare_dependency(
   link_with: static_library(
     'clkmgr_jitter_test_lib',


### PR DESCRIPTION
Fix chip external clock frequency: set it to 100 MHz by default, and add
option to set it to either 100 or 48 MHz via "extclk_freq_mhz" plusargs.
Create clkmgr_testutils_enable_clock_count_measurement testutils for
this test.

Signed-off-by: Guillermo Maturana <maturana@google.com>