### PR TITLE
[pwm/dv] Added pwm_rand_output_vseq and environment changes

### DIFF
--- a/hw/ip/pwm/data/pwm_testplan.hjson
+++ b/hw/ip/pwm/data/pwm_testplan.hjson
@@ -4,8 +4,8 @@
 {
     name: "pwm"
     import_testplans: ["hw/dv/tools/dvsim/testplans/csr_testplan.hjson",
+                       "hw/dv/tools/dvsim/testplans/alert_test_testplan.hjson",
                        "hw/dv/tools/dvsim/testplans/intr_test_testplan.hjson",
-                       "hw/dv/tools/dvsim/testplans/stress_all_with_reset_testplan.hjson",
                        "hw/dv/tools/dvsim/testplans/tl_device_access_types_testplan.hjson",
                        "pwm_sec_cm_testplan.hjson"],
     testpoints: [
@@ -33,7 +33,7 @@
 
             '''
       milestone: V2
-      tests: ["pwm_smoke"]
+      tests: ["pwm_rand_output"]
     }
     {
       name: pulse
@@ -42,16 +42,16 @@
             by de-asserting blink_en field in the PWM_PARAM register
             '''
       milestone: V2
-      tests: ["pwm_smoke"]
+      tests: ["pwm_rand_output"]
     }
     {
-      name: Blink
+      name: blink
       desc: '''
             Verify the blink mode of the PWM
             by asserting the blink_en field in the PWM_PARAM register
             '''
       milestone: V2
-      tests: ["pwm_moke"]
+      tests: ["pwm_rand_output"]
     }
     {
       name: heartbeat
@@ -60,7 +60,7 @@
             by asserting the blink_en and HTBT field in the PWM_PARAM register
             '''
         milestone: V2
-        tests: []
+        tests: ["pwm_rand_output"]
     }
    {
       name: resolution
@@ -68,7 +68,7 @@
             Verify the PWM generates correct duty cycle for different resolution settings
             '''
         milestone: V2
-        tests: ["pwm_smoke"]
+        tests: ["pwm_rand_output"]
     }
     {
       name: multi_channel
@@ -76,7 +76,7 @@
             Verifies that PWM correctly generates pulses on multiple channels concurrently
             '''
         milestone: V2
-        tests: []
+        tests: ["pwm_rand_output"]
     }
     {
       name: polarity
@@ -84,7 +84,7 @@
             Verify that the polarity of the pulse can be inverted by setting the invert channel bit in the invert register
             '''
         milestone: V2
-        tests: []
+        tests: ["pwm_rand_output"]
     }
     {
       name: phase
@@ -92,7 +92,7 @@
             Check that the relative phase between pulses matches the setting in the phase_delay field in the PWM_PARAM register.
             '''
         milestone: V2
-        tests: []
+        tests: ["pwm_rand_output"]
     }
     {
       name: lowpower
@@ -106,7 +106,7 @@
                 - Ensure pulses are still generated when in LP mode
             '''
         milestone: V2
-        tests: []
+        tests: ["pwm_rand_output"]
     }
     {
       name: perf
@@ -122,25 +122,11 @@
                 - Ensure the output pulses are correctly modulated for all channels
             '''
       milestone: V2
-      tests: []
+      tests: ["pwm_stress_perf"]
     }
     {
-          name: clock_domain
-          desc: '''
-            TBD -Verify the function of clock-crossing domain for pwm
-
-            Stimulus:
-                - TBD
-
-            Checking:
-                - TBD
-            '''
-          milestone: V2
-          tests: []
-      }
-      {
-          name: stress_all
-          desc: '''
+      name: stress_all
+      desc: '''
             Combine above sequences in one test then randomly select for running
 
             Stimulus:
@@ -149,9 +135,9 @@
             Checking:
                 - All sequences should be finished and checked by the scoreboard
             '''
-          milestone: V2
-          tests: []
-      }
+      milestone: V2
+      tests: ["pwm_stress_perf"]
+    }
   ]
 
  covergroups: [

--- a/hw/ip/pwm/dv/env/pwm_env.core
+++ b/hw/ip/pwm/dv/env/pwm_env.core
@@ -23,6 +23,7 @@ filesets:
       - seq_lib/pwm_base_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_common_vseq.sv: {is_include_file: true}
       - seq_lib/pwm_smoke_vseq.sv: {is_include_file: true}
+      - seq_lib/pwm_rand_output_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/pwm/dv/env/pwm_env_pkg.sv
+++ b/hw/ip/pwm/dv/env/pwm_env_pkg.sv
@@ -26,6 +26,10 @@ package pwm_env_pkg;
   // alerts
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};
+  parameter bit [31:0] MAX_32 = 32'hFFFF_FFFF;
+  parameter bit [15:0] MAX_16 = 16'hFFFF;
+  parameter uint MIN_NUM_CYCLES = 10000;
+  parameter uint MAX_NUM_CYCLES = 50000;
 
   // datatype
   typedef enum bit [1:0] {

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_rand_output_vseq.sv
@@ -1,0 +1,59 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This sequence randomizes configurations at the output.
+class pwm_rand_output_vseq extends pwm_base_vseq;
+  `uvm_object_utils(pwm_rand_output_vseq)
+  `uvm_object_new
+
+  // variables
+  rand param_reg_t rand_reg_param;
+  rand bit [TL_DW-1:0] rand_chan;
+  rand bit [TL_DW-1:0] rand_invert;
+  rand uint duration_cycles;
+  rand bit low_power;
+
+  // constraints
+  constraint rand_reg_param_c {
+   rand_reg_param.HtbtEn == 1'b1 -> rand_reg_param.BlinkEn == 1'b1;
+   rand_reg_param.RsvParam == 0;
+   rand_reg_param.PhaseDelay inside {[0:MAX_16]};
+  }
+
+  constraint duration_cycles_c {
+    duration_cycles inside {[MIN_NUM_CYCLES:MAX_NUM_CYCLES]};
+  }
+
+  constraint low_power_c {
+    // 1 in 10, in low power mode
+    low_power dist {1'b1:/1, 1'b0:/9};
+  }
+
+  virtual task body();
+
+    set_reg_en(Enable);
+    set_ch_enables(32'h0);
+
+    rand_pwm_cfg_reg();
+
+    // set random dc and params for all channels
+    for (uint i = 0; i < PWM_NUM_CHANNELS; i++) begin
+      rand_pwm_duty_cycle(i);
+      rand_pwm_blink(i);
+      cfg.pwm_param[rand_chan].HtbtEn = rand_reg_param.HtbtEn;
+      cfg.pwm_param[i].BlinkEn = rand_reg_param.BlinkEn;
+      set_param(i, cfg.pwm_param[i]);
+    end
+
+    set_ch_enables(rand_chan);
+    set_ch_invert(rand_invert);
+
+    low_power_mode(low_power, duration_cycles);
+
+    `uvm_info(`gfn, $sformatf("Runtime: %d", duration_cycles), UVM_HIGH)
+    shutdown_dut();
+
+  endtask : body
+
+endclass : pwm_rand_output_vseq

--- a/hw/ip/pwm/dv/env/seq_lib/pwm_vseq_list.sv
+++ b/hw/ip/pwm/dv/env/seq_lib/pwm_vseq_list.sv
@@ -5,4 +5,4 @@
 `include "pwm_base_vseq.sv"
 `include "pwm_smoke_vseq.sv"
 `include "pwm_common_vseq.sv"
-//`include "pwm_rx_tx_vseq.sv"
+`include "pwm_rand_output_vseq.sv"

--- a/hw/ip/pwm/dv/pwm_sim_cfg.hjson
+++ b/hw/ip/pwm/dv/pwm_sim_cfg.hjson
@@ -24,13 +24,13 @@
   ral_spec: "{proj_root}/hw/ip/pwm/data/pwm.hjson"
 
   // Import additional common sim cfg files.
-  // TODO: remove imported cfgs that do not apply.
   import_cfgs: [// Project wide common sim cfg file
                 "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
-                // TODO : enable for V2
+                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
                 //"{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
 
@@ -65,13 +65,17 @@
       name: pwm_smoke
       uvm_test_seq: pwm_smoke_vseq
     }
+    {
+      name: pwm_rand_output
+      uvm_test_seq: pwm_rand_output_vseq
+    }
   ]
 
   // List of regressions.
-//  regressions: [
-//    {
-//      name: smoke
-//      tests: ["pwm_smoke"]
-//    }
-//  ]
+  regressions: [
+    {
+      name: smoke
+      tests: ["pwm_smoke"]
+    }
+  ]
 }


### PR DESCRIPTION
Added a new sequence, pwm_rand_output_vseq, to cover the following V2 testpoints:
- multi_channel
- pulse
- dutycycle
- resolution
- heartbeat
- phase
- lowpower
- polarity

Added new tasks to the base sequence and parameterised any constants and added them to the env_pkg. Also made changes to the environment as needed to accommodate changes.

Signed-off-by: Jason Hoddinett <jason.hoddinett.ensilica@opentitan.org>