### PR TITLE
[all] Ensure all IPs instantiated in the first test-chip are at version 1.0

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.prj.hjson
+++ b/hw/ip/clkmgr/data/clkmgr.prj.hjson
@@ -10,7 +10,7 @@
     sw_checklist:       "/sw/device/lib/dif/dif_clkmgr",
     revisions: [
       {
-        version:            "0.1",
+        version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.prj.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.prj.hjson
@@ -22,7 +22,7 @@
             commit_id:          "7049fd0d5d48e20772f8ebf32b240faa0dad5528",
         },
         {
-            version:            "0.5",
+            version:            "1.0",
             life_stage:         "L1",
             design_stage:       "D2",
             verification_stage: "V1",

--- a/hw/ip/keymgr/data/keymgr.prj.hjson
+++ b/hw/ip/keymgr/data/keymgr.prj.hjson
@@ -10,7 +10,7 @@
     sw_checklist:       "/sw/device/lib/dif/dif_keymgr",
     revisions: [
       {
-        version:            "0.1",
+        version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V2",

--- a/hw/ip/otbn/data/otbn.prj.hjson
+++ b/hw/ip/otbn/data/otbn.prj.hjson
@@ -19,7 +19,7 @@
             notes:              ""
         },
         {
-            version:            "0.2",
+            version:            "1.0",
             life_stage:         "L1",
             design_stage:       "D2",
             verification_stage: "V1",

--- a/hw/ip/pinmux/data/pinmux.prj.hjson
+++ b/hw/ip/pinmux/data/pinmux.prj.hjson
@@ -8,7 +8,7 @@
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
     sw_checklist:       "/sw/device/lib/dif/dif_pinmux",
-    version:            "0.5",
+    version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V2",

--- a/hw/ip/pwrmgr/data/pwrmgr.prj.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.prj.hjson
@@ -18,7 +18,7 @@
         commit_id:          "b2abc989498f072d9a5530f8aab9b58c1f92c9fb"
       }
       {
-        version:            "0.5",
+        version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",

--- a/hw/ip/rstmgr/data/rstmgr.prj.hjson
+++ b/hw/ip/rstmgr/data/rstmgr.prj.hjson
@@ -10,7 +10,7 @@
     sw_checklist:       "/sw/device/lib/dif/dif_rstmgr",
     revisions: [
       {
-        version:            "0.1",
+        version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",

--- a/hw/ip/usbdev/data/usbdev.prj.hjson
+++ b/hw/ip/usbdev/data/usbdev.prj.hjson
@@ -8,7 +8,7 @@
     dv_doc:             "../doc/dv",
     hw_checklist:       "../doc/checklist",
     sw_checklist:       "/sw/device/lib/dif/dif_usbdev",
-    version:            "0.5",
+    version:            "1.0",
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V0",

--- a/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.prj.hjson
+++ b/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.prj.hjson
@@ -9,7 +9,7 @@
     hw_checklist:       "../doc/checklist",
     revisions: [
       {
-        version:            "0.1",
+        version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2",
         verification_stage: "V0", // block level verification not planned


### PR DESCRIPTION
This ensures that all taped-out IPs are at version 1.0.

Versions 0.1 and 0.5 have been used to work towards intermediate milestones in the past (public launch in 2019, FPGA mapping and Bronze in 2020).

As for `sensor_ctrl`: @tjaychen can that be moved to D2 by now? It looks like there is no checklist in the tree for that module...