### PR TITLE
[flash_ctrl] d2s review fixes

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -193,7 +193,13 @@
   ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
-      desc: "End-to-end bus integrity scheme."
+      desc: '''
+        End-to-end bus integrity scheme.
+        Since there are multiple access points for flash, please see
+        Transmission Integrity Faults in the documentation for more details.
+
+        The bus integrity scheme for flash is different from other comportable modules.
+      '''
     }
     { name: "SCRAMBLE.KEY.SIDELOAD",
       desc: "The scrambling key is sideloaded from OTP and thus unreadable by SW."
@@ -226,34 +232,58 @@
       desc: "Global escalation causes memory to no longer be accessible."
     }
     { name: "MEM.CTRL.LOCAL_ESC",
-      desc: "A subset of fatal errors cause memory to no longer be accessible."
+      desc: '''
+        A subset of fatal errors cause memory to no longer be accessible.
+        This subset is defined in !!STD_FAULT_STATUS.
+      '''
     }
     { name: "MEM_DISABLE.CONFIG.MUBI",
-      desc: "Software control for flash disable is multibit."
+      desc: '''
+        Software control for flash disable is multibit.
+        The register is !!DIS.
+      '''
     }
     { name: "MEM_EN.CONFIG.REDUN",
-      desc: "Software control for flash enable is 32-bit constant."
+      desc: '''
+        Software control for flash enable is 32-bit constant.
+        The register is !!EXEC.
+      '''
     }
     { name: "MEM.SCRAMBLE",
-      desc: "Memory is XEX scrambled."
+      desc: '''
+        Memory is XEX scrambled.
+        The cipher used is PRINCE.
+        Please see Flash Scrambling in documentation for more details.
+      '''
     }
     { name: "MEM.INTEGRITY",
-      desc: "Memory is protected with two layers of ECC integrity."
+      desc: '''
+        Memory is protected with two layers of ECC integrity.
+        Please see Flash ECC in the documentation for more details.
+      '''
     }
     { name: "RMA_ENTRY.MEM.SEC_WIPE",
       desc: "RMA entry entry wipes flash memory with random data."
     }
