### PR TITLE
[aes] Bring Aes DIF to S2

### DIFF
--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -100,6 +100,9 @@ static dif_result_t configure(const dif_aes_t *aes,
   reg = bitfield_field32_write(reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
                                transaction->key_len);
 
+  reg = bitfield_field32_write(reg, AES_CTRL_SHADOWED_PRNG_RESEED_RATE_FIELD,
+                               transaction->mask_reseeding);
+
   bool flag = transaction->manual_operation == kDifAesManualOperationManual;
   reg = bitfield_bit32_write(reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, flag);
 

--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -173,16 +173,14 @@ dif_result_t dif_aes_reset(const dif_aes_t *aes) {
   aes_clear_internal_state(aes);
 
   // Any values would do, illegal values chosen here.
-  uint32_t reg =
-      bitfield_field32_write(0, AES_CTRL_SHADOWED_OPERATION_FIELD, 0xffffffff);
+  uint32_t reg = bitfield_field32_write(0, AES_CTRL_SHADOWED_OPERATION_FIELD,
+                                        AES_CTRL_SHADOWED_OPERATION_MASK);
 
   reg = bitfield_field32_write(reg, AES_CTRL_SHADOWED_MODE_FIELD,
                                AES_CTRL_SHADOWED_MODE_VALUE_AES_NONE);
 
-  reg =
-      bitfield_field32_write(reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD, 0xffffffff);
-
-  reg = bitfield_bit32_write(reg, AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, true);
+  reg = bitfield_field32_write(reg, AES_CTRL_SHADOWED_KEY_LEN_FIELD,
+                               AES_CTRL_SHADOWED_KEY_LEN_MASK);
 
   aes_shadowed_write(aes->base_addr, AES_CTRL_SHADOWED_REG_OFFSET, reg);
 

--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -321,3 +321,20 @@ dif_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
 
   return kDifOk;
 }
+
+dif_result_t dif_aes_read_iv(const dif_aes_t *aes, dif_aes_iv_t *iv) {
+  if (aes == NULL || iv == NULL) {
+    return kDifBadArg;
+  }
+
+  if (!aes_idle(aes)) {
+    return kDifUnavailable;
+  }
+
+  for (int i = 0; i < AES_IV_MULTIREG_COUNT; ++i) {
+    ptrdiff_t offset = AES_IV_0_REG_OFFSET + (i * sizeof(uint32_t));
+
+    iv->iv[i] = mmio_region_read32(aes->base_addr, offset);
+  }
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -223,6 +223,23 @@ typedef enum dif_aes_masking {
 } dif_aes_masking_t;
 
 /**
+ * AES key sideloaded.
+ *
+ * Controls whether the AES uses the key provided by the key manager
+ * software.
+ */
+typedef enum dif_aes_key_provider {
+  /**
+   * The key is provided by software via `dif_aes_key_share_t`.
+   */
+  kDifAesKeySoftwareProvided = 0,
+  /**
+   * The key be provided by the key manager.
+   */
+  kDifAesKeySideload,
+} dif_aes_key_provider_t;
+
+/**
  * Parameters for an AES transaction.
  */
 typedef struct dif_aes_transaction {
@@ -231,6 +248,7 @@ typedef struct dif_aes_transaction {
   dif_aes_key_length_t key_len;
   dif_aes_manual_operation_t manual_operation;
   dif_aes_masking_t masking;
+  dif_aes_key_provider_t key_provider;
 } dif_aes_transaction_t;
 
 /**
@@ -255,14 +273,17 @@ dif_result_t dif_aes_reset(const dif_aes_t *aes);
  *
  * @param aes AES state data.
  * @param transaction Configuration data.
- * @param iv AES Initialisation Vector. The iv may not be used for some modes,
- * see `dif_aes_mode_t` for more details.
+ * @param key Encryption/decryption key when `kDifAesKeySoftwareProvided`, can
+ * be `NULL` otherwise.
+ * @param iv Initialization vector when the mode isn't `kDifAesModeEcb`, can be
+ * `NULL` otherwise.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_aes_start(const dif_aes_t *aes,
                            const dif_aes_transaction_t *transaction,
-                           dif_aes_key_share_t key, const dif_aes_iv_t *iv);
+                           const dif_aes_key_share_t *key,
+                           const dif_aes_iv_t *iv);
 /**
  * Ends an AES transaction.
  *

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -449,6 +449,16 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_aes_get_status(const dif_aes_t *aes, dif_aes_status_t flag,
                                 bool *set);
 
+/**
+ * Read the current initialization vector from its register.
+ *
+ * @param aes AES handle.
+ * @param iv The pointer to receive the initialization vector.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_aes_read_iv(const dif_aes_t *aes, dif_aes_iv_t *iv);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -271,6 +271,16 @@ typedef struct dif_aes_transaction {
   dif_aes_masking_t masking;
   dif_aes_key_provider_t key_provider;
   dif_aes_mask_reseeding_t mask_reseeding;
+  /**
+   * If true the internal psudo-random number used for clearing and masking will
+   * be reseeded every time the key changes.
+   */
+  bool reseed_on_key_change;
+  /**
+   * If true the `reseed_on_key_change` will be locked until the device is
+   * reset.
+   */
+  bool reseed_on_key_change_lock;
 } dif_aes_transaction_t;
 
 /**

--- a/sw/device/lib/dif/dif_aes.h
+++ b/sw/device/lib/dif/dif_aes.h
@@ -240,6 +240,27 @@ typedef enum dif_aes_key_provider {
 } dif_aes_key_provider_t;
 
 /**
+ * AES reseeding rate
+ *
+ * Controls the reseeding rate of the internal pseudo-random number generator
+ * (PRNG) used for masking.
+ */
+typedef enum dif_aes_mask_reseeding {
+  /**
+   * The masking PRNG will be reseed every block.
+   */
+  kDifAesReseedPerBlock = 1 << 0,
+  /**
+   * The masking PRNG will be reseed every 64 blocks.
+   */
+  kDifAesReseedPer64Block = 1 << 1,
+  /**
+   * The masking PRNG will be reseed every 8192 blocks.
+   */
+  kDifAesReseedPer8kBlock = 1 << 2,
+} dif_aes_mask_reseeding_t;
+
+/**
  * Parameters for an AES transaction.
  */
 typedef struct dif_aes_transaction {
@@ -249,6 +270,7 @@ typedef struct dif_aes_transaction {
   dif_aes_manual_operation_t manual_operation;
   dif_aes_masking_t masking;
   dif_aes_key_provider_t key_provider;
+  dif_aes_mask_reseeding_t mask_reseeding;
 } dif_aes_transaction_t;
 
 /**

--- a/sw/device/lib/dif/dif_aes.md
+++ b/sw/device/lib/dif/dif_aes.md
@@ -24,7 +24,7 @@ Tests          | [DIF_TEST_SMOKE][]   | Done        |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress | Outstanding issues with implementation
+Implementation | [DIF_FEATURES][]            | Done        | 
 Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -753,5 +753,16 @@ TEST_F(DifUnavailableError, ReadIV) {
   dif_aes_iv_t iv = {{0}};
   EXPECT_EQ(dif_aes_read_iv(&aes_, &iv), kDifUnavailable);
 }
+
+class DifError : public AesTestInitialized {
+ protected:
+  DifError() {}
+};
+
+TEST_F(DifError, ReadOutput) {
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, {{AES_STATUS_OUTPUT_VALID_BIT, false}});
+  dif_aes_data_t data = {{0}};
+  EXPECT_EQ(dif_aes_read_output(&aes_, &data), kDifError);
+}
 }  // namespace
 }  // namespace dif_aes_test

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -47,6 +47,7 @@ class AesTest : public testing::Test, public mock_mmio::MmioTest {
     uint32_t key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128;
     uint32_t mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB;
     uint32_t operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC;
+    uint32_t mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1;
     bool manual_op = false;
     bool force_zero_masks = false;
     bool key_sideloaded = false;
@@ -58,6 +59,7 @@ class AesTest : public testing::Test, public mock_mmio::MmioTest {
         {{AES_CTRL_SHADOWED_KEY_LEN_OFFSET, options.key_len},
          {AES_CTRL_SHADOWED_MODE_OFFSET, options.mode},
          {AES_CTRL_SHADOWED_OPERATION_OFFSET, options.operation},
+         {AES_CTRL_SHADOWED_PRNG_RESEED_RATE_OFFSET, options.mask_reseed},
          {AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, options.manual_op},
          {AES_CTRL_SHADOWED_SIDELOAD_BIT, options.key_sideloaded},
          {AES_CTRL_SHADOWED_FORCE_ZERO_MASKS_BIT, options.force_zero_masks}});
@@ -89,6 +91,7 @@ class AesTestInitialized : public AesTest {
       .manual_operation = kDifAesManualOperationAuto,
       .masking = kDifAesMaskingInternalPrng,
       .key_provider = kDifAesKeySoftwareProvided,
+      .mask_reseeding = kDifAesReseedPerBlock,
   };
 
   const dif_aes_key_share_t kKey_ = {
@@ -108,10 +111,12 @@ class EcbTest : public AesTestInitialized {
 
 TEST_F(EcbTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
 
   EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
@@ -124,10 +129,12 @@ class CbcTest : public AesTestInitialized {
 
 TEST_F(CbcTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_CBC,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_CBC,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
   SetExpectedIv(kIv_);
 
@@ -142,10 +149,12 @@ class CFBTest : public AesTestInitialized {
 
 TEST_F(CFBTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_CFB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_CFB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
   SetExpectedIv(kIv_);
 
@@ -160,10 +169,12 @@ class OFBTest : public AesTestInitialized {
 
 TEST_F(OFBTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_OFB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_OFB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
   SetExpectedIv(kIv_);
 
@@ -178,10 +189,12 @@ class CTRTest : public AesTestInitialized {
 
 TEST_F(CTRTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_CTR,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_CTR,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
   SetExpectedIv(kIv_);
 
@@ -199,10 +212,12 @@ class DecryptTest : public AesTestInitialized {
 
 TEST_F(DecryptTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_DEC,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_DEC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
 
   EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
@@ -216,10 +231,12 @@ class Key192Test : public AesTestInitialized {
 
 TEST_F(Key192Test, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_192,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                    });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_192,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
 
   EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
@@ -233,10 +250,12 @@ class Key256Test : public AesTestInitialized {
 
 TEST_F(Key256Test, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_256,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_256,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+  });
   SetExpectedKey(kKey_, 8);
 
   EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
@@ -252,11 +271,13 @@ class ManualOperationTest : public AesTestInitialized {
 
 TEST_F(ManualOperationTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     .manual_op = true,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+      .manual_op = true,
+  });
   SetExpectedKey(kKey_, 8);
 
   EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
@@ -270,11 +291,13 @@ class ZeroMaskingTest : public AesTestInitialized {
 
 TEST_F(ZeroMaskingTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     .force_zero_masks = true,
-                     });
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+      .force_zero_masks = true,
+  });
   SetExpectedKey(kKey_, 8);
 
   EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
@@ -451,12 +474,43 @@ class SideloadedKeyTest : public AesTestInitialized {
 
 TEST_F(SideloadedKeyTest, start) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
-  SetExpectedConfig({.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
-                     .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
-                     .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
-                     .key_sideloaded = true});
+  SetExpectedConfig(
+      {.key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+       .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+       .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
+       .key_sideloaded = true});
 
   EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, NULL, NULL));
+}
+// Mask reseeding.
+class MaskReseedingTest : public AesTestInitialized {};
+
+TEST_F(MaskReseedingTest, ReseedPer64Block) {
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_64,
+  });
+  SetExpectedKey(kKey_, 8);
+  transaction.mask_reseeding = kDifAesReseedPer64Block;
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+}
+
+TEST_F(MaskReseedingTest, ReseedPer8kBlock) {
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
+  SetExpectedConfig({
+      .key_len = AES_CTRL_SHADOWED_KEY_LEN_VALUE_AES_128,
+      .mode = AES_CTRL_SHADOWED_MODE_VALUE_AES_ECB,
+      .operation = AES_CTRL_SHADOWED_OPERATION_VALUE_AES_ENC,
+      .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_8K,
+  });
+  transaction.mask_reseeding = kDifAesReseedPer8kBlock;
+
+  SetExpectedKey(kKey_, 8);
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
 }
 }  // namespace
 }  // namespace dif_aes_test

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -297,13 +297,13 @@ TEST_F(AlertTest, AlertFatalFault) {
 }
 
 // Data in
-class Data : public AesTestInitialized {
+class DataTest : public AesTestInitialized {
  protected:
   const dif_aes_data_t data_ = {
       .data = {0xA55AA55A, 0xA55AA55A, 0xA55AA55A, 0xA55AA55A}};
 };
 
-TEST_F(Data, DataIn) {
+TEST_F(DataTest, DataIn) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, {
                                            {AES_STATUS_INPUT_READY_BIT, true},
                                        });
@@ -316,7 +316,7 @@ TEST_F(Data, DataIn) {
   EXPECT_DIF_OK(dif_aes_load_data(&aes_, data_));
 }
 
-TEST_F(Data, DataOut) {
+TEST_F(DataTest, DataOut) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, {
                                            {AES_STATUS_INPUT_READY_BIT, true},
                                            {AES_STATUS_OUTPUT_VALID_BIT, true},
@@ -334,15 +334,15 @@ TEST_F(Data, DataOut) {
 }
 
 // Trigger
-class Trigger : public AesTestInitialized {};
+class TriggerTest : public AesTestInitialized {};
 
-TEST_F(Trigger, Start) {
+TEST_F(TriggerTest, Start) {
   EXPECT_WRITE32(AES_TRIGGER_REG_OFFSET, {{AES_TRIGGER_START_BIT, true}});
 
   EXPECT_DIF_OK(dif_aes_trigger(&aes_, kDifAesTriggerStart));
 }
 
-TEST_F(Trigger, KeyIvDataInClear) {
+TEST_F(TriggerTest, KeyIvDataInClear) {
   EXPECT_WRITE32(AES_TRIGGER_REG_OFFSET,
                  {
                      {AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_BIT, true},
@@ -351,7 +351,7 @@ TEST_F(Trigger, KeyIvDataInClear) {
   EXPECT_DIF_OK(dif_aes_trigger(&aes_, kDifAesTriggerKeyIvDataInClear));
 }
 
-TEST_F(Trigger, DataOutClear) {
+TEST_F(TriggerTest, DataOutClear) {
   EXPECT_WRITE32(AES_TRIGGER_REG_OFFSET,
                  {
                      {AES_TRIGGER_DATA_OUT_CLEAR_BIT, true},
@@ -360,7 +360,7 @@ TEST_F(Trigger, DataOutClear) {
   EXPECT_DIF_OK(dif_aes_trigger(&aes_, kDifAesTriggerDataOutClear));
 }
 
-TEST_F(Trigger, PrngReseed) {
+TEST_F(TriggerTest, PrngReseed) {
   EXPECT_WRITE32(AES_TRIGGER_REG_OFFSET,
                  {
                      {AES_TRIGGER_PRNG_RESEED_BIT, true},

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -681,5 +681,52 @@ TEST_F(DifFunctionsTest, End) {
 
   EXPECT_DIF_OK(dif_aes_end(&aes_));
 }
+
+// Dif errors
+class DifBadArgError : public AesTestInitialized {
+ protected:
+  DifBadArgError() {
+    transaction.key_provider = kDifAesKeySoftwareProvided;
+    transaction.mode = kDifAesModeCbc;
+  }
+};
+
+TEST_F(DifBadArgError, start) {
+  EXPECT_DIF_BADARG(dif_aes_start(NULL, &transaction, &kKey_, &kIv_));
+  EXPECT_DIF_BADARG(dif_aes_start(&aes_, NULL, &kKey_, &kIv_));
+  EXPECT_DIF_BADARG(dif_aes_start(&aes_, &transaction, NULL, &kIv_));
+  EXPECT_DIF_BADARG(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+}
+
+TEST_F(DifBadArgError, reset) { EXPECT_DIF_BADARG(dif_aes_reset(NULL)); }
+
+TEST_F(DifBadArgError, end) { EXPECT_DIF_BADARG(dif_aes_end(NULL)); }
+
+TEST_F(DifBadArgError, LoadData) {
+  dif_aes_data_t data = {};
+  EXPECT_DIF_BADARG(dif_aes_load_data(NULL, data));
+}
+
+TEST_F(DifBadArgError, ReadOutput) {
+  dif_aes_data_t data = {};
+  EXPECT_DIF_BADARG(dif_aes_read_output(NULL, &data));
+  EXPECT_DIF_BADARG(dif_aes_read_output(&aes_, NULL));
+}
+
+TEST_F(DifBadArgError, Trigger) {
+  EXPECT_DIF_BADARG(dif_aes_trigger(NULL, kDifAesTriggerPrngReseed));
+}
+
+TEST_F(DifBadArgError, GetStatus) {
+  bool set;
+  EXPECT_DIF_BADARG(dif_aes_get_status(NULL, kDifAesStatusIdle, &set));
+  EXPECT_DIF_BADARG(dif_aes_get_status(&aes_, kDifAesStatusIdle, NULL));
+}
+
+TEST_F(DifBadArgError, ReadIV) {
+  dif_aes_iv_t iv = {};
+  EXPECT_DIF_BADARG(dif_aes_read_iv(NULL, &iv));
+  EXPECT_DIF_BADARG(dif_aes_read_iv(&aes_, NULL));
+}
 }  // namespace
 }  // namespace dif_aes_test

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -728,5 +728,30 @@ TEST_F(DifBadArgError, ReadIV) {
   EXPECT_DIF_BADARG(dif_aes_read_iv(NULL, &iv));
   EXPECT_DIF_BADARG(dif_aes_read_iv(&aes_, NULL));
 }
+
+class DifUnavailableError : public AesTestInitialized {
+ protected:
+  DifUnavailableError() {
+    EXPECT_READ32(AES_STATUS_REG_OFFSET, {{AES_STATUS_IDLE_BIT, false}});
+  }
+};
+
+TEST_F(DifUnavailableError, start) {
+  EXPECT_EQ(dif_aes_start(&aes_, &transaction, &kKey_, NULL), kDifUnavailable);
+}
+
+TEST_F(DifUnavailableError, end) {
+  EXPECT_EQ(dif_aes_end(&aes_), kDifUnavailable);
+}
+
+TEST_F(DifUnavailableError, LoadData) {
+  dif_aes_data_t data = {{0}};
+  EXPECT_EQ(dif_aes_load_data(&aes_, data), kDifUnavailable);
+}
+
+TEST_F(DifUnavailableError, ReadIV) {
+  dif_aes_iv_t iv = {{0}};
+  EXPECT_EQ(dif_aes_read_iv(&aes_, &iv), kDifUnavailable);
+}
 }  // namespace
 }  // namespace dif_aes_test

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -350,7 +350,7 @@ TEST_F(AlertTest, AlertFatalFault) {
   EXPECT_DIF_OK(dif_aes_alert_force(&aes_, kDifAesAlertFatalFault));
 }
 
-// Data in
+// Data tests.
 class DataTest : public AesTestInitialized {
  protected:
   const dif_aes_data_t data_ = {
@@ -383,6 +383,23 @@ TEST_F(DataTest, DataOut) {
   EXPECT_DIF_OK(dif_aes_read_output(&aes_, &out));
 
   EXPECT_THAT(out.data, ElementsAreArray(data_.data));
+}
+
+// Read the IV tests.
+class IVTest : public AesTestInitialized {};
+
+TEST_F(IVTest, Read) {
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, {{AES_STATUS_IDLE_BIT, true}});
+
+  for (uint32_t i = 0; i < ARRAYSIZE(kIv_.iv); ++i) {
+    ptrdiff_t offset = AES_IV_0_REG_OFFSET + (i * sizeof(uint32_t));
+    EXPECT_READ32(offset, kIv_.iv[i]);
+  }
+
+  dif_aes_iv_t iv;
+  EXPECT_DIF_OK(dif_aes_read_iv(&aes_, &iv));
+
+  EXPECT_THAT(iv.iv, ElementsAreArray(kIv_.iv));
 }
 
 // Trigger

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -100,7 +100,7 @@ class AesTestInitialized : public AesTest {
  protected:
   dif_aes_t aes_;
 
-  dif_aes_transaction_t transaction = {
+  dif_aes_transaction_t transaction_ = {
       .operation = kDifAesOperationEncrypt,
       .mode = kDifAesModeEcb,
       .key_len = kDifAesKey128,
@@ -112,11 +112,11 @@ class AesTestInitialized : public AesTest {
       .reseed_on_key_change_lock = false,
   };
 
-  const dif_aes_key_share_t kKey_ = {
+  const dif_aes_key_share_t kKey = {
       .share0 = {0x59, 0x70, 0x33, 0x73, 0x36, 0x76, 0x39, 0x79},
       .share1 = {0x4B, 0x61, 0x50, 0x64, 0x53, 0x67, 0x56, 0x6B}};
 
-  const dif_aes_iv_t kIv_ = {0x50, 0x64, 0x53, 0x67};
+  const dif_aes_iv_t kIv = {0x50, 0x64, 0x53, 0x67};
 
   AesTestInitialized() { EXPECT_DIF_OK(dif_aes_init(dev().region(), &aes_)); }
 };
@@ -124,7 +124,7 @@ class AesTestInitialized : public AesTest {
 // ECB tests.
 class EcbTest : public AesTestInitialized {
  protected:
-  EcbTest() { transaction.mode = kDifAesModeEcb; }
+  EcbTest() { transaction_.mode = kDifAesModeEcb; }
 };
 
 TEST_F(EcbTest, start) {
@@ -136,14 +136,14 @@ TEST_F(EcbTest, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
+  SetExpectedKey(kKey, 8);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 class CbcTest : public AesTestInitialized {
  protected:
-  CbcTest() { transaction.mode = kDifAesModeCbc; }
+  CbcTest() { transaction_.mode = kDifAesModeCbc; }
 };
 
 TEST_F(CbcTest, start) {
@@ -155,16 +155,16 @@ TEST_F(CbcTest, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
-  SetExpectedIv(kIv_);
+  SetExpectedKey(kKey, 8);
+  SetExpectedIv(kIv);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, &kIv_));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, &kIv));
 }
 
 // CFB tests.
 class CFBTest : public AesTestInitialized {
  protected:
-  CFBTest() { transaction.mode = kDifAesModeCfb; }
+  CFBTest() { transaction_.mode = kDifAesModeCfb; }
 };
 
 TEST_F(CFBTest, start) {
@@ -176,16 +176,16 @@ TEST_F(CFBTest, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
-  SetExpectedIv(kIv_);
+  SetExpectedKey(kKey, 8);
+  SetExpectedIv(kIv);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, &kIv_));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, &kIv));
 }
 
 // OFB tests.
 class OFBTest : public AesTestInitialized {
  protected:
-  OFBTest() { transaction.mode = kDifAesModeOfb; }
+  OFBTest() { transaction_.mode = kDifAesModeOfb; }
 };
 
 TEST_F(OFBTest, start) {
@@ -197,16 +197,16 @@ TEST_F(OFBTest, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
-  SetExpectedIv(kIv_);
+  SetExpectedKey(kKey, 8);
+  SetExpectedIv(kIv);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, &kIv_));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, &kIv));
 }
 
 // CTR tests.
 class CTRTest : public AesTestInitialized {
  protected:
-  CTRTest() { transaction.mode = kDifAesModeCtr; }
+  CTRTest() { transaction_.mode = kDifAesModeCtr; }
 };
 
 TEST_F(CTRTest, start) {
@@ -218,18 +218,18 @@ TEST_F(CTRTest, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
-  SetExpectedIv(kIv_);
+  SetExpectedKey(kKey, 8);
+  SetExpectedIv(kIv);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, &kIv_));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, &kIv));
 }
 
 // Decrypt tests.
 class DecryptTest : public AesTestInitialized {
  protected:
   DecryptTest() {
-    transaction.mode = kDifAesModeEcb;
-    transaction.operation = kDifAesOperationDecrypt;
+    transaction_.mode = kDifAesModeEcb;
+    transaction_.operation = kDifAesOperationDecrypt;
   }
 };
 
@@ -242,15 +242,15 @@ TEST_F(DecryptTest, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
+  SetExpectedKey(kKey, 8);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 // Key size test.
 class Key192Test : public AesTestInitialized {
  protected:
-  Key192Test() { transaction.key_len = kDifAesKey192; }
+  Key192Test() { transaction_.key_len = kDifAesKey192; }
 };
 
 TEST_F(Key192Test, start) {
@@ -262,15 +262,15 @@ TEST_F(Key192Test, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
+  SetExpectedKey(kKey, 8);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 // Key size test.
 class Key256Test : public AesTestInitialized {
  protected:
-  Key256Test() { transaction.key_len = kDifAesKey256; }
+  Key256Test() { transaction_.key_len = kDifAesKey256; }
 };
 
 TEST_F(Key256Test, start) {
@@ -282,16 +282,16 @@ TEST_F(Key256Test, start) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
+  SetExpectedKey(kKey, 8);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 // Manual operation
 class ManualOperationTest : public AesTestInitialized {
  protected:
   ManualOperationTest() {
-    transaction.manual_operation = kDifAesManualOperationManual;
+    transaction_.manual_operation = kDifAesManualOperationManual;
   }
 };
 
@@ -305,15 +305,15 @@ TEST_F(ManualOperationTest, start) {
       .manual_op = true,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
+  SetExpectedKey(kKey, 8);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 // Zero masking
 class ZeroMaskingTest : public AesTestInitialized {
  protected:
-  ZeroMaskingTest() { transaction.masking = kDifAesMaskingForceZero; }
+  ZeroMaskingTest() { transaction_.masking = kDifAesMaskingForceZero; }
 };
 
 TEST_F(ZeroMaskingTest, start) {
@@ -326,9 +326,9 @@ TEST_F(ZeroMaskingTest, start) {
       .force_zero_masks = true,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
+  SetExpectedKey(kKey, 8);
 
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 // Alert test.
@@ -391,15 +391,15 @@ class IVTest : public AesTestInitialized {};
 TEST_F(IVTest, Read) {
   EXPECT_READ32(AES_STATUS_REG_OFFSET, {{AES_STATUS_IDLE_BIT, true}});
 
-  for (uint32_t i = 0; i < ARRAYSIZE(kIv_.iv); ++i) {
+  for (uint32_t i = 0; i < ARRAYSIZE(kIv.iv); ++i) {
     ptrdiff_t offset = AES_IV_0_REG_OFFSET + (i * sizeof(uint32_t));
-    EXPECT_READ32(offset, kIv_.iv[i]);
+    EXPECT_READ32(offset, kIv.iv[i]);
   }
 
   dif_aes_iv_t iv;
   EXPECT_DIF_OK(dif_aes_read_iv(&aes_, &iv));
 
-  EXPECT_THAT(iv.iv, ElementsAreArray(kIv_.iv));
+  EXPECT_THAT(iv.iv, ElementsAreArray(kIv.iv));
 }
 
 // Trigger
@@ -514,7 +514,7 @@ TEST_F(Status, False) {
 // Sideloaded key.
 class SideloadedKeyTest : public AesTestInitialized {
  protected:
-  SideloadedKeyTest() { transaction.key_provider = kDifAesKeySideload; }
+  SideloadedKeyTest() { transaction_.key_provider = kDifAesKeySideload; }
 };
 
 TEST_F(SideloadedKeyTest, start) {
@@ -527,7 +527,7 @@ TEST_F(SideloadedKeyTest, start) {
        .key_sideloaded = true});
 
   SetExpectedAuxConfig({});
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, NULL, NULL));
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, NULL, NULL));
 }
 // Mask reseeding.
 class MaskReseedingTest : public AesTestInitialized {};
@@ -541,9 +541,9 @@ TEST_F(MaskReseedingTest, ReseedPer64Block) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_64,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
-  transaction.mask_reseeding = kDifAesReseedPer64Block;
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  SetExpectedKey(kKey, 8);
+  transaction_.mask_reseeding = kDifAesReseedPer64Block;
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 TEST_F(MaskReseedingTest, ReseedPer8kBlock) {
@@ -555,9 +555,9 @@ TEST_F(MaskReseedingTest, ReseedPer8kBlock) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_8K,
   });
   SetExpectedAuxConfig({});
-  SetExpectedKey(kKey_, 8);
-  transaction.mask_reseeding = kDifAesReseedPer8kBlock;
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  SetExpectedKey(kKey, 8);
+  transaction_.mask_reseeding = kDifAesReseedPer8kBlock;
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 // Reseed on key change.
@@ -572,13 +572,13 @@ TEST_F(RessedOnKeyChangeTest, Unlock) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
 
-  transaction.reseed_on_key_change = true;
-  transaction.reseed_on_key_change_lock = false;
+  transaction_.reseed_on_key_change = true;
+  transaction_.reseed_on_key_change_lock = false;
   SetExpectedAuxConfig({
       .reseed_on_key_change = true,
   });
-  SetExpectedKey(kKey_, 8);
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  SetExpectedKey(kKey, 8);
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 TEST_F(RessedOnKeyChangeTest, Lock) {
@@ -590,11 +590,11 @@ TEST_F(RessedOnKeyChangeTest, Lock) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
 
-  transaction.reseed_on_key_change = true;
-  transaction.reseed_on_key_change_lock = true;
+  transaction_.reseed_on_key_change = true;
+  transaction_.reseed_on_key_change_lock = true;
   SetExpectedAuxConfig({.reseed_on_key_change = true, .lock = true});
-  SetExpectedKey(kKey_, 8);
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  SetExpectedKey(kKey, 8);
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 TEST_F(RessedOnKeyChangeTest, LockedSuccess) {
@@ -606,15 +606,15 @@ TEST_F(RessedOnKeyChangeTest, LockedSuccess) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
 
-  transaction.reseed_on_key_change = true;
-  transaction.reseed_on_key_change_lock = true;
+  transaction_.reseed_on_key_change = true;
+  transaction_.reseed_on_key_change_lock = true;
 
   EXPECT_READ32(AES_CTRL_AUX_REGWEN_REG_OFFSET,
                 {{AES_CTRL_AUX_REGWEN_CTRL_AUX_REGWEN_BIT, 0}});
   EXPECT_READ32(AES_CTRL_AUX_SHADOWED_REG_OFFSET,
                 {{AES_CTRL_AUX_SHADOWED_KEY_TOUCH_FORCES_RESEED_BIT, true}});
-  SetExpectedKey(kKey_, 8);
-  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  SetExpectedKey(kKey, 8);
+  EXPECT_DIF_OK(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 TEST_F(RessedOnKeyChangeTest, LockedError) {
@@ -626,15 +626,15 @@ TEST_F(RessedOnKeyChangeTest, LockedError) {
       .mask_reseed = AES_CTRL_SHADOWED_PRNG_RESEED_RATE_VALUE_PER_1,
   });
 
-  transaction.reseed_on_key_change = true;
-  transaction.reseed_on_key_change_lock = true;
+  transaction_.reseed_on_key_change = true;
+  transaction_.reseed_on_key_change_lock = true;
 
   EXPECT_READ32(AES_CTRL_AUX_REGWEN_REG_OFFSET,
                 {{AES_CTRL_AUX_REGWEN_CTRL_AUX_REGWEN_BIT, 0}});
   EXPECT_READ32(AES_CTRL_AUX_SHADOWED_REG_OFFSET,
                 {{AES_CTRL_AUX_SHADOWED_KEY_TOUCH_FORCES_RESEED_BIT, false}});
 
-  EXPECT_EQ(dif_aes_start(&aes_, &transaction, &kKey_, NULL), kDifError);
+  EXPECT_EQ(dif_aes_start(&aes_, &transaction_, &kKey, NULL), kDifError);
 }
 
 // Dif functions.
@@ -686,16 +686,16 @@ TEST_F(DifFunctionsTest, End) {
 class DifBadArgError : public AesTestInitialized {
  protected:
   DifBadArgError() {
-    transaction.key_provider = kDifAesKeySoftwareProvided;
-    transaction.mode = kDifAesModeCbc;
+    transaction_.key_provider = kDifAesKeySoftwareProvided;
+    transaction_.mode = kDifAesModeCbc;
   }
 };
 
 TEST_F(DifBadArgError, start) {
-  EXPECT_DIF_BADARG(dif_aes_start(NULL, &transaction, &kKey_, &kIv_));
-  EXPECT_DIF_BADARG(dif_aes_start(&aes_, NULL, &kKey_, &kIv_));
-  EXPECT_DIF_BADARG(dif_aes_start(&aes_, &transaction, NULL, &kIv_));
-  EXPECT_DIF_BADARG(dif_aes_start(&aes_, &transaction, &kKey_, NULL));
+  EXPECT_DIF_BADARG(dif_aes_start(NULL, &transaction_, &kKey, &kIv));
+  EXPECT_DIF_BADARG(dif_aes_start(&aes_, NULL, &kKey, &kIv));
+  EXPECT_DIF_BADARG(dif_aes_start(&aes_, &transaction_, NULL, &kIv));
+  EXPECT_DIF_BADARG(dif_aes_start(&aes_, &transaction_, &kKey, NULL));
 }
 
 TEST_F(DifBadArgError, reset) { EXPECT_DIF_BADARG(dif_aes_reset(NULL)); }
@@ -737,7 +737,7 @@ class DifUnavailableError : public AesTestInitialized {
 };
 
 TEST_F(DifUnavailableError, start) {
-  EXPECT_EQ(dif_aes_start(&aes_, &transaction, &kKey_, NULL), kDifUnavailable);
+  EXPECT_EQ(dif_aes_start(&aes_, &transaction_, &kKey, NULL), kDifUnavailable);
 }
 
 TEST_F(DifUnavailableError, end) {

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -619,5 +619,50 @@ TEST_F(RessedOnKeyChangeTest, LockedError) {
 
   EXPECT_EQ(dif_aes_start(&aes_, &transaction, &kKey_, NULL), kDifError);
 }
+
+// Dif functions.
+class DifFunctionsTest : public AesTestInitialized {
+ protected:
+  DifFunctionsTest() {}
+};
+
+TEST_F(DifFunctionsTest, Reset) {
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
+  EXPECT_WRITE32_SHADOWED(AES_CTRL_SHADOWED_REG_OFFSET,
+                          {{AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, true}});
+
+  EXPECT_WRITE32(AES_TRIGGER_REG_OFFSET,
+                 {
+                     {AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_BIT, true},
+                     {AES_TRIGGER_DATA_OUT_CLEAR_BIT, true},
+                 });
+
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
+
+  EXPECT_WRITE32_SHADOWED(
+      AES_CTRL_SHADOWED_REG_OFFSET,
+      {{AES_CTRL_SHADOWED_OPERATION_OFFSET, AES_CTRL_SHADOWED_OPERATION_MASK},
+       {AES_CTRL_SHADOWED_MODE_OFFSET, AES_CTRL_SHADOWED_MODE_VALUE_AES_NONE},
+       {AES_CTRL_SHADOWED_KEY_LEN_OFFSET, AES_CTRL_SHADOWED_KEY_LEN_MASK}});
+
+  EXPECT_DIF_OK(dif_aes_reset(&aes_));
+}
+
+TEST_F(DifFunctionsTest, End) {
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
+  EXPECT_WRITE32_SHADOWED(AES_CTRL_SHADOWED_REG_OFFSET,
+                          {{AES_CTRL_SHADOWED_MANUAL_OPERATION_BIT, true}});
+
+  EXPECT_WRITE32(AES_TRIGGER_REG_OFFSET,
+                 {
+                     {AES_TRIGGER_KEY_IV_DATA_IN_CLEAR_BIT, true},
+                     {AES_TRIGGER_DATA_OUT_CLEAR_BIT, true},
+                 });
+
+  EXPECT_READ32(AES_STATUS_REG_OFFSET, 1);
+
+  EXPECT_DIF_OK(dif_aes_end(&aes_));
+}
 }  // namespace
 }  // namespace dif_aes_test

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -63,7 +63,7 @@ static void aes_serial_set_key(const uint8_t *key, size_t key_len) {
   dif_aes_key_share_t key_shares;
   memcpy(key_shares.share0, key, sizeof(key_shares.share0));
   memset(key_shares.share1, 0, sizeof(key_shares.share1));
-  SS_CHECK_DIF_OK(dif_aes_start(&aes, &transaction, key_shares, NULL));
+  SS_CHECK_DIF_OK(dif_aes_start(&aes, &transaction, &key_shares, NULL));
 }
 
 /**

--- a/sw/device/tests/aes_smoketest.c
+++ b/sw/device/tests/aes_smoketest.c
@@ -93,7 +93,7 @@ bool test_main(void) {
       .key_len = kDifAesKey256,
       .manual_operation = kDifAesManualOperationAuto,
   };
-  CHECK_DIF_OK(dif_aes_start(&aes, &transaction, key, NULL));
+  CHECK_DIF_OK(dif_aes_start(&aes, &transaction, &key, NULL));
 
   // "Convert" plain data byte arrays to `dif_aes_data_t`.
   dif_aes_data_t in_data_plain;
@@ -124,7 +124,7 @@ bool test_main(void) {
 
   // Setup ECB decryption transaction.
   transaction.operation = kDifAesOperationDecrypt;
-  CHECK_DIF_OK(dif_aes_start(&aes, &transaction, key, NULL));
+  CHECK_DIF_OK(dif_aes_start(&aes, &transaction, &key, NULL));
 
   // Load the previously produced cipher text to start the decryption operation.
   while (!aes_input_ready(&aes)) {


### PR DESCRIPTION
# This PR:
- Add function to read the iv
- Add unitests for the functions `dif_aes_reset` and `dif_aes_end`
- Add the option to control whether reseed on every key change
- Adds the option to control the reseed rate
- Adds the option to control whether key will provided by sideload
- Refactor the aes status unittest.

Please check each commit individually.

#4833 