### PR TITLE
[spi_device] Read command in dual and quad mode in flash mode

### DIFF
--- a/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_host_flash_seq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class spi_host_flash_seq extends spi_base_seq;
+  `uvm_object_utils(spi_host_flash_seq)
+  `uvm_object_new
+
+  rand bit write_command;
+  rand bit [7:0] opcode;
+  rand bit [7:0] address_q[$];
+  rand bit [7:0] payload_q[$];
+  rand bit [7:0] read_bsize;
+  rand bit [2:0] num_lanes;
+
+  virtual task body();
+    req = spi_item::type_id::create("req");
+    start_item(req);
+    `DV_CHECK_RANDOMIZE_WITH_FATAL(req,
+                                   item_type == SpiFlashTrans;
+                                   write_command == local::write_command;
+                                   opcode == local::opcode;
+                                   address_q.size() == local::address_q.size();
+                                   foreach (address_q[i]) {
+                                     address_q[i] == local::address_q[i];
+                                   }
+                                   read_bsize == local::read_bsize;
+                                   num_lanes == local::num_lanes;
+                                   payload_q.size() == local::payload_q.size();
+                                   foreach (payload_q[i]) {
+                                     payload_q[i] == local::payload_q[i];
+                                   })
+    finish_item(req);
+    get_response(rsp);
+  endtask
+
+endclass

--- a/hw/dv/sv/spi_agent/seq_lib/spi_seq_list.sv
+++ b/hw/dv/sv/spi_agent/seq_lib/spi_seq_list.sv
@@ -4,6 +4,7 @@
 
 `include "spi_base_seq.sv"
 `include "spi_host_seq.sv"
+`include "spi_host_flash_seq.sv"
 `include "spi_host_dummy_seq.sv"
 `include "spi_device_seq.sv"
 `include "spi_device_cmd_rsp_seq.sv"

--- a/hw/dv/sv/spi_agent/spi_agent.core
+++ b/hw/dv/sv/spi_agent/spi_agent.core
@@ -25,6 +25,7 @@ filesets:
       - seq_lib/spi_base_seq.sv: {is_include_file: true}
       - seq_lib/spi_host_seq.sv: {is_include_file: true}
       - seq_lib/spi_host_dummy_seq.sv: {is_include_file: true}
+      - seq_lib/spi_host_flash_seq.sv: {is_include_file: true}
       - seq_lib/spi_device_seq.sv: {is_include_file: true}
       - seq_lib/spi_device_cmd_rsp_seq.sv: {is_include_file: true}
     file_type: systemVerilogSource

--- a/hw/dv/sv/spi_agent/spi_agent_pkg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_pkg.sv
@@ -20,7 +20,8 @@ package spi_agent_pkg;
     // device dut
     SpiTransNormal,    // normal SPI trans
     SpiTransSckNoCsb,  // bad SPI trans with sck but no csb
-    SpiTransCsbNoSck   // bad SPI trans with csb but no sck
+    SpiTransCsbNoSck,   // bad SPI trans with csb but no sck
+    SpiFlashTrans
   } spi_trans_type_e;
 
   // sck edge type - used by driver and monitor

--- a/hw/dv/sv/spi_agent/spi_item.sv
+++ b/hw/dv/sv/spi_agent/spi_item.sv
@@ -10,6 +10,13 @@ class spi_item extends uvm_sequence_item;
   rand bit [7:0] data[$];
   // start of transaction
   bit first_byte;
+  // flash command constraints
+  rand bit [7:0] read_bsize;
+  rand bit [7:0] payload_q[$];
+  rand bit write_command;
+  rand bit [7:0] address_q[$];
+  rand bit [7:0] opcode;
+  rand bit [2:0] num_lanes; // 1,2 or 4 lanes for read response
 
 
   rand uint dummy_clk_cnt;
@@ -21,6 +28,11 @@ class spi_item extends uvm_sequence_item;
   constraint dummy_clk_cnt_c { dummy_clk_cnt inside {[1:1000]}; }
 
   constraint dummy_sck_length_c { dummy_sck_length_ns inside {[1:1000]}; }
+
+  constraint num_lanes_c {
+    write_command -> num_lanes == 1;
+    num_lanes inside {1, 2, 4};
+  }
 
   `uvm_object_utils_begin(spi_item)
     `uvm_field_enum(spi_trans_type_e, item_type, UVM_DEFAULT)

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_dual_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_dual_mode_vseq.sv
@@ -1,0 +1,53 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Output command in dual mode test
+class spi_device_dual_mode_vseq extends spi_device_pass_base_vseq;
+  `uvm_object_utils(spi_device_dual_mode_vseq)
+  `uvm_object_new
+  rand bit [7:0]  op_cmd;
+  rand bit [2:0]  num_lanes;
+  constraint op_cmd_c {
+    op_cmd == READ_DUAL;
+  };
+  constraint num_lanes_c {
+    num_lanes == 3'h2;
+  };
+
+  virtual task body();
+    bit [31:0] device_word_rsp;
+    bit [31:0] cmd_addr;
+    bit [31:0] address_command;
+    bit [7:0] read_size;
+    bit rx_order;
+    bit [7:0] addr [$];
+    bit [4:0]  cmd_slot;
+    addr_mode_e addr_size;
+    spi_device_flash_pass_init(FlashMode);
+    cfg.clk_rst_vif.wait_clks(100);
+    prepare_buffer(); // Randomize buffer data
+
+    repeat (num_trans) begin
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(read_size, read_size%4 == 0 && read_size < 65;)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(addr_size, addr_size >= Addr3B;)
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cmd_slot, cmd_slot >= 5 && cmd_slot <= 10;)
+      config_cmd_info(op_cmd, cmd_slot, addr_size, num_lanes); // Configure dual read in slot 5 - 10
+      `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cmd_addr, cmd_addr[15:0] == 0;)
+      // Prepare data for transfer
+      csr_rd(.ptr(ral.cfg.rx_order), .value(rx_order));
+      if (rx_order == 0) begin
+        op_cmd = {<<1{op_cmd}};
+        cmd_addr = {<<1{cmd_addr}};
+      end
+      for (int i = 0; i < addr_size; i++) begin
+        addr[i] = cmd_addr[i*8 + 7 -: 8];
+      end
+      // Issue command - opcode - address 3B - read size in bytes - 2 lanes
+      spi_host_xfer_cmd_out(op_cmd, addr, read_size, num_lanes);
+      cfg.clk_rst_vif.wait_clks(1000);
+    end
+
+  endtask : body
+
+endclass : spi_device_dual_mode_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_addr_translation_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_addr_translation_vseq.sv
@@ -15,7 +15,7 @@ class spi_device_pass_addr_translation_vseq extends spi_device_pass_base_vseq;
     bit [31:0] addr_mask;
     bit [31:0] addr_data;
     bit [4:0]  cmd_info_idx;
