### PR TITLE
[ast] Fix CDC and DFT issues

### DIFF
--- a/hw/top_earlgrey/ip/ast/data/ast.hjson
+++ b/hw/top_earlgrey/ip/ast/data/ast.hjson
@@ -21,12 +21,6 @@
   ],
   no_auto_alert_regs: "True",
   param_list: [
-    { name:    "NumRegsA",
-      type:    "int",
-      default: "31",
-      desc: "Number of registers in the Array-A",
-      local:   "true",
-    },
     { name:    "NumRegsB",
       type:    "int",
       default: "5",
@@ -36,42 +30,459 @@
   ],
   regwidth: "32",
   registers: [
-    { multireg:
-      {
-        name: "REGA",
-        desc: "AST Registers Array-A for OTP/ROM Write Testing",
-        count: "NumRegsA",
-        cname: "REGA",
-        swaccess: "rw",
-        hwaccess: "hro",
-        fields: [
-          { bits: "31:0",
-            name: "reg32",
-            desc: "32-bit Register",
-            resval: "0",
-          },
-        ],
-      },
-    }, //----------------------------------------------------------------------
-    { name: "REGAL",
-      desc: "AST Array-A Last Register for OTP/ROM Write Testing",
-      swaccess: "rw",
-      hwaccess: "hrw",
-      hwext:    "true",
-      hwqe:     "true",
+    { name: "REGA0",
+      desc: "AST Register 0 for OTP/ROM Write Testing",
+      swaccess: "ro",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclAll" ],
       fields: [
         { bits: "31:0",
           name: "reg32",
           desc: "32-bit Register",
-          resval: "0",
+          resval: "0x00",
         },
       ],
     }, //----------------------------------------------------------------------
-
+    { name: "REGA1",
+      desc: "AST 1 Register for OTP/ROM Write Testing",
+      swaccess: "ro",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclAll" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x01",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA2",
+      desc: "AST 2 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x02",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA3",
+      desc: "AST 3 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x03",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA4",
+      desc: "AST 4 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x04",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA5",
+      desc: "AST 5 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x05",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA6",
+      desc: "AST 6 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x06",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA7",
+      desc: "AST 7 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x07",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA8",
+      desc: "AST 8 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x08",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA9",
+      desc: "AST 9 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x09",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA10",
+      desc: "AST 10 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x0A",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA11",
+      desc: "AST 11 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x0B",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA12",
+      desc: "AST 13 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x0C",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA13",
+      desc: "AST 13 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x0D",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA14",
+      desc: "AST 14 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x0E",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA15",
+      desc: "AST 15 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x0F",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA16",
+      desc: "AST 16 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x10",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA17",
+      desc: "AST 17 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x11",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA18",
+      desc: "AST 18 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x12",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA19",
+      desc: "AST 19 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x13",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA20",
+      desc: "AST 20 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x14",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA21",
+      desc: "AST 21 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x15",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA22",
+      desc: "AST 22 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x16",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA23",
+      desc: "AST 23 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x17",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA24",
+      desc: "AST 24 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x18",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA25",
+      desc: "AST 25 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x19",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA26",
+      desc: "AST 26 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x1A",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA27",
+      desc: "AST 27 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x1B",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA28",
+      desc: "AST 28 Register for OTP/ROM Write Testing",
+      swaccess: "ro",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x1C",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA29",
+      desc: "AST 29 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x1D",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA30",
+      desc: "AST 30 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x1E",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGAL",
+      desc: "AST Last Register for OTP/ROM Write Testing",
+      swaccess: "wo",
+      hwaccess: "hrw",
+      hwext:    "true",
+      hwqe:     "true",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclAll" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x1F",
+        },
+      ],
+    }, //----------------------------------------------------------------------
     ///////////////////////////////////////////////////////////////////////////
     { skipto: "0x200" }
     ///////////////////////////////////////////////////////////////////////////
-
     { multireg:
       {
         name: "REGB",
@@ -80,6 +491,8 @@
         cname: "REGB",
         swaccess: "rw",
         hwaccess: "hro",
+        tags: [ // don't write random data to any of the AST registers
+	        "excl:CsrAllTests:CsrExclAll" ],
         fields: [
           { bits: "31:0",
             name: "reg32",

--- a/hw/top_earlgrey/ip/ast/doc/ast_regs.html
+++ b/hw/top_earlgrey/ip/ast/doc/ast_regs.html
@@ -61,445 +61,11 @@
   font-size: 16px;
  }
 </style>
-<table class="regdef" id="Reg_rega_0">
+<table class="regdef" id="Reg_rega0">
  <tr>
   <th class="regdef" colspan=5>
-   <div>ast.REGA_0 @ 0x0</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_0...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_0</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_0</td><td class="regde"><p>32-bit Register</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_1">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_1 @ 0x4</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_1...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_1</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_1</td><td class="regde"><p>For REGA1</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_2">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_2 @ 0x8</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_2...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_2</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_2</td><td class="regde"><p>For REGA2</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_3">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_3 @ 0xc</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_3...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_3</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_3</td><td class="regde"><p>For REGA3</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_4">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_4 @ 0x10</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_4...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_4</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_4</td><td class="regde"><p>For REGA4</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_5">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_5 @ 0x14</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_5...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_5</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_5</td><td class="regde"><p>For REGA5</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_6">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_6 @ 0x18</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_6...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_6</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_6</td><td class="regde"><p>For REGA6</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_7">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_7 @ 0x1c</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_7...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_7</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_7</td><td class="regde"><p>For REGA7</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_8">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_8 @ 0x20</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_8...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_8</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_8</td><td class="regde"><p>For REGA8</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_9">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_9 @ 0x24</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_9...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_9</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_9</td><td class="regde"><p>For REGA9</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_10">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_10 @ 0x28</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_10...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_10</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_10</td><td class="regde"><p>For REGA10</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_11">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_11 @ 0x2c</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_11...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_11</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_11</td><td class="regde"><p>For REGA11</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_12">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_12 @ 0x30</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_12...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_12</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_12</td><td class="regde"><p>For REGA12</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_13">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_13 @ 0x34</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_13...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_13</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_13</td><td class="regde"><p>For REGA13</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_14">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_14 @ 0x38</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_14...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_14</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_14</td><td class="regde"><p>For REGA14</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_15">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_15 @ 0x3c</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_15...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_15</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_15</td><td class="regde"><p>For REGA15</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_16">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_16 @ 0x40</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_16...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_16</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_16</td><td class="regde"><p>For REGA16</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_17">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_17 @ 0x44</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_17...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_17</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_17</td><td class="regde"><p>For REGA17</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_18">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_18 @ 0x48</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_18...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_18</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_18</td><td class="regde"><p>For REGA18</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_19">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_19 @ 0x4c</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_19...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_19</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_19</td><td class="regde"><p>For REGA19</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_20">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_20 @ 0x50</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_20...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_20</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_20</td><td class="regde"><p>For REGA20</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_21">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_21 @ 0x54</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_21...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_21</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_21</td><td class="regde"><p>For REGA21</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_22">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_22 @ 0x58</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_22...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_22</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_22</td><td class="regde"><p>For REGA22</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_23">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_23 @ 0x5c</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_23...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_23</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_23</td><td class="regde"><p>For REGA23</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_24">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_24 @ 0x60</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_24...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_24</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_24</td><td class="regde"><p>For REGA24</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_25">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_25 @ 0x64</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_25...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_25</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_25</td><td class="regde"><p>For REGA25</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_26">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_26 @ 0x68</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_26...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_26</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_26</td><td class="regde"><p>For REGA26</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_27">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_27 @ 0x6c</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_27...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_27</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_27</td><td class="regde"><p>For REGA27</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_28">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_28 @ 0x70</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_28...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_28</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_28</td><td class="regde"><p>For REGA28</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_29">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_29 @ 0x74</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_29...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_29</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_29</td><td class="regde"><p>For REGA29</p></td></table>
-<br>
-<table class="regdef" id="Reg_rega_30">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGA_30 @ 0x78</div>
-   <div><p>AST Registers Array-A for OTP/ROM Write Testing</p></div>
-   <div>Reset default = 0x0, mask 0xffffffff</div>
-  </th>
- </tr>
-<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32_30...</td>
-</tr>
-<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32_30</td>
-</tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32_30</td><td class="regde"><p>For REGA30</p></td></table>
-<br>
-<table class="regdef" id="Reg_regal">
- <tr>
-  <th class="regdef" colspan=5>
-   <div>ast.REGAL @ 0x7c</div>
-   <div><p>AST Array-A Last Register for OTP/ROM Write Testing</p></div>
+   <div>ast.REGA0 @ 0x0</div>
+   <div><p>AST Register 0 for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x0, mask 0xffffffff</div>
   </th>
  </tr>
@@ -507,7 +73,441 @@
 </tr>
 <tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
 </tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x0</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">ro</td><td class="regrv">0x0</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega1">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA1 @ 0x4</div>
+   <div><p>AST 1 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x1, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">ro</td><td class="regrv">0x1</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega2">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA2 @ 0x8</div>
+   <div><p>AST 2 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x2, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x2</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega3">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA3 @ 0xc</div>
+   <div><p>AST 3 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x3, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x3</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega4">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA4 @ 0x10</div>
+   <div><p>AST 4 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x4, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x4</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega5">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA5 @ 0x14</div>
+   <div><p>AST 5 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x5, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x5</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega6">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA6 @ 0x18</div>
+   <div><p>AST 6 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x6, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x6</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega7">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA7 @ 0x1c</div>
+   <div><p>AST 7 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x7, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x7</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega8">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA8 @ 0x20</div>
+   <div><p>AST 8 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x8, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x8</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega9">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA9 @ 0x24</div>
+   <div><p>AST 9 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x9, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x9</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega10">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA10 @ 0x28</div>
+   <div><p>AST 10 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0xa, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xa</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega11">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA11 @ 0x2c</div>
+   <div><p>AST 11 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0xb, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xb</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega12">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA12 @ 0x30</div>
+   <div><p>AST 13 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0xc, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xc</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega13">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA13 @ 0x34</div>
+   <div><p>AST 13 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0xd, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xd</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega14">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA14 @ 0x38</div>
+   <div><p>AST 14 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0xe, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xe</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega15">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA15 @ 0x3c</div>
+   <div><p>AST 15 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0xf, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0xf</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega16">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA16 @ 0x40</div>
+   <div><p>AST 16 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x10, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x10</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega17">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA17 @ 0x44</div>
+   <div><p>AST 17 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x11, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x11</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega18">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA18 @ 0x48</div>
+   <div><p>AST 18 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x12, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x12</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega19">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA19 @ 0x4c</div>
+   <div><p>AST 19 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x13, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x13</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega20">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA20 @ 0x50</div>
+   <div><p>AST 20 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x14, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x14</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega21">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA21 @ 0x54</div>
+   <div><p>AST 21 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x15, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x15</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega22">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA22 @ 0x58</div>
+   <div><p>AST 22 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x16, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x16</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega23">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA23 @ 0x5c</div>
+   <div><p>AST 23 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x17, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x17</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega24">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA24 @ 0x60</div>
+   <div><p>AST 24 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x18, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x18</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega25">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA25 @ 0x64</div>
+   <div><p>AST 25 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x19, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x19</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega26">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA26 @ 0x68</div>
+   <div><p>AST 26 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x1a, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1a</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega27">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA27 @ 0x6c</div>
+   <div><p>AST 27 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x1b, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1b</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega28">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA28 @ 0x70</div>
+   <div><p>AST 28 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x1c, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">ro</td><td class="regrv">0x1c</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega29">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA29 @ 0x74</div>
+   <div><p>AST 29 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x1d, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1d</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega30">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA30 @ 0x78</div>
+   <div><p>AST 30 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x1e, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1e</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_regal">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGAL @ 0x7c</div>
+   <div><p>AST Last Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x1f, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">wo</td><td class="regrv">0x1f</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
 <br>
 <table class="regdef" id="Reg_regb_0">
  <tr>

--- a/hw/top_earlgrey/ip/ast/rtl/aon_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_clk.sv
@@ -12,7 +12,6 @@ module aon_clk (
   input rst_aon_clk_ni,            // AON Clock Logic reset
   input clk_src_aon_en_i,          // AON Source Clock Enable
   input scan_mode_i,               // Scan Mode
-  input scan_reset_ni,             // Scan Reset
   input aon_osc_cal_i,             // AON Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
   input clk_aon_ext_i,             // FPGA/VERILATOR Clock input
@@ -49,12 +48,12 @@ prim_clock_buf #(
 
 // 2-stage de-assertion
 logic rst_val_n;
-assign rst_val_n = scan_mode_i ? scan_reset_ni : aon_clk_en;
+assign rst_val_n = aon_clk_en;
 
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_val_sync (
+) u_no_scan_val_sync (
   .clk_i ( clk_src_aon_o ),
   .rst_ni ( rst_val_n ),
   .d_i ( 1'b1 ),

--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -21,7 +21,6 @@ module aon_osc (
 // Behavioral Model
 ////////////////////////////////////////
 timeunit 1ns / 10ps;
-import ast_bhv_pkg::* ;
 
 real CLK_PERIOD, ckmul;
 
@@ -29,17 +28,16 @@ reg init_start;
 initial init_start = 1'b0;
 
 initial begin
-  if ( !$value$plusargs("osc200k_freq_multiplier=%f", ckmul) ) begin
-    ckmul = 1.0;
-  end
+  if ( !$value$plusargs("osc200k_freq_multiplier=%f", ckmul) ) ckmul = 1.0;
+
   #1; init_start = 1'b1;
-  $display("\nAON Power-up Base Clock Frequency: %0d Hz", $rtoi(10**9/(CLK_PERIOD*ckmul)));
-  $display("AON Power-up Multiplied Clock Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
+  $display("\n%m: AON Base Clock Power-up Frequency: %0d Hz", $rtoi(10**9/(CLK_PERIOD*ckmul)));
+  $display("%m: AON %0.1fxBase Clock Power-up Frequency: %0d Hz", ckmul, $rtoi(10**9/CLK_PERIOD));
 end
 
 // Enable 5us RC Delay on rise
 wire en_osc_re_buf, en_osc_re;
-buf #(AON_EN_RDLY, 0) b0 (en_osc_re_buf, (vcore_pok_h_i && aon_en_i));
+buf #(ast_bhv_pkg::AON_EN_RDLY, 0) b0 (en_osc_re_buf, (vcore_pok_h_i && aon_en_i));
 assign en_osc_re = en_osc_re_buf && init_start;
 
 // Clock Oscillator

--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -38,22 +38,11 @@ parameter int unsigned UsbCalibWidth    = 20;
 parameter int unsigned Ast2PadOutWidth  = 9;
 parameter int unsigned Pad2AstInWidth   = 9;
 //
-// The number of AST registers programmed during initialization. It includes the register that
-// marks the finalization of init, which asserts the ast_init_done_o. The offset of this register is
-// represented with the AstLastRegOffset parameter.
+// AstRegsNum is the number of AST registers programmed during initialization. It includes
+// the register that marks the finalization of init, which asserts the ast_init_done_o.
+// The offset of this register is represented with the AstLastRegOffset parameter.
 parameter int unsigned AstRegsNum       = 32;
 parameter int unsigned AstLastRegOffset = (AstRegsNum-1)*4;
-
-// These LFSR parameters have been generated with
-// $ ./util/design/gen-lfsr-seed.py --width 64 --seed 691876113 --prefix ""
-parameter int LfsrWidth = 64;
-typedef logic [LfsrWidth-1:0] lfsr_seed_t;
-typedef logic [LfsrWidth-1:0][$clog2(LfsrWidth)-1:0] lfsr_perm_t;
-parameter lfsr_seed_t RndCnstLfsrSeedDefault = 64'h22d326255bd24320;
-parameter lfsr_perm_t RndCnstLfsrPermDefault = {
-  128'h16108c9f9008aa37e5118d1ec1df64a7,
-  256'h24f3f1b73537f42d38383ee8f897286df81d49ab54b6bbbb666cbd1a16c41252
-};
 
 // Memories Read-Write Margin Interface
 typedef struct packed {

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
@@ -7,7 +7,6 @@
 package ast_reg_pkg;
 
   // Param list
-  parameter int NumRegsA = 31;
   parameter int NumRegsB = 5;
 
   // Address widths within the block
@@ -19,7 +18,127 @@ package ast_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
-  } ast_reg2hw_rega_mreg_t;
+  } ast_reg2hw_rega0_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega1_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega2_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega3_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega4_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega5_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega6_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega7_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega8_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega9_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega10_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega11_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega12_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega13_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega14_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega15_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega16_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega17_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega18_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega19_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega20_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega21_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega22_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega23_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega24_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega25_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega26_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega27_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega28_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega29_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega30_reg_t;
 
   typedef struct packed {
     logic [31:0] q;
@@ -36,7 +155,37 @@ package ast_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    ast_reg2hw_rega_mreg_t [30:0] rega; // [1184:193]
+    ast_reg2hw_rega0_reg_t rega0; // [1184:1153]
+    ast_reg2hw_rega1_reg_t rega1; // [1152:1121]
+    ast_reg2hw_rega2_reg_t rega2; // [1120:1089]
+    ast_reg2hw_rega3_reg_t rega3; // [1088:1057]
+    ast_reg2hw_rega4_reg_t rega4; // [1056:1025]
+    ast_reg2hw_rega5_reg_t rega5; // [1024:993]
+    ast_reg2hw_rega6_reg_t rega6; // [992:961]
+    ast_reg2hw_rega7_reg_t rega7; // [960:929]
+    ast_reg2hw_rega8_reg_t rega8; // [928:897]
+    ast_reg2hw_rega9_reg_t rega9; // [896:865]
+    ast_reg2hw_rega10_reg_t rega10; // [864:833]
+    ast_reg2hw_rega11_reg_t rega11; // [832:801]
+    ast_reg2hw_rega12_reg_t rega12; // [800:769]
+    ast_reg2hw_rega13_reg_t rega13; // [768:737]
+    ast_reg2hw_rega14_reg_t rega14; // [736:705]
+    ast_reg2hw_rega15_reg_t rega15; // [704:673]
+    ast_reg2hw_rega16_reg_t rega16; // [672:641]
+    ast_reg2hw_rega17_reg_t rega17; // [640:609]
+    ast_reg2hw_rega18_reg_t rega18; // [608:577]
+    ast_reg2hw_rega19_reg_t rega19; // [576:545]
+    ast_reg2hw_rega20_reg_t rega20; // [544:513]
+    ast_reg2hw_rega21_reg_t rega21; // [512:481]
+    ast_reg2hw_rega22_reg_t rega22; // [480:449]
+    ast_reg2hw_rega23_reg_t rega23; // [448:417]
+    ast_reg2hw_rega24_reg_t rega24; // [416:385]
+    ast_reg2hw_rega25_reg_t rega25; // [384:353]
+    ast_reg2hw_rega26_reg_t rega26; // [352:321]
+    ast_reg2hw_rega27_reg_t rega27; // [320:289]
+    ast_reg2hw_rega28_reg_t rega28; // [288:257]
+    ast_reg2hw_rega29_reg_t rega29; // [256:225]
+    ast_reg2hw_rega30_reg_t rega30; // [224:193]
     ast_reg2hw_regal_reg_t regal; // [192:160]
     ast_reg2hw_regb_mreg_t [4:0] regb; // [159:0]
   } ast_reg2hw_t;
@@ -47,37 +196,37 @@ package ast_reg_pkg;
   } ast_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] AST_REGA_0_OFFSET = 10'h 0;
-  parameter logic [BlockAw-1:0] AST_REGA_1_OFFSET = 10'h 4;
-  parameter logic [BlockAw-1:0] AST_REGA_2_OFFSET = 10'h 8;
-  parameter logic [BlockAw-1:0] AST_REGA_3_OFFSET = 10'h c;
-  parameter logic [BlockAw-1:0] AST_REGA_4_OFFSET = 10'h 10;
-  parameter logic [BlockAw-1:0] AST_REGA_5_OFFSET = 10'h 14;
-  parameter logic [BlockAw-1:0] AST_REGA_6_OFFSET = 10'h 18;
-  parameter logic [BlockAw-1:0] AST_REGA_7_OFFSET = 10'h 1c;
-  parameter logic [BlockAw-1:0] AST_REGA_8_OFFSET = 10'h 20;
-  parameter logic [BlockAw-1:0] AST_REGA_9_OFFSET = 10'h 24;
-  parameter logic [BlockAw-1:0] AST_REGA_10_OFFSET = 10'h 28;
-  parameter logic [BlockAw-1:0] AST_REGA_11_OFFSET = 10'h 2c;
-  parameter logic [BlockAw-1:0] AST_REGA_12_OFFSET = 10'h 30;
-  parameter logic [BlockAw-1:0] AST_REGA_13_OFFSET = 10'h 34;
-  parameter logic [BlockAw-1:0] AST_REGA_14_OFFSET = 10'h 38;
-  parameter logic [BlockAw-1:0] AST_REGA_15_OFFSET = 10'h 3c;
-  parameter logic [BlockAw-1:0] AST_REGA_16_OFFSET = 10'h 40;
-  parameter logic [BlockAw-1:0] AST_REGA_17_OFFSET = 10'h 44;
-  parameter logic [BlockAw-1:0] AST_REGA_18_OFFSET = 10'h 48;
-  parameter logic [BlockAw-1:0] AST_REGA_19_OFFSET = 10'h 4c;
-  parameter logic [BlockAw-1:0] AST_REGA_20_OFFSET = 10'h 50;
-  parameter logic [BlockAw-1:0] AST_REGA_21_OFFSET = 10'h 54;
-  parameter logic [BlockAw-1:0] AST_REGA_22_OFFSET = 10'h 58;
-  parameter logic [BlockAw-1:0] AST_REGA_23_OFFSET = 10'h 5c;
-  parameter logic [BlockAw-1:0] AST_REGA_24_OFFSET = 10'h 60;
-  parameter logic [BlockAw-1:0] AST_REGA_25_OFFSET = 10'h 64;
-  parameter logic [BlockAw-1:0] AST_REGA_26_OFFSET = 10'h 68;
-  parameter logic [BlockAw-1:0] AST_REGA_27_OFFSET = 10'h 6c;
-  parameter logic [BlockAw-1:0] AST_REGA_28_OFFSET = 10'h 70;
-  parameter logic [BlockAw-1:0] AST_REGA_29_OFFSET = 10'h 74;
-  parameter logic [BlockAw-1:0] AST_REGA_30_OFFSET = 10'h 78;
+  parameter logic [BlockAw-1:0] AST_REGA0_OFFSET = 10'h 0;
+  parameter logic [BlockAw-1:0] AST_REGA1_OFFSET = 10'h 4;
+  parameter logic [BlockAw-1:0] AST_REGA2_OFFSET = 10'h 8;
+  parameter logic [BlockAw-1:0] AST_REGA3_OFFSET = 10'h c;
+  parameter logic [BlockAw-1:0] AST_REGA4_OFFSET = 10'h 10;
+  parameter logic [BlockAw-1:0] AST_REGA5_OFFSET = 10'h 14;
+  parameter logic [BlockAw-1:0] AST_REGA6_OFFSET = 10'h 18;
+  parameter logic [BlockAw-1:0] AST_REGA7_OFFSET = 10'h 1c;
+  parameter logic [BlockAw-1:0] AST_REGA8_OFFSET = 10'h 20;
+  parameter logic [BlockAw-1:0] AST_REGA9_OFFSET = 10'h 24;
+  parameter logic [BlockAw-1:0] AST_REGA10_OFFSET = 10'h 28;
+  parameter logic [BlockAw-1:0] AST_REGA11_OFFSET = 10'h 2c;
+  parameter logic [BlockAw-1:0] AST_REGA12_OFFSET = 10'h 30;
+  parameter logic [BlockAw-1:0] AST_REGA13_OFFSET = 10'h 34;
+  parameter logic [BlockAw-1:0] AST_REGA14_OFFSET = 10'h 38;
+  parameter logic [BlockAw-1:0] AST_REGA15_OFFSET = 10'h 3c;
+  parameter logic [BlockAw-1:0] AST_REGA16_OFFSET = 10'h 40;
+  parameter logic [BlockAw-1:0] AST_REGA17_OFFSET = 10'h 44;
+  parameter logic [BlockAw-1:0] AST_REGA18_OFFSET = 10'h 48;
+  parameter logic [BlockAw-1:0] AST_REGA19_OFFSET = 10'h 4c;
+  parameter logic [BlockAw-1:0] AST_REGA20_OFFSET = 10'h 50;
+  parameter logic [BlockAw-1:0] AST_REGA21_OFFSET = 10'h 54;
+  parameter logic [BlockAw-1:0] AST_REGA22_OFFSET = 10'h 58;
+  parameter logic [BlockAw-1:0] AST_REGA23_OFFSET = 10'h 5c;
+  parameter logic [BlockAw-1:0] AST_REGA24_OFFSET = 10'h 60;
+  parameter logic [BlockAw-1:0] AST_REGA25_OFFSET = 10'h 64;
+  parameter logic [BlockAw-1:0] AST_REGA26_OFFSET = 10'h 68;
+  parameter logic [BlockAw-1:0] AST_REGA27_OFFSET = 10'h 6c;
+  parameter logic [BlockAw-1:0] AST_REGA28_OFFSET = 10'h 70;
+  parameter logic [BlockAw-1:0] AST_REGA29_OFFSET = 10'h 74;
+  parameter logic [BlockAw-1:0] AST_REGA30_OFFSET = 10'h 78;
   parameter logic [BlockAw-1:0] AST_REGAL_OFFSET = 10'h 7c;
   parameter logic [BlockAw-1:0] AST_REGB_0_OFFSET = 10'h 200;
   parameter logic [BlockAw-1:0] AST_REGB_1_OFFSET = 10'h 204;
@@ -86,42 +235,42 @@ package ast_reg_pkg;
   parameter logic [BlockAw-1:0] AST_REGB_4_OFFSET = 10'h 210;
 
   // Reset values for hwext registers and their fields
-  parameter logic [31:0] AST_REGAL_RESVAL = 32'h 0;
-  parameter logic [31:0] AST_REGAL_REG32_RESVAL = 32'h 0;
+  parameter logic [31:0] AST_REGAL_RESVAL = 32'h 1f;
+  parameter logic [31:0] AST_REGAL_REG32_RESVAL = 32'h 1f;
 
   // Register index
   typedef enum int {
-    AST_REGA_0,
-    AST_REGA_1,
-    AST_REGA_2,
-    AST_REGA_3,
-    AST_REGA_4,
-    AST_REGA_5,
-    AST_REGA_6,
-    AST_REGA_7,
-    AST_REGA_8,
-    AST_REGA_9,
-    AST_REGA_10,
-    AST_REGA_11,
-    AST_REGA_12,
-    AST_REGA_13,
-    AST_REGA_14,
-    AST_REGA_15,
-    AST_REGA_16,
-    AST_REGA_17,
-    AST_REGA_18,
-    AST_REGA_19,
-    AST_REGA_20,
-    AST_REGA_21,
-    AST_REGA_22,
-    AST_REGA_23,
-    AST_REGA_24,
-    AST_REGA_25,
-    AST_REGA_26,
-    AST_REGA_27,
-    AST_REGA_28,
-    AST_REGA_29,
-    AST_REGA_30,
+    AST_REGA0,
+    AST_REGA1,
+    AST_REGA2,
+    AST_REGA3,
+    AST_REGA4,
+    AST_REGA5,
+    AST_REGA6,
+    AST_REGA7,
+    AST_REGA8,
+    AST_REGA9,
+    AST_REGA10,
+    AST_REGA11,
+    AST_REGA12,
+    AST_REGA13,
+    AST_REGA14,
+    AST_REGA15,
+    AST_REGA16,
+    AST_REGA17,
+    AST_REGA18,
+    AST_REGA19,
+    AST_REGA20,
+    AST_REGA21,
+    AST_REGA22,
+    AST_REGA23,
+    AST_REGA24,
+    AST_REGA25,
+    AST_REGA26,
+    AST_REGA27,
+    AST_REGA28,
+    AST_REGA29,
+    AST_REGA30,
     AST_REGAL,
     AST_REGB_0,
     AST_REGB_1,
@@ -132,37 +281,37 @@ package ast_reg_pkg;
 
   // Register width information to check illegal writes
   parameter logic [3:0] AST_PERMIT [37] = '{
-    4'b 1111, // index[ 0] AST_REGA_0
-    4'b 1111, // index[ 1] AST_REGA_1
-    4'b 1111, // index[ 2] AST_REGA_2
-    4'b 1111, // index[ 3] AST_REGA_3
-    4'b 1111, // index[ 4] AST_REGA_4
-    4'b 1111, // index[ 5] AST_REGA_5
-    4'b 1111, // index[ 6] AST_REGA_6
-    4'b 1111, // index[ 7] AST_REGA_7
-    4'b 1111, // index[ 8] AST_REGA_8
-    4'b 1111, // index[ 9] AST_REGA_9
-    4'b 1111, // index[10] AST_REGA_10
-    4'b 1111, // index[11] AST_REGA_11
-    4'b 1111, // index[12] AST_REGA_12
-    4'b 1111, // index[13] AST_REGA_13
-    4'b 1111, // index[14] AST_REGA_14
-    4'b 1111, // index[15] AST_REGA_15
-    4'b 1111, // index[16] AST_REGA_16
-    4'b 1111, // index[17] AST_REGA_17
-    4'b 1111, // index[18] AST_REGA_18
-    4'b 1111, // index[19] AST_REGA_19
-    4'b 1111, // index[20] AST_REGA_20
-    4'b 1111, // index[21] AST_REGA_21
-    4'b 1111, // index[22] AST_REGA_22
-    4'b 1111, // index[23] AST_REGA_23
-    4'b 1111, // index[24] AST_REGA_24
-    4'b 1111, // index[25] AST_REGA_25
-    4'b 1111, // index[26] AST_REGA_26
-    4'b 1111, // index[27] AST_REGA_27
-    4'b 1111, // index[28] AST_REGA_28
-    4'b 1111, // index[29] AST_REGA_29
-    4'b 1111, // index[30] AST_REGA_30
+    4'b 1111, // index[ 0] AST_REGA0
+    4'b 1111, // index[ 1] AST_REGA1
+    4'b 1111, // index[ 2] AST_REGA2
+    4'b 1111, // index[ 3] AST_REGA3
+    4'b 1111, // index[ 4] AST_REGA4
+    4'b 1111, // index[ 5] AST_REGA5
+    4'b 1111, // index[ 6] AST_REGA6
+    4'b 1111, // index[ 7] AST_REGA7
+    4'b 1111, // index[ 8] AST_REGA8
+    4'b 1111, // index[ 9] AST_REGA9
+    4'b 1111, // index[10] AST_REGA10
+    4'b 1111, // index[11] AST_REGA11
+    4'b 1111, // index[12] AST_REGA12
+    4'b 1111, // index[13] AST_REGA13
+    4'b 1111, // index[14] AST_REGA14
+    4'b 1111, // index[15] AST_REGA15
+    4'b 1111, // index[16] AST_REGA16
+    4'b 1111, // index[17] AST_REGA17
+    4'b 1111, // index[18] AST_REGA18
+    4'b 1111, // index[19] AST_REGA19
+    4'b 1111, // index[20] AST_REGA20
+    4'b 1111, // index[21] AST_REGA21
+    4'b 1111, // index[22] AST_REGA22
+    4'b 1111, // index[23] AST_REGA23
+    4'b 1111, // index[24] AST_REGA24
+    4'b 1111, // index[25] AST_REGA25
+    4'b 1111, // index[26] AST_REGA26
+    4'b 1111, // index[27] AST_REGA27
+    4'b 1111, // index[28] AST_REGA28
+    4'b 1111, // index[29] AST_REGA29
+    4'b 1111, // index[30] AST_REGA30
     4'b 1111, // index[31] AST_REGAL
     4'b 1111, // index[32] AST_REGB_0
     4'b 1111, // index[33] AST_REGB_1

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -108,102 +108,94 @@ module ast_reg_top (
   // Define SW related signals
   // Format: <reg>_<field>_{wd|we|qs}
   //        or <reg>_{wd|we|qs} if field == 1 or 0
-  logic rega_0_we;
-  logic [31:0] rega_0_qs;
-  logic [31:0] rega_0_wd;
-  logic rega_1_we;
-  logic [31:0] rega_1_qs;
-  logic [31:0] rega_1_wd;
-  logic rega_2_we;
-  logic [31:0] rega_2_qs;
-  logic [31:0] rega_2_wd;
-  logic rega_3_we;
-  logic [31:0] rega_3_qs;
-  logic [31:0] rega_3_wd;
-  logic rega_4_we;
-  logic [31:0] rega_4_qs;
-  logic [31:0] rega_4_wd;
-  logic rega_5_we;
-  logic [31:0] rega_5_qs;
-  logic [31:0] rega_5_wd;
-  logic rega_6_we;
-  logic [31:0] rega_6_qs;
-  logic [31:0] rega_6_wd;
-  logic rega_7_we;
-  logic [31:0] rega_7_qs;
-  logic [31:0] rega_7_wd;
-  logic rega_8_we;
-  logic [31:0] rega_8_qs;
-  logic [31:0] rega_8_wd;
-  logic rega_9_we;
-  logic [31:0] rega_9_qs;
-  logic [31:0] rega_9_wd;
-  logic rega_10_we;
-  logic [31:0] rega_10_qs;
-  logic [31:0] rega_10_wd;
-  logic rega_11_we;
-  logic [31:0] rega_11_qs;
-  logic [31:0] rega_11_wd;
-  logic rega_12_we;
-  logic [31:0] rega_12_qs;
-  logic [31:0] rega_12_wd;
-  logic rega_13_we;
-  logic [31:0] rega_13_qs;
-  logic [31:0] rega_13_wd;
-  logic rega_14_we;
-  logic [31:0] rega_14_qs;
-  logic [31:0] rega_14_wd;
-  logic rega_15_we;
-  logic [31:0] rega_15_qs;
-  logic [31:0] rega_15_wd;
-  logic rega_16_we;
-  logic [31:0] rega_16_qs;
-  logic [31:0] rega_16_wd;
-  logic rega_17_we;
-  logic [31:0] rega_17_qs;
-  logic [31:0] rega_17_wd;
-  logic rega_18_we;
-  logic [31:0] rega_18_qs;
-  logic [31:0] rega_18_wd;
-  logic rega_19_we;
-  logic [31:0] rega_19_qs;
-  logic [31:0] rega_19_wd;
-  logic rega_20_we;
-  logic [31:0] rega_20_qs;
-  logic [31:0] rega_20_wd;
-  logic rega_21_we;
-  logic [31:0] rega_21_qs;
-  logic [31:0] rega_21_wd;
-  logic rega_22_we;
-  logic [31:0] rega_22_qs;
-  logic [31:0] rega_22_wd;
-  logic rega_23_we;
-  logic [31:0] rega_23_qs;
-  logic [31:0] rega_23_wd;
-  logic rega_24_we;
-  logic [31:0] rega_24_qs;
-  logic [31:0] rega_24_wd;
-  logic rega_25_we;
-  logic [31:0] rega_25_qs;
-  logic [31:0] rega_25_wd;
-  logic rega_26_we;
-  logic [31:0] rega_26_qs;
-  logic [31:0] rega_26_wd;
-  logic rega_27_we;
-  logic [31:0] rega_27_qs;
-  logic [31:0] rega_27_wd;
-  logic rega_28_we;
-  logic [31:0] rega_28_qs;
-  logic [31:0] rega_28_wd;
-  logic rega_29_we;
-  logic [31:0] rega_29_qs;
-  logic [31:0] rega_29_wd;
-  logic rega_30_we;
-  logic [31:0] rega_30_qs;
-  logic [31:0] rega_30_wd;
-  logic regal_re;
+  logic [31:0] rega0_qs;
+  logic [31:0] rega1_qs;
+  logic rega2_we;
+  logic [31:0] rega2_qs;
+  logic [31:0] rega2_wd;
+  logic rega3_we;
+  logic [31:0] rega3_qs;
+  logic [31:0] rega3_wd;
+  logic rega4_we;
+  logic [31:0] rega4_qs;
+  logic [31:0] rega4_wd;
+  logic rega5_we;
+  logic [31:0] rega5_qs;
+  logic [31:0] rega5_wd;
+  logic rega6_we;
+  logic [31:0] rega6_qs;
+  logic [31:0] rega6_wd;
+  logic rega7_we;
+  logic [31:0] rega7_qs;
+  logic [31:0] rega7_wd;
+  logic rega8_we;
+  logic [31:0] rega8_qs;
+  logic [31:0] rega8_wd;
+  logic rega9_we;
+  logic [31:0] rega9_qs;
+  logic [31:0] rega9_wd;
+  logic rega10_we;
+  logic [31:0] rega10_qs;
+  logic [31:0] rega10_wd;
+  logic rega11_we;
+  logic [31:0] rega11_qs;
+  logic [31:0] rega11_wd;
+  logic rega12_we;
+  logic [31:0] rega12_qs;
+  logic [31:0] rega12_wd;
+  logic rega13_we;
+  logic [31:0] rega13_qs;
+  logic [31:0] rega13_wd;
+  logic rega14_we;
+  logic [31:0] rega14_qs;
+  logic [31:0] rega14_wd;
+  logic rega15_we;
+  logic [31:0] rega15_qs;
+  logic [31:0] rega15_wd;
+  logic rega16_we;
+  logic [31:0] rega16_qs;
+  logic [31:0] rega16_wd;
+  logic rega17_we;
+  logic [31:0] rega17_qs;
+  logic [31:0] rega17_wd;
+  logic rega18_we;
+  logic [31:0] rega18_qs;
+  logic [31:0] rega18_wd;
+  logic rega19_we;
+  logic [31:0] rega19_qs;
+  logic [31:0] rega19_wd;
+  logic rega20_we;
+  logic [31:0] rega20_qs;
+  logic [31:0] rega20_wd;
+  logic rega21_we;
+  logic [31:0] rega21_qs;
+  logic [31:0] rega21_wd;
+  logic rega22_we;
+  logic [31:0] rega22_qs;
+  logic [31:0] rega22_wd;
+  logic rega23_we;
+  logic [31:0] rega23_qs;
+  logic [31:0] rega23_wd;
+  logic rega24_we;
+  logic [31:0] rega24_qs;
+  logic [31:0] rega24_wd;
+  logic rega25_we;
+  logic [31:0] rega25_qs;
+  logic [31:0] rega25_wd;
+  logic rega26_we;
+  logic [31:0] rega26_qs;
+  logic [31:0] rega26_wd;
+  logic rega27_we;
+  logic [31:0] rega27_qs;
+  logic [31:0] rega27_wd;
+  logic [31:0] rega28_qs;
+  logic rega29_we;
+  logic [31:0] rega29_qs;
+  logic [31:0] rega29_wd;
+  logic rega30_we;
+  logic [31:0] rega30_qs;
+  logic [31:0] rega30_wd;
   logic regal_we;
-  logic [31:0] regal_qs;
   logic [31:0] regal_wd;
   logic regb_0_we;
   logic [31:0] regb_0_qs;
@@ -222,19 +214,18 @@ module ast_reg_top (
   logic [31:0] regb_4_wd;
 
   // Register instances
-  // Subregister 0 of Multireg rega
-  // R[rega_0]: V(False)
+  // R[rega0]: V(False)
   prim_subreg #(
     .DW      (32),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (32'h0)
-  ) u_rega_0 (
+  ) u_rega0 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_0_we),
-    .wd     (rega_0_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (1'b0),
@@ -242,26 +233,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[0].q),
+    .q      (reg2hw.rega0.q),
 
     // to register interface (read)
-    .qs     (rega_0_qs)
+    .qs     (rega0_qs)
   );
 
 
-  // Subregister 1 of Multireg rega
-  // R[rega_1]: V(False)
+  // R[rega1]: V(False)
   prim_subreg #(
     .DW      (32),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_1 (
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (32'h1)
+  ) u_rega1 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_1_we),
-    .wd     (rega_1_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (1'b0),
@@ -269,26 +259,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[1].q),
+    .q      (reg2hw.rega1.q),
 
     // to register interface (read)
-    .qs     (rega_1_qs)
+    .qs     (rega1_qs)
   );
 
 
-  // Subregister 2 of Multireg rega
-  // R[rega_2]: V(False)
+  // R[rega2]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_2 (
+    .RESVAL  (32'h2)
+  ) u_rega2 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_2_we),
-    .wd     (rega_2_wd),
+    .we     (rega2_we),
+    .wd     (rega2_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -296,26 +285,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[2].q),
+    .q      (reg2hw.rega2.q),
 
     // to register interface (read)
-    .qs     (rega_2_qs)
+    .qs     (rega2_qs)
   );
 
 
-  // Subregister 3 of Multireg rega
-  // R[rega_3]: V(False)
+  // R[rega3]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_3 (
+    .RESVAL  (32'h3)
+  ) u_rega3 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_3_we),
-    .wd     (rega_3_wd),
+    .we     (rega3_we),
+    .wd     (rega3_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -323,26 +311,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[3].q),
+    .q      (reg2hw.rega3.q),
 
     // to register interface (read)
-    .qs     (rega_3_qs)
+    .qs     (rega3_qs)
   );
 
 
-  // Subregister 4 of Multireg rega
-  // R[rega_4]: V(False)
+  // R[rega4]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_4 (
+    .RESVAL  (32'h4)
+  ) u_rega4 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_4_we),
-    .wd     (rega_4_wd),
+    .we     (rega4_we),
+    .wd     (rega4_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -350,26 +337,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[4].q),
+    .q      (reg2hw.rega4.q),
 
     // to register interface (read)
-    .qs     (rega_4_qs)
+    .qs     (rega4_qs)
   );
 
 
-  // Subregister 5 of Multireg rega
-  // R[rega_5]: V(False)
+  // R[rega5]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_5 (
+    .RESVAL  (32'h5)
+  ) u_rega5 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_5_we),
-    .wd     (rega_5_wd),
+    .we     (rega5_we),
+    .wd     (rega5_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -377,26 +363,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[5].q),
+    .q      (reg2hw.rega5.q),
 
     // to register interface (read)
-    .qs     (rega_5_qs)
+    .qs     (rega5_qs)
   );
 
 
