### PR TITLE
[mask_rom/e2e] Add boot success and no rom_ext signature tests

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan.bzl", "OPENTITAN_CPU", "opentitan_functest", "opentitan_rom_binary", "verilator_params")
+load("//rules:opentitan.bzl", "OPENTITAN_CPU", "cw310_params", "opentitan_functest", "opentitan_rom_binary", "verilator_params")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -260,8 +260,13 @@ cc_test(
     ],
 )
 
+# MASK ROM E2E TESTS
+
+# Bootup tests
+BOOT_FAILURE_MSG = "BFV_[0-9a-z]{{8}}\nLCV_[0-9a-z]{{8}}\n"
+
 opentitan_functest(
-    name = "mask_rom_test",
+    name = "e2e_bootup_success",
     srcs = [
         "mask_rom_test.c",
     ],
@@ -273,4 +278,24 @@ opentitan_functest(
             "failing_verilator",
         ],
     ),
+)
+
+# TODO: Add verilator test
+opentitan_functest(
+    name = "e2e_bootup_no_rom_ext_signature",
+    srcs = [
+        "mask_rom_test.c",
+    ],
+    cw310 = cw310_params(
+        args = [
+            "--exec=\"console -q -t0\"",
+            "--exec=\"bootstrap $(location {test_bin})\"",
+            "console",
+            "--timeout=3600",
+            "--exit-success='{}'".format(BOOT_FAILURE_MSG),
+            "--exit-failure='PASS!'",
+        ],
+    ),
+    signed = False,
+    targets = ["cw310"],
 )


### PR DESCRIPTION
Adds tests for `mask_rom_e2e_bootup_success` and ` mask_rom_e2e_bootup_bad_rom_ext_signature` from #11608.