### PR TITLE
[prim] Make some widening comparisons explicit in prim_clock_*.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_clock_meas.sv
+++ b/hw/ip/prim/rtl/prim_clock_meas.sv
@@ -65,7 +65,7 @@ module prim_clock_meas #(
     end else if (!ref_en && |ref_cnt) begin
       ref_cnt <= '0;
       ref_valid <= '0;
-    end else if (ref_en && (ref_cnt == RefCnt - 1)) begin
+    end else if (ref_en && (int'(ref_cnt) == RefCnt - 1)) begin
       // restart count and measure
       ref_cnt <= '0;
       ref_valid <= 1'b1;

--- a/hw/ip/prim/rtl/prim_clock_timeout.sv
+++ b/hw/ip/prim/rtl/prim_clock_timeout.sv
@@ -27,7 +27,7 @@ module prim_clock_timeout #(
   logic [CntWidth-1:0] cnt;
   logic ack;
   logic timeout;
-  assign timeout = cnt >= TimeOutCnt;
+  assign timeout = int'(cnt) >= TimeOutCnt;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       cnt <= '0;


### PR DESCRIPTION
This makes explicit what the code was doing already and silences some
Verilator lint warnings.

Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>