### PR TITLE
[otbn,dv] Get lc_escalate tests working properly

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -154,20 +154,16 @@ module otbn_core_model
   // exactly two cycles of delay (this is a synchroniser, not a CDC, so its behaviour is easy to
   // predict). Model that delay in the SystemVerilog here, since it's much easier than handling it
   // in the Python.
-  //
-  // We actually do another hack here, where we only delay by one cycle. This is because the easiest
-  // way to make the escalation signal work is to apply it at the *end* of the Python cycle, which
-  // means we gain an extra cycle of delay on the Python side.
-  logic [1:0] escalate_fifo;
+  logic [2:0] escalate_fifo;
   logic       new_escalation;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       escalate_fifo <= '0;
     end else begin
-      escalate_fifo <= {escalate_fifo[0], lc_escalate_en_i};
+      escalate_fifo <= {escalate_fifo[1:0], lc_escalate_en_i};
     end
   end
-  assign new_escalation = escalate_fifo[0] & ~escalate_fifo[1];
+  assign new_escalation = escalate_fifo[1] & ~escalate_fifo[2];
 
   // A "busy" counter. We'd like to avoid stepping the Python process on every cycle when there's
   // nothing going on (since it's rather expensive). But exactly modelling *when* we can safely

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -86,6 +86,11 @@ class OTBNSim:
                   verbose: bool,
                   fetch_next: bool) -> List[Trace]:
         '''This is run on a stall cycle'''
+        if self.state.pending_halt:
+            # We've reached the end of the run because of some error. Register
+            # it on the next cycle.
+            self.state.stop()
+
         changes = self.state.changes()
         self.state.commit(sim_stalled=True)
         if fetch_next:
@@ -94,11 +99,6 @@ class OTBNSim:
             self.stats.record_stall()
         if verbose:
             self._print_trace(self.state.pc, '(stall)', changes)
-
-        if self.state.pending_halt:
-            # We've reached the end of the run because of some error. Register
-            # it on the next cycle.
-            self.state.stop()
 
         return changes
 

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -125,6 +125,14 @@ class OTBNState:
         # number. Initialise to -1 to catch bugs if we forget to set it.
         self.wipe_cycles = -1
 
+        # If this is nonzero, there's been an error injected from outside. The
+        # Sim.step function will OR these bits into err_bits and stop at the
+        # end of the next cycle. (We don't just call stop_at_end_of_cycle
+        # because this runs earlier in the cycle than step(), which would mean
+        # we wouldn't see the final instruction get executed and then
+        # cancelled).
+        self.injected_err_bits = 0
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override
@@ -517,3 +525,9 @@ class OTBNState:
         self.wdrs.wipe()
         self.wsrs.wipe()
         self.csrs.wipe()
+
+    def take_injected_err_bits(self) -> None:
+        '''Apply any injected errors, stopping at the end of the cycle'''
+        if self.injected_err_bits != 0:
+            self.stop_at_end_of_cycle(self.injected_err_bits)
+            self.injected_err_bits = 0

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -421,6 +421,9 @@ class OTBNState:
                                 else FsmState.WIPING_GOOD)
         self.wipe_cycles = (_WIPE_CYCLES if self.secure_wipe_enabled else 1)
 
+        # Clear the "we should stop soon" flag
+        self.pending_halt = False
+
     def get_fsm_state(self) -> FsmState:
         return self._fsm_state
 


### PR DESCRIPTION
*This is a draft PR because it depends on the restructuring in #11339. The first two commits are from there*

Teach the ISS to model STATUS and INSN_CNT changes properly when it gets lc_escalate signals at times other than when it's actually running instructions. This should (mostly) fix the otbn_escalate tests which have been failing in the nightly regressions for ages.