### PR TITLE
Aes idle chip level test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1581,17 +1581,18 @@
       name: chip_sw_aes_idle
       desc: '''Verify AES idle signaling to clkmgr.
 
-            - Write the AES clk hint to 1 within clkmgr to indicate AES clk is ready to be gated.
-              Verify that the AES clk hint status within clkmgr reads 0 (AES is idle).
-            - Initiate an AES operation with a known key, plain text and digest.
-              Verify that the AES clk hint status within clkmgr now reads 1 (AES is not idle),
-              before the AES operation is complete.
-            - After the AES operation is complete, verify the digest for correctness.
-              Verify that the AES clk hint status within clkmgr now reads 0 again (AES is idle),
-              after the AES operation is complete.
+            - Write the AES clk hint to 0 within clkmgr to indicate AES clk can be gated and
+              verify that the AES clk hint status within clkmgr reads 0 (AES is idle).
+            - Write the AES clk hint to 1 within clkmgr to indicate AES clk can be enabled.
+            - Initiate an AES operation with a known key, plain text and digest, write AES clk
+              hint to 0 and verify that the AES clk hint status within clkmgr now reads 1 (AES 
+              is not idle), before the AES operation is complete.
+            - After the AES operation is complete verify that the AES clk hint status within 
+              clkmgr now reads 0 again (AES is idle).
+            - Write the AES clk hint to 1, read and check the AES output for correctness.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_aes_idle"]
     }
     {
       name: chip_sw_aes_sideload

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -433,6 +433,13 @@
       run_opts: ["+sw_test_timeout_ns=22000000"]
     }
     {
+      name: chip_sw_aes_idle
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/aes_idle_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15000000"]
+    }
+    {
       name: chip_sw_hmac_enc_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/hmac_enc_irq_test:1"]

--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -232,19 +232,11 @@ index 26110265f..7354aa9cb 100644
  }
 
 diff --git a/sw/device/tests/aes_smoketest.c b/sw/device/tests/aes_smoketest.c
-index 1286e47c0..308aab5a4 100644
+index 0ceef3630..700e91f23 100644
 --- a/sw/device/tests/aes_smoketest.c
 +++ b/sw/device/tests/aes_smoketest.c
-@@ -7,7 +7,6 @@
- #include "sw/device/lib/dif/dif_aes.h"
- #include "sw/device/lib/runtime/log.h"
- #include "sw/device/lib/testing/check.h"
--#include "sw/device/lib/testing/entropy_testutils.h"
- #include "sw/device/lib/testing/test_framework/ottf.h"
-
- #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-@@ -66,9 +65,6 @@ bool test_main(void) {
-
+@@ -58,9 +58,6 @@ bool test_main(void) {
+ 
    LOG_INFO("Running AES test");
 
 -  // First of all, we need to get the entropy complex up and running.
@@ -254,7 +246,7 @@ index 1286e47c0..308aab5a4 100644
    CHECK_DIF_OK(
        dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
-index 0cb0e09c3..32274f359 100644
+index 084f531e5..58defaffc 100644
 --- a/sw/device/tests/meson.build
 +++ b/sw/device/tests/meson.build
 @@ -277,7 +277,6 @@ aes_smoketest_lib = declare_dependency(
@@ -262,6 +254,6 @@ index 0cb0e09c3..32274f359 100644
        sw_lib_mmio,
        sw_lib_runtime_log,
 -      sw_lib_testing_entropy_testutils,
+       sw_lib_testing_aes_testutils,
        sw_lib_testing_test_status,
      ],
-   ),

--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -145,11 +145,10 @@ inline ibex_timeout_t ibex_timeout_init(uint32_t timeout_usec) {
 }
 
 /**
- * Returns boolean indicating the timeout expired waiting for an expression to
- * be true.
+ * Check whether the timeout has expired.
  *
  * @param timeout Holds the counter start value.
- * @return Boolean indicating the timeout expired.
+ * @return True if the timeout has expired and false otherwise.
  */
 inline bool ibex_timeout_check(const ibex_timeout_t *timeout) {
   return ibex_mcycle_read() - timeout->start > timeout->cycles;
@@ -177,7 +176,7 @@ inline uint64_t ibex_timeout_elapsed(const ibex_timeout_t *timeout) {
   do {                                                                    \
     const ibex_timeout_t timeout_ = ibex_timeout_init(timeout_usec);      \
     while (!(expr)) {                                                     \
-      CHECK(ibex_timeout_check(&timeout_),                                \
+      CHECK(!ibex_timeout_check(&timeout_),                               \
             "Timed out after %d usec (%d CPU cycles) waiting for " #expr, \
             timeout_usec, (uint32_t)timeout_.cycles);                     \
     }                                                                     \

--- a/sw/device/lib/testing/aes_testutils.c
+++ b/sw/device/lib/testing/aes_testutils.c
@@ -9,5 +9,3 @@
 
 extern bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag);
 
-extern void aes_testutils_wait_for_status(dif_aes_t *aes, dif_aes_status_t flag,
-                                          bool value, uint32_t timeout_usec);

--- a/sw/device/lib/testing/aes_testutils.h
+++ b/sw/device/lib/testing/aes_testutils.h
@@ -29,9 +29,8 @@ inline bool aes_testutils_get_status(dif_aes_t *aes, dif_aes_status_t flag) {
  * @param value The status flag value.
  * @param timeout_usec Timeout in microseconds.
  */
-inline void aes_testutils_wait_for_status(dif_aes_t *aes, dif_aes_status_t flag,
-                                          bool value, uint32_t timeout_usec) {
-  IBEX_SPIN_FOR(aes_testutils_get_status(aes, flag) == value, timeout_usec);
-}
+#define AES_TESTUTILS_WAIT_FOR_STATUS(aes_, flag_, value_, timeout_usec_) \
+  IBEX_SPIN_FOR(aes_testutils_get_status((aes_), (flag_)) == (value_),    \
+                (timeout_usec_))
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_AES_TESTUTILS_H_

--- a/sw/device/tests/aes_idle_test.c
+++ b/sw/device/tests/aes_idle_test.c
@@ -1,0 +1,163 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aes.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aes_testutils.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/clkmgr_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// The following plaintext, key and ciphertext are extracted from Appendix C of
+// the Advanced Encryption Standard (AES) FIPS Publication 197 available at
+// https://www.nist.gov/publications/advanced-encryption-standard-aes
+
+#define TIMEOUT (1000 * 1000)
+
+static const uint32_t kPlainText[] = {
+    0x33221100,
+    0x77665544,
+    0xbbaa9988,
+    0xffeeddcc,
+};
+
+static const uint8_t kKey[] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+    0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+    0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+};
+
+static const uint32_t kCipherTextGold[] = {
+    0xcab7a28e,
+    0xbf456751,
+    0x9049fcea,
+    0x8960494b,
+};
+
+// The mask share, used to mask kKey. Note that the masking should not be done
+// manually. Software is expected to get the key in two shares right from the
+// beginning.
+static const uint8_t kKeyShare1[] = {
+    0x0f, 0x1f, 0x2f, 0x3F, 0x4f, 0x5f, 0x6f, 0x7f, 0x8f, 0x9f, 0xaf,
+    0xbf, 0xcf, 0xdf, 0xef, 0xff, 0x0a, 0x1a, 0x2a, 0x3a, 0x4a, 0x5a,
+    0x6a, 0x7a, 0x8a, 0x9a, 0xaa, 0xba, 0xca, 0xda, 0xea, 0xfa,
+};
+
+const test_config_t kTestConfig;
+static dif_clkmgr_t clkmgr;
+static const dif_clkmgr_hintable_clock_t kAesClock =
+    kTopEarlgreyHintableClocksMainAes;
+
+static bool is_hintable_clock_enabled(const dif_clkmgr_t *clkmgr,
+                                      dif_clkmgr_hintable_clock_t clock) {
+  dif_toggle_t clock_state;
+  CHECK_DIF_OK(
+      dif_clkmgr_hintable_clock_get_enabled(clkmgr, clock, &clock_state));
+  return clock_state == kDifToggleEnabled;
+}
+
+static void initialize_clkmgr(void) {
+  mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR);
+  CHECK_DIF_OK(dif_clkmgr_init(addr, &clkmgr));
+
+  // Get initial hint and enable for AES clock and check both are enabled.
+  dif_toggle_t clock_hint_state;
+  CHECK_DIF_OK(dif_clkmgr_hintable_clock_get_hint(&clkmgr, kAesClock,
+                                                  &clock_hint_state));
+  CHECK(clock_hint_state == kDifToggleEnabled);
+  CLKMGR_TESTUTILS_CHECK_CLOCK_HINT(clkmgr, kAesClock, kDifToggleEnabled);
+}
+
+bool test_main(void) {
+  dif_aes_t aes;
+
+  initialize_clkmgr();
+
+  // First of all, we need to get the entropy complex up and running.
+  entropy_testutils_boot_mode_init();
+
+  // Initialise AES.
+  CHECK_DIF_OK(
+      dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  CHECK_DIF_OK(dif_aes_reset(&aes));
+
+  // Mask the key. Note that this should not be done manually. Software is
+  // expected to get the key in two shares right from the beginning.
+  uint8_t key_share0[ARRAYSIZE(kKey)];
+  for (int i = 0; i < ARRAYSIZE(kKey); ++i) {
+    key_share0[i] = kKey[i] ^ kKeyShare1[i];
+  }
+
+  // "Convert" key share byte arrays to `dif_aes_key_share_t`.
+  dif_aes_key_share_t key;
+  memcpy(key.share0, key_share0, ARRAYSIZE(kKey));
+  memcpy(key.share1, kKeyShare1, ARRAYSIZE(kKey));
+
+  // Setup ECB encryption transaction.
+  dif_aes_transaction_t transaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeEcb,
+      .key_len = kDifAesKey256,
+      .manual_operation = kDifAesManualOperationAuto,
+  };
+
+  // Write the AES clk hint to 0 within clkmgr to indicate AES clk can be
+  // gated and verify that the AES clk hint status within clkmgr reads 0 (AES
+  // is idle).
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kAesClock, kDifToggleDisabled, kDifToggleDisabled);
+
+  // Write the AES clk hint to 1 within clkmgr to indicate AES clk can be
+  // enabled.
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kAesClock, kDifToggleEnabled, kDifToggleEnabled);
+
+  // Initiate an AES operation with a known key, plain text and digest, write
+  // AES clk hint to 0 and verify that the AES clk hint status within clkmgr now
+  // reads 1 (AES is not idle), before the AES operation is complete.
+  CHECK_DIF_OK(dif_aes_start(&aes, &transaction, &key, NULL));
+
+  // "Convert" plain data byte arrays to `dif_aes_data_t`.
+  dif_aes_data_t in_data_plain;
+  memcpy(in_data_plain.data, kPlainText, ARRAYSIZE(kPlainText));
+
+  // Load the plain text to trigger the encryption operation.
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true, TIMEOUT);
+  CHECK_DIF_OK(dif_aes_load_data(&aes, in_data_plain));
+
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kAesClock, kDifToggleDisabled, kDifToggleEnabled);
+
+  // This is a bit awkward, but when the AES finishes the operation the clock
+  // will be gated as the clock hint has requested and the AES registers can't
+  // be read. So the safest way to check whether the AES has finished is by
+  // checking that the clock is not gated.
+  IBEX_SPIN_FOR(!is_hintable_clock_enabled(&clkmgr, kAesClock), TIMEOUT);
+
+  // After the AES operation is complete verify that the AES clk hint status
+  // within clkmgr now reads 0 again (AES is idle).
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kAesClock, kDifToggleDisabled, kDifToggleDisabled);
+
+  // Write the AES clk hint to 1, read and check the AES output for
+  // correctness.
+  CLKMGR_TESTUTILS_SET_AND_CHECK_CLOCK_HINT(
+      clkmgr, kAesClock, kDifToggleEnabled, kDifToggleEnabled);
+  dif_aes_data_t out_data_cipher;
+  CHECK_DIF_OK(dif_aes_read_output(&aes, &out_data_cipher));
+
+  // Finish the ECB encryption transaction.
+  CHECK_DIF_OK(dif_aes_end(&aes));
+
+  CHECK_BUFFER(out_data_cipher.data, kCipherTextGold,
+               ARRAYSIZE(kCipherTextGold));
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -289,6 +289,27 @@ sw_tests += {
   }
 }
 
+aes_idle_test_lib = declare_dependency(
+  link_with: static_library(
+    'aes_idle_test_lib',
+    sources: ['aes_idle_test.c'],
+    dependencies: [
+      sw_lib_dif_aes,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+      sw_lib_testing_entropy_testutils,
+      sw_lib_testing_aes_testutils,
+      sw_lib_testing_clkmgr_testutils,
+      sw_lib_testing_test_status,
+    ],
+  ),
+)
+sw_tests += {
+  'aes_idle_test': {
+    'library': aes_idle_test_lib,
+  }
+}
+
 clkmgr_smoketest_lib = declare_dependency(
   link_with: static_library(
     'clkmgr_smoketest_lib',

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -278,6 +278,7 @@ aes_smoketest_lib = declare_dependency(
       sw_lib_mmio,
       sw_lib_runtime_log,
       sw_lib_testing_entropy_testutils,
+      sw_lib_testing_aes_testutils,
       sw_lib_testing_test_status,
     ],
   ),


### PR DESCRIPTION
## This PR:

- Fixes the `IBEX_SPIN_FOR` macro.
- Rafactors the aes_smoketest to use the test_utils.
- Adds the idle test to the smoketest.