### PR TITLE
[otp/dv] try access test_access area when lc_dft_en is Off

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -504,11 +504,13 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
       repeat (10) begin
         bit [TL_DW-1:0] wr_data, rd_data;
         bit [TL_AW-1:0] rand_addr = $urandom_range(0, PRIM_ADDR_SIZE + 3);
+        bit test_access_en = cfg.otp_ctrl_vif.lc_dft_en_i == lc_ctrl_pkg::On;
         `DV_CHECK_STD_RANDOMIZE_FATAL(wr_data)
-        tl_access(.addr(rand_addr), .write(1), .data(wr_data),
+        tl_access(.addr(rand_addr), .write(1), .data(wr_data), .exp_err_rsp(~test_access_en),
                   .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
         tl_access(.addr(rand_addr), .write(0), .data(rd_data), .exp_data(wr_data),
-                  .check_exp_data(1), .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
+                  .exp_err_rsp(~test_access_en), .check_exp_data(test_access_en),
+                  .tl_sequencer_h(p_sequencer.prim_tl_sequencer_h));
       end
     end
   endtask

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -175,7 +175,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       end
 
       // Read/write test access memory
-      if (cfg.otp_ctrl_vif.lc_dft_en_i == lc_ctrl_pkg::On) otp_test_access();
+      otp_test_access();
 
       // lock digests
       `uvm_info(`gfn, "Trigger HW digest calculation", UVM_HIGH)


### PR DESCRIPTION
Issue #11296 - access test_access (prim_tl_o/i) when lc_dft_en is Off
and expect to see d_error.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>