### PR TITLE
[adc_ctrl/dv] Added adc_ctrl_stress_all test

### DIFF
--- a/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
+++ b/hw/ip/adc_ctrl/dv/adc_ctrl_sim_cfg.hjson
@@ -76,17 +76,19 @@
     {
       name: adc_ctrl_filters_wakeup
       uvm_test_seq: adc_ctrl_filters_wakeup_vseq
+      run_opts: ["+test_timeout_ns=2000000000"]
     }
 
     {
       name: adc_ctrl_filters_wakeup_fixed
       uvm_test_seq: adc_ctrl_filters_wakeup_vseq
-      run_opts: ["+filters_fixed=1"]
+      run_opts: ["+filters_fixed=1", "+test_timeout_ns=2000000000"]
     }
 
     {
       name: adc_ctrl_clock_gating
       uvm_test_seq: adc_ctrl_clock_gating_vseq
+      run_opts: ["+test_timeout_ns=2000000000"]
     }
 
     {

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env.core
@@ -31,6 +31,7 @@ filesets:
       - seq_lib/adc_ctrl_lowpower_counter_vseq.sv: {is_include_file: true}
       - seq_lib/adc_ctrl_filters_both_vseq.sv: {is_include_file: true}
       - seq_lib/adc_ctrl_clock_gating_vseq.sv: {is_include_file: true}
+      - seq_lib/adc_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
@@ -11,7 +11,7 @@
 // Wrapper class to allow for multiple instances
 class adc_ctrl_filter_cg_wrapper #(
   // Data width of the ADC CTRL filters
-  int FILTER_WIDTH  = 12,
+  int FILTER_WIDTH  = ADC_CTRL_DATA_WIDTH,
   // Number of values bins to create
   int NUMBER_VALUES = 10
 );

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_clock_gating_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_clock_gating_vseq.sv
@@ -21,8 +21,9 @@ class adc_ctrl_clock_gating_vseq extends adc_ctrl_filters_polled_vseq;
   endtask
 
   virtual task post_start();
-    // Make sure clock is ungated and kill monitor_wakeup process
+    // Make sure clock is ungated and kill background processes
     disable monitor_wakeup;
+    disable check_adc_ctrl_status;
     cfg.clk_rst_vif.start_clk(0);
     super.post_start();
   endtask
@@ -39,6 +40,11 @@ class adc_ctrl_clock_gating_vseq extends adc_ctrl_filters_polled_vseq;
     // Enable interrupts and wakeup
     `DV_CHECK_STD_RANDOMIZE_FATAL(adc_intr_ctl)
     `DV_CHECK_STD_RANDOMIZE_FATAL(adc_wakeup_ctl)
+
+    // Disable interrupts for now
+    // TODO: properly model Interrupt Clock domain crossing
+    adc_intr_ctl = 0;
+
     cfg.testmode = testmode;
     cfg.adc_intr_ctl = adc_intr_ctl;
     cfg.adc_wakeup_ctl = adc_wakeup_ctl;

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_common_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_common_vseq.sv
@@ -5,13 +5,27 @@
 class adc_ctrl_common_vseq extends adc_ctrl_base_vseq;
   `uvm_object_utils(adc_ctrl_common_vseq)
 
-  constraint num_trans_c {
-    num_trans inside {[1:2]};
-  }
+  constraint num_trans_c {num_trans inside {[1 : 2]};}
   `uvm_object_new
+
+  virtual task pre_start();
+    super.pre_start();
+    // Disable ADC_CTRL FSM assertions
+    `DV_ASSERT_CTRL_REQ("ADC_CTRL_FSM_A_CTRL", 0)
+  endtask
+
+  virtual task post_start();
+    super.post_start();
+    // Re-enable ADC_CTRL FSM assertions
+    `DV_ASSERT_CTRL_REQ("ADC_CTRL_FSM_A_CTRL", 1)
+  endtask
 
   virtual task body();
     run_common_vseq_wrapper(num_trans);
