### PR TITLE
[otbn,rtl] Rewire how we pass around error bits

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -14,8 +14,6 @@ module otbn_controller
   parameter int ImemSizeByte = 4096,
   // Size of the data memory, in bytes
   parameter int DmemSizeByte = 4096,
-  // Enable internal secure wipe
-  parameter bit SecWipeEn  = 1'b0,
 
   localparam int ImemAddrWidth = prim_util_pkg::vbits(ImemSizeByte),
   localparam int DmemAddrWidth = prim_util_pkg::vbits(DmemSizeByte)
@@ -26,16 +24,14 @@ module otbn_controller
   input  logic start_i,  // start the processing at address zero
   output logic locked_o, // OTBN in locked state and must be reset to perform any further actions
 
-  output err_bits_t err_bits_o,           // valid when start_secure_wipe_o is asserted
-  output logic      recoverable_err_o,
-  output logic      reg_intg_violation_o,
+  input logic                  escalate_en_i,
+  output controller_err_bits_t err_bits_o,
+  output logic                 recoverable_err_o,
 
   // Next instruction selection (to instruction fetch)
   output logic                     insn_fetch_req_valid_o,
   output logic [ImemAddrWidth-1:0] insn_fetch_req_addr_o,
   output logic                     insn_fetch_resp_clear_o,
-  // Error from fetch requested last cycle
-  input  logic                     insn_fetch_err_i,
 
   // Fetched/decoded instruction
   input logic                     insn_valid_i,
@@ -64,7 +60,6 @@ module otbn_controller
   output logic                     rf_base_rd_commit_o,
 
   input logic rf_base_call_stack_err_i,
-  input logic rf_base_rd_data_err_i,
 
   // Bignum register file (WDRs)
   output logic [4:0]         rf_bignum_wr_addr_o,
@@ -112,7 +107,6 @@ module otbn_controller
 
   input  logic [BaseIntgWidth-1:0] lsu_base_rdata_i,
   input  logic [ExtWLEN-1:0]       lsu_bignum_rdata_i,
-  input  logic                     lsu_rdata_err_i,
 
   // Internal Special-Purpose Registers (ISPRs)
   output ispr_e                       ispr_addr_o,
@@ -125,7 +119,6 @@ module otbn_controller
   output logic rnd_req_o,
   output logic rnd_prefetch_req_o,
   input  logic rnd_valid_i,
-  input  logic urnd_state_err_i,
 
   // Secure Wipe
   input  logic secure_wipe_running_i,
@@ -136,12 +129,8 @@ module otbn_controller
   output logic [31:0] insn_cnt_o,
   input  logic        insn_cnt_clear_i,
   output logic        mems_sec_wipe_o,
-  input  logic        bus_intg_violation_i,
-  input  logic        illegal_bus_access_i,
-  input  logic        lifecycle_escalation_i,
+
   input  logic        software_errs_fatal_i,
-  input  logic        start_stop_state_error_i,
-  input  logic        otbn_scramble_state_error_i,
 
   input logic [1:0] sideload_key_shares_valid_i,
 
@@ -154,11 +143,17 @@ module otbn_controller
 );
   otbn_state_e state_q, state_d;
 
+
+  controller_err_bits_t err_bits_q, err_bits_d;
+
+  // The specific error signals that go into err_bits_d
+  logic fatal_software_err, bad_internal_state_err, reg_intg_violation_err, key_invalid_err;
+  logic illegal_insn_err, bad_data_addr_err, call_stack_err, bad_insn_addr_err;
+
   logic err;
   logic software_err;
   logic non_insn_addr_software_err;
   logic fatal_err;
-  logic recoverable_err;
   logic done_complete;
   logic executing;
   logic state_error;
@@ -242,7 +237,7 @@ module otbn_controller
   logic imem_addr_err, loop_err, ispr_err;
   logic dmem_addr_err, dmem_addr_unaligned_base, dmem_addr_unaligned_bignum, dmem_addr_overflow;
   logic illegal_insn_static;
-  logic key_invalid, key_invalid_err;
+  logic key_invalid;
 
   logic rf_a_indirect_err, rf_b_indirect_err, rf_d_indirect_err, rf_indirect_err;
 
@@ -258,9 +253,6 @@ module otbn_controller
   logic        insn_cnt_clear;
 
   logic [4:0] ld_insn_bignum_wr_addr_q;
-  err_bits_t err_bits;
-  // Only used with SecWipeEn == 1
-  logic      err_bits_en;
 
   // Stall a cycle on loads to allow load data writeback to happen the following cycle. Stall not
   // required on stores as there is no response to deal with.
@@ -273,7 +265,7 @@ module otbn_controller
 
   // OTBN is done when it was executing something (in state OtbnStateUrndRefresh, OtbnStateRun or
   // OtbnStateStall) and either it executes an ecall or an error occurs. A pulse on the done signal
-  // raises the 'done' interrupt and also tells the top-level to update its err_bits status
+  // raises the 'done' interrupt and also tells the top-level to update its ERR_BITS status
   // register.
   //
   // The calculation that ecall triggered done is factored out as `done_complete` to avoid logic
