### PR TITLE
[kmac/pre_syn] Enable Yosys synthesis of full SHA3 core and entire KMAC module

### DIFF
--- a/hw/ip/aes/pre_sca/alma/README.md
+++ b/hw/ip/aes/pre_sca/alma/README.md
@@ -7,7 +7,7 @@ Execution-aware Masking Verification](https://github.com/IAIK/coco-alma).
 ## Prerequisites
 
 Note that this flow is experimental. It has been developed using Yosys 0.9+4306
-(git sha1 3931b3a03) and sv2v v0.0.7-17-g499bd58. Other tool versions might not
+(git sha1 3931b3a03) and sv2v v0.0.9-24-gf868f06. Other tool versions might not
 be compatible.
 
 1. Download the Alma tool

--- a/hw/ip/kmac/pre_syn/syn_setup.example.sh
+++ b/hw/ip/kmac/pre_syn/syn_setup.example.sh
@@ -7,12 +7,14 @@
 # Setup IP name and top module.
 # When changing the top module, some parameters might not exist and
 # tcl/yosys_run_synth.tcl might need to be adjusted accordingly.
+# Known working top modules are: keccak_2share, keccak_round, sha3, kmac
 export LR_SYNTH_IP_NAME=kmac
 export LR_SYNTH_TOP_MODULE=keccak_2share
 
 # Setup module parameters. The Width is actually 1600 but it can have any value
 # in [25, 50, 100, 200, 400, 800, 1600]. We choose 25 instead to get smaller
-# netlist thereby speeding up the formal masking verification.
+# netlist thereby speeding up the formal masking verification. Ignored for sha3
+# and kmac top modules.
 export LR_SYNTH_WIDTH=25
 export LR_SYNTH_EN_MASKING=1
 

--- a/hw/ip/kmac/pre_syn/syn_yosys.sh
+++ b/hw/ip/kmac/pre_syn/syn_yosys.sh
@@ -72,8 +72,21 @@ OT_DEP_SOURCES=(
     "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_flop_en.sv
     "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_buf.sv
     "$LR_SYNTH_SRC_DIR"/../prim_xilinx/rtl/prim_xilinx_xor2.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_adapter_sram.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_sram_byte.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_socket_1n.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_err_resp.sv
+    "$LR_SYNTH_SRC_DIR"/../tlul/rtl/tlul_fifo_sync.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_dom_and_2share.sv
     "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_keccak.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_slicer.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_intr_hw.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_edn_req.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_fifo_sync.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_arbiter_fixed.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_packer.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_count.sv
+    "$LR_SYNTH_SRC_DIR"/../prim/rtl/prim_double_lfsr.sv
 )
 
 # Get OpenTitan dependency packages.
@@ -126,11 +139,6 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
         continue
     fi
 
-    # Skipe certain problematic module files that we don't need for the keccak_2share module.
-    if [ "$module" = "kmac_app" ]; then
-        continue
-    fi
-
     sv2v \
         --define=SYNTHESIS \
         "${OT_DEP_PACKAGES[@]}" \
@@ -155,7 +163,7 @@ for file in "$LR_SYNTH_SRC_DIR"/rtl/*.sv; do
     # Remove the StateEnumT parameter from prim_sparse_fsm_flop instances. Yosys doesn't seem to
     # support this.
     sed -i '/\.StateEnumT(logic \[.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
-    sed -i '/\.StateEnumT_StateWidth(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
+    sed -i '/\.StateEnumT.*StateWidth.*(.*/d' $LR_SYNTH_OUT_DIR/generated/${module}.v
 done
 
 #-------------------------------------------------------------------------

--- a/hw/ip/kmac/pre_syn/tcl/yosys_run_synth.tcl
+++ b/hw/ip/kmac/pre_syn/tcl/yosys_run_synth.tcl
@@ -18,7 +18,9 @@ yosys "read_verilog -sv $lr_synth_out_dir/generated/*.v"
 
 # Set top-module parameters.
 yosys "chparam -set EnMasking $lr_synth_en_masking $lr_synth_top_module"
-yosys "chparam -set Width $lr_synth_width $lr_synth_top_module"
+if { $lr_synth_top_module == "keccak_2share" || $lr_synth_top_module == "keccak_round"} {
+  yosys "chparam -set Width $lr_synth_width $lr_synth_top_module"
+}
 
 # Remap Xilinx Vivado "dont_touch" attributes to Yosys "keep" attributes.
 yosys "attrmap -tocase keep -imap dont_touch=\"yes\" keep=1 -imap dont_touch=\"no\" keep=0 -remove keep=0"

--- a/hw/ip/prim/rtl/prim_count.sv
+++ b/hw/ip/prim/rtl/prim_count.sv
@@ -30,6 +30,8 @@
 //    - en_i increments/decrements the up_count/down_count by step_i, if neither of the above is
 //      set.
 
+`include "prim_assert.sv"
+
 module prim_count import prim_count_pkg::*; #(
   parameter int Width = 2,
   parameter bit OutSelDnCnt = 1, // 0 selects up count

--- a/hw/ip/tlul/rtl/tlul_pkg.sv
+++ b/hw/ip/tlul/rtl/tlul_pkg.sv
@@ -183,7 +183,10 @@ package tlul_pkg;
   function automatic logic [DataIntgWidth-1:0] get_data_intg(logic [top_pkg::TL_DW-1:0] data);
     logic [DataIntgWidth-1:0] data_intg;
     logic [top_pkg::TL_DW-1:0] unused_data;
-    {data_intg, unused_data} = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
+    logic [DataIntgWidth + top_pkg::TL_DW - 1 : 0] enc_data;
+    enc_data = prim_secded_pkg::prim_secded_inv_39_32_enc(data);
+    data_intg = enc_data[DataIntgWidth + top_pkg::TL_DW - 1 : top_pkg::TL_DW];
+    unused_data = enc_data[top_pkg::TL_DW - 1 : 0];
     return data_intg;
   endfunction  // get_data_intg
 


### PR DESCRIPTION
This work is needed to evaluate the area impact of the reworked PRNG required to improve SCA hardening.