### PR TITLE
[keymgr] Minor refactor for long files

### DIFF
--- a/hw/ip/keymgr/keymgr.core
+++ b/hw/ip/keymgr/keymgr.core
@@ -24,15 +24,18 @@ filesets:
       - lowrisc:ip:rom_ctrl_pkg
       - lowrisc:ip:tlul
     files:
-      - rtl/keymgr_reg_top.sv
-      - rtl/keymgr_sideload_key_ctrl.sv
-      - rtl/keymgr_sideload_key.sv
+      - rtl/keymgr.sv
       - rtl/keymgr_ctrl.sv
       - rtl/keymgr_cfg_en.sv
-      - rtl/keymgr_kmac_if.sv
+      - rtl/keymgr_data_en_state.sv
+      - rtl/keymgr_err.sv
       - rtl/keymgr_input_checks.sv
+      - rtl/keymgr_kmac_if.sv
+      - rtl/keymgr_op_state_ctrl.sv
+      - rtl/keymgr_reg_top.sv
       - rtl/keymgr_reseed_ctrl.sv
-      - rtl/keymgr.sv
+      - rtl/keymgr_sideload_key.sv
+      - rtl/keymgr_sideload_key_ctrl.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/keymgr/rtl/keymgr.sv
+++ b/hw/ip/keymgr/rtl/keymgr.sv
@@ -741,7 +741,9 @@ module keymgr
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ReseedCtrlCntAlertCheck_A, u_reseed_ctrl.u_reseed_cnt,
                                          alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlMainFsmCheck_A, u_ctrl.u_state_regs, alert_tx_o[1])
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlDataFsmCheck_A, u_ctrl.u_data_state_regs, alert_tx_o[1])
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlOpFsmCheck_A, u_ctrl.u_op_state_regs, alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlDataFsmCheck_A,
+      u_ctrl.u_data_en.u_state_regs, alert_tx_o[1])
+  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(CtrlOpFsmCheck_A,
+      u_ctrl.u_op_state.u_state_regs, alert_tx_o[1])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(KmacIfFsmCheck_A, u_kmac_if.u_state_regs, alert_tx_o[1])
 endmodule // keymgr

