### PR TITLE
[otbn, dv] Added functions to escalate errros in ISS model

### DIFF
--- a/hw/ip/otbn/dv/model/iss_wrapper.cc
+++ b/hw/ip/otbn/dv/model/iss_wrapper.cc
@@ -504,8 +504,10 @@ void ISSWrapper::reset(bool gen_trace) {
   mirrored_.status = 0;
 }
 
-void ISSWrapper::send_lc_escalation() {
-  run_command("send_lc_escalation\n", nullptr);
+void ISSWrapper::send_err_escalation(uint32_t err_val) {
+  std::ostringstream oss;
+  oss << "send_err_escalation " << std::hex << "0x" << err_val << "\n";
+  run_command(oss.str(), nullptr);
 }
 
 void ISSWrapper::get_regs(std::array<uint32_t, 32> *gprs,

--- a/hw/ip/otbn/dv/model/iss_wrapper.h
+++ b/hw/ip/otbn/dv/model/iss_wrapper.h
@@ -137,8 +137,8 @@ struct ISSWrapper {
   // mirrored registers to their initial states.
   void reset(bool gen_trace);
 
-  // Send a lifecycle controller escalation signal
-  void send_lc_escalation();
+  // Send an error escalation
+  void send_err_escalation(uint32_t err_val);
 
   const MirroredRegs &get_mirrored() const { return mirrored_; }
 

--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -514,15 +514,15 @@ void OtbnModel::reset() {
     iss->reset(has_rtl());
 }
 
-int OtbnModel::send_lc_escalation() {
+int OtbnModel::send_err_escalation(svBitVecVal *err_val /* bit [31:0] */) {
   ISSWrapper *iss = ensure_wrapper();
   if (!iss)
     return -1;
 
   try {
-    iss->send_lc_escalation();
+    iss->send_err_escalation(err_val[0]);
   } catch (const std::exception &err) {
-    std::cerr << "Error when sending LC escalation signal to ISS: "
+    std::cerr << "Error when sending error escalation signal to ISS: "
               << err.what() << "\n";
     return -1;
   }
@@ -884,7 +884,8 @@ int otbn_model_set_keymgr_value(OtbnModel *model, svLogicVecVal *key0,
   return model->set_keymgr_value(key0, key1, valid);
 }
 
-int otbn_model_send_lc_escalation(OtbnModel *model) {
+int otbn_model_send_err_escalation(OtbnModel *model,
+                                   svBitVecVal *err_val /* bit [31:0] */) {
   assert(model);
-  return model->send_lc_escalation();
+  return model->send_err_escalation(err_val);
 }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -101,9 +101,8 @@ class OtbnModel {
   // Flush any information in the model
   void reset();
 
-  // React to a lifecycle controller escalation signal. Returns 0 on
-  // success; -1 on failure.
-  int send_lc_escalation();
+  // Escalate errors. Returns 0 on success; -1 on failure.
+  int send_err_escalation(svBitVecVal *err_val /* bit [31:0] */);
 
   // Returns true if we have an ISS wrapper and it has the START_WIPE flag
   // asserted

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -111,9 +111,9 @@ void otbn_model_reset(OtbnModel *model);
 // Take loop warps from an OtbnMemUtil
 void otbn_take_loop_warps(OtbnModel *model, OtbnMemUtil *memutil);
 
-// React to a lifecycle controller escalation signal. Returns 0 on success or
-// -1 on failure.
-int otbn_model_send_lc_escalation(OtbnModel *model);
+// React to an error escalation. Returns 0 on success or -1 on failure.
+int otbn_model_send_err_escalation(OtbnModel *model,
+                                   svBitVecVal *err_val /* bit [31:0] */);
 }
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_MODEL_DPI_H_

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -58,5 +58,6 @@ import "DPI-C" function void otbn_model_reset(chandle model);
 
 import "DPI-C" function void otbn_take_loop_warps(chandle model, chandle memutil);
 
-import "DPI-C" function int otbn_model_send_lc_escalation(chandle model);
+
+import "DPI-C" function int otbn_model_send_err_escalation(chandle model, bit [31:0] err_val);
 `endif // SYNTHESIS

--- a/hw/ip/otbn/dv/otbnsim/sim/constants.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/constants.py
@@ -37,3 +37,4 @@ class ErrBits(IntEnum):
     ILLEGAL_BUS_ACCESS = 1 << 21
     LIFECYCLE_ESCALATION = 1 << 22
     FATAL_SOFTWARE = 1 << 23
+    MASK = (1 << 24) - 1

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -11,7 +11,6 @@ from .state import OTBNState, FsmState
 from .stats import ExecutionStats
 from .trace import Trace
 
-
 # A dictionary that defines a function of the form "address -> from -> to". If
 # PC is the current PC and cnt is the count for the innermost loop then
 # warps[PC][cnt] = new_cnt means that we should warp the current count to
@@ -302,7 +301,6 @@ class OTBNSim:
             # Also, set wipe_cycles to an invalid value to make really sure
             # we've left the wiping code.
             self.wipe_cycles = -1
-
         return (None, self._on_stall(verbose, fetch_next=False))
 
     def dump_data(self) -> bytes:
@@ -312,10 +310,6 @@ class OTBNSim:
         '''Print a trace of the current instruction'''
         changes_str = ', '.join([t.trace() for t in changes])
         print('{:08x} | {:45} | [{}]'.format(pc, disasm, changes_str))
-
-    def on_lc_escalation(self) -> None:
-        '''React to a lifecycle controller escalation signal'''
-        self.state.injected_err_bits |= ErrBits.LIFECYCLE_ESCALATION
 
     def on_otp_cdc_done(self) -> None:
         '''Signifies when the scrambling key request gets processed'''
@@ -335,3 +329,8 @@ class OTBNSim:
         if old_state in [FsmState.IDLE]:
             self.state.set_fsm_state(FsmState.MEM_SEC_WIPE)
             self.state.dmem_req_pending = True
+
+    def send_err_escalation(self, err_val: int) -> None:
+        '''React to an error escalation'''
+        assert err_val & ~ErrBits.MASK == 0
+        self.state.injected_err_bits |= err_val

--- a/hw/ip/otbn/dv/otbnsim/stepped.py
+++ b/hw/ip/otbn/dv/otbnsim/stepped.py
@@ -70,7 +70,7 @@ prefixed with "0x" if they are hexadecimal.
                          change of state (this is pure, but handled in Python
                          to simplify verification).
 
-    send_lc_escalation   React to lc_escalate_en_i going high
+    send_err_escalation  React to an injected error
 
 '''
 
@@ -405,9 +405,10 @@ def on_step_crc(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
     return None
 
 
-def on_send_lc_escalation(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
-    check_arg_count('send_lc_escalation', 0, args)
-    sim.on_lc_escalation()
+def on_send_err_escalation(sim: OTBNSim, args: List[str]) -> Optional[OTBNSim]:
+    check_arg_count('send_err_escalation', 1, args)
+    err_val = read_word('err_val', args[0], 32)
+    sim.send_err_escalation(err_val)
     return None
 
 
@@ -443,7 +444,7 @@ _HANDLERS = {
     'invalidate_dmem': on_invalidate_dmem,
     'set_keymgr_value': on_set_keymgr_value,
     'step_crc': on_step_crc,
-    'send_lc_escalation': on_send_lc_escalation
+    'send_err_escalation': on_send_err_escalation
 }
 
 

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -123,5 +123,17 @@ class otbn_common_vseq extends otbn_base_vseq;
     end
   endfunction: sec_cm_fi_ctrl_svas
 
+  virtual task sec_cm_inject_fault(sec_cm_base_if_proxy if_proxy);
+    fork
+      begin
+        if_proxy.inject_fault();
+      end
+      begin
+        bit [31:0] err_val = 32'd1 << 20;
+        `uvm_info(`gfn, "injecting fsm error into ISS", UVM_HIGH)
+        cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+      end
+    join
+  endtask : sec_cm_inject_fault
 
 endclass

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -83,8 +83,19 @@ interface otbn_model_if
     u_model.otbn_take_loop_warps(handle, memutil);
   endfunction
 
+  task automatic send_err_escalation(bit [31:0] err_val);
+    `uvm_info("otbn_model_if", "Escalating errors", UVM_HIGH)
+    force u_model.wakeup_iss = 1;
+    `DV_CHECK_FATAL(u_model.otbn_model_send_err_escalation(handle, err_val) == 0,
+                    "Failed to escalate errors", "otbn_model_if")
+    @(posedge clk_i or negedge rst_ni);
+    release u_model.wakeup_iss;
+  endtask: send_err_escalation
+
   // The err signal is asserted by the model if it fails to find the DUT or if it finds a mismatch
   // in results. It should never go high.
   `ASSERT(NoModelErrs, !err)
+
+
 
 endinterface


### PR DESCRIPTION
This commit adds a generic funnction to let the ISS model know that an
error is expected and makes sure the ISS move to locked state.

The commit also deletes lifecycle escalation specific function.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>