### PR TITLE
[aes,dv] Split A-channel write handling into separate functions

### DIFF
--- a/hw/ip/aes/dv/env/aes_scoreboard.sv
+++ b/hw/ip/aes/dv/env/aes_scoreboard.sv
@@ -264,8 +264,6 @@ class aes_scoreboard extends cip_base_scoreboard #(
           // DO nothing- trying to write to a read only register
         end
       endcase // case (1)
-    end // if (cfg.idle_vif)
-
 
 
       ///////////////////////////////////////
@@ -410,7 +408,7 @@ class aes_scoreboard extends cip_base_scoreboard #(
         // is written
         input_item.split_item = 0;
       end
-
+    end
 
     //////////////////////////////////////////////////////////////////////////////
     // get an item from the rcv queue and wait for all output data to be received


### PR DESCRIPTION
*This is a small refactor, triggered by reading #11255 in detail. It's in draft because it depends on the commits in that PR*

The only change in behaviour should be that these functions now all
only run when the transaction is a write (before, some of them didn't
have the check that was probably supposed to be there).

However the split means there's rather less indentation which, in
turn, means we don't have to fight so hard to avoid the 100 column
limit.

@rasmus-madsen: No strong feelings about this: I did it to make sense of the other PR. If you hate it, I'm happy to drop :-)