### PR TITLE
[dif/adc_ctrl] Implement remaining DIFs

### DIFF
--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -473,8 +473,7 @@ dif_result_t dif_adc_ctrl_irq_cause_set_enabled(const dif_adc_ctrl_t *adc_ctrl,
   uint32_t enabled_causes =
       mmio_region_read32(adc_ctrl->base_addr, ADC_CTRL_ADC_INTR_CTL_REG_OFFSET);
   if (enabled == kDifToggleDisabled) {
-    causes = ~causes;
-    enabled_causes &= causes;
+    enabled_causes &= ~causes;
   } else {
     enabled_causes |= causes;
   }

--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -428,3 +428,37 @@ dif_result_t dif_adc_ctrl_irq_clear_causes(const dif_adc_ctrl_t *adc_ctrl,
 
   return kDifOk;
 }
+
+dif_result_t dif_adc_ctrl_filter_match_wakeup_set_enabled(
+    const dif_adc_ctrl_t *adc_ctrl, dif_adc_ctrl_filter_t filter,
+    dif_toggle_t enabled) {
+  if (adc_ctrl == NULL || filter >= ADC_CTRL_PARAM_NUM_ADC_FILTER ||
+      !dif_is_valid_toggle(enabled)) {
+    return kDifBadArg;
+  }
+
+  uint32_t wakeup_ctrl_reg = mmio_region_read32(
+      adc_ctrl->base_addr, ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET);
+  wakeup_ctrl_reg = bitfield_bit32_write(wakeup_ctrl_reg, filter,
+                                         dif_toggle_to_bool(enabled));
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET,
+                      wakeup_ctrl_reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_adc_ctrl_filter_match_wakeup_get_enabled(
+    const dif_adc_ctrl_t *adc_ctrl, dif_adc_ctrl_filter_t filter,
+    dif_toggle_t *is_enabled) {
+  if (adc_ctrl == NULL || filter >= ADC_CTRL_PARAM_NUM_ADC_FILTER ||
+      is_enabled == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t wakeup_ctrl_reg = mmio_region_read32(
+      adc_ctrl->base_addr, ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET);
+  *is_enabled =
+      dif_bool_to_toggle(bitfield_bit32_read(wakeup_ctrl_reg, filter));
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -403,3 +403,28 @@ dif_result_t dif_adc_ctrl_reset(const dif_adc_ctrl_t *adc_ctrl) {
 
   return kDifOk;
 }
+
+dif_result_t dif_adc_ctrl_irq_get_causes(const dif_adc_ctrl_t *adc_ctrl,
+                                         uint32_t *causes) {
+  if (adc_ctrl == NULL || causes == NULL) {
+    return kDifBadArg;
+  }
+
+  *causes = mmio_region_read32(adc_ctrl->base_addr,
+                               ADC_CTRL_ADC_INTR_STATUS_REG_OFFSET);
+
+  return kDifOk;
+}
+
+dif_result_t dif_adc_ctrl_irq_clear_causes(const dif_adc_ctrl_t *adc_ctrl,
+                                           uint32_t causes) {
+  if (adc_ctrl == NULL ||
+      causes >= (1U << (ADC_CTRL_PARAM_NUM_ADC_FILTER + 1))) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_INTR_STATUS_REG_OFFSET,
+                      causes);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_adc_ctrl.h
+++ b/sw/device/lib/dif/dif_adc_ctrl.h
@@ -380,8 +380,8 @@ dif_result_t dif_adc_ctrl_irq_get_causes(const dif_adc_ctrl_t *adc_ctrl,
  * Clears the cause(s) of a `debug_cable` IRQ.
  *
  * @param adc_ctrl An adc_ctrl handle.
- * @param[out] causes The causes of the IRQ (one or more
- *                    `dif_adc_ctrl_irq_cause_t`s ORed together).
+ * @param causes The causes of the IRQ (one or more `dif_adc_ctrl_irq_cause_t`s
+ *               ORed together).
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
@@ -416,31 +416,32 @@ dif_result_t dif_adc_ctrl_filter_match_wakeup_get_enabled(
     dif_toggle_t *is_enabled);
 
 /**
- * Sets the enablement of generating a `debug_cable` IRQ for a given cause.
+ * Sets the enablement of generating a `debug_cable` IRQ for given cause(s).
  *
  * Causes can be filter matches (in Normal Power Scan mode), or when a sample is
  * complete (in Oneshot mode).
  *
  * @param adc_ctrl An adc_ctrl handle.
- * @param irq_cause A cause to generate the `debug_cable` IRQ for.
+ * @param causes Causes (one or more `dif_adc_ctrl_irq_cause_t`s ORed together)
+ *               to generate the `debug_cable` IRQ for.
  * @param enabled The enablement state to set.
  * @return The result of the operation.
  */
-dif_result_t dif_adc_ctrl_irq_cause_set_enabled(
-    const dif_adc_ctrl_t *adc_ctrl, dif_adc_ctrl_irq_cause_t irq_cause,
-    dif_toggle_t enabled);
+dif_result_t dif_adc_ctrl_irq_cause_set_enabled(const dif_adc_ctrl_t *adc_ctrl,
+                                                uint32_t causes,
+                                                dif_toggle_t enabled);
 
 /**
- * Gets the enablement of generating a `debug_cable` IRQ for a given cause.
+ * Gets the causes that will generate a `debug_cable` IRQ.
  *
  * @param adc_ctrl An adc_ctrl handle.
- * @param irq_cause A cause to generate the `debug_cable` IRQ for.
- * @param[out] *is_enabled The enablement state retrieved.
+ * @param[out] enabled_causes Causes (one or more `dif_adc_ctrl_irq_cause_t`s
+ *                            ORed together) that will generate the
+ *                            `debug_cable` IRQ.
  * @return The result of the operation.
  */
-dif_result_t dif_adc_ctrl_irq_cause_get_enabled(
-    const dif_adc_ctrl_t *adc_ctrl, dif_adc_ctrl_irq_cause_t irq_cause,
-    dif_toggle_t *is_enabled);
+dif_result_t dif_adc_ctrl_irq_cause_get_enabled(const dif_adc_ctrl_t *adc_ctrl,
+                                                uint32_t *enabled_causes);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_adc_ctrl.h
+++ b/sw/device/lib/dif/dif_adc_ctrl.h
@@ -99,6 +99,13 @@ typedef enum dif_adc_ctrl_irq_cause {
    * Sample ready cause in Oneshot mode.
    */
   kDifAdcCtrlIrqCauseOneshot = 1U << 8,
+  /**
+   * All IRQ causes ORed together.
+   *
+   * This is useful when clearing all IRQ causes at once, to initialize the ADC
+   * Controller.
+   */
+  kDifAdcCtrlIrqCauseAll = (1U << 9) - 1,
 } dif_adc_ctrl_irq_cause_t;
 
 #undef DIF_ADC_CTRL_IRQ_CAUSE_ENUM_INIT_

--- a/sw/device/lib/dif/dif_adc_ctrl.md
+++ b/sw/device/lib/dif/dif_adc_ctrl.md
@@ -24,8 +24,8 @@ Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress | Only autogen DIFs exist
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
@@ -39,7 +39,7 @@ Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started | [HW Dashboard]
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
 Documentation  | [DIF_DOC_HW][]                   | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
-Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |

--- a/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
@@ -425,5 +425,68 @@ TEST_F(IrqClearCausesTest, Success) {
       &adc_ctrl_, kDifAdcCtrlIrqCauseFilter0 | kDifAdcCtrlIrqCauseFilter3));
 }
 
+class FilterMatchWakeupSetEnabledTest : public AdcCtrlTest {};
+
+TEST_F(FilterMatchWakeupSetEnabledTest, NullHandle) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_filter_match_wakeup_set_enabled(
+      nullptr, kDifAdcCtrlFilter3, kDifToggleEnabled));
+}
+
+TEST_F(FilterMatchWakeupSetEnabledTest, BadFilter) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_filter_match_wakeup_set_enabled(
+      &adc_ctrl_,
+      static_cast<dif_adc_ctrl_filter_t>(ADC_CTRL_PARAM_NUM_ADC_FILTER),
+      kDifToggleEnabled));
+}
+
+TEST_F(FilterMatchWakeupSetEnabledTest, BadEnabled) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_filter_match_wakeup_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlFilter7, static_cast<dif_toggle_t>(2)));
+}
+
+TEST_F(FilterMatchWakeupSetEnabledTest, Success) {
+  EXPECT_READ32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0xF);
+  EXPECT_WRITE32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0x8F);
+  EXPECT_DIF_OK(dif_adc_ctrl_filter_match_wakeup_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlFilter7, kDifToggleEnabled));
+
+  EXPECT_READ32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0x8F);
+  EXPECT_WRITE32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0xF);
+  EXPECT_DIF_OK(dif_adc_ctrl_filter_match_wakeup_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlFilter7, kDifToggleDisabled));
+}
+
+class FilterMatchWakeupGetEnabledTest : public AdcCtrlTest {};
+
+TEST_F(FilterMatchWakeupGetEnabledTest, NullArgs) {
+  dif_toggle_t is_enabled;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_filter_match_wakeup_get_enabled(
+      nullptr, kDifAdcCtrlFilter3, &is_enabled));
+  EXPECT_DIF_BADARG(dif_adc_ctrl_filter_match_wakeup_get_enabled(
+      &adc_ctrl_, kDifAdcCtrlFilter3, nullptr));
+}
+
+TEST_F(FilterMatchWakeupGetEnabledTest, BadFilter) {
+  dif_toggle_t is_enabled;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_filter_match_wakeup_get_enabled(
+      &adc_ctrl_,
+      static_cast<dif_adc_ctrl_filter_t>(ADC_CTRL_PARAM_NUM_ADC_FILTER),
+      &is_enabled));
+}
+
+TEST_F(FilterMatchWakeupGetEnabledTest, Success) {
+  dif_toggle_t is_enabled;
+
+  EXPECT_READ32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0x88);
+  EXPECT_DIF_OK(dif_adc_ctrl_filter_match_wakeup_get_enabled(
+      &adc_ctrl_, kDifAdcCtrlFilter3, &is_enabled));
+  EXPECT_EQ(is_enabled, kDifToggleEnabled);
+
+  EXPECT_READ32(ADC_CTRL_ADC_WAKEUP_CTL_REG_OFFSET, 0x88);
+  EXPECT_DIF_OK(dif_adc_ctrl_filter_match_wakeup_get_enabled(
+      &adc_ctrl_, kDifAdcCtrlFilter2, &is_enabled));
+  EXPECT_EQ(is_enabled, kDifToggleDisabled);
+}
+
 }  // namespace
 }  // namespace dif_adc_ctrl_unittest

