### PR TITLE
[mask_rom] Add Address Translation.

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -552,7 +552,7 @@
                   Subtract 1 from this value and then right shift by one to obtain 0x7FFF.
                   This value is then logically OR'd with the upper address bits that would select which 64KB to translate.
 
-                  In this exampole, the user wishes to translate the 0x8000-th 64KB block.
+                  In this example, the user wishes to translate the 0x8000-th 64KB block.
                   The value programmed is then 0x8000_7FFF.
 
                   If the user were to translate the 0x8001-th 64KB block, the value programmed would be 0x8001_7FFF.

--- a/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
+++ b/hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -13,4 +13,5 @@ MEMORY {
   ram_main(rwx) : ORIGIN = 0x10000000, LENGTH = 0x20000
   rom(rx) : ORIGIN = 0x00008000, LENGTH = 0x8000
   eflash_virtual(rx) : ORIGIN = 0x80000000, LENGTH = 0x100000
+  rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
 }

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -175,6 +175,17 @@ cc_library(
         "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
+    ],
+)
+
+cc_test(
+    name = "ibex_unittest",
+    srcs = ["ibex_unittest.cc"],
+    deps = [
+        ":ibex",
+        "//sw/device/silicon_creator/testing:mask_rom_test",
+        "@googletest//:gtest_main",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/drivers/ibex.c
+++ b/sw/device/silicon_creator/lib/drivers/ibex.c
@@ -5,6 +5,7 @@
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 
 #include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 #include "rv_core_ibex_regs.h"
@@ -15,4 +16,34 @@ enum {
 
 uint32_t ibex_fpga_version(void) {
   return abs_mmio_read32(kBase + RV_CORE_IBEX_FPGA_INFO_REG_OFFSET);
+}
+
+void ibex_addr_remap_0_set(uint32_t matching_addr, uint32_t remap_addr,
+                           size_t size) {
+  uint32_t mask = matching_addr | ((size - 1) >> 1);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET, mask);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET, mask);
+
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
+                   remap_addr);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET,
+                   remap_addr);
+
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET, 1);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET, 1);
+}
+
+void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
+                           size_t size) {
+  uint32_t mask = matching_addr | ((size - 1) >> 1);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET, mask);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET, mask);
+
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_REMAP_ADDR_1_REG_OFFSET,
+                   remap_addr);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_REMAP_ADDR_1_REG_OFFSET,
+                   remap_addr);
+
+  sec_mmio_write32(kBase + RV_CORE_IBEX_IBUS_ADDR_EN_1_REG_OFFSET, 1);
+  sec_mmio_write32(kBase + RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET, 1);
 }

--- a/sw/device/silicon_creator/lib/drivers/ibex.h
+++ b/sw/device/silicon_creator/lib/drivers/ibex.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_IBEX_H_
 #define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_IBEX_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -18,6 +19,46 @@ extern "C" {
  */
 uint32_t ibex_fpga_version(void);
 
+/**
+ * The following constants represent the expected number of sec_mmio register
+ * writes performed by functions in provided in this module. See
+ * `SEC_MMIO_WRITE_INCREMENT()` for more details.
+ *
+ * Example:
+ * ```
+ *  ibex_addr_remap_0_set(...);
+ *  SEC_MMIO_WRITE_INCREMENT(kAddressTranslationSecMmioConfigure);
+ * ```
+ */
+enum {
+  kAddressTranslationSecMmioConfigure = 6,
+};
+
+/**
+ * Configure the instruction and data bus in the address translation slot 0.
+ *
+ * @param matching_addr When an incoming transaction matches the matching
+ * region, it is redirected to the new address. If a transaction does not match,
+ * then it is directly passed through.
+ * @param remap_addr  The region where the matched transtaction will be
+ * redirected to.
+ * @param size The size of the regions mapped.
+ */
+void ibex_addr_remap_0_set(uint32_t matching_addr, uint32_t remap_addr,
+                           size_t size);
+
+/**
+ * Configure the instruction and data bus in the address translation slot 1.
+ *
+ * @param matching_addr When an incoming transaction matches the matching
+ * region, it is redirected to the new address. If a transaction does not match,
+ * then it is directly passed through.
+ * @param remap_addr  The region where the matched transtaction will be
+ * redirected to.
+ * @param size The size of the regions mapped.
+ */
+void ibex_addr_remap_1_set(uint32_t matching_addr, uint32_t remap_addr,
+                           size_t size);
 #ifdef __cplusplus
 }
 #endif

