### PR TITLE
[otbn,dv] Add dummy instructions to pairwise covergroup

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cov.sv
@@ -630,6 +630,8 @@ class otbn_env_cov extends cip_base_env_cov #(.CFG_T(otbn_env_cfg));
     cur_cp: coverpoint cur {
       `DEF_MNEM_BINS_EXCEPT_ECALL
       `DEF_MNEM_BIN(mnem_ecall);
+      `DEF_MNEM_BIN(mnem_dummy);
+      `DEF_MNEM_BIN(mnem_question_mark);
       illegal_bins other = default;
     }
     pair_cross: cross last_cp, cur_cp;


### PR DESCRIPTION
This covergroup is supposed to be tracking pairs of instructions. I'd
carefully avoided putting ECALL in the `last_cp` coverpoint (since if
you get an ECALL, you'll not have a following instruction).

Unfortunately, I hadn't looked properly at the list of mnemonics and
had forgotten "dummy-insn" and "??" which are used for invalid
instructions and failed integrity checks, respectively. Add them to
avoid illegal bin reports.

This is causing lots of failures in the overnights. In particular, the imem error tests (as you'd expect!)