### PR TITLE
[sw/testing] Add bazel target for autogened ISR testutils

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -15,19 +15,22 @@ cc_library(
 
 cc_library(
     name = "test_base",
+    testonly = True,
     hdrs = ["dif_test_base.h"],
     deps = [
         ":base",
         "@googletest//:gtest",
     ],
-    testonly = True,
 )
 
 cc_library(
     name = "adc_ctrl",
-    hdrs = [
+    srcs = [
         "autogen/dif_adc_ctrl_autogen.c",
         "autogen/dif_adc_ctrl_autogen.h",
+    ],
+    hdrs = [
+        "dif_adc_ctrl.h",
     ],
     deps = [
         ":base",
@@ -1171,6 +1174,9 @@ cc_library(
     srcs = [
         "autogen/dif_sysrst_ctrl_autogen.c",
         "autogen/dif_sysrst_ctrl_autogen.h",
+    ],
+    hdrs = [
+        "dif_sysrst_ctrl.h",
     ],
     deps = [
         ":base",

--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -7,6 +7,40 @@ load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 package(default_visibility = ["//visibility:public"])
 
 cc_library(
+    name = "isr_testutils",
+    srcs = ["autogen/isr_testutils.c"],
+    hdrs = ["autogen/isr_testutils.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:adc_ctrl",
+        "//sw/device/lib/dif:alert_handler",
+        "//sw/device/lib/dif:aon_timer",
+        "//sw/device/lib/dif:csrng",
+        "//sw/device/lib/dif:edn",
+        "//sw/device/lib/dif:entropy_src",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:gpio",
+        "//sw/device/lib/dif:hmac",
+        "//sw/device/lib/dif:i2c",
+        "//sw/device/lib/dif:keymgr",
+        "//sw/device/lib/dif:kmac",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/dif:otp_ctrl",
+        "//sw/device/lib/dif:pattgen",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:spi_device",
+        "//sw/device/lib/dif:spi_host",
+        "//sw/device/lib/dif:sysrst_ctrl",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/dif:usbdev",
+        "//sw/device/lib/testing/test_framework",
+    ],
+)
+
+cc_library(
     name = "aes_testutils",
     srcs = ["aes_testutils.c"],
     hdrs = ["aes_testutils.h"],


### PR DESCRIPTION
This adds a bazel target to build the autogenerated ISR testutils that
were added in #11029. This addresses a task in #9038.

Signed-off-by: Timothy Trippel <ttrippel@google.com>