### PR TITLE
[dv/clkmgr] Populate sec_cm testplan

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr_sec_cm_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_sec_cm_testplan.hjson
@@ -81,7 +81,7 @@
       name: sec_cm_idle_ctr_redun
       desc: "Verify the countermeasure(s) IDLE.CTR.REDUN."
       milestone: V2S
-      tests: []
+      tests: ["clkmgr_sec_cm"]
     }
     {
       name: sec_cm_meas_config_regwen

--- a/hw/ip/clkmgr/data/clkmgr_testplan.hjson
+++ b/hw/ip/clkmgr/data/clkmgr_testplan.hjson
@@ -11,7 +11,8 @@
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                      // TODO: Top-level specific Hjson imported here. This will likely be resolved
                      // once we move to IPgen flow.
-                     "hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson"]
+                     "hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson"]
   testpoints: [
     {
       name: smoke

--- a/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
+++ b/hw/ip/clkmgr/dv/clkmgr_sim_cfg.hjson
@@ -32,11 +32,13 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson"
                 ]
 
   // Add additional tops for simulation.
-  sim_tops: ["clkmgr_bind"]
+  sim_tops: ["clkmgr_bind",
+             "sec_cm_prim_count_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50

--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -5,6 +5,7 @@
 package clkmgr_env_pkg;
   // dep packages
   import uvm_pkg::*;
+  import sec_cm_pkg::*;
   import top_pkg::*;
   import dv_utils_pkg::*;
   import dv_lib_pkg::*;

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_common_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_common_vseq.sv
@@ -8,6 +8,19 @@ class clkmgr_common_vseq extends clkmgr_base_vseq;
   constraint num_trans_c {num_trans inside {[1 : 2]};}
   `uvm_object_new
 
+  virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
+    super.check_sec_cm_fi_resp(if_proxy);
+
+    case (if_proxy.sec_cm_type)
+      SecCmPrimCount: begin
+        csr_rd_check(.ptr(ral.fatal_err_code.idle_cnt), .compare_value(1));
+      end
+      default: begin
+        `uvm_error(`gfn, $sformatf("Unexpected sec_cm_type %0s", if_proxy.sec_cm_type.name))
+      end
+    endcase
+  endtask
+
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
@@ -27,7 +27,7 @@
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
       milestone: V2S
-      tests: []
+      tests: ["clkmgr_tl_intg_err"]
     }
     {
       name: sec_cm_timeout_clk_bkgn_chk
@@ -39,7 +39,7 @@
       name: sec_cm_meas_clk_bkgn_chk
       desc: "Verify the countermeasure(s) MEAS.CLK.BKGN_CHK."
       milestone: V2S
-      tests: []
+      tests: ["clkmgr_frequency"]
     }
     {
       name: sec_cm_idle_intersig_mubi
@@ -81,7 +81,7 @@
       name: sec_cm_idle_ctr_redun
       desc: "Verify the countermeasure(s) IDLE.CTR.REDUN."
       milestone: V2S
-      tests: []
+      tests: ["clkmgr_sec_cm"]
     }
     {
       name: sec_cm_meas_config_regwen


### PR DESCRIPTION
Add existing and auto-generated tests to sec_cm testplan.

Signed-off-by: Guillermo Maturana <maturana@google.com>