### PR TITLE
[CDC] Add 2FF synchronizer to the user assets

### DIFF
--- a/hw/cdc/tools/verixcdc/run-cdc.tcl
+++ b/hw/cdc/tools/verixcdc/run-cdc.tcl
@@ -152,6 +152,7 @@ set modules {
   entropy_src
   aes
   rom_ctrl
+  edn
 }
 
 #########################
@@ -169,7 +170,27 @@ report_policy -verbose -skip_empty_summary_status -compat -output vcdc.rpt ALL
 file mkdir ../REPORT/
 
 foreach mod $modules {
-  report_policy -verbose -skip_empty_summary_status -compat -output ../REPORT/vcdc.$mod.rpt -module $mod {NEW TO_BE_FIXED DEFERRED}
+  # Find unique modules
+  set umods [get_all_modules $mod]
+  set umods_length [llength $umods]
+
+  puts "Generating Policy Reports for $mod ( $umods ) ..."
+
+  if {$umods_length == 1} {
+    # Just report as original module
+    report_policy -verbose -skip_empty_summary_status -compat   \
+      -output ../REPORT/vcdc.$mod.rpt -module [lindex $umods 0] \
+      {NEW TO_BE_FIXED DEFERRED}
+  } else {
+    # Report file name is increamental index not uniquified module name
+    set idx 0
+    foreach umod $umods {
+      report_policy -verbose -skip_empty_summary_status -compat \
+        -output ../REPORT/vcdc.$mod_$idx.rpt -module $umod      \
+        {NEW TO_BE_FIXED DEFERRED}
+      incr idx 1
+    }
+  }
 }
 
 # Report waived in a separate file

--- a/hw/cdc/tools/verixcdc/run-cdc.tcl
+++ b/hw/cdc/tools/verixcdc/run-cdc.tcl
@@ -75,6 +75,33 @@ if {$PARAMS != ""} {
   elaborate $DUT
 }
 
+#################################
+## Define Common Synchronizers ##
+#################################
+
+# Glitch Free Mux
+# WARNING!!! prim_clock_mux2 is not a glitch free mux
+#set_user_glitch_free_muxes -name opentitan_clock_mux prim_generic_clock_mux2
+#set_user_glitch_free_muxes -name opentitan_glitchfree_mux prim_generic_clock_glitchfree_mux2
+
+# 2FF synchronizer.
+# TODO: Process dependent module name later
+set prim_2ff_modules {}
+
+# Find every derivated modules from 2FF synchronizer
+foreach mod [get_all_modules prim_flop_2sync] {
+  lappend prim_2ff_modules $mod
+  puts "Adding to list prim_2ff_modules: $mod"
+}
+
+set_user_cntl_synchronizer -name opentitan_2ff $prim_2ff_modules
+
+# Pulse synchronizer
+
+# Req/Ack synchronizer
+
+
+
 #########################
 ## Apply Constraints   ##
 #########################
@@ -97,6 +124,7 @@ if {$ENV_FILE != ""} {
 #########################
 
 analyze_intent
+
 verify_cdc
 
 #########################

--- a/hw/top_earlgrey/cdc/cdc_waivers.tcl
+++ b/hw/top_earlgrey/cdc/cdc_waivers.tcl
@@ -26,3 +26,4 @@ foreach mod $modules {
 }
 
 # Common Waivers
+


### PR DESCRIPTION
Define `prim_generic_flop_2sync` as a user synchronizer to waive most of W_CNTL violations.