--- a/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/ibex_unittest.cc
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/ibex.h"
+
+#include <array>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"
+
+namespace ibex_unittest {
+namespace {
+
+class AddressTranslationTest : public mask_rom_test::MaskRomTest {
+ protected:
+  uint32_t base_ = TOP_EARLGREY_RV_CORE_IBEX_CFG_BASE_ADDR;
+  mask_rom_test::MockSecMmio sec_;
+};
+
+TEST_F(AddressTranslationTest, Slot0Sucess) {
+  uint32_t matching_addr = 0x9000000;
+  uint32_t remap_addr = 0x2000000;
+  uint32_t size = 0x8000;
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET,
+                     0x9003fff);
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET,
+                     0x9003fff);
+
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
+                     remap_addr);
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET,
+                     remap_addr);
+
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET, 1);
+
+  ibex_addr_remap_0_set(matching_addr, remap_addr, size);
+}
+
+TEST_F(AddressTranslationTest, Slot1Sucess) {
+  uint32_t matching_addr = 0xB040000;
+  uint32_t remap_addr = 0x6000000;
+  uint32_t size = 0x80000;
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET,
+                     0xb07ffff);
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET,
+                     0xb07ffff);
+
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_REMAP_ADDR_1_REG_OFFSET,
+                     remap_addr);
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_REMAP_ADDR_1_REG_OFFSET,
+                     remap_addr);
+
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_IBUS_ADDR_EN_1_REG_OFFSET, 1);
+  EXPECT_SEC_WRITE32(base_ + RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET, 1);
+
+  ibex_addr_remap_1_set(matching_addr, remap_addr, size);
+}
+}  // namespace
+}  // namespace ibex_unittest

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -489,6 +489,7 @@ test('sw_silicon_creator_lib_driver_watchdog_unittest', executable(
   suite: 'mask_rom',
 )
 
+
 # Mask ROM otbn driver
 sw_silicon_creator_lib_driver_otbn = declare_dependency(
   link_with: static_library(
@@ -613,6 +614,26 @@ sw_silicon_creator_lib_driver_ibex = declare_dependency(
       sw_lib_abs_mmio,
     ],
   ),
+)
+
+
+test('sw_silicon_creator_lib_driver_ibex_unittest', executable(
+    'sw_silicon_creator_lib_driver_ibex_unittest',
+    sources: [
+       hw_ip_ibex_reg_h,
+      'ibex_unittest.cc',
+      'ibex.c',
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_testing_hardened,
+      sw_silicon_creator_lib_base_mock_sec_mmio,
+    ],
+    native: true,
+    c_args: ['-DMOCK_ABS_MMIO', '-DOT_OFF_TARGET_TEST'],
+    cpp_args: ['-DMOCK_ABS_MMIO', '-DOT_OFF_TARGET_TEST'],
+  ),
+  suite: 'mask_rom',
 )
 
 test('sw_silicon_creator_lib_driver_spi_device_unittest', executable(

--- a/sw/device/silicon_creator/mask_rom/docs/memory_protection.md
+++ b/sw/device/silicon_creator/mask_rom/docs/memory_protection.md
@@ -57,7 +57,7 @@ The entry allocation is shown here:
 | 1     | ROM TEXT                      | RX          | TOR             |
 | 2     | ROM                           | R           | NAPOT           |
 | 3     |                               |             | OFF\*           |
-| 4     | `ROM_EXT` TEXT                 | RX          | TOR             |
+| 4     | `ROM_EXT` TEXT                | RX          | TOR             |
 | 5     | eFlash                        | R           | NAPOT           |
 | 6     | \<Reserved - see test plan\>  |             | OFF             |
 | 7     |                               |             | OFF             |
@@ -89,13 +89,16 @@ Entries that are OFF but for which the address register is in use are marked wit
 Once signature verification is complete the `ROM_EXT` text section can be made executable.
 It is critical that the memory region that is unlocked matches the memory region specified in the verified manifest.
 The unlock address space module will provide an API for unlocking the `ROM_EXT` text section based on a memory region provided to it.
+In case the address translation is enabled, indicated by the `address_translation` field of the manifest, a read-only section will be added
+for the `ROM_EXT` virtual address.
 
 | Entry | Description                   | Permissions | Addressing Mode |
 |-------|-------------------------------|-------------|-----------------|
 | 1     | ROM TEXT                      | RX          | TOR             |
 | 2     | ROM                           | R           | NAPOT           |
-| **4** | **`ROM_EXT` TEXT**             | **RX**      | **TOR**         |
+| **4** | **`ROM_EXT` TEXT**            | **RX**      | **TOR**         |
 | 5     | eFlash                        | R           | NAPOT           |
+| **6** | **`ROM_EXT` section**         | **R**       | **NAPOT**       |
 | 11    | MMIO (includes retention RAM) | RW          | TOR             |
 | 14    | Stack Guard (4 bytes)         | \<none\>    | NA4             |
 | 15    | RAM                           | RW          | NAPOT           |

--- a/sw/device/silicon_creator/mask_rom/mask_rom.ld
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.ld
@@ -23,6 +23,13 @@ INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
  */
 _mask_rom_boot_address = ORIGIN(rom);
 
+/**
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
+ */
+_rom_ext_virtual_start_address = ORIGIN(rom_ext_virtual);
+_rom_ext_virtual_size = LENGTH(rom_ext_virtual);
+ASSERT((_rom_ext_virtual_size <= (LENGTH(eflash) / 2)), "Error: rom ext flash is bigger than slot");
+
 /* Reserving space at the top of the RAM for the stack. */
 _stack_size = 0x2000;
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp.h
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp.h
@@ -55,10 +55,22 @@ void mask_rom_epmp_state_init(epmp_state_t *state, lifecycle_state_t lc_state);
  * hardware configuration.
  *
  * @param state The ePMP state to update.
- * @param image Region for executable sections in ROM_EXT image.
+ * @param region Region for executable sections in ROM_EXT image.
  */
-void mask_rom_epmp_unlock_rom_ext_rx(epmp_state_t *state, epmp_region_t image);
+void mask_rom_epmp_unlock_rom_ext_rx(epmp_state_t *state, epmp_region_t region);
 
+/**
+ * Unlocks the provided ROM_EXT image region with read-only permissions.
+ *
+ * The provided ePMP state is also updated to reflect the changes made to the
+ * hardware configuration.
+ * The image size must be power of 2 as this function uses NAPOT
+ * (Naturally-Aligned-Power-Of-Two) addressing mode.
+ *
+ * @param state The ePMP state to update.
+ * @param region Region in the ROM_EXT image to receive read-only permission.
+ */
+void mask_rom_epmp_unlock_rom_ext_r(epmp_state_t *state, epmp_region_t region);
 /**
  * Configure the ePMP entry to manage access to Debug ROM based on life cycle
  * state.

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -92,6 +92,15 @@ ld_library(
     ],
 )
 
+ld_library(
+    name = "ld_virtual_addr",
+    script = "rom_ext_virtual_addr.ld",
+    deps = [
+        ":ld_common",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey_memory",
+    ],
+)
+
 cc_library(
     name = "rom_ext",
     srcs = ["rom_ext.c"],
@@ -137,6 +146,17 @@ opentitan_flash_binary(
     srcs = ["rom_ext_start.S"],
     deps = [
         ":ld_slot_b",
+        ":rom_ext",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
+    ],
+)
+
+opentitan_flash_binary(
+    name = "virtual_addr",
+    srcs = ["rom_ext_start.S"],
+    deps = [
+        ":ld_virtual_addr",
         ":rom_ext",
         "//sw/device/lib/crt",
         "//sw/device/silicon_creator/lib:manifest_def",

--- a/sw/device/silicon_creator/rom_ext/meson.build
+++ b/sw/device/silicon_creator/rom_ext/meson.build
@@ -51,6 +51,7 @@ test('sw_silicon_creator_rom_ext_boot_policy_unittest', executable(
 
 rom_ext_linkfile_slot_a = files(['rom_ext_slot_a.ld'])
 rom_ext_linkfile_slot_b = files(['rom_ext_slot_b.ld'])
+rom_ext_linkfile_virtual_addr = files(['rom_ext_virtual_addr.ld'])
 
 rom_ext_link_info = {
   'rom_ext_slot_a' :
@@ -75,6 +76,18 @@ rom_ext_link_info = {
     # Link dependency file for slot B.
     [
       rom_ext_linkfile_slot_b,
+    ],
+  ],
+  'rom_ext_virtual_addr' :
+  [
+    # Link arguments for pic.
+    [
+      '-Wl,-L,@0@'.format(meson.project_source_root()),
+      '-Wl,-T,@0@/@1@'.format(meson.project_source_root(), rom_ext_linkfile_virtual_addr[0]),
+    ] + embedded_target_extra_link_args,
+    # Link dependency file for pic.
+    [
+      rom_ext_linkfile_virtual_addr,
     ],
   ],
 }

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -30,26 +30,27 @@ _dv_log_offset = 0x10000;
  * The start of the .text section relative to the beginning of the associated
  * slot for use in the manifest.
  */
-_manifest_code_start = _text_start - _slot_start_address;
+_manifest_code_start = _text_start - _rom_ext_start_address;
 /*
  * The end of the .text section relative to the beginning of the associated slot
  * for use in the manifest.
  */
-_manifest_code_end = _text_end - _slot_start_address;
+_manifest_code_end = _text_end - _rom_ext_start_address;
 /*
  * The location of the entry point relative to the beginning of the associated
  * slot for use in the manifest.
  */
-_manifest_entry_point = _rom_ext_start_boot - _slot_start_address;
+_manifest_entry_point = _rom_ext_start_boot - _rom_ext_start_address;
+
 
 /**
  * NOTE: We have to align each section to word boundaries as our current
  * s19->slm conversion scripts are not able to handle non-word aligned sections.
  */
 SECTIONS {
-  .manifest _slot_start_address : {
+  .manifest _rom_ext_start_address : {
     KEEP(*(.manifest))
-  } > eflash
+  } > rom_ext_flash
 
   /**
    * Ibex interrupt vector.
@@ -60,14 +61,14 @@ SECTIONS {
   .vectors : ALIGN(256) {
     _text_start = .;
     KEEP(*(.vectors))
-  } > eflash
+  } > rom_ext_flash
 
   /**
    * C runtime (CRT) section, containing program initialization code.
    */
   .crt : ALIGN(4) {
     KEEP(*(.crt))
-  } > eflash
+  } > rom_ext_flash
 
   /**
    * Standard text section, containing program code.
@@ -78,7 +79,7 @@ SECTIONS {
 
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
-  } > eflash
+  } > rom_ext_flash
 
   /**
    * Shutdown text section, containing shutdown function(s).
@@ -92,7 +93,7 @@ SECTIONS {
     /* Ensure section end is word-aligned. */
     . = ALIGN(4);
     _text_end = .;
-  } > eflash
+  } > rom_ext_flash
 
   /**
    * Read-only data section, containing all large compile-time constants, like
@@ -105,7 +106,7 @@ SECTIONS {
     *(.srodata.*)
     *(.rodata)
     *(.rodata.*)
-  } > eflash
+  } > rom_ext_flash
 
   /**
    * Critical static data that is accessible by both the mask ROM and the ROM
@@ -155,7 +156,7 @@ SECTIONS {
      *
      * Using `AT>` means we don't have to keep track of the next free part of
      * flash, as we do in our other linker scripts. */
-  } > ram_main AT> eflash
+  } > ram_main AT> rom_ext_flash
 
   /**
    * Standard BSS section. This will be zeroed at runtime by the CRT.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_slot_b.ld
@@ -20,6 +20,9 @@ _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 _stack_start = _stack_end - _stack_size;
 
 /* Slot B starts at the half-size mark of the eFlash. */
