### PR TITLE
[pwrmgr bug] local timeout doesn't occur when

### DIFF
--- a/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -25,57 +25,88 @@
   testpoints: [
     {
       name: sec_cm_bus_integrity
-      desc: "Verify the countermeasure(s) BUS.INTEGRITY."
+      desc: '''
+            Verify the countermeasure(s) BUS.INTEGRITY.
+            This entry is covered by tl_access_test
+            (hw/dv/tools/dvsim/tests/tl_access_tests.hjson)
+            '''
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_tl_intg_err"]
     }
     {
       name: sec_cm_lc_ctrl_intersig_mubi
-      desc: "Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI."
+      desc: '''
+            Verify the countermeasure(s) LC_CTRL.INTERSIG.MUBI.
+
+            **Stimulus**:
+            - Use comprehensive stimulus - reset and wakeup -
+              as background traffic to ensure this counter measure
+              is valid for various states of fast and slow fsm.
+            - Drive lc_hw_debug_en_i and lc_dft_en_i with
+              mixed valid and invalid values.
+
+            **Check**:
+            - Collect coverage by binding cip_mubi_cov_if to
+              tb.dut.lc_hw_debug_en_i and tb.dut.lc_dft_en_i
+            - Add assertion to check whether rom_intg_chk_dis
+              is set to '1' only when lc_dft_en_i or lc_hw_debug_en_i
+              is high.
+            '''
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_sec_cm_lc_ctrl_intersig_mubi"]
     }
     {
       name: sec_cm_rom_ctrl_intersig_mubi
-      desc: "Verify the countermeasure(s) ROM_CTRL.INTERSIG.MUBI."
+      desc: '''
+            Verify the countermeasure(s) ROM_CTRL.INTERSIG.MUBI.
+
+            - Use comprehensive stimulus - reset and wakeup -
+              as background traffic to ensure this counter measure
+              is valid for various states of fast and slow fsm.
+            - Drive rom_ctrl_i with mixed valid and invalid values.
+
+            **Check**:
+            - Collect coverage by binding cip_mubi_cov_if to
+              tb.dut.rom_ctrl_i
+            '''
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_sec_cm_rom_ctrl_intersig_mubi"]
     }
     {
       name: sec_cm_rstmgr_intersig_mubi
       desc: "Verify the countermeasure(s) RSTMGR.INTERSIG.MUBI."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_sec_cm_rstmgr_intersig_mubi"]
     }
     {
       name: sec_cm_esc_rx_clk_bkgn_chk
       desc: "Verify the countermeasure(s) ESC_RX.CLK.BKGN_CHK."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_esc_clk_rst_malfunc"]
     }
     {
       name: sec_cm_esc_rx_clk_local_esc
       desc: "Verify the countermeasure(s) ESC_RX.CLK.LOCAL_ESC."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_sec_cm"]
     }
     {
       name: sec_cm_fsm_sparse
       desc: "Verify the countermeasure(s) FSM.SPARSE."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_sec_cm"]
     }
     {
       name: sec_cm_fsm_local_esc
       desc: "Verify the countermeasure(s) FSM.LOCAL_ESC."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_sec_cm"]
     }
     {
       name: sec_cm_ctrl_flow_global_esc
       desc: "Verify the countermeasure(s) CTRL_FLOW.GLOBAL_ESC."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_sec_cm"]
     }
     {
       name: sec_cm_main_pd_rst_local_esc
@@ -93,13 +124,13 @@
       name: sec_cm_wakeup_config_regwen
       desc: "Verify the countermeasure(s) WAKEUP.CONFIG.REGWEN."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_csr_rw"]
     }
     {
       name: sec_cm_reset_config_regwen
       desc: "Verify the countermeasure(s) RESET.CONFIG.REGWEN."
       milestone: V2S
-      tests: []
+      tests: ["pwrmgr_csr_rw"]
     }
   ]
 }

--- a/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_testplan.hjson
@@ -8,6 +8,8 @@
                      "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                      "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_count_testplan.hjson",
+                     "hw/dv/tools/dvsim/testplans/sec_cm_fsm_testplan.hjson",
                      // TODO: Top-level specific Hjson imported here. This will likely be resolved
                      // once we move to IPgen flow.
                      "hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson"]

