### PR TITLE
[rv_dm dv] Smoke test, cov and scoreboard updates

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -60,8 +60,6 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
 
   // drive jtag req and retrieve rsp
   virtual task drive_jtag_req(jtag_item req, jtag_item rsp);
-    logic [JTAG_DRW-1:0] dout;
-
     cfg.vif.tck_en <= 1'b1;
     @(`HOST_CB); // wait one cycle to ensure clock is stable. TODO: remove.
     if (req.ir_len) begin
@@ -71,10 +69,7 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
         `uvm_info(`gfn, $sformatf("UpdateIR for 0x%0h skipped", selected_ir), UVM_HIGH)
       end
     end
-    if (req.dr_len) begin
-      drive_jtag_dr(req.dr_len, req.dr, dout);
-      rsp.dout = dout;
-    end
+    if (req.dr_len) drive_jtag_dr(req.dr_len, req.dr, rsp.dout);
     cfg.vif.tck_en <= 1'b0;
   endtask
 

--- a/hw/ip/rv_dm/dv/cov/cover.cfg
+++ b/hw/ip/rv_dm/dv/cov/cover.cfg
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Non-RTL assertion only blocks.
+-moduletree rv_dm_regs_csr_assert_fpv
+begin assert
+  +moduletree rv_dm_regs_csr_assert_fpv
+end

--- a/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
+++ b/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg
@@ -5,6 +5,12 @@
 +node tb.dut *_tl_*
 +node tb.dut jtag_*
 
+// Non-RTL assertion only blocks.
+-moduletree rv_dm_regs_csr_assert_fpv
+begin assert
+  +moduletree rv_dm_regs_csr_assert_fpv
+end
+
 // The JTAG DTM is functionally verified, even in CSR tests.
 begin line+cond+fsm+branch+assert
   +moduletree dmi_jtag

--- a/hw/ip/rv_dm/dv/env/rv_dm_env.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env.sv
@@ -59,6 +59,8 @@ class rv_dm_env extends cip_base_env #(
     if (cfg.en_scb) begin
       m_jtag_agent.monitor.analysis_port.connect(m_jtag_dmi_monitor.jtag_item_fifo.analysis_export);
       m_jtag_dmi_monitor.analysis_port.connect(m_sba_access_monitor.jtag_dmi_fifo.analysis_export);
+      m_jtag_dmi_monitor.non_dmi_jtag_dtm_analysis_port.connect(
+          scoreboard.jtag_non_dmi_dtm_fifo.analysis_export);
       m_sba_access_monitor.non_sba_jtag_dmi_analysis_port.connect(
           scoreboard.jtag_non_sba_dmi_fifo.analysis_export);
       m_sba_access_monitor.analysis_port.connect(scoreboard.sba_access_fifo.analysis_export);

--- a/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
+++ b/hw/ip/rv_dm/dv/env/seq_lib/rv_dm_smoke_vseq.sv
@@ -8,8 +8,57 @@ class rv_dm_smoke_vseq extends rv_dm_base_vseq;
 
   `uvm_object_new
 
+  constraint lc_hw_debug_en_c {
+    lc_hw_debug_en == lc_ctrl_pkg::On;
+  }
+  constraint scanmode_c {
+    scanmode == prim_mubi_pkg::MuBi4False;
+  }
+
   task body();
-    `uvm_error(`gfn, "FIXME")
+    // Read the JTAG IDCODE register and verify that it matches the expected value.
+    uvm_reg_data_t data;
+    repeat ($urandom_range(1, 10)) begin
+      `DV_CHECK_STD_RANDOMIZE_FATAL(data)
+      csr_wr(.ptr(jtag_dtm_ral.idcode), .value(data));
+      csr_rd(.ptr(jtag_dtm_ral.idcode), .value(data));
+      `DV_CHECK_EQ(data, RV_DM_JTAG_IDCODE)
+    end
+    repeat ($urandom_range(1, 10)) begin
+      data = $urandom_range(0, 1);
+      // Verify that writing to haltreq results in debug_req output to be set.
+      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.haltreq), .value(data));
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+      `DV_CHECK_EQ(cfg.rv_dm_vif.debug_req, data)
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    end
+    repeat ($urandom_range(1, 10)) begin
+      data = $urandom_range(0, 1);
+      // Verify that writing to ndmreset results in ndmreset output to be set.
+      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.ndmreset), .value(data));
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+      `DV_CHECK_EQ(cfg.rv_dm_vif.ndmreset_req, data)
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    end
+    repeat ($urandom_range(1, 10)) begin
+      data = $urandom_range(0, 1);
+      // Verify that the dmstatus[*unavail] field tracks the unavailable_i input.
+      cfg.rv_dm_vif.unavailable <= data;
+      csr_rd(.ptr(jtag_dmi_ral.dmstatus), .value(data));
+      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
+                   get_field_val(jtag_dmi_ral.dmstatus.anyunavail, data))
+      `DV_CHECK_EQ(cfg.rv_dm_vif.unavailable,
+                   get_field_val(jtag_dmi_ral.dmstatus.allunavail, data))
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    end
+    repeat ($urandom_range(1, 10)) begin
+      data = $urandom_range(0, 1);
+      // Verify that writing to dmactive results in dmactive output to be set.
+      csr_wr(.ptr(jtag_dmi_ral.dmcontrol.dmactive), .value(data));
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 1000));
+      `DV_CHECK_EQ(cfg.rv_dm_vif.dmactive, data)
+      cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
+    end
   endtask : body
 
 endclass : rv_dm_smoke_vseq

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -78,6 +78,7 @@
     {
       name: rv_dm_smoke
       uvm_test_seq: rv_dm_smoke_vseq
+      reseed: 2
     }
     {
       name: rv_dm_jtag_dtm_csr_hw_reset

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -57,6 +57,10 @@
       value: 8
     }
     {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/ip/rv_dm/dv/cov/cover.cfg"
+    }
+    {
       name: cover_reg_top_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover_reg_top.cfg+{proj_root}/hw/ip/rv_dm/dv/cov/cover_reg_top.cfg"
     }


### PR DESCRIPTION
These set of commits are towards progress to V1 signoff. 

The first commit fixes the coverage collection criteria to remove a FPV CSR assertion module from coverage collection (only enable assertion coverage on it). This improves other metrics a bit, which we do not care about. 

The second commit adds a very basic smoke test that verifies DMI writes and reads and checks their effect on RV_DM IOs. 

The third and 4tgh commits are minor fixes to jtag tb components. 

The last commit beefs up the rv_dm_scoreboard with a skeleton framework to process accesses to CSRs in all implemented RAL models. This sets the stage for subsequent V2 tests. 