### PR TITLE
[spi_device] Delay read command statemachine one cycle

### DIFF
--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -413,7 +413,7 @@ module spi_readcmd
       // FSM moves from Reset to Address. At that time of the transition, the
       // datapath should latch the Address[31] or Address[23] too. So, it
       // already counts one beat.
-      addr_cnt_d = (cmdinfo_addr_mode == Addr4B) ? 5'd 30 : 5'd 22;
+      addr_cnt_d = (cmdinfo_addr_mode == Addr4B) ? 5'd 31 : 5'd 23;
 
       // TODO: Dual IO/ Quad IO case
     end else if (addr_cnt_q == '0) begin


### PR DESCRIPTION
This commit pushes the read command state machine moving from
`MainAddress` to others by one cycle.

Issue has been reported in #11764. The address counter when the
state machine enters `MainAddress` was one clock short. I assumed it was
correct value but based on the waveform, it has no time to latch the
last byte.