### PR TITLE
[keymgr] Changing fault wiping behavior

### DIFF
--- a/hw/ip/keymgr/doc/_index.md
+++ b/hw/ip/keymgr/doc/_index.md
@@ -270,31 +270,23 @@ The error is reported in {{< regref FAULT_STATUS >}} and the key manager continu
 
 ### Faults and Operational Faults
 
-Since fatal errors (faults) can happen at any time, their impact on the key manager depends on transaction timing.
-
-If the fault happens while a transaction is ongoing, key manager transitions to the `Invalid` [state](#invalid-entry-wiping).
-
-If the fault happens while there is no transaction, an alert is first sent to the alert handler.
-If before the alert handler escalates an operation is run, the key manager again transitions to `Invalid` [state](#invalid-entry-wiping).
-If the alert handler escalates and disables the key manager, then the key manager will also transition to `Invalid` state if it is not already there.
+When a fatal error is encountered, the key manager transitions to the `Invalid` [state](#invalid-entry-wiping).
+The following are a few examples of when the error occurs and how the key manager behaves.
 
 #### Example 1: Fault During Operation
 The key manager is running a generate operation and a non-onehot command was observed by the kmac interface.
-Since the non-onehot condition is a fault, it will be reflected in {{< regref FAULT_STATUS >}}.
-Since an operation was ongoing when this fault was seen, it will also be reflected in {{< regref ERR_CODE.INVALID_OP >}}.
-This is considered an operational fault and begins transition to `Invalid`.
+Since the non-onehot condition is a fault, it is reflected in {{< regref FAULT_STATUS >}} and a fatal alert is generated.
+The key manager transitions to `Invalid` state, wipes internal storage and reports an invalid operation in {{< regref ERR_CODE.INVALID_OP >}}.
 
 #### Example 2: Fault During Idle
 The key manager is NOT running an operation and is idle.
-During this time, a fault was observed on the regfile (shadow storage error) and FSM (control FSM integrity error).
-The faults will be reflected in {{< regref FAULT_STATUS >}}.
-
-This is **not** considered an operational fault and the key manager will remain in its current state until an operation is invoked or the alert handler escalates.
+During this time, a fault is observed on the regfile (shadow storage error) and FSM (control FSM integrity error).
+The faults are reflected in {{< regref FAULT_STATUS >}}.
+The key manager transitions to `Invalid` state, wipes internal storage but does not report an invalid operation.
 
 #### Example 3: Operation after Fault Detection
-Continuing from the example above, assume now the key manager begins an operation.
-Since the key manager has previous encountered a fault, any operation now is considered an operational fault and begins transition to the `Invalid` [state](#invalid-entry-wiping).
-
+Continuing from the example above, the key manager now begins an operation.
+Since the key manager is already in `Invalid` state, it does not wipe internal storage and reports an invalid operation in {{< regref ERR_CODE.INVALID_OP >}}.
 
 #### Additional Details on Invalid Input
 

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sync_async_fault_cross_vseq.sv
@@ -20,6 +20,10 @@ class keymgr_sync_async_fault_cross_vseq extends keymgr_base_vseq;
     cfg.en_scb = 0;
     cfg.keymgr_vif.en_chk = 0;
 
+    // disable push-pull interface assertion since faults may cause the kmac interface
+    // to be filled with random, constantly changing data
+    $assertoff(0, "tb.keymgr_kmac_intf.req_data_if.H_DataStableWhenValidAndNotReady_A");
+
     fork
       trigger_sync_fault();
       trigger_async_fault();

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -396,7 +396,10 @@ module keymgr_ctrl
   assign dis_state = op_ack & dis_req;
 
   // SEC_CM: CTRL.FSM.LOCAL_ESC
-  assign inv_state = op_ack & op_fault_err;
+  // begin invalidation when faults are observed.
+  // sync faults only invalidate on transaction boudaries
+  // async faults begin invalidating immediately
+  assign inv_state = |fault_o;
 
   always_comb begin
     // persistent data
@@ -768,6 +771,8 @@ module keymgr_ctrl
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       sync_fault_q <= '0;
+    end else if (op_done_o) begin
+       sync_fault_q <= '0;
     end else if (op_update) begin
       sync_fault_q <= sync_fault_d;
     end


### PR DESCRIPTION
- change key manager wiping from operation boundary aligned to immediate.
- this addresses an item in #11387
- this change causes keymgr to enter wiping state much earlier than usual.
- the wiping stage outputs random data to kmac and causes a push-pull assertion failure.
- disable the assertion in the test

Signed-off-by: Timothy Chen <timothytim@google.com>