@@ -315,7 +307,6 @@ module otbn_controller
     insn_fetch_req_valid_raw = 1'b0;
     insn_fetch_req_addr_o    = '0;
     insn_fetch_resp_clear_o  = 1'b1;
-    err_bits_en              = 1'b0;
     prefetch_en_o            = 1'b0;
 
     state_error = 1'b0;
@@ -328,9 +319,6 @@ module otbn_controller
           insn_fetch_req_addr_o    = '0;
           insn_fetch_req_valid_raw = 1'b1;
           prefetch_en_o            = 1'b1;
-
-          // Enable error bits to zero them on start
-          err_bits_en = 1'b1;
         end
       end
       OtbnStateRun: begin
@@ -396,11 +384,6 @@ module otbn_controller
       prefetch_en_o           = 1'b0;
       insn_fetch_resp_clear_o = 1'b1;
 
-      if (!secure_wipe_running_i) begin
-        // Capture error bits on error unless a secure wipe is in progress
-        err_bits_en = 1'b1;
-      end
-
       if (fatal_err) begin
         state_d = OtbnStateLocked;
       end else begin
@@ -441,88 +424,67 @@ module otbn_controller
   // or illegal WSR/CSR referenced).
   assign illegal_insn_static = insn_illegal_i | ispr_err;
 
-  assign err_bits.fatal_software       = software_err & software_errs_fatal_i;
-  assign err_bits.lifecycle_escalation = lifecycle_escalation_i;
-  assign err_bits.illegal_bus_access   = illegal_bus_access_i;
-  assign err_bits.bad_internal_state   = start_stop_state_error_i | state_error |
-                                         otbn_scramble_state_error_i | urnd_state_err_i;
-  assign err_bits.bus_intg_violation   = bus_intg_violation_i;
-  assign err_bits.reg_intg_violation   = rf_base_rd_data_err_i | rf_bignum_rd_data_err;
-  assign err_bits.dmem_intg_violation  = lsu_rdata_err_i;
-  assign err_bits.imem_intg_violation  = insn_fetch_err_i;
-  assign err_bits.key_invalid          = key_invalid_err;
-  assign err_bits.illegal_insn         = illegal_insn_static | rf_indirect_err;
-  assign err_bits.bad_data_addr        = dmem_addr_err;
-  assign err_bits.loop                 = loop_err;
-  assign err_bits.call_stack           = rf_base_call_stack_err_i;
-  assign err_bits.bad_insn_addr        = imem_addr_err & ~non_insn_addr_software_err;
+  assign fatal_software_err       = software_err & software_errs_fatal_i;
+  assign bad_internal_state_err   = state_error;
+  assign reg_intg_violation_err   = rf_bignum_rd_data_err;
+  assign key_invalid_err          = ispr_rd_bignum_insn & insn_valid_i & key_invalid;
+  assign illegal_insn_err         = illegal_insn_static | rf_indirect_err;
+  assign bad_data_addr_err        = dmem_addr_err;
+  assign call_stack_err           = rf_base_call_stack_err_i;
 
   // All software errors that aren't bad_insn_addr. Factored into bad_insn_addr so it is only raised
   // if other software errors haven't ocurred. As bad_insn_addr relates to the next instruction
   // begin fetched it cannot occur if the current instruction has seen an error and failed to
   // execute.
-  assign non_insn_addr_software_err = |{err_bits.key_invalid,
-                                        err_bits.illegal_insn,
-                                        err_bits.bad_data_addr,
-                                        err_bits.loop,
-                                        err_bits.call_stack};
+  assign non_insn_addr_software_err = |{key_invalid_err,
+                                        loop_err,
+                                        illegal_insn_err,
+                                        call_stack_err,
+                                        bad_data_addr_err};
 
-  assign software_err = |{err_bits.key_invalid,
-                          err_bits.illegal_insn,
-                          err_bits.bad_data_addr,
-                          err_bits.loop,
-                          err_bits.call_stack,
-                          err_bits.bad_insn_addr};
+  assign bad_insn_addr_err = imem_addr_err & ~non_insn_addr_software_err;
 
-  assign fatal_err = |{err_bits.fatal_software,
-                       err_bits.lifecycle_escalation,
-                       err_bits.illegal_bus_access,
-                       err_bits.bad_internal_state,
-                       err_bits.bus_intg_violation,
-                       err_bits.reg_intg_violation,
-                       err_bits.dmem_intg_violation,
-                       err_bits.imem_intg_violation};
+  assign err_bits_d = '{
+    fatal_software:     fatal_software_err,
+    bad_internal_state: bad_internal_state_err,
+    reg_intg_violation: reg_intg_violation_err,
+    key_invalid:        key_invalid_err,
+    loop:               loop_err,
+    illegal_insn:       illegal_insn_err,
+    call_stack:         call_stack_err,
+    bad_data_addr:      bad_data_addr_err,
+    bad_insn_addr:      bad_insn_addr_err
+  };
 
