### PR TITLE
[dif/adc_ctrl] clear filter status CSR on IRQ cause clear

### DIFF
--- a/sw/device/lib/dif/dif_adc_ctrl.c
+++ b/sw/device/lib/dif/dif_adc_ctrl.c
@@ -422,6 +422,12 @@ dif_result_t dif_adc_ctrl_irq_clear_causes(const dif_adc_ctrl_t *adc_ctrl,
     return kDifBadArg;
   }
 
+  uint32_t filter_causes = (~kDifAdcCtrlIrqCauseOneshot) & causes;
+  if (filter_causes) {
+    mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_FILTER_STATUS_REG_OFFSET,
+                        filter_causes);
+  }
+
   mmio_region_write32(adc_ctrl->base_addr, ADC_CTRL_ADC_INTR_STATUS_REG_OFFSET,
                       causes);
 

--- a/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_adc_ctrl_unittest.cc
@@ -420,9 +420,15 @@ TEST_F(IrqClearCausesTest, BadCauses) {
 }
 
 TEST_F(IrqClearCausesTest, Success) {
+  EXPECT_WRITE32(ADC_CTRL_FILTER_STATUS_REG_OFFSET, 0x9);
   EXPECT_WRITE32(ADC_CTRL_ADC_INTR_STATUS_REG_OFFSET, 0x9);
   EXPECT_DIF_OK(dif_adc_ctrl_irq_clear_causes(
       &adc_ctrl_, kDifAdcCtrlIrqCauseFilter0 | kDifAdcCtrlIrqCauseFilter3));
+
+  EXPECT_WRITE32(ADC_CTRL_FILTER_STATUS_REG_OFFSET, 0x1);
+  EXPECT_WRITE32(ADC_CTRL_ADC_INTR_STATUS_REG_OFFSET, 0x101);
+  EXPECT_DIF_OK(dif_adc_ctrl_irq_clear_causes(
+      &adc_ctrl_, kDifAdcCtrlIrqCauseFilter0 | kDifAdcCtrlIrqCauseOneshot));
 }
 
 class FilterMatchWakeupSetEnabledTest : public AdcCtrlTest {};


### PR DESCRIPTION
As discussed, in #11354, it is more convenient to hide the ack-ing of
the filter status CSR behind the ack-ing of the IRQ status CSR.
Unfortunately, this required a HW change that was disruptive to DV at
the given moment. Therefore, SW can accomodate this by ack-ing both the
filter and IRQ status CSRs in the same DIF, which is implemented in
this commit.

Signed-off-by: Timothy Trippel <ttrippel@google.com>