### PR TITLE
[bazel] Add rules to build boostrap flash image for DV sim

### DIFF
--- a/sw/host/spiflash/BUILD
+++ b/sw/host/spiflash/BUILD
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_binary(
+    name = "spiflash",
+    srcs = [
+        "ftdi_spi_interface.cc",
+        "ftdi_spi_interface.h",
+        "spi_interface.h",
+        "spiflash.cc",
+        "updater.cc",
+        "updater.h",
+        "verilator_spi_interface.cc",
+        "verilator_spi_interface.h",
+    ],
+    linkopts = [
+        "-lftdi1",
+    ],
+    deps = [
+        "//sw/host/vendor:mpsse",
+        "//sw/vendor:cryptoc_sha256",
+    ],
+)

--- a/sw/host/vendor/BUILD
+++ b/sw/host/vendor/BUILD
@@ -1,0 +1,26 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mpsse",
+    srcs = [
+        "mpsse/mpsse.c",
+        "mpsse/support.c",
+        "mpsse/support.h",
+    ],
+    hdrs = [
+        "mpsse/mpsse.h",
+    ],
+    copts = [
+        # TODO: Remove this once https://github.com/lowRISC/opentitan/issues/3182
+        # is resolved.
+        "-Wno-error=deprecated-declarations",
+    ],
+    linkopts = [
+        "-lftdi1",
+        "-lusb-1.0",
+    ],
+)

--- a/sw/vendor/BUILD
+++ b/sw/vendor/BUILD
@@ -2,4 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+package(default_visibility = ["//visibility:public"])
+
 exports_files(glob(["veri-titan/gen/*.s"]))
+
+cc_library(
+    name = "cryptoc_sha256",
+    srcs = ["cryptoc/sha256.c"],
+    hdrs = [
+        "cryptoc/include/cryptoc/hash-internal.h",
+        "cryptoc/include/cryptoc/sha256.h",
+    ],
+    strip_include_prefix = "cryptoc/include",
+)


### PR DESCRIPTION
This PR has two commits that address tasks in #11559:

**Commit 1:** add bazel rules to build the [spiflash utility](https://github.com/lowRISC/opentitan/tree/master/sw/host/spiflash) and any dependencies (so it can be used to convert a BIN into SPI flash frames)

**Commit 2:** add custom bazel rules, and invokes them from the `opentitan_flash_binary` macro, for translating a flash BIN into SPI flash frames for bootstrapping the chip in DV sim.