### PR TITLE
[otbn,dv] Don't write WIPE_START if not running

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -456,9 +456,12 @@ class OTBNState:
         # expected to stop.
         self.ext_regs.write('STOP_PC', self.pc, True)
 
-        # Set the WIPE_START flag. This will be cleared again on the
+        # Set the WIPE_START flag if we were running. This is used to tell the
+        # C++ model code that this is a good time to inspect DMEM and check
+        # that the RTL and model match. The flag will be cleared again on the
         # next cycle.
-        self.ext_regs.write('WIPE_START', 1, True)
+        if self.fsm_state in [FsmState.FETCH_WAIT, FsmState.EXEC]:
+            self.ext_regs.write('WIPE_START', 1, True)
 
     def set_flags(self, fg: int, flags: FlagReg) -> None:
         '''Update flags for a flag group'''


### PR DESCRIPTION
This is important because the flag tells the C++ model to inspect DMEM
to check the ISS and RTL match. Doing that requires a valid key and
nonce, which might not be available if we haven't actually started
running yet.

(This is needed to get the lc_escalation tests working because we need to avoid checking memory if OTBN gets interrupted before it gets going)