### PR TITLE
[dv] Update sec_cm doc for cip_lc_tx_cov_if and fix cov interface

### DIFF
--- a/hw/dv/sv/cip_lib/doc/index.md
+++ b/hw/dv/sv/cip_lib/doc/index.md
@@ -469,12 +469,13 @@ This covergroup won't be sampled in CSR tests, since CSR tests only test the cor
 Users should randomize the values of all the MUBI CSRs in non-CSR tests and check the design behaves correctly.
 The helper functions `cip_base_pkg::get_rand_mubi4|8|12|16_val(t_weight, f_weight, other_weight)` can be used to get the random values.
 
-### Security Verification for MUBI type ports
+### Security Verification for MUBI/LC_TX type ports
 In OpenTitan [Design Verification Methodology]({{< relref "doc/ug/dv_methodology" >}}), it's mandatory to have 100% toggle coverage on all the ports.
 However, the MUBI defined values (`True` and `False`) are complement numbers.
 If users only test with `True` and `False` without using other values, toggle coverage can be 100%.
 Hence, user should add a functional covergroup for each MUBI type input port, via binding the interface `cip_mubi_cov_if` which contains a covergroup for MUBI.
-The type `lc_ctrl_pkg::lc_tx_t` should be treated as a Mubi4 type, which also needs to be bound with the interface `cip_mubi_cov_if`.
+The type `lc_ctrl_pkg::lc_tx_t` is different than the Mubi4 type, as its defined values are different.
+So, it needs to be bound with the interface `cip_lc_tx_cov_if`.
 The helper functions `cip_base_pkg::get_rand_mubi4|8|12|16_val(t_weight, f_weight, other_weight)` and `cip_base_pkg::get_rand_lc_tx_val` can be used to get the random values.
 
 The following is an example from `sram_ctrl`, in which it binds the coverage interface to 2 MUBI input ports.
@@ -486,9 +487,9 @@ module sram_ctrl_cov_bind;
     .mubi   (lc_hw_debug_en_i)
   );
 
-  bind sram_ctrl cip_mubi_cov_if #(.Width(8)) u_otp_en_sram_ifetch_mubi_cov_if (
+  bind sram_ctrl cip_lc_tx_cov_if u_lc_escalate_en_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (otp_en_sram_ifetch_i)
+    .val    (lc_escalate_en_i)
   );
 endmodule
 ```

--- a/hw/ip/clkmgr/dv/cov/clkmgr_cov_bind.sv
+++ b/hw/ip/clkmgr/dv/cov/clkmgr_cov_bind.sv
@@ -10,14 +10,14 @@ module clkmgr_cov_bind;
     .mubi   (idle_i)
   );
 
-  bind clkmgr cip_mubi_cov_if #(.Width(lc_ctrl_pkg::TxWidth)) u_lc_hw_debug_en_mubi_cov_if (
+  bind clkmgr cip_lc_tx_cov_if u_lc_hw_debug_en_mubi_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (lc_hw_debug_en_i)
+    .val    (lc_hw_debug_en_i)
   );
 
-  bind clkmgr cip_mubi_cov_if #(.Width(lc_ctrl_pkg::TxWidth)) u_lc_clk_byp_req_mubi_cov_if (
+  bind clkmgr cip_lc_tx_cov_if u_lc_clk_byp_req_mubi_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (lc_clk_byp_req_i)
+    .val    (lc_clk_byp_req_i)
   );
 
   bind clkmgr cip_mubi_cov_if #(.Width(prim_mubi_pkg::MuBi4Width)) u_io_clk_byp_ack_mubi_cov_if (

--- a/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
+++ b/hw/ip/otp_ctrl/dv/cov/otp_ctrl_cov_bind.sv
@@ -14,28 +14,28 @@ module otp_ctrl_cov_bind;
     .otbn_otp_key_i   (otbn_otp_key_i)
   );
 
-  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_creator_seed_sw_rw_en_mubi_cov_if (
+  bind otp_ctrl cip_lc_tx_cov_if u_lc_creator_seed_sw_rw_en_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (lc_creator_seed_sw_rw_en_i)
+    .val    (lc_creator_seed_sw_rw_en_i)
   );
 
-  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_seed_hw_rd_en_mubi_cov_if (
+  bind otp_ctrl cip_lc_tx_cov_if u_lc_seed_hw_rd_en_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (lc_seed_hw_rd_en_i)
+    .val    (lc_seed_hw_rd_en_i)
   );
 
-  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_dft_en_mubi_cov_if (
+  bind otp_ctrl cip_lc_tx_cov_if u_lc_dft_en_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (lc_dft_en_i)
+    .val    (lc_dft_en_i)
   );
 
-  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_escalate_en_mubi_cov_if (
+  bind otp_ctrl cip_lc_tx_cov_if u_lc_escalate_en_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (lc_escalate_en_i)
+    .val    (lc_escalate_en_i)
   );
 
-  bind otp_ctrl cip_mubi_cov_if #(.Width(4)) u_lc_check_byp_en_mubi_cov_if (
+  bind otp_ctrl cip_lc_tx_cov_if u_lc_check_byp_en_cov_if (
     .rst_ni (rst_ni),
-    .mubi   (lc_check_byp_en_i)
+    .val    (lc_check_byp_en_i)
   );
 endmodule


### PR DESCRIPTION
lc_tx_t type ports are treated differently.
The doc wasn't described this correctly.

Also updated those that mistakenly used cip_mubi_cov_if for lc_tx_t ports

Signed-off-by: Weicai Yang <weicai@google.com>
