### PR TITLE
[top] Add dedicated jtag id package

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl.hjson
@@ -81,6 +81,13 @@
       local:   "false",
       expose:  "true"
     }
+    { name:    "IdcodeValue",
+      desc:    "JTAG ID code.",
+      type:    "logic [31:0]",
+      default: "32'h00000001",
+      local:   "false",
+      expose:  "true"
+    }
     // Regular parameters
     { name:    "NumTokenWords",
       desc:    "Number of 32bit words in a token.",

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -1795,6 +1795,7 @@
       {
         ChipGen: 16'h 00001
         ChipRev: 16'h 00001
+        IdcodeValue: jtag_id_pkg::JTAG_IDCODE
       }
       clock_connections:
       {
@@ -1863,6 +1864,14 @@
           default: 16'h 00001
           expose: "true"
           name_top: LcCtrlChipRev
+        }
+        {
+          name: IdcodeValue
+          desc: JTAG ID code.
+          type: logic [31:0]
+          default: jtag_id_pkg::JTAG_IDCODE
+          expose: "true"
+          name_top: LcCtrlIdcodeValue
         }
       ]
       inter_signal_list:
@@ -4830,6 +4839,10 @@
           domain: "0"
         }
       }
+      param_decl:
+      {
+        IdcodeValue: jtag_id_pkg::JTAG_IDCODE
+      }
       base_addrs:
       {
         rom: 0x00010000
@@ -4843,7 +4856,6 @@
       [
         "0"
       ]
-      param_decl: {}
       memory: {}
       param_list:
       [
@@ -4851,7 +4863,7 @@
           name: IdcodeValue
           desc: RISC-V debug module JTAG ID code.
           type: logic [31:0]
-          default: 32'h 0000_0001
+          default: jtag_id_pkg::JTAG_IDCODE
           expose: "true"
           name_top: RvDmIdcodeValue
         }

--- a/hw/top_earlgrey/data/top_earlgrey.hjson
+++ b/hw/top_earlgrey/data/top_earlgrey.hjson
@@ -313,7 +313,8 @@
       base_addr: "0x40140000",
       param_decl: {
         ChipGen: "16'h 00001",
-        ChipRev: "16'h 00001"
+        ChipRev: "16'h 00001",
+        IdcodeValue: "jtag_id_pkg::JTAG_IDCODE",
       },
     },
     { name: "alert_handler",
@@ -558,6 +559,9 @@
       clock_srcs: {clk_i: "main"},
       clock_group: "infra",
       reset_connections: {rst_ni: "lc"},
+      param_decl: {
+        IdcodeValue: "jtag_id_pkg::JTAG_IDCODE",
+      }
       // Note that this module also contains a bus host.
       base_addrs: {rom: "0x00010000", regs: "0x41200000"}
     },
