### PR TITLE
[usbdev] Remove USB reset qualification of low_power

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
+++ b/hw/ip/usbdev/rtl/usbdev_aon_wake.sv
@@ -55,7 +55,7 @@ module usbdev_aon_wake import usbdev_pkg::*;(
   // note the _upwr signals are only valid when usb_out_of_rst_upwr_i is set
   assign suspend_req_async = usb_aon_wake_en_upwr_i & usb_suspended_upwr_i & usb_out_of_rst_upwr_i;
   assign wake_ack_async = usb_aon_woken_upwr_i & usb_out_of_rst_upwr_i;
-  assign low_power_async = low_power_alw_i & ~usb_out_of_rst_upwr_i;
+  assign low_power_async = low_power_alw_i;
 
   // The suspend_req / wake ack / low power construction come from multiple clock domains.
   // As a result the 2 flop sync could glitch for up to 1 cycle.  Place a filter after


### PR DESCRIPTION
The low_power signal does not need to be held off by the USB reset
status, so remove it. The AON module is activated and deactivated by
signals coming from the USB IP, and internal state changes only need
depend on the signal from the pwrmgr.

Signed-off-by: Alexander Williams <awill@google.com>