### PR TITLE
[dif/autogen] Use EXPECT_DIF_* macros in unit tests

### DIFF
--- a/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_adc_ctrl_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "adc_ctrl_regs.h"  // Generated.
 
@@ -28,32 +29,31 @@ class AdcCtrlTest : public Test, public MmioTest {
 class InitTest : public AdcCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_adc_ctrl_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_adc_ctrl_init(dev().region(), &adc_ctrl_), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_init(dev().region(), &adc_ctrl_));
 }
 
 class AlertForceTest : public AdcCtrlTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_adc_ctrl_alert_force(nullptr, kDifAdcCtrlAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_alert_force(nullptr, kDifAdcCtrlAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_adc_ctrl_alert_force(nullptr, static_cast<dif_adc_ctrl_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_alert_force(nullptr, static_cast<dif_adc_ctrl_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(ADC_CTRL_ALERT_TEST_REG_OFFSET,
                  {{ADC_CTRL_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_adc_ctrl_alert_force(&adc_ctrl_, kDifAdcCtrlAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_adc_ctrl_alert_force(&adc_ctrl_, kDifAdcCtrlAlertFatalFault));
 }
 
 class IrqGetStateTest : public AdcCtrlTest {};
@@ -61,11 +61,11 @@ class IrqGetStateTest : public AdcCtrlTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_adc_ctrl_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_adc_ctrl_irq_get_state(&adc_ctrl_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_state(&adc_ctrl_, nullptr));
 
-  EXPECT_EQ(dif_adc_ctrl_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -73,7 +73,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_adc_ctrl_irq_get_state(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_get_state(&adc_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -81,7 +81,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_adc_ctrl_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_adc_ctrl_irq_get_state(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_get_state(&adc_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -90,25 +90,21 @@ class IrqIsPendingTest : public AdcCtrlTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqDebugCable,
-                                        &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
+      nullptr, kDifAdcCtrlIrqDebugCable, &is_pending));
 
-  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
-                                        nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
+      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, nullptr));
 
-  EXPECT_EQ(
-      dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqDebugCable, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_is_pending(nullptr, kDifAdcCtrlIrqDebugCable, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(
-                &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_is_pending(
+      &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -118,65 +114,60 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(ADC_CTRL_INTR_STATE_REG_OFFSET,
                 {{ADC_CTRL_INTR_STATE_DEBUG_CABLE_BIT, true}});
-  EXPECT_EQ(dif_adc_ctrl_irq_is_pending(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
-                                        &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_is_pending(
+      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, &irq_state));
   EXPECT_TRUE(irq_state);
 }
 
 class AcknowledgeAllTest : public AdcCtrlTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(ADC_CTRL_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge_all(&adc_ctrl_), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_acknowledge_all(&adc_ctrl_));
 }
 
 class IrqAcknowledgeTest : public AdcCtrlTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge(nullptr, kDifAdcCtrlIrqDebugCable),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_acknowledge(nullptr, kDifAdcCtrlIrqDebugCable));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge(nullptr,
-                                         static_cast<dif_adc_ctrl_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_acknowledge(
+      nullptr, static_cast<dif_adc_ctrl_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(ADC_CTRL_INTR_STATE_REG_OFFSET,
                  {{ADC_CTRL_INTR_STATE_DEBUG_CABLE_BIT, true}});
-  EXPECT_EQ(dif_adc_ctrl_irq_acknowledge(&adc_ctrl_, kDifAdcCtrlIrqDebugCable),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_adc_ctrl_irq_acknowledge(&adc_ctrl_, kDifAdcCtrlIrqDebugCable));
 }
 
 class IrqForceTest : public AdcCtrlTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_adc_ctrl_irq_force(nullptr, kDifAdcCtrlIrqDebugCable),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_force(nullptr, kDifAdcCtrlIrqDebugCable));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(
-      dif_adc_ctrl_irq_force(nullptr, static_cast<dif_adc_ctrl_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_force(nullptr, static_cast<dif_adc_ctrl_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(ADC_CTRL_INTR_TEST_REG_OFFSET,
                  {{ADC_CTRL_INTR_TEST_DEBUG_CABLE_BIT, true}});
-  EXPECT_EQ(dif_adc_ctrl_irq_force(&adc_ctrl_, kDifAdcCtrlIrqDebugCable),
-            kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_force(&adc_ctrl_, kDifAdcCtrlIrqDebugCable));
 }
 
 class IrqGetEnabledTest : public AdcCtrlTest {};
@@ -184,25 +175,21 @@ class IrqGetEnabledTest : public AdcCtrlTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqDebugCable,
-                                         &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
+      nullptr, kDifAdcCtrlIrqDebugCable, &irq_state));
 
-  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
-                                         nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
+      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, nullptr));
 
-  EXPECT_EQ(
-      dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqDebugCable, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_adc_ctrl_irq_get_enabled(nullptr, kDifAdcCtrlIrqDebugCable, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(
-                &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_get_enabled(
+      &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -212,9 +199,8 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
                 {{ADC_CTRL_INTR_ENABLE_DEBUG_CABLE_BIT, true}});
-  EXPECT_EQ(dif_adc_ctrl_irq_get_enabled(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
-                                         &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_get_enabled(
+      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 }
 
@@ -223,17 +209,15 @@ class IrqSetEnabledTest : public AdcCtrlTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_set_enabled(nullptr, kDifAdcCtrlIrqDebugCable,
-                                         irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_set_enabled(
+      nullptr, kDifAdcCtrlIrqDebugCable, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_set_enabled(
-                &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_set_enabled(
+      &adc_ctrl_, static_cast<dif_adc_ctrl_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -243,9 +227,8 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
                 {{ADC_CTRL_INTR_ENABLE_DEBUG_CABLE_BIT, 0x1, true}});
-  EXPECT_EQ(dif_adc_ctrl_irq_set_enabled(&adc_ctrl_, kDifAdcCtrlIrqDebugCable,
-                                         irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_set_enabled(
+      &adc_ctrl_, kDifAdcCtrlIrqDebugCable, irq_state));
 }
 
 class IrqDisableAllTest : public AdcCtrlTest {};
@@ -253,14 +236,14 @@ class IrqDisableAllTest : public AdcCtrlTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -268,7 +251,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -278,7 +261,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_disable_all(&adc_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -287,11 +270,11 @@ class IrqRestoreAllTest : public AdcCtrlTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, nullptr));
 
-  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_adc_ctrl_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -300,14 +283,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_adc_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(ADC_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_restore_all(&adc_ctrl_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aes_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "aes_regs.h"  // Generated.
 
@@ -28,35 +29,35 @@ class AesTest : public Test, public MmioTest {
 class InitTest : public AesTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_aes_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aes_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_aes_init(dev().region(), &aes_), kDifOk);
+  EXPECT_DIF_OK(dif_aes_init(dev().region(), &aes_));
 }
 
 class AlertForceTest : public AesTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_aes_alert_force(nullptr, kDifAesAlertRecovCtrlUpdateErr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_aes_alert_force(nullptr, kDifAesAlertRecovCtrlUpdateErr));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_aes_alert_force(nullptr, static_cast<dif_aes_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_aes_alert_force(nullptr, static_cast<dif_aes_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(AES_ALERT_TEST_REG_OFFSET,
                  {{AES_ALERT_TEST_RECOV_CTRL_UPDATE_ERR_BIT, true}});
-  EXPECT_EQ(dif_aes_alert_force(&aes_, kDifAesAlertRecovCtrlUpdateErr), kDifOk);
+  EXPECT_DIF_OK(dif_aes_alert_force(&aes_, kDifAesAlertRecovCtrlUpdateErr));
 
   // Force last alert.
   EXPECT_WRITE32(AES_ALERT_TEST_REG_OFFSET,
                  {{AES_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_aes_alert_force(&aes_, kDifAesAlertFatalFault), kDifOk);
+  EXPECT_DIF_OK(dif_aes_alert_force(&aes_, kDifAesAlertFatalFault));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_aon_timer_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "aon_timer_regs.h"  // Generated.
 
@@ -28,32 +29,31 @@ class AonTimerTest : public Test, public MmioTest {
 class InitTest : public AonTimerTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_aon_timer_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_aon_timer_init(dev().region(), &aon_timer_), kDifOk);
+  EXPECT_DIF_OK(dif_aon_timer_init(dev().region(), &aon_timer_));
 }
 
 class AlertForceTest : public AonTimerTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_aon_timer_alert_force(nullptr, kDifAonTimerAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_aon_timer_alert_force(nullptr, kDifAonTimerAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_aon_timer_alert_force(nullptr,
-                                      static_cast<dif_aon_timer_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_alert_force(
+      nullptr, static_cast<dif_aon_timer_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(AON_TIMER_ALERT_TEST_REG_OFFSET,
                  {{AON_TIMER_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_aon_timer_alert_force(&aon_timer_, kDifAonTimerAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_aon_timer_alert_force(&aon_timer_, kDifAonTimerAlertFatalFault));
 }
 
 class IrqGetStateTest : public AonTimerTest {};
@@ -61,11 +61,11 @@ class IrqGetStateTest : public AonTimerTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_aon_timer_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_aon_timer_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_aon_timer_irq_get_state(&aon_timer_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_get_state(&aon_timer_, nullptr));
 
-  EXPECT_EQ(dif_aon_timer_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -73,7 +73,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_aon_timer_irq_get_state(&aon_timer_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_aon_timer_irq_get_state(&aon_timer_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -81,7 +81,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_aon_timer_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_aon_timer_irq_get_state(&aon_timer_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_aon_timer_irq_get_state(&aon_timer_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -90,25 +90,21 @@ class IrqIsPendingTest : public AonTimerTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_aon_timer_irq_is_pending(
-                nullptr, kDifAonTimerIrqWkupTimerExpired, &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_is_pending(
+      nullptr, kDifAonTimerIrqWkupTimerExpired, &is_pending));
 
-  EXPECT_EQ(dif_aon_timer_irq_is_pending(
-                &aon_timer_, kDifAonTimerIrqWkupTimerExpired, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_is_pending(
+      &aon_timer_, kDifAonTimerIrqWkupTimerExpired, nullptr));
 
-  EXPECT_EQ(dif_aon_timer_irq_is_pending(
-                nullptr, kDifAonTimerIrqWkupTimerExpired, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_is_pending(
+      nullptr, kDifAonTimerIrqWkupTimerExpired, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_aon_timer_irq_is_pending(
-                &aon_timer_, static_cast<dif_aon_timer_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_is_pending(
+      &aon_timer_, static_cast<dif_aon_timer_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -118,90 +114,82 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET,
                 {{AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT, true}});
-  EXPECT_EQ(dif_aon_timer_irq_is_pending(
-                &aon_timer_, kDifAonTimerIrqWkupTimerExpired, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_aon_timer_irq_is_pending(
+      &aon_timer_, kDifAonTimerIrqWkupTimerExpired, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(AON_TIMER_INTR_STATE_REG_OFFSET,
                 {{AON_TIMER_INTR_STATE_WDOG_TIMER_BARK_BIT, false}});
-  EXPECT_EQ(dif_aon_timer_irq_is_pending(
-                &aon_timer_, kDifAonTimerIrqWdogTimerBark, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_aon_timer_irq_is_pending(
+      &aon_timer_, kDifAonTimerIrqWdogTimerBark, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public AonTimerTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_aon_timer_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(AON_TIMER_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_aon_timer_irq_acknowledge_all(&aon_timer_), kDifOk);
+  EXPECT_DIF_OK(dif_aon_timer_irq_acknowledge_all(&aon_timer_));
 }
 
 class IrqAcknowledgeTest : public AonTimerTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(
-      dif_aon_timer_irq_acknowledge(nullptr, kDifAonTimerIrqWkupTimerExpired),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_aon_timer_irq_acknowledge(nullptr, kDifAonTimerIrqWkupTimerExpired));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_aon_timer_irq_acknowledge(nullptr,
-                                          static_cast<dif_aon_timer_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_aon_timer_irq_acknowledge(
+      nullptr, static_cast<dif_aon_timer_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(AON_TIMER_INTR_STATE_REG_OFFSET,
                  {{AON_TIMER_INTR_STATE_WKUP_TIMER_EXPIRED_BIT, true}});
-  EXPECT_EQ(dif_aon_timer_irq_acknowledge(&aon_timer_,
-                                          kDifAonTimerIrqWkupTimerExpired),
-            kDifOk);
+  EXPECT_DIF_OK(dif_aon_timer_irq_acknowledge(&aon_timer_,
+                                              kDifAonTimerIrqWkupTimerExpired));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(AON_TIMER_INTR_STATE_REG_OFFSET,
                  {{AON_TIMER_INTR_STATE_WDOG_TIMER_BARK_BIT, true}});
-  EXPECT_EQ(
-      dif_aon_timer_irq_acknowledge(&aon_timer_, kDifAonTimerIrqWdogTimerBark),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_aon_timer_irq_acknowledge(&aon_timer_, kDifAonTimerIrqWdogTimerBark));
 }
 
 class IrqForceTest : public AonTimerTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_aon_timer_irq_force(nullptr, kDifAonTimerIrqWkupTimerExpired),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_aon_timer_irq_force(nullptr, kDifAonTimerIrqWkupTimerExpired));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(
-      dif_aon_timer_irq_force(nullptr, static_cast<dif_aon_timer_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_aon_timer_irq_force(nullptr, static_cast<dif_aon_timer_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(AON_TIMER_INTR_TEST_REG_OFFSET,
                  {{AON_TIMER_INTR_TEST_WKUP_TIMER_EXPIRED_BIT, true}});
-  EXPECT_EQ(
-      dif_aon_timer_irq_force(&aon_timer_, kDifAonTimerIrqWkupTimerExpired),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_aon_timer_irq_force(&aon_timer_, kDifAonTimerIrqWkupTimerExpired));
 
   // Force last IRQ.
   EXPECT_WRITE32(AON_TIMER_INTR_TEST_REG_OFFSET,
                  {{AON_TIMER_INTR_TEST_WDOG_TIMER_BARK_BIT, true}});
-  EXPECT_EQ(dif_aon_timer_irq_force(&aon_timer_, kDifAonTimerIrqWdogTimerBark),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_aon_timer_irq_force(&aon_timer_, kDifAonTimerIrqWdogTimerBark));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_clkmgr_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "clkmgr_regs.h"  // Generated.
 
@@ -28,38 +29,34 @@ class ClkmgrTest : public Test, public MmioTest {
 class InitTest : public ClkmgrTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_clkmgr_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_clkmgr_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_clkmgr_init(dev().region(), &clkmgr_), kDifOk);
+  EXPECT_DIF_OK(dif_clkmgr_init(dev().region(), &clkmgr_));
 }
 
 class AlertForceTest : public ClkmgrTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_clkmgr_alert_force(nullptr, kDifClkmgrAlertRecovFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_clkmgr_alert_force(nullptr, kDifClkmgrAlertRecovFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_clkmgr_alert_force(nullptr, static_cast<dif_clkmgr_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_clkmgr_alert_force(nullptr, static_cast<dif_clkmgr_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(CLKMGR_ALERT_TEST_REG_OFFSET,
                  {{CLKMGR_ALERT_TEST_RECOV_FAULT_BIT, true}});
-  EXPECT_EQ(dif_clkmgr_alert_force(&clkmgr_, kDifClkmgrAlertRecovFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_clkmgr_alert_force(&clkmgr_, kDifClkmgrAlertRecovFault));
 
   // Force last alert.
   EXPECT_WRITE32(CLKMGR_ALERT_TEST_REG_OFFSET,
                  {{CLKMGR_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_clkmgr_alert_force(&clkmgr_, kDifClkmgrAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_clkmgr_alert_force(&clkmgr_, kDifClkmgrAlertFatalFault));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_csrng_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "csrng_regs.h"  // Generated.
 
@@ -28,35 +29,34 @@ class CsrngTest : public Test, public MmioTest {
 class InitTest : public CsrngTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_csrng_init(dev().region(), &csrng_), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_init(dev().region(), &csrng_));
 }
 
 class AlertForceTest : public CsrngTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_alert_force(nullptr, kDifCsrngAlertRecovAlert),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_alert_force(nullptr, kDifCsrngAlertRecovAlert));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_csrng_alert_force(nullptr, static_cast<dif_csrng_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_alert_force(nullptr, static_cast<dif_csrng_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(CSRNG_ALERT_TEST_REG_OFFSET,
                  {{CSRNG_ALERT_TEST_RECOV_ALERT_BIT, true}});
-  EXPECT_EQ(dif_csrng_alert_force(&csrng_, kDifCsrngAlertRecovAlert), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_alert_force(&csrng_, kDifCsrngAlertRecovAlert));
 
   // Force last alert.
   EXPECT_WRITE32(CSRNG_ALERT_TEST_REG_OFFSET,
                  {{CSRNG_ALERT_TEST_FATAL_ALERT_BIT, true}});
-  EXPECT_EQ(dif_csrng_alert_force(&csrng_, kDifCsrngAlertFatalAlert), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_alert_force(&csrng_, kDifCsrngAlertFatalAlert));
 }
 
 class IrqGetStateTest : public CsrngTest {};
@@ -64,11 +64,11 @@ class IrqGetStateTest : public CsrngTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_csrng_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_csrng_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_csrng_irq_get_state(&csrng_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_get_state(&csrng_, nullptr));
 
-  EXPECT_EQ(dif_csrng_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -76,7 +76,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_csrng_irq_get_state(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_get_state(&csrng_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -84,7 +84,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_csrng_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_csrng_irq_get_state(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_get_state(&csrng_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -93,25 +93,21 @@ class IrqIsPendingTest : public CsrngTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(
-      dif_csrng_irq_is_pending(nullptr, kDifCsrngIrqCsCmdReqDone, &is_pending),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_is_pending(nullptr, kDifCsrngIrqCsCmdReqDone, &is_pending));
 
-  EXPECT_EQ(
-      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsCmdReqDone, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsCmdReqDone, nullptr));
 
-  EXPECT_EQ(
-      dif_csrng_irq_is_pending(nullptr, kDifCsrngIrqCsCmdReqDone, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_is_pending(nullptr, kDifCsrngIrqCsCmdReqDone, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_csrng_irq_is_pending(&csrng_, static_cast<dif_csrng_irq_t>(32),
-                                     &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_is_pending(
+      &csrng_, static_cast<dif_csrng_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -121,81 +117,77 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET,
                 {{CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT, true}});
-  EXPECT_EQ(
-      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsCmdReqDone, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsCmdReqDone, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(CSRNG_INTR_STATE_REG_OFFSET,
                 {{CSRNG_INTR_STATE_CS_FATAL_ERR_BIT, false}});
-  EXPECT_EQ(
-      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsFatalErr, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_csrng_irq_is_pending(&csrng_, kDifCsrngIrqCsFatalErr, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public CsrngTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(CSRNG_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_csrng_irq_acknowledge_all(&csrng_), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_acknowledge_all(&csrng_));
 }
 
 class IrqAcknowledgeTest : public CsrngTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_irq_acknowledge(nullptr, kDifCsrngIrqCsCmdReqDone),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_acknowledge(nullptr, kDifCsrngIrqCsCmdReqDone));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(
-      dif_csrng_irq_acknowledge(nullptr, static_cast<dif_csrng_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_acknowledge(nullptr, static_cast<dif_csrng_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(CSRNG_INTR_STATE_REG_OFFSET,
                  {{CSRNG_INTR_STATE_CS_CMD_REQ_DONE_BIT, true}});
-  EXPECT_EQ(dif_csrng_irq_acknowledge(&csrng_, kDifCsrngIrqCsCmdReqDone),
-            kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_acknowledge(&csrng_, kDifCsrngIrqCsCmdReqDone));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(CSRNG_INTR_STATE_REG_OFFSET,
                  {{CSRNG_INTR_STATE_CS_FATAL_ERR_BIT, true}});
-  EXPECT_EQ(dif_csrng_irq_acknowledge(&csrng_, kDifCsrngIrqCsFatalErr), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_acknowledge(&csrng_, kDifCsrngIrqCsFatalErr));
 }
 
 class IrqForceTest : public CsrngTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_csrng_irq_force(nullptr, kDifCsrngIrqCsCmdReqDone), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_force(nullptr, kDifCsrngIrqCsCmdReqDone));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_csrng_irq_force(nullptr, static_cast<dif_csrng_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_force(nullptr, static_cast<dif_csrng_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(CSRNG_INTR_TEST_REG_OFFSET,
                  {{CSRNG_INTR_TEST_CS_CMD_REQ_DONE_BIT, true}});
-  EXPECT_EQ(dif_csrng_irq_force(&csrng_, kDifCsrngIrqCsCmdReqDone), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_force(&csrng_, kDifCsrngIrqCsCmdReqDone));
 
   // Force last IRQ.
   EXPECT_WRITE32(CSRNG_INTR_TEST_REG_OFFSET,
                  {{CSRNG_INTR_TEST_CS_FATAL_ERR_BIT, true}});
-  EXPECT_EQ(dif_csrng_irq_force(&csrng_, kDifCsrngIrqCsFatalErr), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_force(&csrng_, kDifCsrngIrqCsFatalErr));
 }
 
 class IrqGetEnabledTest : public CsrngTest {};
@@ -203,25 +195,21 @@ class IrqGetEnabledTest : public CsrngTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(
-      dif_csrng_irq_get_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, &irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_get_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, &irq_state));
 
-  EXPECT_EQ(
-      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, nullptr));
 
-  EXPECT_EQ(
-      dif_csrng_irq_get_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_get_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_csrng_irq_get_enabled(&csrng_, static_cast<dif_csrng_irq_t>(32),
-                                      &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_get_enabled(
+      &csrng_, static_cast<dif_csrng_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -231,18 +219,16 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET,
                 {{CSRNG_INTR_ENABLE_CS_CMD_REQ_DONE_BIT, true}});
-  EXPECT_EQ(
-      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET,
                 {{CSRNG_INTR_ENABLE_CS_FATAL_ERR_BIT, false}});
-  EXPECT_EQ(
-      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsFatalErr, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_csrng_irq_get_enabled(&csrng_, kDifCsrngIrqCsFatalErr, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -251,17 +237,15 @@ class IrqSetEnabledTest : public CsrngTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(
-      dif_csrng_irq_set_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_csrng_irq_set_enabled(nullptr, kDifCsrngIrqCsCmdReqDone, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_csrng_irq_set_enabled(&csrng_, static_cast<dif_csrng_irq_t>(32),
-                                      irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_set_enabled(
+      &csrng_, static_cast<dif_csrng_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -271,17 +255,15 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(CSRNG_INTR_ENABLE_REG_OFFSET,
                 {{CSRNG_INTR_ENABLE_CS_CMD_REQ_DONE_BIT, 0x1, true}});
-  EXPECT_EQ(
-      dif_csrng_irq_set_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_csrng_irq_set_enabled(&csrng_, kDifCsrngIrqCsCmdReqDone, irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(CSRNG_INTR_ENABLE_REG_OFFSET,
                 {{CSRNG_INTR_ENABLE_CS_FATAL_ERR_BIT, 0x1, false}});
-  EXPECT_EQ(
-      dif_csrng_irq_set_enabled(&csrng_, kDifCsrngIrqCsFatalErr, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_csrng_irq_set_enabled(&csrng_, kDifCsrngIrqCsFatalErr, irq_state));
 }
 
 class IrqDisableAllTest : public CsrngTest {};
@@ -289,14 +271,14 @@ class IrqDisableAllTest : public CsrngTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_csrng_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_csrng_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_csrng_irq_disable_all(&csrng_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_disable_all(&csrng_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -304,7 +286,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_csrng_irq_disable_all(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_disable_all(&csrng_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -314,7 +296,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(CSRNG_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_csrng_irq_disable_all(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_disable_all(&csrng_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -323,11 +305,11 @@ class IrqRestoreAllTest : public CsrngTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_csrng_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_csrng_irq_restore_all(&csrng_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_restore_all(&csrng_, nullptr));
 
-  EXPECT_EQ(dif_csrng_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_csrng_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -336,14 +318,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_csrng_irq_restore_all(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_restore_all(&csrng_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_csrng_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(CSRNG_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_csrng_irq_restore_all(&csrng_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_csrng_irq_restore_all(&csrng_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_gpio_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "gpio_regs.h"  // Generated.
 
@@ -28,29 +29,29 @@ class GpioTest : public Test, public MmioTest {
 class InitTest : public GpioTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_gpio_init(dev().region(), &gpio_), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_init(dev().region(), &gpio_));
 }
 
 class AlertForceTest : public GpioTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_alert_force(nullptr, kDifGpioAlertFatalFault), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_alert_force(nullptr, kDifGpioAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_gpio_alert_force(nullptr, static_cast<dif_gpio_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_alert_force(nullptr, static_cast<dif_gpio_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(GPIO_ALERT_TEST_REG_OFFSET,
                  {{GPIO_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_gpio_alert_force(&gpio_, kDifGpioAlertFatalFault), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_alert_force(&gpio_, kDifGpioAlertFatalFault));
 }
 
 class IrqGetStateTest : public GpioTest {};
@@ -58,11 +59,11 @@ class IrqGetStateTest : public GpioTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_gpio_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_gpio_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_gpio_irq_get_state(&gpio_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_state(&gpio_, nullptr));
 
-  EXPECT_EQ(dif_gpio_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -70,7 +71,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_gpio_irq_get_state(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_get_state(&gpio_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -78,7 +79,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_gpio_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_gpio_irq_get_state(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_get_state(&gpio_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -87,22 +88,20 @@ class IrqIsPendingTest : public GpioTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_gpio_irq_is_pending(nullptr, kDifGpioIrqGpio0, &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_is_pending(nullptr, kDifGpioIrqGpio0, &is_pending));
 
-  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio0, nullptr));
 
-  EXPECT_EQ(dif_gpio_irq_is_pending(nullptr, kDifGpioIrqGpio0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_is_pending(nullptr, kDifGpioIrqGpio0, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, static_cast<dif_gpio_irq_t>(32),
-                                    &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_is_pending(
+      &gpio_, static_cast<dif_gpio_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -111,71 +110,69 @@ TEST_F(IrqIsPendingTest, Success) {
   // Get the first IRQ state.
   irq_state = false;
   EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio0, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio0, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(GPIO_INTR_STATE_REG_OFFSET, {{31, false}});
-  EXPECT_EQ(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio31, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_is_pending(&gpio_, kDifGpioIrqGpio31, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public GpioTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(GPIO_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_gpio_irq_acknowledge_all(&gpio_), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_acknowledge_all(&gpio_));
 }
 
 class IrqAcknowledgeTest : public GpioTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_irq_acknowledge(nullptr, kDifGpioIrqGpio0), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_acknowledge(nullptr, kDifGpioIrqGpio0));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_gpio_irq_acknowledge(nullptr, static_cast<dif_gpio_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_acknowledge(nullptr, static_cast<dif_gpio_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(GPIO_INTR_STATE_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(dif_gpio_irq_acknowledge(&gpio_, kDifGpioIrqGpio0), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_acknowledge(&gpio_, kDifGpioIrqGpio0));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(GPIO_INTR_STATE_REG_OFFSET, {{31, true}});
-  EXPECT_EQ(dif_gpio_irq_acknowledge(&gpio_, kDifGpioIrqGpio31), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_acknowledge(&gpio_, kDifGpioIrqGpio31));
 }
 
 class IrqForceTest : public GpioTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_gpio_irq_force(nullptr, kDifGpioIrqGpio0), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_force(nullptr, kDifGpioIrqGpio0));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_gpio_irq_force(nullptr, static_cast<dif_gpio_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_force(nullptr, static_cast<dif_gpio_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(GPIO_INTR_TEST_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(dif_gpio_irq_force(&gpio_, kDifGpioIrqGpio0), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_force(&gpio_, kDifGpioIrqGpio0));
 
   // Force last IRQ.
   EXPECT_WRITE32(GPIO_INTR_TEST_REG_OFFSET, {{31, true}});
-  EXPECT_EQ(dif_gpio_irq_force(&gpio_, kDifGpioIrqGpio31), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_force(&gpio_, kDifGpioIrqGpio31));
 }
 
 class IrqGetEnabledTest : public GpioTest {};
@@ -183,22 +180,21 @@ class IrqGetEnabledTest : public GpioTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_gpio_irq_get_enabled(nullptr, kDifGpioIrqGpio0, &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_get_enabled(nullptr, kDifGpioIrqGpio0, &irq_state));
 
-  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio0, nullptr));
 
-  EXPECT_EQ(dif_gpio_irq_get_enabled(nullptr, kDifGpioIrqGpio0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_get_enabled(nullptr, kDifGpioIrqGpio0, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, static_cast<dif_gpio_irq_t>(32),
-                                     &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_get_enabled(
+      &gpio_, static_cast<dif_gpio_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -207,15 +203,14 @@ TEST_F(IrqGetEnabledTest, Success) {
   // First IRQ is enabled.
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio0, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio0, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, {{31, false}});
-  EXPECT_EQ(dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio31, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_gpio_irq_get_enabled(&gpio_, kDifGpioIrqGpio31, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -224,16 +219,15 @@ class IrqSetEnabledTest : public GpioTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_gpio_irq_set_enabled(nullptr, kDifGpioIrqGpio0, irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_gpio_irq_set_enabled(nullptr, kDifGpioIrqGpio0, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, static_cast<dif_gpio_irq_t>(32),
-                                     irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_set_enabled(
+      &gpio_, static_cast<dif_gpio_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -242,14 +236,12 @@ TEST_F(IrqSetEnabledTest, Success) {
   // Enable first IRQ.
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(GPIO_INTR_ENABLE_REG_OFFSET, {{0, 0x1, true}});
-  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, kDifGpioIrqGpio0, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_set_enabled(&gpio_, kDifGpioIrqGpio0, irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(GPIO_INTR_ENABLE_REG_OFFSET, {{31, 0x1, false}});
-  EXPECT_EQ(dif_gpio_irq_set_enabled(&gpio_, kDifGpioIrqGpio31, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_set_enabled(&gpio_, kDifGpioIrqGpio31, irq_state));
 }
 
 class IrqDisableAllTest : public GpioTest {};
@@ -257,14 +249,14 @@ class IrqDisableAllTest : public GpioTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_gpio_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_gpio_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_gpio_irq_disable_all(&gpio_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_disable_all(&gpio_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -272,7 +264,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_gpio_irq_disable_all(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_disable_all(&gpio_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -282,7 +274,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(GPIO_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_gpio_irq_disable_all(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_disable_all(&gpio_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -291,11 +283,11 @@ class IrqRestoreAllTest : public GpioTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_gpio_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_gpio_irq_restore_all(&gpio_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_restore_all(&gpio_, nullptr));
 
-  EXPECT_EQ(dif_gpio_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_gpio_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -304,14 +296,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_gpio_irq_restore_all(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_restore_all(&gpio_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_gpio_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(GPIO_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_gpio_irq_restore_all(&gpio_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_gpio_irq_restore_all(&gpio_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_kmac_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "kmac_regs.h"  // Generated.
 
@@ -28,36 +29,35 @@ class KmacTest : public Test, public MmioTest {
 class InitTest : public KmacTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_kmac_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_kmac_init(dev().region(), &kmac_), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_init(dev().region(), &kmac_));
 }
 
 class AlertForceTest : public KmacTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_kmac_alert_force(nullptr, kDifKmacAlertRecovOperationErr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_alert_force(nullptr, kDifKmacAlertRecovOperationErr));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_kmac_alert_force(nullptr, static_cast<dif_kmac_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_alert_force(nullptr, static_cast<dif_kmac_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(KMAC_ALERT_TEST_REG_OFFSET,
                  {{KMAC_ALERT_TEST_RECOV_OPERATION_ERR_BIT, true}});
-  EXPECT_EQ(dif_kmac_alert_force(&kmac_, kDifKmacAlertRecovOperationErr),
-            kDifOk);
+  EXPECT_DIF_OK(dif_kmac_alert_force(&kmac_, kDifKmacAlertRecovOperationErr));
 
   // Force last alert.
   EXPECT_WRITE32(KMAC_ALERT_TEST_REG_OFFSET,
                  {{KMAC_ALERT_TEST_FATAL_FAULT_ERR_BIT, true}});
-  EXPECT_EQ(dif_kmac_alert_force(&kmac_, kDifKmacAlertFatalFaultErr), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_alert_force(&kmac_, kDifKmacAlertFatalFaultErr));
 }
 
 class IrqGetStateTest : public KmacTest {};
@@ -65,11 +65,11 @@ class IrqGetStateTest : public KmacTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_kmac_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_kmac_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_kmac_irq_get_state(&kmac_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_get_state(&kmac_, nullptr));
 
-  EXPECT_EQ(dif_kmac_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -77,7 +77,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_kmac_irq_get_state(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_get_state(&kmac_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -85,7 +85,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_kmac_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_kmac_irq_get_state(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_get_state(&kmac_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -94,22 +94,21 @@ class IrqIsPendingTest : public KmacTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_kmac_irq_is_pending(nullptr, kDifKmacIrqKmacDone, &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_is_pending(nullptr, kDifKmacIrqKmacDone, &is_pending));
 
-  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacDone, nullptr));
 
-  EXPECT_EQ(dif_kmac_irq_is_pending(nullptr, kDifKmacIrqKmacDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_is_pending(nullptr, kDifKmacIrqKmacDone, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, static_cast<dif_kmac_irq_t>(32),
-                                    &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_is_pending(
+      &kmac_, static_cast<dif_kmac_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -119,76 +118,76 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET,
                 {{KMAC_INTR_STATE_KMAC_DONE_BIT, true}});
-  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacDone, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacDone, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(KMAC_INTR_STATE_REG_OFFSET,
                 {{KMAC_INTR_STATE_KMAC_ERR_BIT, false}});
-  EXPECT_EQ(dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacErr, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_kmac_irq_is_pending(&kmac_, kDifKmacIrqKmacErr, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public KmacTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_kmac_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(KMAC_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_kmac_irq_acknowledge_all(&kmac_), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_acknowledge_all(&kmac_));
 }
 
 class IrqAcknowledgeTest : public KmacTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_kmac_irq_acknowledge(nullptr, kDifKmacIrqKmacDone), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_acknowledge(nullptr, kDifKmacIrqKmacDone));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_kmac_irq_acknowledge(nullptr, static_cast<dif_kmac_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_acknowledge(nullptr, static_cast<dif_kmac_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(KMAC_INTR_STATE_REG_OFFSET,
                  {{KMAC_INTR_STATE_KMAC_DONE_BIT, true}});
-  EXPECT_EQ(dif_kmac_irq_acknowledge(&kmac_, kDifKmacIrqKmacDone), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_acknowledge(&kmac_, kDifKmacIrqKmacDone));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(KMAC_INTR_STATE_REG_OFFSET,
                  {{KMAC_INTR_STATE_KMAC_ERR_BIT, true}});
-  EXPECT_EQ(dif_kmac_irq_acknowledge(&kmac_, kDifKmacIrqKmacErr), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_acknowledge(&kmac_, kDifKmacIrqKmacErr));
 }
 
 class IrqForceTest : public KmacTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_kmac_irq_force(nullptr, kDifKmacIrqKmacDone), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_force(nullptr, kDifKmacIrqKmacDone));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_kmac_irq_force(nullptr, static_cast<dif_kmac_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_force(nullptr, static_cast<dif_kmac_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(KMAC_INTR_TEST_REG_OFFSET,
                  {{KMAC_INTR_TEST_KMAC_DONE_BIT, true}});
-  EXPECT_EQ(dif_kmac_irq_force(&kmac_, kDifKmacIrqKmacDone), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_force(&kmac_, kDifKmacIrqKmacDone));
 
   // Force last IRQ.
   EXPECT_WRITE32(KMAC_INTR_TEST_REG_OFFSET,
                  {{KMAC_INTR_TEST_KMAC_ERR_BIT, true}});
-  EXPECT_EQ(dif_kmac_irq_force(&kmac_, kDifKmacIrqKmacErr), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_force(&kmac_, kDifKmacIrqKmacErr));
 }
 
 class IrqGetEnabledTest : public KmacTest {};
@@ -196,22 +195,21 @@ class IrqGetEnabledTest : public KmacTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_kmac_irq_get_enabled(nullptr, kDifKmacIrqKmacDone, &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_get_enabled(nullptr, kDifKmacIrqKmacDone, &irq_state));
 
-  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacDone, nullptr));
 
-  EXPECT_EQ(dif_kmac_irq_get_enabled(nullptr, kDifKmacIrqKmacDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_get_enabled(nullptr, kDifKmacIrqKmacDone, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, static_cast<dif_kmac_irq_t>(32),
-                                     &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_get_enabled(
+      &kmac_, static_cast<dif_kmac_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -221,16 +219,16 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET,
                 {{KMAC_INTR_ENABLE_KMAC_DONE_BIT, true}});
-  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacDone, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacDone, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET,
                 {{KMAC_INTR_ENABLE_KMAC_ERR_BIT, false}});
-  EXPECT_EQ(dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacErr, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_kmac_irq_get_enabled(&kmac_, kDifKmacIrqKmacErr, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -239,16 +237,15 @@ class IrqSetEnabledTest : public KmacTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_kmac_irq_set_enabled(nullptr, kDifKmacIrqKmacDone, irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_kmac_irq_set_enabled(nullptr, kDifKmacIrqKmacDone, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_kmac_irq_set_enabled(&kmac_, static_cast<dif_kmac_irq_t>(32),
-                                     irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_set_enabled(
+      &kmac_, static_cast<dif_kmac_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -258,15 +255,15 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(KMAC_INTR_ENABLE_REG_OFFSET,
                 {{KMAC_INTR_ENABLE_KMAC_DONE_BIT, 0x1, true}});
-  EXPECT_EQ(dif_kmac_irq_set_enabled(&kmac_, kDifKmacIrqKmacDone, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_kmac_irq_set_enabled(&kmac_, kDifKmacIrqKmacDone, irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(KMAC_INTR_ENABLE_REG_OFFSET,
                 {{KMAC_INTR_ENABLE_KMAC_ERR_BIT, 0x1, false}});
-  EXPECT_EQ(dif_kmac_irq_set_enabled(&kmac_, kDifKmacIrqKmacErr, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_kmac_irq_set_enabled(&kmac_, kDifKmacIrqKmacErr, irq_state));
 }
 
 class IrqDisableAllTest : public KmacTest {};
@@ -274,14 +271,14 @@ class IrqDisableAllTest : public KmacTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_kmac_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_kmac_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_kmac_irq_disable_all(&kmac_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_disable_all(&kmac_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -289,7 +286,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_kmac_irq_disable_all(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_disable_all(&kmac_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -299,7 +296,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(KMAC_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_kmac_irq_disable_all(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_disable_all(&kmac_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -308,11 +305,11 @@ class IrqRestoreAllTest : public KmacTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_kmac_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_kmac_irq_restore_all(&kmac_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_restore_all(&kmac_, nullptr));
 
-  EXPECT_EQ(dif_kmac_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_kmac_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -321,14 +318,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_kmac_irq_restore_all(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_restore_all(&kmac_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_kmac_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(KMAC_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_kmac_irq_restore_all(&kmac_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_kmac_irq_restore_all(&kmac_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_lc_ctrl_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "lc_ctrl_regs.h"  // Generated.
 
@@ -28,39 +29,37 @@ class LcCtrlTest : public Test, public MmioTest {
 class InitTest : public LcCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_lc_ctrl_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_lc_ctrl_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_lc_ctrl_init(dev().region(), &lc_ctrl_), kDifOk);
+  EXPECT_DIF_OK(dif_lc_ctrl_init(dev().region(), &lc_ctrl_));
 }
 
 class AlertForceTest : public LcCtrlTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_lc_ctrl_alert_force(nullptr, kDifLcCtrlAlertFatalProgError),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_lc_ctrl_alert_force(nullptr, kDifLcCtrlAlertFatalProgError));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_lc_ctrl_alert_force(nullptr, static_cast<dif_lc_ctrl_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_lc_ctrl_alert_force(nullptr, static_cast<dif_lc_ctrl_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(LC_CTRL_ALERT_TEST_REG_OFFSET,
                  {{LC_CTRL_ALERT_TEST_FATAL_PROG_ERROR_BIT, true}});
-  EXPECT_EQ(dif_lc_ctrl_alert_force(&lc_ctrl_, kDifLcCtrlAlertFatalProgError),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_lc_ctrl_alert_force(&lc_ctrl_, kDifLcCtrlAlertFatalProgError));
 
   // Force last alert.
   EXPECT_WRITE32(LC_CTRL_ALERT_TEST_REG_OFFSET,
                  {{LC_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT, true}});
-  EXPECT_EQ(
-      dif_lc_ctrl_alert_force(&lc_ctrl_, kDifLcCtrlAlertFatalBusIntegError),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_lc_ctrl_alert_force(&lc_ctrl_, kDifLcCtrlAlertFatalBusIntegError));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otbn_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "otbn_regs.h"  // Generated.
 
@@ -28,34 +29,34 @@ class OtbnTest : public Test, public MmioTest {
 class InitTest : public OtbnTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_otbn_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_otbn_init(dev().region(), &otbn_), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_init(dev().region(), &otbn_));
 }
 
 class AlertForceTest : public OtbnTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_otbn_alert_force(nullptr, kDifOtbnAlertFatal), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_alert_force(nullptr, kDifOtbnAlertFatal));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_otbn_alert_force(nullptr, static_cast<dif_otbn_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otbn_alert_force(nullptr, static_cast<dif_otbn_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(OTBN_ALERT_TEST_REG_OFFSET,
                  {{OTBN_ALERT_TEST_FATAL_BIT, true}});
-  EXPECT_EQ(dif_otbn_alert_force(&otbn_, kDifOtbnAlertFatal), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_alert_force(&otbn_, kDifOtbnAlertFatal));
 
   // Force last alert.
   EXPECT_WRITE32(OTBN_ALERT_TEST_REG_OFFSET,
                  {{OTBN_ALERT_TEST_RECOV_BIT, true}});
-  EXPECT_EQ(dif_otbn_alert_force(&otbn_, kDifOtbnAlertRecov), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_alert_force(&otbn_, kDifOtbnAlertRecov));
 }
 
 class IrqGetStateTest : public OtbnTest {};
@@ -63,11 +64,11 @@ class IrqGetStateTest : public OtbnTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_otbn_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_otbn_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_otbn_irq_get_state(&otbn_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_state(&otbn_, nullptr));
 
-  EXPECT_EQ(dif_otbn_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -75,7 +76,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_otbn_irq_get_state(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_get_state(&otbn_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -83,7 +84,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_otbn_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otbn_irq_get_state(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_get_state(&otbn_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -92,22 +93,19 @@ class IrqIsPendingTest : public OtbnTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_otbn_irq_is_pending(nullptr, kDifOtbnIrqDone, &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otbn_irq_is_pending(nullptr, kDifOtbnIrqDone, &is_pending));
 
-  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, nullptr));
 
-  EXPECT_EQ(dif_otbn_irq_is_pending(nullptr, kDifOtbnIrqDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_is_pending(nullptr, kDifOtbnIrqDone, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, static_cast<dif_otbn_irq_t>(32),
-                                    &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_is_pending(
+      &otbn_, static_cast<dif_otbn_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -116,57 +114,56 @@ TEST_F(IrqIsPendingTest, Success) {
   // Get the first IRQ state.
   irq_state = false;
   EXPECT_READ32(OTBN_INTR_STATE_REG_OFFSET, {{OTBN_INTR_STATE_DONE_BIT, true}});
-  EXPECT_EQ(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_is_pending(&otbn_, kDifOtbnIrqDone, &irq_state));
   EXPECT_TRUE(irq_state);
 }
 
 class AcknowledgeAllTest : public OtbnTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_otbn_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_otbn_irq_acknowledge_all(&otbn_), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_acknowledge_all(&otbn_));
 }
 
 class IrqAcknowledgeTest : public OtbnTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_otbn_irq_acknowledge(nullptr, kDifOtbnIrqDone), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_acknowledge(nullptr, kDifOtbnIrqDone));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_otbn_irq_acknowledge(nullptr, static_cast<dif_otbn_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otbn_irq_acknowledge(nullptr, static_cast<dif_otbn_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(OTBN_INTR_STATE_REG_OFFSET,
                  {{OTBN_INTR_STATE_DONE_BIT, true}});
-  EXPECT_EQ(dif_otbn_irq_acknowledge(&otbn_, kDifOtbnIrqDone), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_acknowledge(&otbn_, kDifOtbnIrqDone));
 }
 
 class IrqForceTest : public OtbnTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_otbn_irq_force(nullptr, kDifOtbnIrqDone), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_force(nullptr, kDifOtbnIrqDone));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_otbn_irq_force(nullptr, static_cast<dif_otbn_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otbn_irq_force(nullptr, static_cast<dif_otbn_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(OTBN_INTR_TEST_REG_OFFSET, {{OTBN_INTR_TEST_DONE_BIT, true}});
-  EXPECT_EQ(dif_otbn_irq_force(&otbn_, kDifOtbnIrqDone), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_force(&otbn_, kDifOtbnIrqDone));
 }
 
 class IrqGetEnabledTest : public OtbnTest {};
@@ -174,22 +171,20 @@ class IrqGetEnabledTest : public OtbnTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_otbn_irq_get_enabled(nullptr, kDifOtbnIrqDone, &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otbn_irq_get_enabled(nullptr, kDifOtbnIrqDone, &irq_state));
 
-  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, nullptr));
 
-  EXPECT_EQ(dif_otbn_irq_get_enabled(nullptr, kDifOtbnIrqDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otbn_irq_get_enabled(nullptr, kDifOtbnIrqDone, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, static_cast<dif_otbn_irq_t>(32),
-                                     &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_get_enabled(
+      &otbn_, static_cast<dif_otbn_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -199,8 +194,7 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET,
                 {{OTBN_INTR_ENABLE_DONE_BIT, true}});
-  EXPECT_EQ(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_get_enabled(&otbn_, kDifOtbnIrqDone, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 }
 
@@ -209,16 +203,15 @@ class IrqSetEnabledTest : public OtbnTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_otbn_irq_set_enabled(nullptr, kDifOtbnIrqDone, irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otbn_irq_set_enabled(nullptr, kDifOtbnIrqDone, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, static_cast<dif_otbn_irq_t>(32),
-                                     irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_set_enabled(
+      &otbn_, static_cast<dif_otbn_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -228,8 +221,7 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(OTBN_INTR_ENABLE_REG_OFFSET,
                 {{OTBN_INTR_ENABLE_DONE_BIT, 0x1, true}});
-  EXPECT_EQ(dif_otbn_irq_set_enabled(&otbn_, kDifOtbnIrqDone, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_set_enabled(&otbn_, kDifOtbnIrqDone, irq_state));
 }
 
 class IrqDisableAllTest : public OtbnTest {};
@@ -237,14 +229,14 @@ class IrqDisableAllTest : public OtbnTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_otbn_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_otbn_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otbn_irq_disable_all(&otbn_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_disable_all(&otbn_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -252,7 +244,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otbn_irq_disable_all(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_disable_all(&otbn_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -262,7 +254,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(OTBN_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otbn_irq_disable_all(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_disable_all(&otbn_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -271,11 +263,11 @@ class IrqRestoreAllTest : public OtbnTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_otbn_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_otbn_irq_restore_all(&otbn_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_restore_all(&otbn_, nullptr));
 
-  EXPECT_EQ(dif_otbn_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otbn_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -284,14 +276,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_otbn_irq_restore_all(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_restore_all(&otbn_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_otbn_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(OTBN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otbn_irq_restore_all(&otbn_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otbn_irq_restore_all(&otbn_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_otp_ctrl_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "otp_ctrl_regs.h"  // Generated.
 
@@ -28,40 +29,37 @@ class OtpCtrlTest : public Test, public MmioTest {
 class InitTest : public OtpCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_otp_ctrl_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_otp_ctrl_init(dev().region(), &otp_ctrl_), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_init(dev().region(), &otp_ctrl_));
 }
 
 class AlertForceTest : public OtpCtrlTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_otp_ctrl_alert_force(nullptr, kDifOtpCtrlAlertFatalMacroError),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_alert_force(nullptr, kDifOtpCtrlAlertFatalMacroError));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_otp_ctrl_alert_force(nullptr, static_cast<dif_otp_ctrl_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_alert_force(nullptr, static_cast<dif_otp_ctrl_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(OTP_CTRL_ALERT_TEST_REG_OFFSET,
                  {{OTP_CTRL_ALERT_TEST_FATAL_MACRO_ERROR_BIT, true}});
-  EXPECT_EQ(
-      dif_otp_ctrl_alert_force(&otp_ctrl_, kDifOtpCtrlAlertFatalMacroError),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_otp_ctrl_alert_force(&otp_ctrl_, kDifOtpCtrlAlertFatalMacroError));
 
   // Force last alert.
   EXPECT_WRITE32(OTP_CTRL_ALERT_TEST_REG_OFFSET,
                  {{OTP_CTRL_ALERT_TEST_FATAL_BUS_INTEG_ERROR_BIT, true}});
-  EXPECT_EQ(
-      dif_otp_ctrl_alert_force(&otp_ctrl_, kDifOtpCtrlAlertFatalBusIntegError),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_otp_ctrl_alert_force(&otp_ctrl_, kDifOtpCtrlAlertFatalBusIntegError));
 }
 
 class IrqGetStateTest : public OtpCtrlTest {};
@@ -69,11 +67,11 @@ class IrqGetStateTest : public OtpCtrlTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_otp_ctrl_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_get_state(&otp_ctrl_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_state(&otp_ctrl_, nullptr));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -81,7 +79,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_otp_ctrl_irq_get_state(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_get_state(&otp_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -89,7 +87,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_otp_ctrl_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otp_ctrl_irq_get_state(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_get_state(&otp_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -98,25 +96,21 @@ class IrqIsPendingTest : public OtpCtrlTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(nullptr, kDifOtpCtrlIrqOtpOperationDone,
-                                        &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_is_pending(
+      nullptr, kDifOtpCtrlIrqOtpOperationDone, &is_pending));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(
-                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_is_pending(
+      &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, nullptr));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(nullptr, kDifOtpCtrlIrqOtpOperationDone,
-                                        nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_is_pending(
+      nullptr, kDifOtpCtrlIrqOtpOperationDone, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(
-                &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_is_pending(
+      &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -126,87 +120,81 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                 {{OTP_CTRL_INTR_STATE_OTP_OPERATION_DONE_BIT, true}});
-  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(
-                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_is_pending(
+      &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                 {{OTP_CTRL_INTR_STATE_OTP_ERROR_BIT, false}});
-  EXPECT_EQ(dif_otp_ctrl_irq_is_pending(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
-                                        &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_is_pending(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
+                                            &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public OtpCtrlTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_otp_ctrl_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_otp_ctrl_irq_acknowledge_all(&otp_ctrl_), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_acknowledge_all(&otp_ctrl_));
 }
 
 class IrqAcknowledgeTest : public OtpCtrlTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(
-      dif_otp_ctrl_irq_acknowledge(nullptr, kDifOtpCtrlIrqOtpOperationDone),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_irq_acknowledge(nullptr, kDifOtpCtrlIrqOtpOperationDone));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_otp_ctrl_irq_acknowledge(nullptr,
-                                         static_cast<dif_otp_ctrl_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_acknowledge(
+      nullptr, static_cast<dif_otp_ctrl_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                  {{OTP_CTRL_INTR_STATE_OTP_OPERATION_DONE_BIT, true}});
-  EXPECT_EQ(
-      dif_otp_ctrl_irq_acknowledge(&otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_otp_ctrl_irq_acknowledge(&otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(OTP_CTRL_INTR_STATE_REG_OFFSET,
                  {{OTP_CTRL_INTR_STATE_OTP_ERROR_BIT, true}});
-  EXPECT_EQ(dif_otp_ctrl_irq_acknowledge(&otp_ctrl_, kDifOtpCtrlIrqOtpError),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_otp_ctrl_irq_acknowledge(&otp_ctrl_, kDifOtpCtrlIrqOtpError));
 }
 
 class IrqForceTest : public OtpCtrlTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_otp_ctrl_irq_force(nullptr, kDifOtpCtrlIrqOtpOperationDone),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_irq_force(nullptr, kDifOtpCtrlIrqOtpOperationDone));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(
-      dif_otp_ctrl_irq_force(nullptr, static_cast<dif_otp_ctrl_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_otp_ctrl_irq_force(nullptr, static_cast<dif_otp_ctrl_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(OTP_CTRL_INTR_TEST_REG_OFFSET,
                  {{OTP_CTRL_INTR_TEST_OTP_OPERATION_DONE_BIT, true}});
-  EXPECT_EQ(dif_otp_ctrl_irq_force(&otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_otp_ctrl_irq_force(&otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone));
 
   // Force last IRQ.
   EXPECT_WRITE32(OTP_CTRL_INTR_TEST_REG_OFFSET,
                  {{OTP_CTRL_INTR_TEST_OTP_ERROR_BIT, true}});
-  EXPECT_EQ(dif_otp_ctrl_irq_force(&otp_ctrl_, kDifOtpCtrlIrqOtpError), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_force(&otp_ctrl_, kDifOtpCtrlIrqOtpError));
 }
 
 class IrqGetEnabledTest : public OtpCtrlTest {};
@@ -214,25 +202,21 @@ class IrqGetEnabledTest : public OtpCtrlTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
-                nullptr, kDifOtpCtrlIrqOtpOperationDone, &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_enabled(
+      nullptr, kDifOtpCtrlIrqOtpOperationDone, &irq_state));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
-                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_enabled(
+      &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, nullptr));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
-                nullptr, kDifOtpCtrlIrqOtpOperationDone, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_enabled(
+      nullptr, kDifOtpCtrlIrqOtpOperationDone, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
-                &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_get_enabled(
+      &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -242,18 +226,16 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                 {{OTP_CTRL_INTR_ENABLE_OTP_OPERATION_DONE_BIT, true}});
-  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(
-                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_get_enabled(
+      &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                 {{OTP_CTRL_INTR_ENABLE_OTP_ERROR_BIT, false}});
-  EXPECT_EQ(dif_otp_ctrl_irq_get_enabled(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
-                                         &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_get_enabled(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
+                                             &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -262,17 +244,15 @@ class IrqSetEnabledTest : public OtpCtrlTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(
-                nullptr, kDifOtpCtrlIrqOtpOperationDone, irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_set_enabled(
+      nullptr, kDifOtpCtrlIrqOtpOperationDone, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(
-                &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_set_enabled(
+      &otp_ctrl_, static_cast<dif_otp_ctrl_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -282,17 +262,15 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                 {{OTP_CTRL_INTR_ENABLE_OTP_OPERATION_DONE_BIT, 0x1, true}});
-  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(
-                &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_set_enabled(
+      &otp_ctrl_, kDifOtpCtrlIrqOtpOperationDone, irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                 {{OTP_CTRL_INTR_ENABLE_OTP_ERROR_BIT, 0x1, false}});
-  EXPECT_EQ(dif_otp_ctrl_irq_set_enabled(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
-                                         irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_set_enabled(&otp_ctrl_, kDifOtpCtrlIrqOtpError,
+                                             irq_state));
 }
 
 class IrqDisableAllTest : public OtpCtrlTest {};
@@ -300,14 +278,14 @@ class IrqDisableAllTest : public OtpCtrlTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -315,7 +293,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -325,7 +303,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_disable_all(&otp_ctrl_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -334,11 +312,11 @@ class IrqRestoreAllTest : public OtpCtrlTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, nullptr));
 
-  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_otp_ctrl_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -347,14 +325,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_otp_ctrl_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(OTP_CTRL_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_otp_ctrl_irq_restore_all(&otp_ctrl_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pattgen_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "pattgen_regs.h"  // Generated.
 
@@ -28,32 +29,30 @@ class PattgenTest : public Test, public MmioTest {
 class InitTest : public PattgenTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_pattgen_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_pattgen_init(dev().region(), &pattgen_), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_init(dev().region(), &pattgen_));
 }
 
 class AlertForceTest : public PattgenTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_pattgen_alert_force(nullptr, kDifPattgenAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_alert_force(nullptr, kDifPattgenAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_pattgen_alert_force(nullptr, static_cast<dif_pattgen_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_alert_force(nullptr, static_cast<dif_pattgen_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(PATTGEN_ALERT_TEST_REG_OFFSET,
                  {{PATTGEN_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_pattgen_alert_force(&pattgen_, kDifPattgenAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_alert_force(&pattgen_, kDifPattgenAlertFatalFault));
 }
 
 class IrqGetStateTest : public PattgenTest {};
@@ -61,11 +60,11 @@ class IrqGetStateTest : public PattgenTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_pattgen_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_pattgen_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_pattgen_irq_get_state(&pattgen_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_get_state(&pattgen_, nullptr));
 
-  EXPECT_EQ(dif_pattgen_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -73,7 +72,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(PATTGEN_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_pattgen_irq_get_state(&pattgen_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_get_state(&pattgen_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -81,7 +80,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_pattgen_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(PATTGEN_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pattgen_irq_get_state(&pattgen_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_get_state(&pattgen_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -90,24 +89,21 @@ class IrqIsPendingTest : public PattgenTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(
-      dif_pattgen_irq_is_pending(nullptr, kDifPattgenIrqDoneCh0, &is_pending),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_is_pending(nullptr, kDifPattgenIrqDoneCh0, &is_pending));
 
-  EXPECT_EQ(
-      dif_pattgen_irq_is_pending(&pattgen_, kDifPattgenIrqDoneCh0, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_is_pending(&pattgen_, kDifPattgenIrqDoneCh0, nullptr));
 
-  EXPECT_EQ(dif_pattgen_irq_is_pending(nullptr, kDifPattgenIrqDoneCh0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_is_pending(nullptr, kDifPattgenIrqDoneCh0, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_pattgen_irq_is_pending(
-                &pattgen_, static_cast<dif_pattgen_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_is_pending(
+      &pattgen_, static_cast<dif_pattgen_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -117,82 +113,77 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(PATTGEN_INTR_STATE_REG_OFFSET,
                 {{PATTGEN_INTR_STATE_DONE_CH0_BIT, true}});
-  EXPECT_EQ(
-      dif_pattgen_irq_is_pending(&pattgen_, kDifPattgenIrqDoneCh0, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_pattgen_irq_is_pending(&pattgen_, kDifPattgenIrqDoneCh0, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(PATTGEN_INTR_STATE_REG_OFFSET,
                 {{PATTGEN_INTR_STATE_DONE_CH1_BIT, false}});
-  EXPECT_EQ(
-      dif_pattgen_irq_is_pending(&pattgen_, kDifPattgenIrqDoneCh1, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_pattgen_irq_is_pending(&pattgen_, kDifPattgenIrqDoneCh1, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public PattgenTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_pattgen_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(PATTGEN_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_pattgen_irq_acknowledge_all(&pattgen_), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_acknowledge_all(&pattgen_));
 }
 
 class IrqAcknowledgeTest : public PattgenTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_pattgen_irq_acknowledge(nullptr, kDifPattgenIrqDoneCh0),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_acknowledge(nullptr, kDifPattgenIrqDoneCh0));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(
-      dif_pattgen_irq_acknowledge(nullptr, static_cast<dif_pattgen_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_acknowledge(nullptr, static_cast<dif_pattgen_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(PATTGEN_INTR_STATE_REG_OFFSET,
                  {{PATTGEN_INTR_STATE_DONE_CH0_BIT, true}});
-  EXPECT_EQ(dif_pattgen_irq_acknowledge(&pattgen_, kDifPattgenIrqDoneCh0),
-            kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_acknowledge(&pattgen_, kDifPattgenIrqDoneCh0));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(PATTGEN_INTR_STATE_REG_OFFSET,
                  {{PATTGEN_INTR_STATE_DONE_CH1_BIT, true}});
-  EXPECT_EQ(dif_pattgen_irq_acknowledge(&pattgen_, kDifPattgenIrqDoneCh1),
-            kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_acknowledge(&pattgen_, kDifPattgenIrqDoneCh1));
 }
 
 class IrqForceTest : public PattgenTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_pattgen_irq_force(nullptr, kDifPattgenIrqDoneCh0), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_force(nullptr, kDifPattgenIrqDoneCh0));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_pattgen_irq_force(nullptr, static_cast<dif_pattgen_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_force(nullptr, static_cast<dif_pattgen_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(PATTGEN_INTR_TEST_REG_OFFSET,
                  {{PATTGEN_INTR_TEST_DONE_CH0_BIT, true}});
-  EXPECT_EQ(dif_pattgen_irq_force(&pattgen_, kDifPattgenIrqDoneCh0), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_force(&pattgen_, kDifPattgenIrqDoneCh0));
 
   // Force last IRQ.
   EXPECT_WRITE32(PATTGEN_INTR_TEST_REG_OFFSET,
                  {{PATTGEN_INTR_TEST_DONE_CH1_BIT, true}});
-  EXPECT_EQ(dif_pattgen_irq_force(&pattgen_, kDifPattgenIrqDoneCh1), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_force(&pattgen_, kDifPattgenIrqDoneCh1));
 }
 
 class IrqGetEnabledTest : public PattgenTest {};
@@ -200,25 +191,21 @@ class IrqGetEnabledTest : public PattgenTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(
-      dif_pattgen_irq_get_enabled(nullptr, kDifPattgenIrqDoneCh0, &irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_get_enabled(nullptr, kDifPattgenIrqDoneCh0, &irq_state));
 
-  EXPECT_EQ(
-      dif_pattgen_irq_get_enabled(&pattgen_, kDifPattgenIrqDoneCh0, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_get_enabled(&pattgen_, kDifPattgenIrqDoneCh0, nullptr));
 
-  EXPECT_EQ(
-      dif_pattgen_irq_get_enabled(nullptr, kDifPattgenIrqDoneCh0, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_get_enabled(nullptr, kDifPattgenIrqDoneCh0, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_pattgen_irq_get_enabled(
-                &pattgen_, static_cast<dif_pattgen_irq_t>(32), &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_get_enabled(
+      &pattgen_, static_cast<dif_pattgen_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -228,18 +215,16 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(PATTGEN_INTR_ENABLE_REG_OFFSET,
                 {{PATTGEN_INTR_ENABLE_DONE_CH0_BIT, true}});
-  EXPECT_EQ(
-      dif_pattgen_irq_get_enabled(&pattgen_, kDifPattgenIrqDoneCh0, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_get_enabled(&pattgen_, kDifPattgenIrqDoneCh0,
+                                            &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(PATTGEN_INTR_ENABLE_REG_OFFSET,
                 {{PATTGEN_INTR_ENABLE_DONE_CH1_BIT, false}});
-  EXPECT_EQ(
-      dif_pattgen_irq_get_enabled(&pattgen_, kDifPattgenIrqDoneCh1, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_get_enabled(&pattgen_, kDifPattgenIrqDoneCh1,
+                                            &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -248,17 +233,15 @@ class IrqSetEnabledTest : public PattgenTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(
-      dif_pattgen_irq_set_enabled(nullptr, kDifPattgenIrqDoneCh0, irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pattgen_irq_set_enabled(nullptr, kDifPattgenIrqDoneCh0, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_pattgen_irq_set_enabled(
-                &pattgen_, static_cast<dif_pattgen_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_set_enabled(
+      &pattgen_, static_cast<dif_pattgen_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -268,17 +251,15 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(PATTGEN_INTR_ENABLE_REG_OFFSET,
                 {{PATTGEN_INTR_ENABLE_DONE_CH0_BIT, 0x1, true}});
-  EXPECT_EQ(
-      dif_pattgen_irq_set_enabled(&pattgen_, kDifPattgenIrqDoneCh0, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_pattgen_irq_set_enabled(&pattgen_, kDifPattgenIrqDoneCh0, irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(PATTGEN_INTR_ENABLE_REG_OFFSET,
                 {{PATTGEN_INTR_ENABLE_DONE_CH1_BIT, 0x1, false}});
-  EXPECT_EQ(
-      dif_pattgen_irq_set_enabled(&pattgen_, kDifPattgenIrqDoneCh1, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_pattgen_irq_set_enabled(&pattgen_, kDifPattgenIrqDoneCh1, irq_state));
 }
 
 class IrqDisableAllTest : public PattgenTest {};
@@ -286,14 +267,14 @@ class IrqDisableAllTest : public PattgenTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_pattgen_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_pattgen_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_pattgen_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(PATTGEN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pattgen_irq_disable_all(&pattgen_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_disable_all(&pattgen_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -301,7 +282,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(PATTGEN_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(PATTGEN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pattgen_irq_disable_all(&pattgen_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_disable_all(&pattgen_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -311,7 +292,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(PATTGEN_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(PATTGEN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pattgen_irq_disable_all(&pattgen_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_disable_all(&pattgen_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -320,11 +301,11 @@ class IrqRestoreAllTest : public PattgenTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_pattgen_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_pattgen_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_pattgen_irq_restore_all(&pattgen_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_restore_all(&pattgen_, nullptr));
 
-  EXPECT_EQ(dif_pattgen_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pattgen_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -333,14 +314,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(PATTGEN_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_pattgen_irq_restore_all(&pattgen_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_restore_all(&pattgen_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_pattgen_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(PATTGEN_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pattgen_irq_restore_all(&pattgen_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pattgen_irq_restore_all(&pattgen_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pinmux_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "pinmux_regs.h"  // Generated.
 
@@ -28,32 +29,29 @@ class PinmuxTest : public Test, public MmioTest {
 class InitTest : public PinmuxTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_pinmux_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pinmux_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_pinmux_init(dev().region(), &pinmux_), kDifOk);
+  EXPECT_DIF_OK(dif_pinmux_init(dev().region(), &pinmux_));
 }
 
 class AlertForceTest : public PinmuxTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_pinmux_alert_force(nullptr, kDifPinmuxAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pinmux_alert_force(nullptr, kDifPinmuxAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_pinmux_alert_force(nullptr, static_cast<dif_pinmux_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pinmux_alert_force(nullptr, static_cast<dif_pinmux_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(PINMUX_ALERT_TEST_REG_OFFSET,
                  {{PINMUX_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_pinmux_alert_force(&pinmux_, kDifPinmuxAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_pinmux_alert_force(&pinmux_, kDifPinmuxAlertFatalFault));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_pwm_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwm_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "pwm_regs.h"  // Generated.
 
@@ -28,29 +29,29 @@ class PwmTest : public Test, public MmioTest {
 class InitTest : public PwmTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_pwm_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwm_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_pwm_init(dev().region(), &pwm_), kDifOk);
+  EXPECT_DIF_OK(dif_pwm_init(dev().region(), &pwm_));
 }
 
 class AlertForceTest : public PwmTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_pwm_alert_force(nullptr, kDifPwmAlertFatalFault), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwm_alert_force(nullptr, kDifPwmAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_pwm_alert_force(nullptr, static_cast<dif_pwm_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwm_alert_force(nullptr, static_cast<dif_pwm_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(PWM_ALERT_TEST_REG_OFFSET,
                  {{PWM_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_pwm_alert_force(&pwm_, kDifPwmAlertFatalFault), kDifOk);
+  EXPECT_DIF_OK(dif_pwm_alert_force(&pwm_, kDifPwmAlertFatalFault));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_pwrmgr_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "pwrmgr_regs.h"  // Generated.
 
@@ -28,32 +29,29 @@ class PwrmgrTest : public Test, public MmioTest {
 class InitTest : public PwrmgrTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_pwrmgr_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_pwrmgr_init(dev().region(), &pwrmgr_), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_init(dev().region(), &pwrmgr_));
 }
 
 class AlertForceTest : public PwrmgrTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_pwrmgr_alert_force(nullptr, kDifPwrmgrAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_alert_force(nullptr, kDifPwrmgrAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_pwrmgr_alert_force(nullptr, static_cast<dif_pwrmgr_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_alert_force(nullptr, static_cast<dif_pwrmgr_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(PWRMGR_ALERT_TEST_REG_OFFSET,
                  {{PWRMGR_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_pwrmgr_alert_force(&pwrmgr_, kDifPwrmgrAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_alert_force(&pwrmgr_, kDifPwrmgrAlertFatalFault));
 }
 
 class IrqGetStateTest : public PwrmgrTest {};
@@ -61,11 +59,11 @@ class IrqGetStateTest : public PwrmgrTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_pwrmgr_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_pwrmgr_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_pwrmgr_irq_get_state(&pwrmgr_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_get_state(&pwrmgr_, nullptr));
 
-  EXPECT_EQ(dif_pwrmgr_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -73,7 +71,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_pwrmgr_irq_get_state(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_get_state(&pwrmgr_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -81,7 +79,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_pwrmgr_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pwrmgr_irq_get_state(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_get_state(&pwrmgr_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -90,23 +88,21 @@ class IrqIsPendingTest : public PwrmgrTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(
-      dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, &is_pending),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, &is_pending));
 
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr));
 
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_is_pending(nullptr, kDifPwrmgrIrqWakeup, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_pwrmgr_irq_is_pending(
-                &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_is_pending(
+      &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -116,61 +112,58 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(PWRMGR_INTR_STATE_REG_OFFSET,
                 {{PWRMGR_INTR_STATE_WAKEUP_BIT, true}});
-  EXPECT_EQ(
-      dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_pwrmgr_irq_is_pending(&pwrmgr_, kDifPwrmgrIrqWakeup, &irq_state));
   EXPECT_TRUE(irq_state);
 }
 
 class AcknowledgeAllTest : public PwrmgrTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_pwrmgr_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(PWRMGR_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_pwrmgr_irq_acknowledge_all(&pwrmgr_), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_acknowledge_all(&pwrmgr_));
 }
 
 class IrqAcknowledgeTest : public PwrmgrTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(nullptr, kDifPwrmgrIrqWakeup),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_acknowledge(nullptr, kDifPwrmgrIrqWakeup));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(
-      dif_pwrmgr_irq_acknowledge(nullptr, static_cast<dif_pwrmgr_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_acknowledge(nullptr, static_cast<dif_pwrmgr_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(PWRMGR_INTR_STATE_REG_OFFSET,
                  {{PWRMGR_INTR_STATE_WAKEUP_BIT, true}});
-  EXPECT_EQ(dif_pwrmgr_irq_acknowledge(&pwrmgr_, kDifPwrmgrIrqWakeup), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_acknowledge(&pwrmgr_, kDifPwrmgrIrqWakeup));
 }
 
 class IrqForceTest : public PwrmgrTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, kDifPwrmgrIrqWakeup), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_force(nullptr, kDifPwrmgrIrqWakeup));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_pwrmgr_irq_force(nullptr, static_cast<dif_pwrmgr_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_force(nullptr, static_cast<dif_pwrmgr_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(PWRMGR_INTR_TEST_REG_OFFSET,
                  {{PWRMGR_INTR_TEST_WAKEUP_BIT, true}});
-  EXPECT_EQ(dif_pwrmgr_irq_force(&pwrmgr_, kDifPwrmgrIrqWakeup), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_force(&pwrmgr_, kDifPwrmgrIrqWakeup));
 }
 
 class IrqGetEnabledTest : public PwrmgrTest {};
@@ -178,23 +171,21 @@ class IrqGetEnabledTest : public PwrmgrTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(
-      dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, &irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, &irq_state));
 
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, nullptr));
 
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_get_enabled(nullptr, kDifPwrmgrIrqWakeup, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_pwrmgr_irq_get_enabled(
-                &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_get_enabled(
+      &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -204,9 +195,8 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET,
                 {{PWRMGR_INTR_ENABLE_WAKEUP_BIT, true}});
-  EXPECT_EQ(
-      dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_pwrmgr_irq_get_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 }
 
@@ -215,16 +205,15 @@ class IrqSetEnabledTest : public PwrmgrTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(nullptr, kDifPwrmgrIrqWakeup, irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_pwrmgr_irq_set_enabled(nullptr, kDifPwrmgrIrqWakeup, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_pwrmgr_irq_set_enabled(
-                &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_set_enabled(
+      &pwrmgr_, static_cast<dif_pwrmgr_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -234,9 +223,8 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(PWRMGR_INTR_ENABLE_REG_OFFSET,
                 {{PWRMGR_INTR_ENABLE_WAKEUP_BIT, 0x1, true}});
-  EXPECT_EQ(
-      dif_pwrmgr_irq_set_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_pwrmgr_irq_set_enabled(&pwrmgr_, kDifPwrmgrIrqWakeup, irq_state));
 }
 
 class IrqDisableAllTest : public PwrmgrTest {};
@@ -244,14 +232,14 @@ class IrqDisableAllTest : public PwrmgrTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_disable_all(&pwrmgr_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -259,7 +247,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_disable_all(&pwrmgr_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -269,7 +257,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(PWRMGR_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pwrmgr_irq_disable_all(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_disable_all(&pwrmgr_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -278,11 +266,11 @@ class IrqRestoreAllTest : public PwrmgrTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_restore_all(&pwrmgr_, nullptr));
 
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_pwrmgr_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -291,14 +279,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_restore_all(&pwrmgr_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_pwrmgr_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(PWRMGR_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_pwrmgr_irq_restore_all(&pwrmgr_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_pwrmgr_irq_restore_all(&pwrmgr_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_rom_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rom_ctrl_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "rom_ctrl_regs.h"  // Generated.
 
@@ -28,32 +29,29 @@ class RomCtrlTest : public Test, public MmioTest {
 class InitTest : public RomCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rom_ctrl_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rom_ctrl_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rom_ctrl_init(dev().region(), &rom_ctrl_), kDifOk);
+  EXPECT_DIF_OK(dif_rom_ctrl_init(dev().region(), &rom_ctrl_));
 }
 
 class AlertForceTest : public RomCtrlTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_rom_ctrl_alert_force(nullptr, kDifRomCtrlAlertFatal),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rom_ctrl_alert_force(nullptr, kDifRomCtrlAlertFatal));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_rom_ctrl_alert_force(nullptr, static_cast<dif_rom_ctrl_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rom_ctrl_alert_force(nullptr, static_cast<dif_rom_ctrl_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(ROM_CTRL_ALERT_TEST_REG_OFFSET,
                  {{ROM_CTRL_ALERT_TEST_FATAL_BIT, true}});
-  EXPECT_EQ(dif_rom_ctrl_alert_force(&rom_ctrl_, kDifRomCtrlAlertFatal),
-            kDifOk);
+  EXPECT_DIF_OK(dif_rom_ctrl_alert_force(&rom_ctrl_, kDifRomCtrlAlertFatal));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rstmgr_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "rstmgr_regs.h"  // Generated.
 
@@ -28,38 +29,35 @@ class RstmgrTest : public Test, public MmioTest {
 class InitTest : public RstmgrTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rstmgr_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rstmgr_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rstmgr_init(dev().region(), &rstmgr_), kDifOk);
+  EXPECT_DIF_OK(dif_rstmgr_init(dev().region(), &rstmgr_));
 }
 
 class AlertForceTest : public RstmgrTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_rstmgr_alert_force(nullptr, kDifRstmgrAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rstmgr_alert_force(nullptr, kDifRstmgrAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_rstmgr_alert_force(nullptr, static_cast<dif_rstmgr_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rstmgr_alert_force(nullptr, static_cast<dif_rstmgr_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(RSTMGR_ALERT_TEST_REG_OFFSET,
                  {{RSTMGR_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_rstmgr_alert_force(&rstmgr_, kDifRstmgrAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_rstmgr_alert_force(&rstmgr_, kDifRstmgrAlertFatalFault));
 
   // Force last alert.
   EXPECT_WRITE32(RSTMGR_ALERT_TEST_REG_OFFSET,
                  {{RSTMGR_ALERT_TEST_FATAL_CNSTY_FAULT_BIT, true}});
-  EXPECT_EQ(dif_rstmgr_alert_force(&rstmgr_, kDifRstmgrAlertFatalCnstyFault),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_rstmgr_alert_force(&rstmgr_, kDifRstmgrAlertFatalCnstyFault));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_plic_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "rv_plic_regs.h"  // Generated.
 
@@ -28,32 +29,30 @@ class RvPlicTest : public Test, public MmioTest {
 class InitTest : public RvPlicTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rv_plic_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_plic_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rv_plic_init(dev().region(), &rv_plic_), kDifOk);
+  EXPECT_DIF_OK(dif_rv_plic_init(dev().region(), &rv_plic_));
 }
 
 class AlertForceTest : public RvPlicTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_rv_plic_alert_force(nullptr, kDifRvPlicAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rv_plic_alert_force(nullptr, kDifRvPlicAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_rv_plic_alert_force(nullptr, static_cast<dif_rv_plic_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rv_plic_alert_force(nullptr, static_cast<dif_rv_plic_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(RV_PLIC_ALERT_TEST_REG_OFFSET,
                  {{RV_PLIC_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_rv_plic_alert_force(&rv_plic_, kDifRvPlicAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_rv_plic_alert_force(&rv_plic_, kDifRvPlicAlertFatalFault));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_timer_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "rv_timer_regs.h"  // Generated.
 
@@ -28,32 +29,31 @@ class RvTimerTest : public Test, public MmioTest {
 class InitTest : public RvTimerTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_rv_timer_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_rv_timer_init(dev().region(), &rv_timer_), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_init(dev().region(), &rv_timer_));
 }
 
 class AlertForceTest : public RvTimerTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_rv_timer_alert_force(nullptr, kDifRvTimerAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rv_timer_alert_force(nullptr, kDifRvTimerAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_rv_timer_alert_force(nullptr, static_cast<dif_rv_timer_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rv_timer_alert_force(nullptr, static_cast<dif_rv_timer_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(RV_TIMER_ALERT_TEST_REG_OFFSET,
                  {{RV_TIMER_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_rv_timer_alert_force(&rv_timer_, kDifRvTimerAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_rv_timer_alert_force(&rv_timer_, kDifRvTimerAlertFatalFault));
 }
 
 class IrqGetStateTest : public RvTimerTest {};
@@ -61,11 +61,11 @@ class IrqGetStateTest : public RvTimerTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_rv_timer_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_rv_timer_irq_get_state(nullptr, 0, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_state(nullptr, 0, &irq_snapshot));
 
-  EXPECT_EQ(dif_rv_timer_irq_get_state(&rv_timer_, 0, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_state(&rv_timer_, 0, nullptr));
 
-  EXPECT_EQ(dif_rv_timer_irq_get_state(nullptr, 0, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_state(nullptr, 0, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -73,7 +73,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(RV_TIMER_INTR_STATE0_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_rv_timer_irq_get_state(&rv_timer_, 0, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_get_state(&rv_timer_, 0, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -81,7 +81,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_rv_timer_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(RV_TIMER_INTR_STATE0_REG_OFFSET, 0);
-  EXPECT_EQ(dif_rv_timer_irq_get_state(&rv_timer_, 0, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_get_state(&rv_timer_, 0, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -90,25 +90,21 @@ class IrqIsPendingTest : public RvTimerTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_rv_timer_irq_is_pending(
-                nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_is_pending(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, &is_pending));
 
-  EXPECT_EQ(dif_rv_timer_irq_is_pending(
-                &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_is_pending(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr));
 
-  EXPECT_EQ(dif_rv_timer_irq_is_pending(
-                nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_is_pending(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_rv_timer_irq_is_pending(
-                &rv_timer_, static_cast<dif_rv_timer_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_is_pending(
+      &rv_timer_, static_cast<dif_rv_timer_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -117,71 +113,64 @@ TEST_F(IrqIsPendingTest, Success) {
   // Get the first IRQ state.
   irq_state = false;
   EXPECT_READ32(RV_TIMER_INTR_STATE0_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(dif_rv_timer_irq_is_pending(
-                &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_is_pending(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, &irq_state));
   EXPECT_TRUE(irq_state);
 }
 
 class AcknowledgeAllTest : public RvTimerTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_rv_timer_irq_acknowledge_all(nullptr, 0), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_acknowledge_all(nullptr, 0));
 }
 
 TEST_F(AcknowledgeAllTest, BadHartId) {
-  EXPECT_EQ(dif_rv_timer_irq_acknowledge_all(nullptr, 1), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_acknowledge_all(nullptr, 1));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(RV_TIMER_INTR_STATE0_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_rv_timer_irq_acknowledge_all(&rv_timer_, 0), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_acknowledge_all(&rv_timer_, 0));
 }
 
 class IrqAcknowledgeTest : public RvTimerTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_rv_timer_irq_acknowledge(nullptr,
-                                         kDifRvTimerIrqTimerExpiredHart0Timer0),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_acknowledge(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_rv_timer_irq_acknowledge(nullptr,
-                                         static_cast<dif_rv_timer_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_acknowledge(
+      nullptr, static_cast<dif_rv_timer_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(RV_TIMER_INTR_STATE0_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(dif_rv_timer_irq_acknowledge(&rv_timer_,
-                                         kDifRvTimerIrqTimerExpiredHart0Timer0),
-            kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_acknowledge(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0));
 }
 
 class IrqForceTest : public RvTimerTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(
-      dif_rv_timer_irq_force(nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rv_timer_irq_force(nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(
-      dif_rv_timer_irq_force(nullptr, static_cast<dif_rv_timer_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_rv_timer_irq_force(nullptr, static_cast<dif_rv_timer_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(RV_TIMER_INTR_TEST0_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(
-      dif_rv_timer_irq_force(&rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0),
-      kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_force(&rv_timer_,
+                                       kDifRvTimerIrqTimerExpiredHart0Timer0));
 }
 
 class IrqGetEnabledTest : public RvTimerTest {};
@@ -189,25 +178,21 @@ class IrqGetEnabledTest : public RvTimerTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_rv_timer_irq_get_enabled(
-                nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_enabled(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, &irq_state));
 
-  EXPECT_EQ(dif_rv_timer_irq_get_enabled(
-                &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_enabled(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr));
 
-  EXPECT_EQ(dif_rv_timer_irq_get_enabled(
-                nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_enabled(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_rv_timer_irq_get_enabled(
-                &rv_timer_, static_cast<dif_rv_timer_irq_t>(32), &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_get_enabled(
+      &rv_timer_, static_cast<dif_rv_timer_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -216,9 +201,8 @@ TEST_F(IrqGetEnabledTest, Success) {
   // First IRQ is enabled.
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(RV_TIMER_INTR_ENABLE0_REG_OFFSET, {{0, true}});
-  EXPECT_EQ(dif_rv_timer_irq_get_enabled(
-                &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_get_enabled(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 }
 
@@ -227,17 +211,15 @@ class IrqSetEnabledTest : public RvTimerTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_rv_timer_irq_set_enabled(
-                nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_set_enabled(
+      nullptr, kDifRvTimerIrqTimerExpiredHart0Timer0, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_rv_timer_irq_set_enabled(
-                &rv_timer_, static_cast<dif_rv_timer_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_set_enabled(
+      &rv_timer_, static_cast<dif_rv_timer_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -246,9 +228,8 @@ TEST_F(IrqSetEnabledTest, Success) {
   // Enable first IRQ.
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(RV_TIMER_INTR_ENABLE0_REG_OFFSET, {{0, 0x1, true}});
-  EXPECT_EQ(dif_rv_timer_irq_set_enabled(
-                &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_set_enabled(
+      &rv_timer_, kDifRvTimerIrqTimerExpiredHart0Timer0, irq_state));
 }
 
 class IrqDisableAllTest : public RvTimerTest {};
@@ -256,15 +237,14 @@ class IrqDisableAllTest : public RvTimerTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_rv_timer_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_rv_timer_irq_disable_all(nullptr, 0, &irq_snapshot),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_disable_all(nullptr, 0, &irq_snapshot));
 
-  EXPECT_EQ(dif_rv_timer_irq_disable_all(nullptr, 0, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_disable_all(nullptr, 0, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(RV_TIMER_INTR_ENABLE0_REG_OFFSET, 0);
-  EXPECT_EQ(dif_rv_timer_irq_disable_all(&rv_timer_, 0, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_disable_all(&rv_timer_, 0, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -272,7 +252,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(RV_TIMER_INTR_ENABLE0_REG_OFFSET, 0);
   EXPECT_WRITE32(RV_TIMER_INTR_ENABLE0_REG_OFFSET, 0);
-  EXPECT_EQ(dif_rv_timer_irq_disable_all(&rv_timer_, 0, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_disable_all(&rv_timer_, 0, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -282,7 +262,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(RV_TIMER_INTR_ENABLE0_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(RV_TIMER_INTR_ENABLE0_REG_OFFSET, 0);
-  EXPECT_EQ(dif_rv_timer_irq_disable_all(&rv_timer_, 0, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_disable_all(&rv_timer_, 0, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -291,12 +271,11 @@ class IrqRestoreAllTest : public RvTimerTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_rv_timer_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_rv_timer_irq_restore_all(nullptr, 0, &irq_snapshot),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_restore_all(nullptr, 0, &irq_snapshot));
 
-  EXPECT_EQ(dif_rv_timer_irq_restore_all(&rv_timer_, 0, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_restore_all(&rv_timer_, 0, nullptr));
 
-  EXPECT_EQ(dif_rv_timer_irq_restore_all(nullptr, 0, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_rv_timer_irq_restore_all(nullptr, 0, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -305,14 +284,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(RV_TIMER_INTR_ENABLE0_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_rv_timer_irq_restore_all(&rv_timer_, 0, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_restore_all(&rv_timer_, 0, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_rv_timer_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(RV_TIMER_INTR_ENABLE0_REG_OFFSET, 0);
-  EXPECT_EQ(dif_rv_timer_irq_restore_all(&rv_timer_, 0, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_rv_timer_irq_restore_all(&rv_timer_, 0, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_device_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "spi_device_regs.h"  // Generated.
 
@@ -28,33 +29,31 @@ class SpiDeviceTest : public Test, public MmioTest {
 class InitTest : public SpiDeviceTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_spi_device_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_spi_device_init(dev().region(), &spi_device_), kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_init(dev().region(), &spi_device_));
 }
 
 class AlertForceTest : public SpiDeviceTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_spi_device_alert_force(nullptr, kDifSpiDeviceAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_device_alert_force(nullptr, kDifSpiDeviceAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_spi_device_alert_force(nullptr,
-                                       static_cast<dif_spi_device_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_alert_force(
+      nullptr, static_cast<dif_spi_device_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(SPI_DEVICE_ALERT_TEST_REG_OFFSET,
                  {{SPI_DEVICE_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(
-      dif_spi_device_alert_force(&spi_device_, kDifSpiDeviceAlertFatalFault),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_spi_device_alert_force(&spi_device_, kDifSpiDeviceAlertFatalFault));
 }
 
 class IrqGetStateTest : public SpiDeviceTest {};
@@ -62,11 +61,11 @@ class IrqGetStateTest : public SpiDeviceTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_spi_device_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_spi_device_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_spi_device_irq_get_state(&spi_device_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_state(&spi_device_, nullptr));
 
-  EXPECT_EQ(dif_spi_device_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -74,7 +73,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_spi_device_irq_get_state(&spi_device_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_get_state(&spi_device_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -82,7 +81,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_spi_device_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_device_irq_get_state(&spi_device_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_get_state(&spi_device_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -91,26 +90,21 @@ class IrqIsPendingTest : public SpiDeviceTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(dif_spi_device_irq_is_pending(
-                nullptr, kDifSpiDeviceIrqGenericRxFull, &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_is_pending(
+      nullptr, kDifSpiDeviceIrqGenericRxFull, &is_pending));
 
-  EXPECT_EQ(dif_spi_device_irq_is_pending(
-                &spi_device_, kDifSpiDeviceIrqGenericRxFull, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_is_pending(
+      &spi_device_, kDifSpiDeviceIrqGenericRxFull, nullptr));
 
-  EXPECT_EQ(dif_spi_device_irq_is_pending(
-                nullptr, kDifSpiDeviceIrqGenericRxFull, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_is_pending(
+      nullptr, kDifSpiDeviceIrqGenericRxFull, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(
-      dif_spi_device_irq_is_pending(
-          &spi_device_, static_cast<dif_spi_device_irq_t>(32), &is_pending),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_is_pending(
+      &spi_device_, static_cast<dif_spi_device_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -120,91 +114,82 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_STATE_GENERIC_RX_FULL_BIT, true}});
-  EXPECT_EQ(dif_spi_device_irq_is_pending(
-                &spi_device_, kDifSpiDeviceIrqGenericRxFull, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_is_pending(
+      &spi_device_, kDifSpiDeviceIrqGenericRxFull, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_STATE_TPM_HEADER_NOT_EMPTY_BIT, false}});
-  EXPECT_EQ(dif_spi_device_irq_is_pending(
-                &spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_is_pending(
+      &spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public SpiDeviceTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_spi_device_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_spi_device_irq_acknowledge_all(&spi_device_), kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_acknowledge_all(&spi_device_));
 }
 
 class IrqAcknowledgeTest : public SpiDeviceTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(
-      dif_spi_device_irq_acknowledge(nullptr, kDifSpiDeviceIrqGenericRxFull),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_device_irq_acknowledge(nullptr, kDifSpiDeviceIrqGenericRxFull));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_spi_device_irq_acknowledge(
-                nullptr, static_cast<dif_spi_device_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_acknowledge(
+      nullptr, static_cast<dif_spi_device_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                  {{SPI_DEVICE_INTR_STATE_GENERIC_RX_FULL_BIT, true}});
-  EXPECT_EQ(dif_spi_device_irq_acknowledge(&spi_device_,
-                                           kDifSpiDeviceIrqGenericRxFull),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_acknowledge(&spi_device_,
+                                               kDifSpiDeviceIrqGenericRxFull));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(SPI_DEVICE_INTR_STATE_REG_OFFSET,
                  {{SPI_DEVICE_INTR_STATE_TPM_HEADER_NOT_EMPTY_BIT, true}});
-  EXPECT_EQ(dif_spi_device_irq_acknowledge(&spi_device_,
-                                           kDifSpiDeviceIrqTpmHeaderNotEmpty),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_acknowledge(
+      &spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty));
 }
 
 class IrqForceTest : public SpiDeviceTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_spi_device_irq_force(nullptr, kDifSpiDeviceIrqGenericRxFull),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_device_irq_force(nullptr, kDifSpiDeviceIrqGenericRxFull));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(
-      dif_spi_device_irq_force(nullptr, static_cast<dif_spi_device_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_device_irq_force(nullptr, static_cast<dif_spi_device_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
                  {{SPI_DEVICE_INTR_TEST_GENERIC_RX_FULL_BIT, true}});
-  EXPECT_EQ(
-      dif_spi_device_irq_force(&spi_device_, kDifSpiDeviceIrqGenericRxFull),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_spi_device_irq_force(&spi_device_, kDifSpiDeviceIrqGenericRxFull));
 
   // Force last IRQ.
   EXPECT_WRITE32(SPI_DEVICE_INTR_TEST_REG_OFFSET,
                  {{SPI_DEVICE_INTR_TEST_TPM_HEADER_NOT_EMPTY_BIT, true}});
-  EXPECT_EQ(
-      dif_spi_device_irq_force(&spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty),
-      kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_force(&spi_device_,
+                                         kDifSpiDeviceIrqTpmHeaderNotEmpty));
 }
 
 class IrqGetEnabledTest : public SpiDeviceTest {};
@@ -212,26 +197,21 @@ class IrqGetEnabledTest : public SpiDeviceTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_spi_device_irq_get_enabled(
-                nullptr, kDifSpiDeviceIrqGenericRxFull, &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_enabled(
+      nullptr, kDifSpiDeviceIrqGenericRxFull, &irq_state));
 
-  EXPECT_EQ(dif_spi_device_irq_get_enabled(
-                &spi_device_, kDifSpiDeviceIrqGenericRxFull, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_enabled(
+      &spi_device_, kDifSpiDeviceIrqGenericRxFull, nullptr));
 
-  EXPECT_EQ(dif_spi_device_irq_get_enabled(
-                nullptr, kDifSpiDeviceIrqGenericRxFull, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_enabled(
+      nullptr, kDifSpiDeviceIrqGenericRxFull, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(
-      dif_spi_device_irq_get_enabled(
-          &spi_device_, static_cast<dif_spi_device_irq_t>(32), &irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_get_enabled(
+      &spi_device_, static_cast<dif_spi_device_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -241,18 +221,16 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_ENABLE_GENERIC_RX_FULL_BIT, true}});
-  EXPECT_EQ(dif_spi_device_irq_get_enabled(
-                &spi_device_, kDifSpiDeviceIrqGenericRxFull, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_get_enabled(
+      &spi_device_, kDifSpiDeviceIrqGenericRxFull, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_ENABLE_TPM_HEADER_NOT_EMPTY_BIT, false}});
-  EXPECT_EQ(dif_spi_device_irq_get_enabled(
-                &spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty, &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_get_enabled(
+      &spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty, &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -261,17 +239,15 @@ class IrqSetEnabledTest : public SpiDeviceTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(
-                nullptr, kDifSpiDeviceIrqGenericRxFull, irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_set_enabled(
+      nullptr, kDifSpiDeviceIrqGenericRxFull, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(
-                &spi_device_, static_cast<dif_spi_device_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_set_enabled(
+      &spi_device_, static_cast<dif_spi_device_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -281,18 +257,16 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 {{SPI_DEVICE_INTR_ENABLE_GENERIC_RX_FULL_BIT, 0x1, true}});
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(
-                &spi_device_, kDifSpiDeviceIrqGenericRxFull, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_set_enabled(
+      &spi_device_, kDifSpiDeviceIrqGenericRxFull, irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(
       SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
       {{SPI_DEVICE_INTR_ENABLE_TPM_HEADER_NOT_EMPTY_BIT, 0x1, false}});
-  EXPECT_EQ(dif_spi_device_irq_set_enabled(
-                &spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty, irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_set_enabled(
+      &spi_device_, kDifSpiDeviceIrqTpmHeaderNotEmpty, irq_state));
 }
 
 class IrqDisableAllTest : public SpiDeviceTest {};
@@ -300,14 +274,14 @@ class IrqDisableAllTest : public SpiDeviceTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_spi_device_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_spi_device_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_device_irq_disable_all(&spi_device_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_disable_all(&spi_device_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -315,8 +289,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_device_irq_disable_all(&spi_device_, &irq_snapshot),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_disable_all(&spi_device_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -326,8 +299,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_device_irq_disable_all(&spi_device_, &irq_snapshot),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_disable_all(&spi_device_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -336,11 +308,11 @@ class IrqRestoreAllTest : public SpiDeviceTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_spi_device_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_spi_device_irq_restore_all(&spi_device_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_restore_all(&spi_device_, nullptr));
 
-  EXPECT_EQ(dif_spi_device_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_device_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -349,16 +321,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_spi_device_irq_restore_all(&spi_device_, &irq_snapshot),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_restore_all(&spi_device_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_spi_device_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(SPI_DEVICE_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_device_irq_restore_all(&spi_device_, &irq_snapshot),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_device_irq_restore_all(&spi_device_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_spi_host_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "spi_host_regs.h"  // Generated.
 
@@ -28,32 +29,31 @@ class SpiHostTest : public Test, public MmioTest {
 class InitTest : public SpiHostTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_spi_host_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_spi_host_init(dev().region(), &spi_host_), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_init(dev().region(), &spi_host_));
 }
 
 class AlertForceTest : public SpiHostTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_spi_host_alert_force(nullptr, kDifSpiHostAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_alert_force(nullptr, kDifSpiHostAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_spi_host_alert_force(nullptr, static_cast<dif_spi_host_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_alert_force(nullptr, static_cast<dif_spi_host_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(SPI_HOST_ALERT_TEST_REG_OFFSET,
                  {{SPI_HOST_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_spi_host_alert_force(&spi_host_, kDifSpiHostAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_spi_host_alert_force(&spi_host_, kDifSpiHostAlertFatalFault));
 }
 
 class IrqGetStateTest : public SpiHostTest {};
@@ -61,11 +61,11 @@ class IrqGetStateTest : public SpiHostTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_spi_host_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_spi_host_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_spi_host_irq_get_state(&spi_host_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_get_state(&spi_host_, nullptr));
 
-  EXPECT_EQ(dif_spi_host_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -73,7 +73,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(SPI_HOST_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_spi_host_irq_get_state(&spi_host_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_get_state(&spi_host_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -81,7 +81,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_spi_host_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(SPI_HOST_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_host_irq_get_state(&spi_host_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_get_state(&spi_host_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -90,24 +90,21 @@ class IrqIsPendingTest : public SpiHostTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(
-      dif_spi_host_irq_is_pending(nullptr, kDifSpiHostIrqError, &is_pending),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_is_pending(nullptr, kDifSpiHostIrqError, &is_pending));
 
-  EXPECT_EQ(
-      dif_spi_host_irq_is_pending(&spi_host_, kDifSpiHostIrqError, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_is_pending(&spi_host_, kDifSpiHostIrqError, nullptr));
 
-  EXPECT_EQ(dif_spi_host_irq_is_pending(nullptr, kDifSpiHostIrqError, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_is_pending(nullptr, kDifSpiHostIrqError, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_spi_host_irq_is_pending(
-                &spi_host_, static_cast<dif_spi_host_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_is_pending(
+      &spi_host_, static_cast<dif_spi_host_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -117,83 +114,77 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(SPI_HOST_INTR_STATE_REG_OFFSET,
                 {{SPI_HOST_INTR_STATE_ERROR_BIT, true}});
-  EXPECT_EQ(
-      dif_spi_host_irq_is_pending(&spi_host_, kDifSpiHostIrqError, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_spi_host_irq_is_pending(&spi_host_, kDifSpiHostIrqError, &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(SPI_HOST_INTR_STATE_REG_OFFSET,
                 {{SPI_HOST_INTR_STATE_SPI_EVENT_BIT, false}});
-  EXPECT_EQ(dif_spi_host_irq_is_pending(&spi_host_, kDifSpiHostIrqSpiEvent,
-                                        &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_is_pending(&spi_host_, kDifSpiHostIrqSpiEvent,
+                                            &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public SpiHostTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_spi_host_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(SPI_HOST_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_spi_host_irq_acknowledge_all(&spi_host_), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_acknowledge_all(&spi_host_));
 }
 
 class IrqAcknowledgeTest : public SpiHostTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_spi_host_irq_acknowledge(nullptr, kDifSpiHostIrqError),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_acknowledge(nullptr, kDifSpiHostIrqError));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(dif_spi_host_irq_acknowledge(nullptr,
-                                         static_cast<dif_spi_host_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_acknowledge(
+      nullptr, static_cast<dif_spi_host_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(SPI_HOST_INTR_STATE_REG_OFFSET,
                  {{SPI_HOST_INTR_STATE_ERROR_BIT, true}});
-  EXPECT_EQ(dif_spi_host_irq_acknowledge(&spi_host_, kDifSpiHostIrqError),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_acknowledge(&spi_host_, kDifSpiHostIrqError));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(SPI_HOST_INTR_STATE_REG_OFFSET,
                  {{SPI_HOST_INTR_STATE_SPI_EVENT_BIT, true}});
-  EXPECT_EQ(dif_spi_host_irq_acknowledge(&spi_host_, kDifSpiHostIrqSpiEvent),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_spi_host_irq_acknowledge(&spi_host_, kDifSpiHostIrqSpiEvent));
 }
 
 class IrqForceTest : public SpiHostTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_spi_host_irq_force(nullptr, kDifSpiHostIrqError), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_force(nullptr, kDifSpiHostIrqError));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(
-      dif_spi_host_irq_force(nullptr, static_cast<dif_spi_host_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_force(nullptr, static_cast<dif_spi_host_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(SPI_HOST_INTR_TEST_REG_OFFSET,
                  {{SPI_HOST_INTR_TEST_ERROR_BIT, true}});
-  EXPECT_EQ(dif_spi_host_irq_force(&spi_host_, kDifSpiHostIrqError), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_force(&spi_host_, kDifSpiHostIrqError));
 
   // Force last IRQ.
   EXPECT_WRITE32(SPI_HOST_INTR_TEST_REG_OFFSET,
                  {{SPI_HOST_INTR_TEST_SPI_EVENT_BIT, true}});
-  EXPECT_EQ(dif_spi_host_irq_force(&spi_host_, kDifSpiHostIrqSpiEvent), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_force(&spi_host_, kDifSpiHostIrqSpiEvent));
 }
 
 class IrqGetEnabledTest : public SpiHostTest {};
@@ -201,24 +192,21 @@ class IrqGetEnabledTest : public SpiHostTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(
-      dif_spi_host_irq_get_enabled(nullptr, kDifSpiHostIrqError, &irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_get_enabled(nullptr, kDifSpiHostIrqError, &irq_state));
 
-  EXPECT_EQ(
-      dif_spi_host_irq_get_enabled(&spi_host_, kDifSpiHostIrqError, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_get_enabled(&spi_host_, kDifSpiHostIrqError, nullptr));
 
-  EXPECT_EQ(dif_spi_host_irq_get_enabled(nullptr, kDifSpiHostIrqError, nullptr),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_get_enabled(nullptr, kDifSpiHostIrqError, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_spi_host_irq_get_enabled(
-                &spi_host_, static_cast<dif_spi_host_irq_t>(32), &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_get_enabled(
+      &spi_host_, static_cast<dif_spi_host_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -228,18 +216,16 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(SPI_HOST_INTR_ENABLE_REG_OFFSET,
                 {{SPI_HOST_INTR_ENABLE_ERROR_BIT, true}});
-  EXPECT_EQ(
-      dif_spi_host_irq_get_enabled(&spi_host_, kDifSpiHostIrqError, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_get_enabled(&spi_host_, kDifSpiHostIrqError,
+                                             &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(SPI_HOST_INTR_ENABLE_REG_OFFSET,
                 {{SPI_HOST_INTR_ENABLE_SPI_EVENT_BIT, false}});
-  EXPECT_EQ(dif_spi_host_irq_get_enabled(&spi_host_, kDifSpiHostIrqSpiEvent,
-                                         &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_get_enabled(&spi_host_, kDifSpiHostIrqSpiEvent,
+                                             &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -248,17 +234,15 @@ class IrqSetEnabledTest : public SpiHostTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(
-      dif_spi_host_irq_set_enabled(nullptr, kDifSpiHostIrqError, irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_spi_host_irq_set_enabled(nullptr, kDifSpiHostIrqError, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_spi_host_irq_set_enabled(
-                &spi_host_, static_cast<dif_spi_host_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_set_enabled(
+      &spi_host_, static_cast<dif_spi_host_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -268,17 +252,15 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(SPI_HOST_INTR_ENABLE_REG_OFFSET,
                 {{SPI_HOST_INTR_ENABLE_ERROR_BIT, 0x1, true}});
-  EXPECT_EQ(
-      dif_spi_host_irq_set_enabled(&spi_host_, kDifSpiHostIrqError, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_spi_host_irq_set_enabled(&spi_host_, kDifSpiHostIrqError, irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(SPI_HOST_INTR_ENABLE_REG_OFFSET,
                 {{SPI_HOST_INTR_ENABLE_SPI_EVENT_BIT, 0x1, false}});
-  EXPECT_EQ(dif_spi_host_irq_set_enabled(&spi_host_, kDifSpiHostIrqSpiEvent,
-                                         irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_set_enabled(&spi_host_, kDifSpiHostIrqSpiEvent,
+                                             irq_state));
 }
 
 class IrqDisableAllTest : public SpiHostTest {};
@@ -286,14 +268,14 @@ class IrqDisableAllTest : public SpiHostTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_spi_host_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_spi_host_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_spi_host_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(SPI_HOST_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_host_irq_disable_all(&spi_host_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_disable_all(&spi_host_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -301,7 +283,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(SPI_HOST_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(SPI_HOST_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_host_irq_disable_all(&spi_host_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_disable_all(&spi_host_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -311,7 +293,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(SPI_HOST_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(SPI_HOST_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_host_irq_disable_all(&spi_host_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_disable_all(&spi_host_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -320,11 +302,11 @@ class IrqRestoreAllTest : public SpiHostTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_spi_host_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_spi_host_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_spi_host_irq_restore_all(&spi_host_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_restore_all(&spi_host_, nullptr));
 
-  EXPECT_EQ(dif_spi_host_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_spi_host_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -333,14 +315,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(SPI_HOST_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_spi_host_irq_restore_all(&spi_host_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_restore_all(&spi_host_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_spi_host_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(SPI_HOST_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_spi_host_irq_restore_all(&spi_host_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_spi_host_irq_restore_all(&spi_host_, &irq_snapshot));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_sram_ctrl_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "sram_ctrl_regs.h"  // Generated.
 
@@ -28,32 +29,31 @@ class SramCtrlTest : public Test, public MmioTest {
 class InitTest : public SramCtrlTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_sram_ctrl_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_sram_ctrl_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_sram_ctrl_init(dev().region(), &sram_ctrl_), kDifOk);
+  EXPECT_DIF_OK(dif_sram_ctrl_init(dev().region(), &sram_ctrl_));
 }
 
 class AlertForceTest : public SramCtrlTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_sram_ctrl_alert_force(nullptr, kDifSramCtrlAlertFatalError),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_sram_ctrl_alert_force(nullptr, kDifSramCtrlAlertFatalError));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(dif_sram_ctrl_alert_force(nullptr,
-                                      static_cast<dif_sram_ctrl_alert_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_sram_ctrl_alert_force(
+      nullptr, static_cast<dif_sram_ctrl_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(SRAM_CTRL_ALERT_TEST_REG_OFFSET,
                  {{SRAM_CTRL_ALERT_TEST_FATAL_ERROR_BIT, true}});
-  EXPECT_EQ(dif_sram_ctrl_alert_force(&sram_ctrl_, kDifSramCtrlAlertFatalError),
-            kDifOk);
+  EXPECT_DIF_OK(
+      dif_sram_ctrl_alert_force(&sram_ctrl_, kDifSramCtrlAlertFatalError));
 }
 
 }  // namespace

--- a/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_usbdev_autogen_unittest.cc
@@ -10,6 +10,7 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "usbdev_regs.h"  // Generated.
 
@@ -28,32 +29,29 @@ class UsbdevTest : public Test, public MmioTest {
 class InitTest : public UsbdevTest {};
 
 TEST_F(InitTest, NullArgs) {
-  EXPECT_EQ(dif_usbdev_init(dev().region(), nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_init(dev().region(), nullptr));
 }
 
 TEST_F(InitTest, Success) {
-  EXPECT_EQ(dif_usbdev_init(dev().region(), &usbdev_), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_init(dev().region(), &usbdev_));
 }
 
 class AlertForceTest : public UsbdevTest {};
 
 TEST_F(AlertForceTest, NullArgs) {
-  EXPECT_EQ(dif_usbdev_alert_force(nullptr, kDifUsbdevAlertFatalFault),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_alert_force(nullptr, kDifUsbdevAlertFatalFault));
 }
 
 TEST_F(AlertForceTest, BadAlert) {
-  EXPECT_EQ(
-      dif_usbdev_alert_force(nullptr, static_cast<dif_usbdev_alert_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_alert_force(nullptr, static_cast<dif_usbdev_alert_t>(32)));
 }
 
 TEST_F(AlertForceTest, Success) {
   // Force first alert.
   EXPECT_WRITE32(USBDEV_ALERT_TEST_REG_OFFSET,
                  {{USBDEV_ALERT_TEST_FATAL_FAULT_BIT, true}});
-  EXPECT_EQ(dif_usbdev_alert_force(&usbdev_, kDifUsbdevAlertFatalFault),
-            kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_alert_force(&usbdev_, kDifUsbdevAlertFatalFault));
 }
 
 class IrqGetStateTest : public UsbdevTest {};
@@ -61,11 +59,11 @@ class IrqGetStateTest : public UsbdevTest {};
 TEST_F(IrqGetStateTest, NullArgs) {
   dif_usbdev_irq_state_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_usbdev_irq_get_state(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_get_state(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_usbdev_irq_get_state(&usbdev_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_get_state(&usbdev_, nullptr));
 
-  EXPECT_EQ(dif_usbdev_irq_get_state(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_get_state(nullptr, nullptr));
 }
 
 TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -73,7 +71,7 @@ TEST_F(IrqGetStateTest, SuccessAllRaised) {
 
   EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_usbdev_irq_get_state(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_get_state(&usbdev_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -81,7 +79,7 @@ TEST_F(IrqGetStateTest, SuccessNoneRaised) {
   dif_usbdev_irq_state_snapshot_t irq_snapshot = 0;
 
   EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_usbdev_irq_get_state(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_get_state(&usbdev_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -90,25 +88,21 @@ class IrqIsPendingTest : public UsbdevTest {};
 TEST_F(IrqIsPendingTest, NullArgs) {
   bool is_pending;
 
-  EXPECT_EQ(
-      dif_usbdev_irq_is_pending(nullptr, kDifUsbdevIrqPktReceived, &is_pending),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_is_pending(nullptr, kDifUsbdevIrqPktReceived,
+                                              &is_pending));
 
-  EXPECT_EQ(
-      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqPktReceived, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqPktReceived, nullptr));
 
-  EXPECT_EQ(
-      dif_usbdev_irq_is_pending(nullptr, kDifUsbdevIrqPktReceived, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_is_pending(nullptr, kDifUsbdevIrqPktReceived, nullptr));
 }
 
 TEST_F(IrqIsPendingTest, BadIrq) {
   bool is_pending;
   // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-  EXPECT_EQ(dif_usbdev_irq_is_pending(
-                &usbdev_, static_cast<dif_usbdev_irq_t>(32), &is_pending),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_is_pending(
+      &usbdev_, static_cast<dif_usbdev_irq_t>(32), &is_pending));
 }
 
 TEST_F(IrqIsPendingTest, Success) {
@@ -118,83 +112,77 @@ TEST_F(IrqIsPendingTest, Success) {
   irq_state = false;
   EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET,
                 {{USBDEV_INTR_STATE_PKT_RECEIVED_BIT, true}});
-  EXPECT_EQ(
-      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqPktReceived, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqPktReceived,
+                                          &irq_state));
   EXPECT_TRUE(irq_state);
 
   // Get the last IRQ state.
   irq_state = true;
   EXPECT_READ32(USBDEV_INTR_STATE_REG_OFFSET,
                 {{USBDEV_INTR_STATE_LINK_OUT_ERR_BIT, false}});
-  EXPECT_EQ(
-      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqLinkOutErr, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_usbdev_irq_is_pending(&usbdev_, kDifUsbdevIrqLinkOutErr, &irq_state));
   EXPECT_FALSE(irq_state);
 }
 
 class AcknowledgeAllTest : public UsbdevTest {};
 
 TEST_F(AcknowledgeAllTest, NullArgs) {
-  EXPECT_EQ(dif_usbdev_irq_acknowledge_all(nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_acknowledge_all(nullptr));
 }
 
 TEST_F(AcknowledgeAllTest, Success) {
   EXPECT_WRITE32(USBDEV_INTR_STATE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
 
-  EXPECT_EQ(dif_usbdev_irq_acknowledge_all(&usbdev_), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_acknowledge_all(&usbdev_));
 }
 
 class IrqAcknowledgeTest : public UsbdevTest {};
 
 TEST_F(IrqAcknowledgeTest, NullArgs) {
-  EXPECT_EQ(dif_usbdev_irq_acknowledge(nullptr, kDifUsbdevIrqPktReceived),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_acknowledge(nullptr, kDifUsbdevIrqPktReceived));
 }
 
 TEST_F(IrqAcknowledgeTest, BadIrq) {
-  EXPECT_EQ(
-      dif_usbdev_irq_acknowledge(nullptr, static_cast<dif_usbdev_irq_t>(32)),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_acknowledge(nullptr, static_cast<dif_usbdev_irq_t>(32)));
 }
 
 TEST_F(IrqAcknowledgeTest, Success) {
   // Clear the first IRQ state.
   EXPECT_WRITE32(USBDEV_INTR_STATE_REG_OFFSET,
                  {{USBDEV_INTR_STATE_PKT_RECEIVED_BIT, true}});
-  EXPECT_EQ(dif_usbdev_irq_acknowledge(&usbdev_, kDifUsbdevIrqPktReceived),
-            kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_acknowledge(&usbdev_, kDifUsbdevIrqPktReceived));
 
   // Clear the last IRQ state.
   EXPECT_WRITE32(USBDEV_INTR_STATE_REG_OFFSET,
                  {{USBDEV_INTR_STATE_LINK_OUT_ERR_BIT, true}});
-  EXPECT_EQ(dif_usbdev_irq_acknowledge(&usbdev_, kDifUsbdevIrqLinkOutErr),
-            kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_acknowledge(&usbdev_, kDifUsbdevIrqLinkOutErr));
 }
 
 class IrqForceTest : public UsbdevTest {};
 
 TEST_F(IrqForceTest, NullArgs) {
-  EXPECT_EQ(dif_usbdev_irq_force(nullptr, kDifUsbdevIrqPktReceived),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_force(nullptr, kDifUsbdevIrqPktReceived));
 }
 
 TEST_F(IrqForceTest, BadIrq) {
-  EXPECT_EQ(dif_usbdev_irq_force(nullptr, static_cast<dif_usbdev_irq_t>(32)),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_force(nullptr, static_cast<dif_usbdev_irq_t>(32)));
 }
 
 TEST_F(IrqForceTest, Success) {
   // Force first IRQ.
   EXPECT_WRITE32(USBDEV_INTR_TEST_REG_OFFSET,
                  {{USBDEV_INTR_TEST_PKT_RECEIVED_BIT, true}});
-  EXPECT_EQ(dif_usbdev_irq_force(&usbdev_, kDifUsbdevIrqPktReceived), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_force(&usbdev_, kDifUsbdevIrqPktReceived));
 
   // Force last IRQ.
   EXPECT_WRITE32(USBDEV_INTR_TEST_REG_OFFSET,
                  {{USBDEV_INTR_TEST_LINK_OUT_ERR_BIT, true}});
-  EXPECT_EQ(dif_usbdev_irq_force(&usbdev_, kDifUsbdevIrqLinkOutErr), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_force(&usbdev_, kDifUsbdevIrqLinkOutErr));
 }
 
 class IrqGetEnabledTest : public UsbdevTest {};
@@ -202,25 +190,21 @@ class IrqGetEnabledTest : public UsbdevTest {};
 TEST_F(IrqGetEnabledTest, NullArgs) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(
-      dif_usbdev_irq_get_enabled(nullptr, kDifUsbdevIrqPktReceived, &irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_get_enabled(
+      nullptr, kDifUsbdevIrqPktReceived, &irq_state));
 
-  EXPECT_EQ(
-      dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqPktReceived, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqPktReceived, nullptr));
 
-  EXPECT_EQ(
-      dif_usbdev_irq_get_enabled(nullptr, kDifUsbdevIrqPktReceived, nullptr),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_get_enabled(nullptr, kDifUsbdevIrqPktReceived, nullptr));
 }
 
 TEST_F(IrqGetEnabledTest, BadIrq) {
   dif_toggle_t irq_state;
 
-  EXPECT_EQ(dif_usbdev_irq_get_enabled(
-                &usbdev_, static_cast<dif_usbdev_irq_t>(32), &irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_get_enabled(
+      &usbdev_, static_cast<dif_usbdev_irq_t>(32), &irq_state));
 }
 
 TEST_F(IrqGetEnabledTest, Success) {
@@ -230,18 +214,16 @@ TEST_F(IrqGetEnabledTest, Success) {
   irq_state = kDifToggleDisabled;
   EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET,
                 {{USBDEV_INTR_ENABLE_PKT_RECEIVED_BIT, true}});
-  EXPECT_EQ(dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqPktReceived,
-                                       &irq_state),
-            kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqPktReceived,
+                                           &irq_state));
   EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   // Last IRQ is disabled.
   irq_state = kDifToggleEnabled;
   EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET,
                 {{USBDEV_INTR_ENABLE_LINK_OUT_ERR_BIT, false}});
-  EXPECT_EQ(
-      dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqLinkOutErr, &irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_get_enabled(&usbdev_, kDifUsbdevIrqLinkOutErr,
+                                           &irq_state));
   EXPECT_EQ(irq_state, kDifToggleDisabled);
 }
 
@@ -250,17 +232,15 @@ class IrqSetEnabledTest : public UsbdevTest {};
 TEST_F(IrqSetEnabledTest, NullArgs) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(
-      dif_usbdev_irq_set_enabled(nullptr, kDifUsbdevIrqPktReceived, irq_state),
-      kDifBadArg);
+  EXPECT_DIF_BADARG(
+      dif_usbdev_irq_set_enabled(nullptr, kDifUsbdevIrqPktReceived, irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, BadIrq) {
   dif_toggle_t irq_state = kDifToggleEnabled;
 
-  EXPECT_EQ(dif_usbdev_irq_set_enabled(
-                &usbdev_, static_cast<dif_usbdev_irq_t>(32), irq_state),
-            kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_set_enabled(
+      &usbdev_, static_cast<dif_usbdev_irq_t>(32), irq_state));
 }
 
 TEST_F(IrqSetEnabledTest, Success) {
@@ -270,17 +250,15 @@ TEST_F(IrqSetEnabledTest, Success) {
   irq_state = kDifToggleEnabled;
   EXPECT_MASK32(USBDEV_INTR_ENABLE_REG_OFFSET,
                 {{USBDEV_INTR_ENABLE_PKT_RECEIVED_BIT, 0x1, true}});
-  EXPECT_EQ(
-      dif_usbdev_irq_set_enabled(&usbdev_, kDifUsbdevIrqPktReceived, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_set_enabled(&usbdev_, kDifUsbdevIrqPktReceived,
+                                           irq_state));
 
   // Disable last IRQ.
   irq_state = kDifToggleDisabled;
   EXPECT_MASK32(USBDEV_INTR_ENABLE_REG_OFFSET,
                 {{USBDEV_INTR_ENABLE_LINK_OUT_ERR_BIT, 0x1, false}});
-  EXPECT_EQ(
-      dif_usbdev_irq_set_enabled(&usbdev_, kDifUsbdevIrqLinkOutErr, irq_state),
-      kDifOk);
+  EXPECT_DIF_OK(
+      dif_usbdev_irq_set_enabled(&usbdev_, kDifUsbdevIrqLinkOutErr, irq_state));
 }
 
 class IrqDisableAllTest : public UsbdevTest {};
@@ -288,14 +266,14 @@ class IrqDisableAllTest : public UsbdevTest {};
 TEST_F(IrqDisableAllTest, NullArgs) {
   dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_usbdev_irq_disable_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_disable_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_usbdev_irq_disable_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_disable_all(nullptr, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
   EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_usbdev_irq_disable_all(&usbdev_, nullptr), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_disable_all(&usbdev_, nullptr));
 }
 
 TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -303,7 +281,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
 
   EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
   EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_usbdev_irq_disable_all(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_disable_all(&usbdev_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, 0);
 }
 
@@ -313,7 +291,7 @@ TEST_F(IrqDisableAllTest, SuccessSnapshotAllEnabled) {
   EXPECT_READ32(USBDEV_INTR_ENABLE_REG_OFFSET,
                 std::numeric_limits<uint32_t>::max());
   EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_usbdev_irq_disable_all(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_disable_all(&usbdev_, &irq_snapshot));
   EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
 }
 
@@ -322,11 +300,11 @@ class IrqRestoreAllTest : public UsbdevTest {};
 TEST_F(IrqRestoreAllTest, NullArgs) {
   dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
 
-  EXPECT_EQ(dif_usbdev_irq_restore_all(nullptr, &irq_snapshot), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_restore_all(nullptr, &irq_snapshot));
 
-  EXPECT_EQ(dif_usbdev_irq_restore_all(&usbdev_, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_restore_all(&usbdev_, nullptr));
 
-  EXPECT_EQ(dif_usbdev_irq_restore_all(nullptr, nullptr), kDifBadArg);
+  EXPECT_DIF_BADARG(dif_usbdev_irq_restore_all(nullptr, nullptr));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -335,14 +313,14 @@ TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
 
   EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET,
                  std::numeric_limits<uint32_t>::max());
-  EXPECT_EQ(dif_usbdev_irq_restore_all(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_restore_all(&usbdev_, &irq_snapshot));
 }
 
 TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
   dif_usbdev_irq_enable_snapshot_t irq_snapshot = 0;
 
   EXPECT_WRITE32(USBDEV_INTR_ENABLE_REG_OFFSET, 0);
-  EXPECT_EQ(dif_usbdev_irq_restore_all(&usbdev_, &irq_snapshot), kDifOk);
+  EXPECT_DIF_OK(dif_usbdev_irq_restore_all(&usbdev_, &irq_snapshot));
 }
 
 }  // namespace

--- a/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
+++ b/util/make_new_dif/templates/dif_autogen_unittest.cc.tpl
@@ -21,6 +21,7 @@ ${autogen_banner}
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
 
 #include "${ip.name_snake}_regs.h"  // Generated.
 
@@ -39,53 +40,47 @@ namespace {
   class InitTest : public ${ip.name_camel}Test {};
 
   TEST_F(InitTest, NullArgs) {
-    EXPECT_EQ(dif_${ip.name_snake}_init(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_init(
         dev().region(),
-        nullptr),
-      kDifBadArg);
+        nullptr));
   }
 
   TEST_F(InitTest, Success) {
-    EXPECT_EQ(dif_${ip.name_snake}_init(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_init(
         dev().region(),
-        &${ip.name_snake}_),
-      kDifOk);
+        &${ip.name_snake}_));
   }
 
 % if ip.alerts:
   class AlertForceTest : public ${ip.name_camel}Test {};
 
   TEST_F(AlertForceTest, NullArgs) {
-    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_alert_force(
         nullptr, 
-        kDif${ip.name_camel}Alert${ip.alerts[0].name_camel}),
-      kDifBadArg);
+        kDif${ip.name_camel}Alert${ip.alerts[0].name_camel}));
   }
 
   TEST_F(AlertForceTest, BadAlert) {
-    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_alert_force(
         nullptr, 
-        static_cast<dif_${ip.name_snake}_alert_t>(32)),
-      kDifBadArg);
+        static_cast<dif_${ip.name_snake}_alert_t>(32)));
   }
 
   TEST_F(AlertForceTest, Success) {
     // Force first alert.
     EXPECT_WRITE32(${ip.name_upper}_ALERT_TEST_REG_OFFSET,
       {{${ip.name_upper}_ALERT_TEST_${ip.alerts[0].name_upper}_BIT, true}});
-    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_alert_force(
         &${ip.name_snake}_,
-        kDif${ip.name_camel}Alert${ip.alerts[0].name_camel}),
-      kDifOk);
+        kDif${ip.name_camel}Alert${ip.alerts[0].name_camel}));
 
   % if len(ip.alerts) > 1:
     // Force last alert.
     EXPECT_WRITE32(${ip.name_upper}_ALERT_TEST_REG_OFFSET,
         {{${ip.name_upper}_ALERT_TEST_${ip.alerts[-1].name_upper}_BIT, true}});
-    EXPECT_EQ(dif_${ip.name_snake}_alert_force(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_alert_force(
         &${ip.name_snake}_,
-        kDif${ip.name_camel}Alert${ip.alerts[-1].name_camel}),
-      kDifOk);
+        kDif${ip.name_camel}Alert${ip.alerts[-1].name_camel}));
   % endif
   }
 
@@ -97,29 +92,26 @@ namespace {
   TEST_F(IrqGetStateTest, NullArgs) {
     dif_${ip.name_snake}_irq_state_snapshot_t irq_snapshot = 0;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_state(
         nullptr, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifBadArg);
+        &irq_snapshot));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_state(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_state(
         nullptr, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
   }
 
   TEST_F(IrqGetStateTest, SuccessAllRaised) {
@@ -131,13 +123,12 @@ namespace {
     EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 
   % endif
       std::numeric_limits<uint32_t>::max());
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_get_state(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifOk);
+        &irq_snapshot));
     EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
   }
 
@@ -149,13 +140,12 @@ namespace {
   % else:
     EXPECT_READ32(${ip.name_upper}_INTR_STATE_REG_OFFSET, 0);
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_state(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_get_state(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifOk);
+        &irq_snapshot));
     EXPECT_EQ(irq_snapshot, 0);
   }
 
@@ -164,45 +154,41 @@ namespace {
   TEST_F(IrqIsPendingTest, NullArgs) {
     bool is_pending;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_is_pending(
         nullptr, 
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        &is_pending),
-      kDifBadArg);
+        &is_pending));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_, 
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_is_pending(
         nullptr,
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
   }
 
   TEST_F(IrqIsPendingTest, BadIrq) {
     bool is_pending;
     // All interrupt CSRs are 32 bit so interrupt 32 will be invalid.
-    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_, 
         static_cast<dif_${ip.name_snake}_irq_t>(32),
-        &is_pending),
-      kDifBadArg);
+        &is_pending));
   }
 
   TEST_F(IrqIsPendingTest, Success) {
@@ -221,15 +207,14 @@ namespace {
         {{${ip.name_upper}_INTR_STATE_${ip.irqs[0].name_upper}_BIT, true}});
     % endif
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        &irq_state),
-      kDifOk);
+        &irq_state));
     EXPECT_TRUE(irq_state);
 
   % if len(ip.irqs) > 1 or ip.irqs[0].width > 1:
@@ -247,15 +232,14 @@ namespace {
         {{${ip.name_upper}_INTR_STATE_${ip.irqs[-1].name_upper}_BIT, false}});
       % endif
     % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_is_pending(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_is_pending(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}${ip.irqs[0].width - 1},
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel},
       % endif
-        &irq_state),
-      kDifOk);
+        &irq_state));
     EXPECT_FALSE(irq_state);
   % endif
   }
@@ -263,20 +247,18 @@ namespace {
   class AcknowledgeAllTest : public ${ip.name_camel}Test {};
 
   TEST_F(AcknowledgeAllTest, NullArgs) {
-    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge_all(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_acknowledge_all(
         nullptr 
       % if ip.name_snake == "rv_timer":
         , 0
       % endif
-        ),
-      kDifBadArg);
+        ));
   }
 
   % if ip.name_snake == "rv_timer":
   TEST_F(AcknowledgeAllTest, BadHartId) {
-    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge_all(
-        nullptr, ${ip.parameters["N_HARTS"].default}),
-      kDifBadArg);
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_acknowledge_all(
+        nullptr, ${ip.parameters["N_HARTS"].default}));
   }
   % endif
 
@@ -288,33 +270,30 @@ namespace {
   % endif
       std::numeric_limits<uint32_t>::max());
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge_all(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_acknowledge_all(
         &${ip.name_snake}_ 
       % if ip.name_snake == "rv_timer":
         , 0
       % endif
-        ),
-      kDifOk);
+        ));
   }
 
   class IrqAcknowledgeTest : public ${ip.name_camel}Test {};
 
   TEST_F(IrqAcknowledgeTest, NullArgs) {
-    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_acknowledge(
         nullptr, 
       % if ip.irqs[0].width > 1:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0));
       % else:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}));
       % endif
-      kDifBadArg);
   }
 
   TEST_F(IrqAcknowledgeTest, BadIrq) {
-    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_acknowledge(
         nullptr, 
-        static_cast<dif_${ip.name_snake}_irq_t>(32)),
-      kDifBadArg);
+        static_cast<dif_${ip.name_snake}_irq_t>(32)));
   }
 
   TEST_F(IrqAcknowledgeTest, Success) {
@@ -330,14 +309,13 @@ namespace {
       {{${ip.name_upper}_INTR_STATE_${ip.irqs[0].name_upper}_BIT, true}});
     % endif
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_acknowledge(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0));
       % else:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}));
       % endif
-      kDifOk);
 
   % if len(ip.irqs) > 1 or ip.irqs[0].width > 1:
     // Clear the last IRQ state.
@@ -353,35 +331,32 @@ namespace {
         {{${ip.name_upper}_INTR_STATE_${ip.irqs[-1].name_upper}_BIT, true}});
       % endif
     % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_acknowledge(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_acknowledge(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}${ip.irqs[0].width - 1}),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}${ip.irqs[0].width - 1}));
       % else:
-        kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}),
+        kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}));
       % endif
-      kDifOk);
   % endif
   }
 
   class IrqForceTest : public ${ip.name_camel}Test {};
 
   TEST_F(IrqForceTest, NullArgs) {
-    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_force(
         nullptr, 
       % if ip.irqs[0].width > 1:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0));
       % else:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}));
       % endif
-      kDifBadArg);
   }
 
   TEST_F(IrqForceTest, BadIrq) {
-    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_force(
         nullptr, 
-        static_cast<dif_${ip.name_snake}_irq_t>(32)),
-      kDifBadArg);
+        static_cast<dif_${ip.name_snake}_irq_t>(32)));
   }
 
   TEST_F(IrqForceTest, Success) {
@@ -397,14 +372,13 @@ namespace {
       {{${ip.name_upper}_INTR_TEST_${ip.irqs[0].name_upper}_BIT, true}});
     % endif
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_force(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0));
       % else:
-        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}),
+        kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}));
       % endif
-      kDifOk);
 
   % if len(ip.irqs) > 1 or ip.irqs[0].width > 1:
     // Force last IRQ.
@@ -420,14 +394,13 @@ namespace {
         {{${ip.name_upper}_INTR_TEST_${ip.irqs[-1].name_upper}_BIT, true}});
       % endif
     % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_force(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_force(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
-        kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}${ip.irqs[0].width - 1}),
+        kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}${ip.irqs[0].width - 1}));
       % else:
-        kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}),
+        kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel}));
       % endif
-      kDifOk);
   % endif
   }
 
@@ -437,45 +410,41 @@ namespace {
   TEST_F(IrqGetEnabledTest, NullArgs) {
     dif_toggle_t irq_state;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_enabled(
         nullptr, 
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        &irq_state),
-      kDifBadArg);
+        &irq_state));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_, 
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_enabled(
         nullptr, 
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
   }
 
   TEST_F(IrqGetEnabledTest, BadIrq) {
     dif_toggle_t irq_state;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_, 
         static_cast<dif_${ip.name_snake}_irq_t>(32),
-        &irq_state),
-      kDifBadArg);
+        &irq_state));
   }
 
   TEST_F(IrqGetEnabledTest, Success) {
@@ -494,15 +463,14 @@ namespace {
       {{${ip.name_upper}_INTR_ENABLE_${ip.irqs[0].name_upper}_BIT, true}});
     % endif
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        &irq_state),
-      kDifOk);
+        &irq_state));
     EXPECT_EQ(irq_state, kDifToggleEnabled);
 
   % if len(ip.irqs) > 1 or ip.irqs[0].width > 1:
@@ -520,15 +488,14 @@ namespace {
         {{${ip.name_upper}_INTR_ENABLE_${ip.irqs[-1].name_upper}_BIT, false}});
       % endif
     % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_get_enabled(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_get_enabled(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}${ip.irqs[0].width - 1},
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel},
       % endif
-        &irq_state),
-      kDifOk);
+        &irq_state));
     EXPECT_EQ(irq_state, kDifToggleDisabled);
   % endif
   }
@@ -538,25 +505,23 @@ namespace {
   TEST_F(IrqSetEnabledTest, NullArgs) {
     dif_toggle_t irq_state = kDifToggleEnabled;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_set_enabled(
         nullptr, 
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        irq_state),
-      kDifBadArg);
+        irq_state));
   }
 
   TEST_F(IrqSetEnabledTest, BadIrq) {
     dif_toggle_t irq_state = kDifToggleEnabled;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_set_enabled(
         &${ip.name_snake}_, 
         static_cast<dif_${ip.name_snake}_irq_t>(32),
-        irq_state),
-      kDifBadArg);
+        irq_state));
   }
 
   TEST_F(IrqSetEnabledTest, Success) {
@@ -575,15 +540,14 @@ namespace {
       {{${ip.name_upper}_INTR_ENABLE_${ip.irqs[0].name_upper}_BIT, 0x1, true}});
     % endif
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_set_enabled(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}0,
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel},
       % endif
-        irq_state),
-      kDifOk);
+        irq_state));
 
   % if len(ip.irqs) > 1 or ip.irqs[0].width > 1:
     // Disable last IRQ.
@@ -600,15 +564,14 @@ namespace {
         {{${ip.name_upper}_INTR_ENABLE_${ip.irqs[-1].name_upper}_BIT, 0x1, false}});
       % endif
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_set_enabled(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_set_enabled(
         &${ip.name_snake}_,
       % if ip.irqs[0].width > 1:
         kDif${ip.name_camel}Irq${ip.irqs[0].name_camel}${ip.irqs[0].width - 1},
       % else:
         kDif${ip.name_camel}Irq${ip.irqs[-1].name_camel},
       % endif
-        irq_state),
-      kDifOk);
+        irq_state));
   % endif
   }
 
@@ -617,21 +580,19 @@ namespace {
   TEST_F(IrqDisableAllTest, NullArgs) {
     dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_disable_all(
         nullptr, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifBadArg);
+        &irq_snapshot));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_disable_all(
         nullptr, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
   }
 
   TEST_F(IrqDisableAllTest, SuccessNoSnapshot) {
@@ -640,13 +601,12 @@ namespace {
   % else:
     EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_disable_all(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        nullptr),
-      kDifOk);
+        nullptr));
   }
 
   TEST_F(IrqDisableAllTest, SuccessSnapshotAllDisabled) {
@@ -659,13 +619,12 @@ namespace {
     EXPECT_READ32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
     EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_disable_all(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifOk);
+        &irq_snapshot));
     EXPECT_EQ(irq_snapshot, 0);
   }
 
@@ -681,13 +640,12 @@ namespace {
                   std::numeric_limits<uint32_t>::max());
     EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_disable_all(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_disable_all(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifOk);
+        &irq_snapshot));
     EXPECT_EQ(irq_snapshot, std::numeric_limits<uint32_t>::max());
   }
 
@@ -696,29 +654,26 @@ namespace {
   TEST_F(IrqRestoreAllTest, NullArgs) {
     dif_${ip.name_snake}_irq_enable_snapshot_t irq_snapshot = 0;
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_restore_all(
         nullptr, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifBadArg);
+        &irq_snapshot));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_restore_all(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
 
-    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+    EXPECT_DIF_BADARG(dif_${ip.name_snake}_irq_restore_all(
         nullptr, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        nullptr),
-      kDifBadArg);
+        nullptr));
   }
 
   TEST_F(IrqRestoreAllTest, SuccessAllEnabled) {
@@ -731,13 +686,12 @@ namespace {
     EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 
   % endif
       std::numeric_limits<uint32_t>::max());
-    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_restore_all(
         &${ip.name_snake}_, 
       % if ip.name_snake == "rv_timer":
         0,
       % endif
-        &irq_snapshot),
-      kDifOk);
+        &irq_snapshot));
   }
 
   TEST_F(IrqRestoreAllTest, SuccessAllDisabled) {
@@ -748,13 +702,12 @@ namespace {
   % else:
     EXPECT_WRITE32(${ip.name_upper}_INTR_ENABLE_REG_OFFSET, 0);
   % endif
-    EXPECT_EQ(dif_${ip.name_snake}_irq_restore_all(
+    EXPECT_DIF_OK(dif_${ip.name_snake}_irq_restore_all(
         &${ip.name_snake}_, 
   % if ip.name_snake == "rv_timer":
         0,
   % endif
-        &irq_snapshot),
-      kDifOk);
+        &irq_snapshot));
   }
 % endif
 


### PR DESCRIPTION
This updates the autogen'd DIFs to make use of the `EXPECT_DIF_*` macros
that were recently added.

Signed-off-by: Timothy Trippel <ttrippel@google.com>