### PR TITLE
[spi_agent] Read commands response addition

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_device_cmd_rsp_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_device_cmd_rsp_seq.sv
@@ -82,7 +82,7 @@ class spi_device_cmd_rsp_seq extends spi_device_seq;
 
         SpiData: begin
           case (cmd)
-            ReadStd, ReadDual, ReadQuad: begin
+            ReadStd, ReadDual, ReadQuad, ReadSts1, ReadSts2, ReadSts3, ReadJedec: begin
               // read_until CSB low
               data = $urandom();
               addr_cnt += 4;

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -46,7 +46,12 @@ package spi_agent_pkg;
     WriteDual  = 8'b00001100,
     ReadQuad   = 8'b00001111,
     WriteQuad  = 8'b11110000,
-    CmdOnly    = 8'b10000001
+    CmdOnly    = 8'b10000001,
+    ReadSts1   = 8'b00000101,
+    ReadSts2   = 8'b00110101,
+    ReadSts3   = 8'b00010101,
+    ReadJedec  = 8'b10011111,
+    ReadSfdp   = 8'b01011010
   } spi_cmd_e;
 
   // forward declare classes to allow typedefs below


### PR DESCRIPTION
Added device agent response for Read Status commands and Read JEDEC and Read SFDP commands. Assumption is these responses are each 32 bit long.
Added enumeration for given command opcodes.

Signed-off-by: Kosta Kojdic <kosta.kojdic@ensilica.com>