### PR TITLE
[prim_flop] Updates to sparse_fsm_flop usage to increase DV coverage

### DIFF
--- a/doc/project/checklist.md
+++ b/doc/project/checklist.md
@@ -173,7 +173,7 @@ Note:
 
 - For duplicated counters [`prim_count`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_count.sv) must be used.
 - For duplicated LFSRs [`prim_double_lfsr`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_double_lfsr.sv) must be used.
-- For redundantly encoded FSMs, [the sparse-fsm-encode.py script](https://github.com/lowRISC/opentitan/blob/master/util/design/sparse-fsm-encode.py) must be used to generate the encoding (in conjunction with the [`prim_sparse_fsm_flop`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_sparse_fsm_flop.sv)) primitive.
+- For redundantly encoded FSMs, [the sparse-fsm-encode.py script](https://github.com/lowRISC/opentitan/blob/master/util/design/sparse-fsm-encode.py) must be used to generate the encoding (in conjunction with the [`PRIM_FLOP_SPARSE_FSM`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_flop_macros.sv)) macro.
 - For multibit signals, the `mubi` types in [`prim_mubi_pkg`](https://github.com/lowRISC/opentitan/blob/master/hw/ip/prim/rtl/prim_mubi_pkg.sv) should be used if possible.
 
 ### SEC_CM_RTL_REVIEWED

--- a/doc/ug/sec_cm_dv_framework/index.md
+++ b/doc/ug/sec_cm_dv_framework/index.md
@@ -69,6 +69,34 @@ endmodule
 
 ```
 
+### Special Handling of Sparse FSM Primitive
+
+Sparse FSMs in OpenTitan security IPs are implemented with the `prim_sparse_fsm_flop` countermeasure primitive to ensure that the state encoding cannot be altered by synthesis tools.
+This primititive also implements the embedded common checks mentioned above.
+
+However, simulation tools like Xcelium and VCS are at this time not able to correctly infer FSMs and report FSM coverage when the state registers reside in a different hierarchy (such as `prim_sparse_fsm_flop`) than the next-state logic of the FSMs.
+
+In order to work around this issue, the wrapper macro `PRIM_FLOP_SPARSE_FSM` should be used instead of directly instantiating the `prim_sparse_fsm_flop` primitive.
+The `PRIM_FLOP_SPARSE_FSM` macro instantiates a behavioral state register in addition to the `prim_sparse_fsm_flop` primitive when the design is built with `SIMULATION` defined.
+This enables simulation tools to correctly infer FSMs and report coverage accordingly.
+For other build targets that do not define `SIMULATION` this macro only instantiates the `prim_sparse_fsm_flop` primitive.
+
+An example of how the macro should be used is shown below:
+
+```systemverilog
+// u_state_flops: instance name of the prim_sparse_fsm_flop primitive
+// state_d: FSM next state
+// state_q: FSM current state
+// state_e: FSM state enum type
+// ResetSt: FSM reset state
+// clk_i: Clock of the design (defaults to clk_i)
+// rst_ni: Reset of the design (defaults to rst_ni)
+// SvaEn: A value of 1 enables the embedded assertion (defaults to 1)
+`PRIM_FLOP_SPARSE_FSM(u_state_flops, state_d, state__q, state_e, ResetSt, clk_i, rst_ni, SvaEn)
+```
+
+In order to generate a complete template for sparsely encoded FSMs, please refer to the [the sparse-fsm-encode.py script](https://github.com/lowRISC/opentitan/blob/master/util/design/sparse-fsm-encode.py).
+
 ## Verification Framework For The Standardized Design Countermeasures
 
 This verification framework involves three different steps, which are all needed in order to acheive the completed verification for countermeasures.

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -7,7 +7,8 @@
 // This contains a proxy class and store the object in sec_cm_pkg, which can be used in vseq to
 // control inject_fault and restore_fault
 interface prim_sparse_fsm_flop_if #(
-  parameter int Width = 2
+  parameter int Width = 2,
+  parameter string CustomForceName = ""
 ) (
   input clk_i,
   input rst_ni);
@@ -23,6 +24,11 @@ interface prim_sparse_fsm_flop_if #(
   string path = dv_utils_pkg::get_parent_hier($sformatf("%m"));
   string signal_forced = $sformatf("%s.state_o", path);
 
+  // This signal only has to be forced if the associated parameter
+  // CustomForceName in prim_sparse_fsm_flop is set to a non-empty string.
+  string parent_path = dv_utils_pkg::get_parent_hier($sformatf("%m"), 2);
+  string custom_signal_forced = $sformatf("%s.%s", parent_path, CustomForceName);
+
   class prim_sparse_fsm_flop_if_proxy extends sec_cm_pkg::sec_cm_base_if_proxy;
     `uvm_object_new
 
@@ -36,17 +42,26 @@ interface prim_sparse_fsm_flop_if #(
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value,
           $countones(force_value ^ orig_value) inside {[1: MaxFlipBits]};)
 
-      `DV_CHECK(uvm_hdl_deposit(signal_forced, force_value))
       `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
                                   signal_forced, orig_value, force_value), UVM_LOW)
-
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, force_value))
+      if (CustomForceName != "") begin
+        `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
+                                    custom_signal_forced, orig_value, force_value), UVM_LOW)
+        `DV_CHECK(uvm_hdl_deposit(custom_signal_forced, force_value))
+      end
       @(posedge clk_i);
     endtask
 
     virtual task restore_fault();
-      `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
       `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", signal_forced, orig_value),
                 UVM_LOW)
+      `DV_CHECK(uvm_hdl_deposit(signal_forced, orig_value))
+      if (CustomForceName != "") begin
+        `uvm_info(msg_id, $sformatf("Forcing %s to original value %0d", custom_signal_forced,
+                  orig_value), UVM_LOW)
+        `DV_CHECK(uvm_hdl_deposit(custom_signal_forced, orig_value))
+      end
     endtask
   endclass
 

--- a/hw/dv/sv/sec_cm/sec_cm_prim_sparse_fsm_flop_bind.sv
+++ b/hw/dv/sv/sec_cm/sec_cm_prim_sparse_fsm_flop_bind.sv
@@ -4,5 +4,5 @@
 
 module sec_cm_prim_sparse_fsm_flop_bind();
   bind prim_sparse_fsm_flop prim_sparse_fsm_flop_if #(
-         .Width(Width)) u_prim_sparse_fsm_flop_if (.*);
+         .Width(Width), .CustomForceName(CustomForceName)) u_prim_sparse_fsm_flop_if (.*);
 endmodule

