### PR TITLE
[dv/otp] Generate OTP pkg constants on the fly

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_testplan.hjson
@@ -60,6 +60,15 @@
       tests: ["otp_ctrl_smoke"]
     }
     {
+      name: smoke_regr
+      desc: ''' Same as the smoke test, but instead of re-generate `otp_ctrl_part_pkg` on-the-fly,
+            this test will use the existing `otp_ctrl_part_pkg` from the repository. This will make
+            it easier for user to reproduce failure in private CI.
+            '''
+      milestone: V1
+      tests: ["otp_ctrl_smoke_regr"]
+    }
+    {
       name: dai_access_partition_walk
       desc: '''
             Similar to UVM's memory walk test, this test ensures every address in each partition

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -39,6 +39,20 @@
 
   en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
+  build_modes: [
+    {
+      name: default
+      // Re-generate otp_ctrl_part_pkg with random seed.
+      pre_build_cmds: ["cd /${proj_root} && ./util/design/gen-otp-mmap.py --seed ${seed}"]
+    }
+
+    {
+      name: smoke
+      // Override default to skip re-generating otp_ctrl_part_pkg with random seed.
+      pre_build_cmds: []
+    }
+  ]
+
   // Add additional tops for simulation.
   sim_tops: ["otp_ctrl_bind", "otp_ctrl_cov_bind",
              "sec_cm_prim_sparse_fsm_flop_bind",
@@ -67,6 +81,12 @@
     {
       name: otp_ctrl_smoke
       uvm_test_seq: otp_ctrl_smoke_vseq
+    }
+
+    {
+      name: otp_ctrl_smoke_regr
+      uvm_test_seq: otp_ctrl_smoke_vseq
+      build_mode: "smoke"
     }
 
     {
@@ -146,7 +166,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["otp_ctrl_smoke"]
+      tests: ["otp_ctrl_smoke_regr"]
     }
   ]
 }


### PR DESCRIPTION
This PR based on PR #11661, adds a OTP pre_build command to re-generate
OTP constants with different build-seed, so the OTP DV testbench won't
only test on pre checked-in constants values.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>