### PR TITLE
[otbn,dv] Support different CMD operations in DV 

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -381,6 +381,14 @@ void ISSWrapper::start() {
   run_command(oss.str(), nullptr);
 }
 
+void ISSWrapper::dmem_wipe() { run_command("dmem_wipe\n", nullptr); }
+
+void ISSWrapper::imem_wipe() { run_command("imem_wipe\n", nullptr); }
+
+void ISSWrapper::otp_key_cdc_done() {
+  run_command("otp_key_cdc_done\n", nullptr);
+}
+
 void ISSWrapper::edn_rnd_cdc_done() {
   run_command("edn_rnd_cdc_done\n", nullptr);
 }

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -74,6 +74,12 @@ struct ISSWrapper {
   // Jump to address zero and start running
   void start();
 
+  // Start DMEM Secure wipe operation, set status accordingly
+  void dmem_wipe();
+
+  // Start IMEM Secure wipe operation, set status accordingly
+  void imem_wipe();
+
   // Flush EDN related content in model because of edn_rst_n
   void edn_flush();
 
@@ -90,6 +96,9 @@ struct ISSWrapper {
   // Provide keymgr values to model
   void set_keymgr_value(const std::array<uint32_t, 12> &key0_arr,
                         const std::array<uint32_t, 12> &key1_arr, bool valid);
+
+  // Signals that the received OTP key is valid in the RTL.
+  void otp_key_cdc_done();
 
   // Signals 256b EDN random number for RND is valid in the RTL.
   void edn_rnd_cdc_done();

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -46,6 +46,8 @@ module otbn_core_model
   output logic               edn_urnd_o, // EDN request interface for URND seed
   input  logic               edn_urnd_cdc_done_i, // URND seed from EDN is valid (DUT perspective)
 
+  input  logic           otp_key_cdc_done_i, // Scrambling key from OTP is valid (DUT perspective)
+
   output bit [7:0]       status_o,   // STATUS register
   output bit [31:0]      insn_cnt_o, // INSN_CNT register
 

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -33,6 +33,12 @@ class OtbnModel {
   // zero. Returns 0 on success; -1 on failure.
   int start();
 
+  // Starts an IMEM Secure wipe operation
+  int imem_wipe();
+
+  // Starts an DMEM Secure wipe operation
+  int dmem_wipe();
+
   // Flush EDN data from model because of edn_rst_n
   void edn_flush();
 
@@ -47,6 +53,9 @@ class OtbnModel {
 
   // EDN Step sends ISS the URND related EDN data when ACK signal is high.
   void edn_urnd_step(svLogicVecVal *edn_urnd_data /* logic [31:0] */);
+
+  // Signals that RTL is finished processing OTP key
+  void otp_key_cdc_done();
 
   // Signals that RTL is finished processing RND data from EDN
   void edn_rnd_cdc_done();

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -36,6 +36,9 @@ void edn_model_urnd_step(OtbnModel *model,
 // Signal RTL is finished processing RND data to Model
 void edn_model_rnd_cdc_done(OtbnModel *model);
 
+// Signal RTL is finished processing OTP key to the Model
+void otp_key_cdc_done(OtbnModel *model);
+
 // Signal RTL is finished processing EDN data for URND to Model
 void edn_model_urnd_cdc_done(OtbnModel *model);
 
@@ -67,8 +70,8 @@ int otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
 // write out err_bits and stop_pc and set check_due to ensure otbn_model_check
 // runs on the next negedge of the clock.
 //
-// If start is true, we start the model and then step once (as above).
-unsigned otbn_model_step(OtbnModel *model, svLogic start, unsigned model_state,
+unsigned otbn_model_step(OtbnModel *model, unsigned model_state,
+                         svBitVecVal *cmd /* bit [7:0] */,
                          svBitVecVal *status /* bit [7:0] */,
                          svBitVecVal *insn_cnt /* bit [31:0] */,
                          svBitVecVal *rnd_req /* bit [0:0] */,

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -31,10 +31,13 @@ import "DPI-C" function
 import "DPI-C" function
   void edn_model_rnd_cdc_done(chandle model);
 
+import "DPI-C" function
+  void otp_key_cdc_done(chandle model);
+
 import "DPI-C" context function
   int unsigned otbn_model_step(chandle          model,
-                               logic            start,
                                int unsigned     model_state,
+                               bit       [7:0]  cmd,
                                inout bit [7:0]  status,
                                inout bit [31:0] insn_cnt,
                                inout bit        rnd_req,

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -141,7 +141,7 @@ class OTBNSim:
         '''Run a single cycle.
 
         Returns the instruction, together with a list of the architectural
-        changes that have happened. If the model isn't currently running,
+        changes that have happened. If the model isn't currently executing,
         returns no instruction and no changes.
 
         '''

--- a/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/standalonesim.py
@@ -27,7 +27,7 @@ class StandaloneSim(OTBNSim):
         # ISS will stall at start until URND data is valid; immediately set it
         # valid when in free running mode as nothing else will.
         self.state.wsrs.URND.set_seed(_TEST_URND_DATA)
-        while self.state.running():
+        while self.state.executing():
             self.step(verbose)
             insn_count += 1
 

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -283,7 +283,7 @@ class OTBNState:
         c += self.wdrs.changes()
         return c
 
-    def running(self) -> bool:
+    def executing(self) -> bool:
         return self._fsm_state not in [FsmState.IDLE, FsmState.LOCKED]
 
     def wiping(self) -> bool:

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -436,6 +436,7 @@ class OTBNState:
         # next cycle.
         if self._fsm_state in [FsmState.FETCH_WAIT, FsmState.EXEC]:
             self.ext_regs.write('WIPE_START', 1, True)
+            self.ext_regs.regs['WIPE_START'].commit()
 
         # Switch to a 'wiping' state
         self._next_fsm_state = (FsmState.WIPING_BAD if should_lock

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -149,7 +149,7 @@ def on_step(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
         # The trailing space is a bit naff but matches the behaviour in the RTL
         # tracer, where it's rather difficult to change.
         hdr = 'U ' if sim.state.wiping() else 'V '
-    elif (sim.state.running() or
+    elif (sim.state.executing() or
           (changes and not sim.state.secure_wipe_enabled)):
         hdr = 'STALL'
     else:

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -56,6 +56,10 @@ prefixed with "0x" if they are hexadecimal.
     edn_flush            Flush EDN data from model because of reset signal in
                          EDN clock domain
 
+    otp_key_cdc_done     Lowers the request flag for any external secure wipe
+                         operation. Gets called when we acknowledge incoming
+                         scrambling key in RTL.
+
     invalidate_imem      Mark all of IMEM as having invalid ECC checksums
 
     invalidate_dmem      Mark all of DMEM as having invalid ECC checksums
@@ -121,6 +125,22 @@ def on_start(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     sim.state.ext_regs.commit()
     sim.start(collect_stats=False)
 
+    return None
+
+
+def on_dmem_wipe(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    '''Sets Status register as SecWipeDmem '''
+    check_arg_count('dmem_wipe', 0, args)
+
+    sim.on_dmem_wipe()
+    return None
+
+
+def on_imem_wipe(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    '''Sets Status register as SecWipeImem'''
+    check_arg_count('imem_wipe', 0, args)
+
+    sim.on_imem_wipe()
     return None
 
 
@@ -391,8 +411,18 @@ def on_send_lc_escalation(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
+def on_otp_cdc_done(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('otp_key_cdc_done', 0, args)
+
+    sim.on_otp_cdc_done()
+    return None
+
+
 _HANDLERS = {
     'start': on_start,
+    'dmem_wipe': on_dmem_wipe,
+    'imem_wipe': on_imem_wipe,
+    'otp_key_cdc_done': on_otp_cdc_done,
     'configure': on_configure,
     'step': on_step,
     'load_elf': on_load_elf,

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -22,7 +22,8 @@ interface otbn_model_if
   import uvm_pkg::*;
 
   // Inputs to DUT
-  logic                     start;        // Start the operation
+  logic [7:0]               cmd_q;        // CMD register
+  logic                     cmd_qe;       // CMD register enable
 
   // Outputs from DUT
   bit                       err;          // Something went wrong

--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -25,7 +25,7 @@ module otbn_bind;
     .rst_ni   (rst_ni),
     .reg2hw   (reg2hw),
     .hw2reg   (hw2reg),
-    .done_i   (done_core),
+    .done_i   (done),
     .idle_o_i (idle_o),
 
     .otbn_dmem_scramble_key_req_busy_i(otbn_dmem_scramble_key_req_busy),

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -204,7 +204,8 @@ module tb;
   // to grab the decoded signal from TL transactions on the cycle it happens. We have an explicit
   // check in the scoreboard to ensure that this gets asserted at the time we expect (to spot any
   // decoding errors).
-  assign model_if.start = dut.start_d;
+  assign model_if.cmd_q = dut.reg2hw.cmd.q;
+  assign model_if.cmd_qe = dut.reg2hw.cmd.qe;
 
   // Valid signals below are set when DUT finishes processing incoming 32b packages and constructs
   // 256b EDN data. Model checks if the processing of the packages are done in maximum of 5 cycles
@@ -228,7 +229,8 @@ module tb;
     .rst_ni       (model_if.rst_ni),
     .rst_edn_ni   (edn_rst_n),
 
-    .start_i      (model_if.start),
+    .cmd_i        (model_if.cmd_q),
+    .cmd_en_i     (model_if.cmd_qe),
 
     .lc_escalate_en_i (escalate_if.enable == lc_ctrl_pkg::On),
 

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -210,9 +210,11 @@ module tb;
   // 256b EDN data. Model checks if the processing of the packages are done in maximum of 5 cycles
   logic edn_rnd_cdc_done, edn_rnd_req_model;
   logic edn_urnd_cdc_done, edn_urnd_req_model;
+  logic otp_key_cdc_done;
 
   assign edn_rnd_cdc_done = dut.edn_rnd_req & dut.edn_rnd_ack;
   assign edn_urnd_cdc_done = dut.edn_urnd_req & dut.edn_urnd_ack;
+  assign otp_key_cdc_done = dut.u_otbn_scramble_ctrl.otp_key_ack;
 
   bit [31:0] model_insn_cnt;
 
@@ -232,13 +234,15 @@ module tb;
 
     .err_bits_o   (model_if.err_bits),
 
-    .edn_rnd_i             ({edn_if[0].ack, edn_if[0].d_data}),
-    .edn_rnd_o             (edn_rnd_req_model),
-    .edn_rnd_cdc_done_i    (edn_rnd_cdc_done),
+    .edn_rnd_i           ({edn_if[0].ack, edn_if[0].d_data}),
+    .edn_rnd_o           (edn_rnd_req_model),
+    .edn_rnd_cdc_done_i  (edn_rnd_cdc_done),
 
-    .edn_urnd_i             ({edn_if[1].ack, edn_if[1].d_data}),
-    .edn_urnd_o             (edn_urnd_req_model),
-    .edn_urnd_cdc_done_i    (edn_urnd_cdc_done),
+    .edn_urnd_i          ({edn_if[1].ack, edn_if[1].d_data}),
+    .edn_urnd_o          (edn_urnd_req_model),
+    .edn_urnd_cdc_done_i (edn_urnd_cdc_done),
+
+    .otp_key_cdc_done_i  (otp_key_cdc_done),
 
     .status_o     (model_if.status),
     .insn_cnt_o   (model_insn_cnt),

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -424,7 +424,7 @@ module otbn_top_sim (
     end
   end
   always_ff @(negedge IO_CLK or negedge IO_RST_N) begin
-    if (IO_RST_N && u_otbn_core_model.check_due && u_otbn_core_model.running) begin
+    if (IO_RST_N && u_otbn_core_model.check_due) begin
       OtbnTopDumpState();
     end
   end

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -317,7 +317,8 @@ module otbn_top_sim (
     .rst_ni                ( IO_RST_N ),
     .rst_edn_ni            ( IO_RST_N ),
 
-    .start_i               ( otbn_start ),
+    .cmd_i                 ( otbn_pkg::CmdExecute ),
+    .cmd_en_i              ( otbn_start ),
 
     .lc_escalate_en_i      ( 1'b0 ),
 
@@ -330,6 +331,8 @@ module otbn_top_sim (
     .edn_urnd_i            ( urnd_rsp ),
     .edn_urnd_o            ( ),
     .edn_urnd_cdc_done_i   ( edn_urnd_data_valid ),
+
+    .otp_key_cdc_done_i    ( 1'b0 ),
 
     .status_o              ( ),
     .insn_cnt_o            ( otbn_model_insn_cnt ),


### PR DESCRIPTION
First two commits include minor changes, the last big one is the actual work. We are now using CMD register ports in OTBN model rather than a signal suggesting an execution start. Also we are generating random wipe operations just before loading the ELF file and more importantly keeping track of the related status register changes in DV.