### PR TITLE
[flash_ctrl] Further hardening for D2S

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -249,6 +249,9 @@
     { name: "CTR.SPARSE",
       desc: "RMA handling counters are sparsely encoded."
     }
+    { name: "PHY.FSM.SPARSE",
+      desc: "PHY FSMs are sparsely encoded."
+    }
 
 
   ]
@@ -1637,6 +1640,12 @@
             name: "storage_err",
             desc: '''
               A shadow register encountered a storage error.
+            '''
+          },
+          { bits: "5",
+            name: "phy_fsm_err",
+            desc: '''
+              A flash phy fsm has encountered a sparse encoding error.
             '''
           },
         ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -1648,6 +1648,12 @@
               A flash phy fsm has encountered a sparse encoding error.
             '''
           },
+          { bits: "6",
+            name: "ctrl_cnt_err",
+            desc: '''
+              Flash ctrl read/prog has encountered a count error.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -256,6 +256,9 @@
     { name: "CTR.SPARSE",
       desc: "RMA handling counters are sparsely encoded."
     }
+    { name: "PHY.FSM.SPARSE",
+      desc: "PHY FSMs are sparsely encoded."
+    }
 
 
   ]
@@ -1138,6 +1141,12 @@
             name: "storage_err",
             desc: '''
               A shadow register encountered a storage error.
+            '''
+          },
+          { bits: "5",
+            name: "phy_fsm_err",
+            desc: '''
+              A flash phy fsm has encountered a sparse encoding error.
             '''
           },
         ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -1149,6 +1149,12 @@
               A flash phy fsm has encountered a sparse encoding error.
             '''
           },
+          { bits: "6",
+            name: "ctrl_cnt_err",
+            desc: '''
+              Flash ctrl read/prog has encountered a count error.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -986,11 +986,13 @@ module flash_ctrl
   assign hw2reg.std_fault_status.lcmgr_err.d      = 1'b1;
   assign hw2reg.std_fault_status.arb_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.storage_err.d    = 1'b1;
+  assign hw2reg.std_fault_status.phy_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.std_fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de     = lcmgr_err;
   assign hw2reg.std_fault_status.arb_fsm_err.de   = arb_fsm_err;
   assign hw2reg.std_fault_status.storage_err.de   = storage_err;
+  assign hw2reg.std_fault_status.phy_fsm_err.de   = flash_phy_rsp.fsm_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg
@@ -1275,4 +1277,13 @@ module flash_ctrl
     u_flash_hw_if.u_rma_state_regs, alert_tx_o[0])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(ArbFsmCheck_A,
     u_ctrl_arb.u_state_regs, alert_tx_o[0])
+
+   for (genvar i=0; i<NumBanks; i++) begin : gen_phy_assertions
+     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyFsmCheck_A,
+       u_eflash.gen_flash_cores[i].u_core.u_state_regs, alert_tx_o[0])
+
+     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyProgFsmCheck_A,
+       u_eflash.gen_flash_cores[i].u_core.gen_prog_data.u_prog.u_state_regs, alert_tx_o[0])
+   end
+
 endmodule

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -700,7 +700,7 @@ module flash_ctrl
   assign flash_info_sel = op_info_sel;
 
   // flash disable declaration
-  prim_mubi_pkg::mubi4_t flash_disable;
+  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
 
   // tie off hardware clear path
   assign hw2reg.erase_suspend.d = 1'b0;
@@ -713,7 +713,7 @@ module flash_ctrl
     .rst_ni,
 
     // disable flash through memory protection
-    .flash_disable_i(flash_disable),
+    .flash_disable_i(flash_disable[MpDisableIdx]),
 
     // arbiter interface selection
     .if_sel_i(if_sel),
@@ -911,11 +911,22 @@ module flash_ctrl
   // In other words...cowardice.
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
-  assign flash_disable = lc_ctrl_pkg::lc_tx_test_true_loose(lc_disable) ?
-                         prim_mubi_pkg::MuBi4True :
-                         prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
+  prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
+  assign flash_disable_pre_buf = lc_ctrl_pkg::lc_tx_test_true_loose(lc_disable) ?
+                                 prim_mubi_pkg::MuBi4True :
+                                 prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
 
-  assign flash_phy_req.flash_disable = flash_disable;
+  prim_mubi4_sync #(
+    .NumCopies(int'(FlashDisableLast)),
+    .AsyncOn(0)
+  ) u_disable_buf (
+    .clk_i,
+    .rst_ni,
+    .mubi_i(flash_disable_pre_buf),
+    .mubi_o(flash_disable)
+  );
+
+  assign flash_phy_req.flash_disable = flash_disable[PhyDisableIdx];
 
   prim_mubi_pkg::mubi4_t sw_flash_exec_en;
   prim_mubi_pkg::mubi4_t flash_exec_en;
@@ -1144,6 +1155,23 @@ module flash_ctrl
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
   logic flash_host_intg_err;
 
+  import prim_mubi_pkg::mubi4_test_true_loose;
+  logic host_disable;
+  logic disabled_rvalid;
+  logic [1:0] disabled_err;
+
+  // if flash disable is activated, error back from the adapter interface immediately
+  assign host_disable = mubi4_test_true_loose(flash_disable[HostDisableIdx]);
+  assign disabled_err = {2{disabled_rvalid}};
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      disabled_rvalid <= '0;
+    end else begin
+      disabled_rvalid <= host_disable & flash_host_req;
+    end
+  end
+
   tlul_adapter_sram #(
     .SramAw(BusAddrW),
     .SramDw(BusWidth),
