### PR TITLE
[dv/otp] Add cov for sw partition lock status

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -326,6 +326,15 @@
       desc: '''This is an array of covergroups to cover all applicable error codes in five
             buffered partitions.'''
     }
+    { // TODO: this is an array of covergroups, confirm if this is the correct format
+      name: unbuf_access_lock_cg_wrap_cg
+      desc: '''This is an array of covergroups to cover lock conditions below in three
+            unbuffered partitions:
+            - the partition is write-locked
+            - the partition is read-locked
+            - the current operation type
+            Then cross the three coverpoints.'''
+    }
     {
       name: dai_access_secret2_cg
       desc: '''Covers whether `lc_creator_seed_sw_rw_en` is On during any DAI accesses.'''

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_cov.sv
@@ -88,6 +88,29 @@ class otp_ctrl_csr_rd_after_alert_cg_wrap;
   endfunction
 endclass
 
+class otp_ctrl_unbuf_access_lock_cg_wrap;
+  covergroup unbuf_access_lock_cg(string name) with function sample(bit read_lock, bit write_lock,
+                                                                    bit is_write);
+    option.per_instance = 1;
+    option.name         = name;
+    read_access_locked:  coverpoint read_lock;
+    write_access_locked: coverpoint write_lock;
+    operation_type: coverpoint is_write {
+      bins write_op = {1};
+      bins read_op  = {0};
+    }
+    unbuf_part_access_cross: cross read_access_locked, write_access_locked, operation_type;
+  endgroup
+
+  function new(string name);
+    unbuf_access_lock_cg = new(name);
+  endfunction
+
+  function void sample(bit read_lock, bit write_lock, bit is_write);
+    unbuf_access_lock_cg.sample(read_lock, write_lock, is_write);
+  endfunction
+endclass
+
 class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
   `uvm_component_utils(otp_ctrl_env_cov)
 
@@ -97,6 +120,7 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
   otp_ctrl_unbuf_err_code_cg_wrap     unbuf_err_code_cg_wrap[NUM_UNBUFF_PARTS];
   otp_ctrl_buf_err_code_cg_wrap       buf_err_code_cg_wrap[NUM_BUFF_PARTS];
   otp_ctrl_csr_rd_after_alert_cg_wrap csr_rd_after_alert_cg_wrap;
+  otp_ctrl_unbuf_access_lock_cg_wrap  unbuf_access_lock_cg_wrap[NUM_UNBUFF_PARTS];
 
   bit_toggle_cg_wrap lc_prog_cg;
   bit_toggle_cg_wrap otbn_req_cg;
@@ -253,6 +277,10 @@ class otp_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(otp_ctrl_env_cfg));
     foreach (buf_err_code_cg_wrap[i]) begin
       otp_status_e index = otp_status_e'(i + 2);
       buf_err_code_cg_wrap[i] = new($sformatf("buf_err_code_cg_wrap[%0s]", index.name));
+    end
+    foreach (unbuf_access_lock_cg_wrap[i]) begin
+      part_idx_e index = part_idx_e'(i);
+      unbuf_access_lock_cg_wrap[i] = new($sformatf("buf_err_code_cg_wrap[%0s]", index.name));
     end
   endfunction
 

--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -225,6 +225,10 @@ package otp_ctrl_env_pkg;
 
   function automatic bit is_sw_part(bit [TL_DW-1:0] addr);
     int part_idx = get_part_index(addr);
+    return is_sw_part_idx(part_idx);
+  endfunction
+
+  function automatic bit is_sw_part_idx(int part_idx);
     if (part_idx inside {VendorTestIdx, CreatorSwCfgIdx, OwnerSwCfgIdx}) return 1;
     else return 0;
   endfunction

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -216,13 +216,17 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
 
   // SW digest data are calculated in sw and won't be checked in OTP.
   // Here to simplify testbench, write random data to sw digest.
-  virtual task write_sw_digests(bit [1:0] wr_digest = $urandom());
+  virtual task write_sw_digests(bit [NUM_UNBUFF_PARTS-1:0] wr_digest = $urandom());
     bit [TL_DW*2-1:0] wdata;
-    if (wr_digest[0]) begin
+    if (wr_digest[VendorTestIdx]) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
       dai_wr(CreatorSwCfgDigestOffset, wdata[TL_DW-1:0], wdata[TL_DW*2-1:TL_DW]);
     end
-    if (wr_digest[1]) begin
+    if (wr_digest[CreatorSwCfgIdx]) begin
+      `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
+      dai_wr(CreatorSwCfgDigestOffset, wdata[TL_DW-1:0], wdata[TL_DW*2-1:TL_DW]);
+    end
+    if (wr_digest[OwnerSwCfgIdx]) begin
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata);
       dai_wr(OwnerSwCfgDigestOffset, wdata[TL_DW-1:0], wdata[TL_DW*2-1:TL_DW]);
     end


### PR DESCRIPTION
this PR adds a covergroup for sw partition lock status:
1). Collect which SW partition it is.
2). Collect if it is write locked.
3). Collect if it is read locked.
4). Collect the current operation type.
Then cross the above coverpoints.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>