### PR TITLE
[Otbn, dv] Added otbn_zero_state_err_urnd testcase

### DIFF
--- a/hw/ip/otbn/data/otbn_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_testplan.hjson
@@ -123,5 +123,14 @@
       milestone: V2
       tests: ["otbn_escalate"]
     }
+    {
+      name: zero_state_err_urnd
+      desc: '''
+              Trigger the "state is zero" error in URND,
+              Check that fatal error is asserted.
+            '''
+      milestone: V2
+      tests: ["otbn_zero_state_err_urnd"]
+    }
   ]
 }

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -125,10 +125,12 @@ module otbn_core_model
 
   // EDN URND Seed Request Logic
   logic edn_urnd_req_q, edn_urnd_req_d, start_q, start_d;
+  bit is_locked;
 
   // URND Reseeding is only done when OTBN receives EXECUTE command.
   assign start_d = (cmd == CmdExecute);
-  assign edn_urnd_req_d = ~edn_urnd_cdc_done_i & (edn_urnd_req_q | start_q);
+  assign is_locked = otbn_pkg::status_e'(status_o) == StatusLocked;
+  assign edn_urnd_req_d = !is_locked & ~edn_urnd_cdc_done_i & (edn_urnd_req_q | start_q);
 
   assign edn_urnd_o = edn_urnd_req_q;
 

--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -57,6 +57,8 @@ class OTBNSim:
         Use run() or step() to actually execute the program.
 
         '''
+        if self.state.get_fsm_state() != FsmState.IDLE:
+            return
         self.stats = ExecutionStats(self.program) if collect_stats else None
         self._execute_generator = None
         self._next_insn = None
@@ -162,7 +164,6 @@ class OTBNSim:
         }
 
         stepper, handles_injected_err = steppers[fsm_state]
-
         if not handles_injected_err:
             self.state.take_injected_err_bits()
 

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -45,6 +45,7 @@ filesets:
       - seq_lib/otbn_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_stress_all_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_escalate_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_zero_state_err_urnd_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -13,3 +13,4 @@
 `include "otbn_dmem_err_vseq.sv"
 `include "otbn_stress_all_vseq.sv"
 `include "otbn_escalate_vseq.sv"
+`include "otbn_zero_state_err_urnd_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -1,0 +1,35 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
+  `uvm_object_utils(otbn_zero_state_err_urnd_vseq)
+  `uvm_object_new
+
+  task body();
+
+    // We've loaded the binary. Run the processor to see what happens!
+    fork
+      begin
+        super.body();
+      end
+      begin
+        cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
+        fork
+          begin
+            uvm_hdl_force("tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d", 'b0);
+          end
+          begin
+            bit [31:0] err_val = 32'd1 << 20;
+            cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+            `uvm_info(`gfn,"injecting zero state error into ISS", UVM_HIGH)
+          end
+        join
+        repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
+        uvm_hdl_release("tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d");
+      end
+    join
+
+  endtask : body
+
+endclass : otbn_zero_state_err_urnd_vseq

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -239,6 +239,14 @@ name:
       en_run_modes: ["build_otbn_rig_binaries_mode"]
       reseed: 10
     }
+    {
+      name: "otbn_zero_state_err_urnd"
+      uvm_test_seq: "otbn_zero_state_err_urnd_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
+
 
   ]
 


### PR DESCRIPTION
This commit adds otbn_zero_state_err_urnd testcase and all the necessary
changes required to run it.

This is a draft PR and will go in once https://github.com/lowRISC/opentitan/pull/11665 is merged