### PR TITLE
[dv/clkmgr] Fix trans unit handling

### DIFF
--- a/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_env_pkg.sv
@@ -33,8 +33,9 @@ package clkmgr_env_pkg;
   parameter int NUM_TRANS = 4;
 
   typedef logic [NUM_PERI-1:0] peri_enables_t;
-  typedef mubi4_t [NUM_TRANS-1:0] hintables_t;
-  parameter hintables_t IdleAllBusy = {NUM_TRANS{prim_mubi_pkg::MuBi4False}};
+  typedef logic [NUM_TRANS-1:0] hintables_t;
+  typedef mubi4_t [NUM_TRANS-1:0] mubi_hintables_t;
+  parameter mubi_hintables_t IdleAllBusy = {NUM_TRANS{prim_mubi_pkg::MuBi4False}};
 
   parameter int MainClkHz = 100_000_000;
   parameter int IoClkHz = 96_000_000;
@@ -69,7 +70,7 @@ package clkmgr_env_pkg;
     TransAes,
     TransHmac,
     TransKmac,
-    TransOtbnMain
+    TransOtbn
   } trans_e;
   typedef struct packed {
     logic otbn_main;

--- a/hw/ip/clkmgr/dv/env/clkmgr_if.sv
+++ b/hw/ip/clkmgr/dv/env/clkmgr_if.sv
@@ -19,7 +19,7 @@ interface clkmgr_if (
   localparam int LcTxTWidth = $bits(lc_ctrl_pkg::lc_tx_t);
 
   // Encodes the transactional units that are idle.
-  hintables_t idle_i;
+  mubi_hintables_t idle_i;
 
   // pwrmgr req contains ip_clk_en, set to enable the gated clocks.
   pwrmgr_pkg::pwr_clk_req_t pwr_i;
@@ -81,7 +81,7 @@ interface clkmgr_if (
 
   prim_mubi_pkg::mubi4_t extclk_ctrl_csr_step_down;
   always_comb begin
-     extclk_ctrl_csr_step_down = (`CLKMGR_HIER.hi_speed_sel_o == prim_mubi_pkg::MuBi4False) ?
+    extclk_ctrl_csr_step_down = (`CLKMGR_HIER.hi_speed_sel_o == prim_mubi_pkg::MuBi4False) ?
                                  prim_mubi_pkg::MuBi4True :
                                  prim_mubi_pkg::MuBi4False;
   end
@@ -156,7 +156,7 @@ interface clkmgr_if (
   end
   always_comb usb_timeout_err = `CLKMGR_HIER.usb_timeout_err;
 
-  function automatic void update_idle(hintables_t value);
+  function automatic void update_idle(mubi_hintables_t value);
     idle_i = value;
   endfunction
 
@@ -211,7 +211,7 @@ interface clkmgr_if (
     endcase
   endfunction
 
-  task automatic init(hintables_t idle, prim_mubi_pkg::mubi4_t scanmode,
+  task automatic init(mubi_hintables_t idle, prim_mubi_pkg::mubi4_t scanmode,
                       lc_ctrl_pkg::lc_tx_t lc_debug_en = lc_ctrl_pkg::Off,
                       lc_ctrl_pkg::lc_tx_t lc_clk_byp_req = lc_ctrl_pkg::Off);
     `uvm_info("clkmgr_if", "In clkmgr_if init", UVM_MEDIUM)
@@ -240,7 +240,7 @@ interface clkmgr_if (
       ip_clk_en_div4_ffs <= {ip_clk_en_div4_ffs[PIPELINE_DEPTH-2:0], pwr_i.io_ip_clk_en};
     end else begin
       clk_enable_div4_ffs <= '0;
-      ip_clk_en_div4_ffs <= '0;
+      ip_clk_en_div4_ffs  <= '0;
     end
   end
   clocking peri_div4_cb @(posedge clocks_o.clk_io_div4_powerup or negedge rst_io_n);

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_smoke_vseq.sv
@@ -8,7 +8,6 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
 
   `uvm_object_new
 
-
   constraint io_ip_clk_en_on_c {io_ip_clk_en == 1'b1;}
   constraint main_ip_clk_en_on_c {main_ip_clk_en == 1'b1;}
   constraint usb_ip_clk_en_on_c {usb_ip_clk_en == 1'b1;}
@@ -61,7 +60,8 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
     trans_e trans;
     logic bit_value;
     logic [TL_DW-1:0] value;
-    hintables_t idle;
+    mubi_hintables_t idle;
+    hintables_t bool_idle;
     typedef struct {
       trans_e unit;
       uvm_reg_field hint_bit;
@@ -71,7 +71,7 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
         '{TransAes, ral.clk_hints.clk_main_aes_hint, ral.clk_hints_status.clk_main_aes_val},
         '{TransHmac, ral.clk_hints.clk_main_hmac_hint, ral.clk_hints_status.clk_main_hmac_val},
         '{TransKmac, ral.clk_hints.clk_main_kmac_hint, ral.clk_hints_status.clk_main_kmac_val},
-        '{TransOtbnMain, ral.clk_hints.clk_main_otbn_hint, ral.clk_hints_status.clk_main_otbn_val}
+        '{TransOtbn, ral.clk_hints.clk_main_otbn_hint, ral.clk_hints_status.clk_main_otbn_val}
     };
     idle = 0;
     cfg.clkmgr_vif.update_idle(idle);
@@ -93,7 +93,7 @@ class clkmgr_smoke_vseq extends clkmgr_base_vseq;
       cfg.clkmgr_vif.update_idle(idle);
       // Some cycles for the logic to settle.
       // TODO: Temporary update to account for idle counts
-      cfg.clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES*2);
+      cfg.clk_rst_vif.wait_clks(IO_DIV4_SYNC_CYCLES * 2);
       csr_rd(.ptr(descriptor.value_bit), .value(bit_value));
       if (!cfg.under_reset) begin
         `DV_CHECK_EQ(bit_value, 1'b0, $sformatf(


### PR DESCRIPTION
The RTL removed a trans unit and changed each idle input to be mubi.
This caused a major breakage in dv. This updates dv to handle the new
interface.

Signed-off-by: Guillermo Maturana <maturana@google.com>