### PR TITLE
[flash_ctrl] ADD SCOREBOARD ERASE PREDICTION

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -30,18 +30,14 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
   // Knob for scoreboard set expected alert
   bit scb_set_exp_alert = 0;
 
-  // Knob for scoreboard delete memory
-  bit scb_empty_mem = 0;
-
   // Knob for Bank Erase
   bit bank_erase_enable = 1;
 
-  // Parameters for set backdoor scb memory
-  bit                         scb_set_mem = 0;
-  int                         bkd_num_words;
-  flash_dv_part_e             bkd_partition;
-  bit             [TL_AW-1:0] write_bkd_addr;
-  bit             [TL_DW-1:0] set_bkd_val;
+  // mem for scoreboard
+  data_t                     scb_flash_data  [addr_t]  = '{default: 1};
+  data_t                     scb_flash_info  [addr_t]  = '{default: 1};
+  data_t                     scb_flash_info1 [addr_t]  = '{default: 1};
+  data_t                     scb_flash_info2 [addr_t]  = '{default: 1};
 
   // Max delay for alerts in clocks
   uint alert_max_delay;
@@ -375,5 +371,19 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
                                                     const ref data_q_t exp_data);
     return exp_data;
   endfunction : calculate_expected_data
+
+  virtual function void write_data_all_part(flash_dv_part_e part, bit [TL_AW-1:0] addr,
+                                            ref bit [TL_DW-1:0] data);
+  `uvm_info(`gfn, $sformatf("WRITE SCB MEM part: %0s addr:%0h data:0x%0h",
+                            part.name, addr, data), UVM_HIGH)
+    case (part)
+      FlashPartData:  scb_flash_data[addr]   = data;
+      FlashPartInfo:  scb_flash_info[addr]   = data;
+      FlashPartInfo1: scb_flash_info1[addr]  = data;
+      FlashPartInfo2: scb_flash_info2[addr]  = data;
+      default :
+        `uvm_fatal(`gfn,"flash_ctrl_scoreboard: Partition type not supported!")
+    endcase
+  endfunction
 
 endclass

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -70,6 +70,15 @@ package flash_ctrl_env_pkg;
   // Need to create a design parameter for this
   parameter uint FlashFullDataWidth = flash_ctrl_pkg::DataWidth + 4;
 
+  // params for words
+  parameter uint NUM_PAGE_WORDS            = 512;
+  parameter uint NUM_BK_DATA_WORDS         = 131072; // 256 pages
+  parameter uint NUM_BK_INFO_WORDS         = 5120;   // 10 pages
+
+  // params for num of pages
+  parameter uint NUM_PAGE_PART_DATA        = 512;
+  parameter uint NUM_PAGE_PART_INFO0       = 10;
+
   parameter otp_ctrl_pkg::flash_otp_key_rsp_t FLASH_OTP_RSP_DEFAULT = '{
       data_ack: 1'b0,
       addr_ack: 1'b0,
@@ -123,7 +132,7 @@ package flash_ctrl_env_pkg;
     FlashPartData       = 0,
     FlashPartInfo       = 1,
     FlashPartInfo1      = 2,
-    FlashPartRedundancy = 4
+    FlashPartInfo2      = 4
   } flash_dv_part_e;
 
   // Special Partitions

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -69,10 +69,10 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Flash ctrl op randomization knobs.
 
   // Partition select. Make sure to keep sum equals to 100.
-  uint op_on_data_partition_pc;  // Choose data partition.
-  uint op_on_info_partition_pc;  // Choose info partition.
+  uint op_on_data_partition_pc;   // Choose data partition.
+  uint op_on_info_partition_pc;   // Choose info partition.
   uint op_on_info1_partition_pc;  // Choose info1 partition.
-  uint op_on_redundancy_partition_pc;  // Choose redundancy partition.
+  uint op_on_info2_partition_pc;  // Choose info2 partition.
 
   bit op_readonly_on_info_partition;  // Make info partition read-only.
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
@@ -117,27 +117,27 @@ class flash_ctrl_seq_cfg extends uvm_object;
   // Set partition select percentages. Make sure to keep sum equals to 100.
   virtual function void set_partition_pc(uint sel_data_part_pc = 100, uint sel_info_part_pc = 0,
                                          uint sel_info1_part_pc = 0,
-                                         uint sel_redundancy_part_pc = 0);
+                                         uint sel_info2_part_pc = 0);
 
-    `DV_CHECK_EQ(sel_data_part_pc + sel_info_part_pc + sel_info1_part_pc + sel_redundancy_part_pc,
+    `DV_CHECK_EQ(sel_data_part_pc + sel_info_part_pc + sel_info1_part_pc + sel_info2_part_pc,
                  100, $sformatf(
                  {
                    "Error! sum of arguments must be 100. Be aware of arguments ",
                    "default values - 100 for data partition and 0 for all the ",
                    "others. Arguments current value: sel_data_part_pc=%0d , ",
                    "sel_info_part_pc=%0d , sel_info1_part_pc=%0d , ",
-                   "sel_redundancy_part_pc=%0d"
+                   "sel_info2_part_pc=%0d"
                  },
                  sel_data_part_pc,
                  sel_info_part_pc,
                  sel_info1_part_pc,
-                 sel_redundancy_part_pc
+                 sel_info2_part_pc
                  ))
 
     op_on_data_partition_pc       = sel_data_part_pc;
     op_on_info_partition_pc       = sel_info_part_pc;
     op_on_info1_partition_pc      = sel_info1_part_pc;
-    op_on_redundancy_partition_pc = sel_redundancy_part_pc;
+    op_on_info2_partition_pc = sel_info2_part_pc;
 
   endfunction : set_partition_pc
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv
@@ -66,7 +66,7 @@ class flash_ctrl_host_ctrl_arb_vseq extends flash_ctrl_base_vseq;
         flash_op.op == flash_ctrl_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartRedundancy) {
+    if (flash_op.partition == FlashPartInfo2) {
         flash_op.op == flash_ctrl_pkg::FlashOpRead;
     }
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -85,7 +85,7 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_base_vseq;
         flash_op.op == flash_ctrl_pkg::FlashOpRead;
     }
 
-    if (flash_op.partition == FlashPartRedundancy) {
+    if (flash_op.partition == FlashPartInfo2) {
         flash_op.op == flash_ctrl_pkg::FlashOpRead;
     }
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -50,7 +50,7 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
       FlashPartData         :/ cfg.seq_cfg.op_on_data_partition_pc,
       FlashPartInfo         :/ cfg.seq_cfg.op_on_info_partition_pc,
       FlashPartInfo1        :/ cfg.seq_cfg.op_on_info1_partition_pc,
-      FlashPartRedundancy   :/ cfg.seq_cfg.op_on_redundancy_partition_pc
+      FlashPartInfo2        :/ cfg.seq_cfg.op_on_info2_partition_pc
     };
 
     // Bank erase is supported only for data & 1st info partitions


### PR DESCRIPTION
Add Scoreboard erase prediction. Add support for update memory
in scoreboard when backdoor write is initiated.

Signed-off-by: Nikola Miladinovic <nikola.miladinovic@ensilica.com>