### PR TITLE
[otbn,dv] Flip bits in all DMEM words in OTBN passthru sequence

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -102,7 +102,7 @@ class otbn_common_vseq extends otbn_base_vseq;
                           addr, rdata, rep_flip_bits),
                 UVM_LOW)
 
-      cfg.write_dmem_word(addr / (4 * BaseWordsPerWLEN), rdata, key, nonce, flip_bits);
+      cfg.write_dmem_word(addr / (4 * BaseWordsPerWLEN), rdata, key, nonce, rep_flip_bits);
     end
 
   endfunction


### PR DESCRIPTION
This worked just fine until I broke it in aa9a0cdca0 by forgetting to
update a variable name. Oops!
