### PR TITLE
[flash_ctrl,rtl] Fix double import of flash_ctrl_pkg::*

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_erase.sv
@@ -24,8 +24,6 @@ module flash_ctrl_erase import flash_ctrl_pkg::*; (
   input                       flash_phy_err_i
 );
 
-  import flash_ctrl_pkg::*;
-
   localparam int WordsBitWidth = $clog2(BusWordsPerPage);
   localparam int PagesBitWidth = $clog2(PagesPerBank);
 


### PR DESCRIPTION
This is also imported before the port list and the re-import isn't
strictly allowed by SystemVerilog (it also causes a warning from VCS).
