### PR TITLE
[otbn,rtl] Delay the "locked" signal from controller while wiping

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -283,7 +283,7 @@ module otbn_controller
                      (state_q == OtbnStateRun) ||
                      (state_q == OtbnStateStall);
 
-  assign locked_o = state_q == OtbnStateLocked;
+  assign locked_o = (state_q == OtbnStateLocked) & ~secure_wipe_running_i;
   assign start_secure_wipe_o = executing & (done_complete | err) & ~secure_wipe_running_i;
 
   assign jump_or_branch = (insn_valid_i &


### PR DESCRIPTION
This signal feeds straight into the STATUS register and we need to
wait until the operation is complete before setting it to LOCKED.

Note that this still doesn't completely fix tests like otbn_imem_err when secure wipe is enabled. The problem is that we're still issuing an alert immediately upon seeing the error, but the testbench expects that to happen at the same time as the operation completes and STATUS gets updated. Delaying the alert is probably the right thing to do, but that can come in a separate PR.