### PR TITLE
[silicon_creator/mask_rom] fix bug in AST init asm

### DIFF
--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -172,9 +172,9 @@ _mask_rom_start_boot:
   csrc mie, t0
 
   // Check if AST initialization should be skipped.
-  li   t0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
-            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET + \
-            OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET)
+  li   a0, (TOP_EARLGREY_OTP_CTRL_CORE_BASE_ADDR + \
+            OTP_CTRL_SW_CFG_WINDOW_REG_OFFSET)
+  lw   t0, OTP_CTRL_PARAM_CREATOR_SW_CFG_AST_INIT_EN_OFFSET(a0)
   li   t1, MULTIBIT_ASM_BOOL4_TRUE
   bne  t0, t1, .L_ast_init_skip
 


### PR DESCRIPTION
I believe this is a bug in the AST init code in the mask ROM, as detailed in #11117.

Specifically, I believe the AST init code should actually load the correct word at the correct offset in OTP, rather than just loading the address itself.

This fixes #11117.

Signed-off-by: Timothy Trippel <ttrippel@google.com>