@@ -1161,15 +1189,15 @@ module flash_ctrl
     .en_ifetch_i (flash_exec_en),
     .req_o       (flash_host_req),
     .req_type_o  (),
-    .gnt_i       (flash_host_req_rdy),
+    .gnt_i       (flash_host_req_rdy | host_disable),
     .we_o        (),
     .addr_o      (flash_host_addr),
     .wdata_o     (),
     .wmask_o     (),
     .intg_error_o(flash_host_intg_err),
     .rdata_i     (flash_host_rdata),
-    .rvalid_i    (flash_host_req_done),
-    .rerror_i    ({flash_host_rderr,1'b0})
+    .rvalid_i    (flash_host_req_done | disabled_rvalid),
+    .rerror_i    ({flash_host_rderr,1'b0} | disabled_err)
   );
 
   flash_phy #(

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -440,6 +440,7 @@ package flash_ctrl_pkg;
     logic [NumBanks-1:0][BusAddrW-1:0] ecc_addr;
     jtag_pkg::jtag_rsp_t jtag_rsp;
     logic                intg_err;
+    logic                fsm_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -455,7 +456,8 @@ package flash_ctrl_pkg;
     ecc_single_err:     '0,
     ecc_addr:           '0,
     jtag_rsp:           '0,
-    intg_err:           '0
+    intg_err:           '0,
+    fsm_err:            '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -62,7 +62,6 @@ package flash_ctrl_pkg;
   parameter int BusBankAddrW    = PageW + BusWordW;
   parameter int PhyAddrStart    = BusWordW - WordW;
 
-
   // fifo parameters
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);
 
@@ -78,6 +77,14 @@ package flash_ctrl_pkg;
     PageW'(InfoTypeSize[${type}] - 1)${"," if not loop.last else ""}
   % endfor
   };
+
+  // Flash Disable usage
+  typedef enum logic [1:0] {
+    PhyDisableIdx,
+    MpDisableIdx,
+    HostDisableIdx,
+    FlashDisableLast
+  } flash_disable_pos_e;
 
   ////////////////////////////
   // All memory protection, seed related parameters

--- a/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
@@ -137,5 +137,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_phy_fsm_sparse
+      desc: "Verify the countermeasure(s) PHY.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/flash_ctrl/doc/_index.md
+++ b/hw/ip/flash_ctrl/doc/_index.md
@@ -326,6 +326,28 @@ If software programs {{< regref "EXEC" >}} to any other value, code fetch from f
 
 The flash protocol controller distinguishes code / data transactions through the [instruction type attribute]({{< relref "hw/ip/lc_ctrl/doc/_index.md#usage-of-user-bits" >}}) of the TL-UL interface.
 
+#### Flash Escalation
+
+Flash has two sources of escalation - global and local.
+
+Global escalation is triggered by the life cycle controller through `lc_escalate_en`.
+Local escalation is triggered by a standard faults of flash, seen in {{< regref "STD_FAULT_STATUS" >}}.
+Local escalation is not configurable and automatically triggers when this subset of faults are seen.
+
+For the escalation behavior, see [flash access disable]({{< relref "#flash-access-disable" >}})
+
+#### Flash Access Disable
+
+Flash access can be disabled through global escalation trigger, local escalation trigger or software command.
+The escalation triggers are described [here]({{< relref "#flash-escalation" >}}).
+The software command to disable flash can be found in {{< regref "DIS" >}}.
+
+When disabled, the flash has a two layered response:
+- The flash protocol controller memory protection ({{< relref "#memory-protection" >}}) errors back all controller initiated operations.
+- The host-facing tlul adapter errors back all host initiated operations.
+- The flash physical controller completes any existing stateful operations (program or erase) and drops all future flash transactions.
+
+
 ### Flash Physical Controller
 
 The Flash Physical Controller is the wrapper module that contains the actual flash memory instantiation.

--- a/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
+++ b/hw/ip/flash_ctrl/lint/flash_ctrl.waiver
@@ -4,12 +4,12 @@
 #
 # waiver file for Flash Controller
 
-# All leaf resets have a reset multiplex
+# Sparsely encoded states all have terminal behavior
 waive -rules TERMINAL_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StInvalid.*} \
       -comment "StInvalid is intended to be a terminal state"
 
-waive -rules MISSING_STATE -location {flash_ctrl_lcmgr.sv} -regexp {.*StInvalid.*} \
-      -comment "Behavior is part of default state"
+waive -rules TERMINAL_STATE -location {flash_phy_core.sv} -regexp {.*(StInvalid|StDisable).*} \
+      -comment "Behavior is part of terminal invalid and disable states"
 
 # the rst done signals were an intentional choice to address resets
 # that could potentially release at different times

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -987,11 +987,13 @@ module flash_ctrl
   assign hw2reg.std_fault_status.lcmgr_err.d      = 1'b1;
   assign hw2reg.std_fault_status.arb_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.storage_err.d    = 1'b1;
+  assign hw2reg.std_fault_status.phy_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.std_fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de     = lcmgr_err;
   assign hw2reg.std_fault_status.arb_fsm_err.de   = arb_fsm_err;
   assign hw2reg.std_fault_status.storage_err.de   = storage_err;
