### PR TITLE
[sw] Update linker scripts for DWARF version 5

### DIFF
--- a/sw/device/info_sections.ld
+++ b/sw/device/info_sections.ld
@@ -77,6 +77,8 @@
 .debug_line_str 0x0 : { *(.debug_line_str) }
 .debug_loclists 0x0 : { *(.debug_loclists) }
 .debug_rnglists 0x0 : { *(.debug_rnglists) }
+.debug_addr 0x0 : { *(.debug_addr) }
+.debug_str_offsets 0x0 : { *(.debug_str_offsets) }
 
 /* Discarded Sections (Not needed in device images). */
 /DISCARD/ : {


### PR DESCRIPTION
Recent versions of Clang started defaulting to the DWARF debug format version 5. When emitting DWARF 5 clang emits two new debug sections. This patch includes those new sections in the linked ELF files, for proper debug support and to fix build failures caused by warnings of orphan sections.