### PR TITLE
Update lowrisc_ibex to lowRISC/ibex@3438b779

### DIFF
--- a/hw/vendor/lowrisc_ibex.lock.hjson
+++ b/hw/vendor/lowrisc_ibex.lock.hjson
@@ -9,6 +9,6 @@
   upstream:
   {
     url: https://github.com/lowRISC/ibex.git
-    rev: 0f69d4972c5184e8c8de41c4002fb914ef3ce10f
+    rev: 3438b77921941ccbf50cba46b3009a6a37203d4b
   }
 }

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/icache.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/icache.rst
@@ -164,6 +164,8 @@ The remaining data from hits is buffered in the fill buffer data storage and sup
 
 To deal with misalignment caused by compressed instructions, there is a 16bit skid buffer to store the upper halfword.
 
+.. _icache-ecc:
+
 Cache ECC protection
 ^^^^^^^^^^^^^^^^^^^^
 
@@ -193,6 +195,7 @@ Any error (single or double bit) in any RAM will effectively cancel a cache hit 
 The request which observed an error will fetch it's data from the main instruction memory as normal for a cache miss.
 The cache index and way (or ways) with errors are stored in IC1, and a cache write is forced the next cycle to invalidate that line.
 Lookup requests will be blocked in IC0 while the invalidation write is performed.
+If an ECC error is seen a minor alert will be signaled.
 
 Cache invalidation
 ^^^^^^^^^^^^^^^^^^

--- a/hw/vendor/lowrisc_ibex/doc/03_reference/security.rst
+++ b/hw/vendor/lowrisc_ibex/doc/03_reference/security.rst
@@ -81,6 +81,13 @@ When Ibex is configured with the SecureIbex parameter, ECC checking is added to 
 This can be useful to detect fault injection attacks since the register file covers a reasonably large area.
 No attempt is made to correct detected errors, but an internal major alert is signaled for the system to take action.
 
+ICache ECC
+----------
+
+The ICache can be configured with ECC protection.
+When an ECC error is detected a minor alert is signaled.
+See :ref:`icache-ecc` for more information.
+
 Hardened PC
 -----------
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_cs_registers.sv
@@ -696,6 +696,8 @@ module ibex_cs_registers #(
           mstack_en      = 1'b1;
 
           if (!mcause_d[5]) begin
+            // SEC_CM: EXCEPTION.CTRL_FLOW.LOCAL_ESC
+            // SEC_CM: EXCEPTION.CTRL_FLOW.GLOBAL_ESC
             cpuctrl_we = 1'b1;
 
             cpuctrl_d.sync_exc_seen = 1'b1;
@@ -716,6 +718,8 @@ module ibex_cs_registers #(
         mstatus_en     = 1'b1;
         mstatus_d.mie  = mstatus_q.mpie; // re-enable interrupts
 
+        // SEC_CM: EXCEPTION.CTRL_FLOW.LOCAL_ESC
+        // SEC_CM: EXCEPTION.CTRL_FLOW.GLOBAL_ESC
         cpuctrl_we              = 1'b1;
         cpuctrl_d.sync_exc_seen = 1'b0;
 
@@ -1502,6 +1506,7 @@ module ibex_cs_registers #(
 
   // Generate fixed time execution bit
   if (DataIndTiming) begin : gen_dit
+    // SEC_CM: CORE.DATA_REG_SW.SCA
     assign cpuctrl_wdata.data_ind_timing = cpuctrl_wdata_raw.data_ind_timing;
 
   end else begin : gen_no_dit
@@ -1517,6 +1522,7 @@ module ibex_cs_registers #(
 
   // Generate dummy instruction signals
   if (DummyInstructions) begin : gen_dummy
+    // SEC_CM: CTRL_FLOW.UNPREDICTABLE
     assign cpuctrl_wdata.dummy_instr_en   = cpuctrl_wdata_raw.dummy_instr_en;
     assign cpuctrl_wdata.dummy_instr_mask = cpuctrl_wdata_raw.dummy_instr_mask;
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_dummy_instr.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_dummy_instr.sv
@@ -8,6 +8,7 @@
  * Provides pseudo-randomly inserted fake instructions for secure code obfuscation
  */
 
