### PR TITLE
[dv] Enable tlul_assert for CSR tests

### DIFF
--- a/hw/dv/tools/vcs/cover_reg_top.cfg
+++ b/hw/dv/tools/vcs/cover_reg_top.cfg
@@ -7,6 +7,7 @@
 
 +moduletree *_reg_top
 +node tb.dut tl_*
++assert tb.dut.tlul_assert*
 
 // Remove everything else from toggle coverage except:
 // - `prim_alert_sender`: the `alert_test` task under `cip_base_vseq` drives `alert_test_i` and


### PR DESCRIPTION
Some assert coverage can be only covered in CSR tests, such as b2b same
address request.

Signed-off-by: Weicai Yang <weicai@google.com>