### PR TITLE
[chip,dv] Remove chip_sw_rom_ctrl_reset_glitch from testplan

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2040,23 +2040,6 @@
       milestone: V2
       tests: ["chip_sw_rom_ctrl_integrity_check_test"]
     }
-    {
-      name: chip_sw_rom_ctrl_reset_glitch
-      desc: '''Verify that a glitch on the ROM ctrl's reset input is triggered as a fatal alert.
-
-            - In normal boot up from POR, the ROM contents are checked for validity using KMAC.
-            - After boot up, read the reset cause register in rstmgr to confirm POR reset phase.
-            - SW goes into idle state (nothing to do).
-            - The testbench randomly glitches the ROM ctrl's reset input, which causes ROM ctrl to
-              re-check the contents for validity.
-            - Verify that the KMAC detects the repeat presentation of data from ROM ctrl as a fatal
-              alert and the chip is rebooted via the alert escalation path.
-            - After boot up, read the reset cause register in rstmgr to confirm reset due to alert
-              phase.
-            '''
-      milestone: V2
-      tests: []
-    }
 
     // SRAM (pre-verified IP) integration tests:
     {


### PR DESCRIPTION
This test is to verify functionality that we never got around to
adding to KMAC and has been ICEBOXed.

See #10724 for discussion about the feature.