### PR TITLE
[cleanup] Detect target environment

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -31,17 +31,15 @@ cc_library(
 )
 
 cc_library(
+    name = "macros",
+    hdrs = ["macros.h"],
+)
+
+cc_library(
     name = "abs_mmio",
-    srcs = [
-        "abs_mmio.c",
-    ],
-    hdrs = [
-        "abs_mmio.h",
-    ],
-    target_compatible_with = [OPENTITAN_CPU],
-    deps = [
-        ":base",
-    ],
+    srcs = ["abs_mmio.c"],
+    hdrs = ["abs_mmio.h"],
+    deps = [":macros"],
 )
 
 cc_library(

--- a/sw/device/lib/base/abs_mmio.h
+++ b/sw/device/lib/base/abs_mmio.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/macros.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,7 +35,7 @@ extern "C" {
  */
 #define ABS_MMIO_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
 
-#ifndef MOCK_ABS_MMIO
+#ifdef OT_PLATFORM_TARGET
 
 /**
  * Reads uint8_t from MMIO `addr`.
@@ -103,7 +103,7 @@ inline void abs_mmio_write32_shadowed(uint32_t addr, uint32_t value) {
   *((volatile uint32_t *)addr) = value;
 }
 
-#else  // MOCK_ABS_MMIO
+#else  // OT_PLATFORM_TARGET
 
 extern uint8_t abs_mmio_read8(uint32_t addr);
 extern void abs_mmio_write8(uint32_t addr, uint8_t value);
@@ -112,7 +112,7 @@ extern uint32_t abs_mmio_read32(uint32_t addr);
 extern void abs_mmio_write32(uint32_t addr, uint32_t value);
 extern void abs_mmio_write32_shadowed(uint32_t addr, uint32_t value);
 
-#endif  // MOCK_ABS_MMIO
+#endif  // OT_PLATFORM_TARGET
 
 #ifdef __cplusplus
 }

--- a/sw/device/lib/base/csr.h
+++ b/sw/device/lib/base/csr.h
@@ -11,6 +11,7 @@
 
 #include "sw/device/lib/base/csr_registers.h"
 #include "sw/device/lib/base/stdasm.h"
+#include "sw/device/lib/base/macros.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -21,7 +22,7 @@ extern "C" {
  * @brief Ibex Control and Status Register (CSR) interface.
  *
  * A set of macros that provide both read and modify operations on Ibex CSRs.
- * Compiling translation units that include this header file with `-DMOCK_CSR`
+ * Compiling translation units that include this header file with `-DOT_PLATFORM_HOST`
  * will result in the CSR operations being replaced with a mocked
  * implementation.
  */
@@ -32,7 +33,7 @@ extern "C" {
  * The implementation used depends on whether the CSR library is providing a
  * real or a mocked interface.
  */
-#ifdef MOCK_CSR
+#ifdef OT_PLATFORM_HOST
 
 /**
  * Macro to check that an argument is a constant expression at compile time.
@@ -87,7 +88,10 @@ void mock_csr_clear_bits(uint32_t addr, uint32_t mask);
     mock_csr_clear_bits(csr, mask);                 \
   } while (false)
 
-#else  // MOCK_CSR
+#else  // OT_PLATFORM_HOST
+#ifndef OT_PLATFORM_RV32
+#error "Expected OT_PLATFORM_RV32 to be defined!"
+#endif
 
 #define CSR_READ_IMPL(csr, dest)                           \
   do {                                                     \
@@ -117,7 +121,7 @@ void mock_csr_clear_bits(uint32_t addr, uint32_t mask);
     asm volatile("csrc %0, %1;" ::"i"(csr), "r"(mask)); \
   } while (false)
 
-#endif  // MOCK_CSR
+#endif  // OT_PLATFORM_HOST
 
 /**
  * Read the value of a CSR and place the result into the location pointed to by

--- a/sw/device/lib/base/hardened.h
+++ b/sw/device/lib/base/hardened.h
@@ -7,6 +7,7 @@
 
 #include <stdint.h>
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/stdasm.h"
 
 /**
@@ -522,7 +523,7 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
 }
 
 // Implementation details shared across shutdown macros.
-#ifndef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_RV32
 // This string can be tuned to be longer or shorter as desired, for
 // fault-hardening purposes.
 #define HARDENED_UNIMP_SEQUENCE_() "unimp; unimp; unimp; unimp;"
@@ -548,7 +549,10 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
     asm volatile(HARDENED_UNIMP_SEQUENCE_()); \
     __builtin_unreachable();                  \
   } while (false)
-#else  // OT_OFF_TARGET_TEST
+#else  // OT_PLATFORM_RV32
+#ifdef OT_PLATFORM_TARGET
+#error "OT_PLATFORM_TARGET is defined, but not using hardended implementation!"
+#endif
 #include <assert.h>
 
 #define HARDENED_CHECK_OP_EQ_ ==
@@ -561,7 +565,7 @@ inline uintptr_t ct_cmovw(ct_boolw_t c, uintptr_t a, uintptr_t b) {
 #define HARDENED_CHECK_(op_, a_, b_) assert((uint64_t)(a_)op_(uint64_t)(b_))
 
 #define HARDENED_UNREACHABLE_() assert(false)
-#endif  // OT_OFF_TARGET_TEST
+#endif  // OT_PLATFORM_RV32
 
 /**
  * Indicates that the following code is unreachable; it should never be

--- a/sw/device/lib/base/macros.h
+++ b/sw/device/lib/base/macros.h
@@ -101,9 +101,16 @@
 
 /**
  * A macro representing the OpenTitan execution platform.
+ * 
+ * OT_PLATFORM_TARGET represents any valid target platform (currently rv32i).
+ * OT_PLATFORM_HOST represents the host platform (e.g. unit testing).
+ * OT_PLATFORM_RV32 identifies the target platform as RV32.
  */
 #if __riscv_xlen == 32
+#define OT_PLATFORM_TARGET 1
 #define OT_PLATFORM_RV32 1
+#else
+#define OT_PLATFORM_HOST 1
 #endif
 
 /**

--- a/sw/device/lib/base/testing/BUILD
+++ b/sw/device/lib/base/testing/BUILD
@@ -31,8 +31,12 @@ cc_library(
 cc_library(
     name = "mock_abs_mmio",
     testonly = True,
+    srcs = [
+        "mock_abs_mmio.cc",
+    ],
     hdrs = [
         "mock_abs_mmio.h",
+        "mock_mmio_test_utils.h",
     ],
     defines = ["MOCK_ABS_MMIO"],
     deps = [

--- a/sw/device/lib/base/testing/mock_abs_mmio.cc
+++ b/sw/device/lib/base/testing/mock_abs_mmio.cc
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/testing/mock_abs_mmio.h"
+
+namespace mask_rom_test {
+extern "C" {
+
+uint8_t abs_mmio_read8(uint32_t addr) {
+  return MockAbsMmio::Instance().Read8(addr);
+}
+
+void abs_mmio_write8(uint32_t addr, uint8_t value) {
+  MockAbsMmio::Instance().Write8(addr, value);
+}
+
+void abs_mmio_write8_shadowed(uint32_t addr, uint8_t value) {
+  MockAbsMmio::Instance().Write8Shadowed(addr, value);
+}
+
+uint32_t abs_mmio_read32(uint32_t addr) {
+  return MockAbsMmio::Instance().Read32(addr);
+}
+
+void abs_mmio_write32(uint32_t addr, uint32_t value) {
+  MockAbsMmio::Instance().Write32(addr, value);
+}
+
+void abs_mmio_write32_shadowed(uint32_t addr, uint32_t value) {
+  MockAbsMmio::Instance().Write32Shadowed(addr, value);
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test

--- a/sw/device/lib/base/testing/mock_abs_mmio.h
+++ b/sw/device/lib/base/testing/mock_abs_mmio.h
@@ -8,7 +8,7 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
-#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+//#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 namespace mask_rom_test {
 namespace internal {
@@ -98,33 +98,6 @@ using MockAbsMmio = testing::StrictMock<internal::MockAbsMmio>;
   EXPECT_CALL(::mask_rom_test::MockAbsMmio::Instance(), \
               Write32Shadowed(addr, mock_mmio::ToInt<uint32_t>(__VA_ARGS__)));
 
-extern "C" {
-
-uint8_t abs_mmio_read8(uint32_t addr) {
-  return MockAbsMmio::Instance().Read8(addr);
-}
-
-void abs_mmio_write8(uint32_t addr, uint8_t value) {
-  MockAbsMmio::Instance().Write8(addr, value);
-}
-
-void abs_mmio_write8_shadowed(uint32_t addr, uint8_t value) {
-  MockAbsMmio::Instance().Write8Shadowed(addr, value);
-}
-
-uint32_t abs_mmio_read32(uint32_t addr) {
-  return MockAbsMmio::Instance().Read32(addr);
-}
-
-void abs_mmio_write32(uint32_t addr, uint32_t value) {
-  MockAbsMmio::Instance().Write32(addr, value);
-}
-
-void abs_mmio_write32_shadowed(uint32_t addr, uint32_t value) {
-  MockAbsMmio::Instance().Write32Shadowed(addr, value);
-}
-
-}  // extern "C"
 }  // namespace mask_rom_test
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_BASE_TESTING_MOCK_ABS_MMIO_H_

--- a/sw/device/lib/base/testing/mock_mmio_test_utils.h
+++ b/sw/device/lib/base/testing/mock_mmio_test_utils.h
@@ -14,7 +14,6 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "sw/device/lib/base/mmio.h"
 
 namespace mock_mmio {
 

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -94,9 +94,6 @@ cc_test(
     srcs = [
         "epmp_unittest.cc",
     ],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         ":epmp",
         ":error",
@@ -241,6 +238,7 @@ cc_test(
     srcs = [
         "manifest_unittest.cc",
     ],
+    defines = ["MANIFEST_IMPL_TEST=1"],
     deps = [
         ":epmp_intf",
         ":error",
@@ -319,9 +317,6 @@ cc_test(
         "shutdown.c",
         "shutdown_unittest.cc",
     ],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         ":error",
         ":shutdown_intf",
@@ -393,9 +388,6 @@ cc_test(
     srcs = [
         "sigverify.c",
         "sigverify_unittest.cc",
-    ],
-    defines = [
-        "OT_OFF_TARGET_TEST",
     ],
     deps = [
         ":mock_sigverify",

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -12,6 +12,7 @@ cc_library(
     deps = [
         ":error",
         "//sw/device/lib/base",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
     ],
@@ -81,7 +82,6 @@ cc_library(
 cc_library(
     name = "epmp",
     srcs = ["epmp.c"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         ":epmp_intf",
         ":error",
@@ -93,15 +93,12 @@ cc_test(
     name = "epmp_unittest",
     srcs = [
         "epmp_unittest.cc",
-        # sources included here because we need MOCK_CSR.
-        "epmp.c",
-        "epmp.h",
     ],
     defines = [
         "OT_OFF_TARGET_TEST",
     ],
     deps = [
-        ":epmp_intf",
+        ":epmp",
         ":error",
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib/base:mock_csr",
@@ -194,6 +191,7 @@ cc_test(
         "//sw/device/lib/base/testing:global_mock",
         "//sw/device/silicon_creator/lib/drivers:uart",
         "//sw/device/silicon_creator/testing:mask_rom_test",
+        "//sw/device/lib/base/testing:mock_abs_mmio",
         "@googletest//:gtest_main",
     ],
 )
@@ -243,7 +241,6 @@ cc_test(
     srcs = [
         "manifest_unittest.cc",
     ],
-    defines = ["MOCK_CSR"],
     deps = [
         ":epmp_intf",
         ":error",
@@ -253,7 +250,8 @@ cc_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib/base:mock_csr",
-        "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/lib/base/testing:mock_abs_mmio",
+        "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
@@ -409,6 +407,7 @@ cc_test(
         "//sw/device/silicon_creator/lib/drivers:mock_lifecycle",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
         "//sw/device/silicon_creator/testing:mask_rom_test",
+        "//sw/device/lib/base/testing:mock_abs_mmio",
         "@googletest//:gtest_main",
     ],
 )
@@ -542,6 +541,7 @@ cc_test(
         ":sigverify_internal",
         ":sigverify_intf",
         ":sigverify_mod_exp_ibex",
+        "//sw/device/lib/base/testing:mock_abs_mmio",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -61,7 +61,6 @@ cc_test(
         "sec_mmio.h",
         "sec_mmio_unittest.cc",
     ],
-    defines = ["OT_OFF_TARGET_TEST"],
     deps = [
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:mock_abs_mmio",

--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -12,7 +12,6 @@ cc_library(
     testonly = True,
     srcs = ["mock_csr.cc"],
     hdrs = ["mock_csr.h"],
-    defines = ["MOCK_CSR"],
     deps = [
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:global_mock",
@@ -33,7 +32,6 @@ cc_library(
     name = "sec_mmio",
     srcs = ["sec_mmio.c"],
     hdrs = ["sec_mmio.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/base",
         "//sw/device/lib/base:abs_mmio",
@@ -68,6 +66,7 @@ cc_test(
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:mock_abs_mmio",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
+++ b/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 namespace sec_mmio_unittest {
 namespace {

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -91,9 +91,6 @@ cc_test(
         "flash_ctrl.h",
         "flash_ctrl_unittest.cc",
     ],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
@@ -251,9 +248,6 @@ cc_test(
         "lifecycle.h",
         "lifecycle_unittest.cc",
     ],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -284,9 +278,6 @@ cc_test(
         "otbn.c",
         "otbn.h",
         "otbn_unittest.cc",
-    ],
-    defines = [
-        "OT_OFF_TARGET_TEST",
     ],
     deps = [
         "//hw/ip/otbn/data:otbn_regs",
@@ -468,9 +459,6 @@ cc_test(
         "rstmgr.h",
         "rstmgr_unittest.cc",
     ],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -539,9 +527,6 @@ cc_library(
 cc_test(
     name = "watchdog_unittest",
     srcs = ["watchdog_unittest.cc"],
-    defines = [
-        "OT_OFF_TARGET_TEST",
-    ],
     deps = [
         ":watchdog",
         "//hw/ip/aon_timer/data:aon_timer_regs",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -10,7 +10,6 @@ cc_library(
     name = "alert",
     srcs = ["alert.c"],
     hdrs = ["alert.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey:alert_handler_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -47,6 +46,7 @@ cc_test(
         "//sw/device/lib/base",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -72,7 +72,6 @@ cc_library(
     name = "flash_ctrl",
     srcs = ["flash_ctrl.c"],
     hdrs = ["flash_ctrl.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
@@ -105,6 +104,7 @@ cc_test(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -143,6 +143,7 @@ cc_test(
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:mock_abs_mmio",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -162,7 +163,6 @@ cc_library(
     name = "keymgr",
     srcs = ["keymgr.c"],
     hdrs = ["keymgr.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/ip/keymgr/data:keymgr_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -190,6 +190,7 @@ cc_test(
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:keymgr_binding",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -268,7 +269,6 @@ cc_library(
     name = "otbn",
     srcs = ["otbn.c"],
     hdrs = ["otbn.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/ip/otbn/data:otbn_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -303,7 +303,6 @@ cc_library(
     name = "otp",
     srcs = ["otp.c"],
     hdrs = ["otp.h"],
-    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -366,6 +365,7 @@ cc_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:mock_abs_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -391,6 +391,7 @@ cc_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:mock_abs_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -476,6 +477,7 @@ cc_test(
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:mock_abs_mmio",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -502,6 +504,7 @@ cc_test(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base",
         "//sw/device/lib/base/testing:mock_abs_mmio",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )
@@ -548,6 +551,7 @@ cc_test(
         "//sw/device/lib/base/testing:mock_abs_mmio",
         "//sw/device/silicon_creator/lib/base:mock_sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:mock_otp",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/alert_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "alert_handler_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -13,6 +13,7 @@
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "flash_ctrl_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -11,6 +11,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/keymgr_unittest.cc
@@ -11,6 +11,7 @@
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "keymgr_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "pinmux_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sram_ctrl_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <stdnoreturn.h>
 
+#include "sw/device/lib/base/macros.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -98,7 +100,7 @@ void rstmgr_alert_info_enable(void);
 /**
  * Requests a system reset.
  */
-#ifndef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_TARGET
 // Omit `noreturn` to be able to test this function in off-target tests.
 noreturn
 #endif

--- a/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rstmgr_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "uart_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/watchdog_unittest.cc
@@ -11,6 +11,7 @@
 #include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "aon_timer_regs.h"
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/lib/manifest.h
+++ b/sw/device/silicon_creator/lib/manifest.h
@@ -265,7 +265,7 @@ typedef struct manifest_digest_region {
 #define MANIFEST_LENGTH_FIELD_OWNER_STAGE_MIN MANIFEST_SIZE
 #define MANIFEST_LENGTH_FIELD_OWNER_STAGE_MAX 0x70000
 
-#ifndef OT_OFF_TARGET_TEST
+#if defined(OT_PLATFORM_TARGET) || defined(MANIFEST_IMPL_TEST)
 /**
  * Checks the fields of a manifest.
  *

--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -39,7 +39,11 @@ static_assert(ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT <=
 
 #define NO_MODIFIERS
 
-#ifdef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_TARGET
+#define SHUTDOWN_FUNC(modifiers_, name_) \
+  OT_ALWAYS_INLINE                       \
+  static modifiers_ void name_
+#else
 // If we're building as a unit test, rename the shutdown functions so they
 // can be mocked and/or tested individually.
 // The unmodified function name will be declared as `extern` so the test
@@ -49,10 +53,6 @@ static_assert(ALERT_HANDLER_LOC_ALERT_CLASS_SHADOWED_MULTIREG_COUNT <=
 #define SHUTDOWN_FUNC(modifiers_, name_) \
   extern void name_;                     \
   void unmocked_##name_
-#else
-#define SHUTDOWN_FUNC(modifiers_, name_) \
-  OT_ALWAYS_INLINE                       \
-  static modifiers_ void name_
 #endif
 
 // Convert the alert class to an index.
@@ -467,7 +467,7 @@ SHUTDOWN_FUNC(noreturn, shutdown_hang(void)) {
 #endif
 }
 
-#ifndef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_TARGET
 /**
  * The shutdown_finalize function goes into the .shutdown section which is
  * placed by the linker script after all other executable code.

--- a/sw/device/silicon_creator/lib/shutdown.h
+++ b/sw/device/silicon_creator/lib/shutdown.h
@@ -112,7 +112,7 @@ uint32_t shutdown_redact(rom_error_t reason, shutdown_error_redact_t severity);
  *
  * @param reason A reason for entering the shutdown state.
  */
-#ifndef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_TARGET
 // If this is a test, we'll omit `noreturn` so we can call this function
 // from within a test program.
 noreturn

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -41,7 +41,6 @@ cc_test(
         "boot_policy_ptrs.h",
         "boot_policy_unittest.cc",
     ],
-    defines = ["OT_OFF_TARGET_TEST"],
     deps = [
         ":mock_boot_policy_ptrs",
         "//sw/device/lib/base",
@@ -241,7 +240,6 @@ cc_test(
         "sigverify_keys_unittest.cc",
         "//sw/device/silicon_creator/lib:sigverify_src_for_keys_unittest",
     ],
-    defines = ["OT_OFF_TARGET_TEST"],
     deps = [
         ":mock_sigverify_keys_ptrs",
         ":sigverify_keys_ptrs",

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -49,6 +49,7 @@ cc_test(
         "//sw/device/silicon_creator/lib:mock_manifest",
         "//sw/device/silicon_creator/lib:mock_shutdown",
         "//sw/device/silicon_creator/testing:mask_rom_test",
+        "//sw/device/lib/base/testing:mock_abs_mmio",
         "@googletest//:gtest_main",
     ],
 )
@@ -256,6 +257,7 @@ cc_test(
         "//sw/device/silicon_creator/lib/drivers:mock_rnd",
         "//sw/device/silicon_creator/mask_rom/keys:test_public_keys",
         "//sw/device/silicon_creator/testing:mask_rom_test",
+        "//sw/device/lib/base/testing:mock_abs_mmio",
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/mask_rom/boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/boot_policy_ptrs.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOT_POLICY_PTRS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOT_POLICY_PTRS_H_
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -16,7 +17,7 @@ extern "C" {
 static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
               "Flash size is not divisible by 2");
 
-#ifndef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_TARGET
 /**
  * Returns a pointer to the manifest of the ROM_EXT image stored in flash
  * slot A.

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/sigverify_rsa_key.h"
 
 #ifdef __cplusplus
@@ -85,7 +86,7 @@ typedef struct sigverify_mask_rom_key {
  */
 extern const sigverify_mask_rom_key_t kSigVerifyRsaKeys[kSigVerifyNumRsaKeys];
 
-#ifndef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_TARGET
 
 /**
  * Returns a pointer to the RSA public keys stored in the Mask ROM.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_boot_policy_ptrs.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_BOOT_POLICY_PTRS_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_ROM_EXT_ROM_EXT_BOOT_POLICY_PTRS_H_
 
+#include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/manifest.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -16,7 +17,7 @@ extern "C" {
 static_assert((TOP_EARLGREY_EFLASH_SIZE_BYTES % 2) == 0,
               "Flash size is not divisible by 2");
 
-#ifndef OT_OFF_TARGET_TEST
+#ifdef OT_PLATFORM_TARGET
 /**
  * Returns a pointer to the manifest of the first owner boot stage image stored
  * in flash slot A.


### PR DESCRIPTION
1. Detect the target environment (in `macros.h`) by examining compiler
   defined preprocessor symbols.  Define one or more of
   `OT_PLATFORM_TARGET`, `OT_PLATFORM_RV32` and `OT_PLATFORM_HOST` depending
   on the compiler target.
2. Eliminate use of MOCK_*_MMIO in favor of OT_PLATFORM_*.  The mmio and other
   target specific libraries will never work on the host (unittest) platform.
   The only versions of such libraries which make sense are the mocked
   libraries.
3. Relax the `target_compatible_with` constraints on many of the Mask ROM's
   `cc_library` targets.  Being compatible only with OPENTITAN_CPU causes
   many of the unittests to be skipped.

Signed-off-by: Chris Frantz <cfrantz@google.com>