### PR TITLE
[dv/doc] Update dv resource note

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl.prj.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl.prj.hjson
@@ -13,5 +13,4 @@
     design_stage:       "D2S",
     verification_stage: "V1",
     dif_stage:          "S0",
-    notes:              "DV resource allocation pending.",
 }

--- a/hw/ip/flash_ctrl/data/flash_ctrl.prj.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.prj.hjson
@@ -27,7 +27,6 @@
             design_stage:       "D2",
             verification_stage: "V1",
             dif_stage:          "S0",
-            notes:              "DV resource allocation pending.",
         },
     ]
 }

--- a/hw/ip/gpio/data/gpio.prj.hjson
+++ b/hw/ip/gpio/data/gpio.prj.hjson
@@ -23,7 +23,6 @@
         design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S2",
-        notes:              "Rolled back to D2 as the register module is updated",
       }
     ]
 }

--- a/hw/ip/rv_timer/data/rv_timer.prj.hjson
+++ b/hw/ip/rv_timer/data/rv_timer.prj.hjson
@@ -23,7 +23,6 @@
         design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S2",
-        notes:              "Rolled back to D2 as the register module is updated",
       }
     ]
 }

--- a/hw/ip/sysrst_ctrl/data/sysrst_ctrl.prj.hjson
+++ b/hw/ip/sysrst_ctrl/data/sysrst_ctrl.prj.hjson
@@ -13,5 +13,4 @@
     design_stage:       "D2S",
     verification_stage: "V1",
     dif_stage:          "S0",
-    notes:              "DV resource allocation pending.",
 }

--- a/hw/ip/uart/data/uart.prj.hjson
+++ b/hw/ip/uart/data/uart.prj.hjson
@@ -23,7 +23,6 @@
         design_stage:       "D2S",
         verification_stage: "V2",
         dif_stage:          "S2",
-        notes:              "Rolled back to D2 as the register module is updated"
       }
     ]
 }

--- a/hw/ip/usbdev/data/usbdev.prj.hjson
+++ b/hw/ip/usbdev/data/usbdev.prj.hjson
@@ -13,5 +13,4 @@
     design_stage:       "D2S",
     verification_stage: "V0",
     dif_stage:          "S1",
-    notes:              "DV resource allocation pending.",
 }


### PR DESCRIPTION
Clean up dashboard HW status:
This PR removes four blocks' comments about pending DV resource.
Also remove the comments about "Rolled back to D2 as the register module is updated"


Signed-off-by: Cindy Chen <chencindy@opentitan.org>