### PR TITLE
[spi_device] Queue SW req of clr BUSY when active

### DIFF
--- a/hw/top_earlgrey/cdc/cdc_waivers.spi_device.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.spi_device.tcl
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verix CDC waiver file
+# Expression:
+#  ControlSignal==""
+#  ReconSignal==""
+#  MultiClockDomains=="IO_DIV2_CLK::IO_DIV4_CLK"
+
+set_rule_status -rule {W_RECON_GROUPS} -status {Waived}         \
+   -expression {(ControlSignal=~"*u_status_23_to_1_sync.*") &&       \
+                (ReconSignal=~"*u_spid_status.outclk_p2s_byte_*")} \
+   -comment {status bits are converged into SPI line. But transmit bit-by-bit. OK to send old and new status bits in a transaction}

--- a/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
+++ b/hw/top_earlgrey/syn/chip_earlgrey_asic.sdc
@@ -214,6 +214,10 @@ create_generated_clock -name SPI_DEV_IN_CLK -source SPI_DEV_CLK -divide_by 1 \
 create_generated_clock -name SPI_DEV_OUT_CLK -source SPI_DEV_CLK -divide_by 1 \
     -invert [get_pins top_earlgrey/u_spi_device/u_clk_spi_out_buf/clk_o]
 
+# CSb clock
+create_clock -name SPI_CSB_CLK -period ${SPI_DEV_TCK} \
+  [get_pins top_earlgrey/u_spi_device/u_clk_csb_buf/clk_o]
+
 ## TODO: these are dummy constraints and likely incorrect, need to properly constrain min/max
 # FRACTION is reduced to 0.2 as internal datapath for SPI is half clk period
 set SPI_DEV_IN_DEL_FRACTION 0.2
@@ -324,6 +328,10 @@ create_generated_clock -name SPI_DEV_PASSTHRU_IN_CLK -source SPI_DEV_CLK -divide
 create_generated_clock -name SPI_DEV_PASSTHRU_OUT_CLK -source SPI_DEV_CLK -divide_by 1 \
     [get_pins top_earlgrey/u_spi_device/u_clk_spi_out_buf/clk_o] -add -master_clock SPI_DEV_PASSTHRU_CLK
 
+# CSb clock (added to SPI_CSB_CLK)
+create_clock -name SPI_DEV_PASSTHRU_CSB_CLK -period ${SPI_DEV_PASSTHRU_CK} \
+  [get_pins top_earlgrey/u_spi_device/u_clk_csb_buf/clk_o] -add
+
 # clocks accounting for propagation delay to the other side
 create_generated_clock -name SPI_HOST_PASSTHRU_CLK -source SPI_DEV_CLK \
     -master_clock SPI_DEV_PASSTHRU_CLK -divide_by 1 \
@@ -409,8 +417,8 @@ set_output_delay ${SPI_DEV_PASSTHRU_STORAGE_OUT_DEL} [get_ports SPI_HOST_CS_L] -
 set_clock_groups -name group1 -async                                  \
     -group [get_clocks MAIN_CLK                                     ] \
     -group [get_clocks USB_CLK                                      ] \
-    -group [get_clocks {SPI_DEV_CLK SPI_DEV_IN_CLK SPI_DEV_OUT_CLK} ] \
-    -group [get_clocks {SPI_DEV_PASSTHRU_CLK SPI_HOST_PASSTHRU_CLK SPI_DEV_PASSTHRU_IN_CLK SPI_DEV_PASSTHRU_OUT_CLK} ] \
+    -group [get_clocks {SPI_DEV_CLK SPI_DEV_IN_CLK SPI_DEV_OUT_CLK SPI_CSB_CLK} ] \
+    -group [get_clocks {SPI_DEV_PASSTHRU_CLK SPI_HOST_PASSTHRU_CLK SPI_DEV_PASSTHRU_IN_CLK SPI_DEV_PASSTHRU_OUT_CLK SPI_DEV_PASSTHRU_CSB_CLK} ] \
     -group [get_clocks {IO_CLK SPI_HOST_INT_CLK SPI_HOST_CLK}       ] \
     -group [get_clocks IO_DIV2_CLK                                  ] \
     -group [get_clocks IO_DIV4_CLK                                  ] \


### PR DESCRIPTION
Design Doc: https://docs.google.com/document/d/1wUIynMYVfVg9HmCL0q5-6r9BuN-XM0z--wGqU0bXRQ0

This commit adds a flag register to store the SW request of clearing the
BUSY bit in the STATUS register when the HW is not able to accept the
request due to the CDC issue.
    
The HW then checks the flag and clears the BUSY bit when the SPI is in
idle state.