### PR TITLE
[spi_device] Block the passthrough with BUSY status

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -517,7 +517,8 @@
       fields: [
         { bits: "0"
           name: "busy"
-          desc: "BUSY"
+          desc: '''BUSY signal is cleared when CSb is high. SW should read
+            back the register to confirm the value is cleared.'''
           swaccess: "rw0c"
           hwaccess: "hrw"
           tags: [

--- a/hw/ip/spi_device/doc/_index.md
+++ b/hw/ip/spi_device/doc/_index.md
@@ -410,6 +410,13 @@ Except BUSY bit, other bits are controlled by SW.
 BUSY bit is set by HW when it receives any commands that are uploaded to the FIFOs.
 SW may clear BUSY bit when it completes the received commands (e.g Erase/ Program).
 
+If BUSY is set, SPI_DEVICE IP blocks the passhthrough interface in Passthrough mode.
+The blocking of the interface occurs in SPI transaction idle state (CSb == 1).
+However, due to the instrinsic delay of the CDC, CSb transition is delayed by 2 SYS_CLK cycles.
+It may introduce a corner case when the host system starts sending a SPI transaction while SW may clear the BUSY signal.
+In that case, the blocking and unblocking of the passthrough may happen while SPI is active.
+The HW behavior in this scenario is not determined.
+
 If the host sends the Write Status commands, the commands are not processed in this module.
 SW must configure the remaining command information entries to upload the Write Status commands to the FIFOs.
 

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -100,6 +100,11 @@ module spi_passthrough
 
   input spi_mode_e spi_mode_i,
 
+  // Control: Passthrough block
+  //   If passthrough_block_i is 1, the passthrough is turned off.
+  //   The signal should be changed when CSb is high (SPI inactive).
+  input passthrough_block_i,
+
   // Command Info structure
   input cmd_info_t [NumTotalCmdInfo-1:0] cmd_info_i,
 
@@ -644,7 +649,7 @@ module spi_passthrough
   assign passthrough_o.csb    = host_csb_i | csb_deassert_outclk ;
 
   // passthrough_en
-  assign passthrough_o.passthrough_en = is_active ;
+  assign passthrough_o.passthrough_en = is_active && !passthrough_block_i;
 
   // - END:   Passthrough Mux (!important) ------------------------------------
 


### PR DESCRIPTION
This commit addresses the issue #10785.

The BUSY @ SYS_CLK is set when SPI_DEVICE receives commands that satisfy:

- busy field in the CMD_INFO of the opcode is set
- CSb is de-asserted (SPI transaction completion)

When BUSY is set, SW may process the received command (assuming upload
field is set). After the command is processed by SW, SW may clear the
BUSY @SYS_CLK, which then will be propagated into SPI CLK (SCK) domain
at the next SPI transaction.

This commit is to turn off the passthrough interface if BUSY is set. So,
that the SW does not have to manually turn off the passthrough.

Keep in mind that this change cannot fully cover the corner cases:

- CSb is about to asserted (Beginning of the SPI transaction) at the
  same time BUSY is cleared by SW.

It is due to the CDC path of CSb to be used in SYS_CLK domain. It needs
to pass through 2FF synchronizer to be used in SYS_CLK safely. The delay
is 2 SYS_CLK. If BUSY falls in that window, the BUSY clearing may
unblock passthrough while SPI is active. The behavior of the IP is
undetermined.