### PR TITLE
chip dv] Fix AST initialization routine

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -24,6 +24,8 @@ filesets:
       - lowrisc:dv:uart_agent
       - lowrisc:dv:pwm_monitor
       - lowrisc:ip:otp_ctrl_pkg
+      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
+      - "fileset_partner ? (partner:systems:ast_pkg)"
     files:
       - chip_env_pkg.sv
       - chip_env_cfg.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -40,7 +40,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   //
   // In closed source, tests can modify this data directly in the extended sequence's dut_init(),
   // before invoking super.dut_init(), or any other suitable place.
-  rand uint creator_sw_cfg_ast_cfg_data[otp_ctrl_reg_pkg::CreatorSwCfgAstCfgSize / 4];
+  rand uint creator_sw_cfg_ast_cfg_data[ast_pkg::AstRegsNum - 1];
 
   // sw related
   // Directory from where to pick up the SW test images -default to PWD {run_dir}.

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -8,6 +8,7 @@ package chip_env_pkg;
   import uvm_pkg::*;
   import top_pkg::*;
 
+  import ast_pkg::AstRegsNum, ast_pkg::AstLastRegOffset;
   import bus_params_pkg::*;
   import chip_ral_pkg::*;
   import cip_base_pkg::*;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -101,6 +101,9 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
 
   // Initialize the OTP creator SW cfg region with AST configuration data.
   virtual function void initialize_otp_creator_sw_cfg_ast_cfg();
+    // Ensure that the allocated size of the AST cfg region in OTP is greater than the number of AST
+    // registers to be programmed.
+    `DV_CHECK_GE_FATAL(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgSize, ast_pkg::AstLastRegOffset)
     foreach (cfg.creator_sw_cfg_ast_cfg_data[i]) begin
       `uvm_info(`gfn, $sformatf({"OTP: Preloading creator_sw_cfg_ast_cfg_data[%0d] with 0x%0h ",
                                  "via backdoor"}, i, cfg.creator_sw_cfg_ast_cfg_data[i]),

--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -38,6 +38,9 @@ parameter int unsigned UsbCalibWidth    = 20;
 parameter int unsigned Ast2PadOutWidth  = 9;
 parameter int unsigned Pad2AstInWidth   = 9;
 //
+// The number of AST registers programmed during initialization. It includes the register that
+// marks the finalization of init, which asserts the ast_init_done_o. The offset of this register is
+// represented with the AstLastRegOffset parameter.
 parameter int unsigned AstRegsNum       = 32;
 parameter int unsigned AstLastRegOffset = (AstRegsNum-1)*4;
 


### PR DESCRIPTION
Use absolute address range of AST rather than reference the AST CSRs via
RAL, because those structures do not exist in the closed source.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>