### PR TITLE
[otl_ctrl RTL, chip dv] Fix AST initialization routine

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -40,7 +40,11 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   //
   // In closed source, tests can modify this data directly in the extended sequence's dut_init(),
   // before invoking super.dut_init(), or any other suitable place.
-  rand uint creator_sw_cfg_ast_cfg_data[ast_pkg::AstRegsNum - 1];
+  rand uint creator_sw_cfg_ast_cfg_data[ast_pkg::AstRegsNum];
+
+  // A knob that controls whether the AST initialization is done, enabled by default.
+  // Can be updated with plusarg.
+  bit do_creator_sw_cfg_ast_cfg = 1;
 
   // sw related
   // Directory from where to pick up the SW test images -default to PWD {run_dir}.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -124,9 +124,15 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
 
   // Initialize the OTP creator SW cfg region with AST configuration data.
   virtual function void initialize_otp_creator_sw_cfg_ast_cfg();
-    // Ensure that the allocated size of the AST cfg region in OTP is greater than the number of AST
+    // The knob controls whether the AST is actually programmed.
+    if (cfg.do_creator_sw_cfg_ast_cfg) begin
+      cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
+                                       prim_mubi_pkg::MuBi4True);
+    end
+
+    // Ensure that the allocated size of the AST cfg region in OTP is equal to the number of AST
     // registers to be programmed.
-    `DV_CHECK_GE_FATAL(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgSize, ast_pkg::AstLastRegOffset)
+    `DV_CHECK_EQ_FATAL(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgSize, ast_pkg::AstRegsNum * 4)
     foreach (cfg.creator_sw_cfg_ast_cfg_data[i]) begin
       `uvm_info(`gfn, $sformatf({"OTP: Preloading creator_sw_cfg_ast_cfg_data[%0d] with 0x%0h ",
                                  "via backdoor"}, i, cfg.creator_sw_cfg_ast_cfg_data[i]),
@@ -134,8 +140,6 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
       cfg.mem_bkdr_util_h[Otp].write32(
           otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset + i * 4, cfg.creator_sw_cfg_ast_cfg_data[i]);
     end
-    cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset,
-                                     prim_mubi_pkg::MuBi4True);
   endfunction
 
 endclass : chip_base_vseq

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_stub_cpu_base_vseq.sv
@@ -65,20 +65,16 @@ class chip_stub_cpu_base_vseq extends chip_base_vseq;
     // initialization and asserts the `ast_init_done_o` signal.
     uvm_reg_addr_t ast_addr = ral.ast.default_map.get_base_addr();
 
-    for (int i = 0; i < ast_pkg::AstRegsNum - 1; i++) begin
-      data = cfg.mem_bkdr_util_h[Otp].read32(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset + i * 4);
-      `uvm_info(`gfn, $sformatf("Writing 0x%0h to 0x%0h", data, ast_addr), UVM_MEDIUM)
-      tl_access(.addr(ast_addr), .write(1), .data(data));
-      predict_csr_wr(ral.get_default_map(), ast_addr, data);
-      ast_addr += 4;
+    if (cfg.mem_bkdr_util_h[Otp].read32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset) ==
+        prim_mubi_pkg::MuBi4True) begin
+      for (int i = 0; i < ast_pkg::AstRegsNum; i++) begin
+        data = cfg.mem_bkdr_util_h[Otp].read32(otp_ctrl_reg_pkg::CreatorSwCfgAstCfgOffset + i * 4);
+        `uvm_info(`gfn, $sformatf("Writing 0x%0h to 0x%0h", data, ast_addr), UVM_MEDIUM)
+        tl_access(.addr(ast_addr), .write(1), .data(data));
+        predict_csr_wr(ral.get_default_map(), ast_addr, data);
+        ast_addr += 4;
+      end
     end
-
-    // The next ast_addr finalizes the AST initialization.
-    data = cfg.mem_bkdr_util_h[Otp].read32(otp_ctrl_reg_pkg::CreatorSwCfgAstInitEnOffset);
-    `uvm_info(`gfn, $sformatf("Writing 0x%0h to 0x%0h to finalize the AST initialization",
-                              data, ast_addr), UVM_MEDIUM)
-    tl_access(.addr(ast_addr), .write(1), .data(data));
-    predict_csr_wr(ral.get_default_map(), ast_addr, data);
   endtask
 
   // Finds the register associated with the given address in the given map, and updates the

--- a/hw/top_earlgrey/dv/tests/chip_base_test.sv
+++ b/hw/top_earlgrey/dv/tests/chip_base_test.sv
@@ -60,6 +60,9 @@ class chip_base_test extends cip_base_test #(
       cfg.parse_sw_images_string(sw_images_plusarg);
     end
 
+    // Knob to perform the AST configuration.
+    void'($value$plusargs("do_creator_sw_cfg_ast_cfg=%0b", cfg.do_creator_sw_cfg_ast_cfg));
+
     // Override the initial AST configuration data at runtime via plusarg.
     foreach (cfg.creator_sw_cfg_ast_cfg_data[i]) begin
       void'($value$plusargs({$sformatf("creator_sw_cfg_ast_cfg_data[%0d]", i), "=%0h"},


### PR DESCRIPTION
Fixes #11504. 

This commit adds a knob to control whether the AST init if even done, via a plusarg that will work for both, SW and non SW tests. It also improves and fixes a bug in the previous code. 