-  // Subregister 6 of Multireg rega
-  // R[rega_6]: V(False)
+  // R[rega6]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_6 (
+    .RESVAL  (32'h6)
+  ) u_rega6 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_6_we),
-    .wd     (rega_6_wd),
+    .we     (rega6_we),
+    .wd     (rega6_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -404,26 +389,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[6].q),
+    .q      (reg2hw.rega6.q),
 
     // to register interface (read)
-    .qs     (rega_6_qs)
+    .qs     (rega6_qs)
   );
 
 
-  // Subregister 7 of Multireg rega
-  // R[rega_7]: V(False)
+  // R[rega7]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_7 (
+    .RESVAL  (32'h7)
+  ) u_rega7 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_7_we),
-    .wd     (rega_7_wd),
+    .we     (rega7_we),
+    .wd     (rega7_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -431,26 +415,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[7].q),
+    .q      (reg2hw.rega7.q),
 
     // to register interface (read)
-    .qs     (rega_7_qs)
+    .qs     (rega7_qs)
   );
 
 
-  // Subregister 8 of Multireg rega
-  // R[rega_8]: V(False)
+  // R[rega8]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_8 (
+    .RESVAL  (32'h8)
+  ) u_rega8 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_8_we),
-    .wd     (rega_8_wd),
+    .we     (rega8_we),
+    .wd     (rega8_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -458,26 +441,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[8].q),
+    .q      (reg2hw.rega8.q),
 
     // to register interface (read)
