### PR TITLE
[opentitantlib] Adds new Emulator transport trait

### DIFF
--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -6,6 +6,7 @@
 pub mod command;
 pub mod conf;
 
+use crate::io::emu::Emulator;
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
@@ -86,6 +87,11 @@ impl TransportWrapper {
         self.transport
             .borrow()
             .gpio_pin(Self::map_name(&self.pin_map, name).as_str())
+    }
+
+    /// Returns a [`Emulator`] implementation.
+    pub fn emulator(&self) -> Result<Rc<dyn Emulator>> {
+        self.transport.borrow().emulator()
     }
 
     /// Invoke non-standard functionality of some Transport implementations.

--- a/sw/host/opentitanlib/src/io/emu.rs
+++ b/sw/host/opentitanlib/src/io/emu.rs
@@ -1,0 +1,75 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::transport::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use thiserror::Error;
+
+/// Error related to the `Emulator` trait. These error messages will be printed in the context of
+/// a TransportError::EmuError, that is "Emulator error: {}".  So including the words "error" or
+/// "Emulator" in texts below will probably be redundant.
+#[derive(Error, Debug, Serialize, Deserialize)]
+pub enum EmuError {
+    #[error("Invalid argument name {0}")]
+    InvalidArgumetName(String),
+    #[error("Argument {0} has invalid value {1}")]
+    InvalidArgumentValue(String, String),
+    #[error("Start failed with cause {0}")]
+    StartFailureCause(String),
+    #[error("Stop failed with cause {0}")]
+    StopFailureCause(String),
+    #[error("Can't restore resource to initial state: {0}")]
+    ResetError(String),
+    #[error("Runtime error {0}")]
+    RuntimeError(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum EmuValue {
+    Empty,
+    String(String),
+    FilePath(String),
+    StringList(Vec<String>),
+    FilePathList(Vec<String>),
+}
+
+#[derive(PartialEq, Eq, Clone, Copy, Debug, Serialize, Deserialize)]
+pub enum EmuState {
+    Off,
+    On,
+    Busy,
+    Error,
+}
+
+/// A trait which represents a `Emulator` instance
+pub trait Emulator {
+    /// Simple function with return `EmuState` representing current state of Emulator instance.
+    fn get_state(&self) -> Result<EmuState>;
+
+    /// Start Emulator with provided arguments.
+    /// Parameter `factory_reset` is a flag that describe if internal state
+    /// and "resources" should be set to its "initial state" before applying
+    /// the changes from the parameter `args`.
+    /// If `factory_reset` is set to true - all internal state and "resources"
+    /// will be set to its "initial state". The "initial state" for most devices
+    /// means that the content is set to zero.
+    /// If `factory_reset` is set to false - all internal state will be preserved
+    /// form last run.
+    /// Parameter `args` describe set of named flags, value and resources passed
+    /// to Emulator in order to update the content of its internal state.
+    /// In the context of the function below, "resources" denote files
+    /// representing the state of devices, for example: EEPROM, FUSES, FLASH, SRAM...
+    /// (most often binary files). Resources files sent via parameter `args`
+    /// cannot be modified by the Emulator directly, the Emulator backend should have
+    /// copy-on-write implementations to enable resource modification during DUT Emulation.
+    /// It should be noted that the method of resources interpretation
+    /// and their format depends on the backend implementing the Emulator trait.
+    /// More detail about supported `args` value and its content can be found
+    /// in the documentation of individual backend.
+    fn start(&self, factory_reset: bool, args: &HashMap<String, EmuValue>) -> Result<()>;
+
+    /// Stop emulator instance.
+    fn stop(&self) -> Result<()>;
+}

--- a/sw/host/opentitanlib/src/io/mod.rs
+++ b/sw/host/opentitanlib/src/io/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod emu;
 pub mod gpio;
 pub mod i2c;
 pub mod spi;

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -3,7 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
+use crate::io::emu::{EmuState, EmuValue};
 use crate::io::gpio::{PinMode, PullMode};
 use crate::io::spi::TransferMode;
 use crate::transport::{Capabilities, TransportError};
@@ -22,6 +24,7 @@ pub enum Request {
     Uart { id: String, command: UartRequest },
     Spi { id: String, command: SpiRequest },
     I2c { id: String, command: I2cRequest },
+    Emu { command: EmuRequest },
 }
 
 #[derive(Serialize, Deserialize)]
@@ -31,6 +34,7 @@ pub enum Response {
     Uart(UartResponse),
     Spi(SpiResponse),
     I2c(I2cResponse),
+    Emu(EmuResponse),
 }
 
 #[derive(Serialize, Deserialize)]
@@ -161,4 +165,20 @@ pub enum I2cResponse {
     RunTransaction {
         transaction: Vec<I2cTransferResponse>,
     },
+}
+#[derive(Serialize, Deserialize)]
+pub enum EmuRequest {
+    GetState,
+    Start {
+        factory_reset: bool,
+        args: HashMap<String, EmuValue>,
+    },
+    Stop,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum EmuResponse {
+    GetState { state: EmuState },
+    Start,
+    Stop,
 }

--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -60,6 +60,8 @@ pub enum TransportError {
     SpiError(#[from] crate::io::spi::SpiError),
     #[error("SPI error: {0}")]
     I2cError(#[from] crate::io::i2c::I2cError),
+    #[error("Emulator error: {0}")]
+    EmuError(#[from] crate::io::emu::EmuError),
 }
 
 /// Enum value used by `TransportError::InvalidInstance`.
@@ -69,6 +71,7 @@ pub enum TransportInterfaceType {
     Uart,
     Spi,
     I2c,
+    Emulator,
 }
 
 /// Return type to be used in `Transport` methods.

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -8,6 +8,7 @@ use std::any::Any;
 use std::path::PathBuf;
 use std::rc::Rc;
 
+use crate::io::emu::Emulator;
 use crate::io::gpio::GpioPin;
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
@@ -34,6 +35,7 @@ bitflags! {
         const GPIO = 0x00000004;
         const I2C = 0x00000008;
         const PROXY = 0x00000010;
+        const EMULATOR = 0x00000020;
     }
 }
 
@@ -116,6 +118,13 @@ pub trait Transport {
             TransportInterfaceType::Gpio,
         ))
     }
+    /// Returns a [`Emulator`] implementation.
+    fn emulator(&self) -> Result<Rc<dyn Emulator>> {
+        Err(TransportError::InvalidInterface(
+            TransportInterfaceType::Emulator,
+        ))
+    }
+
     /// Invoke non-standard functionality of some Transport implementations.
     fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
         Err(TransportError::UnsupportedOperation)


### PR DESCRIPTION
Introduce of new Emulator trait and EMU capabilities.
Add support of Emulator Request/Response to JSON protocol.
Add support for Emulator message in proxy handler.

The Emulator instance provide abstraction necessary
for on-off state transition in emulated DUT. Using session-daemon with
backend implementing Emulator should allow to simulate flash update and
power cycle like in real DUT.

This code is part of the issue: #10217

Signed-off-by: Michał Mazurek <maz@semihalf.com>