### PR TITLE
[bazel/clang] fixes to enable llvm built Mask ROM

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -90,6 +90,7 @@ opentitan_rom_binary(
         "//sw/device/silicon_creator/lib:epmp",
         "//sw/device/silicon_creator/lib:error",
         "//sw/device/silicon_creator/lib:irq_asm",
+        "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib:shutdown",
         "//sw/device/silicon_creator/lib:sigverify",
         "//sw/device/silicon_creator/lib:sigverify_intf",

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys.c
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys.c
@@ -242,3 +242,4 @@ rom_error_t sigverify_rsa_key_get(uint32_t key_id, lifecycle_state_t lc_state,
 
 extern const sigverify_mask_rom_key_t *sigverify_rsa_keys_ptr_get(void);
 extern size_t sigverify_num_rsa_keys_get(void);
+extern size_t sigverify_rsa_keys_step_get(void);


### PR DESCRIPTION
GCC inlined a couple things that clang doesn't so we missed the
following defects that are fixed in this commit
* the mask rom depends on //sw/device/silicon_creator/lib:manifest
* we need to declare an extern for sigverify_rsa_keys_step_get()

Signed-off-by: Drew Macrae <drewmacrae@google.com>