### PR TITLE
[sw/silicon_creator] Add spi_device_init()

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -144,7 +144,6 @@ cc_library(
     srcs = ["abs_mmio.c"],
     hdrs = ["abs_mmio.h"],
     deps = [
-        ":mmio",
         ":macros",
     ],
 )

--- a/sw/device/lib/base/abs_mmio.h
+++ b/sw/device/lib/base/abs_mmio.h
@@ -8,7 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/macros.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sw/device/lib/base/testing/BUILD
+++ b/sw/device/lib/base/testing/BUILD
@@ -30,6 +30,7 @@ cc_library(
     testonly = True,
     hdrs = [
         "mock_abs_mmio.h",
+        "mock_mmio_test_utils.h",
     ],
     defines = ["MOCK_ABS_MMIO"],
     deps = [

--- a/sw/device/lib/base/testing/mock_abs_mmio.h
+++ b/sw/device/lib/base/testing/mock_abs_mmio.h
@@ -8,7 +8,6 @@
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/testing/global_mock.h"
 #include "sw/device/lib/base/testing/mock_mmio_test_utils.h"
-#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 namespace mask_rom_test {
 namespace internal {

--- a/sw/device/lib/base/testing/mock_mmio_test_utils.h
+++ b/sw/device/lib/base/testing/mock_mmio_test_utils.h
@@ -14,7 +14,6 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "sw/device/lib/base/mmio.h"
 
 namespace mock_mmio {
 

--- a/sw/device/lib/crypto/drivers/hmac.c
+++ b/sw/device/lib/crypto/drivers/hmac.c
@@ -65,14 +65,14 @@ hmac_error_t hmac_sha256_final(hmac_digest_t *digest) {
   if (digest == NULL) {
     return kHmacErrorBadArg;
   }
-  mmio_region_t hmac_base = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
 
   uint32_t reg = 0;
   reg = bitfield_bit32_write(reg, HMAC_CMD_HASH_PROCESS_BIT, true);
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_CMD_REG_OFFSET, reg);
 
   do {
-    reg = mmio_region_read32(hmac_base, HMAC_INTR_STATE_REG_OFFSET);
+    reg = abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR +
+                          HMAC_INTR_STATE_REG_OFFSET);
   } while (!bitfield_bit32_read(reg, HMAC_INTR_STATE_HMAC_DONE_BIT));
   abs_mmio_write32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_INTR_STATE_REG_OFFSET,
                    reg);
@@ -80,8 +80,9 @@ hmac_error_t hmac_sha256_final(hmac_digest_t *digest) {
   // Read the digest in reverse to preserve the numerical value.
   // The least significant word is at HMAC_DIGEST_7_REG_OFFSET.
   for (size_t i = 0; i < ARRAYSIZE(digest->digest); ++i) {
-    digest->digest[i] = mmio_region_read32(
-        hmac_base, HMAC_DIGEST_7_REG_OFFSET - (i * sizeof(uint32_t)));
+    digest->digest[i] =
+        abs_mmio_read32(TOP_EARLGREY_HMAC_BASE_ADDR + HMAC_DIGEST_7_REG_OFFSET -
+                        (i * sizeof(uint32_t)));
   }
   return kHmacOk;
 }

--- a/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
+++ b/sw/device/silicon_creator/lib/base/sec_mmio_unittest.cc
@@ -11,6 +11,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 namespace sec_mmio_unittest {
 namespace {

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -569,3 +569,31 @@ opentitan_functest(
         "//sw/device/silicon_creator/lib/base:sec_mmio",
     ],
 )
+
+cc_library(
+    name = "spi_device",
+    srcs = ["spi_device.c"],
+    hdrs = ["spi_device.h"],
+    deps = [
+        "//hw/ip/spi_device/data:spi_device_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib:error",
+    ],
+)
+
+cc_test(
+    name = "spi_device_unittest",
+    srcs = [
+        "spi_device_unittest.cc",
+    ],
+    deps = [
+        ":spi_device",
+        "//hw/ip/spi_device/data:spi_device_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base/testing:mock_abs_mmio",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
+    ],
+)

--- a/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/hmac_unittest.cc
@@ -11,6 +11,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
 #include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hmac_regs.h"  // Generated.
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -576,3 +576,35 @@ test('sw_silicon_creator_lib_driver_flash_ctrl_unittest', executable(
   ),
   suite: 'mask_rom',
 )
+
+# Mask ROM spi_device driver
+sw_silicon_creator_lib_driver_spi_device = declare_dependency(
+  link_with: static_library(
+    'sw_silicon_creator_lib_driver_spi_device',
+    sources: [
+      hw_ip_spi_device_reg_h,
+      'spi_device.c',
+    ],
+    dependencies: [
+      sw_lib_abs_mmio,
+    ],
+  ),
+)
+
+test('sw_silicon_creator_lib_driver_spi_device_unittest', executable(
+    'sw_silicon_creator_lib_driver_spi_device_unittest',
+    sources: [
+      'spi_device_unittest.cc',
+      hw_ip_spi_device_reg_h,
+      'spi_device.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_testing_mock_abs_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO'],
+    cpp_args: ['-DMOCK_ABS_MMIO'],
+    ),
+  suite: 'mask_rom',
+)

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "pinmux_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "sram_ctrl_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/rstmgr_unittest.cc
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/multibits.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rstmgr_regs.h"  // Generated.

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -1,0 +1,69 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/spi_device.h"
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "spi_device_regs.h"  // Generated.
+
+enum {
+  /**
+   * Base address of the spi_device registers.
+   */
+  kBase = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR,
+};
+
+void spi_device_init(void) {
+  // CPOL = 0, CPHA = 0, MSb-first TX and RX, 3-byte addressing.
+  uint32_t reg = bitfield_bit32_write(0, SPI_DEVICE_CFG_CPOL_BIT, false);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_CPHA_BIT, false);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_TX_ORDER_BIT, false);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_RX_ORDER_BIT, false);
+  reg = bitfield_field32_write(reg, SPI_DEVICE_CFG_TIMER_V_FIELD, 0x7f);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_ADDR_4B_EN_BIT, false);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CFG_MAILBOX_EN_BIT, false);
+  abs_mmio_write32(kBase + SPI_DEVICE_CFG_REG_OFFSET, reg);
+
+  // JEDEC manufacturer and device ID.
+  // spi_device sends these in the following order: continuation codes,
+  // manufacturer ID, LSB of device ID, and MSB of device ID (density).
+  reg = bitfield_field32_write(0, SPI_DEVICE_JEDEC_CC_CC_FIELD,
+                               kSpiDeviceJedecContCode);
+  reg = bitfield_field32_write(reg, SPI_DEVICE_JEDEC_CC_NUM_CC_FIELD,
+                               kSpiDeviceJedecContCodeCount);
+  abs_mmio_write32(kBase + SPI_DEVICE_JEDEC_CC_REG_OFFSET, reg);
+  // TODO(#11605): Use the HW revision register when available.
+  reg = bitfield_field32_write(0, SPI_DEVICE_DEV_ID_CHIP_REV_FIELD, 0);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_DEV_ID_ROM_BOOTSTRAP_BIT, true);
+  reg = bitfield_field32_write(reg, SPI_DEVICE_DEV_ID_CHIP_GEN_FIELD, 0);
+  reg = bitfield_field32_write(reg, SPI_DEVICE_DEV_ID_DENSITY_FIELD,
+                               kSpiDeviceJedecDensity);
+  reg = bitfield_field32_write(reg, SPI_DEVICE_JEDEC_ID_MF_FIELD,
+                               kSpiDeviceJedecManufId);
+  abs_mmio_write32(kBase + SPI_DEVICE_JEDEC_ID_REG_OFFSET, reg);
+
+  // Configure READ_JEDEC_ID command (CMD_INFO_3).
+  reg = bitfield_field32_write(0, SPI_DEVICE_CMD_INFO_3_OPCODE_3_FIELD,
+                               kSpiDeviceCmdReadJedecId);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CMD_INFO_3_VALID_3_BIT, true);
+  abs_mmio_write32(kBase + SPI_DEVICE_CMD_INFO_3_REG_OFFSET, reg);
+
+  // Reset status register
+  abs_mmio_write32(kBase + SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0);
+
+  // Switch to flash mode. Both clocks (SRAM and SPI) must be disabled prior to
+  // mode change for proper SRAM operation.
+  reg = abs_mmio_read32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, false);
+  abs_mmio_write32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET, reg);
+  reg = bitfield_field32_write(0, SPI_DEVICE_CONTROL_MODE_FIELD,
+                               SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE);
+  abs_mmio_write32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET, reg);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, true);
+  abs_mmio_write32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET, reg);
+}

