### PR TITLE
[otbn,dv] Allow traced changes from ISS when no operation is running

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -157,7 +157,7 @@ class RandWSR(WSR):
         if self.req_high and self._random_value is not None:
             ret = [TraceExtRegChange('RND_REQ', ExtRegChange('=', 0, True, 0))]
             self.req_high = False
-        elif self.pending_request:
+        elif self.pending_request and not self.req_high:
             self.req_high = True
             ret = [TraceExtRegChange('RND_REQ', ExtRegChange('=', 1, True, 1))]
         return ret

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -161,9 +161,16 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
         if rt is not None:
             rtl_changes.append(rt)
 
-    if hdr is None:
-        assert not rtl_changes
-    else:
+    # This is a bit of a hack. Very occasionally, we'll see traced changes when
+    # there's not actually an instruction in flight. For example, this happens
+    # if there's a RND request still pending when an operation stops. In this
+    # case, we might see a change where we drop the REQ signal after the secure
+    # wipe has finished. Rather than define a special "do-nothing" trace entry
+    # format for this situation, we cheat and use STALL.
+    if hdr is None and rtl_changes:
+        hdr = 'STALL'
+
+    if hdr is not None:
         print(hdr)
         for rt in rtl_changes:
             print(rt)


### PR DESCRIPTION
The second commit (which has no commit message because most of the diff is an explanation of what it's doing!) is the interesting part. The first part just improves some state tracking slightly to avoid some spurious trace entries.