### PR TITLE
[otbn,dv] Don't check recov alert on SecWipes

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_scoreboard.sv
@@ -373,9 +373,7 @@ class otbn_scoreboard extends cip_base_scoreboard #(
 
       case (item.item_type)
         OtbnModelStatus: begin
-          bit was_running = model_status inside {otbn_pkg::StatusBusyExecute,
-                                                 otbn_pkg::StatusBusySecWipeDmem,
-                                                 otbn_pkg::StatusBusySecWipeImem};
+          bit was_executing = model_status inside {otbn_pkg::StatusBusyExecute};
           bit is_running = item.status inside {otbn_pkg::StatusBusyExecute,
                                                otbn_pkg::StatusBusySecWipeDmem,
                                                otbn_pkg::StatusBusySecWipeImem};
@@ -393,9 +391,10 @@ class otbn_scoreboard extends cip_base_scoreboard #(
           if (item.status == otbn_pkg::StatusLocked) begin
             expect_alert("fatal");
           end
-          // Has the status changed from busy to idle with a nonzero err_bits? If so, we should see
-          // a recoverable alert.
-          if (was_running && item.status == otbn_pkg::StatusIdle && item.err_bits != 0) begin
+          // Has the status changed from executing to idle with a nonzero err_bits?
+          // If so, we should see a recoverable alert. Note that we are not expecting to catch
+          // recoverable alert when we do SecWipe of any kind.
+          if (was_executing && item.status == otbn_pkg::StatusIdle && item.err_bits != 0) begin
             expect_alert("recov");
           end
 


### PR DESCRIPTION
This commit makes sure that we are not double checking the
recoverable alerts in the case of running different operations
than EXEC. That is because we are not clearing the error bits in
either of the SecWipe operation operations.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>