-    .qs     (rega_8_qs)
+    .qs     (rega8_qs)
   );
 
 
-  // Subregister 9 of Multireg rega
-  // R[rega_9]: V(False)
+  // R[rega9]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_9 (
+    .RESVAL  (32'h9)
+  ) u_rega9 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_9_we),
-    .wd     (rega_9_wd),
+    .we     (rega9_we),
+    .wd     (rega9_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -485,26 +467,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[9].q),
+    .q      (reg2hw.rega9.q),
 
     // to register interface (read)
-    .qs     (rega_9_qs)
+    .qs     (rega9_qs)
   );
 
 
-  // Subregister 10 of Multireg rega
-  // R[rega_10]: V(False)
+  // R[rega10]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_10 (
+    .RESVAL  (32'ha)
+  ) u_rega10 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_10_we),
-    .wd     (rega_10_wd),
+    .we     (rega10_we),
+    .wd     (rega10_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -512,26 +493,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[10].q),
+    .q      (reg2hw.rega10.q),
 
     // to register interface (read)
-    .qs     (rega_10_qs)
+    .qs     (rega10_qs)
   );
 
 
-  // Subregister 11 of Multireg rega
-  // R[rega_11]: V(False)
+  // R[rega11]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_11 (
+    .RESVAL  (32'hb)
+  ) u_rega11 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_11_we),
-    .wd     (rega_11_wd),
+    .we     (rega11_we),
+    .wd     (rega11_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -539,26 +519,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[11].q),
+    .q      (reg2hw.rega11.q),
 
     // to register interface (read)