+// SEC_CM: CTRL_FLOW.UNPREDICTABLE
 module ibex_dummy_instr import ibex_pkg::*; #(
     parameter lfsr_seed_t RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
     parameter lfsr_perm_t RndCnstLfsrPerm = RndCnstLfsrPermDefault

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_id_stage.sv
@@ -658,6 +658,7 @@ module ibex_id_stage #(
     // (condition pass/fail used same cycle as generated instruction request)
     assign branch_set_raw      = branch_set_raw_d;
   end else begin : g_branch_set_flop
+    // SEC_CM: CORE.DATA_REG_SW.SCA
     // Branch set flopped without branch target ALU, or in fixed time execution mode
     // (condition pass/fail used next cycle where branch target is calculated)
     logic branch_set_raw_q;
@@ -703,6 +704,7 @@ module ibex_id_stage #(
   // Branch condition is calculated in the first cycle and flopped for use in the second cycle
   // (only used in fixed time execution mode to determine branch destination).
   if (DataIndTiming) begin : g_sec_branch_taken
+    // SEC_CM: CORE.DATA_REG_SW.SCA
     logic branch_taken_q;
 
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -799,6 +801,7 @@ module ibex_id_stage #(
               // cond branch operation
               // All branches take two cycles in fixed time execution mode, regardless of branch
               // condition.
+              // SEC_CM: CORE.DATA_REG_SW.SCA
               id_fsm_d         = (data_ind_timing_i || (!BranchTargetALU && branch_decision_i)) ?
                                      MULTI_CYCLE : FIRST_CYCLE;
               stall_branch     = (~BranchTargetALU & branch_decision_i) | data_ind_timing_i;

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_lockstep.sv
@@ -6,6 +6,8 @@
 // This module instantiates a second copy of the core logic, and compares it's outputs against
 // those from the main core. The second core runs synchronously with the main core, delayed by
 // LockstepOffset cycles.
+
+// SEC_CM: LOGIC.SHADOW
 module ibex_lockstep import ibex_pkg::*; #(
   parameter int unsigned LockstepOffset    = 2,
   parameter bit          PMPEnable         = 1'b0,
@@ -241,6 +243,7 @@ module ibex_lockstep import ibex_pkg::*; #(
   // Bus integrity checking //
   ////////////////////////////
 
+  // SEC_CM: BUS.INTEGRITY
   logic        bus_intg_err;
   logic [1:0]  instr_intg_err, data_intg_err;
   logic [31:0] unused_wdata;

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_fast.sv
@@ -423,6 +423,7 @@ module ibex_multdiv_fast #(
           // Note with data-independent time option, the full divide operation will proceed as
           // normal and will naturally return -1
           op_remainder_d = '1;
+          // SEC_CM: CORE.DATA_REG_SW.SCA
           md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
           // Record that this is a div by zero to stop the sign change at the end of the
           // division (in data_ind_timing mode).
@@ -433,6 +434,7 @@ module ibex_multdiv_fast #(
           // Note with data-independent time option, the full divide operation will proceed as
           // normal and will naturally return operand a
           op_remainder_d = {2'b0, op_a_i};
+          // SEC_CM: CORE.DATA_REG_SW.SCA
           md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
         end
         // 0 - B = 0 iff B == 0

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_slow.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_multdiv_slow.sv
@@ -190,6 +190,7 @@ module ibex_multdiv_slow
                                          op_a_ext[31:0] & {32{op_b_i[0]}}  };
               op_b_shift_d   = op_b_ext >> 1;
               // Proceed with multiplication by 0/1 in data-independent time mode
+              // SEC_CM: CORE.DATA_REG_SW.SCA
               md_state_d     = (!data_ind_timing_i && ((op_b_ext >> 1) == 0)) ? MD_LAST : MD_COMP;
             end
             MD_OP_MULH: begin
