### PR TITLE
[dv/otp_ctrl] Fix stress_all_with_rand_reset seq

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -693,8 +693,8 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
               ongoing_reset = 1'b1;
               `uvm_info(`gfn, $sformatf("\nReset is issued for run %0d/%0d", i, num_times), UVM_LOW)
               apply_resets_concurrently();
-              ongoing_reset = 1'b0;
               do_read_and_check_all_csrs = 1'b1;
+              ongoing_reset = 1'b0;
             end
           join_any
           disable fork;

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_background_chks_vseq.sv
@@ -64,9 +64,10 @@ class otp_ctrl_background_chks_vseq extends otp_ctrl_dai_lock_vseq;
     end
   endtask
 
+  // Enable scoreboard is done in stress_all sequence and `apply_resets_concurrently` task to
+  // avoid otp_ctrl_scoreboard reporting failures when reset has not been issued.
   virtual task post_start();
     expect_fatal_alerts = 1;
     super.post_start();
-    cfg.en_scb = 1;
   endtask
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_base_vseq.sv
@@ -67,6 +67,17 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
     cfg.otp_ctrl_vif.release_part_access_mubi();
   endtask
 
+
+  // For stress_all_with_rand_reset test only.
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
+    cfg.otp_ctrl_vif.release_part_access_mubi();
+    cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
+    otp_ctrl_init();
+    otp_pwr_init();
+    super.apply_resets_concurrently(reset_duration_ps);
+    cfg.en_scb = 1;
+  endtask
+
   virtual task dut_shutdown();
     // check for pending otp_ctrl operations and wait for them to complete
     // TODO
@@ -261,56 +272,58 @@ class otp_ctrl_base_vseq extends cip_base_vseq #(
   // If the partition is read/write locked, there is 20% chance we will force the internal mubi
   // access signal to the values other than mubi::true or mubi::false.
   virtual task force_mubi_part_access();
-    otp_part_access_lock_t forced_mubi_part_access[NumPart-1];
+    if (cfg.otp_ctrl_vif.alert_reqs == 0) begin
+      otp_part_access_lock_t forced_mubi_part_access[NumPart-1];
 
-    if (`gmv(ral.vendor_test_digest[0]) || `gmv(ral.vendor_test_digest[1])) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[VendorTestIdx].write_lock = 1;
-    end
-    if (`gmv(ral.vendor_test_read_lock) == 0) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[VendorTestIdx].read_lock = 1;
-    end
+      if (`gmv(ral.vendor_test_digest[0]) || `gmv(ral.vendor_test_digest[1])) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[VendorTestIdx].write_lock = 1;
+      end
+      if (`gmv(ral.vendor_test_read_lock) == 0) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[VendorTestIdx].read_lock = 1;
+      end
 
-    if (`gmv(ral.creator_sw_cfg_digest[0]) || `gmv(ral.creator_sw_cfg_digest[1])) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[CreatorSwCfgIdx].write_lock = 1;
-    end
-    if (`gmv(ral.creator_sw_cfg_read_lock) == 0) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[CreatorSwCfgIdx].read_lock = 1;
-    end
+      if (`gmv(ral.creator_sw_cfg_digest[0]) || `gmv(ral.creator_sw_cfg_digest[1])) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[CreatorSwCfgIdx].write_lock = 1;
+      end
+      if (`gmv(ral.creator_sw_cfg_read_lock) == 0) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[CreatorSwCfgIdx].read_lock = 1;
+      end
 
-    if (`gmv(ral.owner_sw_cfg_digest[0]) || `gmv(ral.owner_sw_cfg_digest[1])) begin
-      if ($urandom_range(0, 4) == 0) forced_mubi_part_access[OwnerSwCfgIdx].write_lock = 1;
-    end
-    if (`gmv(ral.owner_sw_cfg_read_lock) == 0) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[OwnerSwCfgIdx].read_lock = 1;
-    end
+      if (`gmv(ral.owner_sw_cfg_digest[0]) || `gmv(ral.owner_sw_cfg_digest[1])) begin
+        if ($urandom_range(0, 4) == 0) forced_mubi_part_access[OwnerSwCfgIdx].write_lock = 1;
+      end
+      if (`gmv(ral.owner_sw_cfg_read_lock) == 0) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[OwnerSwCfgIdx].read_lock = 1;
+      end
 
