### PR TITLE
[dv/otp] Add mubi cov and implementations for V2S

### DIFF
--- a/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
+++ b/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
@@ -14,4 +14,28 @@ module otp_ctrl_cov_bind;
     .otbn_otp_key_i   (otbn_otp_key_i)
   );
 
+  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_creator_seed_sw_rw_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_creator_seed_sw_rw_en_i)
+  );
+
+  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_seed_hw_rd_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_seed_hw_rd_en_i)
+  );
+
+  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_dft_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_dft_en_i)
+  );
+
+  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_escalate_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_escalate_en_i)
+  );
+
+  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_check_byp_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_check_byp_en_i)
+  );
 endmodule

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -241,16 +241,6 @@ package otp_ctrl_env_pkg;
     return dai_addr + SW_WINDOW_BASE_ADDR;
   endfunction
 
-  // This function randomizes lc_tx_t with 25% lc_ctrl_pkg::On, 25% lc_ctrl_pkg::Off,
-  // and 50% random values
-  function automatic lc_ctrl_pkg::lc_tx_t randomize_lc_tx_t_val();
-    randomize_lc_tx_t_val = $urandom();
-    if ($urandom_range(0, 1)) begin
-      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(randomize_lc_tx_t_val,
-          randomize_lc_tx_t_val inside {lc_ctrl_pkg::On, lc_ctrl_pkg::Off};, , "otp_ctrl_env_pkg")
-    end
-  endfunction
-
   function automatic bit [TL_DW-1:0] normalize_dai_addr(bit [TL_DW-1:0] dai_addr);
     normalize_dai_addr = (is_secret(dai_addr) || is_digest(dai_addr)) ? dai_addr >> 3 << 3 :
                                                                         dai_addr >> 2 << 2;

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -29,6 +29,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   import otp_ctrl_pkg::*;
   import otp_ctrl_reg_pkg::*;
   import otp_ctrl_part_pkg::*;
+  import cip_base_pkg::*;
 
   // Output from DUT
   otp_hw_cfg_t       otp_hw_cfg_o;
@@ -87,7 +88,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
       lc_prog_err_dly1  <= 0;
       lc_esc_dly1       <= lc_ctrl_pkg::Off;
       lc_esc_dly2       <= lc_ctrl_pkg::Off;
-      lc_check_byp_en_i <= randomize_lc_tx_t_val();
+      lc_check_byp_en_i <= get_rand_lc_tx_val();
       lc_esc_on         <= 0;
     end else begin
       lc_prog_err_dly1 <= lc_prog_err;
@@ -96,7 +97,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
       if (lc_prog_req) begin
         lc_check_byp_en_i <= lc_check_byp_en ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off;
       end
-      if (lc_esc_dly2 == lc_ctrl_pkg::On && !lc_esc_on) begin
+      if (lc_esc_dly2 != lc_ctrl_pkg::Off && !lc_esc_on) begin
         lc_esc_on <= 1;
       end
     end

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -613,7 +613,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
           end else begin
             if (cfg.en_cov && part_idx == Secret2Idx) begin
               cov.dai_access_secret2_cg.sample(
-                  !(cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i == lc_ctrl_pkg::Off),
+                  !(cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On),
                   item.a_data);
             end
 
@@ -640,7 +640,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                     // If the partition is secret2 and lc_creator_seed_sw_rw is disable, then
                     // return access error.
                     (part_idx == Secret2Idx && !is_digest(dai_addr) &&
-                     cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i == lc_ctrl_pkg::Off)) begin
+                     cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On)) begin
                   predict_err(OtpDaiErrIdx, OtpAccessError);
                   predict_rdata(is_secret(dai_addr) || is_digest(dai_addr), 0, 0);
 
@@ -691,7 +691,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
                 // check if write locked
                 if (get_digest_reg_val(part_idx) != 0 ||
                     (part_idx == Secret2Idx && !is_digest(dai_addr) &&
-                     cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i == lc_ctrl_pkg::Off)) begin
+                     cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On)) begin
                   predict_err(OtpDaiErrIdx, OtpAccessError);
                 end else begin
                   predict_no_err(OtpDaiErrIdx);
