### PR TITLE
[sysrst_ctrl,dv] Randomize flash_wp_l_in for flash_wp_prot test

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_flash_wr_prot_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_flash_wr_prot_vseq.sv
@@ -38,6 +38,10 @@ class sysrst_ctrl_flash_wr_prot_vseq extends sysrst_ctrl_base_vseq;
       // It takes 2-3 clock cycles to sync register values
       cfg.clk_aon_rst_vif.wait_clks(3);
 
+      // Randomize the input pins
+      cfg.clk_aon_rst_vif.wait_clks(1);
+      cfg.vif.randomize_input();
+
       en_override_flash_wp_value = get_field_val(ral.pin_out_ctl.flash_wp_l, en_override_value);
 
       override_val_flash_wp = get_field_val(ral.pin_out_value.flash_wp_l, set_value);


### PR DESCRIPTION
This pull request randomizes the flash_wp_l_in input pin for sysrst_ctrl_flash_wr_prot test 
to confirm flash_wp_l_in does not affect flash_wp_l_o output pin.

Signed-off-by: Madhuri Patel <madhuri.patel@ensilica.com>