### PR TITLE
[dv/chip] Fix csr_bit_bash failure

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -43,4 +43,20 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  virtual task pre_start();
+    super.pre_start();
+    // Disable assertions failed due to CSR random write value.
+    $assertoff(0,
+        "tb.dut.top_earlgrey.u_adc_ctrl_aon.u_adc_ctrl_core.u_adc_ctrl_fsm.LpSampleCntCfg_M");
+    $assertoff(0,
+        "tb.dut.top_earlgrey.u_adc_ctrl_aon.u_adc_ctrl_core.u_adc_ctrl_fsm.NpSampleCntCfg_M");
+  endtask
+
+  virtual task post_start();
+    super.post_start();
+    $asserton(0,
+        "tb.dut.top_earlgrey.u_adc_ctrl_aon.u_adc_ctrl_core.u_adc_ctrl_fsm.LpSampleCntCfg_M");
+    $asserton(0,
+        "tb.dut.top_earlgrey.u_adc_ctrl_aon.u_adc_ctrl_core.u_adc_ctrl_fsm.NpSampleCntCfg_M");
+  endtask
 endclass


### PR DESCRIPTION
This PR fixes csr_bit_bash failure due to random write illegal values
that causes an assertion error. There is no RTL error so instead of
excluding the registers, we will just disable the assertion.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>