### PR TITLE
[kmac] Add missing CM IDs and sec buffer

### DIFF
--- a/hw/ip/kmac/data/kmac.hjson
+++ b/hw/ip/kmac/data/kmac.hjson
@@ -204,6 +204,15 @@
     { name: "CFG_SHADOWED.CONFIG.REGWEN"
       desc: "CFG_SHADOWED is protected by REGWEN"
     }
+    { name: "FSM.GLOBAL_ESC"
+      desc: "Escalation moves all sparse FSMs into an invalid state."
+    }
+    { name: "FSM.LOCAL_ESC"
+      desc: "Local fatal faults move all sparse FSMs into an invalid state."
+    }
+    { name: "LOGIC.INTEGRITY"
+      desc: "The reset net for the internal state register and critical nets around the output register are buried."
+    }
   ]
   regwidth: "32"
   registers: [

--- a/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
+++ b/hw/ip/kmac/data/kmac_sec_cm_testplan.hjson
@@ -37,7 +37,7 @@
     }
     {
       name: sec_cm_sw_key_key_masking
-      desc: "Verify the countermeasure(s) SW_KEY.KEY_MASKING."
+      desc: "Verify the countermeasure(s) SW_KEY.KEY.MASKING."
       milestone: V2S
       tests: []
     }
@@ -73,7 +73,25 @@
     }
     {
       name: sec_cm_cfg_shadowed_config_regwen
-      desc: "Verify the countermeasure(s) CFG_SHADOWED.CONFIG.REGWEN"
+      desc: "Verify the countermeasure(s) CFG_SHADOWED.CONFIG.REGWEN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_global_esc
+      desc: "Verify the countermeasure(s) FSM.GLOBAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_fsm_local_esc
+      desc: "Verify the countermeasure(s) FSM.LOCAL_ESC."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_logic_integrity
+      desc: "Verify the countermeasure(s) LOGIC.INTEGRITY."
       milestone: V2S
       tests: []
     }

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -322,6 +322,7 @@ module keccak_round
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin
@@ -337,10 +338,20 @@ module keccak_round
   ////////////////////////////
   // Keccak state registers //
   ////////////////////////////
+
+  // SEC_CM: LOGIC.INTEGRITY
+  logic rst_n;
+  prim_sec_anchor_buf #(
+   .Width(1)
+  ) u_prim_sec_anchor_buf (
+    .in_i(rst_ni),
+    .out_o(rst_n)
+  );
+
   logic [Width-1:0] storage   [Share];
   logic [Width-1:0] storage_d [Share];
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_n) begin
+    if (!rst_n) begin
       storage <= '{default:'0};
     end else if (rst_storage) begin
       storage <= '{default:'0};

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -766,6 +766,7 @@ module kmac
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en[0] != lc_ctrl_pkg::Off) begin
@@ -1399,7 +1400,7 @@ module kmac
   logic unused_alerts_q0;
   assign unused_alerts_q0 = alerts_q[0];
 
-  // SEC_CM: LC_ESCALATE_EN.INTERSIG.MUBI
+  // SEC_CM: LC_ESCALATE_EN.INTERSIG.MUBI, FSM.GLOBAL_ESC, FSM.LOCAL_ESC
   lc_ctrl_pkg::lc_tx_t alert_to_lc_tx;
   assign alert_to_lc_tx = lc_ctrl_pkg::lc_tx_bool_to_lc_tx(alerts_q[1]);
   for (genvar i = 0; i < NumLcSyncCopies; i++) begin : gen_or_alert_lc_sync

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -524,6 +524,7 @@ module kmac_app
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin
@@ -613,6 +614,7 @@ module kmac_app
   logic [AppMuxWidth-1:0] mux_sel_buf_output_logic;
   assign mux_sel_buf_output = app_mux_sel_e'(mux_sel_buf_output_logic);
 
+  // SEC_CM: LOGIC.INTEGRITY
   prim_sec_anchor_buf #(
    .Width(AppMuxWidth)
   ) u_prim_buf_state_output_sel (
@@ -623,6 +625,7 @@ module kmac_app
   logic [AppMuxWidth-1:0] mux_sel_buf_err_check_logic;
   assign mux_sel_buf_err_check = app_mux_sel_e'(mux_sel_buf_err_check_logic);
 
+  // SEC_CM: LOGIC.INTEGRITY
   prim_sec_anchor_buf #(
    .Width(AppMuxWidth)
   ) u_prim_buf_state_err_check (
@@ -633,6 +636,7 @@ module kmac_app
   logic [AppMuxWidth-1:0] mux_sel_buf_kmac_logic;
   assign mux_sel_buf_kmac = app_mux_sel_e'(mux_sel_buf_kmac_logic);
 
+  // SEC_CM: LOGIC.INTEGRITY
   prim_sec_anchor_buf #(
    .Width(AppMuxWidth)
   ) u_prim_buf_state_kmac_sel (
@@ -643,6 +647,7 @@ module kmac_app
   logic [AppMuxWidth-1:0] mux_sel_buf_key_logic;
   assign mux_sel_buf_key = app_mux_sel_e'(mux_sel_buf_key_logic);
 
+  // SEC_CM: LOGIC.INTEGRITY
   prim_sec_anchor_buf #(
    .Width(AppMuxWidth)
   ) u_prim_buf_state_key_sel (
@@ -650,6 +655,7 @@ module kmac_app
     .out_o(mux_sel_buf_key_logic)
   );
 
+  // SEC_CM: LOGIC.INTEGRITY
   logic reg_state_valid;
   prim_sec_anchor_buf #(
    .Width(1)

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -245,6 +245,7 @@ module kmac_core
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -651,6 +651,7 @@ module kmac_entropy
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -386,6 +386,7 @@ module kmac_errchk
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -289,6 +289,7 @@ module sha3
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -496,6 +496,7 @@ module sha3pad
       end
     endcase
 
+    // SEC_CM: FSM.GLOBAL_ESC, FSM.LOCAL_ESC
     // Unconditionally jump into the terminal error state
     // if the life cycle controller triggers an escalation.
     if (lc_escalate_en_i != lc_ctrl_pkg::Off) begin


### PR DESCRIPTION
These items where identified when comparing the spreadsheet with the hjson entries. 

Fixes https://github.com/lowRISC/opentitan/issues/10823

Signed-off-by: Michael Schaffner <msf@google.com>