+    // Make sure we have valid values in np_sample_cnt lp_sample_cnt to stop assertions firing
+    // Write the reset values
+    csr_wr(ral.adc_sample_ctl, ral.adc_sample_ctl.get_reset());
+    csr_wr(ral.adc_lp_sample_ctl, ral.adc_lp_sample_ctl.get_reset());
     // Short delay to prevent register CDC assertions triggering at the end of test
     cfg.clk_aon_rst_vif.wait_clks(3);
   endtask : body

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_counter_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_counter_vseq.sv
@@ -38,6 +38,9 @@ class adc_ctrl_counter_vseq extends adc_ctrl_base_vseq;
     super.post_start();
     // Reenable assertions
     `DV_ASSERT_CTRL_REQ("ADC_IF_A_CTRL", 1)
+    // Randomize cfg to get reasonable values for pwrup_time and wakeup_time for
+    // a subsequent sequence if this sequence is used in a stress test
+    `DV_CHECK_RANDOMIZE_FATAL(cfg)
   endtask
 
   virtual task body();

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_both_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_both_vseq.sv
@@ -8,6 +8,12 @@ class adc_ctrl_filters_both_vseq extends adc_ctrl_filters_polled_vseq;
 
   `uvm_object_new
 
+  virtual task post_start();
+    // Kill background processes
+    disable check_adc_ctrl_status;
+    super.post_start();
+  endtask
+
   virtual task configure_adc_ctrl();
     adc_ctrl_testmode_e testmode;
     bit [ADC_CTRL_NUM_FILTERS:0] adc_intr_ctl;
@@ -45,6 +51,10 @@ class adc_ctrl_filters_both_vseq extends adc_ctrl_filters_polled_vseq;
         csr_wr(ral.adc_intr_status, $urandom());
         csr_wr(ral.filter_status, $urandom());
         csr_wr(ral.intr_state, $urandom());
+      end else begin
+        // Otherwise check the adc_chn_val registers
+        csr_rd(ral.adc_chn_val[0], rdata);
+        csr_rd(ral.adc_chn_val[1], rdata);
       end
     end
   endtask

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_interrupt_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_interrupt_vseq.sv
@@ -9,6 +9,12 @@ class adc_ctrl_filters_interrupt_vseq extends adc_ctrl_filters_polled_vseq;
 
   `uvm_object_new
 
+  virtual task post_start();
+    // Kill background processes
+    disable check_adc_ctrl_status;
+    super.post_start();
+  endtask
+
   virtual task configure_adc_ctrl();
     bit [ADC_CTRL_NUM_FILTERS:0] adc_intr_ctl;
     super.configure_adc_ctrl();
@@ -35,6 +41,10 @@ class adc_ctrl_filters_interrupt_vseq extends adc_ctrl_filters_polled_vseq;
         csr_wr(ral.adc_intr_status, $urandom());
         csr_wr(ral.filter_status, $urandom());
         csr_wr(ral.intr_state, $urandom());
