### PR TITLE
[otbn] Remove dependency on model from the RTL

### DIFF
--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -52,7 +52,6 @@ filesets:
       - lowrisc:prim:edn_req
       - lowrisc:ip:otbn_pkg
       - lowrisc:ip:otp_ctrl_pkg
-      - lowrisc:dv:otbn_model
     files:
       - rtl/otbn_reg_pkg.sv
       - rtl/otbn_reg_top.sv


### PR DESCRIPTION
This was needed when we had the option of running the ISS instead of
the RTL, but we ripped that out in 0d0fa1a.
