### PR TITLE
[rstmgr/rtl] Swap alert_test alerts orders

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -200,8 +200,8 @@ module rstmgr
 
 
   assign alert_test = {
-    reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe,
-    reg2hw.alert_test.fatal_cnsty_fault.q & reg2hw.alert_test.fatal_cnsty_fault.qe
+    reg2hw.alert_test.fatal_cnsty_fault.q & reg2hw.alert_test.fatal_cnsty_fault.qe,
+    reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe
   };
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -203,8 +203,8 @@ module rstmgr
 
 
   assign alert_test = {
-    reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe,
-    reg2hw.alert_test.fatal_cnsty_fault.q & reg2hw.alert_test.fatal_cnsty_fault.qe
+    reg2hw.alert_test.fatal_cnsty_fault.q & reg2hw.alert_test.fatal_cnsty_fault.qe,
+    reg2hw.alert_test.fatal_fault.q & reg2hw.alert_test.fatal_fault.qe
   };
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx


### PR DESCRIPTION
I believe the order of alert_test is swapped.
From the hjson file: https://github.com/lowRISC/opentitan/blob/master/hw/ip/rstmgr/data/rstmgr.hjson.tpl#L25-L37
fatal_fault is at index 0 and fatal_cnsty_fault is at index 1.

From the current waves below, if alert_test writes at index 0 with value 1, alert_test[1] and alert[1] fires.
![image](https://user-images.githubusercontent.com/11466553/157749663-7ae44233-785e-4d03-b5d2-8ca45e9824b8.png)

Signed-off-by: Cindy Chen <chencindy@opentitan.org>