### PR TITLE
[fpv/flash] Fix flash compile error

### DIFF
--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -452,6 +452,12 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/flash_ctrl/{sub_flow}/{tool}"
                cov: false
+               overrides: [
+                 {
+                   name:  design_level
+                   value: "top"
+                 }
+               ]
                task: "FpvSecCm"
                stopats: "*u_state_regs.state_o"
              }


### PR DESCRIPTION
This PR fixed flash compile error by overriding the `design_level` to
`top` in order to import the correct files.
Thanks Tim for providing the fix in PR #11564 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>