### PR TITLE
[dv] enable tlul_assert for csr part2

### DIFF
--- a/hw/dv/tools/xcelium/cover_reg_top.ccf
+++ b/hw/dv/tools/xcelium/cover_reg_top.ccf
@@ -8,6 +8,7 @@ include_ccf ${dv_root}/tools/xcelium/common.ccf
 // Only collect code coverage on the *_reg_top instance.
 deselect_coverage -betfs -module ${DUT_TOP}...
 select_coverage -befs -module *_reg_top...
+select_coverage -assert -module tlul_assert
 
 // Include toggle coverage on `prim_alert_sender` because the `alert_test` task under
 // `cip_base_vseq` drives `alert_test_i` and verifies `alert_rx/tx` handshake in each IP.


### PR DESCRIPTION
Some assert coverage can be only covered in CSR tests, such as b2b same
address request.

This is part two  of #11482
and addresses a problem that came up in #11433