### PR TITLE
[chip dv] Add AST initialization routine

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -483,11 +483,14 @@ class mem_bkdr_util extends uvm_object;
   endfunction
 
   // load mem from file
-  virtual function void load_mem_from_file(string file);
+  virtual task load_mem_from_file(string file);
     check_file(file, "r");
     this.file = file;
     ->readmemh_event;
-  endfunction
+    // The delay below avoids a race condition between this mem backdoor load and a subsequent
+    // backdoor write to a particular location.
+    #0;
+  endtask
 
   // save mem contents to file
   virtual function void write_mem_to_file(string file);

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -23,6 +23,7 @@ filesets:
       - lowrisc:dv:sw_logger_if
       - lowrisc:dv:uart_agent
       - lowrisc:dv:pwm_monitor
+      - lowrisc:ip:otp_ctrl_pkg
     files:
       - chip_env_pkg.sv
       - chip_env_cfg.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -30,6 +30,18 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   // Memory backdoor util instances for all memory instances in the chip.
   mem_bkdr_util mem_bkdr_util_h[chip_mem_e];
 
+  // Creator SW config region in OTP that holds the AST config data. Randomized for open source.
+  //
+  // These are written via backdoor to the OTP region that starts at
+  // otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset. SW based tests (via test ROM or the production mask
+  // ROM) will read out from this OTP region and write blindly to AST at the start. Non-SW based
+  // tests will do the same, prior to the test starting, see
+  // chip_stub_cpu_base_vseq::dut_init().
+  //
+  // In closed source, tests can modify this data directly in the extended sequence's dut_init(),
+  // before invoking super.dut_init(), or any other suitable place.
+  rand uint creator_sw_cfg_ast_cfg_data[otp_ctrl_reg_pkg::CreatorSwCfgAstCfgSize / 4];
+
   // sw related
   // Directory from where to pick up the SW test images -default to PWD {run_dir}.
   string sw_build_bin_dir = ".";

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -44,5 +44,3 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   endtask : body
 
 endclass
-
-`undef add_ip_csr_exclusions

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -24,7 +24,6 @@ class chip_sw_base_vseq extends chip_base_vseq;
      int size_bytes;
      int total_bytes;
 
-
     `uvm_info(`gfn, "Started cpu_init", UVM_MEDIUM)
     // TODO: Fixing this for now - need to find a way to pass this on to the SW test.
     foreach (cfg.m_uart_agent_cfgs[i]) begin
@@ -77,10 +76,6 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.sw_test_status_vif.sw_test_status = SwTestStatusBooted;
 
     `uvm_info(`gfn, "CPU_init done", UVM_MEDIUM)
-    // If we load the mem with a file in the same time step as overwriting a symbol in the
-    // ELF file, then adding zero delay helps with avoiding a race condition. Do all symbol
-    // overrides after this zero delay.
-    #0;
   endtask
 
   virtual function void main_sram_bkdr_write32(

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -6,8 +6,8 @@ class chip_base_test extends cip_base_test #(
     .ENV_T(chip_env),
     .CFG_T(chip_env_cfg)
   );
-  `uvm_component_utils(chip_base_test)
   `uvm_component_new
+  `uvm_component_utils(chip_base_test)
 
   // The base class dv_base_test creates the following instances:
   // chip_env_cfg: cfg
@@ -58,6 +58,12 @@ class chip_base_test extends cip_base_test #(
     // Knob to set custom sw image names for rom and sw.
     if ($value$plusargs("sw_images=%0s", sw_images_plusarg)) begin
       cfg.parse_sw_images_string(sw_images_plusarg);
+    end
+
+    // Override the initial AST configuration data at runtime via plusarg.
+    foreach (cfg.creator_sw_cfg_ast_cfg_data[i]) begin
+      void'($value$plusargs({$sformatf("creator_sw_cfg_ast_cfg_data[%0d]", i), "=%0h"},
+                            cfg.creator_sw_cfg_ast_cfg_data[i]));
     end
 
     // Knob to select the OTP image based on LC state.


### PR DESCRIPTION
This commit adds the initialization routine to:
- Backdoor load the AST configuration partion in OTP with data that will
  be read by the test/mask ROM and written to the AST rega registers,
  for the SW tests

- Do the same for non-SW tests, but also manually write the AST
  registers via the TLUL interface in dut_init(), before the tests
  begin.

This is an alternate approach to the PR #11275.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>