### PR TITLE
[otbn,dv] Cleanly handle failures when passing sideload keys to ISS

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -263,9 +263,9 @@ void OtbnModel::edn_urnd_step(svLogicVecVal *edn_urnd_data /* logic [31:0] */) {
   iss->edn_urnd_step(edn_urnd_data->aval);
 }
 
-void OtbnModel::set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
-                                 svLogicVecVal *key1 /* logic [383:0] */,
-                                 unsigned char valid) {
+int OtbnModel::set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
+                                svLogicVecVal *key1 /* logic [383:0] */,
+                                unsigned char valid) {
   ISSWrapper *iss = ensure_wrapper();
 
   std::array<uint32_t, 12> key0_arr;
@@ -276,7 +276,14 @@ void OtbnModel::set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
     key1_arr[i] = key1[i].aval;
   }
 
-  iss->set_keymgr_value(key0_arr, key1_arr, valid != 0);
+  try {
+    iss->set_keymgr_value(key0_arr, key1_arr, valid != 0);
+  } catch (const std::runtime_error &err) {
+    std::cerr << "Error when setting keymgr value: " << err.what() << "\n";
+    return -1;
+  }
+
+  return 0;
 }
 
 void OtbnModel::edn_urnd_cdc_done() {
@@ -807,10 +814,10 @@ void otbn_take_loop_warps(OtbnModel *model, OtbnMemUtil *memutil) {
   model->take_loop_warps(*memutil);
 }
 
-void otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
-                                 svLogicVecVal *key1, unsigned char valid) {
+int otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
+                                svLogicVecVal *key1, unsigned char valid) {
   assert(model && key0 && key1);
-  model->set_keymgr_value(key0, key1, valid);
+  return model->set_keymgr_value(key0, key1, valid);
 }
 
 int otbn_model_send_lc_escalation(OtbnModel *model) {

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -39,9 +39,11 @@ class OtbnModel {
   // EDN Step sends ISS the RND data when ACK signal is high.
   void edn_rnd_step(svLogicVecVal *edn_rnd_data /* logic [31:0] */);
 
-  void set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
-                        svLogicVecVal *key1 /* logic [383:0] */,
-                        unsigned char valid);
+  // Set or unset the two keys from keymgr. Returns 0 on success or -1
+  // on error.
+  int set_keymgr_value(svLogicVecVal *key0 /* logic [383:0] */,
+                       svLogicVecVal *key1 /* logic [383:0] */,
+                       unsigned char valid);
 
   // EDN Step sends ISS the URND related EDN data when ACK signal is high.
   void edn_urnd_step(svLogicVecVal *edn_urnd_data /* logic [31:0] */);

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -39,9 +39,9 @@ void edn_model_rnd_cdc_done(OtbnModel *model);
 // Signal RTL is finished processing EDN data for URND to Model
 void edn_model_urnd_cdc_done(OtbnModel *model);
 
-// Pass keymgr data to model
-void otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
-                                 svLogicVecVal *key1, unsigned char valid);
+// Pass keymgr data to model. Returns 0 on success; -1 on error.
+int otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
+                                svLogicVecVal *key1, unsigned char valid);
 
 // The main entry point to the OTBN model, exported from here and used in
 // otbn_core_model.sv.

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -25,8 +25,8 @@ import "DPI-C" function
   void edn_model_urnd_cdc_done(chandle model);
 
 import "DPI-C" function
-  void otbn_model_set_keymgr_value(chandle model, logic [383:0] key0,
-                                   logic [383:0] key1, bit valid);
+  int otbn_model_set_keymgr_value(chandle model, logic [383:0] key0,
+                                  logic [383:0] key1, bit valid);
 
 import "DPI-C" function
   void edn_model_rnd_cdc_done(chandle model);


### PR DESCRIPTION
We've been a bit lazy and not defined an error return for some of
these functions and this one just bit me! Tidy it up.