+      end else begin
+        // Otherwise check the adc_chn_val registers
+        csr_rd(ral.adc_chn_val[0], rdata);
+        csr_rd(ral.adc_chn_val[1], rdata);
       end
     end
   endtask

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_wakeup_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_wakeup_vseq.sv
@@ -9,6 +9,12 @@ class adc_ctrl_filters_wakeup_vseq extends adc_ctrl_filters_polled_vseq;
 
   `uvm_object_new
 
+  virtual task post_start();
+    // Kill background processes
+    disable check_adc_ctrl_status;
+    super.post_start();
+  endtask
+
   virtual task configure_adc_ctrl();
     bit [ADC_CTRL_NUM_FILTERS-1:0] adc_wakeup_ctl;
     super.configure_adc_ctrl();

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_stress_all_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_stress_all_vseq.sv
@@ -1,0 +1,62 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// combine all adc_ctrl seqs (except below seqs) in one seq to run sequentially
+// 1. csr seq, which requires scb to be disabled
+// 2. adc_ctrl_rx_oversample_vseq, which requires zero_delays as it's very timing sensitive
+class adc_ctrl_stress_all_vseq extends adc_ctrl_base_vseq;
+  `uvm_object_utils(adc_ctrl_stress_all_vseq)
+
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[2 : 5]};}
+
+  virtual task pre_start();
+    // Disable read of intr_state at the end of the sequence
+    do_clear_all_interrupts = 0;
+    super.pre_start();
+  endtask
+
+  task body();
+    string seq_names[] = {"adc_ctrl_smoke_vseq",
+                          "adc_ctrl_filters_polled_vseq",
+                          "adc_ctrl_filters_interrupt_vseq",
+                          "adc_ctrl_filters_both_vseq",
+                          "adc_ctrl_clock_gating_vseq",
+                          "adc_ctrl_poweron_counter_vseq",
+                          "adc_ctrl_lowpower_counter_vseq",
+                          "adc_ctrl_fsm_reset_vseq",
+                          "adc_ctrl_common_vseq"};
+
+    // Short delay after initial reset
+    cfg.clk_rst_vif.wait_clks($urandom_range(10, 5));
+
+    for (int i = 1; i <= num_trans; i++) begin
+      uvm_sequence seq;
+      adc_ctrl_base_vseq adc_ctrl_vseq;
+      uint seq_idx = $urandom_range(0, seq_names.size - 1);
+      // Test sequences which take a long time - restrict to one iteration
+      bit long_test = seq_names[seq_idx] inside {"adc_ctrl_filters_polled_vseq",
+        "adc_ctrl_filters_interrupt_vseq", "adc_ctrl_filters_both_vseq",
+        "adc_ctrl_clock_gating_vseq"};
+
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+
+      seq = create_seq_by_name(seq_names[seq_idx]);
+      `downcast(adc_ctrl_vseq, seq)
+
+      adc_ctrl_vseq.set_sequencer(p_sequencer);
+      `DV_CHECK_RANDOMIZE_WITH_FATAL(adc_ctrl_vseq, if (long_test) num_trans == 1;)
+      if (seq_names[seq_idx] == "adc_ctrl_common_vseq") begin
+        adc_ctrl_common_vseq common_vseq;
+        `downcast(common_vseq, adc_ctrl_vseq);
+        common_vseq.common_seq_type = "intr_test";
+      end
+      `uvm_info(`gfn, $sformatf("body: executing sequence %s", adc_ctrl_vseq.get_type_name()),
+                UVM_LOW)
+      adc_ctrl_vseq.start(p_sequencer);
+
+    end
+  endtask : body
+endclass

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_vseq_list.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_vseq_list.sv
@@ -15,4 +15,5 @@
 `include "adc_ctrl_fsm_reset_vseq.sv"
 `include "adc_ctrl_filters_both_vseq.sv"
 `include "adc_ctrl_clock_gating_vseq.sv"
+`include "adc_ctrl_stress_all_vseq.sv"
 

--- a/hw/ip/adc_ctrl/dv/tb.sv
+++ b/hw/ip/adc_ctrl/dv/tb.sv
@@ -264,6 +264,7 @@ module tb;
   `DV_ASSERT_CTRL("PwrupTime_A_CTRL", PwrupTime_A)
   `DV_ASSERT_CTRL("WakeupTime_A_CTRL", WakeupTime_A)
   `DV_ASSERT_CTRL("EnterLowPower_A_CTRL", EnterLowPower_A)
+  `DV_ASSERT_CTRL("ADC_CTRL_FSM_A_CTRL", dut.u_adc_ctrl_core.u_adc_ctrl_fsm)
 
 endmodule
 


### PR DESCRIPTION
- Added tests
  - adc_ctrl_stress_all
- Added test sequences
  - adc_ctrl_stress_all_vseq - runs a random choice of the others test sequences
- Fixed adc_ctrl_intr - Disabled scoreboard and enabled autopredict
- Fixed adc_ctrl_bit_bash - Added assertion control ADC_CTRL_FSM_A_CTRL
- Fixed adc_ctrl_clock_gating - Disabled interrupts for this test
- Corrected filter parameter coverage
- Enhanced variable filter config constraints to generate maximum and
minimum values for min_v and max_v
- Added reads of channel value registers to interrupt/both tests
- Aligned capture of interrupt channel values in model with RTL
- Modelling intr_test in scoreboard
- Added interrupt cover groups sampling to scoreboard

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>