### PR TITLE
[bazel] fix protobuf repo dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -143,10 +143,10 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 gazelle_dependencies()
 
 # Protobuf
-http_archive(
+git_repository(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    commit = "520c601c99012101c816b6ccc89e8d6fc28fdbb8",
+    remote = "https://github.com/protocolbuffers/protobuf",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")


### PR DESCRIPTION
The protobuf repo dependency was resolved via the `http_archive` rule.
However, it was downloading the protobuf repo from GitHub. Recently, the
name of the main branch of this repo changed from `master` to `main`
which caused a build failure when building from a clean cache.

This updates the protobuf repo dependency to be resolved via the
`git_repository` rule, which additionally allows us to anchor this
dependency to a specific commit.

Signed-off-by: Timothy Trippel <ttrippel@google.com>