--- a/hw/ip/keymgr/rtl/keymgr_data_en_state.sv
+++ b/hw/ip/keymgr/rtl/keymgr_data_en_state.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Key manager date enable generation
+// This is a redundant alternative to data_valid
+
+`include "prim_assert.sv"
+
+module keymgr_data_en_state
+  import keymgr_pkg::*;
+  import keymgr_reg_pkg::*;
+(
+  input clk_i,
+  input rst_ni,
+
+  input adv_en_i,
+  input id_en_i,
+  input gen_en_i,
+  input op_done_i,
+  input op_start_i,
+  output logic data_en_o,
+  output logic fsm_err_o
+);
+
+  // This is a separate data path from the FSM used to control the data_en_o output
+  // Hamming distance histogram:
+  //
+  //  0: --
+  //  1: --
+  //  2: --
+  //  3: --
+  //  4: --
+  //  5: |||||||||||||||||||| (50.00%)
+  //  6: |||||||||||||||| (40.00%)
+  //  7: |||| (10.00%)
+  //  8: --
+  //  9: --
+  // 10: --
+  //
+  // Minimum Hamming distance: 5
+  // Maximum Hamming distance: 7
+  // Minimum Hamming weight: 5
+  // Maximum Hamming weight: 7
+  //
+  localparam int DataStateWidth = 10;
+  typedef enum logic [DataStateWidth-1:0] {
+    StCtrlDataIdle    = 10'b1001110111,
+    StCtrlDataEn      = 10'b1110001011,
+    StCtrlDataDis     = 10'b0110100110,
+    StCtrlDataWait    = 10'b1010111000,
+    StCtrlDataInvalid = 10'b1111010100
+  } state_e;
+
+  state_e state_d, state_q;
+
+  // This primitive is used to place a size-only constraint on the
+  // flops in order to prevent FSM state encoding optimizations.
+  logic [DataStateWidth-1:0] state_raw_q;
+  assign state_q = state_e'(state_raw_q);
+  // SEC_CM: DATA.FSM.SPARSE
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
+    .Width(DataStateWidth),
+    .ResetValue(DataStateWidth'(StCtrlDataIdle))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .state_i ( state_d     ),
+    .state_o ( state_raw_q )
+  );
+
+  // The below control path is used for modulating the datapath to sideload and sw keys.
+  // This path is separate from the data_valid_o path, thus creating two separate attack points.
+  // The data is only enabled when a non-advance operation is invoked.
+  // When an advance operation is called, the data is disabled. It will stay disabled until an
+  // entire completion sequence is seen (op_done_o assert -> start_i de-assertion).
+  // When a generate operation is called, the data is enabled.  However, any indication of this
+  // supposedly being an advance call will force the path to disable again.
+  always_comb begin
+    state_d = state_q;
+    data_en_o = 1'b0;
+    fsm_err_o = 1'b0;
+    unique case (state_q)
+
+      StCtrlDataIdle: begin
+        if (adv_en_i) begin
+          state_d = StCtrlDataDis;
+        end else if (id_en_i || gen_en_i) begin
+          state_d = StCtrlDataEn;
+        end
+      end
+
+      StCtrlDataEn: begin
+        data_en_o = 1'b1;
+        if (op_done_i) begin
+          state_d = StCtrlDataWait;
+        end else if (adv_en_i) begin
+          state_d = StCtrlDataDis;
+        end
+      end
+
+      StCtrlDataDis: begin
+        if (op_done_i) begin
+          state_d = StCtrlDataWait;
+        end
+      end
+
+      StCtrlDataWait: begin
+        if (!op_start_i) begin
+          state_d = StCtrlDataIdle;
+        end
+      end
+
+      default: begin
+        fsm_err_o = 1'b1;
+      end
+
+
+    endcase // unique case (state_q)
+  end
+
+
+endmodule // keymgr_data_en_state

--- a/hw/ip/keymgr/rtl/keymgr_err.sv
+++ b/hw/ip/keymgr/rtl/keymgr_err.sv
@@ -1,0 +1,153 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Key manager error and fault collection
+//
+
+`include "prim_assert.sv"
+
+module keymgr_err
+  import keymgr_pkg::*;
+  import keymgr_reg_pkg::*;
+(
+  input clk_i,
+  input rst_ni,
+
+  input invalid_op_i,
+  input disabled_i,
+  input invalid_i,
+  input kmac_input_invalid_i,
+  input shadowed_update_err_i,
+  input kmac_op_err_i,
+  input invalid_kmac_out_i,
+  input sideload_sel_err_i,
+  input kmac_cmd_err_i,
+  input kmac_fsm_err_i,
+  input kmac_done_err_i,
+  input regfile_intg_err_i,
+  input shadowed_storage_err_i,
+  input ctrl_fsm_err_i,
+  input data_fsm_err_i,
+  input op_fsm_err_i,
+  input ecc_err_i,
+  input state_change_err_i,
+  input op_state_cmd_err_i,
+  input cnt_err_i,
+  input reseed_cnt_err_i,
+  input sideload_fsm_err_i,
+
+  input op_update_i,
+  input op_done_i,
+
+  // The following outputs are very similar, but have slightly different timing for
+  // for CDIs on sync errors/faults.
+  // Advance operations must go through for all CDIs.
+  // The sync_err/fault outputs register when any CDI completes and helps with
+  // the appropriate behavior on key state change.
+  // The sync error_o/fault_o outputs on the other hand only output when the entire
+  // operation is complete, which could be multiple CDIs.
+  output logic [SyncErrLastIdx-1:0] sync_err_o,
+  output logic [AsyncErrLastIdx-1:0] async_err_o,
+  output logic [SyncFaultLastIdx-1:0] sync_fault_o,
+  output logic [AsyncFaultLastIdx-1:0] async_fault_o,
+  output logic [ErrLastPos-1:0] error_o,
+  output logic [FaultLastPos-1:0] fault_o
+);
+
+  // Advance calls are made up of multiple rounds of kmac operations.
+  // Any sync error that occurs is treated as an error of the entire call.
+  // Therefore sync errors that happen before the end of the call must be
+  // latched.
+  logic[SyncErrLastIdx-1:0] sync_err_q, sync_err_d;
+  logic[SyncFaultLastIdx-1:0] sync_fault_q, sync_fault_d;
+
+  logic err_vld;
+  assign err_vld = op_update_i | op_done_i;
+
+  // sync errors
+  // When an operation encounters a fault, the operation is always rejected as the FSM
+  // transitions to wipe.  When an operation is ongoing and en drops, it is also rejected.
+  assign sync_err_d[SyncErrInvalidOp] = err_vld & (invalid_op_i |
+                                                   disabled_i |
+                                                   invalid_i |
+                                                   |fault_o);
+  assign sync_err_d[SyncErrInvalidIn] = err_vld & kmac_input_invalid_i;
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      sync_err_q <= '0;
+    end else if (op_done_i) begin
+      sync_err_q <= '0;
+    end else if (op_update_i) begin
+      sync_err_q <= sync_err_d;
+    end
+  end
+  assign sync_err_o = sync_err_q | sync_err_d;
+
+  // async errors
+  assign async_err_o[AsyncErrShadowUpdate] = shadowed_update_err_i;
+
+  // sync faults
+  assign sync_fault_d[SyncFaultKmacOp] = err_vld & kmac_op_err_i;
+  assign sync_fault_d[SyncFaultKmacOut] = err_vld & invalid_kmac_out_i;
+  assign sync_fault_d[SyncFaultSideSel] = err_vld & sideload_sel_err_i;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      sync_fault_q <= '0;
+    end else if (op_done_i) begin
+      sync_fault_q <= '0;
+    end else if (op_update_i) begin
+      sync_fault_q <= sync_fault_d;
+    end
+  end
+  assign sync_fault_o = sync_fault_q | sync_fault_d;
+
+  // async faults
+  logic [AsyncFaultLastIdx-1:0] async_fault_q, async_fault_d;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      async_fault_q <= '0;
+    end else begin
+      async_fault_q <= async_fault_o;
+    end
+  end
+  assign async_fault_o = async_fault_q | async_fault_d;
+  assign async_fault_d[AsyncFaultKmacCmd]  = kmac_cmd_err_i;
+  assign async_fault_d[AsyncFaultKmacFsm]  = kmac_fsm_err_i;
+  assign async_fault_d[AsyncFaultKmacDone] = kmac_done_err_i;
+  assign async_fault_d[AsyncFaultRegIntg]  = regfile_intg_err_i;
+  assign async_fault_d[AsyncFaultShadow ]  = shadowed_storage_err_i;
+  assign async_fault_d[AsyncFaultFsmIntg]  = ctrl_fsm_err_i | data_fsm_err_i | op_fsm_err_i;
+  assign async_fault_d[AsyncFaultKeyEcc]   = ecc_err_i;
+
+  // SEC_CM: CTRL.FSM.CONSISTENCY
+  assign async_fault_d[AsyncFaultFsmChk]   = state_change_err_i | op_state_cmd_err_i;
+  assign async_fault_d[AsyncFaultCntErr ]  = cnt_err_i;
+  assign async_fault_d[AsyncFaultRCntErr]  = reseed_cnt_err_i;
+  assign async_fault_d[AsyncFaultSideErr]  = sideload_fsm_err_i;
+
+  // certain errors/faults can only happen when there's an actual kmac transaction,
+  // others can happen with or without.
+  assign error_o[ErrInvalidOp]    = op_done_i & sync_err_o[SyncErrInvalidOp];
+  assign error_o[ErrInvalidIn]    = op_done_i & sync_err_o[SyncErrInvalidIn];
+  assign error_o[ErrShadowUpdate] = async_err_o[AsyncErrShadowUpdate];
+
+  // output to fault code register
+  assign fault_o[FaultKmacOp]     = op_done_i & sync_fault_o[SyncFaultKmacOp];
+  assign fault_o[FaultKmacOut]    = op_done_i & sync_fault_o[SyncFaultKmacOut];
+  assign fault_o[FaultSideSel]    = op_done_i & sync_fault_o[SyncFaultSideSel];
+  assign fault_o[FaultKmacCmd]    = async_fault_o[AsyncFaultKmacCmd];
+  assign fault_o[FaultKmacFsm]    = async_fault_o[AsyncFaultKmacFsm];
+  assign fault_o[FaultKmacDone]   = async_fault_o[AsyncFaultKmacDone];
+  assign fault_o[FaultRegIntg]    = async_fault_o[AsyncFaultRegIntg];
+  assign fault_o[FaultShadow]     = async_fault_o[AsyncFaultShadow];
+  assign fault_o[FaultCtrlFsm]    = async_fault_o[AsyncFaultFsmIntg];
+  assign fault_o[FaultCtrlFsmChk] = async_fault_o[AsyncFaultFsmChk];
+  assign fault_o[FaultCtrlCnt]    = async_fault_o[AsyncFaultCntErr];
+  assign fault_o[FaultReseedCnt]  = async_fault_o[AsyncFaultRCntErr];
+  assign fault_o[FaultSideFsm]    = async_fault_o[AsyncFaultSideErr];
+  assign fault_o[FaultKeyEcc]     = async_fault_o[AsyncFaultKeyEcc];
+
+
+endmodule // keymgr_err