@@ -205,6 +206,7 @@ module ibex_multdiv_slow
               // Note with data-independent time option, the full divide operation will proceed as
               // normal and will naturally return -1
               accum_window_d = {33{1'b1}};
+              // SEC_CM: CORE.DATA_REG_SW.SCA
               md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
               // Record that this is a div by zero to stop the sign change at the end of the
               // division (in data_ind_timing mode).
@@ -216,6 +218,7 @@ module ibex_multdiv_slow
               // Note with data-independent time option, the full divide operation will proceed as
               // normal and will naturally return operand a
               accum_window_d = op_a_ext;
+              // SEC_CM: CORE.DATA_REG_SW.SCA
               md_state_d     = (!data_ind_timing_i && equal_to_zero_i) ? MD_FINISH : MD_ABS_A;
             end
             default:;
@@ -248,6 +251,7 @@ module ibex_multdiv_slow
               op_b_shift_d   = op_b_shift_q >> 1;
               // Multiplication is complete once op_b is zero, unless in data_ind_timing mode where
               // the maximum possible shift-add operations will be completed regardless of op_b
+              // SEC_CM: CORE.DATA_REG_SW.SCA
               md_state_d     = ((!data_ind_timing_i && (op_b_shift_d == 0)) ||
                                 (multdiv_count_q == 5'd1)) ? MD_LAST : MD_COMP;
             end

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_register_file_ff.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_register_file_ff.sv
@@ -66,6 +66,7 @@ module ibex_register_file_ff #(
   // With dummy instructions enabled, R0 behaves as a real register but will always return 0 for
   // real instructions.
   if (DummyInstructions) begin : g_dummy_r0
+    // SEC_CM: CTRL_FLOW.UNPREDICTABLE
     logic                 we_r0_dummy;
     logic [DataWidth-1:0] rf_r0_q;
 

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_register_file_latch.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_register_file_latch.sv
@@ -122,6 +122,7 @@ module ibex_register_file_latch #(
   // With dummy instructions enabled, R0 behaves as a real register but will always return 0 for
   // real instructions.
   if (DummyInstructions) begin : g_dummy_r0
+    // SEC_CM: CTRL_FLOW.UNPREDICTABLE
     logic                 we_r0_dummy;
     logic                 r0_clock;
     logic [DataWidth-1:0] mem_r0;

--- a/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
+++ b/hw/vendor/lowrisc_ibex/rtl/ibex_top.sv
@@ -422,8 +422,9 @@ module ibex_top import ibex_pkg::*; #(
 
   if (ICacheScramble) begin : gen_scramble
 
-  // Scramble key valid starts with OTP returning new valid key and stays high
-  // until we request a new valid key.
+    // SEC_CM: ICACHE.MEM.SCRAMBLE
+    // Scramble key valid starts with OTP returning new valid key and stays high
+    // until we request a new valid key.
     assign scramble_key_valid_d = scramble_req_q ? scramble_key_valid_i :
                                   icache_inval   ? 1'b0                 :
                                                    scramble_key_valid_q;
@@ -476,6 +477,7 @@ module ibex_top import ibex_pkg::*; #(
 
     for (genvar way = 0; way < IC_NUM_WAYS; way++) begin : gen_rams_inner
 
+      // SEC_CM: ICACHE.MEM.SCRAMBLE
       // Tag RAM instantiation
       prim_ram_1p_scr #(
         .Width            (TagSizeECC),
@@ -563,6 +565,7 @@ module ibex_top import ibex_pkg::*; #(
 
   // Redundant lockstep core implementation
   if (Lockstep) begin : gen_lockstep
+    // SEC_CM: LOGIC.SHADOW
     // Note: certain synthesis tools like DC are very smart at optimizing away redundant logic.
     // Hence, we have to insert an optimization barrier at the IOs of the lockstep Ibex.
     // This is achieved by manually buffering each bit using prim_buf.


### PR DESCRIPTION
Update code from upstream repository
https://github.com/lowRISC/ibex.git to revision
3438b77921941ccbf50cba46b3009a6a37203d4b

* [rtl] Add minor alert for icache ECC error (Greg Chadwick)
* [icache, rtl] Fix ECC error indication (Greg Chadwick)
* [rtl] Add SEC_CM markers for security features (Greg Chadwick)
* [ibex, dv] Makes delays between req, gnt and rvalid configurable
  (Prajwala Puttappa)
* [ibex, dv] Added new base, interrupt, debug and mem error sequences
  (Prajwala Puttappa)
* [icache] Define some fake DPI functions to simplify linking (Rupert
  Swarbrick)
* [ibex, dv] Added agent configuration for
  ibex_mem_intf_response_agent (Prajwala Puttappa)

Signed-off-by: Greg Chadwick <gac@lowrisc.org>