### PR TITLE
[otbn,dv] Only clear INSN_CNT in ISS if necessary

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -167,10 +167,9 @@ class OTBNSim:
 
         changes = self._on_stall(verbose, fetch_next=False)
 
-        # Zero INSN_CNT the cycle after we are told to start (and every
-        # cycle after that until we start executing instructions, but that
-        # doesn't really matter)
-        self.state.ext_regs.write('INSN_CNT', 0, True)
+        # Zero INSN_CNT the cycle after we are told to start
+        if self.state.ext_regs.read('INSN_CNT', True) != 0:
+            self.state.ext_regs.write('INSN_CNT', 0, True)
 
         return (None, changes)
 

--- a/hw/ip/otbn/dv/otbnsim/test/simple/multi/bnlid-0.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/multi/bnlid-0.exp
@@ -2,5 +2,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-INSN_CNT = 0
 ERR_BITS = 0x8  # ILLEGAL_INSN

--- a/hw/ip/otbn/dv/otbnsim/test/simple/multi/bnmovr-0.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/multi/bnmovr-0.exp
@@ -2,5 +2,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-INSN_CNT = 0
 ERR_BITS = 0x8  # ILLEGAL_INSN

--- a/hw/ip/otbn/dv/otbnsim/test/simple/multi/bnsid-0.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/multi/bnsid-0.exp
@@ -2,5 +2,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-INSN_CNT = 0
 ERR_BITS = 0x8  # ILLEGAL_INSN

--- a/hw/ip/otbn/dv/otbnsim/test/simple/multi/csrrs-0.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/multi/csrrs-0.exp
@@ -2,5 +2,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-INSN_CNT = 0
 ERR_BITS = 0x8  # ILLEGAL_INSN

--- a/hw/ip/otbn/dv/otbnsim/test/simple/multi/csrrw-0.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/multi/csrrw-0.exp
@@ -2,5 +2,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-INSN_CNT = 0
 ERR_BITS = 0x8  # ILLEGAL_INSN

--- a/hw/ip/otbn/dv/otbnsim/test/simple/multi/sw-0.exp
+++ b/hw/ip/otbn/dv/otbnsim/test/simple/multi/sw-0.exp
@@ -2,5 +2,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-INSN_CNT = 0
 ERR_BITS = 0x5  # BAD_DATA_ADDR, CALL_STACK


### PR DESCRIPTION
This should cause no functional change, but it makes debugging the
change messages from stepped.py a little less verbose.