--- a/hw/ip/pwrmgr/dv/cov/pwrmgr_cov_bind.sv
+++ b/hw/ip/pwrmgr/dv/cov/pwrmgr_cov_bind.sv
@@ -1,0 +1,27 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Add description here TBD
+module pwrmgr_cov_bind;
+
+  bind pwrmgr cip_mubi_cov_if #(.Width(lc_ctrl_pkg::TxWidth)) u_lc_dft_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_dft_en_i)
+  );
+
+  bind pwrmgr cip_mubi_cov_if #(.Width(lc_ctrl_pkg::TxWidth)) u_lc_hw_debug_en_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (lc_hw_debug_en_i)
+  );
+
+  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width*2)) u_rom_ctrl_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (rom_ctrl_i)
+  );
+
+  bind pwrmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_sw_rst_req_mubi_cov_if (
+    .rst_ni (rst_ni),
+    .mubi   (sw_rst_req_i)
+  );
+endmodule // pwrmgr_cov_bind

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
@@ -27,6 +27,9 @@ filesets:
       - seq_lib/pwrmgr_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_wakeup_reset_vseq.sv: {is_include_file: true}
       - seq_lib/pwrmgr_wakeup_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_sw_reset_vseq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -30,6 +30,9 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
     num_interrupts = ral.intr_state.get_n_used_bits();
     `ASSERT_I(NumInstrMatch_A, num_interrupts == NUM_INTERRUPTS)
     `uvm_info(`gfn, $sformatf("num_interrupts = %0d", num_interrupts), UVM_MEDIUM)
+
+    // pwrmgr_tl_intg_err test uses default alert name "fata_fault"
+    // and it requires following field to be '1'
     tl_intg_alert_fields[ral.fault_status.reg_intg_err] = 1;
     m_tl_agent_cfg.max_outstanding_req = 1;
     m_esc_agent_cfg = alert_esc_agent_cfg::type_id::create("m_esc_agent_cfg");

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
@@ -18,7 +18,7 @@ package pwrmgr_env_pkg;
   import prim_mubi_pkg::mubi4_t;
   import prim_mubi_pkg::MuBi4False;
   import prim_mubi_pkg::MuBi4True;
-
+  import sec_cm_pkg::*;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"
@@ -39,6 +39,12 @@ package pwrmgr_env_pkg;
     WakeupAonTimer,
     WakeupSensorCtrl
   } wakeup_e;
+
+  typedef enum int {
+    PwrmgrMubiNone = 0,
+    PwrmgrMubiLcCtrl = 1,
+    PwrmgrMubiRomCtrl = 2
+  } pwrmgr_mubi_e;
 
   typedef struct packed {
     logic main_pd_n;

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_if.sv
@@ -38,6 +38,8 @@ interface pwrmgr_if (
   pwrmgr_pkg::pwr_cpu_t                                        pwr_cpu;
 
   lc_ctrl_pkg::lc_tx_t                                         fetch_en;
+  lc_ctrl_pkg::lc_tx_t                                         lc_hw_debug_en;
+  lc_ctrl_pkg::lc_tx_t                                         lc_dft_en;
 
   logic                       [  pwrmgr_reg_pkg::NumWkups-1:0] wakeups_i;
 

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -111,6 +111,8 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
   endfunction
 
   task pre_start();
+    cfg.pwrmgr_vif.lc_hw_debug_en = lc_ctrl_pkg::Off;
+    cfg.pwrmgr_vif.lc_dft_en = lc_ctrl_pkg::Off;
     if (do_pwrmgr_init) pwrmgr_init();
     disable_unnecessary_exclusions();
     cfg.slow_clk_rst_vif.wait_for_reset(.wait_negedge(0));

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_common_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_common_vseq.sv
@@ -12,4 +12,11 @@ class pwrmgr_common_vseq extends pwrmgr_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
+    bit[TL_DW-1:0] exp;
+
+    super.check_sec_cm_fi_resp(if_proxy);
+
+    `uvm_info(`gfn, $sformatf("JDONDBG: sec_cm_type %s", if_proxy.sec_cm_type.name), UVM_MEDIUM)
+  endtask // check_sec_cm_fi_resp
 endclass

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_esc_clk_rst_malfunc_vseq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_esc_clk_rst_malfunc_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_esc_clk_rst_malfunc_vseq)
+
+  constraint num_trans_c {num_trans inside {[1 : 2]};}
+  `uvm_object_new
+
+  virtual task body();
+    `uvm_info(`gfn, $sformatf("JDONDBG:I am body"), UVM_MEDIUM)
+    // before body, fast state become active state
+    #1us;
+    repeat(10)begin
+      add_noise();
+      clear_noise();
+    end
+
+  endtask : body
+
+  task add_noise();
+    int delay = $urandom_range(10,50);
+    randcase
+      1:void'(uvm_hdl_force("tb.dut.rst_esc_ni", 0));
+      1:void'(uvm_hdl_force("tb.dut.clk_esc_i", 0));
+    endcase // randcase
+    #(delay * 1us);
+  endtask // add_noise
+
+  task clear_noise();
+    int delay = $urandom_range(1,5);
+    void'(uvm_hdl_release("tb.dut.rst_esc_ni"));
+    void'(uvm_hdl_release("tb.dut.clk_esc_i"));
+    #(delay * 100ns);
+  endtask // clear_noise
+endclass

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_repeat_wakeup_reset_vseq.sv
@@ -1,0 +1,256 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The wakeup_reset test randomly enables wakeups and resets, info capture, and interrupts,
+// and sends wakeups and resets in close temporal proximity at random times.
+class pwrmgr_repeat_wakeup_reset_vseq extends pwrmgr_base_vseq;
+  `uvm_object_utils(pwrmgr_repeat_wakeup_reset_vseq)
+
+  `uvm_object_new
+
+  bit[lc_ctrl_pkg::TxWidth-1:0] bad_lc_tx;
+  pwrmgr_mubi_e mubi_mode;
+
+  constraint wakeups_c {wakeups != 0;}
+
+  constraint wakeup_en_c {
+    solve wakeups before wakeups_en;
+    (wakeups_en & wakeups) != 0;
+  }
+  constraint disable_wakeup_capture_c {disable_wakeup_capture == 1'b0;}
+
+  // Cause some delays for the rom_ctrl done and good inputs. Simple, enough to hold the
+  // transition to active state.
+  // Consider adding SVA to monitor fast state transitions are compliant
+  // with "ROM Integrity Checks" at
+  // https://docs.opentitan.org/hw/ip/pwrmgr/doc/#fast-clock-domain-fsm
+  // TODO(maturana) https://github.com/lowRISC/opentitan/issues/10241
+
+// typedef struct packed {
+//    prim_mubi_pkg::mubi4_t done;
+//    prim_mubi_pkg::mubi4_t good;
+//  } pwrmgr_data_t;
+
+  task twirl_rom_response();
+    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    @(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateAckPwrUp);
+    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    @(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheck);
+    cfg.clk_rst_vif.wait_clks(10);
+    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.clk_rst_vif.wait_clks(5);
+    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.clk_rst_vif.wait_clks(5);
+    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+  endtask
+
+
+  task twirl_rom_response_with_noise();
+    add_rom_rsp_noise();
+    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4False;
+    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4False;
+    cfg.clk_rst_vif.wait_clks(5);
+    add_rom_rsp_noise();
+    wait(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateRomCheck);
+    add_rom_rsp_noise();
+    cfg.pwrmgr_vif.rom_ctrl.good = prim_mubi_pkg::MuBi4True;
+    cfg.clk_rst_vif.wait_clks(5);
+    cfg.pwrmgr_vif.rom_ctrl.done = prim_mubi_pkg::MuBi4True;
+  endtask
+
+  function bit[lc_ctrl_pkg::TxWidth-1:0] get_lc_ctrl();
+    randcase
+      1: get_lc_ctrl = lc_ctrl_pkg::On;
+      1: get_lc_ctrl = lc_ctrl_pkg::Off;
+      2: std::randomize(get_lc_ctrl) with {
+           get_lc_ctrl != lc_ctrl_pkg::On &&
+           get_lc_ctrl != lc_ctrl_pkg::Off;
+         };
+    endcase
+  endfunction // get_lc_ctrl
+
+  task body();
+    mubi_mode = PwrmgrMubiNone;
+    void'($value$plusargs("pwrmgr_mubi_mode=%0d", mubi_mode));
+    fork
+      proc_pwr_down();
+      drv_stim(mubi_mode);
+    join
+  endtask // body
+
+  task drv_stim(pwrmgr_mubi_e mubi_mode);
+    `uvm_info(`gfn, $sformatf("pwrmgr mubi mode : %s",mubi_mode.name()), UVM_MEDIUM)
+    case (mubi_mode)
+      PwrmgrMubiLcCtrl : drv_lc_ctrl();
+      default : begin
+        `uvm_info(`gfn, "No mubi stimulus selected", UVM_MEDIUM)
+      end
+    endcase
+  endtask // drv_stim
+
+  task drv_lc_ctrl();
+    int delay;
+
+    repeat(50) begin
+      cfg.pwrmgr_vif.lc_hw_debug_en = get_lc_ctrl();
+      delay = $urandom_range(5,20);
+      #(delay * 1us);
+      cfg.pwrmgr_vif.lc_dft_en = get_lc_ctrl();
+      delay = $urandom_range(5,20);
+      #(delay * 1us);
+    end
+  endtask // drv_lc_ctrl
+
+  // {done, good}
+  task add_rom_rsp_noise();
+    bit[prim_mubi_pkg::MuBi4Width*2-1:0] bad_bits;
+    int delay;
+
+    repeat(10) begin
+      delay = $urandom_range(5,10);
+      std::randomize(bad_bits) with {
+        bad_bits[prim_mubi_pkg::MuBi4Width*2-1:prim_mubi_pkg::MuBi4Width] != prim_mubi_pkg::MuBi4True;
+        bad_bits[prim_mubi_pkg::MuBi4Width*2-1:prim_mubi_pkg::MuBi4Width] != prim_mubi_pkg::MuBi4False;
+        bad_bits[prim_mubi_pkg::MuBi4Width-1:0] != prim_mubi_pkg::MuBi4False;
+        bad_bits[prim_mubi_pkg::MuBi4Width-1:0] != prim_mubi_pkg::MuBi4True;
+      };
+      cfg.pwrmgr_vif.rom_ctrl = bad_bits;
+      #(delay * 10ns);
+    end
+  endtask // add_rom_rsp_nose
+
+  task proc_pwr_down();
+    logic [TL_DW-1:0] value;
+    resets_t enabled_resets;
+    wakeups_t enabled_wakeups;
+    wait_for_fast_fsm_active();
+
+    check_reset_status('0);
+    check_wake_status('0);
+    num_trans_c.constraint_mode(0);
+    num_trans = 50;
+    `uvm_info(`gfn, $sformatf("JDONDBG: num_trans=%0d",num_trans), UVM_MEDIUM)
+    for (int i = 0; i < num_trans; ++i) begin
+      `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      setup_interrupt(.enable(en_intr));
+      // Enable resets.
+      enabled_resets = resets_en & resets;
+      `uvm_info(`gfn, $sformatf(
+                "Enabled resets=0x%x, power_reset=%b, escalation=%b, sw_reset=%b",
+                enabled_resets,
+                power_glitch_reset,
+                escalation_reset,
+                sw_rst_from_rstmgr
+                ), UVM_MEDIUM)
+      csr_wr(.ptr(ral.reset_en[0]), .value(resets_en));
+
+      // Enable wakeups.
+      enabled_wakeups = wakeups_en & wakeups;
+      `DV_CHECK(enabled_wakeups, $sformatf(
+                "Some wakeup must be enabled: wkups=%b, wkup_en=%b", wakeups, wakeups_en))
+      `uvm_info(`gfn, $sformatf("Enabled wakeups=0x%x", enabled_wakeups), UVM_MEDIUM)
+      csr_wr(.ptr(ral.wakeup_en[0]), .value(wakeups_en));
+
+      clear_wake_info();
+
+      `uvm_info(`gfn, $sformatf("%0sabling wakeup capture", disable_wakeup_capture ? "Dis" : "En"),
+                UVM_MEDIUM)
+      csr_wr(.ptr(ral.wake_info_capture_dis), .value(disable_wakeup_capture));
+
+      low_power_hint = 1'b1;
+      update_control_csr();
+
+      wait_for_csr_to_propagate_to_slow_domain();
+
+      // Initiate low power transition.
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b1);
+      set_nvms_idle();
+
+      // Wait for the slow state machine to be in low power.
+      wait(cfg.pwrmgr_vif.slow_state == pwrmgr_pkg::SlowPwrStateLowPower);
+
+      // This will send the wakeup and reset so they almost coincide.
+      fork
+        begin
+          cfg.clk_rst_vif.wait_clks(cycles_before_reset);
+          cfg.pwrmgr_vif.update_resets(resets);
+          if (power_glitch_reset) begin
+            `uvm_info(`gfn, "Sending power glitch", UVM_MEDIUM)
+            cfg.pwrmgr_vif.glitch_power_reset();
+          end
+          if (escalation_reset) send_escalation_reset();
+          `uvm_info(`gfn, $sformatf(
+                    "Sending reset=%b, power_glitch=%b, escalation=%b",
+                    resets,
+                    power_glitch_reset,
+                    escalation_reset
+                    ), UVM_MEDIUM)
+        end
+        begin
+          cfg.clk_rst_vif.wait_clks(cycles_before_wakeup);
+          cfg.pwrmgr_vif.update_wakeups(wakeups);
+          `uvm_info(`gfn, $sformatf("Sending wakeup=%b", wakeups), UVM_MEDIUM)
+        end
+      join
+
+      if (cfg.en_cov) begin
+        cov.reset_wakeup_distance_cg.sample(cycles_before_reset - cycles_before_wakeup);
+      end
+      // twirl_rom_response has some waits, and so does the code to check wake_status,
+      // so we fork them to avoid conflicts.
+      fork
+        begin
+          cfg.slow_clk_rst_vif.wait_clks(4);
+          // Check wake_status prior to wakeup, or the unit requesting wakeup will have been reset.
+          // This read will not work in the chip, since the processor will be asleep.
+          check_wake_status(enabled_wakeups);
+          `uvm_info(`gfn, $sformatf("Got wake_status=0x%x", enabled_wakeups), UVM_MEDIUM)
+          check_reset_status(enabled_resets);
+        end
+        begin
+          if (mubi_mode == PwrmgrMubiRomCtrl) begin
+            twirl_rom_response_with_noise();
+          end else begin
+            twirl_rom_response();
+          end
+        end
+      join
+      wait_for_fast_fsm_active();
+
+      check_reset_status('0);
+
+      check_wake_info(.reasons(enabled_wakeups), .prior_reasons(1'b0), .fall_through(1'b0),
+                      .prior_fall_through(1'b0), .abort(1'b0), .prior_abort(1'b0));
+
+      if (mubi_mode == PwrmgrMubiRomCtrl) begin
+        add_rom_rsp_noise();
+      end
+
+      // This is the expected side-effect of the low power entry reset, since the source of the
+      // non-aon wakeup sources will deassert it as a consequence of their reset.
+      // Some aon wakeups may remain active until software clears them. If they didn't, such wakeups
+      // will remain active, preventing the device from going to sleep.
+      cfg.pwrmgr_vif.update_wakeups('0);
+      cfg.slow_clk_rst_vif.wait_clks(10);
+      check_reset_status('0);
+      check_wake_status('0);
+
+      cfg.slow_clk_rst_vif.wait_clks(10);
+      // An interrupt will be generated depending on the exact timing of the slow fsm getting
+      // the reset and wakeup. We choose not to predict it here (it is checked on other tests).
+      // Instead, we just check if the interrupt status is asserted and it is enabled the
+      // output interrupt is active.
+      check_and_clear_interrupt(.expected(1'b1), .check_expected('0));
+      // Clear hardware resets: if they are enabled they are cleared when rst_lc_req[1] goes active,
+      // but this makes sure they are cleared even if none is enabled for the next round.
+      cfg.pwrmgr_vif.update_resets('0);
+      // And make the cpu active.
+      cfg.pwrmgr_vif.update_cpu_sleeping(1'b0);
+    end
+    clear_wake_info();
+  endtask
+
+endclass : pwrmgr_repeat_wakeup_reset_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_sw_reset_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_sw_reset_vseq.sv
@@ -1,0 +1,47 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// The reset test randomly introduces external resets, power glitches, and escalation resets.
+class pwrmgr_sw_reset_vseq extends pwrmgr_base_vseq;
+
+  `uvm_object_utils(pwrmgr_sw_reset_vseq)
+  `uvm_object_new
+
+  constraint wakeups_c {wakeups == 0;}
+  constraint wakeups_en_c {wakeups_en == 0;}
+
+  task body();
+    wait_for_fast_fsm_active();
+
+    check_reset_status('0);
+    num_trans_c.constraint_mode(0);
+    num_trans = 30;
+    for (int i = 0; i < num_trans; ++i) begin
+      `uvm_info(`gfn, "Starting new round", UVM_MEDIUM)
+      `DV_CHECK_RANDOMIZE_FATAL(this)
+      setup_interrupt(.enable(en_intr));
+
+      cfg.pwrmgr_vif.sw_rst_req_i = $urandom_range(0,15);
+
+      cfg.slow_clk_rst_vif.wait_clks(4);
+
+      // This read is not always possible since the CPU may be off.
+
+      wait(cfg.pwrmgr_vif.pwr_clk_req.main_ip_clk_en == 1'b1);
+
+      wait_for_fast_fsm_active();
+      `uvm_info(`gfn, "Back from reset", UVM_MEDIUM)
+
+      check_wake_info(.reasons('0), .fall_through(1'b0), .abort(1'b0));
+
+      cfg.slow_clk_rst_vif.wait_clks(4);
+      check_reset_status('0);
+
+      // And check interrupt is not set.
+      check_and_clear_interrupt(.expected(1'b0));
+    end
+    clear_wake_info();
+  endtask
+
+endclass : pwrmgr_sw_reset_vseq

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_vseq_list.sv
@@ -11,3 +11,6 @@
 `include "pwrmgr_wakeup_reset_vseq.sv"
 `include "pwrmgr_wakeup_vseq.sv"
 `include "pwrmgr_common_vseq.sv"
+`include "pwrmgr_repeat_wakeup_reset_vseq.sv"
+`include "pwrmgr_sw_reset_vseq.sv"
+`include "pwrmgr_esc_clk_rst_malfunc_vseq.sv"

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim.core
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim.core
@@ -8,13 +8,13 @@ filesets:
   files_rtl:
     depend:
       - lowrisc:ip:pwrmgr
-
   files_dv:
     depend:
       - lowrisc:dv:pwrmgr_test
       - lowrisc:dv:pwrmgr_sva
     files:
       - tb.sv
+      - cov/pwrmgr_cov_bind.sv
     file_type: systemVerilogSource
 
 targets:

--- a/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
+++ b/hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson
@@ -32,6 +32,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
   // Overrides
@@ -44,7 +45,10 @@
 
   // Add additional tops for simulation.
   sim_tops: ["pwrmgr_bind",
-             "pwrmgr_rstmgr_bind"]
+             "pwrmgr_rstmgr_bind",
+             "pwrmgr_cov_bind",
+             "sec_cm_prim_count_bind",
+             "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
@@ -84,7 +88,26 @@
       name: pwrmgr_aborted_low_power
       uvm_test_seq: pwrmgr_aborted_low_power_vseq
     }
-
+    {
+      name: pwrmgr_sec_cm_lc_ctrl_intersig_mubi
+      uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
+      run_opts: ["+test_timeout_ns=2000000", "+pwrmgr_mubi_mode=1"]
+    }
+    {
+      name: pwrmgr_sec_cm_rom_ctrl_intersig_mubi
+      uvm_test_seq: pwrmgr_repeat_wakeup_reset_vseq
+      run_opts: ["+test_timeout_ns=2000000", "+pwrmgr_mubi_mode=2"]
+    }
+    {
+      name: pwrmgr_sec_cm_rstmgr_intersig_mubi
+      uvm_test_seq: pwrmgr_sw_reset_vseq
+      run_opts: ["+test_timeout_ns=1000000"]
+    }
+    {
+      name: pwrmgr_esc_clk_rst_malfunc
+      uvm_test_seq: pwrmgr_esc_clk_rst_malfunc_vseq
+      run_opts: ["+test_timeout_ns=1000000"]
+    }
     // TODO: add more tests here
   ]
 

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -53,4 +53,33 @@ module pwrmgr_bind;
     .usb_status(pwr_clk_i.usb_status)
   );
 
+  bind pwrmgr pwrmgr_rstmgr_sva_if pwrmgr_rstmgr_sva_if (
+    .clk_i,
+    .rst_ni,
+    .clk_slow_i,
+    .rst_slow_ni,
+    // Input resets.
+    .rstreqs_i(rstreqs_i),
+    .reset_en(reg2hw.reset_en),
+    .sw_rst_req_i(prim_mubi_pkg::mubi4_test_true_strict(sw_rst_req_i)),
+    .main_rst_req_i(rst_main_ni),
+    .esc_rst_req_i(esc_rst_req),
+    // The outputs from pwrmgr.
+    .rst_lc_req(pwr_rst_o.rst_lc_req),
+    .rst_sys_req(pwr_rst_o.rst_sys_req),
+    .rstreqs(pwr_rst_o.rstreqs),
+    .ndm_sys_req(1'b0),
+    .reset_cause(pwr_rst_o.reset_cause),
+    // The inputs from rstmgr.
+    .rst_lc_src_n(pwr_rst_i.rst_lc_src_n),
+    .rst_sys_src_n(pwr_rst_i.rst_sys_src_n)
+  );
+
+  bind pwrmgr pwrmgr_sec_cm_checker_assert pwrmgr_sec_cm_checker_assert (
+    .clk_i,
+    .rst_ni,
+    .rom_intg_chk_dis(u_fsm.rom_intg_chk_dis),
+    .lc_dft_en_i,
+    .lc_hw_debug_en_i
+  );
 endmodule

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
@@ -1,0 +1,30 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// add description here TBD
+module pwrmgr_sec_cm_checker_assert (
+  input clk_i,
+  input rst_ni,
+  input prim_mubi_pkg::mubi4_t rom_intg_chk_dis,
+  input lc_ctrl_pkg::lc_tx_t lc_dft_en_i,
+  input lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i
+);
+
+  bit   disable_sva;
+  bit   reset_or_disable;
+
+  always_comb reset_or_disable = !rst_ni || disable_sva;
+
+
+  // Assuming lc_dft_en_i and lc_hw_debug_en_i are asynchronous
+  `ASSERT(RomIntgChkDisTrue_A,
+          rom_intg_chk_dis == prim_mubi_pkg::MuBi4True |=>
+          (lc_dft_en_i == lc_ctrl_pkg::On && lc_hw_debug_en_i == lc_ctrl_pkg::On),
+          rom_intg_chk_dis, reset_or_disable)
+
+  `ASSERT(RomIntgChkDisFalse_A,
+          rom_intg_chk_dis == prim_mubi_pkg::MuBi4False |=>
+          (lc_dft_en_i != lc_ctrl_pkg::On || lc_hw_debug_en_i != lc_ctrl_pkg::On),
+          rom_intg_chk_dis, reset_or_disable)
+endmodule // pwrmgr_sec_cm_checker_assert

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_sva.core
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_sva.core
@@ -17,6 +17,7 @@ filesets:
       - pwrmgr_rstmgr_bind.sv
       - pwrmgr_ast_sva_if.sv
       - pwrmgr_clock_enables_sva_if.sv
+      - pwrmgr_sec_cm_checker_assert.sv
     file_type: systemVerilogSource
 
   files_formal:

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -87,8 +87,8 @@ module tb;
     .wakeups_i (pwrmgr_if.wakeups_i),
     .rstreqs_i (pwrmgr_if.rstreqs_i),
 
-    .lc_dft_en_i     (lc_ctrl_pkg::Off),
-    .lc_hw_debug_en_i(lc_ctrl_pkg::Off),
+    .lc_dft_en_i     (pwrmgr_if.lc_dft_en),
+    .lc_hw_debug_en_i(pwrmgr_if.lc_hw_debug_en),
 
     .strap_o    (pwrmgr_if.strap),
     .low_power_o(pwrmgr_if.low_power),
@@ -126,4 +126,22 @@ module tb;
     run_test();
   end
 
+  initial begin
+    pwrmgr_mubi_e mubi_mode;
+    if (!$value$plusargs("pwrmgr_mubi_mode=%0d", mubi_mode)) begin
+      mubi_mode = PwrmgrMubiNone;
+    end
+
+    if (mubi_mode == PwrmgrMubiRomCtrl) begin
+      $assertoff(0, tb.dut.u_cdc.u_sync_rom_ctrl);
+    end
+  end
+
+  // sandbox
+//  initial begin
+//    #15us;
+//    $display("JDONDBG: force rst_esc to x");
+//    wait(pwrmgr_if.fast_state == pwrmgr_pkg::FastPwrStateActive);
+//    force tb.dut.rst_esc_ni = 0;
+//  end
 endmodule


### PR DESCRIPTION
cmd: ./util/dvsim/dvsim.py ./hw/ip/pwrmgr/dv/pwrmgr_sim_cfg.hjson -i
pwrmgr_esc_clk_rst_malfunc -r 1 -v m -w fsdb

esc_rst takes fsm to low power state and that prevent local timeout event.

Signed-off-by: Jaedon Kim <jdonjdon@google.com>