### PR TITLE
[otbn,rtl] Make sure INSN_CNT gets cleared at the right time

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -798,7 +798,7 @@ module otbn
   logic        insn_cnt_clear;
   logic        unused_insn_cnt_q;
   assign hw2reg.insn_cnt.d = insn_cnt;
-  assign insn_cnt_clear = (reg2hw.insn_cnt.qe & is_not_running) | lifecycle_escalation;
+  assign insn_cnt_clear = reg2hw.insn_cnt.qe & is_not_running;
   // Ignore all write data to insn_cnt. All writes zero the register.
   assign unused_insn_cnt_q = ^reg2hw.insn_cnt.q;
 


### PR DESCRIPTION
This commit reverts 9002f2044e (where I added the "clear INSN_CNT on
an escalation" logic) because that takes effect one cycle too early.
To be precise, we'd much prefer it if we changed STATUS and INSN_CNT
on the same cycle: it's probably more understandable, and it's also
easier to model for DV.

(I think the original behaviour was probably right and my first commit
just broke it: oops).
