### PR TITLE
[dvsim] Introduce a compile-time randomization mechanism using a randomly picked seed

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -67,7 +67,13 @@
                "+define+UVM_REG_DATA_WIDTH={tl_dw}",
                "+define+UVM_REG_BYTENABLE_WIDTH={tl_dbw}",
                "+define+SIMULATION",
-               "+define+DUT_HIER={dut_instance}"]
+               "+define+DUT_HIER={dut_instance}",
+               // Introduce compile-time randomization. Use `BUILD_SEED in Verilog sources to set
+               // constants that have no side-effects, such as addition or deletion of logic. Useful
+               // to mutate fixed device values such as secret keys, identification constants, etc.
+               // across successive simulation runs. Note that this will always be a 32-bit unsigned
+               // value.
+               "+define+BUILD_SEED={seed}"]
 
   run_opts: ["+UVM_NO_RELNOTES",
              "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]

--- a/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
+++ b/hw/ip/rv_dm/dv/env/rv_dm_env_pkg.sv
@@ -27,14 +27,7 @@ package rv_dm_env_pkg;
 
   // parameters
   parameter uint NUM_HARTS = rv_dm_reg_pkg::NrHarts;
-
-`ifndef RV_DM_JTAG_IDCODE
-`define RV_DM_JTAG_IDCODE 32'h0000_0001 // Match the RTL default.
-`endif
-
-  parameter uint RV_DM_JTAG_IDCODE = `RV_DM_JTAG_IDCODE;
-
-`undef RV_DM_JTAG_IDCODE
+  parameter uint RV_DM_JTAG_IDCODE = `BUILD_SEED;
 
   // Design uses 5 bits for IR.
   parameter uint JTAG_IR_LEN = 5;

--- a/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
+++ b/hw/ip/rv_dm/dv/rv_dm_sim_cfg.hjson
@@ -39,9 +39,6 @@
   // Default iterations for all tests - each test entry can override this.
   reseed: 50
 
-  // TODO: Set JTAG ID code value to a build-time random value.
-  build_opts: ["+define+RV_DM_JTAG_IDCODE=12345678"]
-
   overrides: [
     {
       // This sets the width of UVM data (UVM_REG_DATA_WIDTH) to sufficiently large value. RV_DM DV

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -296,8 +296,13 @@ class CompileSim(Deploy):
     cmds_list_vars = ["pre_build_cmds", "post_build_cmds"]
     weight = 5
 
+    # A static, randomized seed that is fixed across all builds.
+    # This value can be overridden by --build-seed switch.
+    seed = random.getrandbits(32)
+
     def __init__(self, build_mode, sim_cfg):
         self.build_mode_obj = build_mode
+        self.seed = CompileSim.seed
         super().__init__(sim_cfg)
 
     def _define_attrs(self):
@@ -351,8 +356,13 @@ class CompileOneShot(Deploy):
 
     target = "build"
 
+    # A static, randomized seed that is fixed across all builds.
+    # This value can be overridden by --build-seed switch.
+    seed = random.getrandbits(32)
+
     def __init__(self, build_mode, sim_cfg):
         self.build_mode_obj = build_mode
+        self.seed = CompileOneShot.seed
         super().__init__(sim_cfg)
 
     def _define_attrs(self):

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -618,6 +618,10 @@ class SimCfg(FlowCfg):
 
         results_str += f"### Simulator: {self.tool.upper()}\n"
 
+        # Print the build seed used for clarity.
+        if not self.run_only:
+            results_str += f"### Build seed: {CompileSim.seed}\n"
+
         if not results.table:
             results_str += "No results to display.\n"
 


### PR DESCRIPTION
The first commit makes a minor enhancement to `dvsim`, introducing `seed` to CompileSim and CompileOneShot classes. This seed value is picked randomly, or set via command line using the `--build-seed` switch. 

This seed value can thus be referenced in `build_opts` in the simulation configuration `hjson` file using the special substvar `{seed}`. 

The second commit test-drives this approach in RV_DM testbench, where the JTAG IDCODE is one such design constant that can be mutated without any side-effects. It sets a global pre-processor macro `BUILD_SEED` which can be used in any Verilog source as the source compile-time randomness. 

If different seed values are sought at compile-time, the `BUILD_SEED` macro can be mutated further (PRNG?), to derive secondary random constants. This will make the compilation deterministically reproducible. 
