### PR TITLE
[dif, aes] Add new funciton to improve performance

### DIFF
--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -362,6 +362,27 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_aes_read_output(const dif_aes_t *aes, dif_aes_data_t *data);
 
 /**
+ * Process a stream of data containing the plain text and outbut a stream of
+ * data with the cipher text.
+ *
+ * This function should be used when performance is desired. It requires the
+ * automatic operation mode activated.
+ *
+ * The peripheral must be able to accept the input (INPUT_READY set), and
+ * will return `kDifAesLoadDataBusy` if this condition is not met.
+ *
+ * @param aes AES handle.
+ * @param plain_text AES Input Data.
+ * @param cipher_text AES Input Data.
+ * @param block_amount The amount of blocks to be encrypted.
+ * @return The result of the operation.
+ */
+dif_result_t dif_aes_process_data(const dif_aes_t *aes,
+                                  const dif_aes_data_t *plain_text,
+                                  dif_aes_data_t *cipher_text,
+                                  size_t block_amount);
+
+/**
  * AES Trigger flags.
  */
 typedef enum dif_aes_trigger {

--- a/sw/device/lib/dif/dif_base.h
+++ b/sw/device/lib/dif/dif_base.h
@@ -20,6 +20,19 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * Evaluate an expression and return if the result is an error.
+ *
+ * @param expr_ An expression which results in an dif_result_t.
+ */
+#define DIF_RETURN_IF_ERROR(expr_)       \
+  do {                                   \
+    dif_result_t local_error_ = (expr_); \
+    if (local_error_ != kDifOk) {        \
+      return local_error_;               \
+    }                                    \
+  } while (false)
+
+/**
  * The result of a DIF operation.
  *
  * NOTE: additional result values can be defined in the manually-implemented


### PR DESCRIPTION
This PR is a prototype to address the last pending item of the issue #4833 described bellow by the @vogelpi comment.

@vogelpi commented:
> The DIF currently provides two separate functions for providing new data (load) and reading the output data. These functions check if new data can be loaded or if new output data is available. This is how these generic functions should work. However, when going for maximum performance, the input ready bit does not need to be checked anymore after the second block as illustrated in the block operation section in the technical spec. This allows you to spare 1 out of 10 peripheral accesses which will probably be significant when processing large messages. I think the DIF should provide either a function for doing large transfers directly, or a separate load function that does not check the input ready bit (with a note that drivers should use this one to implement block operation as mentioned in the spec). Maybe this collides a bit with other requirements/guidelines on DIFs and we might need to find another way. We can also discuss this.

If it is still relevante I'll finish this PR and implement the unit test. If it is not relevant we should close both this PR and the Issue.