### PR TITLE
[dv/otp] Fix sec_cm testplan typo

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_sec_cm_testplan.hjson
@@ -285,7 +285,7 @@
       name: sec_cm_macro_mem_integrity
       desc: "Verify the countermeasure(s) MACRO.MEM.INTEGRITY."
       milestone: V2S
-      tests: ["otp_ctrl_macro_err"]
+      tests: ["otp_ctrl_macro_errs"]
     }
     {
       name: sec_cm_macro_mem_cm


### PR DESCRIPTION
Fix a test name in sec_cm testplan that causes unmatched tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>