+  assign hw2reg.std_fault_status.phy_fsm_err.de   = flash_phy_rsp.fsm_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg
@@ -1276,4 +1278,13 @@ module flash_ctrl
     u_flash_hw_if.u_rma_state_regs, alert_tx_o[0])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(ArbFsmCheck_A,
     u_ctrl_arb.u_state_regs, alert_tx_o[0])
+
+   for (genvar i=0; i<NumBanks; i++) begin : gen_phy_assertions
+     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyFsmCheck_A,
+       u_eflash.gen_flash_cores[i].u_core.u_state_regs, alert_tx_o[0])
+
+     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyProgFsmCheck_A,
+       u_eflash.gen_flash_cores[i].u_core.gen_prog_data.u_prog.u_state_regs, alert_tx_o[0])
+   end
+
 endmodule

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -515,6 +515,8 @@ module flash_ctrl
                                          reg2hw.prog_type_en.normal.q;
   assign prog_type_en[FlashProgRepair] = flash_phy_rsp.prog_type_avail[FlashProgRepair] &
                                          reg2hw.prog_type_en.repair.q;
+
+  logic prog_cnt_err;
   flash_ctrl_prog u_flash_ctrl_prog (
     .clk_i,
     .rst_ni,
@@ -529,6 +531,7 @@ module flash_ctrl
     .op_type_i      (op_prog_type),
     .type_avail_i   (prog_type_en),
     .op_err_addr_o  (prog_err_addr),
+    .cnt_err_o      (prog_cnt_err),
 
     // FIFO Interface
     .data_i         (prog_fifo_rdata),
@@ -610,6 +613,7 @@ module flash_ctrl
     .rdata_o (rd_fifo_rdata)
   );
 
+  logic rd_cnt_err;
   // Read handler is consumer of rd_fifo
   assign rd_op_valid = op_start & rd_op;
   flash_ctrl_rd  u_flash_ctrl_rd (
@@ -624,6 +628,7 @@ module flash_ctrl
     .op_err_addr_o  (rd_err_addr),
     .op_addr_i      (op_addr),
     .op_addr_oob_i  ('0),
+    .cnt_err_o      (rd_cnt_err),
 
     // FIFO Interface
     .data_rdy_i     (rd_fifo_wready),
@@ -988,12 +993,14 @@ module flash_ctrl
   assign hw2reg.std_fault_status.arb_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.storage_err.d    = 1'b1;
   assign hw2reg.std_fault_status.phy_fsm_err.d    = 1'b1;
+  assign hw2reg.std_fault_status.ctrl_cnt_err.d   = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.std_fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de     = lcmgr_err;
   assign hw2reg.std_fault_status.arb_fsm_err.de   = arb_fsm_err;
   assign hw2reg.std_fault_status.storage_err.de   = storage_err;
   assign hw2reg.std_fault_status.phy_fsm_err.de   = flash_phy_rsp.fsm_err;
+  assign hw2reg.std_fault_status.ctrl_cnt_err.de  = rd_cnt_err | prog_cnt_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg
@@ -1270,6 +1277,10 @@ module flash_ctrl
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WordCntAlertCheck_A, u_flash_hw_if.u_word_cnt,
                                          alert_tx_o[0])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WipeIdx_A, u_flash_hw_if.u_wipe_idx_cnt,
+                                         alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ProgCnt_A, u_flash_ctrl_prog.u_cnt,
+                                         alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(RdCnt_A, u_flash_ctrl_rd.u_cnt,
                                          alert_tx_o[0])
 
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(LcCtrlFsmCheck_A,

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -971,6 +971,8 @@ module flash_ctrl_core_reg_top (
   logic std_fault_status_lcmgr_err_qs;
   logic std_fault_status_arb_fsm_err_qs;
   logic std_fault_status_storage_err_qs;
+  logic std_fault_status_phy_fsm_err_qs;
+  logic std_fault_status_ctrl_cnt_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
   logic fault_status_prog_win_err_qs;
@@ -12245,6 +12247,56 @@ module flash_ctrl_core_reg_top (
     .qs     (std_fault_status_storage_err_qs)
   );
 
+  //   F[phy_fsm_err]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_std_fault_status_phy_fsm_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.std_fault_status.phy_fsm_err.de),
+    .d      (hw2reg.std_fault_status.phy_fsm_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.std_fault_status.phy_fsm_err.q),
+
+    // to register interface (read)
+    .qs     (std_fault_status_phy_fsm_err_qs)
+  );
+
+  //   F[ctrl_cnt_err]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_std_fault_status_ctrl_cnt_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.std_fault_status.ctrl_cnt_err.de),
+    .d      (hw2reg.std_fault_status.ctrl_cnt_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.std_fault_status.ctrl_cnt_err.q),
+
+    // to register interface (read)
+    .qs     (std_fault_status_ctrl_cnt_err_qs)
+  );
+
 
   // R[fault_status]: V(False)
   //   F[mp_err]: 1:1
@@ -14407,6 +14459,8 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[2] = std_fault_status_lcmgr_err_qs;
         reg_rdata_next[3] = std_fault_status_arb_fsm_err_qs;
         reg_rdata_next[4] = std_fault_status_storage_err_qs;
+        reg_rdata_next[5] = std_fault_status_phy_fsm_err_qs;
+        reg_rdata_next[6] = std_fault_status_ctrl_cnt_err_qs;
       end
 
       addr_hit[87]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -440,6 +440,7 @@ package flash_ctrl_pkg;
     logic [NumBanks-1:0][BusAddrW-1:0] ecc_addr;
     jtag_pkg::jtag_rsp_t jtag_rsp;
     logic                intg_err;
+    logic                fsm_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -455,7 +456,8 @@ package flash_ctrl_pkg;
     ecc_single_err:     '0,
     ecc_addr:           '0,
     jtag_rsp:           '0,
-    intg_err:           '0
+    intg_err:           '0,
+    fsm_err:            '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -62,7 +62,6 @@ package flash_ctrl_pkg;
   parameter int BusBankAddrW    = PageW + BusWordW;
   parameter int PhyAddrStart    = BusWordW - WordW;
 
-
   // fifo parameters
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);
 
