### PR TITLE
[lc_ctrl] Spin out reg package into its own core

### DIFF
--- a/hw/ip/lc_ctrl/lc_ctrl_reg_pkg.core
+++ b/hw/ip/lc_ctrl/lc_ctrl_reg_pkg.core
@@ -2,16 +2,15 @@ CAPI=2:
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
-name: "lowrisc:ip:lc_ctrl_pkg:0.1"
-description: "LC Controller Package"
+name: "lowrisc:ip:lc_ctrl_reg_pkg:0.1"
+description: "LC Controller Reg Package"
 filesets:
   files_rtl:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:ip:lc_ctrl_state_pkg
-      - lowrisc:ip:lc_ctrl_reg_pkg
     files:
-      - rtl/lc_ctrl_pkg.sv
+      - rtl/lc_ctrl_reg_pkg.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
@@ -20,7 +19,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/lc_ctrl_pkg.vlt
     file_type: vlt
 
   files_ascentlint_waiver:
@@ -29,7 +27,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/lc_ctrl_pkg.waiver
     file_type: waiver
 
   files_veriblelint_waiver:
@@ -38,7 +35,6 @@ filesets:
       - lowrisc:lint:common
       - lowrisc:lint:comportable
     files:
-      - lint/lc_ctrl_pkg.vbl
     file_type: veribleLintWaiver
 
 parameters:


### PR DESCRIPTION
Due to inter-package dependencies, the compilation order has to be made
explicit since otherwise this may fail.

Signed-off-by: Michael Schaffner <msf@opentitan.org>