### PR TITLE
[rtl/otp] Some workaround for FPV security countermeasure assertions

### DIFF
--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -560,6 +560,7 @@ module otp_ctrl_kdi
     // SEC_CM: KDI.FSM.LOCAL_ESC, KDI.FSM.GLOBAL_ESC
     if (escalate_en_i != lc_ctrl_pkg::Off || seed_cnt_err || entropy_cnt_err) begin
       state_d = ErrorSt;
+      fsm_err_o = 1'b1;
     end
   end
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -353,6 +353,7 @@ module otp_ctrl_lfsr_timer
     // SEC_CM: TIMER.FSM.LOCAL_ESC, TIMER.FSM.GLOBAL_ESC
     if (lfsr_err || integ_cnt_err || cnsty_cnt_err || escalate_en_i != lc_ctrl_pkg::Off) begin
        state_d = ErrorSt;
+       fsm_err_o = 1'b1;
     end
   end
 

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -428,6 +428,7 @@ module otp_ctrl_scrmbl
     // SEC_CM: SCRMBL.FSM.LOCAL_ESC, SCRMBL.FSM.GLOBAL_ESC
     if (escalate_en_i != lc_ctrl_pkg::Off || cnt_err) begin
       state_d = ErrorSt;
+      fsm_err_o = 1'b1;
     end
   end
 


### PR DESCRIPTION
Hi @msfschaffner,

I do not think they are necessary RTL functional changes, but related to
how formal checks these security countermeasure assertions.
What we did are:
- blackbox prim_counts and prim_lfsrs
- stop at the logic with sparse_fsm outputs
The side-effects of these manual injections are - at some cases,
`state_q <= state_d` does not work anymore.

So if the prim_counter has err_o, sometimes it only propogates to
state_d but not state_q. So it will never trigger a `fsm_err_o`. Please
see the waves attached.

Because of that, I think maybe this workaround would work?
If you do not want it to be in the acutal RTL code, I can also add a
ifdef `FPV_SEC_CM_ON` to only include these code in FPV.
Please let me know what you think.

![image](https://user-images.githubusercontent.com/11466553/158498181-e73e46cb-ca5c-4783-9511-8fc65c44ae77.png)

Thanks
Cindy

Signed-off-by: Cindy Chen <chencindy@opentitan.org>