### PR TITLE
[chip dv] Testplan mapping fixes

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -680,7 +680,7 @@
             - Stop the escalation process and fail the test in the interrupt handler in case the
               bark interrupt is fired.
             - Program the alert handler to escalate on alerts upto phase 2 (i.e. reset) but the
-              phase 1 (i.e. wipe secrets) should occur and last during the time the wdog is 
+              phase 1 (i.e. wipe secrets) should occur and last during the time the wdog is
               programed to bark and bite.
             - Trigger an alert to cause an escalation condition before the bark signal asserts.
             - After the reset ensure that the reset cause was due to the escalation to prove that
@@ -1652,7 +1652,7 @@
             the NIST vectors). SW validates the reception of kmac done and fifo empty interrupts.
             '''
       milestone: V2
-      tests: ["chip_sw_kmac_mode_cshake_test", "chip_sw_kmac_mode_kmac_test"]
+      tests: ["chip_sw_kmac_mode_cshake", "chip_sw_kmac_mode_kmac"]
     }
     {
       name: chip_sw_kmac_app_keymgr
@@ -1696,7 +1696,7 @@
             X-ref'ed with ROM_CTRL test/env.
             '''
       milestone: V2
-      tests: ["chip_sw_kmac_app_rom_test"]
+      tests: ["chip_sw_kmac_app_rom"]
     }
     {
       name: chip_sw_kmac_entropy
@@ -1733,7 +1733,7 @@
               Verify that the KMAC clk enabled status reads as disabled (KMAC is idle).
             '''
       milestone: V2
-      tests: ["chip_sw_kmac_idle_test"]
+      tests: ["chip_sw_kmac_idle"]
     }
 
     // ENTROPY_SRC (pre-verified IP) integration tests:
@@ -2016,7 +2016,7 @@
             - Verify that the CPU can fetch instructions from the ROM.
             '''
       milestone: V2
-      tests: ["chip_sw_rom_ctrl_integrity_check_test"]
+      tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {
       name: chip_conn_rom_ctrl_ast_rom_cfg
@@ -2038,7 +2038,7 @@
               digest does not match the top 8 words of the ROM.
             '''
       milestone: V2
-      tests: ["chip_sw_rom_ctrl_integrity_check_test"]
+      tests: ["chip_sw_rom_ctrl_integrity_check"]
     }
     {
       name: chip_sw_rom_ctrl_reset_glitch
@@ -2663,10 +2663,8 @@
       tests: ["chip_sw_aes_smoketest",
               "chip_sw_aon_timer_smoketest",
               "chip_sw_clkmgr_smoketest",
-              // TODO(lowrisc/opentitan#7505): Debug CSRNG generate bits mismatch.
-              // "chip_sw_csrng_smoketest",
-              // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
-              // "chip_sw_entropy_src_smoketest",
+              "chip_sw_csrng_smoketest",
+              "chip_sw_entropy_src_smoketest",
               "chip_sw_gpio_smoketest",
               "chip_sw_hmac_smoketest",
               "chip_sw_kmac_smoketest",

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -303,7 +303,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/flash_ctrl_idle_low_power_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-    }    
+    }
     {
       name: chip_sw_lc_ctrl_otp_hw_cfg
       uvm_test_seq: chip_sw_base_vseq
@@ -401,37 +401,37 @@
       run_opts: ["+sw_test_timeout_ns=22000000"]
     }
     {
-      name: chip_sw_hmac_enc_irq_test
+      name: chip_sw_hmac_enc_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/hmac_enc_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
-      name: chip_sw_kmac_mode_cshake_test
+      name: chip_sw_kmac_mode_cshake
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_cshake_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
-      name: chip_sw_kmac_mode_kmac_test
+      name: chip_sw_kmac_mode_kmac
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_kmac_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
-      name: chip_sw_kmac_app_rom_test
+      name: chip_sw_kmac_app_rom
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_app_rom_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
-      name: chip_sw_kmac_idle_test
+      name: chip_sw_kmac_idle
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_idle_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
-      name: chip_sw_rom_ctrl_integrity_check_test
+      name: chip_sw_rom_ctrl_integrity_check
       uvm_test_seq: chip_sw_rom_ctrl_integrity_check_vseq
       sw_images: ["sw/device/tests/rom_ctrl_integrity_check_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]

--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -26,12 +26,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     // TODO(lowrisc/opentitan#7505): Debug CSRNG generate bits mismatch.
-    // {
-    //  name: chip_sw_csrng_smoketest
-    //  uvm_test_seq: chip_sw_base_vseq
-    //  sw_images: ["sw/device/tests/csrng_smoketest:1"]
-    //  en_run_modes: ["sw_test_mode_test_rom"]
-    // }
+    {
+     name: chip_sw_csrng_smoketest
+     uvm_test_seq: chip_sw_base_vseq
+     sw_images: ["sw/device/tests/csrng_smoketest:1"]
+     en_run_modes: ["sw_test_mode_test_rom"]
+    }
     // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
     {
       name: chip_sw_entropy_src_smoketest
@@ -118,7 +118,7 @@
               "chip_sw_aon_timer_smoketest",
               "chip_sw_clkmgr_smoketest",
               // TODO(lowrisc/opentitan#7505): Debug CSRNG generate bits mismatch.
-              // "chip_sw_csrng_smoketest",
+              "chip_sw_csrng_smoketest",
               // TODO(lowrisc/opentitan#10092): Remove dependency on uncontrolled environment.
               "chip_sw_entropy_src_smoketest",
               "chip_sw_gpio_smoketest",


### PR DESCRIPTION
Fix incorrect test mapping that result in unmapped tests in the report.
Remove _test suffix in tests specified in the hjson, since it is not
needed.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>