### PR TITLE
[sram_ctrl] Timing optimizations

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -163,8 +163,8 @@ module sram_ctrl
   assign hw2reg.status.escalated.de = escalate;
 
   // SEC_CM: KEY.LOCAL_ESC
-  // Aggregate external and internal escalation sources. This is used on countermeasures further
-  // below (key reset, transaction blocking and scrambling nonce reversal).
+  // Aggregate external and internal escalation sources.
+  // This is used on countermeasures further below (key reset and transaction blocking).
   logic local_esc;
   assign local_esc = escalate                   ||
                      init_error                 ||

--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -405,7 +405,8 @@ module sram_ctrl
   );
 
   // Interposing mux logic for initialization with pseudo random data.
-  assign sram_req        = tlul_req | init_req;
+  // TODO: use tlul_lc_gate for local_esc gating instead.
+  assign sram_req        = tlul_req & ~local_esc | init_req;
   assign tlul_gnt        = sram_gnt & ~init_req & ~local_esc;
   assign sram_we         = tlul_we | init_req;
   assign sram_intg_error = local_esc & ~init_req;

--- a/hw/ip/sram_ctrl/sram_ctrl.core
+++ b/hw/ip/sram_ctrl/sram_ctrl.core
@@ -65,3 +65,12 @@ targets:
         mode: lint-only
         verilator_options:
           - "-Wall"
+
+  syn:
+    <<: *default_target
+    # TODO: set default to DC once
+    # this option is available
+    # olofk/edalize#89
+    default_tool: icarus
+    parameters:
+      - SYNTHESIS=true

--- a/hw/ip/sram_ctrl/syn/constraints.sdc
+++ b/hw/ip/sram_ctrl/syn/constraints.sdc
@@ -1,0 +1,63 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Generic constraints file for simple testsynthesis flow
+
+# note that we do not fix hold timing in this flow
+set SETUP_CLOCK_UNCERTAINTY 0.5
+
+#####################
+# main clock        #
+#####################
+set MAIN_CLK_PIN clk_i
+set MAIN_RST_PIN rst_ni
+# overconstrain to 125 MHz
+set MAIN_TCK  8.0
+set_ideal_network ${MAIN_CLK_PIN}
+set_ideal_network ${MAIN_RST_PIN}
+set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} ${MAIN_CLK_PIN}
+
+# other timing constraint in ns
+set IN_DEL    7.0
+set OUT_DEL   0.0
+set DELAY     ${MAIN_TCK}
+
+create_clock ${MAIN_CLK_PIN} -period ${MAIN_TCK}
+
+# in to out
+set_max_delay ${DELAY} -from [all_inputs] -to [all_outputs]
+# in to reg / reg to out
+set_input_delay ${IN_DEL} [remove_from_collection [all_inputs] {${MAIN_CLK_PIN}}] -clock ${MAIN_CLK_PIN}
+set_output_delay ${OUT_DEL}  [all_outputs] -clock ${MAIN_CLK_PIN}
+
+#####################
+# otp clock        #
+#####################
+set OTP_CLK_PIN clk_otp_i
+set OTP_RST_PIN rst_otp_ni
+# overconstrain to 125 MHz
+set OTP_TCK  8.0
+set_ideal_network ${OTP_CLK_PIN}
+set_ideal_network ${OTP_RST_PIN}
+set_clock_uncertainty ${SETUP_CLOCK_UNCERTAINTY} ${OTP_CLK_PIN}
+
+create_clock ${OTP_CLK_PIN} -period ${OTP_TCK}
+
+#####################
+# I/O drive/load    #
+#####################
+
+# attach load and drivers to IOs to get a more realistic estimate
+set_driving_cell  -no_design_rule -lib_cell ${DRIVING_CELL} -pin ${DRIVING_CELL_PIN} [all_inputs]
+set_load [load_of ${LOAD_CELL_LIB}/${LOAD_CELL}/${LOAD_CELL_PIN}] [all_outputs]
+
+# set a nonzero critical range to be able to spot the violating paths better
+# in the report
+set_critical_range 0.5 ${DUT}
+
+#####################
+# Size Only Cells   #
+#####################
+
+set_size_only -all_instances [get_cells -h *u_size_only*] true

--- a/hw/ip/sram_ctrl/syn/post_elab_gtech.tcl
+++ b/hw/ip/sram_ctrl/syn/post_elab_gtech.tcl
@@ -1,0 +1,9 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Post elab script, used in GTECH runs to modify the unmapped netlist before
+# writing it out.
+
+# Remove generic views of ram macros
+remove_design prim_generic_ram_1p_Width*

--- a/hw/ip/sram_ctrl/syn/sram_ctrl_gtech_syn_cfg.hjson
+++ b/hw/ip/sram_ctrl/syn/sram_ctrl_gtech_syn_cfg.hjson
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Top level dut name (sv module).
+  name: sram_ctrl
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:ip:{name}:0.1
+
+  import_cfgs: [// Project wide common GTECH synthesis config file
+                "{proj_root}/hw/syn/tools/dvsim/common_gtech_syn_cfg.hjson"]
+
+  overrides: [
+    { // Deletes black-boxed hierarchies before writing out the unmapped netlist
+      name: post_elab_script
+      value: "{proj_root}/hw/ip/{name}/syn/post_elab_gtech.tcl"
+    }
+  ]
+}

--- a/hw/ip/sram_ctrl/syn/sram_ctrl_syn_cfg.hjson
+++ b/hw/ip/sram_ctrl/syn/sram_ctrl_syn_cfg.hjson
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Top level dut name (sv module).
+  name: sram_ctrl
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:ip:{name}:0.1
+
+  import_cfgs: [// Project wide common synthesis config file
+                "{proj_root}/hw/syn/tools/dvsim/common_syn_cfg.hjson"]
+
+  // Timing constraints for this module
+  sdc_file: "{proj_root}/hw/ip/{name}/syn/constraints.sdc"
+
+  // This is not needed for this module
+  foundry_sdc_file: ""
+}
+


### PR DESCRIPTION
The first commit retimes the address mux in `sram_ctrl` so that address scrambling always occurs first, before muxing between the latched write address and the incoming scrambled address.

The second commit removes error qualification on the data and address signals in the tlul adapter, so that only the request signals carry the ECC check delay.

The third commit adds a blocklevel synthesis environment for `sram_ctrl` so that we can run a few experiments (runs are still pending - I will report back).