### PR TITLE
[sw,crypto] Add bazel targets for RSA-3072 and its tests.

### DIFF
--- a/sw/device/lib/crypto/rsa_3072/BUILD
+++ b/sw/device/lib/crypto/rsa_3072/BUILD
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
+
+cc_library(
+    name = "rsa_3072_verify",
+    srcs = ["rsa_3072_verify.c"],
+    hdrs = ["rsa_3072_verify.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base",
+        "//sw/device/lib/crypto:otbn_util",
+        "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/otbn/crypto:run_rsa_verify_3072",
+    ],
+)

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -36,3 +36,21 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
     ],
 )
+
+cc_library(
+    name = "rsa_3072_verify_testvectors",
+    hdrs = ["rsa_3072_verify_testvectors.h"],
+)
+
+opentitan_functest(
+    name = "rsa_3072_verify_functest",
+    srcs = ["rsa_3072_verify_functest.c"],
+    deps = [
+        ":rsa_3072_verify_testvectors",
+        "//sw/device/lib/crypto:otbn_util",
+        "//sw/device/lib/crypto/drivers:hmac",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/rsa_3072:rsa_3072_verify",
+        "//sw/device/lib/runtime:log",
+    ],
+)


### PR DESCRIPTION
After #11285 added a bazel target for the crypto library's RSA-3072 entrypoint, we can now add targets for all the RSA-3072 code and tests in the crypto library.

After this change,  everything in the crypto library can be built/tested with bazel.