### PR TITLE
[CDC] Define AST_BYPASS_CLK

### DIFF
--- a/hw/cdc/tools/verixcdc/run-cdc.tcl
+++ b/hw/cdc/tools/verixcdc/run-cdc.tcl
@@ -62,10 +62,11 @@ set ri_max_total_range_bits 100000
 ## Analyze & Elaborate ##
 #########################
 
+# TODO(#11492): Fix the issue of CDC delay
 if {$DEFINE != ""} {
-  analyze -sverilog +define+${DEFINE} -f ${SV_FLIST}
+  analyze -sverilog +define+${DEFINE} +define+AST_BYPASS_CLK -f ${SV_FLIST}
 } else {
-  analyze -sverilog -f ${SV_FLIST}
+  analyze -sverilog  +define+AST_BYPASS_CLK -f ${SV_FLIST}
 }
 
 if {$PARAMS != ""} {


### PR DESCRIPTION
Issue #11492

ast SYNTHESIS does not generate any meaningful clock as they are
replaced to the .db model. Due to the clock, CDC run-time is increased
significantly.

This commit rolls back the AST_BYPASS_CLK definition for a temporary
fix.

The proper solution will be discussed in the issue #11492.