--- a/sw/device/silicon_creator/lib/drivers/spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.h
@@ -1,0 +1,67 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SPI_DEVICE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SPI_DEVICE_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Bit field definitions for JEDEC device ID.
+ *
+ * Note: spi_device sends bits 7:0 of the device ID first.
+ */
+#define SPI_DEVICE_DEV_ID_CHIP_REV_FIELD \
+  ((bitfield_field32_t){.mask = 0x7, .index = 0})
+#define SPI_DEVICE_DEV_ID_ROM_BOOTSTRAP_BIT 3
+#define SPI_DEVICE_DEV_ID_CHIP_GEN_FIELD \
+  ((bitfield_field32_t){.mask = 0xf, .index = 4})
+#define SPI_DEVICE_DEV_ID_DENSITY_FIELD \
+  ((bitfield_field32_t){.mask = 0xff, .index = 8})
+
+enum {
+  /**
+   * lowRISC's manufacturer ID from the JEDEC JEP106BE standard.
+   */
+  kSpiDeviceJedecContCode = 0x7f,
+  kSpiDeviceJedecContCodeCount = 12,
+  kSpiDeviceJedecManufId = 0xef,
+  /**
+   * LSB of the 2-byte device ID.
+   */
+  kSpiDeviceJedecDensity = 0x0a,
+  /**
+   * READ_JECEC_ID command.
+   *
+   * This command is handled by the spi_device. Upon receiving this instruction,
+   * spi_device sends `kSpiDeviceJedecContCodeCount` repetitions of
+   * `kSpiDeviceJedecContCode`, followed by `kSpiDeviceJedecManufId` and 2 bytes
+   * of device id.
+   */
+  kSpiDeviceCmdReadJedecId = 0x9f,
+};
+
+/**
+ * Initializes the spi_device in flash mode for bootstrap in mask ROM.
+ *
+ * This function initializes the spi_device in the following configuration:
+ * - CPOL = 0, CPHA = 0 (clock low in idle, data sampled on rising clock edge).
+ * - MSb-first bit order for RX and TX.
+ * - Flash mode with 3-byte addressing.
+ * - Commands:
+ *   - READ_JEDEC_ID
+ */
+void spi_device_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_SPI_DEVICE_H_

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -1,0 +1,86 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/spi_device.h"
+
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/error.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "spi_device_regs.h"
+
+namespace spi_device_unittest {
+namespace {
+
+class SpiDeviceTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_SPI_DEVICE_BASE_ADDR;
+  mask_rom_test::MockAbsMmio mmio_;
+};
+
+class InitTest : public SpiDeviceTest {};
+
+TEST_F(InitTest, Init) {
+  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CFG_REG_OFFSET,
+                     {
+                         {SPI_DEVICE_CFG_CPOL_BIT, 0},
+                         {SPI_DEVICE_CFG_CPHA_BIT, 0},
+                         {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
+                         {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
+                         {SPI_DEVICE_CFG_TIMER_V_OFFSET, 0x7f},
+                         {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 0},
+                         {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 0},
+                     });
+
+  EXPECT_ABS_WRITE32(
+      base_ + SPI_DEVICE_JEDEC_CC_REG_OFFSET,
+      {
+          {SPI_DEVICE_JEDEC_CC_CC_OFFSET, kSpiDeviceJedecContCode},
+          {SPI_DEVICE_JEDEC_CC_NUM_CC_OFFSET, kSpiDeviceJedecContCodeCount},
+      });
+  EXPECT_ABS_WRITE32(
+      base_ + SPI_DEVICE_JEDEC_ID_REG_OFFSET,
+      {
+          {SPI_DEVICE_DEV_ID_CHIP_REV_FIELD.index, 0},
+          {SPI_DEVICE_DEV_ID_ROM_BOOTSTRAP_BIT, 1},
+          {SPI_DEVICE_DEV_ID_CHIP_GEN_FIELD.index, 0},
+          {SPI_DEVICE_DEV_ID_DENSITY_FIELD.index, kSpiDeviceJedecDensity},
+          {SPI_DEVICE_JEDEC_ID_MF_OFFSET, kSpiDeviceJedecManufId},
+      });
+
+  EXPECT_ABS_WRITE32(
+      base_ + SPI_DEVICE_CMD_INFO_3_REG_OFFSET,
+      {
+          {SPI_DEVICE_CMD_INFO_3_OPCODE_3_OFFSET, kSpiDeviceCmdReadJedecId},
+          {SPI_DEVICE_CMD_INFO_3_VALID_3_BIT, 1},
+      });
+
+  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0);
+
+  uint32_t control_reg = std::numeric_limits<uint32_t>::max();
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET, control_reg);
+  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET,
+                     control_reg ^ 1 << SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT);
+  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET,
+                     {
+                         {SPI_DEVICE_CONTROL_MODE_OFFSET,
+                          SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE},
+                         {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 0},
+                     });
+  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CONTROL_REG_OFFSET,
+                     {
+                         {SPI_DEVICE_CONTROL_MODE_OFFSET,
+                          SPI_DEVICE_CONTROL_MODE_VALUE_FLASHMODE},
+                         {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 1},
+                     });
+
+  spi_device_init();
+}
+
+}  // namespace
+}  // namespace spi_device_unittest