@@ -1035,7 +1035,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
       predict_err(OtpDaiErrIdx, OtpAccessError);
       return;
     end else if (part_idx == Secret2Idx &&
-                 cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i == lc_ctrl_pkg::Off) begin
+                 cfg.otp_ctrl_vif.lc_creator_seed_sw_rw_en_i != lc_ctrl_pkg::On) begin
       predict_err(OtpDaiErrIdx, OtpAccessError);
       return;
     end else begin

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -72,10 +72,10 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task otp_ctrl_vif_init();
-    cfg.otp_ctrl_vif.drive_lc_creator_seed_sw_rw_en(On);
-    cfg.otp_ctrl_vif.drive_lc_seed_hw_rd_en(randomize_lc_tx_t_val());
-    cfg.otp_ctrl_vif.drive_lc_dft_en(Off);
-    cfg.otp_ctrl_vif.drive_lc_escalate_en(Off);
+    cfg.otp_ctrl_vif.drive_lc_creator_seed_sw_rw_en(lc_ctrl_pkg::On);
+    cfg.otp_ctrl_vif.drive_lc_seed_hw_rd_en(get_rand_lc_tx_val());
+    cfg.otp_ctrl_vif.drive_lc_dft_en(get_rand_lc_tx_val(.t_weight(0)));
+    cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
     cfg.otp_ctrl_vif.drive_pwr_otp_init(0);
     cfg.otp_ctrl_vif.drive_ext_voltage_h_io(1'bz);
 
@@ -147,7 +147,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     // - zero delays in TLUL interface, otherwise dai operation might be finished before reading
     //   these two CSRs
     if (cfg.zero_delays && is_valid_dai_op &&
-        cfg.otp_ctrl_vif.lc_escalate_en_i != lc_ctrl_pkg::On) begin
+        cfg.otp_ctrl_vif.lc_escalate_en_i == lc_ctrl_pkg::Off) begin
       csr_rd_check(ral.status.dai_idle, .compare_value(0), .backdoor(1));
       if ($urandom_range(0, 1)) csr_rd(.ptr(ral.direct_access_regwen), .value(val));
     end
@@ -166,7 +166,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     csr_wr(ral.direct_access_cmd, int'(otp_ctrl_pkg::DaiRead));
 
     if (cfg.zero_delays && is_valid_dai_op &&
-        cfg.otp_ctrl_vif.lc_escalate_en_i != lc_ctrl_pkg::On) begin
+        cfg.otp_ctrl_vif.lc_escalate_en_i == lc_ctrl_pkg::Off) begin
       csr_rd_check(ral.status.dai_idle, .compare_value(0), .backdoor(1));
       if ($urandom_range(0, 1)) csr_rd(.ptr(ral.direct_access_regwen), .value(val));
     end
@@ -195,7 +195,7 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     csr_wr(ral.direct_access_cmd, otp_ctrl_pkg::DaiDigest);
 
     if (cfg.zero_delays && is_valid_dai_op &&
-        cfg.otp_ctrl_vif.lc_escalate_en_i != lc_ctrl_pkg::On) begin
+        cfg.otp_ctrl_vif.lc_escalate_en_i == lc_ctrl_pkg::Off) begin
       csr_rd_check(ral.status.dai_idle, .compare_value(0), .backdoor(1));
       if ($urandom_range(0, 1)) csr_rd(.ptr(ral.direct_access_regwen), .value(val));
     end

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_dai_lock_vseq.sv
@@ -59,8 +59,10 @@ class otp_ctrl_dai_lock_vseq extends otp_ctrl_smoke_vseq;
 
   virtual task dut_init(string reset_kind = "HARD");
     super.dut_init(reset_kind);
-    if ($urandom_range(0, 1)) cfg.otp_ctrl_vif.drive_lc_creator_seed_sw_rw_en(lc_ctrl_pkg::Off);
-  endtask;
+    if ($urandom_range(0, 1)) begin
+      cfg.otp_ctrl_vif.drive_lc_creator_seed_sw_rw_en(get_rand_lc_tx_val(.t_weight(0)));
+    end
+  endtask
 
 endclass
 

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_parallel_lc_esc_vseq.sv
@@ -51,7 +51,7 @@ class otp_ctrl_parallel_lc_esc_vseq extends otp_ctrl_dai_lock_vseq;
     endcase
     cfg.clk_rst_vif.wait_clks($urandom_range(0, 50));
 
