### PR TITLE
[otbn, rtl] Fix `idle_o` timing and interrupt

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -229,7 +229,7 @@
     { name: "STATUS",
       desc: "Status Register",
       swaccess: "ro",
-      hwaccess: "hwo",
+      hwaccess: "hrw",
       fields: [
         { bits: "7:0",
           name: "status",

--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -25,7 +25,7 @@ module otbn_bind;
     .rst_ni   (rst_ni),
     .reg2hw   (reg2hw),
     .hw2reg   (hw2reg),
-    .done_i   (done),
+    .done_i   (done_core),
     .idle_o_i (idle_o)
   );
 

--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -23,12 +23,14 @@ module otbn_idle_checker
   assign do_start = start_req && (hw2reg.status.d == otbn_pkg::StatusIdle);
 
   // Our model of whether OTBN is running or not. We start on do_start and stop on done.
-  logic running_q, running_d;
+  logic running_qq, running_q, running_d;
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      running_q <= 1'b0;
+      running_q  <= 1'b0;
+      running_qq <= 1'b0;
     end else begin
-      running_q <= running_d;
+      running_q  <= running_d;
+      running_qq <= running_q;
     end
   end
   assign running_d = (do_start & ~running_q) | (running_q & ~done_i);
@@ -40,7 +42,6 @@ module otbn_idle_checker
   `ASSERT(IdleIfStart_A, do_start |-> !running_q)
 
   // Check that we've modelled the running/not-running logic correctly. The idle_o pin from OTBN
-  // should be true iff running is false
-  `ASSERT(IdleIfNotRunning_A, (idle_o_i == prim_mubi_pkg::MuBi4True) ^ running_q)
-
+  // should be true iff running is false (`running_qq` used as idle_o has a one cycle delay)
+  `ASSERT(IdleIfNotRunning_A, (idle_o_i == prim_mubi_pkg::MuBi4True) ^ running_qq)
 endmodule

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -68,6 +68,10 @@ package otbn_pkg;
     StatusLocked          = 8'hFF
   } status_e;
 
+  function automatic logic is_busy_status(status_e status);
+    return status inside {StatusBusyExecute, StatusBusySecWipeDmem, StatusBusySecWipeImem};
+  endfunction
+
   // Error bits
   //
   // Note: These errors are duplicated in other places. If updating them here, update those too.

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -51,6 +51,10 @@ package otbn_reg_pkg;
   } otbn_reg2hw_ctrl_reg_t;
 
   typedef struct packed {
+    logic [7:0]  q;
+  } otbn_reg2hw_status_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
@@ -223,12 +227,13 @@ package otbn_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    otbn_reg2hw_intr_state_reg_t intr_state; // [112:112]
-    otbn_reg2hw_intr_enable_reg_t intr_enable; // [111:111]
-    otbn_reg2hw_intr_test_reg_t intr_test; // [110:109]
-    otbn_reg2hw_alert_test_reg_t alert_test; // [108:105]
-    otbn_reg2hw_cmd_reg_t cmd; // [104:96]
-    otbn_reg2hw_ctrl_reg_t ctrl; // [95:94]
+    otbn_reg2hw_intr_state_reg_t intr_state; // [120:120]
+    otbn_reg2hw_intr_enable_reg_t intr_enable; // [119:119]
+    otbn_reg2hw_intr_test_reg_t intr_test; // [118:117]
+    otbn_reg2hw_alert_test_reg_t alert_test; // [116:113]
+    otbn_reg2hw_cmd_reg_t cmd; // [112:104]
+    otbn_reg2hw_ctrl_reg_t ctrl; // [103:102]
+    otbn_reg2hw_status_reg_t status; // [101:94]
     otbn_reg2hw_err_bits_reg_t err_bits; // [93:66]
     otbn_reg2hw_insn_cnt_reg_t insn_cnt; // [65:33]
     otbn_reg2hw_load_checksum_reg_t load_checksum; // [32:0]

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -396,7 +396,7 @@ module otbn_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (),
+    .q      (reg2hw.status.q),
 
     // to register interface (read)
     .qs     (status_qs)

--- a/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
+++ b/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
@@ -221,9 +221,11 @@ module otbn_scramble_ctrl
     endcase
   end
 
-  assign otbn_dmem_scramble_key_req_busy_o = state_q == ScrambleCtrlDmemReq;
-  assign otbn_imem_scramble_key_req_busy_o = state_q == ScrambleCtrlImemReq;
+  assign otbn_dmem_scramble_key_req_busy_o =
+    (state_q == ScrambleCtrlDmemReq) | dmem_scramble_req_pending_q;
 
+  assign otbn_imem_scramble_key_req_busy_o =
+    (state_q == ScrambleCtrlImemReq) | imem_scramble_req_pending_q;
 
   prim_sync_reqack_data #(
     .Width($bits(otp_ctrl_pkg::otbn_otp_key_rsp_t)-1),


### PR DESCRIPTION
`idle_o` will gate the clock if clock hints are setup to do so. Any done
interrupt raised must occur at or before the cycle `idle_o` changes to
ensure the clock gating doesn't erase the interrupt.

This adds a delay to the externally visible `idle_o` to ensure it
synchronises with changes to the status register and gives correct
interrupt timing.

It also tweaks the internal interrupt signal to behave correctly with
secure wipe.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>