### PR TITLE
[topgen] Fix SW autogen header guard and template

### DIFF
--- a/util/topgen/templates/toplevel.h.tpl
+++ b/util/topgen/templates/toplevel.h.tpl
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _TOP_${top["name"].upper()}_H_
-#define _TOP_${top["name"].upper()}_H_
+#ifndef ${helper.header_macro_prefix}_TOP_${top["name"].upper()}_H_
+#define ${helper.header_macro_prefix}_TOP_${top["name"].upper()}_H_
 
 /**
  * @file
@@ -198,4 +198,4 @@ ${helper.clkmgr_hintable_clocks.render()}
 }  // extern "C"
 #endif
 
-#endif  // _TOP_${top["name"].upper()}_H_
+#endif  // ${helper.header_macro_prefix}_TOP_${top["name"].upper()}_H_

--- a/util/topgen/templates/toplevel_memory.h.tpl
+++ b/util/topgen/templates/toplevel_memory.h.tpl
@@ -2,8 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#ifndef _TOP_${top["name"].upper()}_MEMORY_H_
-#define _TOP_${top["name"].upper()}_MEMORY_H_
+#ifndef ${helper.header_macro_prefix}_TOP_${top["name"].upper()}_MEMORY_H_
+#define ${helper.header_macro_prefix}_TOP_${top["name"].upper()}_MEMORY_H_
 
 /**
  * @file
@@ -67,4 +67,4 @@
 % endfor
 #endif  // __ASSEMBLER__
 
-#endif  // _TOP_${top["name"].upper()}_MEMORY_H_
+#endif  // ${helper.header_macro_prefix}_TOP_${top["name"].upper()}_MEMORY_H_


### PR DESCRIPTION
Explicitly define the header guard prefix root directory so we don't
need to apply a fix afterwards.

If the sw/autogen/top_{}/top_{}*.h is generated out of the opentitan
tree, the header guard should be based on the output directory
directly.

Signed-off-by: Cindy Liu <hcindyl@google.com>