### PR TITLE
[rtl/flash] Add missing file to flash_ctrl.core

### DIFF
--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -32,6 +32,7 @@ filesets:
       - rtl/flash_ctrl_arb.sv
       - rtl/flash_ctrl_info_cfg.sv
       - rtl/flash_ctrl_lcmgr.sv
+      - rtl/flash_ctrl_region_cfg.sv
       - rtl/flash_mp.sv
       - rtl/flash_mp_data_region_sel.sv
       - rtl/flash_phy.sv


### PR DESCRIPTION
This PR adds the missing `flash_ctrl_region_cfg.sv` to flash core file.
I found this missing pkg in formal, but seems to work fine with DV.
Please let me know if I missed anything.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>