-    .qs     (rega_11_qs)
+    .qs     (rega11_qs)
   );
 
 
-  // Subregister 12 of Multireg rega
-  // R[rega_12]: V(False)
+  // R[rega12]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_12 (
+    .RESVAL  (32'hc)
+  ) u_rega12 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_12_we),
-    .wd     (rega_12_wd),
+    .we     (rega12_we),
+    .wd     (rega12_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -566,26 +545,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[12].q),
+    .q      (reg2hw.rega12.q),
 
     // to register interface (read)
-    .qs     (rega_12_qs)
+    .qs     (rega12_qs)
   );
 
 
-  // Subregister 13 of Multireg rega
-  // R[rega_13]: V(False)
+  // R[rega13]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_13 (
+    .RESVAL  (32'hd)
+  ) u_rega13 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_13_we),
-    .wd     (rega_13_wd),
+    .we     (rega13_we),
+    .wd     (rega13_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -593,26 +571,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[13].q),
+    .q      (reg2hw.rega13.q),
 
     // to register interface (read)
-    .qs     (rega_13_qs)
+    .qs     (rega13_qs)
   );
 
 
-  // Subregister 14 of Multireg rega
-  // R[rega_14]: V(False)
+  // R[rega14]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_14 (
+    .RESVAL  (32'he)
+  ) u_rega14 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_14_we),
-    .wd     (rega_14_wd),
+    .we     (rega14_we),
+    .wd     (rega14_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -620,26 +597,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[14].q),
+    .q      (reg2hw.rega14.q),
 
     // to register interface (read)
