### PR TITLE
[dif/bazel] Fix up adc_ctrl target

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -34,9 +34,6 @@ cc_library(
     hdrs = [
         "dif_adc_ctrl.h",
     ],
-    hdrs = [
-        "dif_adc_ctrl.h",
-    ],
     deps = [
         ":base",
         "//hw/ip/adc_ctrl/data:adc_ctrl_regs",


### PR DESCRIPTION
Remove duplicated hdrs field.

Signed-off-by: Alexander Williams <awill@google.com>