-    { name: "FSM.SPARSE",
-      desc: "RMA handling FSMs are sparsely encoded."
-    }
-    { name: "CTR.SPARSE",
-      desc: "RMA handling counters are sparsely encoded."
+    { name: "CTRL.FSM.SPARSE",
+      desc: '''
+        RMA handling FSMs in flash_ctrl_lcmgr are sparsely encoded.
+        FSM in flash_ctrl_arb is sparsely encoded.
+      '''
     }
     { name: "PHY.FSM.SPARSE",
       desc: "PHY FSMs are sparsely encoded."
     }
-
-
+    { name: "PHY_PROG.FSM.SPARSE",
+      desc: "PHY program FSMs are sparsely encoded."
+    }
+    { name: "CTR.REDUN",
+      desc: '''
+        flash_ctrl_lcmgr handling counters are redundantly encoded.
+        This includes seed count and address count used during seed reading phase,
+        as well as word count, page count and wipe index in RMA entry phase.
+      '''
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -200,7 +200,13 @@
   ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
-      desc: "End-to-end bus integrity scheme."
+      desc: '''
+        End-to-end bus integrity scheme.
+        Since there are multiple access points for flash, please see
+        Transmission Integrity Faults in the documentation for more details.
+
+        The bus integrity scheme for flash is different from other comportable modules.
+      '''
     }
     { name: "SCRAMBLE.KEY.SIDELOAD",
       desc: "The scrambling key is sideloaded from OTP and thus unreadable by SW."
@@ -233,34 +239,58 @@
       desc: "Global escalation causes memory to no longer be accessible."
     }
     { name: "MEM.CTRL.LOCAL_ESC",
-      desc: "A subset of fatal errors cause memory to no longer be accessible."
+      desc: '''
+        A subset of fatal errors cause memory to no longer be accessible.
+        This subset is defined in !!STD_FAULT_STATUS.
+      '''
     }
     { name: "MEM_DISABLE.CONFIG.MUBI",
-      desc: "Software control for flash disable is multibit."
+      desc: '''
+        Software control for flash disable is multibit.
+        The register is !!DIS.
+      '''
     }
     { name: "MEM_EN.CONFIG.REDUN",
-      desc: "Software control for flash enable is 32-bit constant."
+      desc: '''
+        Software control for flash enable is 32-bit constant.
+        The register is !!EXEC.
+      '''
     }
     { name: "MEM.SCRAMBLE",
-      desc: "Memory is XEX scrambled."
+      desc: '''
+        Memory is XEX scrambled.
+        The cipher used is PRINCE.
+        Please see Flash Scrambling in documentation for more details.
+      '''
     }
     { name: "MEM.INTEGRITY",
-      desc: "Memory is protected with two layers of ECC integrity."
+      desc: '''
+        Memory is protected with two layers of ECC integrity.
+        Please see Flash ECC in the documentation for more details.
+      '''
     }
     { name: "RMA_ENTRY.MEM.SEC_WIPE",
       desc: "RMA entry entry wipes flash memory with random data."
     }
-    { name: "FSM.SPARSE",
-      desc: "RMA handling FSMs are sparsely encoded."
-    }
-    { name: "CTR.SPARSE",
-      desc: "RMA handling counters are sparsely encoded."
+    { name: "CTRL.FSM.SPARSE",
+      desc: '''
+        RMA handling FSMs in flash_ctrl_lcmgr are sparsely encoded.
+        FSM in flash_ctrl_arb is sparsely encoded.
+      '''
     }
     { name: "PHY.FSM.SPARSE",
       desc: "PHY FSMs are sparsely encoded."
     }
-
-
+    { name: "PHY_PROG.FSM.SPARSE",
+      desc: "PHY program FSMs are sparsely encoded."
+    }
+    { name: "CTR.REDUN",
+      desc: '''
+        flash_ctrl_lcmgr handling counters are redundantly encoded.
+        This includes seed count and address count used during seed reading phase,
+        as well as word count, page count and wipe index in RMA entry phase.
+      '''
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -268,6 +268,10 @@ module flash_ctrl
   flash_rsp_t flash_phy_rsp;
   flash_req_t flash_phy_req;
 
+  // import commonly used routines
+  import lc_ctrl_pkg::lc_tx_test_true_strict;
+  import lc_ctrl_pkg::lc_tx_test_true_loose;
+
   // life cycle connections
   lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
 
@@ -299,10 +303,16 @@ module flash_ctrl
     .state_o(rand_val)
   );
 
+  // flash disable declaration
+  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
+
   // flash control arbitration between softawre / harware interfaces
   flash_ctrl_arb u_ctrl_arb (
     .clk_i,
     .rst_ni,
+
+    // combined disable
+    .disable_i(flash_disable[ArbFsmDisableIdx]),
 
     // error output shared by both interfaces
     .ctrl_err_addr_o(ctrl_err_addr),
@@ -405,7 +415,10 @@ module flash_ctrl
     .rst_otp_ni,
 
     .init_i(reg2hw.init),
-    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
+    .provision_en_i(lc_tx_test_true_strict(lc_seed_hw_rd_en)),
+
+    // combined disable
+    .disable_i(flash_disable[LcMgrDisableIdx]),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -709,9 +722,6 @@ module flash_ctrl
   assign flash_part_sel = op_part;
   assign flash_info_sel = op_info_sel;
 
-  // flash disable declaration
-  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
-
   // tie off hardware clear path
   assign hw2reg.erase_suspend.d = 1'b0;
 
@@ -921,7 +931,7 @@ module flash_ctrl
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
   prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
-  assign flash_disable_pre_buf = lc_ctrl_pkg::lc_tx_test_true_loose(lc_disable) ?
+  assign flash_disable_pre_buf = lc_tx_test_true_loose(lc_disable) ?
                                  prim_mubi_pkg::MuBi4True :
                                  prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
 
@@ -945,7 +955,7 @@ module flash_ctrl
                             prim_mubi_pkg::MuBi4True :
                             prim_mubi_pkg::MuBi4False;
 
-  assign flash_exec_en = lc_ctrl_pkg::lc_tx_test_true_loose(lc_escalate_en) ?
+  assign flash_exec_en = lc_tx_test_true_loose(lc_escalate_en) ?
                          prim_mubi_pkg::MuBi4False :
                          sw_flash_exec_en;
 
@@ -1179,21 +1189,26 @@ module flash_ctrl
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
 
   import prim_mubi_pkg::mubi4_test_true_loose;
-  logic host_disable;
-  logic disabled_rvalid;
-  logic [1:0] disabled_err;
+  lc_ctrl_pkg::lc_tx_t host_enable;
+
 
   // if flash disable is activated, error back from the adapter interface immediately
-  assign host_disable = mubi4_test_true_loose(flash_disable[HostDisableIdx]);
-  assign disabled_err = {2{disabled_rvalid}};
+  assign host_enable = mubi4_test_true_loose(flash_disable[HostDisableIdx]) ?
+                       lc_ctrl_pkg::Off :
+                       lc_ctrl_pkg::On;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      disabled_rvalid <= '0;
-    end else begin
-      disabled_rvalid <= host_disable & flash_host_req;
-    end
-  end
+  tlul_pkg::tl_h2d_t gate_tl_h2d;
+  tlul_pkg::tl_d2h_t gate_tl_d2h;
+
+  tlul_lc_gate u_tl_gate (
+    .clk_i,
+    .rst_ni,
+    .tl_h2d_i(mem_tl_i),
+    .tl_d2h_o(mem_tl_o),
+    .tl_h2d_o(gate_tl_h2d),
+    .tl_d2h_i(gate_tl_d2h),
+    .lc_en_i(host_enable)
+  );
 
   tlul_adapter_sram #(
     .SramAw(BusAddrW),
@@ -1208,20 +1223,20 @@ module flash_ctrl
   ) u_tl_adapter_eflash (
     .clk_i,
     .rst_ni,
-    .tl_i        (mem_tl_i),
-    .tl_o        (mem_tl_o),
+    .tl_i        (gate_tl_h2d),
+    .tl_o        (gate_tl_d2h),
     .en_ifetch_i (flash_exec_en),
     .req_o       (flash_host_req),
     .req_type_o  (),
-    .gnt_i       (flash_host_req_rdy | host_disable),
+    .gnt_i       (flash_host_req_rdy),
     .we_o        (),
     .addr_o      (flash_host_addr),
     .wdata_o     (),
     .wmask_o     (),
     .intg_error_o(),
     .rdata_i     (flash_host_rdata),
-    .rvalid_i    (flash_host_req_done | disabled_rvalid),
-    .rerror_i    ({flash_host_rderr,1'b0} | disabled_err)
+    .rvalid_i    (flash_host_req_done),
+    .rerror_i    ({flash_host_rderr,1'b0})
   );
 
   flash_phy #(
@@ -1285,6 +1300,10 @@ module flash_ctrl
   assign unused_op_valid = prog_op_valid | rd_op_valid | erase_op_valid;
 
   // add more assertions
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(SeedCntAlertCheck_A, u_flash_hw_if.u_seed_cnt,
+                                         alert_tx_o[1])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(AddrCntAlertCheck_A, u_flash_hw_if.u_addr_cnt,
+                                         alert_tx_o[1])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PageCntAlertCheck_A, u_flash_hw_if.u_page_cnt,
                                          alert_tx_o[1])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WordCntAlertCheck_A, u_flash_hw_if.u_word_cnt,

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -81,8 +81,10 @@ package flash_ctrl_pkg;
   };
 
   // Flash Disable usage
-  typedef enum logic [1:0] {
+  typedef enum logic [2:0] {
     PhyDisableIdx,
+    ArbFsmDisableIdx,
+    LcMgrDisableIdx,
     MpDisableIdx,
     HostDisableIdx,
     FlashDisableLast

--- a/hw/ip/flash_ctrl/data/flash_ctrl_region_cfg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_region_cfg.sv.tpl
@@ -145,6 +145,8 @@ module flash_ctrl_region_cfg
     end
   end
 
+  import lc_ctrl_pkg::lc_tx_test_true_strict;
+
   // qualify software settings with creator / owner privileges
   for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
     for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
@@ -153,10 +155,10 @@ module flash_ctrl_region_cfg
         .InfoSel(j)
       ) u_info_cfg (
         .cfgs_i(info_cfgs[i][j]),
-        .creator_seed_priv_i(lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On),
-        .owner_seed_priv_i(lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .creator_seed_priv_i(lc_tx_test_true_strict(lc_creator_seed_sw_rw_en)),
+        .owner_seed_priv_i(lc_tx_test_true_strict(lc_owner_seed_sw_rw_en)),
+        .iso_flash_wr_en_i(lc_tx_test_true_strict(lc_iso_part_sw_wr_en)),
+        .iso_flash_rd_en_i(lc_tx_test_true_strict(lc_iso_part_sw_rd_en)),
         .cfgs_o(info_page_cfgs_o[i][j])
       );
     end

--- a/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
@@ -126,20 +126,26 @@
       tests: []
     }
     {
-      name: sec_cm_fsm_sparse
-      desc: "Verify the countermeasure(s) FSM.SPARSE."
-      milestone: V2S
-      tests: []
-    }
-    {
-      name: sec_cm_ctr_sparse
-      desc: "Verify the countermeasure(s) CTR.SPARSE."
+      name: sec_cm_ctrl_fsm_sparse
+      desc: "Verify the countermeasure(s) CTRL.FSM.SPARSE."
       milestone: V2S
       tests: []
     }
     {
       name: sec_cm_phy_fsm_sparse
       desc: "Verify the countermeasure(s) PHY.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_phy_prog_fsm_sparse
+      desc: "Verify the countermeasure(s) PHY_PROG.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctr_redun
+      desc: "Verify the countermeasure(s) CTR.REDUN."
       milestone: V2S
       tests: []
     }

--- a/hw/ip/flash_ctrl/doc/_index.md
+++ b/hw/ip/flash_ctrl/doc/_index.md
@@ -398,6 +398,8 @@ Flash reliability ECC errors (multi-bit errors) and integrity ECC errors (storag
 That means if a host direct read, controller initiated read or hardware initiated read encounters one of these errors, the error is directly reflected in the operation status.
 
 Further, reliability / integrity ECC errors are also captured in {{< regref "FAULT_STATUS" >}} and can be used to generate fatal alerts.
+The reason ECC errors are captured not captured in {{< regref "STD_FAULT_STATUS" >}} is because it is assumed 2-bit errors can occur in real usage.
+If we assume 2-bit errors can occur, then software must have a mechanism to recover from the error instead of [escalation](#flash-escalation).
 
 #### Flash Escalation
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -81,8 +81,10 @@ package flash_ctrl_pkg;
   };
 
   // Flash Disable usage
-  typedef enum logic [1:0] {
+  typedef enum logic [2:0] {
     PhyDisableIdx,
+    ArbFsmDisableIdx,
+    LcMgrDisableIdx,
     MpDisableIdx,
     HostDisableIdx,
     FlashDisableLast

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_region_cfg.sv
@@ -147,6 +147,8 @@ module flash_ctrl_region_cfg
     end
   end
 
+  import lc_ctrl_pkg::lc_tx_test_true_strict;
+
   // qualify software settings with creator / owner privileges
   for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
     for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
@@ -155,10 +157,10 @@ module flash_ctrl_region_cfg
         .InfoSel(j)
       ) u_info_cfg (
         .cfgs_i(info_cfgs[i][j]),
-        .creator_seed_priv_i(lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On),
-        .owner_seed_priv_i(lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .creator_seed_priv_i(lc_tx_test_true_strict(lc_creator_seed_sw_rw_en)),
+        .owner_seed_priv_i(lc_tx_test_true_strict(lc_owner_seed_sw_rw_en)),
+        .iso_flash_wr_en_i(lc_tx_test_true_strict(lc_iso_part_sw_wr_en)),
+        .iso_flash_rd_en_i(lc_tx_test_true_strict(lc_iso_part_sw_rd_en)),
         .cfgs_o(info_page_cfgs_o[i][j])
       );
     end

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -167,6 +167,7 @@ module flash_phy_core
     CtrlDisableIdx,
     FsmDisableIdx,
     ScrDisableIdx,
+    ProgFsmDisableIdx,
     LastDisableIdx
   } phy_core_disable_e;
 
@@ -351,6 +352,7 @@ module flash_phy_core
       .clk_i,
       .rst_ni,
       .req_i(reqs[PhyProg]),
+      .disable_i(flash_disable[ProgFsmDisableIdx]),
       .scramble_i(muxed_scramble_en),
       .ecc_i(muxed_ecc_en),
       .sel_i(addr_i[0 +: WordSelW]),

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -199,7 +199,13 @@
   ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
-      desc: "End-to-end bus integrity scheme."
+      desc: '''
+        End-to-end bus integrity scheme.
+        Since there are multiple access points for flash, please see
+        Transmission Integrity Faults in the documentation for more details.
+
+        The bus integrity scheme for flash is different from other comportable modules.
+      '''
     }
     { name: "SCRAMBLE.KEY.SIDELOAD",
       desc: "The scrambling key is sideloaded from OTP and thus unreadable by SW."
@@ -232,34 +238,58 @@
       desc: "Global escalation causes memory to no longer be accessible."
     }
     { name: "MEM.CTRL.LOCAL_ESC",
-      desc: "A subset of fatal errors cause memory to no longer be accessible."
+      desc: '''
+        A subset of fatal errors cause memory to no longer be accessible.
+        This subset is defined in !!STD_FAULT_STATUS.
+      '''
     }
     { name: "MEM_DISABLE.CONFIG.MUBI",
-      desc: "Software control for flash disable is multibit."
+      desc: '''
+        Software control for flash disable is multibit.
+        The register is !!DIS.
+      '''
     }
     { name: "MEM_EN.CONFIG.REDUN",
-      desc: "Software control for flash enable is 32-bit constant."
+      desc: '''
+        Software control for flash enable is 32-bit constant.
+        The register is !!EXEC.
+      '''
     }
     { name: "MEM.SCRAMBLE",
-      desc: "Memory is XEX scrambled."
+      desc: '''
+        Memory is XEX scrambled.
+        The cipher used is PRINCE.
+        Please see Flash Scrambling in documentation for more details.
+      '''
     }
     { name: "MEM.INTEGRITY",
-      desc: "Memory is protected with two layers of ECC integrity."
+      desc: '''
+        Memory is protected with two layers of ECC integrity.
+        Please see Flash ECC in the documentation for more details.
+      '''
     }
     { name: "RMA_ENTRY.MEM.SEC_WIPE",
       desc: "RMA entry entry wipes flash memory with random data."
     }
-    { name: "FSM.SPARSE",
-      desc: "RMA handling FSMs are sparsely encoded."
-    }
-    { name: "CTR.SPARSE",
-      desc: "RMA handling counters are sparsely encoded."
+    { name: "CTRL.FSM.SPARSE",
+      desc: '''
+        RMA handling FSMs in flash_ctrl_lcmgr are sparsely encoded.
+        FSM in flash_ctrl_arb is sparsely encoded.
+      '''
     }
     { name: "PHY.FSM.SPARSE",
       desc: "PHY FSMs are sparsely encoded."
     }
-
-
+    { name: "PHY_PROG.FSM.SPARSE",
+      desc: "PHY program FSMs are sparsely encoded."
+    }
+    { name: "CTR.REDUN",
+      desc: '''
+        flash_ctrl_lcmgr handling counters are redundantly encoded.
+        This includes seed count and address count used during seed reading phase,
+        as well as word count, page count and wipe index in RMA entry phase.
+      '''
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -126,20 +126,26 @@
       tests: []
     }
     {
-      name: sec_cm_fsm_sparse
-      desc: "Verify the countermeasure(s) FSM.SPARSE."
-      milestone: V2S
-      tests: []
-    }
-    {
-      name: sec_cm_ctr_sparse
-      desc: "Verify the countermeasure(s) CTR.SPARSE."
+      name: sec_cm_ctrl_fsm_sparse
+      desc: "Verify the countermeasure(s) CTRL.FSM.SPARSE."
       milestone: V2S
       tests: []
     }
     {
       name: sec_cm_phy_fsm_sparse
       desc: "Verify the countermeasure(s) PHY.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_phy_prog_fsm_sparse
+      desc: "Verify the countermeasure(s) PHY_PROG.FSM.SPARSE."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_ctr_redun
+      desc: "Verify the countermeasure(s) CTR.REDUN."
       milestone: V2S
       tests: []
     }

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -275,6 +275,10 @@ module flash_ctrl
   flash_rsp_t flash_phy_rsp;
   flash_req_t flash_phy_req;
 
+  // import commonly used routines
+  import lc_ctrl_pkg::lc_tx_test_true_strict;
+  import lc_ctrl_pkg::lc_tx_test_true_loose;
+
   // life cycle connections
   lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
 
@@ -306,10 +310,16 @@ module flash_ctrl
     .state_o(rand_val)
   );
 
+  // flash disable declaration
+  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
+
   // flash control arbitration between softawre / harware interfaces
   flash_ctrl_arb u_ctrl_arb (
     .clk_i,
     .rst_ni,
+
+    // combined disable
+    .disable_i(flash_disable[ArbFsmDisableIdx]),
 
     // error output shared by both interfaces
     .ctrl_err_addr_o(ctrl_err_addr),
@@ -412,7 +422,10 @@ module flash_ctrl
     .rst_otp_ni,
 
     .init_i(reg2hw.init),
-    .provision_en_i(lc_seed_hw_rd_en == lc_ctrl_pkg::On),
+    .provision_en_i(lc_tx_test_true_strict(lc_seed_hw_rd_en)),
+
+    // combined disable
+    .disable_i(flash_disable[LcMgrDisableIdx]),
 
     // interface to ctrl arb control ports
     .ctrl_o(hw_ctrl),
@@ -716,9 +729,6 @@ module flash_ctrl
   assign flash_part_sel = op_part;
   assign flash_info_sel = op_info_sel;
 
-  // flash disable declaration
-  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
-
   // tie off hardware clear path
   assign hw2reg.erase_suspend.d = 1'b0;
 
@@ -928,7 +938,7 @@ module flash_ctrl
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
   prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
-  assign flash_disable_pre_buf = lc_ctrl_pkg::lc_tx_test_true_loose(lc_disable) ?
+  assign flash_disable_pre_buf = lc_tx_test_true_loose(lc_disable) ?
                                  prim_mubi_pkg::MuBi4True :
                                  prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
 
@@ -952,7 +962,7 @@ module flash_ctrl
                             prim_mubi_pkg::MuBi4True :
                             prim_mubi_pkg::MuBi4False;
 
-  assign flash_exec_en = lc_ctrl_pkg::lc_tx_test_true_loose(lc_escalate_en) ?
+  assign flash_exec_en = lc_tx_test_true_loose(lc_escalate_en) ?
                          prim_mubi_pkg::MuBi4False :
                          sw_flash_exec_en;
 
@@ -1186,21 +1196,26 @@ module flash_ctrl
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
 
   import prim_mubi_pkg::mubi4_test_true_loose;
-  logic host_disable;
-  logic disabled_rvalid;
-  logic [1:0] disabled_err;
+  lc_ctrl_pkg::lc_tx_t host_enable;
+
 
   // if flash disable is activated, error back from the adapter interface immediately
-  assign host_disable = mubi4_test_true_loose(flash_disable[HostDisableIdx]);
-  assign disabled_err = {2{disabled_rvalid}};
+  assign host_enable = mubi4_test_true_loose(flash_disable[HostDisableIdx]) ?
+                       lc_ctrl_pkg::Off :
+                       lc_ctrl_pkg::On;
 
-  always_ff @(posedge clk_i or negedge rst_ni) begin
-    if (!rst_ni) begin
-      disabled_rvalid <= '0;
-    end else begin
-      disabled_rvalid <= host_disable & flash_host_req;
-    end
-  end
+  tlul_pkg::tl_h2d_t gate_tl_h2d;
+  tlul_pkg::tl_d2h_t gate_tl_d2h;
+
+  tlul_lc_gate u_tl_gate (
+    .clk_i,
+    .rst_ni,
+    .tl_h2d_i(mem_tl_i),
+    .tl_d2h_o(mem_tl_o),
+    .tl_h2d_o(gate_tl_h2d),
+    .tl_d2h_i(gate_tl_d2h),
+    .lc_en_i(host_enable)
+  );
 
   tlul_adapter_sram #(
     .SramAw(BusAddrW),
@@ -1215,20 +1230,20 @@ module flash_ctrl
   ) u_tl_adapter_eflash (
     .clk_i,
     .rst_ni,
-    .tl_i        (mem_tl_i),
-    .tl_o        (mem_tl_o),
+    .tl_i        (gate_tl_h2d),
+    .tl_o        (gate_tl_d2h),
     .en_ifetch_i (flash_exec_en),
     .req_o       (flash_host_req),
     .req_type_o  (),
-    .gnt_i       (flash_host_req_rdy | host_disable),
+    .gnt_i       (flash_host_req_rdy),
     .we_o        (),
     .addr_o      (flash_host_addr),
     .wdata_o     (),
     .wmask_o     (),
     .intg_error_o(),
     .rdata_i     (flash_host_rdata),
-    .rvalid_i    (flash_host_req_done | disabled_rvalid),
-    .rerror_i    ({flash_host_rderr,1'b0} | disabled_err)
+    .rvalid_i    (flash_host_req_done),
+    .rerror_i    ({flash_host_rderr,1'b0})
   );
 
   flash_phy #(
@@ -1292,6 +1307,10 @@ module flash_ctrl
   assign unused_op_valid = prog_op_valid | rd_op_valid | erase_op_valid;
 
   // add more assertions
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(SeedCntAlertCheck_A, u_flash_hw_if.u_seed_cnt,
+                                         alert_tx_o[1])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(AddrCntAlertCheck_A, u_flash_hw_if.u_addr_cnt,
+                                         alert_tx_o[1])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PageCntAlertCheck_A, u_flash_hw_if.u_page_cnt,
                                          alert_tx_o[1])
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(WordCntAlertCheck_A, u_flash_hw_if.u_word_cnt,

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -87,8 +87,10 @@ package flash_ctrl_pkg;
   };
 
   // Flash Disable usage
-  typedef enum logic [1:0] {
+  typedef enum logic [2:0] {
     PhyDisableIdx,
+    ArbFsmDisableIdx,
+    LcMgrDisableIdx,
     MpDisableIdx,
     HostDisableIdx,
     FlashDisableLast

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_region_cfg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_region_cfg.sv
@@ -153,6 +153,8 @@ module flash_ctrl_region_cfg
     end
   end
 
+  import lc_ctrl_pkg::lc_tx_test_true_strict;
+
   // qualify software settings with creator / owner privileges
   for(genvar i = 0; i < NumBanks; i++) begin : gen_info_priv_bank
     for (genvar j = 0; j < InfoTypes; j++) begin : gen_info_priv_type
@@ -161,10 +163,10 @@ module flash_ctrl_region_cfg
         .InfoSel(j)
       ) u_info_cfg (
         .cfgs_i(info_cfgs[i][j]),
-        .creator_seed_priv_i(lc_creator_seed_sw_rw_en == lc_ctrl_pkg::On),
-        .owner_seed_priv_i(lc_owner_seed_sw_rw_en == lc_ctrl_pkg::On),
-        .iso_flash_wr_en_i(lc_iso_part_sw_wr_en == lc_ctrl_pkg::On),
-        .iso_flash_rd_en_i(lc_iso_part_sw_rd_en == lc_ctrl_pkg::On),
+        .creator_seed_priv_i(lc_tx_test_true_strict(lc_creator_seed_sw_rw_en)),
+        .owner_seed_priv_i(lc_tx_test_true_strict(lc_owner_seed_sw_rw_en)),
+        .iso_flash_wr_en_i(lc_tx_test_true_strict(lc_iso_part_sw_wr_en)),
+        .iso_flash_rd_en_i(lc_tx_test_true_strict(lc_iso_part_sw_rd_en)),
         .cfgs_o(info_page_cfgs_o[i][j])
       );
     end


### PR DESCRIPTION
- convert lc compare to lc_tx_test_true_strict
- expand disable usage to more fsms
- add additional prim counters to lcmgr
- Add countermeasure clarifications
- switch to mubi sync where appropriate
- Add tlul_lc_gate in front of adapter sram to error back
  transactions when disabled
- documentation updates and clarifications