### PR TITLE
[sw/silicon_creator] Move exception handler into .shutdown section

### DIFF
--- a/sw/device/lib/testing/test_framework/ottf.ld
+++ b/sw/device/lib/testing/test_framework/ottf.ld
@@ -86,6 +86,12 @@ SECTIONS {
     *(.text)
     *(.text.*)
 
+    /**
+     * Some tests place functions into the .shutdown section.
+     */
+    *(.shutdown)
+    *(.shutdown.*)
+
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
   } > eflash

--- a/sw/device/silicon_creator/lib/irq_asm.S
+++ b/sw/device/silicon_creator/lib/irq_asm.S
@@ -7,12 +7,12 @@
 #include "flash_ctrl_regs.h"
 #include "rstmgr_regs.h"
 
-  // This code is in the .crt section since it is designed to be safe
-  // to run before the C runtime has been initialized.
+  // Place this code into the .shutdown section together with the other
+  // code that resets the chip.
   //
   // NOTE: The "ax" flag below is necessary to ensure that this section
   // is allocated executable space in ROM by the linker.
-  .section .crt, "ax"
+  .section .shutdown, "ax"
 
 /**
  * Exception handler that is safe to call before the C runtime has been


### PR DESCRIPTION
Move the assembly exception handler into the `.shutdown` section. The
`.shutdown` section is the last section in the executable part of the
ROM and is where the `shutdown_finalize` function is (which serves a
similar function).