### PR TITLE
[dif/adc_ctrl] Implement configuration DIFs

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -15,19 +15,23 @@ cc_library(
 
 cc_library(
     name = "test_base",
+    testonly = True,
     hdrs = ["dif_test_base.h"],
     deps = [
         ":base",
         "@googletest//:gtest",
     ],
-    testonly = True,
 )
 
 cc_library(
     name = "adc_ctrl",
-    hdrs = [
+    srcs = [
         "autogen/dif_adc_ctrl_autogen.c",
         "autogen/dif_adc_ctrl_autogen.h",
+        "dif_adc_ctrl.c",
+    ],
+    hdrs = [
+        "dif_adc_ctrl.h",
     ],
     deps = [
         ":base",
@@ -42,6 +46,9 @@ cc_test(
         "autogen/dif_adc_ctrl_autogen.c",
         "autogen/dif_adc_ctrl_autogen.h",
         "autogen/dif_adc_ctrl_autogen_unittest.cc",
+        "dif_adc_ctrl.c",
+        "dif_adc_ctrl.h",
+        "dif_adc_ctrl_unittest.cc",
     ],
     defines = [
         "MOCK_MMIO=1",

--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -1,0 +1,175 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_adc_ctrl.h"
+
+#include <assert.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "adc_ctrl_regs.h"  // Generated.
+
+static_assert(ADC_CTRL_PARAM_NUM_ADC_CHANNEL == 2,
+              "Expected two ADC Controller channels.");
+static_assert(ADC_CTRL_PARAM_NUM_ADC_FILTER == 8,
+              "Expected eight ADC Controller filters.");
+static_assert(ADC_CTRL_ADC_CHN0_FILTER_CTL_MIN_V_FIELD_WIDTH == 10,
+              "Expected channel-0 filter min-voltage field to be 10 bits.");
+static_assert(ADC_CTRL_ADC_CHN1_FILTER_CTL_MIN_V_FIELD_WIDTH == 10,
+              "Expected channel-1 filter min-voltage field to be 10 bits.");
+static_assert(ADC_CTRL_ADC_CHN0_FILTER_CTL_MAX_V_FIELD_WIDTH == 10,
+              "Expected channel-0 filter max-voltage field to be 10 bits.");
+static_assert(ADC_CTRL_ADC_CHN1_FILTER_CTL_MAX_V_FIELD_WIDTH == 10,
+              "Expected channel-1 filter max-voltage field to be 10 bits.");
+
+dif_result_t dif_adc_ctrl_configure(const dif_adc_ctrl_t *adc_ctrl,
+                                    dif_adc_ctrl_config_t config) {
+  if (adc_ctrl == NULL ||
+      config.power_up_time_aon_cycles > ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_MASK ||
+      config.wake_up_time_aon_cycles > ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_MASK) {
+    return kDifBadArg;
+  }
+
+  uint32_t en_ctrl_reg = 0;
+  uint32_t pd_ctrl_reg = 0;
+  uint32_t lp_sample_ctrl_reg = 0;
+  uint32_t np_sample_ctrl_reg = 0;
+
+  switch (config.mode) {
+    case kDifAdcCtrlLowPowerScanMode:
+      pd_ctrl_reg = bitfield_bit32_write(pd_ctrl_reg,
+                                         ADC_CTRL_ADC_PD_CTL_LP_MODE_BIT, true);
+      pd_ctrl_reg = bitfield_field32_write(
+          pd_ctrl_reg, ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_FIELD,
+          config.wake_up_time_aon_cycles);
+      lp_sample_ctrl_reg = bitfield_field32_write(
+          lp_sample_ctrl_reg, ADC_CTRL_ADC_LP_SAMPLE_CTL_LP_SAMPLE_CNT_FIELD,
+          config.num_low_power_samples);
+      OT_FALLTHROUGH_INTENDED;
+    case kDifAdcCtrlNormalPowerScanMode:
+      np_sample_ctrl_reg = bitfield_field32_write(
+          np_sample_ctrl_reg, ADC_CTRL_ADC_SAMPLE_CTL_NP_SAMPLE_CNT_FIELD,
+          config.num_normal_power_samples);
+      break;
+    case kDifAdcCtrlOneshotMode:
+      en_ctrl_reg = bitfield_bit32_write(
+          en_ctrl_reg, ADC_CTRL_ADC_EN_CTL_ONESHOT_MODE_BIT, true);
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  // Regardless of the mode, the ADC could be powered down, so we need to set
+  // the power-up time.
+  pd_ctrl_reg =
+      bitfield_field32_write(pd_ctrl_reg, ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_FIELD,
+                             config.power_up_time_aon_cycles);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_EN_CTL_REG_OFFSET,
+                      en_ctrl_reg);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_PD_CTL_REG_OFFSET,
+                      pd_ctrl_reg);
+  mmio_region_write32(adc_ctrl->base_addr,
+                      ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET,
+                      lp_sample_ctrl_reg);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
+                      np_sample_ctrl_reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_adc_ctrl_configure_filter(const dif_adc_ctrl_t *adc_ctrl,
+                                           dif_adc_ctrl_channel_t channel,
+                                           dif_adc_ctrl_filter_config_t config,
+                                           dif_toggle_t enabled) {
+  if (adc_ctrl == NULL || config.min_voltage > 1023 ||
+      config.max_voltage > 1023) {
+    return kDifBadArg;
+  }
+
+  ptrdiff_t filter_ctrl_reg_offset;
+  bitfield_field32_t min_voltage_field;
+  bitfield_field32_t max_voltage_field;
+  bitfield_bit32_index_t in_range_bit;
+  bitfield_bit32_index_t enable_bit;
+
+#define DIF_ADC_CTRL_CHANNEL0_FILTER_CONFIG_CASE_(filter_)                    \
+  case kDifAdcCtrlFilter##filter_:                                            \
+    filter_ctrl_reg_offset =                                                  \
+        ADC_CTRL_ADC_CHN0_FILTER_CTL_##filter_##_REG_OFFSET;                  \
+    min_voltage_field =                                                       \
+        ADC_CTRL_ADC_CHN0_FILTER_CTL_##filter_##_MIN_V_##filter_##_FIELD;     \
+    max_voltage_field =                                                       \
+        ADC_CTRL_ADC_CHN0_FILTER_CTL_##filter_##_MAX_V_##filter_##_FIELD;     \
+    in_range_bit =                                                            \
+        ADC_CTRL_ADC_CHN0_FILTER_CTL_##filter_##_COND_##filter_##_BIT;        \
+    enable_bit = ADC_CTRL_ADC_CHN0_FILTER_CTL_##filter_##_EN_##filter_##_BIT; \
+    break;
+
+#define DIF_ADC_CTRL_CHANNEL1_FILTER_CONFIG_CASE_(filter_)                    \
+  case kDifAdcCtrlFilter##filter_:                                            \
+    filter_ctrl_reg_offset =                                                  \
+        ADC_CTRL_ADC_CHN1_FILTER_CTL_##filter_##_REG_OFFSET;                  \
+    min_voltage_field =                                                       \
+        ADC_CTRL_ADC_CHN1_FILTER_CTL_##filter_##_MIN_V_##filter_##_FIELD;     \
+    max_voltage_field =                                                       \
+        ADC_CTRL_ADC_CHN1_FILTER_CTL_##filter_##_MAX_V_##filter_##_FIELD;     \
+    in_range_bit =                                                            \
+        ADC_CTRL_ADC_CHN1_FILTER_CTL_##filter_##_COND_##filter_##_BIT;        \
+    enable_bit = ADC_CTRL_ADC_CHN1_FILTER_CTL_##filter_##_EN_##filter_##_BIT; \
+    break;
+
+  switch (channel) {
+    case kDifAdcCtrlChannel0:
+      switch (config.filter) {
+        DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL0_FILTER_CONFIG_CASE_)
+        default:
+          return kDifBadArg;
+      }
+      break;
+    case kDifAdcCtrlChannel1:
+      switch (config.filter) {
+        DIF_ADC_CTRL_FILTER_LIST(DIF_ADC_CTRL_CHANNEL1_FILTER_CONFIG_CASE_)
+        default:
+          return kDifBadArg;
+      }
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+#undef DIF_ADC_CTRL_CHANNEL0_FILTER_CONFIG_CASE_
+#undef DIF_ADC_CTRL_CHANNEL1_FILTER_CONFIG_CASE_
+
+  // Configure filter control register.
+  uint32_t filter_ctrl_reg =
+      bitfield_field32_write(0, min_voltage_field, config.min_voltage);
+  filter_ctrl_reg = bitfield_field32_write(filter_ctrl_reg, max_voltage_field,
+                                           config.max_voltage);
+  filter_ctrl_reg =
+      bitfield_bit32_write(filter_ctrl_reg, in_range_bit, config.in_range);
+  filter_ctrl_reg = bitfield_bit32_write(filter_ctrl_reg, enable_bit,
+                                         dif_toggle_to_bool(enabled));
+  mmio_region_write32(adc_ctrl->base_addr, filter_ctrl_reg_offset,
+                      filter_ctrl_reg);
+
+  // Configure wakeup control register.
+  uint32_t wakeup_ctrl_reg = mmio_region_read32(
+      adc_ctrl->base_addr, ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET);
+  wakeup_ctrl_reg = bitfield_bit32_write(wakeup_ctrl_reg, config.filter,
+                                         config.generate_wakeup_on_match);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET,
+                      wakeup_ctrl_reg);
+
+  // Configure interrupt control register.
+  uint32_t intr_ctrl_reg =
+      mmio_region_read32(adc_ctrl->base_addr, ADC_CTRL_ADC_INTR_CTL_REG_OFFSET);
+  intr_ctrl_reg = bitfield_bit32_write(intr_ctrl_reg, config.filter,
+                                       config.generate_irq_on_match);
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_INTR_CTL_REG_OFFSET,
+                      intr_ctrl_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_adc_ctrl.h
+++ b/sw/device/lib/dif/dif_adc_ctrl.h
@@ -62,7 +62,7 @@ typedef enum dif_adc_ctrl_channel {
  * @filter_ ADC Controller filter of the enumeration constant.
  */
 #define DIF_ADC_CTRL_FILTER_ENUM_INIT_(filter_) \
-  kDifAdcCtrlFilter##filter_ = 1U << filter_,
+  kDifAdcCtrlFilter##filter_ = filter_,
 
 /**
  * An ADC Controller filter.
@@ -163,7 +163,7 @@ typedef struct dif_adc_ctrl_config {
    *
    * Only relevant in Low Power Scan mode.
    */
-  uint8_t wake_up_time_aon_cycles;
+  uint32_t wake_up_time_aon_cycles;
   /**
    * The number of filter-matching samples to count in Low Power Scan mode
    * before switching to Normal Power Scan mode.
@@ -227,11 +227,15 @@ typedef struct dif_adc_ctrl_filter_config {
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_adc_ctrl_configure(const dif_adc_ctrl_t *adc_ctrl,
-                                    dif_adc_ctrl_config_t config,
-                                    dif_toggle_t enabled);
+                                    dif_adc_ctrl_config_t config);
 
 /**
  * Configures a channel filter.
+ *
+ * This should be invoked for each desired filter _before_ the sampling sequence
+ * is enabled via `dif_adc_ctrl_set_enabled()`.
+ *
+ * This only applies in Low / Normal Power Scan sampling modes.
  *
  * @param adc_ctrl An adc_ctrl handle.
  * @param channel The channel of the filter to configure.
@@ -340,9 +344,8 @@ dif_result_t dif_adc_ctrl_get_latest_value(const dif_adc_ctrl_t *adc_ctrl,
                                            uint16_t *value);
 
 /**
- * Reset all ADC Controller FSMs and counters.
- *
- * If in Oneshot mode, this also retriggers a sample capture.
+ * Reset all ADC Controller FSMs and counters, and if enabled, begin sampling
+ * sequence.
  *
  * @param adc_ctrl An adc_ctrl handle.
  * @return The result of the operation.

--- a/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
@@ -1,0 +1,173 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_adc_ctrl.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_test_base.h"
+
+#include "adc_ctrl_regs.h"  // Generated.
+
+namespace dif_adc_ctrl_unittest {
+namespace {
+using ::mock_mmio::LeInt;
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+
+class AdcCtrlTest : public testing::Test, public MmioTest {
+ protected:
+  dif_adc_ctrl_t adc_ctrl_ = {.base_addr = dev().region()};
+  dif_adc_ctrl_config_t config_ = {
+      .mode = kDifAdcCtrlLowPowerScanMode,
+      .power_up_time_aon_cycles = 8,
+      .wake_up_time_aon_cycles = 128,
+      .num_low_power_samples = 4,
+      .num_normal_power_samples = 32,
+  };
+  dif_adc_ctrl_filter_config_t filter_config_ = {
+      .filter = kDifAdcCtrlFilter2,
+      .min_voltage = 512,
+      .max_voltage = 768,
+      .in_range = true,
+      .generate_wakeup_on_match = true,
+      .generate_irq_on_match = true,
+  };
+};
+
+class ConfigTest : public AdcCtrlTest {};
+
+TEST_F(ConfigTest, NullHandle) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure(nullptr, config_));
+}
+
+TEST_F(ConfigTest, BadMode) {
+  config_.mode = static_cast<dif_adc_ctrl_mode_t>(3);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
+TEST_F(ConfigTest, BadPowerUpTime) {
+  config_.power_up_time_aon_cycles = ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_MASK + 1;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
+TEST_F(ConfigTest, BadWakeUpTime) {
+  config_.wake_up_time_aon_cycles = ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_MASK + 1;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
+TEST_F(ConfigTest, LowPowerModeSuccess) {
+  EXPECT_WRITE32(ADC_CTRL_ADC_EN_CTL_REG_OFFSET, 0);
+  EXPECT_WRITE32(ADC_CTRL_ADC_PD_CTL_REG_OFFSET,
+                 {{ADC_CTRL_ADC_PD_CTL_WAKEUP_TIME_OFFSET,
+                   config_.wake_up_time_aon_cycles},
+                  {ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_OFFSET,
+                   config_.power_up_time_aon_cycles},
+                  {ADC_CTRL_ADC_PD_CTL_LP_MODE_BIT, 1}});
+  EXPECT_WRITE32(ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET,
+                 {{ADC_CTRL_ADC_LP_SAMPLE_CTL_LP_SAMPLE_CNT_OFFSET,
+                   config_.num_low_power_samples}});
+  EXPECT_WRITE32(ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
+                 {{ADC_CTRL_ADC_SAMPLE_CTL_NP_SAMPLE_CNT_OFFSET,
+                   config_.num_normal_power_samples}});
+  EXPECT_DIF_OK(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
+TEST_F(ConfigTest, NormalPowerModeSuccess) {
+  config_.mode = kDifAdcCtrlNormalPowerScanMode;
+  EXPECT_WRITE32(ADC_CTRL_ADC_EN_CTL_REG_OFFSET, 0);
+  EXPECT_WRITE32(ADC_CTRL_ADC_PD_CTL_REG_OFFSET,
+                 {{ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_OFFSET,
+                   config_.power_up_time_aon_cycles}});
+  EXPECT_WRITE32(ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET, 0);
+  EXPECT_WRITE32(ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET,
+                 {{ADC_CTRL_ADC_SAMPLE_CTL_NP_SAMPLE_CNT_OFFSET,
+                   config_.num_normal_power_samples}});
+  EXPECT_DIF_OK(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
+TEST_F(ConfigTest, OneshotModeSuccess) {
+  config_.mode = kDifAdcCtrlOneshotMode;
+  EXPECT_WRITE32(ADC_CTRL_ADC_EN_CTL_REG_OFFSET,
+                 {{ADC_CTRL_ADC_EN_CTL_ONESHOT_MODE_BIT, true}});
+  EXPECT_WRITE32(ADC_CTRL_ADC_PD_CTL_REG_OFFSET,
+                 {{ADC_CTRL_ADC_PD_CTL_PWRUP_TIME_OFFSET,
+                   config_.power_up_time_aon_cycles}});
+  EXPECT_WRITE32(ADC_CTRL_ADC_LP_SAMPLE_CTL_REG_OFFSET, 0);
+  EXPECT_WRITE32(ADC_CTRL_ADC_SAMPLE_CTL_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_adc_ctrl_configure(&adc_ctrl_, config_));
+}
+
+class FilterConfigTest : public AdcCtrlTest {};
+
+TEST_F(FilterConfigTest, NullHandle) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure_filter(
+      nullptr, kDifAdcCtrlChannel0, filter_config_, kDifToggleEnabled));
+}
+
+TEST_F(FilterConfigTest, BadMinVoltage) {
+  filter_config_.min_voltage = 1024;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure_filter(
+      &adc_ctrl_, kDifAdcCtrlChannel0, filter_config_, kDifToggleEnabled));
+}
+
+TEST_F(FilterConfigTest, BadMaxVoltage) {
+  filter_config_.max_voltage = 1024;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure_filter(
+      &adc_ctrl_, kDifAdcCtrlChannel0, filter_config_, kDifToggleEnabled));
+}
+
+TEST_F(FilterConfigTest, BadChannel) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure_filter(
+      &adc_ctrl_,
+      static_cast<dif_adc_ctrl_channel_t>(ADC_CTRL_PARAM_NUM_ADC_CHANNEL),
+      filter_config_, kDifToggleEnabled));
+}
+
+TEST_F(FilterConfigTest, BadFilter) {
+  filter_config_.filter =
+      static_cast<dif_adc_ctrl_filter_t>(ADC_CTRL_PARAM_NUM_ADC_FILTER);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure_filter(
+      &adc_ctrl_, kDifAdcCtrlChannel0, filter_config_, kDifToggleEnabled));
+  EXPECT_DIF_BADARG(dif_adc_ctrl_configure_filter(
+      &adc_ctrl_, kDifAdcCtrlChannel1, filter_config_, kDifToggleEnabled));
+}
+
+TEST_F(FilterConfigTest, Success) {
+  EXPECT_WRITE32(ADC_CTRL_ADC_CHN1_FILTER_CTL_2_REG_OFFSET,
+                 {{ADC_CTRL_ADC_CHN1_FILTER_CTL_2_MIN_V_2_OFFSET,
+                   filter_config_.min_voltage},
+                  {ADC_CTRL_ADC_CHN1_FILTER_CTL_2_MAX_V_2_OFFSET,
+                   filter_config_.max_voltage},
+                  {ADC_CTRL_ADC_CHN1_FILTER_CTL_2_COND_2_BIT, true},
+                  {ADC_CTRL_ADC_CHN1_FILTER_CTL_2_EN_2_BIT, true}});
+  EXPECT_READ32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0);
+  EXPECT_WRITE32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET,
+                 {{filter_config_.filter, true}});
+  EXPECT_READ32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0);
+  EXPECT_WRITE32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET,
+                 {{filter_config_.filter, true}});
+  EXPECT_DIF_OK(dif_adc_ctrl_configure_filter(
+      &adc_ctrl_, kDifAdcCtrlChannel1, filter_config_, kDifToggleEnabled));
+
+  EXPECT_WRITE32(ADC_CTRL_ADC_CHN0_FILTER_CTL_6_REG_OFFSET,
+                 {{ADC_CTRL_ADC_CHN0_FILTER_CTL_6_MIN_V_6_OFFSET,
+                   filter_config_.min_voltage},
+                  {ADC_CTRL_ADC_CHN0_FILTER_CTL_6_MAX_V_6_OFFSET,
+                   filter_config_.max_voltage},
+                  {ADC_CTRL_ADC_CHN0_FILTER_CTL_6_COND_6_BIT, true},
+                  {ADC_CTRL_ADC_CHN0_FILTER_CTL_6_EN_6_BIT, true}});
+  EXPECT_READ32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0x4);
+  EXPECT_WRITE32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0x44);
+  EXPECT_READ32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0x4);
+  EXPECT_WRITE32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0x44);
+  filter_config_.filter = kDifAdcCtrlFilter6;
+  EXPECT_DIF_OK(dif_adc_ctrl_configure_filter(
+      &adc_ctrl_, kDifAdcCtrlChannel0, filter_config_, kDifToggleEnabled));
+}
+
+}  // namespace
+}  // namespace dif_adc_ctrl_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -20,6 +20,7 @@ sw_lib_dif_adc_ctrl = declare_dependency(
     'sw_lib_dif_adc_ctrl',
     sources: [
       hw_ip_adc_ctrl_reg_h,
+      'dif_adc_ctrl.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -31,7 +32,10 @@ sw_lib_dif_adc_ctrl = declare_dependency(
 test('dif_adc_ctrl_unittest', executable(
     'dif_adc_ctrl_unittest',
     sources: [
+      'dif_adc_ctrl_unittest.cc',
       'autogen/dif_adc_ctrl_autogen_unittest.cc',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_base.c',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_adc_ctrl.c',
       meson.project_source_root() / 'sw/device/lib/dif/autogen/dif_adc_ctrl_autogen.c',
       hw_ip_adc_ctrl_reg_h,
     ],


### PR DESCRIPTION
This adds implementations (and unit tests) for the two configuration
DIFs for the ADC Controller, including:

1. the block-level configuration DIF, and
2. the filter configuration DIF.

Signed-off-by: Timothy Trippel <ttrippel@google.com>