### PR TITLE
[prim] Fix Verilator lint warnings in prim_gf_mult.sv

### DIFF
--- a/hw/ip/prim/rtl/prim_gf_mult.sv
+++ b/hw/ip/prim/rtl/prim_gf_mult.sv
@@ -33,13 +33,13 @@ module prim_gf_mult #(
   // The field-generating, irreducible polynomial of degree Width.
   // Can for example be a Conway polynomial, see
   // http://www.math.rwth-aachen.de/~Frank.Luebeck/data/ConwayPol/CP2.html
-  // For Width = 33, the Conway polynomial hast bits 32, 15, 9, 7, 4, 3, 0 set to one.
-  parameter logic[Width-1:0] IPoly = 1'b1 << 15 |
-                                     1'b1 << 9  |
-                                     1'b1 << 7  |
-                                     1'b1 << 4  |
-                                     1'b1 << 3  |
-                                     1'b1 << 0
+  // For Width = 33, the Conway polynomial has bits 32, 15, 9, 7, 4, 3, 0 set to one.
+  parameter logic[Width-1:0] IPoly = Width'(1'b1) << 15 |
+                                     Width'(1'b1) << 9  |
+                                     Width'(1'b1) << 7  |
+                                     Width'(1'b1) << 4  |
+                                     Width'(1'b1) << 3  |
+                                     Width'(1'b1) << 0
 ) (
   input clk_i,
   input rst_ni,
@@ -94,7 +94,7 @@ module prim_gf_mult #(
   end else begin : gen_decomposed
 
     // multiply is done
-    assign ack_o = cnt == (Loops - 1);
+    assign ack_o = int'(cnt) == (Loops - 1);
 
     // advance the stage count and also advance the bit position count
     always_ff @(posedge clk_i or negedge rst_ni) begin
@@ -102,7 +102,7 @@ module prim_gf_mult #(
         cnt <= '0;
       end else if (req_i && ack_o) begin
         cnt <= '0;
-      end else if (req_i && cnt < (Loops - 1)) begin
+      end else if (req_i && int'(cnt) < (Loops - 1)) begin
         cnt <= cnt + 1'b1;
       end
     end
@@ -155,14 +155,14 @@ module prim_gf_mult #(
 
   // Galois multiply step
   function automatic logic [Width-1:0] gf_mult(
-    logic [StagesPerCycle-1:0][Width-1:0] matrix,
+    logic [StagesPerCycle-1:0][Width-1:0] matrix_,
     logic [StagesPerCycle-1:0] operand
   );
     logic [Width-1:0] mult_out;
     logic [Width-1:0] add_vector;
     mult_out = '0;
     for (int i = 0; i < StagesPerCycle; i++) begin
-      add_vector = operand[i] ? matrix[i] : '0;
+      add_vector = operand[i] ? matrix_[i] : '0;
       mult_out = mult_out ^ add_vector;
     end
     return mult_out;


### PR DESCRIPTION
These are almost all width mismatches, where this commit makes
Verilog's implicit widening behaviour explicit. The only other change
is in the gf_mult() function, where the matrix argument shadows an
in-scope variable. Fix that by just appending an underscore.