### PR TITLE
[topgen] Remove hard-code top name from topgen templates

### DIFF
--- a/util/topgen/templates/plic_all_irqs_test.c.tpl
+++ b/util/topgen/templates/plic_all_irqs_test.c.tpl
@@ -23,13 +23,13 @@ def args(p):
 #include "sw/device/lib/testing/rv_plic_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf.h"
 #include "sw/device/lib/testing/test_framework/test_status.h"
-#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "hw/top_${top["name"]}/sw/autogen/top_${top["name"]}.h"
 
 % for p in helper.irq_peripherals:
 static dif_${p.name}_t ${p.inst_name};
 % endfor
 static dif_rv_plic_t plic;
-static const top_earlgrey_plic_target_t kHart = kTopEarlgreyPlicTargetIbex0;
+static const top_${top["name"]}_plic_target_t kHart = kTop${top["name"].capitalize()}PlicTargetIbex0;
 
 /**
  * Flag indicating which peripheral is under test.
@@ -37,7 +37,7 @@ static const top_earlgrey_plic_target_t kHart = kTopEarlgreyPlicTargetIbex0;
  * Declared volatile because it is referenced in the main program flow as well
  * as the ISR.
  */
-static volatile top_earlgrey_plic_peripheral_t peripheral_expected;
+static volatile top_${top["name"]}_plic_peripheral_t peripheral_expected;
 
 /**
  * Flags indicating the IRQ expected to have triggered and serviced within the
@@ -68,8 +68,8 @@ void ottf_external_isr(void) {
   dif_rv_plic_irq_id_t plic_irq_id;
   CHECK_DIF_OK(dif_rv_plic_irq_claim(&plic, kHart, &plic_irq_id));
 
-  top_earlgrey_plic_peripheral_t peripheral = (top_earlgrey_plic_peripheral_t)
-      top_earlgrey_plic_interrupt_for_peripheral[plic_irq_id];
+  top_${top["name"]}_plic_peripheral_t peripheral = (top_${top["name"]}_plic_peripheral_t)
+      top_${top["name"]}_plic_interrupt_for_peripheral[plic_irq_id];
   CHECK(peripheral == peripheral_expected,
         "Interrupt from incorrect peripheral: exp = %d, obs = %d",
         peripheral_expected, peripheral);
@@ -117,7 +117,7 @@ static void peripherals_init(void) {
   CHECK_DIF_OK(dif_${p.name}_init(base_addr, &${p.inst_name}));
 
   % endfor
-  base_addr = mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  base_addr = mmio_region_from_addr(TOP_${top["name"].upper()}_RV_PLIC_BASE_ADDR);
   CHECK_DIF_OK(dif_rv_plic_init(base_addr, &plic));
 }
 
@@ -213,7 +213,7 @@ bool test_main(void) {
   irq_external_ctrl(true);
   peripherals_init();
   rv_plic_testutils_irq_range_enable(
-      &plic, kHart, kTopEarlgreyPlicIrqIdNone + 1, kTopEarlgreyPlicIrqIdLast);
+      &plic, kHart, kTop${top["name"].capitalize()}PlicIrqIdNone + 1, kTop${top["name"].capitalize()}PlicIrqIdLast);
   peripheral_irqs_clear();
   peripheral_irqs_enable();
   peripheral_irqs_trigger();

--- a/util/topgen/templates/tb__xbar_connect.sv.tpl
+++ b/util/topgen/templates/tb__xbar_connect.sv.tpl
@@ -33,27 +33,27 @@ def escape_if_name(qual_if_name):
     return qual_if_name.replace('.', '__')
 
 %>\
-<%text>
-`define DRIVE_CHIP_TL_HOST_IF(tl_name, inst_name, sig_name) \
-     force ``tl_name``_tl_if.d2h = dut.top_earlgrey.u_``inst_name``.``sig_name``_i; \
-     force dut.top_earlgrey.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.h2d; \
-     force dut.top_earlgrey.u_``inst_name``.clk_i = 0; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
+
+## Need to use a variable assignment for "\" to bypass the newline filter.
+`define DRIVE_CHIP_TL_HOST_IF(tl_name, inst_name, sig_name) ${"\\"}
+     force ``tl_name``_tl_if.d2h = dut.top_${top["name"]}.u_``inst_name``.``sig_name``_i; ${"\\"}
+     force dut.top_${top["name"]}.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.h2d; ${"\\"}
+     force dut.top_${top["name"]}.u_``inst_name``.clk_i = 0; ${"\\"}
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", ${"\\"}
                                         ``tl_name``_tl_if);
 
-`define DRIVE_CHIP_TL_DEVICE_IF(tl_name, inst_name, sig_name) \
-     force ``tl_name``_tl_if.h2d = dut.top_earlgrey.u_``inst_name``.``sig_name``_i; \
-     force dut.top_earlgrey.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.d2h; \
-     force dut.top_earlgrey.u_``inst_name``.clk_i = 0; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
+`define DRIVE_CHIP_TL_DEVICE_IF(tl_name, inst_name, sig_name) ${"\\"}
+     force ``tl_name``_tl_if.h2d = dut.top_${top["name"]}.u_``inst_name``.``sig_name``_i; ${"\\"}
+     force dut.top_${top["name"]}.u_``inst_name``.``sig_name``_o = ``tl_name``_tl_if.d2h; ${"\\"}
+     force dut.top_${top["name"]}.u_``inst_name``.clk_i = 0; ${"\\"}
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", ${"\\"}
                                         ``tl_name``_tl_if);
 
-`define DRIVE_CHIP_TL_EXT_DEVICE_IF(tl_name, port_name) \
-     force ``tl_name``_tl_if.h2d = dut.top_earlgrey.``port_name``_req_o; \
-     force dut.top_earlgrey.``port_name``_rsp_i = ``tl_name``_tl_if.d2h; \
-     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", \
+`define DRIVE_CHIP_TL_EXT_DEVICE_IF(tl_name, port_name) ${"\\"}
+     force ``tl_name``_tl_if.h2d = dut.top_${top["name"]}.``port_name``_req_o; ${"\\"}
+     force dut.top_${top["name"]}.``port_name``_rsp_i = ``tl_name``_tl_if.d2h; ${"\\"}
+     uvm_config_db#(virtual tl_if)::set(null, $sformatf("*env.%0s_agent", `"tl_name`"), "vif", ${"\\"}
                                         ``tl_name``_tl_if);
-</%text>\
 
 % for c in clk_freq.keys():
 wire clk_${c};

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -263,7 +263,7 @@ module top_${top["name"]} #(
 
   // See #7978 This below is a hack.
   // This is because ast is a comportable-like module that sits outside
-  // of top_earlgrey's boundary.
+  // of top_${top["name"]}'s boundary.
   assign clks_ast_o = ${top['clocks'].hier_paths['top'][:-1]};
   assign rsts_ast_o = ${top['resets'].hier_paths['top'][:-1]};
 


### PR DESCRIPTION
Retrieve the top name from the config dictionary.