### PR TITLE
[otbn] Make run_smoke.sh throw error in a mismatch

### DIFF
--- a/hw/ip/otbn/dv/smoke/run_smoke.sh
+++ b/hw/ip/otbn/dv/smoke/run_smoke.sh
@@ -51,9 +51,10 @@ if [ $? -ne 0 ]; then
   fail "Simulator run failed"
 fi
 
-grep -A 74 "Call Stack:" $RUN_LOG | diff $SMOKE_SRC_DIR/smoke_expected.txt -
+had_diff=0
+grep -A 74 "Call Stack:" $RUN_LOG | diff -U3 $SMOKE_SRC_DIR/smoke_expected.txt - || had_diff=1
 
-if [ $? -eq 0 ]; then
+if [ $had_diff == 0 ]; then
   echo "OTBN SMOKE PASS"
 else
   fail "Simulator output does not match expected output"


### PR DESCRIPTION
Ensures that if the produced smoke test output is not matching
the expected output, it will get implied in the error message

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>