--- a/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_cipher_control_fsm.sv
@@ -476,20 +476,8 @@ module aes_cipher_control_fsm import aes_pkg::*;
   end
 
   // SEC_CM: CIPHER.FSM.SPARSE
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] aes_cipher_ctrl_cs_raw;
-  assign aes_cipher_ctrl_cs = aes_cipher_ctrl_e'(aes_cipher_ctrl_cs_raw);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(aes_cipher_ctrl_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(IDLE))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( aes_cipher_ctrl_ns     ),
-    .state_o ( aes_cipher_ctrl_cs_raw )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, aes_cipher_ctrl_ns,
+      aes_cipher_ctrl_cs, aes_cipher_ctrl_e, IDLE)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : reg_fsm
     if (!rst_ni) begin

--- a/hw/ip/aes/rtl/aes_control_fsm.sv
+++ b/hw/ip/aes/rtl/aes_control_fsm.sv
@@ -651,20 +651,7 @@ module aes_control_fsm
   end
 
   // SEC_CM: MAIN.FSM.SPARSE
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] aes_ctrl_cs_raw;
-  assign aes_ctrl_cs = aes_ctrl_e'(aes_ctrl_cs_raw);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(aes_ctrl_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(IDLE))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( aes_ctrl_ns     ),
-    .state_o ( aes_ctrl_cs_raw )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, aes_ctrl_ns, aes_ctrl_cs, aes_ctrl_e, IDLE)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : reg_fsm
     if (!rst_ni) begin

--- a/hw/ip/aes/rtl/aes_ctr_fsm.sv
+++ b/hw/ip/aes/rtl/aes_ctr_fsm.sv
@@ -131,20 +131,7 @@ module aes_ctr_fsm import aes_pkg::*;
   end
 
   // SEC_CM: CTR.FSM.SPARSE
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] aes_ctr_cs_raw;
-  assign aes_ctr_cs = aes_ctr_e'(aes_ctr_cs_raw);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(aes_ctr_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(IDLE))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( aes_ctr_ns     ),
-    .state_o ( aes_ctr_cs_raw )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, aes_ctr_ns, aes_ctr_cs, aes_ctr_e, IDLE)
 
   // Forward slice index.
   assign ctr_slice_idx_o = ctr_slice_idx_q;

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -234,23 +234,7 @@ module csrng_cmd_stage import csrng_pkg::*; #(
   } state_e;
 
   state_e state_d, state_q;
-
-  logic [StateWidth-1:0] state_raw_q;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(Idle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
-
-  assign state_q = state_e'(state_raw_q);
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
   always_comb begin
     state_d = state_q;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -215,24 +215,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
 
   state_e state_d, state_q;
 
-  logic [StateWidth-1:0] state_raw_q;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
   // SEC_CM: UPDATE.FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(ReqIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
-
-  assign state_q = state_e'(state_raw_q);
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, ReqIdle)
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -183,24 +183,9 @@ module csrng_ctr_drbg_upd #(
 
   blk_enc_state_e blk_enc_state_d, blk_enc_state_q;
 
-  logic [BlkEncStateWidth-1:0] blk_enc_state_raw_q;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
   // SEC_CM: BLK_ENC.FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(blk_enc_state_e),
-    .Width(BlkEncStateWidth),
-    .ResetValue(BlkEncStateWidth'(ReqIdle))
-  ) u_blk_enc_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( blk_enc_state_d ),
-    .state_o ( blk_enc_state_raw_q )
-  );
-
-  assign blk_enc_state_q = blk_enc_state_e'(blk_enc_state_raw_q);
+  `PRIM_FLOP_SPARSE_FSM(u_blk_enc_state_regs, blk_enc_state_d,
+      blk_enc_state_q, blk_enc_state_e, ReqIdle)
 
 // Encoding generated with:
 // $ ./util/design/sparse-fsm-encode.py -d 3 -m 4 -n 6 \
@@ -232,24 +217,9 @@ module csrng_ctr_drbg_upd #(
 
   outblk_state_e outblk_state_d, outblk_state_q;
 
-  logic [OutBlkStateWidth-1:0] outblk_state_raw_q;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
   // SEC_CM: OUTBLK.FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(outblk_state_e),
-    .Width(OutBlkStateWidth),
-    .ResetValue(OutBlkStateWidth'(AckIdle))
-  ) u_outblk_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( outblk_state_d ),
-    .state_o ( outblk_state_raw_q )
-  );
-
-  assign outblk_state_q = outblk_state_e'(outblk_state_raw_q);
+  `PRIM_FLOP_SPARSE_FSM(u_outblk_state_regs, outblk_state_d,
+      outblk_state_q, outblk_state_e, AckIdle)
 
   always_ff @(posedge clk_i or negedge rst_ni)
     if (!rst_ni) begin

