### PR TITLE
[ci, utils] Add Rust format checker to CI

### DIFF
--- a/ci/jobs/quick-lint.sh
+++ b/ci/jobs/quick-lint.sh
@@ -56,6 +56,9 @@ ci/scripts/clang-format.sh $tgt_branch
 echo -e "\n### Check formatting on header guards"
 ci/scripts/include-guard.sh $tgt_branch
 
+echo -e "\n### Use rustfmt to check Rust coding style"
+ci/scripts/rust-format.sh $tgt_branch
+
 echo -e "\n### Style-Lint RTL Verilog source files with Verible"
 ci/scripts/verible-lint.sh rtl
 

--- a/ci/scripts/rust-format.sh
+++ b/ci/scripts/rust-format.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# A wrapper around rustfmt, used for CI.
+#
+# Expects a single argument, which is the pull request's target branch
+# (usually "master").
+
+set -e
+
+if [ $# != 1 ]; then
+    echo >&2 "Usage: rust-format.sh <tgt-branch>"
+    exit 1
+fi
+tgt_branch="$1"
+
+merge_base="$(git merge-base origin/$tgt_branch HEAD)" || {
+    echo >&2 "Failed to find fork point for origin/$tgt_branch."
+    exit 1
+}
+echo "Running Rust lint checks on files changed since $merge_base"
+
+set -o pipefail
+git diff -z --name-only --diff-filter=ACMRTUXB "$merge_base" -- "*.rs" ':!*/vendor/*' | \
+    xargs -0 -r rustfmt --check || {
+    echo -n "##vso[task.logissue type=error]"
+    echo "Rust lint failed."
+    exit 1
+}

--- a/ci/scripts/show-env.sh
+++ b/ci/scripts/show-env.sh
@@ -14,6 +14,7 @@ tools=(
     yapf
     isort
     clang-format
+    rustfmt
     flake8
     ninja
     meson

--- a/util/run-rustfmt.sh
+++ b/util/run-rustfmt.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+find sw hw \
+    -name '*.rs' \
+    -exec rustfmt --check {} \;
+


### PR DESCRIPTION
Add new script rust-format.sh for checking of
code format in modified files.
Add support for rust in quick-lint.
Add small tools for checking Rust format in whole project.

This PR is part of issue: #11108

Signed-off-by: Michal Mazurek <maz@semihalf.com>