### PR TITLE
[otbn,dv] Drop a bogus assertion about OTBN RND interface

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_rnd_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_rnd_if.sv
@@ -125,8 +125,6 @@ interface otbn_rnd_if (
   // No edge from READING to IDLE or PREFETCHING
   `ASSERT_NO_EDGE(READING, IDLE)
   `ASSERT_NO_EDGE(READING, PREFETCHING)
-  // The controller doesn't drop rnd_req_i when we're in the READING state
-  `ASSERT_IN_STATE(RndReqStableInReading_A, READING, rnd_req_i)
   // We don't see a prefetch request when in READING
   `ASSERT_IN_STATE(NoPrefetchWhenReading_A, READING, !rnd_prefetch_req_i)
   // There is an outstanding EDN request when we're reading


### PR DESCRIPTION
The logic behind this assertion was that the `READING` state only
happens when we're blocking on a CSR/WSR read of the `RND` register. The
controller will only drop its request for the data if something goes
wrong, which can't happen because it can't execute another instruction
to cause an error.

Of course, this is false: an error might come in from outside, either
from an illegal bus access or the `lc_escalate_en_i` signal.

Drop the assertion, since it just isn't true.

(This causes failures in ~20% of `otbn_escalate` tests, once all their other problems are fixed)