-    cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::On);
+    cfg.otp_ctrl_vif.drive_lc_escalate_en(get_rand_lc_tx_val(.f_weight(0)));
 
     // TODO: in alert_esc_monitor, makes it auto-response like push-pull agent
     if (en_auto_alerts_response && cfg.list_of_alerts.size()) run_alert_rsp_seq_nonblocking();

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -193,27 +193,27 @@ module tb;
   initial begin
     // These SVA checks the lc_escalate_en is either Off or On, we will use more than these
     // 2 values.
-    // If it's not Off, it should be On.
+    // If the value is not lc_ctrl_pkg::Off, design will treat it as lc_ctrl_pkg::On.
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.PrimLcSyncCheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.PrimLcSyncCheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_escalate_en.PrimLcSyncCheckTransients1_A);
 
     // These SVA checks the lc_sync_seed_hw_rd_en is either Off or On, we will use more than these
     // 2 values.
-    // If it's not On, it should be Off.
+    // If the value is not lc_ctrl_pkg::On, design will treat it as lc_ctrl_pkg::Off.
     $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.PrimLcSyncCheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.PrimLcSyncCheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_seed_hw_rd_en.PrimLcSyncCheckTransients1_A);
 
     // These SVA checks the lc_check_byp_en is either Off or On, we will use more than these
     // 2 values.
-    // If it's not On, it should be Off.
+    // If the value is not lc_ctrl_pkg::On, design will treat it as lc_ctrl_pkg::Off.
     $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients1_A);
 
     // These SVA checks the lc_dft_en is either Off or On, we will use more than these 2 values.
-    // If it's not On, it should be Off.
+    // If the value is not lc_ctrl_pkg::On, design will treat it as lc_ctrl_pkg::Off.
     $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients1_A);
@@ -223,7 +223,7 @@ module tb;
 
     // These SVA checks the lc_sync_creator_seed_sw_rw_en is either Off or On, we will use more
     // than these 2 values.
-    // If it's not On, it should be Off.
+    // If the value is not lc_ctrl_pkg::On, design will treat it as lc_ctrl_pkg::Off.
     $assertoff(0, tb.dut.u_prim_lc_sync_creator_seed_sw_rw_en.PrimLcSyncCheckTransients_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_creator_seed_sw_rw_en.PrimLcSyncCheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_creator_seed_sw_rw_en.PrimLcSyncCheckTransients1_A);

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -212,6 +212,22 @@ module tb;
     $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients0_A);
     $assertoff(0, tb.dut.u_prim_lc_sync_check_byp_en.PrimLcSyncCheckTransients1_A);
 
+    // These SVA checks the lc_dft_en is either Off or On, we will use more than these 2 values.
+    // If it's not On, it should be Off.
+    $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_dft_en.PrimLcSyncCheckTransients1_A);
+    $assertoff(0, tb.dut.u_tlul_lc_gate.u_prim_lc_sync.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_tlul_lc_gate.u_prim_lc_sync.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_tlul_lc_gate.u_prim_lc_sync.PrimLcSyncCheckTransients1_A);
+
+    // These SVA checks the lc_sync_creator_seed_sw_rw_en is either Off or On, we will use more
+    // than these 2 values.
+    // If it's not On, it should be Off.
+    $assertoff(0, tb.dut.u_prim_lc_sync_creator_seed_sw_rw_en.PrimLcSyncCheckTransients_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_creator_seed_sw_rw_en.PrimLcSyncCheckTransients0_A);
+    $assertoff(0, tb.dut.u_prim_lc_sync_creator_seed_sw_rw_en.PrimLcSyncCheckTransients1_A);
+
     // DV forced otp_cmd_i to reach invalid state, thus violate the assertions
     $assertoff(0, tb.dut.gen_partitions[3].gen_buffered.u_part_buf.OtpErrorState_A);
     $assertoff(0, tb.dut.gen_partitions[4].gen_buffered.u_part_buf.OtpErrorState_A);


### PR DESCRIPTION
This PR has two commits:
1). Some mubi inputs I did not randomize their values rather than just On and Off.
     So this PR randomize all of them and add supports in sequence and scb accordingly.
     Also remove the local `randomize_lc_tx_t_val` and use cip_base_pkg's `get_rand_lc_tx_val` instead.
2). Bind mubi coverages for all the ports that are mubi types.