-_slot_start_address = ORIGIN(eflash) + (LENGTH(eflash) / 2);
+_rom_ext_size = LENGTH(eflash) / 2;
+_rom_ext_start_address = ORIGIN(eflash) + _rom_ext_size;
+
+REGION_ALIAS("rom_ext_flash", eflash);
 
 INCLUDE sw/device/silicon_creator/rom_ext/rom_ext_common.ld

--- a/sw/device/silicon_creator/rom_ext/rom_ext_virtual_addr.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_virtual_addr.ld
@@ -9,7 +9,9 @@
  *
  * The ROM_EXT is actually kept in flash, rather than ROM. While a ROM_EXT can
  * be loaded into either Slot A (the start of flash), or Slot B (the start of
- * the upper half of flash), this linker script only targets Slot A.
+ * the upper half of flash), this linker script targets both by using a virtual
+ * address. The ROM must configure the address translation before jumping to
+ * to the virtual address.
  */
 
 INCLUDE hw/top_earlgrey/sw/autogen/top_earlgrey_memory.ld
@@ -19,10 +21,13 @@ _stack_size = 0x2000;
 _stack_end = ORIGIN(ram_main) + LENGTH(ram_main);
 _stack_start = _stack_end - _stack_size;
 
-/* Slot A starts at begining of the eFlash. */
-_rom_ext_size = LENGTH(eflash) / 2;
-_rom_ext_start_address = ORIGIN(eflash);
+/**
+ * Symbols to be used in the setup of the address translation for ROM_EXT.
+ */
+_rom_ext_start_address = ORIGIN(rom_ext_virtual);
+_rom_ext_size = LENGTH(rom_ext_virtual);
+ASSERT((_rom_ext_size <= (LENGTH(eflash) / 2)), "Error: rom ext flash is bigger than slot");
 
