### PR TITLE
[clkmgr] Add missing items from d2s

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -173,6 +173,9 @@
     { name: "MEAS.CLK.BKGN_CHK",
       desc: "Background check for clock frequency."
     },
+    { name: "MEAS.CONFIG.SHADOW",
+      desc: "Measurement configurations are shadowed."
+    }
     { name: "IDLE.INTERSIG.MUBI",
       desc: "Idle inputs are multibit encoded."
     }

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -155,6 +155,7 @@ from topgen.lib import Name
   clkmgr_reg_pkg::clkmgr_hw2reg_t hw2reg;
 
   // SEC_CM: MEAS.CONFIG.REGWEN
+  // SEC_CM: MEAS.CONFIG.SHADOW
   // SEC_CM: CLK_CTRL.CONFIG.REGWEN
   clkmgr_reg_top u_reg (
     .clk_i,

--- a/hw/ip/clkmgr/doc/_index.md
+++ b/hw/ip/clkmgr/doc/_index.md
@@ -154,6 +154,10 @@ The following is a high level block diagram of the clock manager.
 
 ![Clock Manager Block Diagram](clkmgr_block_diagram.svg)
 
+## Hardware Interfaces
+
+{{< incGenFromIpDesc "/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson" "hwcfg" >}}
+
 ## Design Details
 
 ### Root Clock Gating and Interface with Power Manager

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -171,6 +171,9 @@
     { name: "MEAS.CLK.BKGN_CHK",
       desc: "Background check for clock frequency."
     },
+    { name: "MEAS.CONFIG.SHADOW",
+      desc: "Measurement configurations are shadowed."
+    }
     { name: "IDLE.INTERSIG.MUBI",
       desc: "Idle inputs are multibit encoded."
     }

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr_sec_cm_testplan.hjson
@@ -42,6 +42,12 @@
       tests: ["clkmgr_frequency"]
     }
     {
+      name: sec_cm_meas_config_shadow
+      desc: "Verify the countermeasure(s) MEAS.CONFIG.SHADOW."
+      milestone: V2S
+      tests: [""]
+    }
+    {
       name: sec_cm_idle_intersig_mubi
       desc: "Verify the countermeasure(s) IDLE.INTERSIG.MUBI."
       milestone: V2S

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -176,6 +176,7 @@
   clkmgr_reg_pkg::clkmgr_hw2reg_t hw2reg;
 
   // SEC_CM: MEAS.CONFIG.REGWEN
+  // SEC_CM: MEAS.CONFIG.SHADOW
   // SEC_CM: CLK_CTRL.CONFIG.REGWEN
   clkmgr_reg_top u_reg (
     .clk_i,


### PR DESCRIPTION
- shadow registers were somehow missed
- documentation needs an update to show countermeasures

Signed-off-by: Timothy Chen <timothytim@google.com>