### PR TITLE
[flash_ctrl dv] Avoid referencing scb in cfg

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.sv
@@ -42,7 +42,6 @@ class flash_ctrl_env #(
         end
       end
     end
-    cfg.scoreboard = scoreboard;
   endfunction
 
   virtual function void connect_phase(uvm_phase phase);

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -33,9 +33,6 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Max delay for alerts in clocks
   uint alert_max_delay;
 
-  // A handle to the scoreboard
-  flash_ctrl_scoreboard scoreboard;
-
   // read data by host if
   data_q_t flash_rd_data;
 


### PR DESCRIPTION
The scb has handle to the cfg already. If vseqs need access to data from
the scoreboard, then create instead, a TLM port between scoreboard and
vseqr.

Reverting this change because it breaks the closed source DV env.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>