### PR TITLE
[otbn,rtl] Wire up the local escalation signal to mem intg_error_i

### DIFF
--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -310,7 +310,7 @@ module otbn
     .addr_i      (imem_index),
     .wdata_i     (imem_wdata),
     .wmask_i     (imem_wmask),
-    .intg_error_i(1'b0),
+    .intg_error_i(locked),
 
     .rdata_o (imem_rdata),
     .rvalid_o(imem_rvalid),
@@ -472,7 +472,7 @@ module otbn
     .addr_i      (dmem_index),
     .wdata_i     (dmem_wdata),
     .wmask_i     (dmem_wmask),
-    .intg_error_i(1'b0),
+    .intg_error_i(locked),
 
     .rdata_o (dmem_rdata),
     .rvalid_o(dmem_rvalid),


### PR DESCRIPTION
This matches the structure of `sram_ctrl` and ensures that any memory
access after locking gets mis-scrambled.
