### PR TITLE
[otbn,dv] Tweak tracer to handle STALL + ERROR properly

### DIFF
--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -99,7 +99,8 @@ interface otbn_trace_if
   assign insn_valid     = insn_fetch_resp_valid;
   assign insn_addr      = {{(32-ImemAddrWidth){1'b0}}, insn_fetch_resp_addr};
   assign insn_data      = insn_fetch_resp_data;
-  assign insn_stall     = u_otbn_core.u_otbn_controller.state_d == OtbnStateStall;
+  assign insn_stall     = ((u_otbn_core.u_otbn_controller.state_q == OtbnStateRun) &&
+                           u_otbn_core.u_otbn_controller.stall);
 
   logic [31:0] rf_base_rd_data_a;
   logic [31:0] rf_base_rd_data_b;


### PR DESCRIPTION
A 2-cycle instruction normally generates a stall (S) trace entry and
then an execute (E) entry. If an error is injected (for example, with
the `lc_escalate_en_i` signal) that arrives on the 1st cycle, we want
the RTL to spit out the S entry and stop.

Before this change, the code that decided whether we were stalling
looked at `state_d`. Unfortunately, this doesn't quite work because when
we've got an error, `state_d` is `OtbnStateLocked`.
