### PR TITLE
[rv_core_ibex] Move to D2S and bump version to 1.0

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.prj.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.prj.hjson
@@ -7,8 +7,8 @@
     design_spec:        "../doc",
     hw_checklist:       "../doc/checklist",
     dv_doc:             "../doc/dv",
-    version:            "0.5",
+    version:            "1.0",
     life_stage:         "L1",
-    design_stage:       "D2",
+    design_stage:       "D2S",
     verification_stage: "V1",
 }


### PR DESCRIPTION
This PR vendoring in the latest Ibex must be merged before we can declare D2S: https://github.com/lowRISC/opentitan/pull/11330

There's two outstanding points of discussion:

Write data integrity generation - https://github.com/lowRISC/opentitan/issues/9528 as explained there I feel what we have is sufficient so no further action required

Should an ECC error in icache trigger a major or minor alert? Right now it's minor but it's trivial to switch over. I'd be tempted to say we can declare D2S without having to decide this specific point as it's a very quick change if we decide we want a major alert instead.