### PR TITLE
[otbn, dv] Generalises otbn_escalate test to allow invalid LC signals

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_escalate_if.sv
@@ -15,15 +15,21 @@ interface otbn_escalate_if (
     enable = lc_ctrl_pkg::Off;
   endfunction
 
-  task automatic set_after_n_clocks(int unsigned n);
+  task automatic randomize_after_n_clocks(int unsigned n,
+                                          int t_weight = 2,
+                                          int f_weight = 2,
+                                          int other_weight = 1);
     `DV_SPINWAIT_EXIT(
       begin
         repeat (n) @(posedge clk_i);
-        enable = lc_ctrl_pkg::On;
+          enable = cip_base_pkg::get_rand_lc_tx_val(.t_weight(t_weight),
+                                                    .f_weight(f_weight),
+                                                    .other_weight(other_weight));
       end,
       @(negedge rst_ni);,
       "Not setting enable signal because we've gone into reset",
       "otbn_escalate_if")
   endtask
+
 
 endinterface

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_escalate_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_escalate_vseq.sv
@@ -60,14 +60,16 @@ class otbn_escalate_vseq extends otbn_base_vseq;
   // Wait between zero and max_cycles clock cycles and then set the escalation signal to enabled.
   // Return immediately if we go into reset.
   task send_escalation_signal(int unsigned max_cycles);
-    cfg.escalate_vif.set_after_n_clocks($urandom_range(max_cycles));
+    cfg.escalate_vif.randomize_after_n_clocks($urandom_range(max_cycles), .f_weight(0));
   endtask
 
   // Wait for a fatal alert to come out and retrigger at least once. Then reset the DUT. This is
   // needed at the end of the sequence because otherwise the monitor that sees the re-triggering
   // fatal alert will stop the test from ever finishing.
   task wait_alert_and_reset();
-    repeat (2) wait_alert_trigger("fatal", .wait_complete(1));
+    if(cfg.escalate_vif.enable != lc_ctrl_pkg::Off) begin
+      repeat (2) wait_alert_trigger("fatal", .wait_complete(1));
+    end
 
     do_apply_reset = 1'b1;
     dut_init("HARD");


### PR DESCRIPTION
This commit adds a new function randomize_after_n_clocks in otbn_escalate_if to allow
setting enable pin to invalid value. This function replaces set_after_n_clocks in
otbn_escalate_vseq.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>