--- a/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
@@ -392,5 +392,38 @@ TEST_F(ResetFsmTest, Success) {
   EXPECT_DIF_OK(dif_adc_ctrl_reset(&adc_ctrl_));
 }
 
+class IrqGetCausesTest : public AdcCtrlTest {};
+
+TEST_F(IrqGetCausesTest, NullArgs) {
+  uint32_t causes;
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_causes(nullptr, &causes));
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_causes(&adc_ctrl_, nullptr));
+}
+
+TEST_F(IrqGetCausesTest, Success) {
+  uint32_t causes;
+  EXPECT_READ32(ADC_CTRL_ADC_INTR_STATUS_REG_OFFSET, 0x1FF);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_get_causes(&adc_ctrl_, &causes));
+  EXPECT_EQ(causes, 0x1FF);
+}
+
+class IrqClearCausesTest : public AdcCtrlTest {};
+
+TEST_F(IrqClearCausesTest, NullHandle) {
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_clear_causes(nullptr, kDifAdcCtrlIrqCauseOneshot));
+}
+
+TEST_F(IrqClearCausesTest, BadCauses) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_clear_causes(
+      &adc_ctrl_, 1U << (ADC_CTRL_PARAM_NUM_ADC_FILTER + 1)));
+}
+
+TEST_F(IrqClearCausesTest, Success) {
+  EXPECT_WRITE32(ADC_CTRL_ADC_INTR_STATUS_REG_OFFSET, 0x9);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_clear_causes(
+      &adc_ctrl_, kDifAdcCtrlIrqCauseFilter0 | kDifAdcCtrlIrqCauseFilter3));
+}
+
 }  // namespace
 }  // namespace dif_adc_ctrl_unittest

