### PR TITLE
[flash_ctrl] Enhance lc/mubi conversion

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -9,8 +9,7 @@
 `include "prim_assert.sv"
 
 module flash_ctrl
-  import flash_ctrl_pkg::*;
-  import flash_ctrl_reg_pkg::*;
+  import flash_ctrl_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
@@ -931,10 +930,12 @@ module flash_ctrl
   // In other words...cowardice.
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
+  prim_mubi_pkg::mubi4_t lc_conv_disable;
   prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
-  assign flash_disable_pre_buf = lc_tx_test_true_loose(lc_disable) ?
-                                 prim_mubi_pkg::MuBi4True :
-                                 prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
+  assign lc_conv_disable = lc_ctrl_pkg::lc_to_mubi4(lc_disable);
+  assign flash_disable_pre_buf = prim_mubi_pkg::mubi4_or_hi(
+      lc_conv_disable,
+      prim_mubi_pkg::mubi4_t'(reg2hw.dis.q));
 
   prim_mubi4_sync #(
     .NumCopies(int'(FlashDisableLast)),
@@ -1194,9 +1195,7 @@ module flash_ctrl
 
 
   // if flash disable is activated, error back from the adapter interface immediately
-  assign host_enable = mubi4_test_true_loose(flash_disable[HostDisableIdx]) ?
-                       lc_ctrl_pkg::Off :
-                       lc_ctrl_pkg::On;
+  assign host_enable = lc_ctrl_pkg::mubi4_to_lc_inv(flash_disable[HostDisableIdx]);
 
   tlul_pkg::tl_h2d_t gate_tl_h2d;
   tlul_pkg::tl_d2h_t gate_tl_d2h;

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl.sv
@@ -121,6 +121,11 @@ module lc_ctrl
   `ASSERT_INIT(OtpTestCtrlWidth_A, otp_ctrl_pkg::OtpTestCtrlWidth == CsrOtpTestCtrlWidth)
   `ASSERT_INIT(HwRevFieldWidth_A, HwRevFieldWidth <= 16)
 
+  // Check for bit-width matching between lc_tx_t and mubi4_t
+  `ASSERT_INIT(LcMuBiWidthCheck_A, (TxWidth % prim_mubi_pkg::MuBi4Width) == '0)
+  `ASSERT_INIT(LcTxComplCheck_A, On == ~Off)
+  `ASSERT_INIT(MuBi4ComplCheck_A, prim_mubi_pkg::MuBi4True == ~prim_mubi_pkg::MuBi4False)
+
   /////////////
   // Regfile //
   /////////////

--- a/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
+++ b/hw/ip/lc_ctrl/rtl/lc_ctrl_pkg.sv
@@ -58,6 +58,31 @@ package lc_ctrl_pkg;
   // Helper Functions for Life Cycle Signals //
   /////////////////////////////////////////////
 
+  // Convert a life cycle signal to mubi4
+  // If in the future other versions are desired, this should really be
+  // moved to prim_mubi_pkg
+  //
+  // The On ^ MuBi4True determines the bit differences between
+  // an lc_ctrl_pkg::On and prim_mubi_pkg::MuBi4True.
+  // Once the required inversions are determined, it is then applied
+  // to the incoming value.  If the incoming value is true, it will
+  // appropriately flip to the correct MuBiValue.
+  // Since the false value is always complement of the true value,
+  // this mechanism will also work for the other polarity.
+  function automatic prim_mubi_pkg::mubi4_t lc_to_mubi4(lc_tx_t val);
+    return prim_mubi_pkg::mubi4_t'(val ^ (On ^ prim_mubi_pkg::MuBi4True));
+  endfunction // lc_to_mubi4
+
+  function automatic lc_tx_t mubi4_to_lc(prim_mubi_pkg::mubi4_t val);
+    return lc_tx_t'(val ^ (prim_mubi_pkg::MuBi4True ^ On));
+  endfunction // mubi4_to_lc
+
+  // same function as above, but for an input that is MuBi4True, return Off
+  // for an input that is MuBi4False, return On
+  function automatic lc_tx_t mubi4_to_lc_inv(prim_mubi_pkg::mubi4_t val);
+    return lc_tx_t'(val ^ (prim_mubi_pkg::MuBi4True ^ Off));
+  endfunction // mubi4_to_lc_inv
+
   // Test whether the value is supplied is one of the valid enumerations
   function automatic logic lc_tx_test_invalid(lc_tx_t val);
     return ~(val inside {On, Off});

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -15,8 +15,7 @@
 `include "prim_assert.sv"
 
 module flash_ctrl
-  import flash_ctrl_pkg::*;
-  import flash_ctrl_reg_pkg::*;
+  import flash_ctrl_pkg::*;  import flash_ctrl_reg_pkg::*;
 #(
   parameter logic [NumAlerts-1:0] AlertAsyncOn    = {NumAlerts{1'b1}},
   parameter flash_key_t           RndCnstAddrKey  = RndCnstAddrKeyDefault,
@@ -937,10 +936,12 @@ module flash_ctrl
   // In other words...cowardice.
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
+  prim_mubi_pkg::mubi4_t lc_conv_disable;
   prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
-  assign flash_disable_pre_buf = lc_tx_test_true_loose(lc_disable) ?
-                                 prim_mubi_pkg::MuBi4True :
-                                 prim_mubi_pkg::mubi4_t'(reg2hw.dis.q);
+  assign lc_conv_disable = lc_ctrl_pkg::lc_to_mubi4(lc_disable);
+  assign flash_disable_pre_buf = prim_mubi_pkg::mubi4_or_hi(
+      lc_conv_disable,
+      prim_mubi_pkg::mubi4_t'(reg2hw.dis.q));
 
   prim_mubi4_sync #(
     .NumCopies(int'(FlashDisableLast)),
@@ -1200,9 +1201,7 @@ module flash_ctrl
 
 
   // if flash disable is activated, error back from the adapter interface immediately
-  assign host_enable = mubi4_test_true_loose(flash_disable[HostDisableIdx]) ?
-                       lc_ctrl_pkg::Off :
-                       lc_ctrl_pkg::On;
+  assign host_enable = lc_ctrl_pkg::mubi4_to_lc_inv(flash_disable[HostDisableIdx]);
 
   tlul_pkg::tl_h2d_t gate_tl_h2d;
   tlul_pkg::tl_d2h_t gate_tl_d2h;


### PR DESCRIPTION
- This adds a function to directly convert between
  lc and mubi types as long as the widths match.
- One additional requirement of this conversion is that the
  On/Off, True/False values of lc and mubi must be completely
  complementary.
- Move several flash functions to the new mubi-lc multibit
  direct conversion