### PR TITLE
[flash_ctrl] Remove scramble for english_breakfast

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -384,6 +384,14 @@
       default:   "2724870391",
       local:     "true"
     },
+
+    { name:      "SecScrambleEn",
+      desc:      "Compile-time option to enable flash scrambling",
+      type:      "bit",
+      default:   "1",
+      local:     "false",
+      expose:    "true",
+    },
   ],
 
   regwidth: "32",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -381,6 +381,14 @@
       default:   "${int("0xa26a38f7", 16)}",
       local:     "true"
     },
+
+    { name:      "SecScrambleEn",
+      desc:      "Compile-time option to enable flash scrambling",
+      type:      "bit",
+      default:   "1",
+      local:     "false",
+      expose:    "true",
+    },
   ],
 
   regwidth: "32",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -16,7 +16,8 @@ module flash_ctrl
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t           RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter lfsr_seed_t           RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
-  parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault
+  parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault,
+  parameter bit                   SecScrambleEn   = 1'b1
 ) (
   input        clk_i,
   input        rst_ni,
@@ -1150,7 +1151,9 @@ module flash_ctrl
     .rerror_i    ({flash_host_rderr,1'b0})
   );
 
-  flash_phy u_eflash (
+  flash_phy #(
+    .SecScrambleEn(SecScrambleEn)
+  ) u_eflash (
     .clk_i,
     .rst_ni,
     .host_req_i        (flash_host_req),

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -16,7 +16,8 @@ module flash_ctrl
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t           RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter lfsr_seed_t           RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
-  parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault
+  parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault,
+  parameter bit                   SecScrambleEn   = 1'b1
 ) (
   input        clk_i,
   input        rst_ni,
@@ -1151,7 +1152,9 @@ module flash_ctrl
     .rerror_i    ({flash_host_rderr,1'b0})
   );
 
-  flash_phy u_eflash (
+  flash_phy #(
+    .SecScrambleEn(SecScrambleEn)
+  ) u_eflash (
     .clk_i,
     .rst_ni,
     .host_req_i        (flash_host_req),

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -13,7 +13,9 @@
 module flash_phy
   import flash_ctrl_pkg::*;
   import prim_mubi_pkg::mubi4_t;
-
+#(
+  parameter bit SecScrambleEn = 1'b1
+)
 (
   input clk_i,
   input rst_ni,
@@ -211,7 +213,9 @@ module flash_phy
     assign ctrl_req = flash_ctrl_i.req & (ctrl_bank_sel == bank);
     assign ecc_addr[bank][BusBankAddrW +: BankW] = bank;
 
-    flash_phy_core u_core (
+    flash_phy_core #(
+      .SecScrambleEn(SecScrambleEn)
+    ) u_core (
       .clk_i,
       .rst_ni,
       // integrity error is either from host or from controller

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -12,7 +12,8 @@ module flash_phy_core
   import flash_phy_pkg::*;
   import prim_mubi_pkg::mubi4_t;
 #(
-  parameter int unsigned ArbCnt = 4
+  parameter int unsigned ArbCnt = 4,
+  parameter bit SecScrambleEn = 1'b1
 ) (
   input                              clk_i,
   input                              rst_ni,
@@ -376,7 +377,9 @@ module flash_phy_core
                                                rd_calc_addr;
 
   // SEC_CM: MEM.SCRAMBLE
-  flash_phy_scramble u_scramble (
+  flash_phy_scramble #(
+    .SecScrambleEn(SecScrambleEn)
+  ) u_scramble (
     .clk_i,
     .rst_ni,
     // both escalation and and integrity error cause the scramble keys to change

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -4456,6 +4456,14 @@
           default: 0x3480d1896c7ff9ed5941bd125c6eb18772e220f3
           randwidth: 160
         }
+        {
+          name: SecScrambleEn
+          desc: Compile-time option to enable flash scrambling
+          type: bit
+          default: "1"
+          expose: "true"
+          name_top: SecFlashCtrlScrambleEn
+        }
       ]
       inter_signal_list:
       [

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -390,6 +390,14 @@
       default:   "2724870391",
       local:     "true"
     },
+
+    { name:      "SecScrambleEn",
+      desc:      "Compile-time option to enable flash scrambling",
+      type:      "bit",
+      default:   "1",
+      local:     "false",
+      expose:    "true",
+    },
   ],
 
   regwidth: "32",

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -22,7 +22,8 @@ module flash_ctrl
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
   parameter flash_key_t           RndCnstDataKey  = RndCnstDataKeyDefault,
   parameter lfsr_seed_t           RndCnstLfsrSeed = RndCnstLfsrSeedDefault,
-  parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault
+  parameter lfsr_perm_t           RndCnstLfsrPerm = RndCnstLfsrPermDefault,
+  parameter bit                   SecScrambleEn   = 1'b1
 ) (
   input        clk_i,
   input        rst_ni,
@@ -1157,7 +1158,9 @@ module flash_ctrl
     .rerror_i    ({flash_host_rderr,1'b0})
   );
 
-  flash_phy u_eflash (
+  flash_phy #(
+    .SecScrambleEn(SecScrambleEn)
+  ) u_eflash (
     .clk_i,
     .rst_ni,
     .host_req_i        (flash_host_req),

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -48,6 +48,7 @@ module top_earlgrey #(
   // parameters for sram_ctrl_ret_aon
   parameter bit SramCtrlRetAonInstrExec = 0,
   // parameters for flash_ctrl
+  parameter bit SecFlashCtrlScrambleEn = 1,
   // parameters for rv_dm
   parameter logic [31:0] RvDmIdcodeValue = 32'h 0000_0001,
   // parameters for rv_plic
@@ -2029,7 +2030,8 @@ module top_earlgrey #(
     .RndCnstAddrKey(RndCnstFlashCtrlAddrKey),
     .RndCnstDataKey(RndCnstFlashCtrlDataKey),
     .RndCnstLfsrSeed(RndCnstFlashCtrlLfsrSeed),
-    .RndCnstLfsrPerm(RndCnstFlashCtrlLfsrPerm)
+    .RndCnstLfsrPerm(RndCnstFlashCtrlLfsrPerm),
+    .SecScrambleEn(SecFlashCtrlScrambleEn)
   ) u_flash_ctrl (
 
       // Input

--- a/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
+++ b/hw/top_englishbreakfast/data/top_englishbreakfast.hjson
@@ -360,6 +360,9 @@
       clock_group: "infra",
       reset_connections: {rst_ni: "lc", rst_otp_ni: "lc_io_div4"},
       base_addrs: {core: "0x41000000", prim: "0x41008000", mem: "0x20000000"}
+      param_decl: {
+        SecScrambleEn: "0"
+      }
       memory: {
         mem: {
           label:      "eflash",


### PR DESCRIPTION
- allow flash scramble to be removed for cw305 to give some
  fpga breathing space
- the parameter is a Sec parameter that should be double
  checked prior to tapeout