### PR TITLE
[otbn,dv] Tidy up flag in ISS commit routine

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/loop.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/loop.py
@@ -152,6 +152,7 @@ class LoopStack:
 
         if self._pop_stack_on_commit:
             self.stack.pop()
+            self._pop_stack_on_commit = False
 
         self.trace = []
 


### PR DESCRIPTION
This doesn't matter because it gets cleared again in the next call to
`Loop.step()`, unless we call commit again before calling step the next
time. This event isn't possible with the current code, but it is
planned in some code refactorings to support secure wipe better in the
ISS.
