### PR TITLE
[prim] Waive unused parameters for Verilator in prim_generic_otp

### DIFF
--- a/hw/ip/prim_generic/lint/prim_generic_otp.vlt
+++ b/hw/ip/prim_generic/lint/prim_generic_otp.vlt
@@ -2,3 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
+
+`verilator_config
+
+// The generic OTP module doesn't use vendor-specific parameters
+lint_off -rule UNUSED -file "*/rtl/prim_generic_otp.sv" -match "*VendorTestOffset*"
+lint_off -rule UNUSED -file "*/rtl/prim_generic_otp.sv" -match "*VendorTestSize*"


### PR DESCRIPTION
Signed-off-by: Rupert Swarbrick <rswarbrick@lowrisc.org>