### PR TITLE
[lc_ctrl/dv] Added common security countermeasures test.

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
@@ -27,7 +27,7 @@
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_tl_intg_err"]
     }
     {
       name: sec_cm_transition_config_regwen
@@ -45,37 +45,37 @@
       name: sec_cm_transition_ctr_sparse
       desc: "Verify the countermeasure(s) TRANSITION.CTR.SPARSE."
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
       name: sec_cm_manuf_state_bkgn_chk
       desc: "Verify the countermeasure(s) MANUF.STATE.BKGN_CHK."
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
       name: sec_cm_transition_ctr_bkgn_chk
       desc: "Verify the countermeasure(s) TRANSITION.CTR.BKGN_CHK."
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
       name: sec_cm_state_config_sparse
       desc: "Verify the countermeasure(s) STATE.CONFIG.SPARSE."
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
       name: sec_cm_main_fsm_sparse
       desc: "Verify the countermeasure(s) MAIN.FSM.SPARSE."
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
       name: sec_cm_kmac_fsm_sparse
       desc: "Verify the countermeasure(s) KMAC.FSM.SPARSE."
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
       name: sec_cm_main_fsm_local_esc

--- a/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
+++ b/hw/ip/lc_ctrl/dv/cov/lc_ctrl_cov_bind.sv
@@ -4,5 +4,36 @@
 //
 // Binds LC_CTRL functional coverage interaface to the top level LC_CTRL module.
 module lc_ctrl_cov_bind;
+  // LC_CTRL FSM coverage
   bind lc_ctrl_fsm lc_ctrl_fsm_cov_if u_lc_ctrl_fsm_cov_if (.*);
+
+  // MUBI coverage
+  bind lc_ctrl cip_mubi_cov_if #(
+    .Width(4)
+  ) u_scanmode_i_if (
+    .rst_ni(rst_ni),
+    .mubi  (scanmode_i)
+  );
+  bind lc_ctrl cip_lc_tx_cov_if u_lc_clk_byp_ack_i_if (
+    .rst_ni(rst_ni),
+    .val(lc_clk_byp_ack_i)
+  );
+  bind lc_ctrl cip_lc_tx_cov_if u_lc_flash_rma_ack_i_if (
+    .rst_ni(rst_ni),
+    .val(lc_flash_rma_ack_i)
+  );
+  // otp_lc_data_t otp_lc_data_i struct
+  bind lc_ctrl cip_lc_tx_cov_if u_otp_lc_data_i_secrets_valid_if (
+    .rst_ni(rst_ni),
+    .val(otp_lc_data_i.secrets_valid)
+  );
+  bind lc_ctrl cip_lc_tx_cov_if u_otp_lc_data_i_test_tokens_valid_if (
+    .rst_ni(rst_ni),
+    .val(otp_lc_data_i.test_tokens_valid)
+  );
+  bind lc_ctrl cip_lc_tx_cov_if u_otp_lc_data_i_rma_token_valid_if (
+    .rst_ni(rst_ni),
+    .val(otp_lc_data_i.rma_token_valid)
+  );
+
 endmodule

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -44,8 +44,8 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   // OTP
   rand otp_device_id_t otp_device_id;
   rand otp_device_id_t otp_manuf_state;
-  rand logic [OtpTestCtrlWidth-1:0]  otp_vendor_test_ctrl;
-  rand logic [OtpTestStatusWidth-1:0]  otp_vendor_test_status;
+  rand logic [OtpTestCtrlWidth-1:0] otp_vendor_test_ctrl;
+  rand logic [OtpTestStatusWidth-1:0] otp_vendor_test_status;
 
 
 
@@ -57,6 +57,7 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   virtual function void initialize(bit [31:0] csr_base_addr = '1);
     list_of_alerts = lc_ctrl_env_pkg::LIST_OF_ALERTS;
     tl_intg_alert_name = "fatal_bus_integ_error";
+    sec_cm_alert_name = "fatal_state_error";
     super.initialize(csr_base_addr);
 
     // Find parameters on config db

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -22,6 +22,7 @@ package lc_ctrl_env_pkg;
   import kmac_app_agent_pkg::*;
   import lc_ctrl_dv_utils_pkg::*;
   import prim_mubi_pkg::MuBi8True;
+  import sec_cm_pkg::*;
 
   // macro includes
   `include "uvm_macros.svh"

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_common_vseq.sv
@@ -5,13 +5,49 @@
 class lc_ctrl_common_vseq extends lc_ctrl_base_vseq;
   `uvm_object_utils(lc_ctrl_common_vseq)
 
-  constraint num_trans_c {
-    num_trans inside {[1:2]};
-  }
+  constraint num_trans_c {num_trans inside {[1 : 2]};}
   `uvm_object_new
 
   virtual task body();
     run_common_vseq_wrapper(num_trans);
   endtask : body
+
+  virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
+    // Expected state error bit of status register
+    bit exp_state_error = 0;
+    // Expected lc_state register (actual value is this repeated 6 times)
+    // Without error lc_state reflects OTP input
+    dec_lc_state_e exp_lc_state_single = dec_lc_state(lc_state_e'(cfg.lc_ctrl_vif.otp_i.state));
+
+    super.check_sec_cm_fi_resp(if_proxy);
+
+    case (if_proxy.sec_cm_type)
+      SecCmPrimSparseFsmFlop: begin
+        exp_state_error = 1;
+        exp_lc_state_single = DecLcStInvalid;
+      end
+
+      default: `uvm_fatal(`gfn, $sformatf("unexpected sec_cm_type %s", if_proxy.sec_cm_type.name))
+    endcase
+    csr_rd_check(.ptr(ral.status.state_error), .compare_value(exp_state_error));
+    csr_rd_check(.ptr(ral.lc_state), .compare_value({6{exp_lc_state_single}}));
+
+    // Check DUT outputs
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_dft_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_nvm_debug_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_hw_debug_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_cpu_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_creator_seed_sw_rw_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_owner_seed_sw_rw_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_rd_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_iso_part_sw_wr_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_seed_hw_rd_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_keymgr_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_escalate_en_o, lc_ctrl_pkg::On)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.lc_check_byp_en_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.clk_byp_req_o, lc_ctrl_pkg::Off)
+    `DV_CHECK_EQ(cfg.lc_ctrl_vif.flash_rma_req_o, lc_ctrl_pkg::Off)
+
+  endtask : check_sec_cm_fi_resp
 
 endclass

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -30,12 +30,13 @@
                 // Common CIP test lists
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson"]
                 // TODO: temp commented out stress_test
                 // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
 
   // Add additional tops for simulation.
-  sim_tops: ["lc_ctrl_bind", "lc_ctrl_cov_bind"]
+  sim_tops: ["lc_ctrl_bind", "lc_ctrl_cov_bind", "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // Default iterations for all tests - each test entry can override this.
   reseed: 50


### PR DESCRIPTION
- Added sec_cm_tests.hjson to import list in lc_ctrl_sim_cfg.hjson
- Imported sec_cm_pkg into lc_ctrl_env_pkg
- Set sec_cm_alert_name to "fatal_state_error" in lc_ctrl_env_cfg
- Checking status and lc_state registers in lc_ctrl_common_vseq
- Checking DUT outputs in lc_ctrl_common_vseq
- Added lc_ctrl_sec_cm, lc_ctrl_state_failure and lc_ctrl_tl_intg_err
  to lc_ctrl_sec_cm_testplan.hjson
- Added MUBI coverage to lc_ctrl_cov_bind.sv

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>