@@ -602,11 +606,11 @@
       type: "otbn",
       clock_srcs: {
         clk_i: {
-	  clock: "main", 
+	  clock: "main",
 	  group: "trans"
 	},
 	clk_edn_i: {
-          clock: "main", 
+          clock: "main",
           group: "secure"
         },
         clk_otp_i: {

--- a/hw/top_earlgrey/jtag_id_pkg.core
+++ b/hw/top_earlgrey/jtag_id_pkg.core
@@ -1,0 +1,19 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "lowrisc:constants:jtag_id_pkg"
+description: "jtag id for top_earlgrey"
+filesets:
+  files_rtl:
+    depend:
+      - "fileset_partner  ? (partner:constants:jtag_id_pkg)"
+    files:
+      - "!fileset_partner ? (rtl/jtag_id_pkg.sv)"
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_rtl

--- a/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
+++ b/hw/top_earlgrey/rtl/autogen/top_earlgrey.sv
@@ -32,6 +32,7 @@ module top_earlgrey #(
   // parameters for lc_ctrl
   parameter logic [15:0] LcCtrlChipGen = 16'h 00001,
   parameter logic [15:0] LcCtrlChipRev = 16'h 00001,
+  parameter logic [31:0] LcCtrlIdcodeValue = jtag_id_pkg::JTAG_IDCODE,
   // parameters for alert_handler
   // parameters for spi_host0
   // parameters for spi_host1
@@ -52,7 +53,7 @@ module top_earlgrey #(
   // parameters for flash_ctrl
   parameter bit SecFlashCtrlScrambleEn = 1,
   // parameters for rv_dm
-  parameter logic [31:0] RvDmIdcodeValue = 32'h 0000_0001,
+  parameter logic [31:0] RvDmIdcodeValue = jtag_id_pkg::JTAG_IDCODE,
   // parameters for rv_plic
   // parameters for aes
   parameter bit SecAesMasking = 1,
@@ -191,18 +192,6 @@ module top_earlgrey #(
   input                      scan_en_i,
   input prim_mubi_pkg::mubi4_t scanmode_i   // lc_ctrl_pkg::On for Scan
 );
-
-  // JTAG IDCODE for development versions of this code.
-  // Manufacturers of OpenTitan chips must replace this code with one of their
-  // own IDs.
-  // Field structure as defined in the IEEE 1149.1 (JTAG) specification,
-  // section 12.1.1.
-  localparam logic [31:0] JTAG_IDCODE = {
-    4'h0,     // Version
-    16'h4F54, // Part Number: "OT"
-    11'h426,  // Manufacturer Identity: Google
-    1'b1      // (fixed)
-  };
 
   import tlul_pkg::*;
   import top_pkg::*;
@@ -1510,7 +1499,8 @@ module top_earlgrey #(
     .RndCnstLcKeymgrDivProduction(RndCnstLcCtrlLcKeymgrDivProduction),
     .RndCnstInvalidTokens(RndCnstLcCtrlInvalidTokens),
     .ChipGen(LcCtrlChipGen),
-    .ChipRev(LcCtrlChipRev)
+    .ChipRev(LcCtrlChipRev),
+    .IdcodeValue(LcCtrlIdcodeValue)
   ) u_lc_ctrl (
       // [15]: fatal_prog_error
       // [16]: fatal_state_error

--- a/hw/top_earlgrey/rtl/jtag_id_pkg.sv
+++ b/hw/top_earlgrey/rtl/jtag_id_pkg.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package jtag_id_pkg;
+
+  // This is the open source facing JTAG value that should be replaced
+  // by manufacturers of each OpenTitan
+  localparam logic [31:0] JTAG_IDCODE = {
+    4'h0,     // Version
+    16'h4F54, // Part Number: "OT"
+    11'h426,  // TODO: This should be replaced with Lowrisc Identity
+    1'b1      // (fixed)
+  };
+
+endpackage : jtag_id_pkg

--- a/hw/top_earlgrey/top_earlgrey.core
+++ b/hw/top_earlgrey/top_earlgrey.core
@@ -34,6 +34,7 @@ filesets:
       - lowrisc:ip:sram_ctrl
       - lowrisc:ip:keymgr
       - lowrisc:constants:top_pkg
+      - lowrisc:constants:jtag_id_pkg
       - lowrisc:ip:otp_ctrl
       - lowrisc:ip:lc_ctrl
       - lowrisc:ip:usbdev
@@ -47,13 +48,13 @@ filesets:
       - lowrisc:ip:rom_ctrl
       - lowrisc:systems:clkmgr
       - lowrisc:systems:sensor_ctrl
-      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
-      - "fileset_partner ? (partner:systems:ast_pkg)"
       - lowrisc:tlul:headers
       - lowrisc:prim:all
       - lowrisc:prim:usb_diff_rx
       - lowrisc:prim:mubi
       - lowrisc:systems:top_earlgrey_pkg
+      - "fileset_partner  ? (partner:systems:ast_pkg)"
+      - "!fileset_partner ? (lowrisc:systems:ast_pkg)"
     files:
       - rtl/autogen/top_earlgrey_rnd_cnst_pkg.sv
       - rtl/autogen/top_earlgrey.sv

--- a/util/topgen/templates/toplevel.sv.tpl
+++ b/util/topgen/templates/toplevel.sv.tpl
@@ -109,18 +109,6 @@ module top_${top["name"]} #(
   input prim_mubi_pkg::mubi4_t scanmode_i   // lc_ctrl_pkg::On for Scan
 );
 
-  // JTAG IDCODE for development versions of this code.
-  // Manufacturers of OpenTitan chips must replace this code with one of their
-  // own IDs.
-  // Field structure as defined in the IEEE 1149.1 (JTAG) specification,
-  // section 12.1.1.
-  localparam logic [31:0] JTAG_IDCODE = {
-    4'h0,     // Version
-    16'h4F54, // Part Number: "OT"
-    11'h426,  // Manufacturer Identity: Google
-    1'b1      // (fixed)
-  };
-
   import tlul_pkg::*;
   import top_pkg::*;
   import tl_main_pkg::*;


### PR DESCRIPTION
- Partially addresses #11616
- allows partners to override jtag id package directly
  without having to modify the seed or generation flow

Signed-off-by: Timothy Chen <timothytim@google.com>