--- a/hw/ip/keymgr/rtl/keymgr_op_state_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_op_state_ctrl.sv
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Key manager operation state control
+//
+
+`include "prim_assert.sv"
+
+module keymgr_op_state_ctrl
+  import keymgr_pkg::*;
+  import keymgr_reg_pkg::*;
+(
+  input clk_i,
+  input rst_ni,
+
+  input adv_req_i,
+  input dis_req_i,
+  input id_req_i,
+  input gen_req_i,
+  input [CdiWidth-1:0] cnt_i,
+  output logic op_ack_o,
+  output logic op_busy_o,
+  output logic op_update_o,
+
+  input kmac_done_i,
+  output logic adv_en_o,
+  output logic id_en_o,
+  output logic gen_en_o,
+
+  output logic op_fsm_err_o
+
+);
+
+  localparam int OpStateWidth = 8;
+  typedef enum logic [OpStateWidth-1:0] {
+    StIdle   = 8'b10010101,
+    StAdv    = 8'b00101000,
+    StAdvAck = 8'b01000011,
+    StWait   = 8'b11111110
+  } state_e;
+
+  state_e state_q, state_d;
+  logic [OpStateWidth-1:0] state_raw_q;
+
+  assign state_q = state_e'(state_raw_q);
+  prim_sparse_fsm_flop #(
+    .StateEnumT(state_e),
+    .Width(OpStateWidth),
+    .ResetValue(OpStateWidth'(StIdle))
+  ) u_state_regs (
+    .clk_i,
+    .rst_ni,
+    .state_i ( state_d     ),
+    .state_o ( state_raw_q )
+  );
+
+  logic gen_en;
+  assign id_en_o = gen_en & id_req_i;
+  assign gen_en_o = gen_en & gen_req_i;
+
+  always_comb begin
+    state_d = state_q;
+    op_update_o = 1'b0;
+    op_ack_o = 1'b0;
+    op_busy_o = 1'b1;
+
+    // output to kmac interface
+    adv_en_o = 1'b0;
+
+    gen_en = 1'b0;
+    op_fsm_err_o = 1'b0;
+
+    unique case (state_q)
+      StIdle: begin
+        op_busy_o = '0;
+        if (adv_req_i || dis_req_i) begin
+          state_d = StAdv;
+        end else if (id_req_i || gen_req_i) begin
+          state_d = StWait;
+        end
+      end
+
+      StAdv: begin
+        adv_en_o = 1'b1;
+
+        if (kmac_done_i && (cnt_i == CDIs-1)) begin
+          op_ack_o = 1'b1;
+          state_d = StIdle;
+        end else if (kmac_done_i && (cnt_i < CDIs-1)) begin
+          op_update_o = 1'b1;
+          state_d = StAdvAck;
+        end
+      end
+
+      // drop adv_en_o to allow kmac interface handshake
+      StAdvAck: begin
+        state_d = StAdv;
+      end
+
+      // Not an advanced operation
+      StWait: begin
+        gen_en = 1'b1;
+
+        if (kmac_done_i) begin
+          op_ack_o = 1'b1;
+          state_d = StIdle;
+        end
+      end
+
+      // error state
+      default: begin
+        // allow completion of transaction
+        op_ack_o = 1'b1;
+        op_fsm_err_o = 1'b1;
+      end
+
+    endcase // unique case (adv_state_q)
+  end
+
+
+endmodule // keymgr_op_state_ctrl


### PR DESCRIPTION
- move data fsm, op fsm and error collection into their own
  separate modules.
- also some minor clean-up.

first commit will be rebased away. 