### PR TITLE
[sw] Fix invalid includes of <limits.h>

### DIFF
--- a/sw/device/lib/base/freestanding/README.md
+++ b/sw/device/lib/base/freestanding/README.md
@@ -3,11 +3,21 @@
 title: "Freestanding C Headers"
 ---
 
-This subtree defines headers requred for a C freestanding implementation, as specified in S4p6 of the C11 standard.
-Said headers are implemented to the letter as described in respective sections of said standard.
+This subtree defines headers requred for a C freestanding implementation, as
+specified in S4p6 of the C11 standard. Said headers are implemented *to the
+letter* as described in respective sections of said standard. These headers
+must be substitutable for those provided by the system toolchain when building
+for host-side code, so that includes of these headers do not cause breakage
+when building on host-side, where these headers are *never* included.
 
-All of `sw/device` is compiled using only these headers, and this directory acts as the sole root against which `#include <...>` directives are resolved.
-Headers provided by the system or the compiler are totally inaccessible and should not be used.
+All of `sw/device` is compiled using only these headers, and this directory acts
+as the sole root against which `#include <...>` directives are resolved.
+Headers provided by the system or the compiler are totally inaccessible and
+should not be used. Conversely, these headers must *never* be included via
+their full paths, since they can easily clash with the corresponding headers
+provided by the host-side toolchain, as described above.
 
-These headers are guaranteed to be compatible with processors and compilers implementing the RISC-V ILP32 psABI, though they may be compatible with other architectures and calling conventions on a best-effort basis.
+These headers are guaranteed to be compatible with processors and compilers
+implementing the RISC-V ILP32 psABI, though they may be compatible with other
+architectures and calling conventions on a best-effort basis.
 However, compilers *must* be compatible with Clang and GCC's intrinsics.

--- a/sw/device/silicon_creator/lib/drivers/keymgr.c
+++ b/sw/device/silicon_creator/lib/drivers/keymgr.c
@@ -4,8 +4,9 @@
 
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 
+#include <assert.h>
+
 #include "sw/device/lib/base/abs_mmio.h"
-#include "sw/device/lib/base/freestanding/assert.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 

--- a/sw/device/tests/aon_timer_irq_test.c
+++ b/sw/device/tests/aon_timer_irq_test.c
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <assert.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/freestanding/limits.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/dif/dif_rv_plic.h"

--- a/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
+++ b/sw/device/tests/aon_timer_sleep_wdog_sleep_pause_test.c
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/freestanding/limits.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/dif/dif_pwrmgr.h"

--- a/sw/device/tests/aon_timer_wdog_bite_reset_test.c
+++ b/sw/device/tests/aon_timer_wdog_bite_reset_test.c
@@ -2,10 +2,10 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/freestanding/limits.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"
 #include "sw/device/lib/dif/dif_pwrmgr.h"

--- a/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
+++ b/sw/device/tests/aon_timer_wdog_lc_escalate_test.c
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <assert.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/freestanding/limits.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_alert_handler.h"
 #include "sw/device/lib/dif/dif_aon_timer.h"

--- a/sw/device/tests/autogen/plic_all_irqs_test.c
+++ b/sw/device/tests/autogen/plic_all_irqs_test.c
@@ -7,8 +7,8 @@
 // PLEASE DO NOT HAND-EDIT THIS FILE. IT HAS BEEN AUTO-GENERATED WITH THE FOLLOWING COMMAND:
 // util/topgen.py -t hw/top_earlgrey/data/top_earlgrey.hjson
 // -o hw/top_earlgrey
+#include <limits.h>
 
-#include "sw/device/lib/base/freestanding/limits.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_adc_ctrl.h"
 #include "sw/device/lib/dif/dif_alert_handler.h"

--- a/util/topgen/templates/plic_all_irqs_test.c.tpl
+++ b/util/topgen/templates/plic_all_irqs_test.c.tpl
@@ -11,8 +11,8 @@ def args(p):
     extra_arg = ", kHart" if p.name == "rv_timer" else ""
     return f"&{p.inst_name}{extra_arg}"
 %>\
+#include <limits.h>
 
-#include "sw/device/lib/base/freestanding/limits.h"
 #include "sw/device/lib/base/mmio.h"
 % for n in sorted(irq_peripheral_names + ["rv_plic"]):
 #include "sw/device/lib/dif/dif_${n}.h"


### PR DESCRIPTION
<limits.h> is a member of our free-standing libc, so it should be included as a libc header.
I think I reviewed these files, so it's on me for not noticing.

Added further notes; this actually causes breakages when performing refactorings due to conflicting definitions provided by our libc and the host toolchain libc headers, when building on the host side.

FYI @engdoreis