-    .qs     (rega_14_qs)
+    .qs     (rega14_qs)
   );
 
 
-  // Subregister 15 of Multireg rega
-  // R[rega_15]: V(False)
+  // R[rega15]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_15 (
+    .RESVAL  (32'hf)
+  ) u_rega15 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_15_we),
-    .wd     (rega_15_wd),
+    .we     (rega15_we),
+    .wd     (rega15_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -647,26 +623,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[15].q),
+    .q      (reg2hw.rega15.q),
 
     // to register interface (read)
-    .qs     (rega_15_qs)
+    .qs     (rega15_qs)
   );
 
 
-  // Subregister 16 of Multireg rega
-  // R[rega_16]: V(False)
+  // R[rega16]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_16 (
+    .RESVAL  (32'h10)
+  ) u_rega16 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_16_we),
-    .wd     (rega_16_wd),
+    .we     (rega16_we),
+    .wd     (rega16_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -674,26 +649,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[16].q),
+    .q      (reg2hw.rega16.q),
 
     // to register interface (read)
-    .qs     (rega_16_qs)
+    .qs     (rega16_qs)
   );
 
 
-  // Subregister 17 of Multireg rega
-  // R[rega_17]: V(False)
+  // R[rega17]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_17 (
+    .RESVAL  (32'h11)
+  ) u_rega17 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_17_we),
-    .wd     (rega_17_wd),
+    .we     (rega17_we),
+    .wd     (rega17_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -701,26 +675,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[17].q),
+    .q      (reg2hw.rega17.q),
 
     // to register interface (read)
-    .qs     (rega_17_qs)
+    .qs     (rega17_qs)
   );
 
 
-  // Subregister 18 of Multireg rega
-  // R[rega_18]: V(False)
+  // R[rega18]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_18 (
+    .RESVAL  (32'h12)
+  ) u_rega18 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_18_we),
-    .wd     (rega_18_wd),
+    .we     (rega18_we),
+    .wd     (rega18_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -728,26 +701,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[18].q),
+    .q      (reg2hw.rega18.q),
 
     // to register interface (read)
-    .qs     (rega_18_qs)
+    .qs     (rega18_qs)
   );
 
 
-  // Subregister 19 of Multireg rega
-  // R[rega_19]: V(False)
+  // R[rega19]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_19 (
+    .RESVAL  (32'h13)
+  ) u_rega19 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_19_we),
-    .wd     (rega_19_wd),
+    .we     (rega19_we),
+    .wd     (rega19_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -755,26 +727,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[19].q),
+    .q      (reg2hw.rega19.q),
 
     // to register interface (read)
-    .qs     (rega_19_qs)
+    .qs     (rega19_qs)
   );
 
 
-  // Subregister 20 of Multireg rega
-  // R[rega_20]: V(False)
+  // R[rega20]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_20 (
+    .RESVAL  (32'h14)
+  ) u_rega20 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_20_we),
-    .wd     (rega_20_wd),
+    .we     (rega20_we),
+    .wd     (rega20_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -782,26 +753,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[20].q),
+    .q      (reg2hw.rega20.q),
 
     // to register interface (read)
-    .qs     (rega_20_qs)
+    .qs     (rega20_qs)
   );
 
 
-  // Subregister 21 of Multireg rega
-  // R[rega_21]: V(False)
+  // R[rega21]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_21 (
+    .RESVAL  (32'h15)
+  ) u_rega21 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_21_we),
-    .wd     (rega_21_wd),
+    .we     (rega21_we),
+    .wd     (rega21_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -809,26 +779,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[21].q),
+    .q      (reg2hw.rega21.q),
 
     // to register interface (read)
-    .qs     (rega_21_qs)
+    .qs     (rega21_qs)
   );
 
 
-  // Subregister 22 of Multireg rega
-  // R[rega_22]: V(False)
+  // R[rega22]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_22 (
+    .RESVAL  (32'h16)
+  ) u_rega22 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_22_we),
-    .wd     (rega_22_wd),
+    .we     (rega22_we),
+    .wd     (rega22_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -836,26 +805,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[22].q),
+    .q      (reg2hw.rega22.q),
 
     // to register interface (read)
-    .qs     (rega_22_qs)
+    .qs     (rega22_qs)
   );
 
 
-  // Subregister 23 of Multireg rega
-  // R[rega_23]: V(False)
+  // R[rega23]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_23 (
+    .RESVAL  (32'h17)
+  ) u_rega23 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_23_we),
-    .wd     (rega_23_wd),
+    .we     (rega23_we),
+    .wd     (rega23_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -863,26 +831,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[23].q),
+    .q      (reg2hw.rega23.q),
 
     // to register interface (read)
-    .qs     (rega_23_qs)
+    .qs     (rega23_qs)
   );
 
 
-  // Subregister 24 of Multireg rega
-  // R[rega_24]: V(False)
+  // R[rega24]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_24 (
+    .RESVAL  (32'h18)
+  ) u_rega24 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_24_we),
-    .wd     (rega_24_wd),
+    .we     (rega24_we),
+    .wd     (rega24_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -890,26 +857,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[24].q),
+    .q      (reg2hw.rega24.q),
 
     // to register interface (read)
-    .qs     (rega_24_qs)
+    .qs     (rega24_qs)
   );
 
 
-  // Subregister 25 of Multireg rega
-  // R[rega_25]: V(False)
+  // R[rega25]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_25 (
+    .RESVAL  (32'h19)
+  ) u_rega25 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_25_we),
-    .wd     (rega_25_wd),
+    .we     (rega25_we),
+    .wd     (rega25_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -917,26 +883,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[25].q),
+    .q      (reg2hw.rega25.q),
 
     // to register interface (read)
-    .qs     (rega_25_qs)
+    .qs     (rega25_qs)
   );
 
 
-  // Subregister 26 of Multireg rega
-  // R[rega_26]: V(False)
+  // R[rega26]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_26 (
+    .RESVAL  (32'h1a)
+  ) u_rega26 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_26_we),
-    .wd     (rega_26_wd),
+    .we     (rega26_we),
+    .wd     (rega26_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -944,26 +909,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[26].q),
+    .q      (reg2hw.rega26.q),
 
     // to register interface (read)
-    .qs     (rega_26_qs)
+    .qs     (rega26_qs)
   );
 
 
-  // Subregister 27 of Multireg rega
-  // R[rega_27]: V(False)
+  // R[rega27]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_27 (
+    .RESVAL  (32'h1b)
+  ) u_rega27 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_27_we),
-    .wd     (rega_27_wd),
+    .we     (rega27_we),
+    .wd     (rega27_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -971,26 +935,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[27].q),
+    .q      (reg2hw.rega27.q),
 
     // to register interface (read)
-    .qs     (rega_27_qs)
+    .qs     (rega27_qs)
   );
 
 
-  // Subregister 28 of Multireg rega
-  // R[rega_28]: V(False)
+  // R[rega28]: V(False)
   prim_subreg #(
     .DW      (32),
-    .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_28 (
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (32'h1c)
+  ) u_rega28 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_28_we),
-    .wd     (rega_28_wd),
+    .we     (1'b0),
+    .wd     ('0),
 
     // from internal hardware
     .de     (1'b0),
@@ -998,26 +961,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[28].q),
+    .q      (reg2hw.rega28.q),
 
     // to register interface (read)
-    .qs     (rega_28_qs)
+    .qs     (rega28_qs)
   );
 
 
-  // Subregister 29 of Multireg rega
-  // R[rega_29]: V(False)
+  // R[rega29]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_29 (
+    .RESVAL  (32'h1d)
+  ) u_rega29 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_29_we),
-    .wd     (rega_29_wd),
+    .we     (rega29_we),
+    .wd     (rega29_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1025,26 +987,25 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[29].q),
+    .q      (reg2hw.rega29.q),
 
     // to register interface (read)
-    .qs     (rega_29_qs)
+    .qs     (rega29_qs)
   );
 
 
-  // Subregister 30 of Multireg rega
-  // R[rega_30]: V(False)
+  // R[rega30]: V(False)
   prim_subreg #(
     .DW      (32),
     .SwAccess(prim_subreg_pkg::SwAccessRW),
