### PR TITLE
[aes/dv] Use Canright S-Box for DV of the unmasked configuration

### DIFF
--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -58,7 +58,7 @@
     {
       name: aes_no_masking
       build_opts: ["+define+EN_MASKING=0",
-                   "+define+SBOX_IMPL=aes_pkg::SBoxImplLut" ]
+                   "+define+SBOX_IMPL=aes_pkg::SBoxImplCanright" ]
     }
     {
       name: aes_masking


### PR DESCRIPTION
Previously, the LUT-based S-Box was used but it makes more sense to verify the unmasked Canright S-Box for the unmasked configuration as this is what should be used on ASIC.