### PR TITLE
[dif/spi_host] fix style and update checklist

### DIFF
--- a/hw/ip/spi_host/data/spi_host.prj.hjson
+++ b/hw/ip/spi_host/data/spi_host.prj.hjson
@@ -14,7 +14,7 @@
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V1",
-        dif_stage:          "S0",
+        dif_stage:          "S2",
       }
     ]
 }

--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -95,12 +95,19 @@ dif_result_t dif_spi_host_configure(const dif_spi_host_t *spi_host,
   return kDifOk;
 }
 
-void dif_spi_host_output(const dif_spi_host_t *spi_host, bool enable) {
+dif_result_t dif_spi_host_output_set_enabled(const dif_spi_host_t *spi_host,
+                                             bool enabled) {
+  if (spi_host == NULL) {
+    return kDifBadArg;
+  }
+
   uint32_t reg =
       mmio_region_read32(spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET);
   mmio_region_write32(
       spi_host->base_addr, SPI_HOST_CONTROL_REG_OFFSET,
-      bitfield_bit32_write(reg, SPI_HOST_CONTROL_OUTPUT_EN_BIT, enable));
+      bitfield_bit32_write(reg, SPI_HOST_CONTROL_OUTPUT_EN_BIT, enabled));
+
+  return kDifOk;
 }
 
 static void wait_ready(const dif_spi_host_t *spi_host) {

--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -24,8 +24,8 @@ void spi_host_fifo_write_alias(const dif_spi_host_t *spi_host, const void *src,
 
 OT_WEAK
 OT_ALIAS("dif_spi_host_fifo_read")
-void spi_host_fifo_read_alias(const dif_spi_host_t *spi_host, void *dst,
-                              uint16_t len);
+dif_result_t spi_host_fifo_read_alias(const dif_spi_host_t *spi_host, void *dst,
+                                      uint16_t len);
 
 static void spi_host_reset(const dif_spi_host_t *spi_host) {
   // Set the software reset request bit.
@@ -206,8 +206,12 @@ static uint32_t dequeue_word(queue_t *queue) {
   return val;
 }
 
-void dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
-                            uint16_t len) {
+dif_result_t dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
+                                    uint16_t len) {
+  if (spi_host == NULL || (dst == NULL && len > 0)) {
+    return kDifBadArg;
+  }
+
   uintptr_t ptr = (uintptr_t)dst;
   // We always have to read from the RXFIFO as a 32-bit word.  We use a
   // two-word queue to handle destination and length mis-alignments.
@@ -251,6 +255,8 @@ void dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
     ptr += 1;
     len -= 1;
   }
+
+  return kDifOk;
 }
 
 static void write_command_reg(const dif_spi_host_t *spi_host, uint16_t length,

--- a/sw/device/lib/dif/dif_spi_host.c
+++ b/sw/device/lib/dif/dif_spi_host.c
@@ -19,8 +19,8 @@
 // the FIFO functions and the overall transaction management functions.
 OT_WEAK
 OT_ALIAS("dif_spi_host_fifo_write")
-void spi_host_fifo_write_alias(const dif_spi_host_t *spi_host, const void *src,
-                               uint16_t len);
+dif_result_t spi_host_fifo_write_alias(const dif_spi_host_t *spi_host,
+                                       const void *src, uint16_t len);
 
 OT_WEAK
 OT_ALIAS("dif_spi_host_fifo_read")
@@ -144,9 +144,12 @@ static inline void tx_fifo_write32(const dif_spi_host_t *spi_host,
   mmio_region_write32(spi_host->base_addr, SPI_HOST_TXDATA_REG_OFFSET, val);
 }
 
-void dif_spi_host_fifo_write(const dif_spi_host_t *spi_host, const void *src,
-                             uint16_t len) {
+dif_result_t dif_spi_host_fifo_write(const dif_spi_host_t *spi_host,
+                                     const void *src, uint16_t len) {
   uintptr_t ptr = (uintptr_t)src;
+  if (spi_host == NULL || (src == NULL && len > 0)) {
+    return kDifBadArg;
+  }
 
   // If the pointer starts mis-aligned, write until we are aligned.
   while (misalignment32_of(ptr) && len > 0) {
@@ -168,6 +171,8 @@ void dif_spi_host_fifo_write(const dif_spi_host_t *spi_host, const void *src,
     ptr += 1;
     len -= 1;
   }
+
+  return kDifOk;
 }
 
 typedef struct queue {

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -168,12 +168,15 @@ dif_result_t dif_spi_host_configure(const dif_spi_host_t *spi_host,
                                     dif_spi_host_config_t config);
 
 /**
- * Enable or disable SPI host output buffers.
+ * Sets the enablement of the SPI host output buffers.
  *
  * @param spi_host A SPI Host handle.
- * @param enable Enable or disable the output buffers.
+ * @param enabled Enable or disable the output buffers.
+ * @return The result of the operation.
  */
-void dif_spi_host_output(const dif_spi_host_t *spi_host, bool enable);
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_output_set_enabled(const dif_spi_host_t *spi_host,
+                                             bool enabled);
 
 /**
  * Write to the SPI Host transmit FIFO.

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -140,20 +140,6 @@ typedef struct dif_spi_host_segment {
 } dif_spi_host_segment_t;
 
 /**
- * Creates a new handle for SPI Host.
- *
- * This function does not actuate the hardware.
- *
- * @param base_addr The MMIO base address of the IP.
- * @param params Hardware instantiation parameters. (optional, may remove)
- * @param[out] spi_host Out param for the initialized handle.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_host_init(mmio_region_t base_addr,
-                               dif_spi_host_t *spi_host);
-
-/**
  * Configures SPI Host with runtime information.
  *
  * This function should only need to be called once for the lifetime of

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -181,9 +181,11 @@ void dif_spi_host_output(const dif_spi_host_t *spi_host, bool enable);
  * @param spi_host A SPI Host handle.
  * @param src A pointer to the buffer to transmit.
  * @param len The length of the transmit buffer.
+ * @return The result of the operation.
  */
-void dif_spi_host_fifo_write(const dif_spi_host_t *spi_host, const void *src,
-                             uint16_t len);
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_fifo_write(const dif_spi_host_t *spi_host,
+                                     const void *src, uint16_t len);
 
 /**
  * Read from the SPI Host receive FIFO.

--- a/sw/device/lib/dif/dif_spi_host.h
+++ b/sw/device/lib/dif/dif_spi_host.h
@@ -74,7 +74,6 @@ typedef enum dif_spi_host_direction {
 
 /**
  * Segment types for segments in a transaction.
- *
  */
 typedef enum dif_spi_host_segment_type {
   /** The segment is a SPI opcode. */
@@ -192,9 +191,11 @@ void dif_spi_host_fifo_write(const dif_spi_host_t *spi_host, const void *src,
  * @param spi_host A SPI Host handle.
  * @param dst A pointer to the buffer to receive the data.
  * @param len The length of the receive buffer.
+ * @return The result of the operation.
  */
-void dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
-                            uint16_t len);
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_host_fifo_read(const dif_spi_host_t *spi_host, void *dst,
+                                    uint16_t len);
 
 /**
  * Begins a SPI Host transaction.

--- a/sw/device/lib/dif/dif_spi_host.md
+++ b/sw/device/lib/dif/dif_spi_host.md
@@ -11,9 +11,9 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | In Progress |
-Implementation | [DIF_USED_IN_TREE][] | In Progress |
-Tests          | [DIF_TEST_SMOKE][]   | Not Started |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
+Tests          | [DIF_TEST_SMOKE][]   | Done        |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
 [DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
@@ -24,8 +24,8 @@ Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
@@ -39,7 +39,7 @@ Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
 Documentation  | [DIF_DOC_HW][]                   | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
-Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |

--- a/sw/device/lib/dif/dif_spi_host_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_host_unittest.cc
@@ -140,6 +140,11 @@ TEST_F(ConfigTest, Default) {
   EXPECT_DIF_OK(dif_spi_host_configure(&spi_host_, config_));
 }
 
+// Checks the arguments to the output-enablement DIF are validated.
+TEST_F(ConfigTest, OutputSetEnabledNullHandle) {
+  EXPECT_DIF_BADARG(dif_spi_host_output_set_enabled(nullptr, true));
+}
+
 // Checks manipulation of the output enable bit.
 TEST_F(ConfigTest, OutputEnable) {
   EXPECT_READ32(SPI_HOST_CONTROL_REG_OFFSET, 0);
@@ -147,7 +152,7 @@ TEST_F(ConfigTest, OutputEnable) {
                  {
                      {SPI_HOST_CONTROL_OUTPUT_EN_BIT, true},
                  });
-  dif_spi_host_output(&spi_host_, true);
+  EXPECT_DIF_OK(dif_spi_host_output_set_enabled(&spi_host_, true));
 }
 
 // Checks that the clock divider gets calculated correctly.

--- a/sw/device/tests/spi_host_smoketest.c
+++ b/sw/device/tests/spi_host_smoketest.c
@@ -76,7 +76,7 @@ bool test_main(void) {
                        .peripheral_clock_freq_hz = kClockFreqPeripheralHz,
                    }),
                "SPI_HOST config failed!");
-  dif_spi_host_output(&spi_host, true);
+  CHECK_DIF_OK(dif_spi_host_output_set_enabled(&spi_host, true));
 
   read_sfdp(&spi_host);
   return true;


### PR DESCRIPTION
The SPI Host DIF was mostly complete, except a few of the DIFs did not comply with the return code / parameter validation requirements of the style guide. This fixes said DIFs to bring them into compliance.

Additionally, the handle initialization DIF was declared twice (once in the autogenerated header and once in the manually implemented one). This removes the duplicated declaration. 

Lastly, this updates the DIF checklist and marks the DIF as S2, since it is complete.