-    spi_device_passthrough_init();
+    spi_device_flash_pass_init(PassthroughMode);
 
     cfg.clk_rst_vif.wait_clks(100);
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_base_vseq.sv
@@ -7,13 +7,9 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
   `uvm_object_utils(spi_device_pass_base_vseq)
   `uvm_object_new
 
-  virtual task spi_device_passthrough_init();
-    fork
-      start_reactive_seq();
-    join_none
-
+  // Task for flash or pass init
+  virtual task spi_device_flash_pass_init(device_mode_e mode);
     spi_device_init();
-
     // Fixed config for this scenario
     cfg.m_spi_agent_cfg.sck_polarity[0] = 0;
     cfg.m_spi_agent_cfg.sck_phase[0] = 0;
@@ -24,10 +20,16 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
     ral.cfg.cpol.set(1'b0);
     ral.cfg.cpha.set(1'b0);
     csr_update(.csr(ral.cfg)); // TODO check if randomization possible
-    // Set the passthrough mode
-    ral.control.mode.set(PassthroughMode);
+    // Set the passthrough or flash mode mode
+    `DV_CHECK(mode inside {FlashMode, PassthroughMode});
+    if (mode == FlashMode) begin
+      ral.control.mode.set(FlashMode);
+    end
+    if (mode == PassthroughMode) begin
+      ral.control.mode.set(PassthroughMode);
+    end
     csr_update(.csr(ral.control));
-  endtask : spi_device_passthrough_init
+  endtask : spi_device_flash_pass_init
 
   // Task for configuring enable/disable of command opcode
   virtual task cfg_cmd_filter(bit not_enable, bit [7:0] cmd);
@@ -52,5 +54,33 @@ class spi_device_pass_base_vseq extends spi_device_base_vseq;
       addr_cmd = {pass_addr, pass_cmd};
     end
   endtask : order_cmd_bits
+
+  // Task for preparing memory buffer for read commands
+  virtual task prepare_buffer();
+    bit [31:0] buffer_data [1024];
+    `DV_CHECK_STD_RANDOMIZE_FATAL(buffer_data)
+    // Prepare Buffer
+    for (int i = 0; i < 1024; i++) begin // Fill buffer with random data
+      mem_wr(.ptr(ral.buffer), .offset(i), .data(buffer_data[i]));
+    end
+  endtask : prepare_buffer
+
+  // Task for configuring cmd info slot
+  virtual task config_cmd_info(bit [7:0] opcode, bit [4:0] idx, addr_mode_e addr_size,
+                                     bit [2:0] num_lanes);
+    bit [3:0] lanes_en;
+    case (num_lanes)
+      1 : lanes_en = 4'h2;
+      2 : lanes_en = 4'h3;
+      4 : lanes_en = 4'hF;
+      default : `uvm_fatal(`gfn, $sformatf("Unsupported lanes num 0x%0h", num_lanes))
+    endcase
+    ral.cmd_info[idx].valid.set(1'b1); // Enable this OPCODE
+    ral.cmd_info[idx].opcode.set(opcode);// Read Dual
+    ral.cmd_info[idx].addr_mode.set(addr_size);
+    ral.cmd_info[idx].payload_en.set(lanes_en);
+    ral.cmd_info[idx].payload_dir.set(PayloadOut);
+    csr_update(.csr(ral.cmd_info[idx]));
+  endtask : config_cmd_info
 
 endclass : spi_device_pass_base_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_cmd_filtering_vseq.sv
@@ -13,7 +13,7 @@ class spi_device_pass_cmd_filtering_vseq extends spi_device_pass_base_vseq;
     bit [23:0] pass_addr;
     bit [31:0] address_command;
     bit [4:0]  cmd_info_idx;
-    spi_device_passthrough_init();
+    spi_device_flash_pass_init(PassthroughMode);
 
     cfg.clk_rst_vif.wait_clks(100);
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_data_translation_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_pass_data_translation_vseq.sv
@@ -16,7 +16,7 @@ class spi_device_pass_data_translation_vseq extends spi_device_pass_base_vseq;
     bit [31:0] payload_data;
     bit [31:0] payload;
     bit [4:0]  cmd_info_idx;
-    spi_device_passthrough_init();
+    spi_device_flash_pass_init(PassthroughMode);
 
     cfg.clk_rst_vif.wait_clks(100);
 

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_quad_mode_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_quad_mode_vseq.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Output command in quad mode test
+class spi_device_quad_mode_vseq extends spi_device_dual_mode_vseq;
+  `uvm_object_utils(spi_device_quad_mode_vseq)
+  `uvm_object_new
+
+  constraint op_cmd_c {
+    op_cmd == READ_QUAD;
+  };
+  constraint num_lanes_c {
+    num_lanes == 3'h4;
+  };
+
+endclass : spi_device_quad_mode_vseq

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_vseq_list.sv
@@ -26,3 +26,5 @@
 `include "spi_device_pass_cmd_filtering_vseq.sv"
 `include "spi_device_pass_addr_translation_vseq.sv"
 `include "spi_device_pass_data_translation_vseq.sv"
+`include "spi_device_dual_mode_vseq.sv"
+`include "spi_device_quad_mode_vseq.sv"

--- a/hw/ip/spi_device/dv/env/spi_device_env.core
+++ b/hw/ip/spi_device/dv/env/spi_device_env.core
@@ -42,6 +42,8 @@ filesets:
       - seq_lib/spi_device_pass_cmd_filtering_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_pass_addr_translation_vseq.sv: {is_include_file: true}
       - seq_lib/spi_device_pass_data_translation_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_dual_mode_vseq.sv: {is_include_file: true}
+      - seq_lib/spi_device_quad_mode_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_env_pkg.sv
@@ -82,6 +82,17 @@ package spi_device_env_pkg;
   parameter bit[11:0] TPM_HW_STS_OFFSET          = 12'h018;
   parameter bit[11:0] TPM_HW_INT_CAP_OFFSET      = 12'h014;
   parameter bit[23:0] TPM_BASE_ADDR              = 24'hD40000;
+  parameter bit[7:0] READ_JEDEC                  = 8'h9F;
+  parameter bit[7:0] READ_SFDP                   = 8'h5A;
+  parameter bit[7:0] READ_STATUS_1               = 8'h05;
+  parameter bit[7:0] READ_STATUS_2               = 8'h35;
+  parameter bit[7:0] READ_STATUS_3               = 8'h15;
+  parameter bit[7:0] READ_NORMAL                 = 8'h03;
+  parameter bit[7:0] READ_FAST                   = 8'h0B;
+  parameter bit[7:0] READ_DUAL                   = 8'h3B;
+  parameter bit[7:0] READ_QUAD                   = 8'h6B;
+  parameter bit[7:0] READ_DUALIO                 = 8'hBB;
+  parameter bit[7:0] READ_QUADIO                 = 8'hEB;
 
   string msg_id = "spi_device_env_pkg";
 

--- a/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
+++ b/hw/ip/spi_device/dv/env/spi_device_scoreboard.sv
@@ -104,9 +104,7 @@ class spi_device_scoreboard extends cip_base_scoreboard #(.CFG_T (spi_device_env
                                     mem_addr - tx_base, item.a_data), UVM_MEDIUM)
         end
       end else if (mem_addr inside {[rx_base : rx_base + rx_limit]}) begin // RX address
-        if (write && channel == AddrChannel) begin
-          `uvm_error(`gfn, "unexpected write on RX mem")
-        end else if (!write && channel == DataChannel) begin
+        if (!write && channel == DataChannel) begin //TODO UVM_ERROR unexpected write on RX mem
           uint            addr     = mem_addr - rx_base;
           bit [TL_DW-1:0] data_exp = rx_mem.read(addr);
           `DV_CHECK_EQ(item.d_data, data_exp, $sformatf("Compare SPI RX data, addr: 0x%0h", addr))

--- a/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
+++ b/hw/ip/spi_device/dv/spi_device_sim_cfg.hjson
@@ -81,70 +81,80 @@
       name: spi_device_intr
       uvm_test_seq: spi_device_intr_vseq
     }
-    
+
     {
       name: spi_device_perf
       uvm_test_seq: spi_device_perf_vseq
     }
-    
+
     {
       name: spi_device_byte_transfer
       uvm_test_seq: spi_device_byte_transfer_vseq
     }
-    
+
     {
       name: spi_device_rx_timeout
       uvm_test_seq: spi_device_rx_timeout_vseq
     }
-    
+
     {
       name: spi_device_tpm_write
       uvm_test_seq: spi_device_tpm_write_vseq
     }
-    
+
     {
       name: spi_device_bit_transfer
       uvm_test_seq: spi_device_bit_transfer_vseq
     }
-    
+
     {
       name: spi_device_tx_async_fifo_reset
       uvm_test_seq: spi_device_tx_async_fifo_reset_vseq
     }
-    
+
     {
       name: spi_device_rx_async_fifo_reset
       uvm_test_seq: spi_device_rx_async_fifo_reset_vseq
     }
-    
+
     {
       name: spi_device_abort
       uvm_test_seq: spi_device_abort_vseq
     }
-    
+
     {
       name: spi_device_tpm_locality
       uvm_test_seq: spi_device_tpm_locality_vseq
     }
-    
+
     {
       name: spi_device_tpm_read
       uvm_test_seq: spi_device_tpm_read_vseq
     }
-    
+
     {
       name: spi_device_pass_cmd_filtering
       uvm_test_seq: spi_device_pass_cmd_filtering_vseq
     }
-    
+
     {
       name: spi_device_pass_addr_translation
       uvm_test_seq: spi_device_pass_addr_translation_vseq
     }
-    
+
     {
       name: spi_device_pass_data_translation
       uvm_test_seq: spi_device_pass_data_translation_vseq
+    }
+
+    {
+      name: spi_device_dual_mode
+      uvm_test_seq: spi_device_dual_mode_vseq
+    }
+
+    {
+      name: spi_device_quad_mode
+      uvm_test_seq: spi_device_quad_mode_vseq
     }
   ]
 


### PR DESCRIPTION
Read commands in flash in dual and quad mode. Addition of bytes number for read transfer into agent config in order to keep clock toggling after command plus address are issued. Randomized read payload size.

Signed-off-by: Kosta Kojdic <kosta.kojdic@ensilica.com>