-REGION_ALIAS("rom_ext_flash", eflash);
+REGION_ALIAS("rom_ext_flash", rom_ext_virtual);
 
 INCLUDE sw/device/silicon_creator/rom_ext/rom_ext_common.ld

--- a/util/topgen/templates/toplevel_memory.ld.tpl
+++ b/util/topgen/templates/toplevel_memory.ld.tpl
@@ -52,4 +52,5 @@ MEMORY {
   ${m["name"]}(${memory_to_flags(m)}) : ORIGIN = ${m["base_addr"]}, LENGTH = ${m["size"]}
 % endfor
   eflash_virtual(rx) : ORIGIN = 0x80000000, LENGTH = 0x100000
+  rom_ext_virtual(rx) : ORIGIN = 0x90000000, LENGTH = 0x80000
 }


### PR DESCRIPTION
# Introdution
Currently we generate two binaries for ROM_EXT, one statically linked for slot A and one statically linked for slot B. Ideally we would like to generate a single ROM_EXT binary that will work regardless of which position in flash it is placed in.

This PR intruduces the Ibex Simple Address Translation feature in the `MASK_ROM` to allow the `ROM_EXT` be pisition independent in case it is signalized in the manifest.

See issue https://github.com/lowRISC/opentitan/issues/9930
See the [proposal](https://docs.google.com/document/d/1wscqObX895t9Nbd2mPZCC7gUJL_wJLUaaMgBAT_sYhg/edit#heading=h.yqwfe0dy7w4k) for more detail.