### PR TITLE
[dv/kmac] Update shadow reg

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__shadow_reg_errors.svh
@@ -313,6 +313,12 @@ virtual function void predict_shadow_reg_status(bit predict_update_err  = 0,
   end
 endfunction
 
+virtual function void clear_update_err_status();
+  foreach (cfg.shadow_update_err_status_fields[status_field]) begin
+    void'(status_field.predict(~cfg.shadow_update_err_status_fields[status_field]));
+  end
+endfunction
+
 // Verify update and storage error status with RAL mirrored value.
 virtual task read_check_shadow_reg_status(string msg_id);
   foreach (cfg.shadow_update_err_status_fields[status_field]) begin


### PR DESCRIPTION
As fix #11307 is merged, this PR updates and fixes a few corner cases in
shadow reg.
1). Clear shadowed reg update eror when `err_processed` is set.
2). Disable a few assertions when storage error happened.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>