### PR TITLE
[bazel] fixup CI for batched testing of merge

### DIFF
--- a/ci/scripts/mask-rom-tests.sh
+++ b/ci/scripts/mask-rom-tests.sh
@@ -67,8 +67,7 @@ else
   # fairly hard to review so let's leave that alone for now. We wouldn't act on
   # it anyway.
   echo "Test is failing but I can't compare it to a merge base because we're on upstream/$DEFAULT"
-  cat bazel-results/newresults.txt
-  git switch "$ORIGINAL_BRANCH_NAME" || git checkout "$ORIGINAL_SHA"
+  cat bazel-results/newresult.txt
   exit 0
 fi
 


### PR DESCRIPTION
I mispelled newresult.txt so the cat command is failing as seen here
https://dev.azure.com/lowrisc/opentitan/_build/results?buildId=73045
the switch afterwards is a nop and not worth the risk.

Signed-off-by: Drew Macrae <drewmacrae@google.com>