### PR TITLE
[rtl] Convert some non-ANSI parameters to localparams

### DIFF
--- a/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
+++ b/hw/ip/aes/pre_dv/aes_sbox_tb/rtl/aes_sbox_tb.sv
@@ -73,9 +73,9 @@ module aes_sbox_tb #(
   assign masked_stimulus = stimulus ^ in_mask;
 
   // PRD Generation
-  parameter int unsigned WidthPRDSBoxCanrightMasked        = 8;
-  parameter int unsigned WidthPRDSBoxCanrightMaskedNoreuse = 18;
-  parameter int unsigned WidthPRDSBoxDOM                   = 28;
+  localparam int unsigned WidthPRDSBoxCanrightMasked        = 8;
+  localparam int unsigned WidthPRDSBoxCanrightMaskedNoreuse = 18;
+  localparam int unsigned WidthPRDSBoxDOM                   = 28;
 
   logic                                   [31:0] prd;
   logic [31-WidthPRDSBoxCanrightMaskedNoreuse:0] unused_prd;

--- a/hw/ip/prim/rtl/prim_lc_combine.sv
+++ b/hw/ip/prim/rtl/prim_lc_combine.sv
@@ -19,7 +19,7 @@ module prim_lc_combine #(
 
   // Determine whether which multibit value is considered "active" for the
   // purpose of the logical function below.
-  parameter lc_ctrl_pkg::lc_tx_t ActiveValue = (ActiveLow) ? lc_ctrl_pkg::Off : lc_ctrl_pkg::On;
+  localparam lc_ctrl_pkg::lc_tx_t ActiveValue = (ActiveLow) ? lc_ctrl_pkg::Off : lc_ctrl_pkg::On;
   // Truth tables:
   //
   // ActiveLow: 0, CombineMode: 0 (active-high "OR")

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_asic.sv
@@ -93,15 +93,15 @@ module chip_earlgrey_asic (
   // Special Signal Indices //
   ////////////////////////////
 
-  parameter int Tap0PadIdx = 30;
-  parameter int Tap1PadIdx = 27;
-  parameter int Dft0PadIdx = 25;
-  parameter int Dft1PadIdx = 26;
-  parameter int TckPadIdx = 38;
-  parameter int TmsPadIdx = 35;
-  parameter int TrstNPadIdx = 39;
-  parameter int TdiPadIdx = 37;
-  parameter int TdoPadIdx = 36;
+  localparam int Tap0PadIdx = 30;
+  localparam int Tap1PadIdx = 27;
+  localparam int Dft0PadIdx = 25;
+  localparam int Dft1PadIdx = 26;
+  localparam int TckPadIdx = 38;
+  localparam int TmsPadIdx = 35;
+  localparam int TrstNPadIdx = 39;
+  localparam int TdiPadIdx = 37;
+  localparam int TdoPadIdx = 36;
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_cw310.sv
@@ -83,15 +83,15 @@ module chip_earlgrey_cw310 #(
   // Special Signal Indices //
   ////////////////////////////
 
-  parameter int Tap0PadIdx = 22;
-  parameter int Tap1PadIdx = 16;
-  parameter int Dft0PadIdx = 23;
-  parameter int Dft1PadIdx = 34;
-  parameter int TckPadIdx = 59;
-  parameter int TmsPadIdx = 60;
-  parameter int TrstNPadIdx = 18;
-  parameter int TdiPadIdx = 53;
-  parameter int TdoPadIdx = 54;
+  localparam int Tap0PadIdx = 22;
+  localparam int Tap1PadIdx = 16;
+  localparam int Dft0PadIdx = 23;
+  localparam int Dft1PadIdx = 34;
+  localparam int TckPadIdx = 59;
+  localparam int TmsPadIdx = 60;
+  localparam int TrstNPadIdx = 18;
+  localparam int TdiPadIdx = 53;
+  localparam int TdoPadIdx = 54;
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{

--- a/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
+++ b/hw/top_earlgrey/rtl/autogen/chip_earlgrey_nexysvideo.sv
@@ -78,15 +78,15 @@ module chip_earlgrey_nexysvideo #(
   // Special Signal Indices //
   ////////////////////////////
 
-  parameter int Tap0PadIdx = 22;
-  parameter int Tap1PadIdx = 16;
-  parameter int Dft0PadIdx = 23;
-  parameter int Dft1PadIdx = 34;
-  parameter int TckPadIdx = 59;
-  parameter int TmsPadIdx = 60;
-  parameter int TrstNPadIdx = 18;
-  parameter int TdiPadIdx = 53;
-  parameter int TdoPadIdx = 54;
+  localparam int Tap0PadIdx = 22;
+  localparam int Tap1PadIdx = 16;
+  localparam int Dft0PadIdx = 23;
+  localparam int Dft1PadIdx = 34;
+  localparam int TckPadIdx = 59;
+  localparam int TmsPadIdx = 60;
+  localparam int TrstNPadIdx = 18;
+  localparam int TdiPadIdx = 53;
+  localparam int TdoPadIdx = 54;
 
   // DFT and Debug signal positions in the pinout.
   localparam pinmux_pkg::target_cfg_t PinmuxTargetCfg = '{

--- a/util/topgen/templates/chiplevel.sv.tpl
+++ b/util/topgen/templates/chiplevel.sv.tpl
@@ -124,7 +124,7 @@ module chip_${top["name"]}_${target["name"]} (
 <% param_name = (lib.Name.from_snake_case(entry["name"]) +
                  lib.Name(["pad", "idx"])).as_camel_case()
 %>\
-  parameter int ${param_name} = ${entry["idx"]};
+  localparam int ${param_name} = ${entry["idx"]};
   % endfor
 % endif
 


### PR DESCRIPTION
It turns out that there's a slightly obscure corner of the SV spec
that says that if you have a module like this:

```systemverilog
module foo #(
  parameter int Foo = 0
) (
  // ...
);
  parameter int Bar = 1;
  // ...

endmodule
```

then `Bar` essentially becomes a localparam: the presence of the ANSI
parameter list means that all non-ANSI parameters get treated as
localparams. Furthermore, some tools (Vivado, at least) warn when this
happens.

Convert these parameters to localparams, which is how they will behave
anyway.

This commit switches all occurrences that I found with

    git ls-files -- '*.sv' | \
      grep -v vendor | \
      xargs -n1 awk '\
        /module.*#\(/ {if(x==0) x=1} \
        /\)\s*\(/ {if(x==1) x=2;} \
        /^[^/]*parameter/ {\
          if(x==2) printf("%s:%s: %s\n", FILENAME, FNR, $0);\
        }'

(Note: there are a few false positives that this script finds in
aes_sbox_dom.sv, which has more than one module in the file).
