### PR TITLE
[keymgr/dv] Minor update in keymgr_hwsw_invalid_input_vseq

### DIFF
--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_hwsw_invalid_input_vseq.sv
@@ -28,7 +28,6 @@ class keymgr_hwsw_invalid_input_vseq extends keymgr_sw_invalid_input_vseq;
   endfunction
 
   task post_start();
-    expect_fatal_alerts = 1;
     super.post_start();
   endtask
 


### PR DESCRIPTION
Removed `expect_fatal_alerts` in keymgr_hwsw_invalid_input_vseq as this
test should only trigger recoverable alerts

Signed-off-by: Weicai Yang <weicai@google.com>