-  assign recoverable_err = software_err & ~software_errs_fatal_i;
-
-  assign reg_intg_violation_o = err_bits.reg_intg_violation;
-  assign mems_sec_wipe_o = (state_d == OtbnStateLocked) & (state_q != OtbnStateLocked);
-
-  if (SecWipeEn) begin : gen_sec_wipe
-    err_bits_t err_bits_d, err_bits_q;
-    logic      recoverable_err_d, recoverable_err_q;
-
-    assign err_bits_d = err_bits;
-    assign err_bits_o = err_bits_q;
-    assign recoverable_err_d = recoverable_err;
-    assign recoverable_err_o = recoverable_err_q;
-
-    always_ff @(posedge clk_i or negedge rst_ni) begin
-      if (!rst_ni) begin
-        recoverable_err_q <= 1'b0;
+  always @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      err_bits_q <= '0;
+    end else begin
+      if (start_i && !locked_o) begin
         err_bits_q <= '0;
-      end else if (err_bits_en) begin
-        err_bits_q <= err_bits_d;
-        recoverable_err_q <= recoverable_err_d;
+      end else begin
+        err_bits_q <= err_bits_q | err_bits_d;
       end
     end
-
-    `ASSERT(ErrBitSetOnErr, err |=> |err_bits_o)
-  end else begin : gen_bypass_sec_wipe
-    logic unused_err_bits_en;
-
-    assign unused_err_bits_en = err_bits_en;
-    assign err_bits_o = err_bits;
-    assign recoverable_err_o = recoverable_err;
-
-    `ASSERT(ErrBitSetOnErr, err |-> |err_bits_o)
   end
+  assign err_bits_o = err_bits_q;
+
+  assign software_err = non_insn_addr_software_err | bad_insn_addr_err;
+
+  assign fatal_err = |{fatal_software_err,
+                       bad_internal_state_err,
+                       reg_intg_violation_err,
+                       escalate_en_i};
+
+  assign recoverable_err_o = software_err & ~software_errs_fatal_i;
+  assign mems_sec_wipe_o   = (state_d == OtbnStateLocked) & (state_q != OtbnStateLocked);
 
   assign err = software_err | fatal_err;
 
   // Instructions must not execute if there is an error
   assign insn_executing = insn_valid_i & ~err;
 
+  `ASSERT(ErrBitSetOnErr, err & ~escalate_en_i |=> err_bits_o)
   `ASSERT(ErrSetOnFatalErr, fatal_err |-> err)
   `ASSERT(SoftwareErrIfNonInsnAddrSoftwareErr, non_insn_addr_software_err |-> software_err)
 
@@ -1059,9 +1021,6 @@ module otbn_controller
 
   assign wsr_wdata = insn_dec_shared_i.ispr_rs_insn ? ispr_rdata_i | rf_bignum_rd_data_a_no_intg :
                                                       rf_bignum_rd_data_a_no_intg;
-
-  // Invalid key only becomes an error if we're trying to read it
-  assign key_invalid_err = ispr_rd_bignum_insn & insn_valid_i & key_invalid;
 
   assign ispr_illegal_addr = insn_dec_shared_i.subset == InsnSubsetBase ? csr_illegal_addr :
                                                                           wsr_illegal_addr;

--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -92,6 +92,36 @@ package otbn_pkg;
     logic bad_data_addr;
   } err_bits_t;
 
+  // All the error signals that can be generated directly from the controller. Note that this is
+  // organised to include every software error (including 'call_stack', which actually gets fed in
+  // from the base register file)
+  typedef struct packed {
+    logic fatal_software;
+    logic bad_internal_state;
+    logic reg_intg_violation;
+    logic key_invalid;
+    logic loop;
+    logic illegal_insn;
+    logic call_stack;
+    logic bad_insn_addr;
+    logic bad_data_addr;
+  } controller_err_bits_t;
+
+  // All the error signals that can be generated somewhere inside otbn_core
+  typedef struct packed {
+    logic fatal_software;
+    logic bad_internal_state;
+    logic reg_intg_violation;
+    logic dmem_intg_violation;
+    logic imem_intg_violation;
+    logic key_invalid;
+    logic loop;
+    logic illegal_insn;
+    logic call_stack;
+    logic bad_insn_addr;
+    logic bad_data_addr;
+  } core_err_bits_t;
+
   // Constants =====================================================================================
 
   typedef enum logic {


### PR DESCRIPTION
Before this change, we passed lots of signals up to
top-level, where they were assembled into an "`err_bits`" struct and
then passed back down to the core. This had lots of scope for
accidental combinational loops because as soon as you qualify one
error with another, you've got a loop all the way around.

This commit tries to simplify things a bit. Now, the controller and
core have their own cut-down versions of the `err_bits_t` struct that
they pass out. We also need signals going "the other way" to tell the
controller when there has been a fatal error. Since these are
all (morally) local escalation signals, I've standardised on that
naming. Now, for example, `otbn.sv` defines `core_escalate_en` which
contains all the "extra" error signals that are OR'd into `err_bits` and
didn't come from otbn_core. This signal gets passed down to tell the
core to stop.

The net result should be that the flow of information is a bit
clearer (and more one-way!).