--- a/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/uart_unittest.cc
@@ -7,6 +7,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "uart_regs.h"  // Generated.

--- a/sw/host/opentitantool/src/command/spi.rs
+++ b/sw/host/opentitantool/src/command/spi.rs
@@ -101,7 +101,7 @@ pub struct SpiReadId {
     #[structopt(
         short = "n",
         long,
-        default_value = "3",
+        default_value = "15",
         help = "Number of JEDEC ID bytes to read."
     )]
     length: usize,


### PR DESCRIPTION
This PR adds `spi_device_init()` for initializing the spi_device in flash mode for bootstrap in mask ROM. Currently it only registers the READ_JEDEC_ID command. I'll add the remaining commands listed [here](https://docs.google.com/document/d/1X_x7f62IrPeHRLGBzybhDu9TsvsSCb6_1uKOjQO_fI4/edit?resourcekey=0-vLsVqyrt1F2mGwLrz73uwA#heading=h.3jn8vcz1y6rj) in future PRs.

The first commit has some minor bazel-related fixes for mock_abs_mmio to be able to build this change in bazel. The scope of these changes are limited to minimize conflict with #11416 but I was able to successfully run
```
$ bazel build //sw/device/silicon_creator/lib/drivers:spi_device
$ bazel test //sw/device/silicon_creator/lib/drivers:spi_device_unittest
```

@cfrantz PLMK if you would like me to use something else for `kSpiDeviceJedecDevId` and `kSpiDeviceJedecDensity`.

I also tested these changes with logic pro 16 and opentitantool using the bitstream from #10874:
```
$ opentitantool spi read-id
{
  "jedec_id": [
    127,
    127,
    127,
    127,
    127,
    127,
    127,
    127,
    127,
    127,
    127,
    127,
    239,
    7,
    10
  ]
}
```

![image](https://user-images.githubusercontent.com/57949550/159342792-7245ae65-0717-4245-a925-57b873783100.png)
