### PR TITLE
[dv/fpv] Fix how we import uvm_pkg

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -11,6 +11,7 @@ interface clkmgr_if (
   input logic rst_main_n,
   input logic rst_usb_n
 );
+  import uvm_pkg::*;
   import clkmgr_env_pkg::*;
 
   // The ports to the dut side.

--- a/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_path_if.sv
@@ -8,6 +8,7 @@ interface entropy_src_path_if
 (
   input entropy_src_hw_if_i
 );
+  import uvm_pkg::*;
 
   string core_path = "tb.dut.u_entropy_src_core";
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -19,6 +19,7 @@ interface otbn_model_if
   input logic rst_ni,
   input otbn_key_req_t keymgr_key_i
 );
+  import uvm_pkg::*;
 
   // Inputs to DUT
   logic                     start;        // Start the operation

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -24,6 +24,7 @@
 `endif
 
 interface otp_ctrl_if(input clk_i, input rst_ni);
+  import uvm_pkg::*;
   import otp_ctrl_env_pkg::*;
   import otp_ctrl_pkg::*;
   import otp_ctrl_reg_pkg::*;

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -11,6 +11,7 @@ interface pwrmgr_if (
   input logic clk_slow,
   input logic rst_slow_n
 );
+  import uvm_pkg::*;
   import pwrmgr_env_pkg::*;
 
   // Ports to the dut side.

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.sv
@@ -47,6 +47,8 @@ interface pwrmgr_rstmgr_sva_if
   bit check_rstreqs_en = 1;
 
 `ifdef UVM
+  import uvm_pkg::*;
+
   initial
     forever begin
       uvm_config_db#(bit)::wait_modified(null, "pwrmgr_rstmgr_sva_if", "check_rstreqs_en");

--- a/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/ip_templates/alert_handler/dv/env/alert_handler_if.sv
@@ -4,6 +4,7 @@
 //
 // Interface for LPG and crashdump output.
 interface alert_handler_if(input clk, input rst_n);
+  import uvm_pkg::*;
   import alert_pkg::*;
   import prim_mubi_pkg::*;
   import cip_base_pkg::*;

--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -14,6 +14,7 @@ interface ast_supply_if (
   input logic clk,
   input logic trigger
 );
+  import uvm_pkg::*;
 
   // The amount of time to hold the glitch. Should be enough to span more than one aon_clk cycles
   // so it is sampled.

--- a/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/dv/env/alert_handler_if.sv
@@ -4,6 +4,7 @@
 //
 // Interface for LPG and crashdump output.
 interface alert_handler_if(input clk, input rst_n);
+  import uvm_pkg::*;
   import alert_pkg::*;
   import prim_mubi_pkg::*;
   import cip_base_pkg::*;

--- a/util/reggen/fpv_csr.sv.tpl
+++ b/util/reggen/fpv_csr.sv.tpl
@@ -21,9 +21,6 @@
 <%def name="construct_classes(block)">\
 
 `include "prim_assert.sv"
-`ifdef UVM
-  import uvm_pkg::*;
-`endif
 
 `ifndef FPV_ON
   `define REGWEN_PATH tb.dut.${reg_block_path}
@@ -50,6 +47,10 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
   max_reg_addr = rb.flat_regs[-1].offset
   windows = rb.windows
 %>\
+
+`ifdef UVM
+  import uvm_pkg::*;
+`endif
 
 // Currently FPV csr assertion only support HRO registers.
 % if num_hro_regs > 0:
@@ -221,5 +222,7 @@ module ${mod_base}_csr_assert_fpv import tlul_pkg::*;
 `endif
 % endif
 endmodule
+
+`undef REGWEN_PATH
 </%def>\
 ${construct_classes(block)}


### PR DESCRIPTION
This sorts out a couple of "uvm_pkg already wildcard imported" warnings in the VCS chip build.