### PR TITLE
[chip dv] Fix ext clock

### DIFF
--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -97,15 +97,14 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     `uvm_field_object(m_spi_agent_cfg,        UVM_DEFAULT)
   `uvm_object_utils_end
 
-  // TODO: Fixing core clk freq to 50MHz for now.
-  // Need to find a way to pass this to the SW test.
   constraint clk_freq_mhz_c {
-    clk_freq_mhz == 50;
+    clk_freq_mhz == 100;
   }
 
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
+    int extclk_freq_mhz;
     has_devmode = 0;
     list_of_alerts = chip_env_pkg::LIST_OF_ALERTS;
 
@@ -139,6 +138,14 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
 
     `DV_CHECK_LE_FATAL(num_ram_main_tiles, 16)
     `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)
+
+    // Set external clock frequency.
+    if ($value$plusargs("extclk_freq_mhz=%d", extclk_freq_mhz)) begin
+      `DV_CHECK(extclk_freq_mhz inside {48, 100},
+                $sformatf("Unexpected extclk frequency %0d: valid numbers are 100 and 48",
+                          extclk_freq_mhz))
+        clk_freq_mhz = extclk_freq_mhz;
+    end
   endfunction
 
   // Apply RAL fixes before it is locked.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -10,8 +10,6 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
   );
   `uvm_object_utils(chip_base_vseq)
 
-  typedef enum int {ExtClkFreq48MHz = 48, ExtClkFreq100MHz = 100} ext_clk_freq_e;
-
   // knobs to enable pre_start routines
   bit do_strap_pins_init = 1'b1; // initialize the strap
 
@@ -80,8 +78,6 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
   virtual task pre_start();
     // Do DUT init after some additional settings.
     bit do_dut_init_save = do_dut_init;
-    int extclk_frequency_mhz = ExtClkFreq100MHz;
-    int extclk_frequency_attempted;
     do_dut_init = 1'b0;
     `uvm_create_on(callback_vseq, p_sequencer);
     `DV_CHECK_RANDOMIZE_FATAL(callback_vseq)
@@ -94,19 +90,6 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
       cfg.dft_straps_vif.drive(2'b00);
       cfg.sw_straps_vif.drive({2'b00, cfg.use_spi_load_bootstrap});
     end
-
-    // Set external clock frequency.
-    if ($value$plusargs("extclk_freq_mhz=%d", extclk_frequency_attempted)) begin
-      if (extclk_frequency_attempted == ExtClkFreq100MHz ||
-          extclk_frequency_attempted == ExtClkFreq48MHz) begin
-        extclk_frequency_mhz = extclk_frequency_attempted;
-      end else begin
-        `uvm_error(`gfn, $sformatf(
-                   "Unexpected extclk frequency %0d: valid numbers are 100 and 48",
-                   extclk_frequency_attempted))
-      end
-    end
-    cfg.clk_rst_vif.set_freq_mhz(extclk_frequency_mhz);
 
     // Now safe to do DUT init.
     if (do_dut_init) dut_init();


### PR DESCRIPTION
In #11327, we introduced another variable for the ext clock frequency,
but we already have one in env_cfg which is used in some uart tests.

Removed the new variable and changed it to use `cfg.clk_freq_mhz`

Signed-off-by: Weicai Yang <weicai@google.com>