### PR TITLE
[sw,otbn] Add Bazel rules for all sw/otbn/crypto targets.

### DIFF
--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -6,11 +6,230 @@ load("//rules:otbn.bzl", "otbn_binary", "otbn_library")
 
 package(default_visibility = ["//visibility:public"])
 
+otbn_library(
+    name = "modexp",
+    srcs = [
+        "modexp.s",
+    ],
+)
+
+otbn_library(
+    name = "p256",
+    srcs = [
+        "p256.s",
+    ],
+)
+
+otbn_binary(
+    name = "p256_base_mult_test",
+    srcs = [
+        "p256_base_mult_test.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
 otbn_binary(
     name = "p256_ecdsa",
     srcs = [
         "p256_ecdsa.s",
-        "p256.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_binary(
+    name = "p256_ecdsa_sign_test",
+    srcs = [
+        "p256_ecdsa_sign_test.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_binary(
+    name = "p256_ecdsa_verify_test",
+    srcs = [
+        "p256_ecdsa_verify_test.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_binary(
+    name = "p256_isoncurve_test",
+    srcs = [
+        "p256_isoncurve_test.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_binary(
+    name = "p256_proj_add_test",
+    srcs = [
+        "p256_proj_add_test.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_binary(
+    name = "p256_scalar_mult_test",
+    srcs = [
+        "p256_scalar_mult_test.s",
+    ],
+    deps = [
+        ":p256",
+    ],
+)
+
+otbn_library(
+    name = "p384_base",
+    srcs = [
+        "p384_base.s",
+    ],
+)
+
+otbn_library(
+    name = "p384_sign",
+    srcs = [
+        "p384_sign.s",
+    ],
+)
+
+otbn_library(
+    name = "p384_verify",
+    srcs = [
+        "p384_verify.s",
+    ],
+)
+
+otbn_binary(
+    name = "p384_base_mult_test",
+    srcs = [
+        "p384_base_mult_test.s",
+    ],
+    deps = [
+        ":p384_base",
+        ":p384_sign",
+    ],
+)
+
+otbn_binary(
+    name = "p384_ecdsa_sign_test",
+    srcs = [
+        "p384_ecdsa_sign_test.s",
+    ],
+    deps = [
+        ":p384_base",
+        ":p384_sign",
+    ],
+)
+
+otbn_binary(
+    name = "p384_ecdsa_verify_test",
+    srcs = [
+        "p384_ecdsa_verify_test.s",
+    ],
+    deps = [
+        ":p384_base",
+        ":p384_verify",
+    ],
+)
+
+otbn_binary(
+    name = "p384_isoncurve_test",
+    srcs = [
+        "p384_isoncurve_test.s",
+    ],
+    deps = [
+        ":p384_base",
+        ":p384_verify",
+    ],
+)
+
+otbn_binary(
+    name = "p384_proj_add_test",
+    srcs = [
+        "p384_proj_add_test.s",
+    ],
+    deps = [
+        ":p384_base",
+    ],
+)
+
+otbn_binary(
+    name = "p384_scalar_mult_test",
+    srcs = [
+        "p384_scalar_mult_test.s",
+    ],
+    deps = [
+        ":p384_base",
+        ":p384_sign",
+    ],
+)
+
+otbn_binary(
+    name = "rsa",
+    srcs = [
+        "rsa.s",
+    ],
+    deps = [
+        ":modexp",
+    ],
+)
+
+otbn_binary(
+    name = "rsa_1024_dec_test",
+    srcs = [
+        "rsa_1024_dec_test.s",
+    ],
+    deps = [
+        ":modexp",
+    ],
+)
+
+otbn_binary(
+    name = "rsa_1024_enc_test",
+    srcs = [
+        "rsa_1024_enc_test.s",
+    ],
+    deps = [
+        ":modexp",
+    ],
+)
+
+otbn_library(
+    name = "rsa_verify",
+    srcs = [
+        "rsa_verify.s",
+    ],
+)
+
+otbn_binary(
+    name = "rsa_verify_test",
+    srcs = [
+        "rsa_verify_test.s",
+    ],
+    deps = [
+        ":rsa_verify",
+    ],
+)
+
+otbn_binary(
+    name = "rsa_verify_test_exp3",
+    srcs = [
+        "rsa_verify_test_exp3.s",
+    ],
+    deps = [
+        ":rsa_verify",
     ],
 )
 
@@ -32,6 +251,28 @@ otbn_library(
     name = "rsa_verify_3072_rr",
     srcs = [
         "rsa_verify_3072_rr.s",
+    ],
+)
+
+otbn_binary(
+    name = "rsa_verify_3072_consts_test",
+    srcs = [
+        "rsa_verify_3072_consts_test.s",
+    ],
+    deps = [
+        ":rsa_verify_3072",
+        ":rsa_verify_3072_m0inv",
+        ":rsa_verify_3072_rr",
+    ],
+)
+
+otbn_binary(
+    name = "rsa_verify_3072_test",
+    srcs = [
+        "rsa_verify_3072_test.s",
+    ],
+    deps = [
+        ":rsa_verify_3072",
     ],
 )
 


### PR DESCRIPTION
Files that can only be linked but are not independently executable are `otbn_library` targets, while files with executable entrypoints are `otbn_binary` targets. This differs slightly from the Meson rules, which did not distinguish the two (and as a result, silently overwrite object files in the background!).

Resolves #11506