-    if (`gmv(ral.hw_cfg_digest[0]) || `gmv(ral.hw_cfg_digest[1])) begin
-      // TODO: hw_cfg part cannot be read locked.
-      // if (!$urandom_range(0, 4)) cfg.forced_mubi_part_access[HwCfgIdx].read_lock = 1;
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[HwCfgIdx].write_lock = 1;
-    end
+      if (`gmv(ral.hw_cfg_digest[0]) || `gmv(ral.hw_cfg_digest[1])) begin
+        // TODO: hw_cfg part cannot be read locked.
+        // if (!$urandom_range(0, 4)) cfg.forced_mubi_part_access[HwCfgIdx].read_lock = 1;
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[HwCfgIdx].write_lock = 1;
+      end
 
-    if (`gmv(ral.secret0_digest[0]) || `gmv(ral.secret0_digest[1])) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret0Idx].read_lock = 1;
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret0Idx].write_lock = 1;
-    end
+      if (`gmv(ral.secret0_digest[0]) || `gmv(ral.secret0_digest[1])) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret0Idx].read_lock = 1;
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret0Idx].write_lock = 1;
+      end
 
-    if (`gmv(ral.secret1_digest[0]) || `gmv(ral.secret1_digest[1])) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret1Idx].read_lock = 1;
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret1Idx].write_lock = 1;
-    end
+      if (`gmv(ral.secret1_digest[0]) || `gmv(ral.secret1_digest[1])) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret1Idx].read_lock = 1;
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret1Idx].write_lock = 1;
+      end
 
-    if (`gmv(ral.secret2_digest[0]) || `gmv(ral.secret2_digest[1])) begin
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret2Idx].read_lock = 1;
-      if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret2Idx].write_lock = 1;
-    end
+      if (`gmv(ral.secret2_digest[0]) || `gmv(ral.secret2_digest[1])) begin
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret2Idx].read_lock = 1;
+        if (!$urandom_range(0, 4)) forced_mubi_part_access[Secret2Idx].write_lock = 1;
+      end
 
-    foreach (forced_mubi_part_access[i]) begin
-      `uvm_info(`gfn, $sformatf("partition %0d inject mubi value: read=%0b, write=%0b", i,
-          forced_mubi_part_access[i].read_lock, forced_mubi_part_access[i].write_lock), UVM_HIGH)
-    end
+      foreach (forced_mubi_part_access[i]) begin
+        `uvm_info(`gfn, $sformatf("partition %0d inject mubi value: read=%0b, write=%0b", i,
+            forced_mubi_part_access[i].read_lock, forced_mubi_part_access[i].write_lock), UVM_HIGH)
+      end
 
-    cfg.otp_ctrl_vif.force_part_access_mubi(forced_mubi_part_access);
+      cfg.otp_ctrl_vif.force_part_access_mubi(forced_mubi_part_access);
+    end
   endtask
 
   // This function backdoor inject error according to ecc_err.

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_stress_all_vseq.sv
@@ -80,11 +80,5 @@ class otp_ctrl_stress_all_vseq extends otp_ctrl_base_vseq;
     end
   endtask : body
 
-  virtual task read_and_check_all_csrs_after_reset();
-    cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
-    otp_pwr_init();
-    super.read_and_check_all_csrs_after_reset();
-  endtask
-
 endclass
 


### PR DESCRIPTION
This PR fixes otp_ctrl's stress_all_with_rand_reset:
1). Update the method to force mubi values - previous method try to use "for
  loop" and pre-assign the mubi values to all partitions before forcing
  them. This will work for normal sequences but not for
  stress_all_with_rand_reset. Because if the previous partition is not
  locked (sequence will force it to unlocked value), then next sequence locks the partition
 without reset (usually sequence will reset here), then next sequence cannot be locked
  because of the forced value.
  So this PR change it to only force locked value to undeclared mubi values.

2). In stress_all_with_rand_reset sequence, for reset we use a
  different task `apply_resets_concurrently`. It is a separate task and does not
  include any overrides for `apply_reset` and `dut_init`. To adds the additional
  overrides, I used to put it under `otp_ctrl_stress_all_vseq`. However,
  stress_all_with_rand_reset is based on `common_sequence` instead, so
  this override did not apply to `stress_all_with_rand_reset` sequence.
  So I moved the override to base task.

3). For the timing to re-enable scb: because in some fatal error user
  has to issue reset to get a functional OTP again, so
  stress_all_with_rand_reset child sequence will wait until reset is
  issue. If we enable the scb during post_start(), but did not issue
  reset immediately, scb will report error.
  The solution here is to move `en_scb` when apply_reset is issued.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>