### PR TITLE
[dif/pattgen] Add implementations of all DIFs

### DIFF
--- a/hw/ip/pattgen/data/pattgen.hjson
+++ b/hw/ip/pattgen/data/pattgen.hjson
@@ -77,7 +77,7 @@
         { bits: "3",
           resval: "0",
           name: "POLARITY_CH1",
-          desc: "Clock (`pcl`) polarity for Channel 1.  If high, `pda` signal changes on falling edge of `pcl` signal, otherwise pda changes on rising edge. Note that writes to a channel's configuration registers have no effect while the channel is enabled."
+          desc: "Clock (`pcl`) polarity for Channel 1.  If low, `pda` signal changes on falling edge of `pcl` signal, otherwise pda changes on rising edge. Note that writes to a channel's configuration registers have no effect while the channel is enabled."
         }
       ]
     }

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -815,6 +815,10 @@ cc_library(
     srcs = [
         "autogen/dif_pattgen_autogen.c",
         "autogen/dif_pattgen_autogen.h",
+        "dif_pattgen.c",
+    ],
+    hdrs = [
+        "dif_pattgen.h",
     ],
     deps = [
         ":base",
@@ -829,6 +833,9 @@ cc_test(
         "autogen/dif_pattgen_autogen.c",
         "autogen/dif_pattgen_autogen.h",
         "autogen/dif_pattgen_autogen_unittest.cc",
+        "dif_pattgen.c",
+        "dif_pattgen.h",
+        "dif_pattgen_unittest.cc",
     ],
     defines = [
         "MOCK_MMIO=1",

--- a/sw/device/lib/dif/dif_pattgen.c
+++ b/sw/device/lib/dif/dif_pattgen.c
@@ -1,0 +1,141 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_pattgen.h"
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "pattgen_regs.h"  // Generated.
+
+dif_result_t dif_pattgen_configure_channel(
+    const dif_pattgen_t *pattgen, dif_pattgen_channel_t channel,
+    dif_pattgen_channel_config_t config) {
+  if (pattgen == NULL || config.polarity >= kDifPattgenPolarityCount ||
+      config.seed_pattern_length == 0 || config.seed_pattern_length > 64 ||
+      config.num_pattern_repetitions == 0 ||
+      config.num_pattern_repetitions > 1024) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t enable_bit_idx;
+  bitfield_bit32_index_t polarity_bit_idx;
+  ptrdiff_t clock_divisor_reg_offset;
+  ptrdiff_t seed_lower_reg_offset;
+  ptrdiff_t seed_upper_reg_offset;
+  bitfield_field32_t seed_pattern_length_field;
+  bitfield_field32_t num_pattern_repetitions_field;
+
+#define DIF_PATTGEN_CHANNEL_CONFIG_CASE_(channel_)                          \
+  case kDifPattgenChannel##channel_:                                        \
+    enable_bit_idx = PATTGEN_CTRL_ENABLE_CH##channel_##_BIT;                \
+    polarity_bit_idx = PATTGEN_CTRL_POLARITY_CH##channel_##_BIT;            \
+    clock_divisor_reg_offset = PATTGEN_PREDIV_CH##channel_##_REG_OFFSET;    \
+    seed_lower_reg_offset = PATTGEN_DATA_CH##channel_##_0_REG_OFFSET;       \
+    seed_upper_reg_offset = PATTGEN_DATA_CH##channel_##_1_REG_OFFSET;       \
+    seed_pattern_length_field = PATTGEN_SIZE_LEN_CH##channel_##_FIELD;      \
+    num_pattern_repetitions_field = PATTGEN_SIZE_REPS_CH##channel_##_FIELD; \
+    break;
+
+  switch (channel) {
+    DIF_PATTGEN_CHANNEL_LIST(DIF_PATTGEN_CHANNEL_CONFIG_CASE_)
+    default:
+      return kDifBadArg;
+  }
+#undef DIF_PATTGEN_CHANNEL_CONFIG_CASE_
+
+  uint32_t ctrl_reg =
+      mmio_region_read32(pattgen->base_addr, PATTGEN_CTRL_REG_OFFSET);
+
+  // Check if channel is enabled. We cannot configure the channel if so.
+  if (bitfield_bit32_read(ctrl_reg, enable_bit_idx)) {
+    return kDifError;
+  }
+
+  // Set the polarity.
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, polarity_bit_idx, config.polarity);
+  mmio_region_write32(pattgen->base_addr, PATTGEN_CTRL_REG_OFFSET, ctrl_reg);
+
+  // Set the clock divisor.
+  mmio_region_write32(pattgen->base_addr, clock_divisor_reg_offset,
+                      config.clock_divisor);
+
+  // Write the seed data.
+  mmio_region_write32(pattgen->base_addr, seed_lower_reg_offset,
+                      config.seed_pattern_lower_word);
+  if (config.seed_pattern_length > 31) {
+    mmio_region_write32(pattgen->base_addr, seed_upper_reg_offset,
+                        config.seed_pattern_upper_word);
+  }
+
+  // Set the size and repetition values.
+  uint32_t size_reg =
+      mmio_region_read32(pattgen->base_addr, PATTGEN_SIZE_REG_OFFSET);
+  size_reg = bitfield_field32_write(size_reg, seed_pattern_length_field,
+                                    config.seed_pattern_length - 1);
+  size_reg = bitfield_field32_write(size_reg, num_pattern_repetitions_field,
+                                    config.num_pattern_repetitions - 1);
+  mmio_region_write32(pattgen->base_addr, PATTGEN_SIZE_REG_OFFSET, size_reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_pattgen_channel_set_enabled(const dif_pattgen_t *pattgen,
+                                             dif_pattgen_channel_t channel,
+                                             dif_toggle_t enabled) {
+  if (pattgen == NULL || !dif_is_valid_toggle(enabled)) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t enable_bit_idx;
+
+#define DIF_PATTGEN_CHANNEL_SET_ENABLED_CASE_(channel_)      \
+  case kDifPattgenChannel##channel_:                         \
+    enable_bit_idx = PATTGEN_CTRL_ENABLE_CH##channel_##_BIT; \
+    break;
+
+  switch (channel) {
+    DIF_PATTGEN_CHANNEL_LIST(DIF_PATTGEN_CHANNEL_SET_ENABLED_CASE_)
+    default:
+      return kDifBadArg;
+  }
+#undef DIF_PATTGEN_CHANNEL_SET_ENABLED_CASE_
+
+  uint32_t ctrl_reg =
+      mmio_region_read32(pattgen->base_addr, PATTGEN_CTRL_REG_OFFSET);
+  ctrl_reg = bitfield_bit32_write(ctrl_reg, enable_bit_idx,
+                                  dif_toggle_to_bool(enabled));
+  mmio_region_write32(pattgen->base_addr, PATTGEN_CTRL_REG_OFFSET, ctrl_reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_pattgen_channel_get_enabled(const dif_pattgen_t *pattgen,
+                                             dif_pattgen_channel_t channel,
+                                             dif_toggle_t *is_enabled) {
+  if (pattgen == NULL || is_enabled == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t enable_bit_idx;
+
+#define DIF_PATTGEN_CHANNEL_SET_ENABLED_CASE_(channel_)      \
+  case kDifPattgenChannel##channel_:                         \
+    enable_bit_idx = PATTGEN_CTRL_ENABLE_CH##channel_##_BIT; \
+    break;
+
+  switch (channel) {
+    DIF_PATTGEN_CHANNEL_LIST(DIF_PATTGEN_CHANNEL_SET_ENABLED_CASE_)
+    default:
+      return kDifBadArg;
+  }
+#undef DIF_PATTGEN_CHANNEL_SET_ENABLED_CASE_
+
+  uint32_t ctrl_reg =
+      mmio_region_read32(pattgen->base_addr, PATTGEN_CTRL_REG_OFFSET);
+  *is_enabled =
+      dif_bool_to_toggle(bitfield_bit32_read(ctrl_reg, enable_bit_idx));
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_pattgen.h
+++ b/sw/device/lib/dif/dif_pattgen.h
@@ -60,6 +60,10 @@ typedef enum dif_pattgen_polarity {
    * output clock (PCL) edge.
    */
   kDifPattgenPolarityHigh = 1,
+  /**
+   * Number of polarity values, used for argument validation.
+   */
+  kDifPattgenPolarityCount = 2,
 } dif_pattgen_polarity_t;
 
 /**
@@ -72,6 +76,11 @@ typedef struct dif_pattgen_channel_config {
   dif_pattgen_polarity_t polarity;
   /**
    * The I/O clock divisor that determines the frequency of channel's clock.
+   *
+   * Specifically, the output clock frequency (f_pcl) is computed from the I/O
+   * clock frequency (f_io_clk):
+   *
+   *            f_pcl = f_io_clk / (2 * (clock_divisor + 1))
    */
   uint32_t clock_divisor;
   /**
@@ -88,15 +97,16 @@ typedef struct dif_pattgen_channel_config {
    */
   uint32_t seed_pattern_upper_word;
   /**
-   * The length of the seed pattern in bits.
+   * The length of the seed pattern.
    *
-   * Valid range: [0, 63]
+   * Units: bits
+   * Valid range: [1, 64]
    */
   uint8_t seed_pattern_length;
   /**
    * The number of times to repeat the pattern.
    *
-   * Valid range: [0, 1023]
+   * Valid range: [1, 1024]
    */
   uint16_t num_pattern_repetitions;
 } dif_pattgen_channel_config_t;

--- a/sw/device/lib/dif/dif_pattgen.md
+++ b/sw/device/lib/dif/dif_pattgen.md
@@ -24,8 +24,8 @@ Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
@@ -39,7 +39,7 @@ Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
 Documentation  | [DIF_DOC_HW][]                   | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
-Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |

--- a/sw/device/lib/dif/dif_pattgen_unittest.cc
+++ b/sw/device/lib/dif/dif_pattgen_unittest.cc
@@ -1,0 +1,188 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_pattgen.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_test_base.h"
+
+#include "pattgen_regs.h"  // Generated.
+
+namespace dif_pattgen_unittest {
+namespace {
+using ::mock_mmio::LeInt;
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+
+class PattgenTest : public testing::Test, public MmioTest {
+ protected:
+  dif_pattgen_t pattgen_ = {.base_addr = dev().region()};
+  dif_pattgen_channel_config_t config_ = {
+      .polarity = kDifPattgenPolarityHigh,
+      .clock_divisor = 31,
+      .seed_pattern_lower_word = 0xDEADBEEF,
+      .seed_pattern_upper_word = 0xCAFEFEED,
+      .seed_pattern_length = 64,
+      .num_pattern_repetitions = 64,
+  };
+};
+
+class ConfigChannelTest : public PattgenTest {};
+
+TEST_F(ConfigChannelTest, NullHandle) {
+  EXPECT_DIF_BADARG(
+      dif_pattgen_configure_channel(nullptr, kDifPattgenChannel0, config_));
+}
+
+TEST_F(ConfigChannelTest, BadChannel) {
+  EXPECT_DIF_BADARG(dif_pattgen_configure_channel(
+      &pattgen_, static_cast<dif_pattgen_channel_t>(2), config_));
+}
+
+TEST_F(ConfigChannelTest, BadPolarity) {
+  config_.polarity = static_cast<dif_pattgen_polarity_t>(2);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel0, config_));
+}
+
+TEST_F(ConfigChannelTest, BadSeedPatternLength) {
+  config_.seed_pattern_length = 0;
+  EXPECT_DIF_BADARG(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel0, config_));
+
+  config_.seed_pattern_length = 65;
+  EXPECT_DIF_BADARG(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel0, config_));
+}
+
+TEST_F(ConfigChannelTest, BadNumPatternRepetitions) {
+  config_.num_pattern_repetitions = 0;
+  EXPECT_DIF_BADARG(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel0, config_));
+
+  config_.num_pattern_repetitions = 1025;
+  EXPECT_DIF_BADARG(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel0, config_));
+}
+
+TEST_F(ConfigChannelTest, ConfigAttemptWhileEnabled) {
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH0_BIT, 1}});
+  EXPECT_EQ(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel0, config_),
+      kDifError);
+
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH1_BIT, 1}});
+  EXPECT_EQ(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel1, config_),
+      kDifError);
+}
+
+TEST_F(ConfigChannelTest, FullSeedSuccess) {
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH0_BIT, 0},
+                                          {PATTGEN_CTRL_ENABLE_CH1_BIT, 1}});
+  EXPECT_WRITE32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_POLARITY_CH0_BIT, 1},
+                                           {PATTGEN_CTRL_ENABLE_CH1_BIT, 1}});
+  EXPECT_WRITE32(PATTGEN_PREDIV_CH0_REG_OFFSET, config_.clock_divisor);
+  EXPECT_WRITE32(PATTGEN_DATA_CH0_0_REG_OFFSET,
+                 config_.seed_pattern_lower_word);
+  EXPECT_WRITE32(PATTGEN_DATA_CH0_1_REG_OFFSET,
+                 config_.seed_pattern_upper_word);
+  EXPECT_READ32(PATTGEN_SIZE_REG_OFFSET, {{PATTGEN_SIZE_REPS_CH1_OFFSET, 127},
+                                          {PATTGEN_SIZE_LEN_CH1_OFFSET, 31}});
+  EXPECT_WRITE32(PATTGEN_SIZE_REG_OFFSET,
+                 {{PATTGEN_SIZE_LEN_CH0_OFFSET,
+                   static_cast<uint8_t>(config_.seed_pattern_length - 1)},
+                  {PATTGEN_SIZE_REPS_CH0_OFFSET,
+                   static_cast<uint16_t>(config_.num_pattern_repetitions - 1)},
+                  {PATTGEN_SIZE_LEN_CH1_OFFSET, 31},
+                  {PATTGEN_SIZE_REPS_CH1_OFFSET, 127}});
+  EXPECT_DIF_OK(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel0, config_));
+}
+
+TEST_F(ConfigChannelTest, HalfSeedSuccess) {
+  config_.seed_pattern_length = 16;
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH1_BIT, 0}});
+  EXPECT_WRITE32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_POLARITY_CH1_BIT, 1}});
+  EXPECT_WRITE32(PATTGEN_PREDIV_CH1_REG_OFFSET, config_.clock_divisor);
+  EXPECT_WRITE32(PATTGEN_DATA_CH1_0_REG_OFFSET,
+                 config_.seed_pattern_lower_word);
+  EXPECT_READ32(PATTGEN_SIZE_REG_OFFSET, 0);
+  EXPECT_WRITE32(
+      PATTGEN_SIZE_REG_OFFSET,
+      {{PATTGEN_SIZE_LEN_CH1_OFFSET,
+        static_cast<uint8_t>(config_.seed_pattern_length - 1)},
+       {PATTGEN_SIZE_REPS_CH1_OFFSET,
+        static_cast<uint16_t>(config_.num_pattern_repetitions - 1)}});
+  EXPECT_DIF_OK(
+      dif_pattgen_configure_channel(&pattgen_, kDifPattgenChannel1, config_));
+}
+
+class ChannelSetEnabledTest : public PattgenTest {};
+
+TEST_F(ChannelSetEnabledTest, NullHandle) {
+  EXPECT_DIF_BADARG(dif_pattgen_channel_set_enabled(
+      nullptr, kDifPattgenChannel0, kDifToggleEnabled));
+}
+
+TEST_F(ChannelSetEnabledTest, BadChannel) {
+  EXPECT_DIF_BADARG(dif_pattgen_channel_set_enabled(
+      &pattgen_, static_cast<dif_pattgen_channel_t>(2), kDifToggleEnabled));
+}
+
+TEST_F(ChannelSetEnabledTest, BadEnableValue) {
+  EXPECT_DIF_BADARG(dif_pattgen_channel_set_enabled(
+      &pattgen_, kDifPattgenChannel0, static_cast<dif_toggle_t>(2)));
+}
+
+TEST_F(ChannelSetEnabledTest, Success) {
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH0_BIT, 0},
+                                          {PATTGEN_CTRL_ENABLE_CH1_BIT, 1}});
+  EXPECT_WRITE32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH0_BIT, 1},
+                                           {PATTGEN_CTRL_ENABLE_CH1_BIT, 1}});
+  EXPECT_DIF_OK(dif_pattgen_channel_set_enabled(&pattgen_, kDifPattgenChannel0,
+                                                kDifToggleEnabled));
+
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH0_BIT, 1},
+                                          {PATTGEN_CTRL_ENABLE_CH1_BIT, 1}});
+  EXPECT_WRITE32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH0_BIT, 1},
+                                           {PATTGEN_CTRL_ENABLE_CH1_BIT, 0}});
+  EXPECT_DIF_OK(dif_pattgen_channel_set_enabled(&pattgen_, kDifPattgenChannel1,
+                                                kDifToggleDisabled));
+}
+
+class ChannelGetEnabledTest : public PattgenTest {};
+
+TEST_F(ChannelGetEnabledTest, NullArgs) {
+  dif_toggle_t is_enabled;
+  EXPECT_DIF_BADARG(dif_pattgen_channel_get_enabled(
+      nullptr, kDifPattgenChannel0, &is_enabled));
+  EXPECT_DIF_BADARG(
+      dif_pattgen_channel_get_enabled(&pattgen_, kDifPattgenChannel0, nullptr));
+}
+
+TEST_F(ChannelGetEnabledTest, BadChannel) {
+  dif_toggle_t is_enabled;
+  EXPECT_DIF_BADARG(dif_pattgen_channel_get_enabled(
+      &pattgen_, static_cast<dif_pattgen_channel_t>(2), &is_enabled));
+}
+
+TEST_F(ChannelGetEnabledTest, Success) {
+  dif_toggle_t is_enabled;
+
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH1_BIT, 1}});
+  EXPECT_DIF_OK(dif_pattgen_channel_get_enabled(&pattgen_, kDifPattgenChannel1,
+                                                &is_enabled));
+  EXPECT_EQ(is_enabled, kDifToggleEnabled);
+
+  EXPECT_READ32(PATTGEN_CTRL_REG_OFFSET, {{PATTGEN_CTRL_ENABLE_CH0_BIT, 0}});
+  EXPECT_DIF_OK(dif_pattgen_channel_get_enabled(&pattgen_, kDifPattgenChannel0,
+                                                &is_enabled));
+  EXPECT_EQ(is_enabled, kDifToggleDisabled);
+}
+
+}  // namespace
+}  // namespace dif_pattgen_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -1048,6 +1048,7 @@ sw_lib_dif_pattgen = declare_dependency(
     'sw_lib_dif_pattgen',
     sources: [
       hw_ip_pattgen_reg_h,
+      'dif_pattgen.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -1059,7 +1060,10 @@ sw_lib_dif_pattgen = declare_dependency(
 test('dif_pattgen_unittest', executable(
     'dif_pattgen_unittest',
     sources: [
+      'dif_pattgen_unittest.cc',
       'autogen/dif_pattgen_autogen_unittest.cc',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_base.c',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_pattgen.c',
       meson.project_source_root() / 'sw/device/lib/dif/autogen/dif_pattgen_autogen.c',
       hw_ip_pattgen_reg_h,
     ],


### PR DESCRIPTION
This adds implementations (and unittests) of all DIFs for the PATTGEN IP.

Signed-off-by: Timothy Trippel <ttrippel@google.com>