### PR TITLE
[dv] Reduce max delay in kmac_app_agent to 100 cycles

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -8,11 +8,11 @@ class kmac_app_agent_cfg extends dv_base_agent_cfg;
   virtual kmac_app_intf vif;
 
   int unsigned req_delay_min = 0;
-  int unsigned req_delay_max = 1000;
+  int unsigned req_delay_max = 100;
 
   // delay between last for req data and done for digest data
   int unsigned rsp_delay_min = 0;
-  int unsigned rsp_delay_max = 1000;
+  int unsigned rsp_delay_max = 100;
 
   // Enables/disable all protocol delays.
   rand bit zero_delays;


### PR DESCRIPTION
In some case, it runs over 1ms for an operation. Not really necessary to
drive kmac data that slow

Signed-off-by: Weicai Yang <weicai@google.com>