### PR TITLE
opentitantool: Rustfmt fix

### DIFF
--- a/sw/host/opentitanlib/src/transport/errors.rs
+++ b/sw/host/opentitanlib/src/transport/errors.rs
@@ -91,7 +91,9 @@ pub type Result<T> = anyhow::Result<T, TransportError>;
 #[macro_export]
 macro_rules! bail {
     ($err:expr $(,)?) => {
-        return Err($err.into());
+        {
+            return Err($err.into());
+        }
     };
 }
 


### PR DESCRIPTION
Rustfmt insisted on putting a semicolon after the `return` statement in the custom `bail!()`
macro.  However, having that semicolon caused the Rust compiler to emit a warning, when the macro
was used in an expression context (as in `match ... { _ => bail!(...), }`.  Adding an extra level
of curly brackets seems to satisfy both rustfmt and the Rust compiler.

Signed-off-by: Jes B. Klinke <jbk@chromium.org>
Change-Id: I6735dc3ad40ac943347ddb8dc55cb6148f10e43f