### PR TITLE
[dv/otp] Add assertion for otp_alert_o

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -217,14 +217,17 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
     endcase
   endtask
 
+  // In open source environment, `otp_alert_o` to is tied to 2'b01 (alert_p is 0 and alert_n is 1).
+  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) `ASSERT(OtpAstAlertO_A, otp_alert_o == 2'b01)
+
   // Connectivity assertions for test related I/Os.
   `ASSERT(LcOtpTestStatusO_A, otp_vendor_test_status_o == `PRIM_GENERIC_OTP_PATH.test_status_o)
   `ASSERT(LcOtpTestCtrlI_A, otp_vendor_test_ctrl_i == `PRIM_GENERIC_OTP_PATH.test_ctrl_i)
 
-  `ASSERT(CioTestOWithDftOn_A,    lc_dft_en_i == lc_ctrl_pkg::On |->
-                                  ##2 cio_test_o == `PRIM_GENERIC_OTP_PATH.test_vect_o)
-  `ASSERT(CioTestOWithDftOff_A,   lc_dft_en_i != lc_ctrl_pkg::On |-> ##2 cio_test_o == 0)
-  `ASSERT(CioTestEnOWithDftOn_A,  lc_dft_en_i == lc_ctrl_pkg::On |-> ##2 cio_test_en_o == '1)
+  `ASSERT(CioTestOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |->
+                               ##2 cio_test_o == `PRIM_GENERIC_OTP_PATH.test_vect_o)
+  `ASSERT(CioTestOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##2 cio_test_o == 0)
+  `ASSERT(CioTestEnOWithDftOn_A, lc_dft_en_i == lc_ctrl_pkg::On |-> ##2 cio_test_en_o == '1)
   `ASSERT(CioTestEnOWithDftOff_A, lc_dft_en_i != lc_ctrl_pkg::On |-> ##2 cio_test_en_o == 0)
 
 

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -25,7 +25,7 @@ module tb;
   // since partner base tests inherit from otp_ctrl_base_test#(CFG_T, ENV_T) and
   // specify directly (CFG_T, ENV_T) via the class extension and use a different
   // UVM_TESTNAME
-  if (`PRIM_DEFAULT_IMPL==prim_pkg::ImplGeneric) begin : gen_spec_base_test_params
+  if (`PRIM_DEFAULT_IMPL == prim_pkg::ImplGeneric) begin : gen_spec_base_test_params
     typedef otp_ctrl_base_test #(.CFG_T(otp_ctrl_env_cfg),
                                  .ENV_T(otp_ctrl_env)) otp_ctrl_base_test_t;
   end


### PR DESCRIPTION
This PR adds an assertion for open source OTP output otp_alert_o.
This should be tied to 2'b01 in open source.
This PR also fixes some small spacing syntax.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>