--- a/hw/ip/csrng/rtl/csrng_main_sm.sv
+++ b/hw/ip/csrng/rtl/csrng_main_sm.sv
@@ -73,25 +73,9 @@ module csrng_main_sm import csrng_pkg::*; #(
   } state_e;
 
   state_e state_d, state_q;
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
-  logic [StateWidth-1:0] state_raw_q;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(Idle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
-
-  assign state_q = state_e'(state_raw_q);
-  assign main_sm_state_o = state_raw_q;
+  assign main_sm_state_o = {state_q};
 
   always_comb begin
     state_d = state_q;

--- a/hw/ip/edn/rtl/edn_ack_sm.sv
+++ b/hw/ip/edn/rtl/edn_ack_sm.sv
@@ -47,24 +47,7 @@ module edn_ack_sm (
 
   state_e state_d, state_q;
 
-  logic [StateWidth-1:0] state_raw_q;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
-
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(Idle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
-
-  assign state_q = state_e'(state_raw_q);
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
   always_comb begin
     state_d = state_q;

--- a/hw/ip/edn/rtl/edn_main_sm.sv
+++ b/hw/ip/edn/rtl/edn_main_sm.sv
@@ -80,25 +80,9 @@ module edn_main_sm #(
 
   state_e state_d, state_q;
 
-  logic [StateWidth-1:0] state_raw_q;
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
-
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(Idle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
-
-  assign state_q = state_e'(state_raw_q);
-  assign main_sm_state_o = state_raw_q;
+  assign main_sm_state_o = state_q;
 
   assign main_sm_busy_o = (state_q != Idle) && (state_q != BootPulse) &&
          (state_q != BootDone) && (state_q != SWPortMode);

--- a/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_ack_sm.sv
@@ -48,23 +48,7 @@ module entropy_src_ack_sm (
 
   state_e state_d, state_q;
 
-  logic [StateWidth-1:0] state_raw_q;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(Idle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
-
-  assign state_q = state_e'(state_raw_q);
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
   always_comb begin
     state_d = state_q;

--- a/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_main_sm.sv
@@ -88,24 +88,9 @@ module entropy_src_main_sm #(
 
   state_e state_d, state_q;
 
-  logic [StateWidth-1:0] state_raw_q;
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Idle)
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(Idle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
-
-  assign state_q = state_e'(state_raw_q);
-  assign main_sm_state_o = state_raw_q;
+  assign main_sm_state_o = state_q;
 
   always_comb begin
     state_d = state_q;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_arb.sv
@@ -129,21 +129,8 @@ module flash_ctrl_arb import flash_ctrl_pkg::*; (
   logic sw_req;
   assign sw_req = sw_ctrl_i.start.q;
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = arb_state_e'(state_raw_q);
   // SEC_CM: FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(arb_state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StReset))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, arb_state_e, StReset)
 
   always_comb begin
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -130,21 +130,8 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; #(
   lcmgr_state_e state_q, state_d;
   logic state_err;
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = lcmgr_state_e'(state_raw_q);
   //SEC_CM: FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(lcmgr_state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, lcmgr_state_e, StIdle)
 
   lc_ctrl_pkg::lc_tx_t err_sts_d, err_sts_q;
   logic err_sts_set;
@@ -522,21 +509,8 @@ module flash_ctrl_lcmgr import flash_ctrl_pkg::*; #(
                     RmaWipeEntries[rma_wipe_idx].num_pages;
 
   rma_state_e rma_state_d, rma_state_q;
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [RmaStateWidth-1:0] rma_state_raw_q;
-  assign rma_state_q = rma_state_e'(rma_state_raw_q);
   // SEC_CM: FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(rma_state_e),
-    .Width(RmaStateWidth),
-    .ResetValue(RmaStateWidth'(StRmaIdle))
-  ) u_rma_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( rma_state_d ),
-    .state_o ( rma_state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_rma_state_regs, rma_state_d, rma_state_q, rma_state_e, StRmaIdle)
 
   // SEC_CM: CTR.SPARSE
   logic page_err_q, page_err_d;

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -157,21 +157,8 @@ module flash_phy_core
   import prim_mubi_pkg::mubi4_test_false_strict;
   import prim_mubi_pkg::mubi4_test_true_loose;
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
   // SEC_CM: PHY.FSM.SPARSE
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StIdle)
 
   typedef enum logic [2:0] {
     HostDisableIdx,

--- a/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
@@ -124,21 +124,8 @@ module flash_phy_prog import flash_phy_pkg::*; (
     end
   end
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
   // SEC_CM: PHY.FSM.SPARSE
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StIdle)
 
   // If the first beat of an incoming transaction is not aligned to word boundary (for example
   // if each flash word is 4 bus words wide, and the first word to program starts at index 1),

--- a/hw/ip/keymgr/dv/env/keymgr_if.sv
+++ b/hw/ip/keymgr/dv/env/keymgr_if.sv
@@ -379,19 +379,19 @@ interface keymgr_if(input clk, input rst_n);
       end
       1: begin
         `uvm_info(msg_id, "Force KMC_IF FSM", UVM_LOW)
-        prev_state = tb.dut.u_kmac_if.state_raw_q;
+        prev_state = tb.dut.u_kmac_if.u_state_regs.state_raw;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_state,
             !(invalid_state inside {KmacIfValidStates});,
             , msg_id)
 
-        force tb.dut.u_kmac_if.state_raw_q = invalid_state;
+        force tb.dut.u_kmac_if.u_state_regs.state_raw = invalid_state;
         @(posedge clk);
 
         if ($urandom_range(0, 1)) begin
-          force tb.dut.u_kmac_if.state_raw_q = prev_state;
+          force tb.dut.u_kmac_if.u_state_regs.state_raw = prev_state;
           @(posedge clk);
         end
-        release tb.dut.u_kmac_if.state_raw_q;
+        release tb.dut.u_kmac_if.u_state_regs.state_raw;
         is_kmac_if_fsm_err = 1;
       end
       1: begin
@@ -426,19 +426,19 @@ interface keymgr_if(input clk, input rst_n);
       end
       1: begin
         `uvm_info(msg_id, "Force ctrl FSM", UVM_LOW)
-        prev_state = tb.dut.u_ctrl.state_raw_q;
+        prev_state = tb.dut.u_ctrl.u_state_regs.state_raw;
         `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(invalid_state,
             !(invalid_state inside {CtrlValidStates});,
             , msg_id)
 
-        force tb.dut.u_ctrl.state_raw_q = invalid_state;
+        force tb.dut.u_ctrl.u_state_regs.state_raw = invalid_state;
         @(posedge clk);
 
         if ($urandom_range(0, 1)) begin
-          force tb.dut.u_ctrl.state_raw_q = prev_state;
+          force tb.dut.u_ctrl.u_state_regs.state_raw = prev_state;
           @(posedge clk);
         end
-        release tb.dut.u_ctrl.state_raw_q;
+        release tb.dut.u_ctrl.u_state_regs.state_raw;
         is_ctrl_fsm_err = 1;
       end
       1: begin

--- a/hw/ip/keymgr/rtl/keymgr_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_ctrl.sv
@@ -237,19 +237,8 @@ module keymgr_ctrl
   //////////////////////////
   // Main Control FSM
   //////////////////////////
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
   // SEC_CM: CTRL.FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StCtrlReset))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StCtrlReset)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/keymgr/rtl/keymgr_data_en_state.sv
+++ b/hw/ip/keymgr/rtl/keymgr_data_en_state.sv
@@ -54,21 +54,8 @@ module keymgr_data_en_state
 
   state_e state_d, state_q;
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [DataStateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
   // SEC_CM: DATA.FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(DataStateWidth),
-    .ResetValue(DataStateWidth'(StCtrlDataIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StCtrlDataIdle)
 
   // The below control path is used for modulating the datapath to sideload and sw keys.
   // This path is separate from the data_valid_o path, thus creating two separate attack points.

--- a/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
+++ b/hw/ip/keymgr/rtl/keymgr_kmac_if.sv
@@ -159,22 +159,8 @@ module keymgr_kmac_if import keymgr_pkg::*;(
     end
    end
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = data_state_e'(state_raw_q);
-
   // SEC_CM: KMAC_IF.FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(data_state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, data_state_e, StIdle)
 
   always_comb begin
     cnt_clr = 1'b0;

--- a/hw/ip/keymgr/rtl/keymgr_op_state_ctrl.sv
+++ b/hw/ip/keymgr/rtl/keymgr_op_state_ctrl.sv
@@ -41,19 +41,7 @@ module keymgr_op_state_ctrl
   } state_e;
 
   state_e state_q, state_d;
-  logic [OpStateWidth-1:0] state_raw_q;
-
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(OpStateWidth),
-    .ResetValue(OpStateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StIdle)
 
   logic gen_en;
   assign id_en_o = gen_en & id_req_i;

--- a/hw/ip/kmac/rtl/keccak_round.sv
+++ b/hw/ip/kmac/rtl/keccak_round.sv
@@ -189,21 +189,7 @@ module keccak_round
       StTerminalError = 6'b110110
   } keccak_st_e;
   keccak_st_e keccak_st, keccak_st_d;
-
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign keccak_st = keccak_st_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(keccak_st_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( keccak_st_d ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, keccak_st_d, keccak_st, keccak_st_e, StIdle)
 
   // Next state logic and output logic
   // SEC_CM: FSM.SPARSE

--- a/hw/ip/kmac/rtl/kmac.sv
+++ b/hw/ip/kmac/rtl/kmac.sv
@@ -129,8 +129,7 @@ module kmac
 
   } kmac_st_e;
 
-  logic [StateWidth-1:0] kmac_st_raw;
-  kmac_st_e              kmac_st, kmac_st_d;
+  kmac_st_e kmac_st, kmac_st_d;
 
   /////////////
   // Signals //
@@ -677,19 +676,7 @@ module kmac
   ///////////////////
 
   // State FF
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  prim_sparse_fsm_flop #(
-    .StateEnumT(kmac_st_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(KmacIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i (kmac_st_d),
-    .state_o (kmac_st_raw)
-  );
-  assign kmac_st = kmac_st_e'(kmac_st_raw);
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, kmac_st_d, kmac_st, kmac_st_e, KmacIdle)
 
   always_comb begin
     // Default value

--- a/hw/ip/kmac/rtl/kmac_app.sv
+++ b/hw/ip/kmac/rtl/kmac_app.sv
@@ -353,20 +353,7 @@ module kmac_app
   /////////
 
   // State register
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] st_raw;
-  assign st = st_e'(st_raw);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(st_e),
-    .Width      (StateWidth),
-    .ResetValue (StateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( st_d   ),
-    .state_o ( st_raw )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_d, st, st_e, StIdle)
 
   // Create a lint error to reduce the risk of accidentally enabling this feature.
   `ASSERT_STATIC_LINT_ERROR(KmacSecIdleAcceptSwMsgNonDefault, SecIdleAcceptSwMsg == 0)

--- a/hw/ip/kmac/rtl/kmac_core.sv
+++ b/hw/ip/kmac/rtl/kmac_core.sv
@@ -156,20 +156,7 @@ module kmac_core
   kmac_st_e st, st_d;
 
   // State register
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign st = kmac_st_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(kmac_st_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StKmacIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( st_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_d, st, kmac_st_e, StKmacIdle)
 
   // Next state and output logic
   // SEC_CM: FSM.SPARSE

--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -419,22 +419,9 @@ module kmac_entropy
   ///////////////////
 
   rand_st_e st, st_d;
-  logic [StateWidth-1:0] st_raw_q;
-  assign st = rand_st_e'(st_raw_q);
 
   // State FF
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  prim_sparse_fsm_flop #(
-    .StateEnumT(rand_st_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StRandReset))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( st_d     ),
-    .state_o ( st_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_d, st, rand_st_e, StRandReset)
 
   // State: Next State and Output Logic
   // SEC_CM: FSM.SPARSE

--- a/hw/ip/kmac/rtl/kmac_errchk.sv
+++ b/hw/ip/kmac/rtl/kmac_errchk.sv
@@ -322,20 +322,7 @@ module kmac_errchk
   ///////////////////
   // State Machine //
   ///////////////////
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign st = st_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(st_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( st_d        ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_d, st, st_e, StIdle)
 
   always_comb begin : next_state
     st_d = st;

--- a/hw/ip/kmac/rtl/sha3.sv
+++ b/hw/ip/kmac/rtl/sha3.sv
@@ -185,20 +185,7 @@ module sha3
   ///////////////////
 
   // State Register
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign st = sha3_st_sparse_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(sha3_st_sparse_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(StIdle_sparse))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( st_d        ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_d, st, sha3_st_sparse_e, StIdle_sparse)
 
 
   // Next State and Output Logic

--- a/hw/ip/kmac/rtl/sha3pad.sv
+++ b/hw/ip/kmac/rtl/sha3pad.sv
@@ -275,20 +275,7 @@ module sha3pad
   // State Register ===========================================================
   pad_st_e st, st_d;
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidthPad-1:0] state_raw_q;
-  assign st = pad_st_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(pad_st_e),
-    .Width(StateWidthPad),
-    .ResetValue(StateWidthPad'(StPadIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( st_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, st_d, st, pad_st_e, StPadIdle)
 
   // `end_of_block` indicates current beat is end of the block
   // It shall set when the address reaches to the end of the block. End address

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_fsm.sv
@@ -4,6 +4,8 @@
 //
 // Main Life Cycle Controller FSM.
 
+`include "prim_assert.sv"
+
 module lc_ctrl_fsm
   import lc_ctrl_pkg::*;
   import lc_ctrl_state_pkg::*;
@@ -440,46 +442,9 @@ module lc_ctrl_fsm
   // State Flops //
   /////////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [FsmStateWidth-1:0] fsm_state_raw_q;
-  assign fsm_state_q = fsm_state_e'(fsm_state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(fsm_state_e),
-    .Width(FsmStateWidth),
-    .ResetValue(FsmStateWidth'(ResetSt))
-  ) u_fsm_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( fsm_state_d     ),
-    .state_o ( fsm_state_raw_q )
-  );
-
-  logic [LcStateWidth-1:0] lc_state_raw_q;
-  assign lc_state_q = lc_state_e'(lc_state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(lc_state_e),
-    .Width(LcStateWidth),
-    .ResetValue(LcStateWidth'(LcStScrap))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( lc_state_d     ),
-    .state_o ( lc_state_raw_q )
-  );
-
-  logic [LcCountWidth-1:0] lc_cnt_raw_q;
-  assign lc_cnt_q = lc_cnt_e'(lc_cnt_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(lc_cnt_e),
-    .Width(LcCountWidth),
-    .ResetValue(LcCountWidth'(LcCnt24))
-  ) u_cnt_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( lc_cnt_d     ),
-    .state_o ( lc_cnt_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_fsm_state_regs, fsm_state_d, fsm_state_q, fsm_state_e, ResetSt)
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, lc_state_d, lc_state_q, lc_state_e, LcStScrap)
+  `PRIM_FLOP_SPARSE_FSM(u_cnt_regs, lc_cnt_d, lc_cnt_q, lc_cnt_e, LcCnt24)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_kmac_if.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_kmac_if.sv
@@ -202,19 +202,6 @@ module lc_ctrl_kmac_if
     endcase // state_q
   end
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(FirstSt))
-  ) u_state_regs (
-    .clk_i   ( clk_kmac_i  ),
-    .rst_ni  ( rst_kmac_ni ),
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, FirstSt, clk_kmac_i, rst_kmac_ni)
 
 endmodule : lc_ctrl_kmac_if

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -533,20 +533,7 @@ module otbn_controller
   `ASSERT(NoStallOnBranch,
       insn_valid_i & insn_dec_shared_i.branch_insn |-> state_q != OtbnStateStall)
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateControllerWidth-1:0] state_raw_q;
-  assign state_q = otbn_state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(otbn_state_e),
-    .Width(StateControllerWidth),
-    .ResetValue(StateControllerWidth'(OtbnStateHalt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, otbn_state_e, OtbnStateHalt)
 
   assign insn_cnt_clear = state_reset_i | (state_q == OtbnStateLocked) | insn_cnt_clear_i;
 

--- a/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
+++ b/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
@@ -132,20 +132,7 @@ module otbn_scramble_ctrl
     end
   end
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateScrambleCtrlWidth-1:0] state_raw_q;
-  assign state_q = scramble_ctrl_state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(scramble_ctrl_state_e),
-    .Width(StateScrambleCtrlWidth),
-    .ResetValue(StateScrambleCtrlWidth'(ScrambleCtrlIdle))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, scramble_ctrl_state_e, ScrambleCtrlIdle)
 
   always_comb begin
     dmem_key_valid_d            = dmem_key_valid_q;

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -62,20 +62,8 @@ module otbn_start_stop_control
   logic addr_cnt_inc;
   logic [4:0] addr_cnt_q, addr_cnt_d;
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateStartStopWidth-1:0] state_raw_q;
-  assign state_q = otbn_start_stop_state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(otbn_start_stop_state_e),
-    .Width(StateStartStopWidth),
-    .ResetValue(StateStartStopWidth'(OtbnStartStopStateHalt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q,
+      otbn_start_stop_state_e, OtbnStartStopStateHalt)
 
   always_comb begin
     urnd_reseed_req_o      = 1'b0;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_dai.sv
@@ -5,7 +5,7 @@
 // Direct access interface for OTP controller.
 //
 
-`include "prim_assert.sv"
+`include "prim_flop_macros.sv"
 
 module otp_ctrl_dai
   import otp_ctrl_pkg::*;
@@ -765,20 +765,7 @@ module otp_ctrl_dai
   // Registers //
   ///////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(ResetSt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, ResetSt)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_kdi.sv
@@ -5,7 +5,7 @@
 // Scrambling key derivation module for OTP.
 //
 
-`include "prim_assert.sv"
+`include "prim_flop_macros.sv"
 
 module otp_ctrl_kdi
   import otp_ctrl_pkg::*;
@@ -348,7 +348,6 @@ module otp_ctrl_kdi
   } state_e;
 
   state_e state_d, state_q;
-
   logic edn_req_d, edn_req_q;
   assign edn_req_o = edn_req_q;
 
@@ -568,20 +567,7 @@ module otp_ctrl_kdi
   // Registers //
   ///////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(ResetSt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, ResetSt)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lci.sv
@@ -5,7 +5,7 @@
 // Life cycle interface for performing life cycle transitions in OTP.
 //
 
-`include "prim_assert.sv"
+`include "prim_flop_macros.sv"
 
 module otp_ctrl_lci
   import otp_ctrl_pkg::*;
@@ -105,10 +105,10 @@ module otp_ctrl_lci
     ErrorSt     = 9'b011111101
   } state_e;
 
+  state_e state_d, state_q;
   logic cnt_clr, cnt_en, cnt_err;
   logic [CntWidth-1:0] cnt;
   otp_err_e error_d, error_q;
-  state_e state_d, state_q;
 
   // Output LCI errors
   assign error_o = error_q;
@@ -270,20 +270,7 @@ module otp_ctrl_lci
   // Registers //
   ///////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(ResetSt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, ResetSt)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_lfsr_timer.sv
@@ -26,7 +26,7 @@
 // This can be useful if SW chooses to leave the periodic checks disabled.
 //
 
-`include "prim_assert.sv"
+`include "prim_flop_macros.sv"
 
 module otp_ctrl_lfsr_timer
   import otp_ctrl_pkg::*;
@@ -241,7 +241,7 @@ module otp_ctrl_lfsr_timer
   assign chk_timeout_o = chk_timeout_q;
 
   always_comb begin : p_fsm
-    state_d = state_e'(state_q);
+    state_d = state_q;
 
     // LFSR and counter signals
     lfsr_en = 1'b0;
@@ -361,20 +361,7 @@ module otp_ctrl_lfsr_timer
   // Registers //
   ///////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(ResetSt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, ResetSt)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_buf.sv
@@ -5,7 +5,7 @@
 // Buffered partition for OTP controller.
 //
 
-`include "prim_assert.sv"
+`include "prim_flop_macros.sv"
 
 module otp_ctrl_part_buf
   import otp_ctrl_pkg::*;
@@ -744,20 +744,7 @@ module otp_ctrl_part_buf
   // Registers //
   ///////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(ResetSt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, ResetSt)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_unbuf.sv
@@ -5,7 +5,7 @@
 // Unbuffered partition for OTP controller.
 //
 
-`include "prim_assert.sv"
+`include "prim_flop_macros.sv"
 
 module otp_ctrl_part_unbuf
   import otp_ctrl_pkg::*;
@@ -434,20 +434,7 @@ module otp_ctrl_part_unbuf
   // Registers //
   ///////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(ResetSt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, ResetSt)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_scrmbl.sv
@@ -68,6 +68,8 @@
 //             - http://www.lightweightcrypto.org/present/present_ches2007.pdf
 //
 
+`include "prim_flop_macros.sv"
+
 module otp_ctrl_scrmbl
   import otp_ctrl_pkg::*;
   import otp_ctrl_part_pkg::*;
@@ -468,20 +470,7 @@ module otp_ctrl_scrmbl
   // Registers //
   ///////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(IdleSt))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, IdleSt)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin : p_regs
     if (!rst_ni) begin

--- a/hw/ip/prim/lint/prim_assert.waiver
+++ b/hw/ip/prim/lint/prim_assert.waiver
@@ -6,7 +6,10 @@
 
 waive -rules {UNDEF_MACRO_REF} -location {prim_assert.sv} -regexp {Macro definition for 'ASSERT_RPT' includes expansion of undefined macro '__(FILE|LINE)__'} \
       -comment "This is an UVM specific macro inside our assertion shortcuts"
-# unfortunately most tools do not support line wrapping within the declaration of macro functions, hence we have to waive
-# line length violations.
+
+# unfortunately most tools do not support line wrapping within the declaration of macro functions,
+# hence we have to waive line length violations.
 waive -rules {LINE_LENGTH} -location {prim_assert.sv} -msg {Line length of} \
+      -comment "Some macros cannot be line-wrapped, as some tools do not support that."
+waive -rules {LINE_LENGTH} -location {prim_flop_macros.sv} -msg {Line length of} \
       -comment "Some macros cannot be line-wrapped, as some tools do not support that."

--- a/hw/ip/prim/lint/prim_sparse_fsm_flop.vlt
+++ b/hw/ip/prim/lint/prim_sparse_fsm_flop.vlt
@@ -6,3 +6,4 @@
 
 // This parameter is only used in DV/FPV.
 lint_off -rule UNUSED -file "*/rtl/prim_sparse_fsm_flop.sv" -match "*EnableAlertTriggerSVA*"
+lint_off -rule UNUSED -file "*/rtl/prim_sparse_fsm_flop.sv" -match "*CustomForceName*"

--- a/hw/ip/prim/prim_assert.core
+++ b/hw/ip/prim/prim_assert.core
@@ -13,6 +13,7 @@ filesets:
       - rtl/prim_assert_yosys_macros.svh : {is_include_file : true}
       - rtl/prim_assert_standard_macros.svh : {is_include_file : true}
       - rtl/prim_assert_sec_cm.svh : {is_include_file : true}
+      - rtl/prim_flop_macros.sv : {is_include_file : true}
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/prim/rtl/prim_assert.sv
+++ b/hw/ip/prim/rtl/prim_assert.sv
@@ -141,5 +141,6 @@
 `endif
 
 `include "prim_assert_sec_cm.svh"
+`include "prim_flop_macros.sv"
 
 `endif // PRIM_ASSERT_SV

--- a/hw/ip/prim/rtl/prim_flop_macros.sv
+++ b/hw/ip/prim/rtl/prim_flop_macros.sv
@@ -1,0 +1,74 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef PRIM_FLOP_MACROS_SV
+`define PRIM_FLOP_MACROS_SV
+
+/////////////////////////////////////
+// Default Values for Macros below //
+/////////////////////////////////////
+
+`define PRIM_FLOP_CLK clk_i
+`define PRIM_FLOP_RST rst_ni
+`define PRIM_FLOP_RESVAL '0
+
+/////////////////////
+// Register Macros //
+/////////////////////
+
+// TODO: define other variations of register macros so that they can be used throughout all designs
+// to make the code more concise.
+
+// Register with asynchronous reset.
+`define PRIM_FLOP_A(__d, __q, __resval = `PRIM_FLOP_RESVAL, __clk = `PRIM_FLOP_CLK, __rst_n = `PRIM_FLOP_RST) \
+  always_ff @(posedge __clk or negedge __rst_n) begin \
+    if (!__rst_n) begin                               \
+      __q <= __resval;                                \
+    end else begin                                    \
+      __q <= __d;                                     \
+    end                                               \
+  end
+
+///////////////////////////
+// Macro for Sparse FSMs //
+///////////////////////////
+
+// Simulation tools typically infer FSMs and report coverage for these separately. However, tools
+// like Xcelium and VCS seem to have problems inferring FSMs if the state register is not coded in
+// a behavioral always_ff block in the same hierarchy. To that end, this uses a modified variant
+// with a second behavioral register definition for RTL simulations so that FSMs can be inferred.
+// Note that in this variant, the __q output is disconnected from prim_sparse_fsm_flop and attached
+// to the behavioral flop. An assertion is added to ensure equivalence between the
+// prim_sparse_fsm_flop output and the behavioral flop output in that case.
+`define PRIM_FLOP_SPARSE_FSM(__name, __d, __q, __type, __resval = `PRIM_FLOP_RESVAL, __clk = `PRIM_FLOP_CLK, __rst_n = `PRIM_FLOP_RST, __alert_trigger_sva_en = 1) \
+  `ifdef SIMULATION                                   \
+    prim_sparse_fsm_flop #(                           \
+      .StateEnumT(__type),                            \
+      .Width($bits(__type)),                          \
+      .ResetValue($bits(__type)'(__resval)),          \
+      .EnableAlertTriggerSVA(__alert_trigger_sva_en), \
+      .CustomForceName(`PRIM_STRINGIFY(__q))          \
+    ) __name (                                        \
+      .clk_i   ( __clk   ),                           \
+      .rst_ni  ( __rst_n ),                           \
+      .state_i ( __d     ),                           \
+      .state_o (         )                            \
+    );                                                \
+    `PRIM_FLOP_A(__d, __q, __resval, __clk, __rst_n)  \
+    `ASSERT(``__name``_A, __q === ``__name``.state_o) \
+  `else                                               \
+    prim_sparse_fsm_flop #(                           \
+      .StateEnumT(__type),                            \
+      .Width($bits(__type)),                          \
+      .ResetValue($bits(__type)'(__resval)),          \
+      .EnableAlertTriggerSVA(__alert_trigger_sva_en)  \
+    ) __name (                                        \
+      .clk_i   ( __clk   ),                           \
+      .rst_ni  ( __rst_n ),                           \
+      .state_i ( __d     ),                           \
+      .state_o ( __q     )                            \
+    );                                                \
+  `endif
+
+`endif // PRIM_FLOP_MACROS_SV

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -155,19 +155,8 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
     end
   end
 
-  logic [FastPwrStateWidth-1:0] state_raw_q;
-  assign state_q = fast_pwr_state_e'(state_raw_q);
   // SEC_CM: FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(fast_pwr_state_e),
-    .Width(FastPwrStateWidth),
-    .ResetValue(FastPwrStateWidth'(FastPwrStateLowPower))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, fast_pwr_state_e, FastPwrStateLowPower)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
@@ -130,19 +130,8 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
     end
   end
 
-  logic [SlowPwrStateWidth-1:0] state_raw_q;
-  assign state_q = slow_pwr_state_e'(state_raw_q);
   // SEC_CM: FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(slow_pwr_state_e),
-    .Width(SlowPwrStateWidth),
-    .ResetValue(SlowPwrStateWidth'(SlowPwrStateReset))
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, slow_pwr_state_e, SlowPwrStateReset)
 
   always_comb begin
     state_d        = state_q;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_compare.sv
@@ -88,20 +88,11 @@ module rom_ctrl_compare
     Done     = 5'b11001
   } state_e;
 
-  logic [4:0]  state_q, state_d;
-  logic        matches_q, matches_d;
-  logic        fsm_alert;
+  state_e state_q, state_d;
+  logic   matches_q, matches_d;
+  logic   fsm_alert;
 
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(5),
-    .ResetValue({Waiting})
-  ) u_state_regs (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-    .state_i (state_d),
-    .state_o (state_q)
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Waiting)
 
   always_comb begin
     state_d = state_q;

--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -132,19 +132,12 @@ module rom_ctrl_fsm
   // SEC_CM: FSM.SPARSE
   // SEC_CM: INTERSIG.MUBI
 
-  logic [9:0]  state_q, state_d;
-  logic        fsm_alert;
+  fsm_state_e state_d, state_q;
+  logic [9:0] logic_state_q;
+  logic       fsm_alert;
 
-  prim_sparse_fsm_flop #(
-    .StateEnumT(fsm_state_e),
-    .Width(10),
-    .ResetValue({ReadingLow})
-  ) u_state_regs (
-    .clk_i   (clk_i),
-    .rst_ni  (rst_ni),
-    .state_i (state_d),
-    .state_o (state_q)
-  );
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, fsm_state_e, ReadingLow)
+  assign logic_state_q = {state_q};
 
   always_comb begin
     state_d = state_q;
@@ -218,7 +211,7 @@ module rom_ctrl_fsm
   // bottom 4 bits of state_q is equivalent to "mubi4_bool_to_mubi(state_q == Done)" except that it
   // doesn't have a 1-bit signal on the way.
   mubi4_t in_state_done;
-  assign in_state_done = mubi4_t'(state_q[3:0]);
+  assign in_state_done = mubi4_t'(logic_state_q[3:0]);
 
   // Route digest signals coming back from KMAC straight to the CSRs
   assign digest_o     = kmac_digest_i;

--- a/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -108,22 +108,9 @@ module rstmgr_cnsty_chk
 
   state_e state_q, state_d;
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  //SEC_CM: LEAF.FSM.SPARSE
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(Reset)),
-    .EnableAlertTriggerSVA(0)
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  // SEC_CM: LEAF.FSM.SPARSE
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, Reset,
+      clk_i, rst_ni, 0)
 
   logic timeout;
   logic cnt_inc;

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -291,23 +291,10 @@ module alert_handler_esc_timer import alert_pkg::*; (
   // FSM Registers //
   ///////////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(IdleSt)),
-    // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
-    // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
+  // an alert signal, this condition is handled internally in the alert handler. The
+  // EnableAlertTriggerSVA parameter is therefore set to 0.
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, IdleSt, clk_i, rst_ni, 0)
 
   ////////////////
   // Assertions //

--- a/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -377,23 +377,10 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   // FSM Registers //
   ///////////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(InitSt)),
-    // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
-    // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
+  // an alert signal, this condition is handled internally in the alert handler. The
+  // EnableAlertTriggerSVA parameter is therefore set to 0.
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, InitSt, clk_i, rst_ni, 0)
 
   ////////////////
   // Assertions //

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_esc_timer.sv
@@ -291,23 +291,10 @@ module alert_handler_esc_timer import alert_pkg::*; (
   // FSM Registers //
   ///////////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(IdleSt)),
-    // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
-    // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
+  // an alert signal, this condition is handled internally in the alert handler. The
+  // EnableAlertTriggerSVA parameter is therefore set to 0.
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, IdleSt, clk_i, rst_ni, 0)
 
   ////////////////
   // Assertions //

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_ping_timer.sv
@@ -377,23 +377,10 @@ module alert_handler_ping_timer import alert_pkg::*; #(
   // FSM Registers //
   ///////////////////
 
-  // This primitive is used to place a size-only constraint on the
-  // flops in order to prevent FSM state encoding optimizations.
-  logic [StateWidth-1:0] state_raw_q;
-  assign state_q = state_e'(state_raw_q);
-  prim_sparse_fsm_flop #(
-    .StateEnumT(state_e),
-    .Width(StateWidth),
-    .ResetValue(StateWidth'(InitSt)),
-    // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
-    // an alert signal, this condition is handled internally in the alert handler.
-    .EnableAlertTriggerSVA(0)
-  ) u_state_regs (
-    .clk_i,
-    .rst_ni,
-    .state_i ( state_d     ),
-    .state_o ( state_raw_q )
-  );
+  // The alert handler behaves differently than other comportable IP. I.e., instead of sending out
+  // an alert signal, this condition is handled internally in the alert handler. The
+  // EnableAlertTriggerSVA parameter is therefore set to 0.
+  `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, InitSt, clk_i, rst_ni, 0)
 
   ////////////////
   // Assertions //

--- a/util/design/sparse-fsm-encode.py
+++ b/util/design/sparse-fsm-encode.py
@@ -235,20 +235,8 @@ always_comb begin : p_fsm
   endcase
 end
 
-// This primitive is used to place a size-only constraint on the
-// flops in order to prevent FSM state encoding optimizations.
-logic [StateWidth-1:0] state_raw_q;
-assign state_q = state_e'(state_raw_q);
-prim_sparse_fsm_flop #(
-  .StateEnumT(state_e),
-  .Width(StateWidth),
-  .ResetValue(StateWidth'(State0))
-) u_state_regs (
-  .clk_i,
-  .rst_ni,
-  .state_i ( state_d     ),
-  .state_o ( state_raw_q )
-);
+`PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, State0)
+
 '''.format(state_str))
 
     elif args.language == "c":


### PR DESCRIPTION
Unfortunately, our use of `prim_sparse_fsm_flop` prevents both Xcelium and VCS from inferring FSMs and reporting coverage for them. This is not great, since we have many sparse FSMs in the design.

To that end, @cindychip and I experimented a bit with different FSM styles.
It appears that the tools expect a behavioral RTL flop description within the same hierarchy.

One possible solution for this problem would be to introduce a sparse fsm flop macro that behaves differently for RTL simulations, and this PR outlines such a solution.

This has been tested successfully with VCS, Xcelium, AscentLint , VerilatorLint and DC.

Note that:
1) equivalence between the additional RTL flop output and the `prim_sparse_fsm_flop` is checked with an assertion.
2) this would only affect RTL simulations, but not GL simulations where the "real" registers are compiled in.
3) since LEC is run on the synthesizable view, this should not affect the outcome.

As for the commits:
- The first commit only represents a cleanup pass to avoid additional casting
- The second commit contains the actual solution described above
- This is currently only applied to OTP, hence other simulations currently fail

LMKWYT...

Signed-off-by: Michael Schaffner <msf@opentitan.org>