-    .RESVAL  (32'h0)
-  ) u_rega_30 (
+    .RESVAL  (32'h1e)
+  ) u_rega30 (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
     // from register interface
-    .we     (rega_30_we),
-    .wd     (rega_30_wd),
+    .we     (rega30_we),
+    .wd     (rega30_wd),
 
     // from internal hardware
     .de     (1'b0),
@@ -1052,10 +1013,10 @@ module ast_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.rega[30].q),
+    .q      (reg2hw.rega30.q),
 
     // to register interface (read)
-    .qs     (rega_30_qs)
+    .qs     (rega30_qs)
   );
 
 
@@ -1066,14 +1027,14 @@ module ast_reg_top (
   prim_subreg_ext #(
     .DW    (32)
   ) u_regal (
-    .re     (regal_re),
+    .re     (1'b0),
     .we     (regal_we),
     .wd     (regal_wd),
     .d      (hw2reg.regal.d),
     .qre    (),
     .qe     (regal_flds_we[0]),
     .q      (reg2hw.regal.q),
-    .qs     (regal_qs)
+    .qs     ()
   );
   assign reg2hw.regal.qe = regal_qe;
 
@@ -1217,37 +1178,37 @@ module ast_reg_top (
   logic [36:0] addr_hit;
   always_comb begin
     addr_hit = '0;
-    addr_hit[ 0] = (reg_addr == AST_REGA_0_OFFSET);
-    addr_hit[ 1] = (reg_addr == AST_REGA_1_OFFSET);
-    addr_hit[ 2] = (reg_addr == AST_REGA_2_OFFSET);
-    addr_hit[ 3] = (reg_addr == AST_REGA_3_OFFSET);
-    addr_hit[ 4] = (reg_addr == AST_REGA_4_OFFSET);
-    addr_hit[ 5] = (reg_addr == AST_REGA_5_OFFSET);
-    addr_hit[ 6] = (reg_addr == AST_REGA_6_OFFSET);
-    addr_hit[ 7] = (reg_addr == AST_REGA_7_OFFSET);
-    addr_hit[ 8] = (reg_addr == AST_REGA_8_OFFSET);
-    addr_hit[ 9] = (reg_addr == AST_REGA_9_OFFSET);
-    addr_hit[10] = (reg_addr == AST_REGA_10_OFFSET);
-    addr_hit[11] = (reg_addr == AST_REGA_11_OFFSET);
-    addr_hit[12] = (reg_addr == AST_REGA_12_OFFSET);
-    addr_hit[13] = (reg_addr == AST_REGA_13_OFFSET);
-    addr_hit[14] = (reg_addr == AST_REGA_14_OFFSET);
-    addr_hit[15] = (reg_addr == AST_REGA_15_OFFSET);
-    addr_hit[16] = (reg_addr == AST_REGA_16_OFFSET);
-    addr_hit[17] = (reg_addr == AST_REGA_17_OFFSET);
-    addr_hit[18] = (reg_addr == AST_REGA_18_OFFSET);
-    addr_hit[19] = (reg_addr == AST_REGA_19_OFFSET);
-    addr_hit[20] = (reg_addr == AST_REGA_20_OFFSET);
-    addr_hit[21] = (reg_addr == AST_REGA_21_OFFSET);
-    addr_hit[22] = (reg_addr == AST_REGA_22_OFFSET);
-    addr_hit[23] = (reg_addr == AST_REGA_23_OFFSET);
-    addr_hit[24] = (reg_addr == AST_REGA_24_OFFSET);
-    addr_hit[25] = (reg_addr == AST_REGA_25_OFFSET);
-    addr_hit[26] = (reg_addr == AST_REGA_26_OFFSET);
-    addr_hit[27] = (reg_addr == AST_REGA_27_OFFSET);
-    addr_hit[28] = (reg_addr == AST_REGA_28_OFFSET);
-    addr_hit[29] = (reg_addr == AST_REGA_29_OFFSET);
-    addr_hit[30] = (reg_addr == AST_REGA_30_OFFSET);
+    addr_hit[ 0] = (reg_addr == AST_REGA0_OFFSET);
+    addr_hit[ 1] = (reg_addr == AST_REGA1_OFFSET);
+    addr_hit[ 2] = (reg_addr == AST_REGA2_OFFSET);
+    addr_hit[ 3] = (reg_addr == AST_REGA3_OFFSET);
+    addr_hit[ 4] = (reg_addr == AST_REGA4_OFFSET);
+    addr_hit[ 5] = (reg_addr == AST_REGA5_OFFSET);
+    addr_hit[ 6] = (reg_addr == AST_REGA6_OFFSET);
+    addr_hit[ 7] = (reg_addr == AST_REGA7_OFFSET);
+    addr_hit[ 8] = (reg_addr == AST_REGA8_OFFSET);
+    addr_hit[ 9] = (reg_addr == AST_REGA9_OFFSET);
+    addr_hit[10] = (reg_addr == AST_REGA10_OFFSET);
+    addr_hit[11] = (reg_addr == AST_REGA11_OFFSET);
+    addr_hit[12] = (reg_addr == AST_REGA12_OFFSET);
+    addr_hit[13] = (reg_addr == AST_REGA13_OFFSET);
+    addr_hit[14] = (reg_addr == AST_REGA14_OFFSET);
+    addr_hit[15] = (reg_addr == AST_REGA15_OFFSET);
+    addr_hit[16] = (reg_addr == AST_REGA16_OFFSET);
+    addr_hit[17] = (reg_addr == AST_REGA17_OFFSET);
+    addr_hit[18] = (reg_addr == AST_REGA18_OFFSET);
+    addr_hit[19] = (reg_addr == AST_REGA19_OFFSET);
+    addr_hit[20] = (reg_addr == AST_REGA20_OFFSET);
+    addr_hit[21] = (reg_addr == AST_REGA21_OFFSET);
+    addr_hit[22] = (reg_addr == AST_REGA22_OFFSET);
+    addr_hit[23] = (reg_addr == AST_REGA23_OFFSET);
+    addr_hit[24] = (reg_addr == AST_REGA24_OFFSET);
+    addr_hit[25] = (reg_addr == AST_REGA25_OFFSET);
+    addr_hit[26] = (reg_addr == AST_REGA26_OFFSET);
+    addr_hit[27] = (reg_addr == AST_REGA27_OFFSET);
+    addr_hit[28] = (reg_addr == AST_REGA28_OFFSET);
+    addr_hit[29] = (reg_addr == AST_REGA29_OFFSET);
+    addr_hit[30] = (reg_addr == AST_REGA30_OFFSET);
     addr_hit[31] = (reg_addr == AST_REGAL_OFFSET);
     addr_hit[32] = (reg_addr == AST_REGB_0_OFFSET);
     addr_hit[33] = (reg_addr == AST_REGB_1_OFFSET);
@@ -1299,100 +1260,90 @@ module ast_reg_top (
                (addr_hit[35] & (|(AST_PERMIT[35] & ~reg_be))) |
                (addr_hit[36] & (|(AST_PERMIT[36] & ~reg_be)))));
   end
-  assign rega_0_we = addr_hit[0] & reg_we & !reg_error;
+  assign rega2_we = addr_hit[2] & reg_we & !reg_error;
 
-  assign rega_0_wd = reg_wdata[31:0];
-  assign rega_1_we = addr_hit[1] & reg_we & !reg_error;
+  assign rega2_wd = reg_wdata[31:0];
+  assign rega3_we = addr_hit[3] & reg_we & !reg_error;
 
-  assign rega_1_wd = reg_wdata[31:0];
-  assign rega_2_we = addr_hit[2] & reg_we & !reg_error;
+  assign rega3_wd = reg_wdata[31:0];
+  assign rega4_we = addr_hit[4] & reg_we & !reg_error;
 
-  assign rega_2_wd = reg_wdata[31:0];
-  assign rega_3_we = addr_hit[3] & reg_we & !reg_error;
+  assign rega4_wd = reg_wdata[31:0];
+  assign rega5_we = addr_hit[5] & reg_we & !reg_error;
 
-  assign rega_3_wd = reg_wdata[31:0];
-  assign rega_4_we = addr_hit[4] & reg_we & !reg_error;
+  assign rega5_wd = reg_wdata[31:0];
+  assign rega6_we = addr_hit[6] & reg_we & !reg_error;
 
-  assign rega_4_wd = reg_wdata[31:0];
-  assign rega_5_we = addr_hit[5] & reg_we & !reg_error;
+  assign rega6_wd = reg_wdata[31:0];
+  assign rega7_we = addr_hit[7] & reg_we & !reg_error;
 
-  assign rega_5_wd = reg_wdata[31:0];
-  assign rega_6_we = addr_hit[6] & reg_we & !reg_error;
+  assign rega7_wd = reg_wdata[31:0];
+  assign rega8_we = addr_hit[8] & reg_we & !reg_error;
 
-  assign rega_6_wd = reg_wdata[31:0];
-  assign rega_7_we = addr_hit[7] & reg_we & !reg_error;
+  assign rega8_wd = reg_wdata[31:0];
+  assign rega9_we = addr_hit[9] & reg_we & !reg_error;
 
-  assign rega_7_wd = reg_wdata[31:0];
-  assign rega_8_we = addr_hit[8] & reg_we & !reg_error;
+  assign rega9_wd = reg_wdata[31:0];
+  assign rega10_we = addr_hit[10] & reg_we & !reg_error;
 
-  assign rega_8_wd = reg_wdata[31:0];
-  assign rega_9_we = addr_hit[9] & reg_we & !reg_error;
+  assign rega10_wd = reg_wdata[31:0];
+  assign rega11_we = addr_hit[11] & reg_we & !reg_error;
 
-  assign rega_9_wd = reg_wdata[31:0];
-  assign rega_10_we = addr_hit[10] & reg_we & !reg_error;
+  assign rega11_wd = reg_wdata[31:0];
+  assign rega12_we = addr_hit[12] & reg_we & !reg_error;
 
-  assign rega_10_wd = reg_wdata[31:0];
-  assign rega_11_we = addr_hit[11] & reg_we & !reg_error;
+  assign rega12_wd = reg_wdata[31:0];
+  assign rega13_we = addr_hit[13] & reg_we & !reg_error;
 
-  assign rega_11_wd = reg_wdata[31:0];
-  assign rega_12_we = addr_hit[12] & reg_we & !reg_error;
+  assign rega13_wd = reg_wdata[31:0];
+  assign rega14_we = addr_hit[14] & reg_we & !reg_error;
 
-  assign rega_12_wd = reg_wdata[31:0];
-  assign rega_13_we = addr_hit[13] & reg_we & !reg_error;
+  assign rega14_wd = reg_wdata[31:0];
+  assign rega15_we = addr_hit[15] & reg_we & !reg_error;
 
-  assign rega_13_wd = reg_wdata[31:0];
-  assign rega_14_we = addr_hit[14] & reg_we & !reg_error;
+  assign rega15_wd = reg_wdata[31:0];
+  assign rega16_we = addr_hit[16] & reg_we & !reg_error;
 
-  assign rega_14_wd = reg_wdata[31:0];
-  assign rega_15_we = addr_hit[15] & reg_we & !reg_error;
+  assign rega16_wd = reg_wdata[31:0];
+  assign rega17_we = addr_hit[17] & reg_we & !reg_error;
 
-  assign rega_15_wd = reg_wdata[31:0];
-  assign rega_16_we = addr_hit[16] & reg_we & !reg_error;
+  assign rega17_wd = reg_wdata[31:0];
+  assign rega18_we = addr_hit[18] & reg_we & !reg_error;
 
-  assign rega_16_wd = reg_wdata[31:0];
-  assign rega_17_we = addr_hit[17] & reg_we & !reg_error;
+  assign rega18_wd = reg_wdata[31:0];
+  assign rega19_we = addr_hit[19] & reg_we & !reg_error;
 
-  assign rega_17_wd = reg_wdata[31:0];
-  assign rega_18_we = addr_hit[18] & reg_we & !reg_error;
+  assign rega19_wd = reg_wdata[31:0];
+  assign rega20_we = addr_hit[20] & reg_we & !reg_error;
 
-  assign rega_18_wd = reg_wdata[31:0];
-  assign rega_19_we = addr_hit[19] & reg_we & !reg_error;
+  assign rega20_wd = reg_wdata[31:0];
+  assign rega21_we = addr_hit[21] & reg_we & !reg_error;
 
-  assign rega_19_wd = reg_wdata[31:0];
-  assign rega_20_we = addr_hit[20] & reg_we & !reg_error;
+  assign rega21_wd = reg_wdata[31:0];
+  assign rega22_we = addr_hit[22] & reg_we & !reg_error;
 
-  assign rega_20_wd = reg_wdata[31:0];
-  assign rega_21_we = addr_hit[21] & reg_we & !reg_error;
+  assign rega22_wd = reg_wdata[31:0];
+  assign rega23_we = addr_hit[23] & reg_we & !reg_error;
 
-  assign rega_21_wd = reg_wdata[31:0];
-  assign rega_22_we = addr_hit[22] & reg_we & !reg_error;
+  assign rega23_wd = reg_wdata[31:0];
+  assign rega24_we = addr_hit[24] & reg_we & !reg_error;
 
-  assign rega_22_wd = reg_wdata[31:0];
-  assign rega_23_we = addr_hit[23] & reg_we & !reg_error;
+  assign rega24_wd = reg_wdata[31:0];
+  assign rega25_we = addr_hit[25] & reg_we & !reg_error;
 
-  assign rega_23_wd = reg_wdata[31:0];
-  assign rega_24_we = addr_hit[24] & reg_we & !reg_error;
+  assign rega25_wd = reg_wdata[31:0];
+  assign rega26_we = addr_hit[26] & reg_we & !reg_error;
 
-  assign rega_24_wd = reg_wdata[31:0];
-  assign rega_25_we = addr_hit[25] & reg_we & !reg_error;
+  assign rega26_wd = reg_wdata[31:0];
+  assign rega27_we = addr_hit[27] & reg_we & !reg_error;
 
-  assign rega_25_wd = reg_wdata[31:0];
-  assign rega_26_we = addr_hit[26] & reg_we & !reg_error;
+  assign rega27_wd = reg_wdata[31:0];
+  assign rega29_we = addr_hit[29] & reg_we & !reg_error;
 
-  assign rega_26_wd = reg_wdata[31:0];
-  assign rega_27_we = addr_hit[27] & reg_we & !reg_error;
+  assign rega29_wd = reg_wdata[31:0];
+  assign rega30_we = addr_hit[30] & reg_we & !reg_error;
 
-  assign rega_27_wd = reg_wdata[31:0];
-  assign rega_28_we = addr_hit[28] & reg_we & !reg_error;
-
-  assign rega_28_wd = reg_wdata[31:0];
-  assign rega_29_we = addr_hit[29] & reg_we & !reg_error;
-
-  assign rega_29_wd = reg_wdata[31:0];
-  assign rega_30_we = addr_hit[30] & reg_we & !reg_error;
-
-  assign rega_30_wd = reg_wdata[31:0];
-  assign regal_re = addr_hit[31] & reg_re & !reg_error;
+  assign rega30_wd = reg_wdata[31:0];
   assign regal_we = addr_hit[31] & reg_we & !reg_error;
 
   assign regal_wd = reg_wdata[31:0];
@@ -1417,131 +1368,131 @@ module ast_reg_top (
     reg_rdata_next = '0;
     unique case (1'b1)
       addr_hit[0]: begin
-        reg_rdata_next[31:0] = rega_0_qs;
+        reg_rdata_next[31:0] = rega0_qs;
       end
 
       addr_hit[1]: begin
-        reg_rdata_next[31:0] = rega_1_qs;
+        reg_rdata_next[31:0] = rega1_qs;
       end
 
       addr_hit[2]: begin
-        reg_rdata_next[31:0] = rega_2_qs;
+        reg_rdata_next[31:0] = rega2_qs;
       end
 
       addr_hit[3]: begin
-        reg_rdata_next[31:0] = rega_3_qs;
+        reg_rdata_next[31:0] = rega3_qs;
       end
 
       addr_hit[4]: begin
-        reg_rdata_next[31:0] = rega_4_qs;
+        reg_rdata_next[31:0] = rega4_qs;
       end
 
       addr_hit[5]: begin
-        reg_rdata_next[31:0] = rega_5_qs;
+        reg_rdata_next[31:0] = rega5_qs;
       end
 
       addr_hit[6]: begin
-        reg_rdata_next[31:0] = rega_6_qs;
+        reg_rdata_next[31:0] = rega6_qs;
       end
 
       addr_hit[7]: begin
-        reg_rdata_next[31:0] = rega_7_qs;
+        reg_rdata_next[31:0] = rega7_qs;
       end
 
       addr_hit[8]: begin
-        reg_rdata_next[31:0] = rega_8_qs;
+        reg_rdata_next[31:0] = rega8_qs;
       end
 
       addr_hit[9]: begin
-        reg_rdata_next[31:0] = rega_9_qs;
+        reg_rdata_next[31:0] = rega9_qs;
       end
 
       addr_hit[10]: begin
-        reg_rdata_next[31:0] = rega_10_qs;
+        reg_rdata_next[31:0] = rega10_qs;
       end
 
       addr_hit[11]: begin
-        reg_rdata_next[31:0] = rega_11_qs;
+        reg_rdata_next[31:0] = rega11_qs;
       end
 
       addr_hit[12]: begin
-        reg_rdata_next[31:0] = rega_12_qs;
+        reg_rdata_next[31:0] = rega12_qs;
       end
 
       addr_hit[13]: begin
-        reg_rdata_next[31:0] = rega_13_qs;
+        reg_rdata_next[31:0] = rega13_qs;
       end
 
       addr_hit[14]: begin
-        reg_rdata_next[31:0] = rega_14_qs;
+        reg_rdata_next[31:0] = rega14_qs;
       end
 
       addr_hit[15]: begin
-        reg_rdata_next[31:0] = rega_15_qs;
+        reg_rdata_next[31:0] = rega15_qs;
       end
 
       addr_hit[16]: begin
-        reg_rdata_next[31:0] = rega_16_qs;
+        reg_rdata_next[31:0] = rega16_qs;
       end
 
       addr_hit[17]: begin
-        reg_rdata_next[31:0] = rega_17_qs;
+        reg_rdata_next[31:0] = rega17_qs;
       end
 
       addr_hit[18]: begin
-        reg_rdata_next[31:0] = rega_18_qs;
+        reg_rdata_next[31:0] = rega18_qs;
       end
 
       addr_hit[19]: begin
-        reg_rdata_next[31:0] = rega_19_qs;
+        reg_rdata_next[31:0] = rega19_qs;
       end
 
       addr_hit[20]: begin
-        reg_rdata_next[31:0] = rega_20_qs;
+        reg_rdata_next[31:0] = rega20_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[31:0] = rega_21_qs;
+        reg_rdata_next[31:0] = rega21_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[31:0] = rega_22_qs;
+        reg_rdata_next[31:0] = rega22_qs;
       end
 
       addr_hit[23]: begin
-        reg_rdata_next[31:0] = rega_23_qs;
+        reg_rdata_next[31:0] = rega23_qs;
       end
 
       addr_hit[24]: begin
-        reg_rdata_next[31:0] = rega_24_qs;
+        reg_rdata_next[31:0] = rega24_qs;
       end
 
       addr_hit[25]: begin
-        reg_rdata_next[31:0] = rega_25_qs;
+        reg_rdata_next[31:0] = rega25_qs;
       end
 
       addr_hit[26]: begin
-        reg_rdata_next[31:0] = rega_26_qs;
+        reg_rdata_next[31:0] = rega26_qs;
       end
 
       addr_hit[27]: begin
-        reg_rdata_next[31:0] = rega_27_qs;
+        reg_rdata_next[31:0] = rega27_qs;
       end
 
       addr_hit[28]: begin
-        reg_rdata_next[31:0] = rega_28_qs;
+        reg_rdata_next[31:0] = rega28_qs;
       end
 
       addr_hit[29]: begin
-        reg_rdata_next[31:0] = rega_29_qs;
+        reg_rdata_next[31:0] = rega29_qs;
       end
 
       addr_hit[30]: begin
-        reg_rdata_next[31:0] = rega_30_qs;
+        reg_rdata_next[31:0] = rega30_qs;
       end
 
       addr_hit[31]: begin
-        reg_rdata_next[31:0] = regal_qs;
+        reg_rdata_next[31:0] = '0;
       end
 
       addr_hit[32]: begin

--- a/hw/top_earlgrey/ip/ast/rtl/io_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/io_clk.sv
@@ -12,7 +12,6 @@ module io_clk (
   input rst_io_clk_ni,               // IO Clock Logic reset
   input clk_src_io_en_i,             // IO Source Clock Enable
   input scan_mode_i,                 // Scan Mode
-  input scan_reset_ni,               // Scan Reset
   input io_osc_cal_i,                // IO Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
   input clk_io_ext_i,                // FPGA/VERILATOR Clock input
@@ -49,12 +48,12 @@ prim_clock_buf #(
 
 // 2-stage de-assertion
 logic rst_val_n;
-assign rst_val_n = scan_mode_i ? scan_reset_ni : io_clk_en;
+assign rst_val_n = io_clk_en;
 
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_val_sync (
+) u_no_scan_val_sync (
   .clk_i ( clk_src_io_o ),
   .rst_ni ( rst_val_n ),
   .d_i ( 1'b1 ),

--- a/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
@@ -21,7 +21,6 @@ module io_osc (
 // Behavioral Model
 ////////////////////////////////////////
 timeunit 1ns / 1ps;
-import ast_bhv_pkg::* ;
 
 real CLK_PERIOD;
 
@@ -30,12 +29,12 @@ initial init_start = 1'b0;
 
 initial begin
   #1; init_start  = 1'b1;
-  $display("\nIO Power-up Clock Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
+  $display("\n%m: IO Clock Power-up Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
 end
 
 // Enable 5us RC Delay on rise
 wire en_osc_re_buf, en_osc_re;
-buf #(IO_EN_RDLY, 0) b0 (en_osc_re_buf, (vcore_pok_h_i && io_en_i));
+buf #(ast_bhv_pkg::IO_EN_RDLY, 0) b0 (en_osc_re_buf, (vcore_pok_h_i && io_en_i));
 assign en_osc_re = en_osc_re_buf && init_start;
 
 

--- a/hw/top_earlgrey/ip/ast/rtl/rng.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/rng.sv
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //############################################################################
 // *Name: rng
-// *Module Description:  Random (bit/s) Generator
+// *Module Description:  Random (bit/s) Generator (Pseudo Model)
 //############################################################################
 
 module rng #(
@@ -28,13 +28,24 @@ logic[EntropyStreams-1:0] lfsr_val;
 
 assign rst_n = scan_mode_i ? rst_ni : rst_ni && rng_en_i;
 
+// These LFSR parameters have been generated with
+// $ ./util/design/gen-lfsr-seed.py --width 64 --seed 15513 --prefix "Rng"
+localparam int RngLfsrWidth = 64;
+typedef logic [RngLfsrWidth-1:0] rng_lfsr_seed_t;
+typedef logic [RngLfsrWidth-1:0][$clog2(RngLfsrWidth)-1:0] rng_lfsr_perm_t;
+localparam rng_lfsr_seed_t RndCnstRngLfsrSeedDefault = 64'h1d033d20eed3b14;
+localparam rng_lfsr_perm_t RndCnstRngLfsrPermDefault = {
+  128'h98c2c94ab5e40420ed73f6c7396cd9e1,
+  256'h58c6d7435ddb2ed1f22400c53a5aaa796ef7785e120628fbabc87f0b3928550f
+};
+
 prim_lfsr #(
-  .LfsrDw ( ast_pkg::LfsrWidth ),
+  .LfsrDw ( RngLfsrWidth ),
   .EntropyDw ( 1 ),
   .StateOutDw ( EntropyStreams ),
-  .DefaultSeed ( ast_pkg::RndCnstLfsrSeedDefault ),
+  .DefaultSeed ( RndCnstRngLfsrSeedDefault ),
   .StatePermEn ( 1'b1 ),
-  .StatePerm ( ast_pkg::RndCnstLfsrPermDefault ),
+  .StatePerm ( RndCnstRngLfsrPermDefault ),
   .ExtSeedSVA ( 1'b0 )  // ext seed is unused
 ) u_rng_lfsr (
   .clk_i ( clk_i ),

--- a/hw/top_earlgrey/ip/ast/rtl/sys_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/sys_clk.sv
@@ -13,7 +13,6 @@ module sys_clk (
   input rst_sys_clk_ni,              // System Clock Logic reset
   input vcore_pok_h_i,               // VCORE POK @3.3V (for OSC)
   input scan_mode_i,                 // Scan Mode
-  input scan_reset_ni,               // Scan Reset
   input sys_osc_cal_i,               // System Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
   input clk_sys_ext_i,               // FPGA/VERILATOR Clock input
@@ -51,12 +50,12 @@ prim_clock_buf #(
 
 // 2-stage de-assertion
 logic rst_val_n;
-assign rst_val_n = scan_mode_i ? scan_reset_ni : sys_clk_en;
+assign rst_val_n = sys_clk_en;
 
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_val_sync (
+) u_no_scan_val_sync (
   .clk_i ( clk_src_sys_o ),
   .rst_ni ( rst_val_n ),
   .d_i ( 1'b1 ),

--- a/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
@@ -22,7 +22,6 @@ module sys_osc (
 // Behavioral Model
 ////////////////////////////////////////
 timeunit  1ns / 1ps;
-import ast_bhv_pkg::* ;
 
 real CLK_PERIOD;
 
@@ -31,12 +30,12 @@ initial init_start = 1'b0;
 
 initial begin
   #1; init_start  = 1'b1;
-  $display("\nSystem Power-up Clock Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
+  $display("\n%m: System Clock Power-up Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
 end
 
 // Enable 5us RC Delay on rise
 wire en_osc_re_buf, en_osc_re, sys_jen;
-buf #(SYS_EN_RDLY, 0) b0 (en_osc_re_buf, (vcore_pok_h_i && sys_en_i));
+buf #(ast_bhv_pkg::SYS_EN_RDLY, 0) b0 (en_osc_re_buf, (vcore_pok_h_i && sys_en_i));
 assign en_osc_re = en_osc_re_buf && init_start;
 assign sys_jen = sys_jen_i && en_osc_re_buf && init_start;
 

--- a/hw/top_earlgrey/ip/ast/rtl/usb_clk.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_clk.sv
@@ -14,7 +14,6 @@ module usb_clk (
   input usb_ref_val_i,               // USB Reference (Pulse) Valid
   input usb_ref_pulse_i,             // USB Reference Pulse
   input scan_mode_i,                 // Scan Mode
-  input scan_reset_ni,               // Scan Reset
   input usb_osc_cal_i,               // USB Oscillator Calibrated
 `ifdef AST_BYPASS_CLK
   input clk_usb_ext_i,               // FPGA/VERILATOR Clock input
@@ -53,12 +52,12 @@ prim_clock_buf #(
 
 // 2-stage de-assertion
 logic rst_val_n;
-assign rst_val_n = scan_mode_i ? scan_reset_ni : usb_clk_en;
+assign rst_val_n = usb_clk_en;
 
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_val_sync (
+) u_no_scan_val_sync (
   .clk_i ( clk_src_usb_o ),
   .rst_ni ( rst_val_n ),
   .d_i ( 1'b1 ),

--- a/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcaon_pgd.sv
@@ -22,8 +22,6 @@ assign gen_supp_a = 1'b1;
 `ifndef SYNTHESIS
 // Behavioral Model
 ////////////////////////////////////////
-import ast_bhv_pkg::* ;
-
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
 logic init_start;
@@ -37,9 +35,9 @@ always @( * ) begin
   if ( init_start ) begin
     vcaon_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin
-    vcaon_pok_o <= #(VCAON_POK_RDLY) gen_supp_a;
+    vcaon_pok_o <= #(ast_bhv_pkg::VCAON_POK_RDLY) gen_supp_a;
   end else if ( !init_start && !gen_supp_a ) begin
-    vcaon_pok_o <= #(VCAON_POK_FDLY) gen_supp_a;
+    vcaon_pok_o <= #(ast_bhv_pkg::VCAON_POK_FDLY) gen_supp_a;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcc_pgd.sv
@@ -22,8 +22,6 @@ assign gen_supp_a = 1'b1;
 `ifndef SYNTHESIS
 // Behavioral Model
 ////////////////////////////////////////
-import ast_bhv_pkg::* ;
-
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
 logic init_start;
@@ -37,9 +35,9 @@ always @( * ) begin
   if ( init_start ) begin
     vcc_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin
-    vcc_pok_o <= #(VCC_POK_RDLY) gen_supp_a;
+    vcc_pok_o <= #(ast_bhv_pkg::VCC_POK_RDLY) gen_supp_a;
   end else if ( !init_start && !gen_supp_a ) begin
-    vcc_pok_o <= #(VCC_POK_FDLY) gen_supp_a;
+    vcc_pok_o <= #(ast_bhv_pkg::VCC_POK_FDLY) gen_supp_a;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vcmain_pgd.sv
@@ -22,8 +22,6 @@ assign gen_supp_a = 1'b1;
 `ifndef SYNTHESIS
 // Behavioral Model
 ////////////////////////////////////////
-import ast_bhv_pkg::* ;
-
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
 logic init_start;
@@ -37,9 +35,9 @@ always @( * ) begin
   if ( init_start ) begin
     vcmain_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin
-    vcmain_pok_o <= #(VCMAIN_POK_RDLY) gen_supp_a;
+    vcmain_pok_o <= #(ast_bhv_pkg::VCMAIN_POK_RDLY) gen_supp_a;
   end else if ( !init_start && !gen_supp_a ) begin
-    vcmain_pok_o <= #(VCMAIN_POK_FDLY) gen_supp_a;
+    vcmain_pok_o <= #(ast_bhv_pkg::VCMAIN_POK_FDLY) gen_supp_a;
   end
 end
 `else

--- a/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/vio_pgd.sv
@@ -22,8 +22,6 @@ assign gen_supp_a = 1'b1;
 `ifndef SYNTHESIS
 // Behavioral Model
 ////////////////////////////////////////
-import ast_bhv_pkg::* ;
-
 // The initial is needed to clear the X of the delays at the start
 // Also to force a power-up effect at the bgining.
 logic init_start;
@@ -37,9 +35,9 @@ always @( * ) begin
   if ( init_start ) begin
     vio_pok_o <= 1'b0;
   end else if ( !init_start && gen_supp_a ) begin
-    vio_pok_o <= #(VIO_POK_RDLY) gen_supp_a;
+    vio_pok_o <= #(ast_bhv_pkg::VIO_POK_RDLY) gen_supp_a;
   end else if ( !init_start && !gen_supp_a ) begin
-    vio_pok_o <= #(VIO_POK_FDLY) gen_supp_a;
+    vio_pok_o <= #(ast_bhv_pkg::VIO_POK_FDLY) gen_supp_a;
   end
 end
 `else

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -45,7 +45,7 @@ index 7092c858a..101d3bc7e 100644
 -  bne  t0, t1, .L_ast_init_skip
 -
 -  // Copy the AST configuration from OTP.
--  li   a0, (TOP_EARLGREY_AST_BASE_ADDR + AST_REGA_0_REG_OFFSET)
+-  li   a0, (TOP_EARLGREY_AST_BASE_ADDR)
 -  li   a1, (TOP_EARLGREY_AST_BASE_ADDR + AST_REGAL_REG_OFFSET + 4)
 -  li   a2, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
 -            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + \

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -154,7 +154,7 @@ _start:
   bne  t0, t1, .L_ast_init_skip
 
   // Copy the AST configuration from OTP.
-  li   a0, (TOP_EARLGREY_AST_BASE_ADDR + AST_REGA_0_REG_OFFSET)
+  li   a0, (TOP_EARLGREY_AST_BASE_ADDR)
   li   a1, (TOP_EARLGREY_AST_BASE_ADDR + AST_REGAL_REG_OFFSET + 4)
   li   a2, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
             OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + \

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -179,7 +179,7 @@ _mask_rom_start_boot:
   bne  t0, t1, .L_ast_init_skip
 
   // Copy the AST configuration from OTP.
-  li   a0, (TOP_EARLGREY_AST_BASE_ADDR + AST_REGA_0_REG_OFFSET)
+  li   a0, (TOP_EARLGREY_AST_BASE_ADDR)
   li   a1, (TOP_EARLGREY_AST_BASE_ADDR + AST_REGAL_REG_OFFSET + 4)
   li   a2, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
             OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + \


### PR DESCRIPTION
Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>

* Fix CDC & DFT Issues (ast.sv & ast_clks_byp.sv).
* Update main_pok reset through regulator SM (ast.sv & rglts_pdm_3p3v.sv).
* Update ast.hjson with CSR exclude information, access type, and different reset value for each register.
* Add flag `calibrate_usb_clk` to USB oscillator and add `%m`  to `$display` in osc files (<*>_osc.sv) 