@@ -78,6 +77,14 @@ package flash_ctrl_pkg;
     PageW'(InfoTypeSize[1] - 1),
     PageW'(InfoTypeSize[2] - 1)
   };
+
+  // Flash Disable usage
+  typedef enum logic [1:0] {
+    PhyDisableIdx,
+    MpDisableIdx,
+    HostDisableIdx,
+    FlashDisableLast
+  } flash_disable_pos_e;
 
   ////////////////////////////
   // All memory protection, seed related parameters

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_prog.sv
@@ -19,6 +19,7 @@ module flash_ctrl_prog import flash_ctrl_pkg::*; (
   input flash_prog_e       op_type_i,
   input [ProgTypes-1:0]    type_avail_i,
   output logic [BusAddrW-1:0] op_err_addr_o,
+  output logic             cnt_err_o,
 
   // FIFO Interface
   input                    data_rdy_i,
@@ -58,15 +59,31 @@ module flash_ctrl_prog import flash_ctrl_pkg::*; (
     end
   end
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      cnt <= '0;
-    end else if (op_start_i && op_done_o) begin
-      cnt <= '0;
-    end else if (data_rd_o) begin
-      cnt <= cnt + 1'b1;
-    end
-  end
+  //always_ff @(posedge clk_i or negedge rst_ni) begin
+  //  if (!rst_ni) begin
+  //    cnt <= '0;
+  //  end else if (op_start_i && op_done_o) begin
+  //    cnt <= '0;
+  //  end else if (data_rd_o) begin
+  //    cnt <= cnt + 1'b1;
+  //  end
+  //end
+
+  prim_count #(
+    .Width(12),
+    .OutSelDnCnt(0),
+    .CntStyle(prim_count_pkg::DupCnt)
+  ) u_cnt (
+    .clk_i,
+    .rst_ni,
+    .clr_i(op_start_i && op_done_o),
+    .set_i('0),
+    .set_cnt_i('0),
+    .en_i(data_rd_o),
+    .step_i(12'h1),
+    .cnt_o(cnt),
+    .err_o(cnt_err_o)
+  );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -77,7 +94,7 @@ module flash_ctrl_prog import flash_ctrl_pkg::*; (
   end
 
   assign txn_done = flash_req_o && flash_done_i;
-  assign cnt_hit = (cnt == op_num_words_i);
+  assign cnt_hit = (cnt >= op_num_words_i);
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
@@ -122,8 +139,13 @@ module flash_ctrl_prog import flash_ctrl_pkg::*; (
       // Note the address counter is incremented on tx_done
       // and cleared when the entire operation is complete.
       StNorm: begin
-        // if the select operation type is not available, error
-        if (op_start_i && prog_type_avail && !win_err) begin
+
+        if (cnt_err_o) begin
+          // if count error'd don't bother doing anything else, just try to finish
+          st_d = StErr;
+
+        end else if (op_start_i && prog_type_avail && !win_err) begin
+          // if the select operation type is not available, error
           flash_req_o = data_rdy_i;
 
           if (txn_done) begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -501,6 +501,12 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } storage_err;
+    struct packed {
+      logic        q;
+    } phy_fsm_err;
+    struct packed {
+      logic        q;
+    } ctrl_cnt_err;
   } flash_ctrl_reg2hw_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -679,6 +685,14 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_fsm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_cnt_err;
   } flash_ctrl_hw2reg_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -740,33 +754,33 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [579:574]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [573:568]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [567:556]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [555:550]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [549:546]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [545:514]
-    flash_ctrl_reg2hw_init_reg_t init; // [513:513]
-    flash_ctrl_reg2hw_control_reg_t control; // [512:493]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [492:473]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [472:471]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [470:470]
-    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [469:262]
-    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [261:256]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [581:576]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [575:570]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [569:558]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [557:552]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [551:548]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [547:516]
+    flash_ctrl_reg2hw_init_reg_t init; // [515:515]
+    flash_ctrl_reg2hw_control_reg_t control; // [514:495]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [494:475]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [474:473]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [472:472]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [471:264]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [263:258]
     flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank0_info0_page_cfg_shadowed; // [255:186]
+        bank0_info0_page_cfg_shadowed; // [257:188]
     flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank0_info1_page_cfg_shadowed; // [185:179]
+        bank0_info1_page_cfg_shadowed; // [187:181]
     flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank0_info2_page_cfg_shadowed; // [178:165]
+        bank0_info2_page_cfg_shadowed; // [180:167]
     flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank1_info0_page_cfg_shadowed; // [164:95]
+        bank1_info0_page_cfg_shadowed; // [166:97]
     flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank1_info1_page_cfg_shadowed; // [94:88]
+        bank1_info1_page_cfg_shadowed; // [96:90]
     flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank1_info2_page_cfg_shadowed; // [87:74]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [73:72]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [71:67]
+        bank1_info2_page_cfg_shadowed; // [89:76]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [75:74]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [73:67]
     flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [66:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -777,14 +791,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [151:140]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [139:139]
-    flash_ctrl_hw2reg_control_reg_t control; // [138:137]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [136:135]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [134:131]
-    flash_ctrl_hw2reg_status_reg_t status; // [130:121]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [120:109]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [108:99]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [155:144]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [143:143]
+    flash_ctrl_hw2reg_control_reg_t control; // [142:141]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [140:139]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [138:135]
+    flash_ctrl_hw2reg_status_reg_t status; // [134:125]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [124:113]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [112:99]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [98:87]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [86:66]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [65:48]

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -90,10 +90,10 @@ module flash_phy
   // common interface
   logic [BusWidth-1:0] rd_data [NumBanks];
   logic [NumBanks-1:0] rd_err;
-   
+
   // fsm error per block
   logic [NumBanks-1:0] fsm_err;
-       
+
   // select which bank each is operating on
   assign host_bank_sel = host_req_i ? host_addr_i[BusAddrW-1 -: BankW] : '0;
   assign ctrl_bank_sel = flash_ctrl_i.addr[BusAddrW-1 -: BankW];
@@ -117,7 +117,7 @@ module flash_phy
   // feed through host integrity error directly
   assign flash_ctrl_o.intg_err = host_intg_err_i;
   assign flash_ctrl_o.fsm_err = |fsm_err;
-   
+
 
   // This fifo holds the expected return order
   prim_fifo_sync #(

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -90,7 +90,10 @@ module flash_phy
   // common interface
   logic [BusWidth-1:0] rd_data [NumBanks];
   logic [NumBanks-1:0] rd_err;
-
+   
+  // fsm error per block
+  logic [NumBanks-1:0] fsm_err;
+       
   // select which bank each is operating on
   assign host_bank_sel = host_req_i ? host_addr_i[BusAddrW-1 -: BankW] : '0;
   assign ctrl_bank_sel = flash_ctrl_i.addr[BusAddrW-1 -: BankW];
@@ -113,6 +116,8 @@ module flash_phy
   assign flash_ctrl_o.init_busy = init_busy;
   // feed through host integrity error directly
   assign flash_ctrl_o.intg_err = host_intg_err_i;
+  assign flash_ctrl_o.fsm_err = |fsm_err;
+   
 
   // This fifo holds the expected return order
   prim_fifo_sync #(
@@ -257,7 +262,8 @@ module flash_phy
       .prim_flash_req_o(prim_flash_req[bank]),
       .prim_flash_rsp_i(prim_flash_rsp[bank]),
       .ecc_single_err_o(ecc_single_err[bank]),
-      .ecc_addr_o(ecc_addr[bank][BusBankAddrW-1:0])
+      .ecc_addr_o(ecc_addr[bank][BusBankAddrW-1:0]),
+      .fsm_err_o(fsm_err[bank])
     );
   end // block: gen_flash_banks
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
@@ -92,8 +92,6 @@ module flash_phy_prog import flash_phy_pkg::*; (
     Actual
   } data_sel_e;
 
-
-
   // The currently observed data beat
   logic [WordSelW-1:0] idx;
   logic [WordSelW-1:0] idx_sub_one;

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -255,6 +255,9 @@
     { name: "CTR.SPARSE",
       desc: "RMA handling counters are sparsely encoded."
     }
+    { name: "PHY.FSM.SPARSE",
+      desc: "PHY FSMs are sparsely encoded."
+    }
 
 
   ]
@@ -1643,6 +1646,12 @@
             name: "storage_err",
             desc: '''
               A shadow register encountered a storage error.
+            '''
+          },
+          { bits: "5",
+            name: "phy_fsm_err",
+            desc: '''
+              A flash phy fsm has encountered a sparse encoding error.
             '''
           },
         ]

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -1654,6 +1654,12 @@
               A flash phy fsm has encountered a sparse encoding error.
             '''
           },
+          { bits: "6",
+            name: "ctrl_cnt_err",
+            desc: '''
+              Flash ctrl read/prog has encountered a count error.
+            '''
+          },
         ]
       },
 

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -137,5 +137,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_phy_fsm_sparse
+      desc: "Verify the countermeasure(s) PHY.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -707,7 +707,7 @@ module flash_ctrl
   assign flash_info_sel = op_info_sel;
 
   // flash disable declaration
-  prim_mubi_pkg::mubi4_t flash_disable;
+  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
 
   // tie off hardware clear path
   assign hw2reg.erase_suspend.d = 1'b0;
@@ -720,7 +720,7 @@ module flash_ctrl
     .rst_ni,
 
     // disable flash through memory protection
-    .flash_disable_i(flash_disable),
+    .flash_disable_i(flash_disable[MpDisableIdx]),
 
     // arbiter interface selection
     .if_sel_i(if_sel),
@@ -918,11 +918,22 @@ module flash_ctrl
   // In other words...cowardice.
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
-  assign flash_disable = lc_ctrl_pkg::lc_tx_test_true_loose(lc_disable) ?
-                         prim_mubi_pkg::MuBi4True :
-                         prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
+  prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
+  assign flash_disable_pre_buf = lc_ctrl_pkg::lc_tx_test_true_loose(lc_disable) ?
+                                 prim_mubi_pkg::MuBi4True :
+                                 prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
 
-  assign flash_phy_req.flash_disable = flash_disable;
+  prim_mubi4_sync #(
+    .NumCopies(int'(FlashDisableLast)),
+    .AsyncOn(0)
+  ) u_disable_buf (
+    .clk_i,
+    .rst_ni,
+    .mubi_i(flash_disable_pre_buf),
+    .mubi_o(flash_disable)
+  );
+
+  assign flash_phy_req.flash_disable = flash_disable[PhyDisableIdx];
 
   prim_mubi_pkg::mubi4_t sw_flash_exec_en;
   prim_mubi_pkg::mubi4_t flash_exec_en;
@@ -1151,6 +1162,23 @@ module flash_ctrl
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
   logic flash_host_intg_err;
 
+  import prim_mubi_pkg::mubi4_test_true_loose;
+  logic host_disable;
+  logic disabled_rvalid;
+  logic [1:0] disabled_err;
+
+  // if flash disable is activated, error back from the adapter interface immediately
+  assign host_disable = mubi4_test_true_loose(flash_disable[HostDisableIdx]);
+  assign disabled_err = {2{disabled_rvalid}};
+
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      disabled_rvalid <= '0;
+    end else begin
+      disabled_rvalid <= host_disable & flash_host_req;
+    end
+  end
+
   tlul_adapter_sram #(
     .SramAw(BusAddrW),
     .SramDw(BusWidth),
@@ -1168,15 +1196,15 @@ module flash_ctrl
     .en_ifetch_i (flash_exec_en),
     .req_o       (flash_host_req),
     .req_type_o  (),
-    .gnt_i       (flash_host_req_rdy),
+    .gnt_i       (flash_host_req_rdy | host_disable),
     .we_o        (),
     .addr_o      (flash_host_addr),
     .wdata_o     (),
     .wmask_o     (),
     .intg_error_o(flash_host_intg_err),
     .rdata_i     (flash_host_rdata),
-    .rvalid_i    (flash_host_req_done),
-    .rerror_i    ({flash_host_rderr,1'b0})
+    .rvalid_i    (flash_host_req_done | disabled_rvalid),
+    .rerror_i    ({flash_host_rderr,1'b0} | disabled_err)
   );
 
   flash_phy #(

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -521,6 +521,8 @@ module flash_ctrl
                                          reg2hw.prog_type_en.normal.q;
   assign prog_type_en[FlashProgRepair] = flash_phy_rsp.prog_type_avail[FlashProgRepair] &
                                          reg2hw.prog_type_en.repair.q;
+
+  logic prog_cnt_err;
   flash_ctrl_prog u_flash_ctrl_prog (
     .clk_i,
     .rst_ni,
@@ -535,6 +537,7 @@ module flash_ctrl
     .op_type_i      (op_prog_type),
     .type_avail_i   (prog_type_en),
     .op_err_addr_o  (prog_err_addr),
+    .cnt_err_o      (prog_cnt_err),
 
     // FIFO Interface
     .data_i         (prog_fifo_rdata),
@@ -616,6 +619,7 @@ module flash_ctrl
     .rdata_o (rd_fifo_rdata)
   );
 
+  logic rd_cnt_err;
   // Read handler is consumer of rd_fifo
   assign rd_op_valid = op_start & rd_op;
   flash_ctrl_rd  u_flash_ctrl_rd (
@@ -630,6 +634,7 @@ module flash_ctrl
     .op_err_addr_o  (rd_err_addr),
     .op_addr_i      (op_addr),
     .op_addr_oob_i  ('0),
+    .cnt_err_o      (rd_cnt_err),
 
     // FIFO Interface
     .data_rdy_i     (rd_fifo_wready),
@@ -994,12 +999,14 @@ module flash_ctrl
   assign hw2reg.std_fault_status.arb_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.storage_err.d    = 1'b1;
   assign hw2reg.std_fault_status.phy_fsm_err.d    = 1'b1;
+  assign hw2reg.std_fault_status.ctrl_cnt_err.d   = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.std_fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de     = lcmgr_err;
   assign hw2reg.std_fault_status.arb_fsm_err.de   = arb_fsm_err;
   assign hw2reg.std_fault_status.storage_err.de   = storage_err;
   assign hw2reg.std_fault_status.phy_fsm_err.de   = flash_phy_rsp.fsm_err;
+  assign hw2reg.std_fault_status.ctrl_cnt_err.de  = rd_cnt_err | prog_cnt_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg
@@ -1276,6 +1283,10 @@ module flash_ctrl
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WordCntAlertCheck_A, u_flash_hw_if.u_word_cnt,
                                          alert_tx_o[0])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WipeIdx_A, u_flash_hw_if.u_wipe_idx_cnt,
+                                         alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(ProgCnt_A, u_flash_ctrl_prog.u_cnt,
+                                         alert_tx_o[0])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(RdCnt_A, u_flash_ctrl_rd.u_cnt,
                                          alert_tx_o[0])
 
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(LcCtrlFsmCheck_A,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -993,11 +993,13 @@ module flash_ctrl
   assign hw2reg.std_fault_status.lcmgr_err.d      = 1'b1;
   assign hw2reg.std_fault_status.arb_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.storage_err.d    = 1'b1;
+  assign hw2reg.std_fault_status.phy_fsm_err.d    = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de  = intg_err;
   assign hw2reg.std_fault_status.phy_intg_err.de  = flash_phy_rsp.intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de     = lcmgr_err;
   assign hw2reg.std_fault_status.arb_fsm_err.de   = arb_fsm_err;
   assign hw2reg.std_fault_status.storage_err.de   = storage_err;
+  assign hw2reg.std_fault_status.phy_fsm_err.de   = flash_phy_rsp.fsm_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg
@@ -1282,4 +1284,13 @@ module flash_ctrl
     u_flash_hw_if.u_rma_state_regs, alert_tx_o[0])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(ArbFsmCheck_A,
     u_ctrl_arb.u_state_regs, alert_tx_o[0])
+
+   for (genvar i=0; i<NumBanks; i++) begin : gen_phy_assertions
+     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyFsmCheck_A,
+       u_eflash.gen_flash_cores[i].u_core.u_state_regs, alert_tx_o[0])
+
+     `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyProgFsmCheck_A,
+       u_eflash.gen_flash_cores[i].u_core.gen_prog_data.u_prog.u_state_regs, alert_tx_o[0])
+   end
+
 endmodule

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -972,6 +972,7 @@ module flash_ctrl_core_reg_top (
   logic std_fault_status_arb_fsm_err_qs;
   logic std_fault_status_storage_err_qs;
   logic std_fault_status_phy_fsm_err_qs;
+  logic std_fault_status_ctrl_cnt_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
   logic fault_status_prog_win_err_qs;
@@ -12271,6 +12272,31 @@ module flash_ctrl_core_reg_top (
     .qs     (std_fault_status_phy_fsm_err_qs)
   );
 
+  //   F[ctrl_cnt_err]: 6:6
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_std_fault_status_ctrl_cnt_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.std_fault_status.ctrl_cnt_err.de),
+    .d      (hw2reg.std_fault_status.ctrl_cnt_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.std_fault_status.ctrl_cnt_err.q),
+
+    // to register interface (read)
+    .qs     (std_fault_status_ctrl_cnt_err_qs)
+  );
+
 
   // R[fault_status]: V(False)
   //   F[mp_err]: 1:1
@@ -14434,6 +14460,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[3] = std_fault_status_arb_fsm_err_qs;
         reg_rdata_next[4] = std_fault_status_storage_err_qs;
         reg_rdata_next[5] = std_fault_status_phy_fsm_err_qs;
+        reg_rdata_next[6] = std_fault_status_ctrl_cnt_err_qs;
       end
 
       addr_hit[87]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -971,6 +971,7 @@ module flash_ctrl_core_reg_top (
   logic std_fault_status_lcmgr_err_qs;
   logic std_fault_status_arb_fsm_err_qs;
   logic std_fault_status_storage_err_qs;
+  logic std_fault_status_phy_fsm_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
   logic fault_status_prog_win_err_qs;
@@ -12245,6 +12246,31 @@ module flash_ctrl_core_reg_top (
     .qs     (std_fault_status_storage_err_qs)
   );
 
+  //   F[phy_fsm_err]: 5:5
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_std_fault_status_phy_fsm_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.std_fault_status.phy_fsm_err.de),
+    .d      (hw2reg.std_fault_status.phy_fsm_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.std_fault_status.phy_fsm_err.q),
+
+    // to register interface (read)
+    .qs     (std_fault_status_phy_fsm_err_qs)
+  );
+
 
   // R[fault_status]: V(False)
   //   F[mp_err]: 1:1
@@ -14407,6 +14433,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[2] = std_fault_status_lcmgr_err_qs;
         reg_rdata_next[3] = std_fault_status_arb_fsm_err_qs;
         reg_rdata_next[4] = std_fault_status_storage_err_qs;
+        reg_rdata_next[5] = std_fault_status_phy_fsm_err_qs;
       end
 
       addr_hit[87]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -446,6 +446,7 @@ package flash_ctrl_pkg;
     logic [NumBanks-1:0][BusAddrW-1:0] ecc_addr;
     jtag_pkg::jtag_rsp_t jtag_rsp;
     logic                intg_err;
+    logic                fsm_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -461,7 +462,8 @@ package flash_ctrl_pkg;
     ecc_single_err:     '0,
     ecc_addr:           '0,
     jtag_rsp:           '0,
-    intg_err:           '0
+    intg_err:           '0,
+    fsm_err:            '0
   };
 
   // RMA entries

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -68,7 +68,6 @@ package flash_ctrl_pkg;
   parameter int BusBankAddrW    = PageW + BusWordW;
   parameter int PhyAddrStart    = BusWordW - WordW;
 
-
   // fifo parameters
   parameter int FifoDepthW      = prim_util_pkg::vbits(FifoDepth+1);
 
@@ -84,6 +83,14 @@ package flash_ctrl_pkg;
     PageW'(InfoTypeSize[1] - 1),
     PageW'(InfoTypeSize[2] - 1)
   };
+
+  // Flash Disable usage
+  typedef enum logic [1:0] {
+    PhyDisableIdx,
+    MpDisableIdx,
+    HostDisableIdx,
+    FlashDisableLast
+  } flash_disable_pos_e;
 
   ////////////////////////////
   // All memory protection, seed related parameters

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -504,6 +504,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } phy_fsm_err;
+    struct packed {
+      logic        q;
+    } ctrl_cnt_err;
   } flash_ctrl_reg2hw_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -686,6 +689,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } phy_fsm_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } ctrl_cnt_err;
   } flash_ctrl_hw2reg_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -747,33 +754,33 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [580:575]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [574:569]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [568:557]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [556:551]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [550:547]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [546:515]
-    flash_ctrl_reg2hw_init_reg_t init; // [514:514]
-    flash_ctrl_reg2hw_control_reg_t control; // [513:494]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [493:474]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [473:472]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [471:471]
-    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [470:263]
-    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [262:257]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [581:576]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [575:570]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [569:558]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [557:552]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [551:548]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [547:516]
+    flash_ctrl_reg2hw_init_reg_t init; // [515:515]
+    flash_ctrl_reg2hw_control_reg_t control; // [514:495]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [494:475]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [474:473]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [472:472]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [471:264]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [263:258]
     flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank0_info0_page_cfg_shadowed; // [256:187]
+        bank0_info0_page_cfg_shadowed; // [257:188]
     flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank0_info1_page_cfg_shadowed; // [186:180]
+        bank0_info1_page_cfg_shadowed; // [187:181]
     flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank0_info2_page_cfg_shadowed; // [179:166]
+        bank0_info2_page_cfg_shadowed; // [180:167]
     flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank1_info0_page_cfg_shadowed; // [165:96]
+        bank1_info0_page_cfg_shadowed; // [166:97]
     flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank1_info1_page_cfg_shadowed; // [95:89]
+        bank1_info1_page_cfg_shadowed; // [96:90]
     flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank1_info2_page_cfg_shadowed; // [88:75]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [74:73]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [72:67]
+        bank1_info2_page_cfg_shadowed; // [89:76]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [75:74]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [73:67]
     flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [66:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -784,14 +791,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [153:142]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [141:141]
-    flash_ctrl_hw2reg_control_reg_t control; // [140:139]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [138:137]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [136:133]
-    flash_ctrl_hw2reg_status_reg_t status; // [132:123]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [122:111]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [110:99]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [155:144]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [143:143]
+    flash_ctrl_hw2reg_control_reg_t control; // [142:141]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [140:139]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [138:135]
+    flash_ctrl_hw2reg_status_reg_t status; // [134:125]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [124:113]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [112:99]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [98:87]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [86:66]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [65:48]

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -501,6 +501,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } storage_err;
+    struct packed {
+      logic        q;
+    } phy_fsm_err;
   } flash_ctrl_reg2hw_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -679,6 +682,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } phy_fsm_err;
   } flash_ctrl_hw2reg_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -740,33 +747,33 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [579:574]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [573:568]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [567:556]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [555:550]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [549:546]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [545:514]
-    flash_ctrl_reg2hw_init_reg_t init; // [513:513]
-    flash_ctrl_reg2hw_control_reg_t control; // [512:493]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [492:473]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [472:471]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [470:470]
-    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [469:262]
-    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [261:256]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [580:575]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [574:569]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [568:557]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [556:551]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [550:547]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [546:515]
+    flash_ctrl_reg2hw_init_reg_t init; // [514:514]
+    flash_ctrl_reg2hw_control_reg_t control; // [513:494]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [493:474]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [473:472]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [471:471]
+    flash_ctrl_reg2hw_mp_region_cfg_shadowed_mreg_t [7:0] mp_region_cfg_shadowed; // [470:263]
+    flash_ctrl_reg2hw_default_region_shadowed_reg_t default_region_shadowed; // [262:257]
     flash_ctrl_reg2hw_bank0_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank0_info0_page_cfg_shadowed; // [255:186]
+        bank0_info0_page_cfg_shadowed; // [256:187]
     flash_ctrl_reg2hw_bank0_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank0_info1_page_cfg_shadowed; // [185:179]
+        bank0_info1_page_cfg_shadowed; // [186:180]
     flash_ctrl_reg2hw_bank0_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank0_info2_page_cfg_shadowed; // [178:165]
+        bank0_info2_page_cfg_shadowed; // [179:166]
     flash_ctrl_reg2hw_bank1_info0_page_cfg_shadowed_mreg_t [9:0]
-        bank1_info0_page_cfg_shadowed; // [164:95]
+        bank1_info0_page_cfg_shadowed; // [165:96]
     flash_ctrl_reg2hw_bank1_info1_page_cfg_shadowed_mreg_t [0:0]
-        bank1_info1_page_cfg_shadowed; // [94:88]
+        bank1_info1_page_cfg_shadowed; // [95:89]
     flash_ctrl_reg2hw_bank1_info2_page_cfg_shadowed_mreg_t [1:0]
-        bank1_info2_page_cfg_shadowed; // [87:74]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [73:72]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [71:67]
+        bank1_info2_page_cfg_shadowed; // [88:75]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [74:73]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [72:67]
     flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [66:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -777,14 +784,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [151:140]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [139:139]
-    flash_ctrl_hw2reg_control_reg_t control; // [138:137]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [136:135]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [134:131]
-    flash_ctrl_hw2reg_status_reg_t status; // [130:121]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [120:109]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [108:99]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [153:142]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [141:141]
+    flash_ctrl_hw2reg_control_reg_t control; // [140:139]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [138:137]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [136:133]
+    flash_ctrl_hw2reg_status_reg_t status; // [132:123]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [122:111]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [110:99]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [98:87]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [86:66]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [65:48]


### PR DESCRIPTION
- slightly simplify phy arbitration fsm.
- add more sparse fsms, and add multiple buffers to disable
- add duplicate counts.

ignore first commit, it will be rebased away as part of #11502 