### PR TITLE
[dv,verilator] Make multiple sim_ctrl extensions play nicely

### DIFF
--- a/hw/dv/verilator/cpp/verilator_memutil.cc
+++ b/hw/dv/verilator/cpp/verilator_memutil.cc
@@ -112,7 +112,7 @@ bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
   // some arguments
   optind = 1;
   while (1) {
-    int c = getopt_long(argc, argv, ":r:m:f:l:E:h", long_options, nullptr);
+    int c = getopt_long(argc, argv, "-:r:m:f:l:E:h", long_options, nullptr);
     if (c == -1) {
       break;
     }
@@ -122,6 +122,7 @@ bool VerilatorMemUtil::ParseCLIArguments(int argc, char **argv,
 
     switch (c) {
       case 0:
+      case 1:
         break;
       case 'r':
         load_args.push_back(

--- a/hw/dv/verilator/simutil_verilator/cpp/sim_ctrl_extension.h
+++ b/hw/dv/verilator/simutil_verilator/cpp/sim_ctrl_extension.h
@@ -13,6 +13,13 @@ class SimCtrlExtension {
    * Parse command line arguments
    *
    * Process all recognized command-line arguments from argc/argv.
+   * Note that other extensions might also be registered with their
+   * own command line arguments.
+   *
+   * To make this work properly, the extension must only parse options
+   * (no positional arguments) and must leave the ordering of argv
+   * unchanged. In particular, if the code uses getopt_long, it should
+   * pass an optstring argument starting with a '-' character.
    *
    * @param argc, argv Standard C command line arguments
    * @param exit_app Indicate that program should terminate

--- a/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
+++ b/hw/dv/verilator/simutil_verilator/cpp/verilator_sim_ctrl.cc
@@ -114,7 +114,7 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
       {nullptr, no_argument, nullptr, 0}};
 
   while (1) {
-    int c = getopt_long(argc, argv, ":c:th", long_options, nullptr);
+    int c = getopt_long(argc, argv, "-:c:th", long_options, nullptr);
     if (c == -1) {
       break;
     }
@@ -124,6 +124,7 @@ bool VerilatorSimCtrl::ParseCommandArgs(int argc, char **argv, bool &exit_app) {
 
     switch (c) {
       case 0:
+      case 1:
         break;
       case 't':
         if (!tracing_possible_) {

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.cc
@@ -70,13 +70,14 @@ class OtbnTraceUtil : public SimCtrlExtension {
     // some arguments
     optind = 1;
     while (1) {
-      int c = getopt_long(argc, argv, "h", long_options, nullptr);
+      int c = getopt_long(argc, argv, "-h", long_options, nullptr);
       if (c == -1) {
         break;
       }
 
       switch (c) {
         case 0:
+        case 1:
           break;
         case 'l':
           return SetupTraceLog(optarg);


### PR DESCRIPTION
I'd finally got annoyed enough about not being able to pass `-t` in
the middle of a command line to figure out what was going on. It turns
out that by default `getopt_long` rearranges its arguments to put all
positional args at the end. That's nice, because it allows you code to
easily support stuff like

    my_program -a -b positional0 -c -d positional1

and, post-parse, it will find `positional0` and `positional1` as the last
two arguments. (If long enough in the tooth, you might remember having
to do `my_program -a -b -c -d positional0 positional1` for some
programs: this is what getopt fixes for us!)

Unfortunately, this behaviour plays havoc when more than one parser
wants to look at argv at once. For example, suppose you have

    my_program --some-args ARG --no-args

and you parse this twice. The first parser understands `--no-args` and
the second understands `--some-args`. With the default behaviour and `":"`
at the start of the `optstring`, the first parser will ignore the
unknown `--some-args` argument and move the positional `ARG` to the end.
But then the second parser sees

    my_program  --some-args --no-args ARG

and tries to pass `--no-args` as the value to `--some-args`. Much
confusion ensues...

Fortunately, we can pass `'-'` at the start of `optstring` to disable this
behaviour. The result is harder to parse if you're interested in
positional arguments (which is why this isn't the default behaviour)
but works when you have multiple parsers that have to place nicely
together.