--- a/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
@@ -488,5 +488,53 @@ TEST_F(FilterMatchWakeupGetEnabledTest, Success) {
   EXPECT_EQ(is_enabled, kDifToggleDisabled);
 }
 
+class IrqCauseSetEnabledTest : public AdcCtrlTest {};
+
+TEST_F(IrqCauseSetEnabledTest, NullHandle) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_cause_set_enabled(
+      nullptr, kDifAdcCtrlIrqCauseFilter2, kDifToggleEnabled));
+}
+
+TEST_F(IrqCauseSetEnabledTest, BadCauses) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_cause_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlIrqCauseAll + 1, kDifToggleEnabled));
+}
+
+TEST_F(IrqCauseSetEnabledTest, BadEnabled) {
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_cause_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlIrqCauseAll, static_cast<dif_toggle_t>(2)));
+}
+
+TEST_F(IrqCauseSetEnabledTest, Success) {
+  EXPECT_READ32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0x33);
+  EXPECT_WRITE32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0x3F);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_cause_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlIrqCauseFilter2 | kDifAdcCtrlIrqCauseFilter3,
+      kDifToggleEnabled));
+
+  EXPECT_READ32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0x3F);
+  EXPECT_WRITE32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0x33);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_cause_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlIrqCauseFilter2 | kDifAdcCtrlIrqCauseFilter3,
+      kDifToggleDisabled));
+}
+
+class IrqCauseGetEnabledTest : public AdcCtrlTest {};
+
+TEST_F(IrqCauseGetEnabledTest, NullArgs) {
+  uint32_t enabled_causes;
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_cause_get_enabled(nullptr, &enabled_causes));
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_cause_get_enabled(&adc_ctrl_, nullptr));
+}
+
+TEST_F(IrqCauseGetEnabledTest, Success) {
+  uint32_t enabled_causes;
+  EXPECT_READ32(ADC_CTRL_ADC_INTR_CTL_REG_OFFSET, 0x1AA);
+  EXPECT_DIF_OK(
+      dif_adc_ctrl_irq_cause_get_enabled(&adc_ctrl_, &enabled_causes));
+  EXPECT_EQ(enabled_causes, 0x1AA);
+}
+
 }  // namespace
 }  // namespace dif_adc_ctrl_unittest


### PR DESCRIPTION
This implements the remaining ADC Controller DIFs and unit tests. Additionally this updates the DIF checklist to reflect the completed state of the ADC Controller DIF library.

**_Note: this depends on #11471 and #11476._**