### PR TITLE
[pwm/pwm_item] Removed get_duty_cycle function from pwm_item

### DIFF
--- a/hw/dv/sv/pwm_monitor/pwm_item.sv
+++ b/hw/dv/sv/pwm_monitor/pwm_item.sv
@@ -38,16 +38,4 @@ class pwm_item extends uvm_sequence_item;
       return txt;
     endfunction // convert2string
 
-  function int get_duty_cycle();
-    int dc;
-    dc = (active_cnt/period) * 100;
-
-    if (invert) begin
-      duty_cycle = (100-dc);
-      return (100-dc);
-    end else begin
-      duty_cycle = dc;
-      return dc;
-    end
-  endfunction // get_duty_cycle
 endclass

--- a/hw/ip/pwm/dv/env/pwm_scoreboard.sv
+++ b/hw/ip/pwm/dv/env/pwm_scoreboard.sv
@@ -219,6 +219,7 @@ class pwm_scoreboard extends cip_base_scoreboard #(
     int period;
     int high_cycles;
     int low_cycles;
+    int duty;
 
     if (channel_param[channel].BlinkEn) begin
       if (blink_cnt[channel] == 0) begin
@@ -245,6 +246,7 @@ class pwm_scoreboard extends cip_base_scoreboard #(
     period      = beats_cycle * (channel_cfg.ClkDiv + 1);
     high_cycles = (int_dc>>(16-(channel_cfg.DcResn+1)))*(channel_cfg.ClkDiv +1);
     low_cycles  = period - high_cycles;
+    duty = (high_cycles / period) * 100;
 
     // ID
     item.monitor_id      = channel;
@@ -257,7 +259,7 @@ class pwm_scoreboard extends cip_base_scoreboard #(
     // inactive cycles
     item.inactive_cnt    = invert[channel] ? high_cycles : low_cycles;
     // duty_cycle
-    item.duty_cycle      = item.get_duty_cycle();
+    item.duty_cycle      = invert[channel] ? (100 - duty) : duty;
     // phase
     //TODO
   endtask // generate_exp_item


### PR DESCRIPTION
Removed the get_duty_cycle function, which was not providing the correct duty cycle, from pwm_item to the scoreboard to accurately calculate duty cycle.

Signed-off-by: Jason Hoddinett <jason.hoddinett.ensilica@opentitan.org>