### PR TITLE
[dv] Make build randomization opt-in

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -378,11 +378,11 @@ class dv_base_reg_block extends uvm_reg_block;
     foreach (subblks[i]) subblks[i].set_default_map_w_subblks_by_name(map_name);
   endfunction
 
-  function uvm_reg_map get_map_by_name(string map_name);
+  function uvm_reg_map get_map_by_name(string name);
     uvm_reg_map maps[$];
     this.get_maps(maps);
     foreach (maps[i]) begin
-      if (maps[i].get_name() == map_name) return maps[i];
+      if (maps[i].get_name() == name) return maps[i];
     end
     return null;
   endfunction

--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -534,3 +534,10 @@
     100     :/ 1  \
   };
 `endif
+
+// Enables build-time randomization of fixed design constants.
+//
+// This is meant to be overridden externally by passing `+define+BUILD_SEED=<value>`.
+`ifndef BUILD_SEED
+  `define BUILD_SEED 1
+`endif

--- a/hw/dv/tools/dvsim/common_modes.hjson
+++ b/hw/dv/tools/dvsim/common_modes.hjson
@@ -45,6 +45,27 @@
       is_sim_mode: 1
       en_build_modes: ["{tool}_loopdetect"]
     }
+    // Enables randomization of testbench / RTL build.
+    //
+    // Build randomization is achieved by passing `--build-seed <optional-seed>` on the dvsim
+    // command-line. If not passed, the build is not randomized. Build randomization is achieved
+    // in two ways. One of them is setting the pre-processor macro `BUILD_SEED` to the seed value,
+    // which is done below. The SystemVerilog testbench sources can use the `BUILD_SEED` macro
+    // value to set some design constants (such as parameters) upon instantiation. The `BUILD_SEED`,
+    // if not set externally (by passing the --build-seed switch) is set to 1 in 
+    // `hw/dv/sv/dv_utils/dv_macros.svh`. The other way is by passing the {seed} value to utility 
+    // scripts that generate packages that contain randomized constants. These utility scripts can 
+    // be invoked as a `pre_build_cmd`, wrapped within the `build_seed` sim mode in the DUT 
+    // simulation configuration Hjson file. All forms of build randomization must be wrapped within
+    // this `build_seed` sim mode. They will all use the same {seed} value, which allows us to 
+    // deterministically reproduce failures. The `--build-seed` switch is expected to be passed 
+    // when running the nightly regressions. The `seed` value set by dvsim is a 32-bit unsigned 
+    // integer (unless specified on the command-line).
+    {
+      name: build_seed
+      is_sim_mode: 1
+      build_opts: ["+define+BUILD_SEED={seed}"]
+    }
   ]
 
   run_modes: [

--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -67,13 +67,7 @@
                "+define+UVM_REG_DATA_WIDTH={tl_dw}",
                "+define+UVM_REG_BYTENABLE_WIDTH={tl_dbw}",
                "+define+SIMULATION",
-               "+define+DUT_HIER={dut_instance}",
-               // Introduce compile-time randomization. Use `BUILD_SEED in Verilog sources to set
-               // constants that have no side-effects, such as addition or deletion of logic. Useful
-               // to mutate fixed device values such as secret keys, identification constants, etc.
-               // across successive simulation runs. Note that this will always be a 32-bit unsigned
-               // value.
-               "+define+BUILD_SEED={seed}"]
+               "+define+DUT_HIER={dut_instance}"]
 
   run_opts: ["+UVM_NO_RELNOTES",
              "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -39,6 +39,16 @@
 
   en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
 
+  build_modes: [
+    // Sim mode that enables build randomization. See the `build_seed` mode
+    // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
+    {
+      name: build_seed
+      pre_build_cmds: ["cd /${proj_root} && ./util/design/gen-otp-mmap.py --seed ${seed}"]
+      is_sim_mode: 1
+    }
+  ]
+
   // Add additional tops for simulation.
   sim_tops: ["otp_ctrl_bind", "otp_ctrl_cov_bind",
              "sec_cm_prim_sparse_fsm_flop_bind",

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -113,6 +113,18 @@
       name: en_ibex_tracer
       build_opts: ["+define+RVFI=1"]
     }
+    // Sim mode that enables build randomization. See the `build_seed` mode
+    // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
+    {
+      name: build_seed
+      pre_build_cmds: [
+        '''cd {proj_root} && ./util/topgen.py -t {ral_spec} \
+               -o hw/top_earlgrey --rnd_cnst_seed {seed}
+        ''',
+        "cd /${proj_root} && ./util/design/gen-otp-mmap.py --seed ${seed}"
+      ]
+      is_sim_mode: 1
+    }
   ]
 
   // Add options needed to compile against otbn_memutil, otbn_tracer, and
@@ -405,7 +417,7 @@
       sw_images: ["sw/device/tests/otbn_ecdsa_op_irq_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=28000000"]
-    }  
+    }
     {
       name: chip_sw_otbn_mem_scramble
       uvm_test_seq: chip_sw_base_vseq

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -296,13 +296,9 @@ class CompileSim(Deploy):
     cmds_list_vars = ["pre_build_cmds", "post_build_cmds"]
     weight = 5
 
-    # A static, randomized seed that is fixed across all builds.
-    # This value can be overridden by --build-seed switch.
-    seed = random.getrandbits(32)
-
     def __init__(self, build_mode, sim_cfg):
         self.build_mode_obj = build_mode
-        self.seed = CompileSim.seed
+        self.seed = sim_cfg.build_seed
         super().__init__(sim_cfg)
 
     def _define_attrs(self):
@@ -356,13 +352,8 @@ class CompileOneShot(Deploy):
 
     target = "build"
 
-    # A static, randomized seed that is fixed across all builds.
-    # This value can be overridden by --build-seed switch.
-    seed = random.getrandbits(32)
-
     def __init__(self, build_mode, sim_cfg):
         self.build_mode_obj = build_mode
-        self.seed = CompileOneShot.seed
         super().__init__(sim_cfg)
 
     def _define_attrs(self):

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -74,6 +74,7 @@ class SimCfg(FlowCfg):
         self.en_run_modes = []
         self.en_run_modes.extend(args.run_modes)
         self.build_unique = args.build_unique
+        self.build_seed = args.build_seed
         self.build_only = args.build_only
         self.run_only = args.run_only
         self.reseed_ovrd = args.reseed
@@ -105,6 +106,8 @@ class SimCfg(FlowCfg):
             self.en_build_modes.append("profile")
         if self.xprop_off is not True:
             self.en_build_modes.append("xprop")
+        if self.build_seed:
+            self.en_build_modes.append("build_seed")
 
         # Options built from cfg_file files
         self.project = ""
@@ -619,8 +622,9 @@ class SimCfg(FlowCfg):
         results_str += f"### Simulator: {self.tool.upper()}\n"
 
         # Print the build seed used for clarity.
-        if not self.run_only:
-            results_str += f"### Build seed: {CompileSim.seed}\n"
+        if self.build_seed and not self.run_only:
+            results_str += ("### Build randomization enabled with "
+                            f"--build-seed {self.build_seed}\n")
 
         if not results.table:
             results_str += "No results to display.\n"

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -23,6 +23,7 @@ import argparse
 import datetime
 import logging as log
 import os
+import random
 import shlex
 import subprocess
 import sys
@@ -33,7 +34,7 @@ import Launcher
 import LauncherFactory
 import LocalLauncher
 from CfgFactory import make_cfg
-from Deploy import CompileOneShot, CompileSim, RunTest
+from Deploy import RunTest
 from Timer import Timer
 from utils import (TS_FORMAT, TS_FORMAT_LONG, VERBOSE, rm_path,
                    run_cmd_with_timeout)
@@ -474,9 +475,13 @@ def parse_args():
     seedg = parser.add_argument_group('Build / test seeds')
 
     seedg.add_argument("--build-seed",
+                       nargs="?",
                        type=int,
+                       const=random.getrandbits(32),
                        metavar="S",
-                       help=('Seed used for compile-time randomization.'))
+                       help=('Randomize the build. Uses the seed value passed '
+                             'an additional argument, else it randomly picks '
+                             'a 32-bit unsigned integer.'))
 
     seedg.add_argument("--seeds",
                        "-s",
@@ -656,10 +661,7 @@ def main():
     setattr(args, "timestamp_long", curr_ts.strftime(TS_FORMAT_LONG))
     setattr(args, "timestamp", curr_ts.strftime(TS_FORMAT))
 
-    # Register the seeds from command line with Compile* / RunTest classes.
-    if args.build_seed:
-        CompileSim.seed = args.build_seed
-        CompileOneShot.seed = args.build_seed
+    # Register the seeds from command line with the RunTest class.
     RunTest.seeds = args.seeds
 
     # If we are fixing a seed value, no point in tests having multiple reseeds.


### PR DESCRIPTION
The previous build randomization implemented in PR #11661 enabled build randomization by default, by allowing a randomized seed value to be passed by dvsim to our SV compilation infra. It did not factor the usecase of modifying in-tree sources that represent randomized design constants (rand const packages created for OTP and top level). Enabling randomization by default made the tooling setup and reproduction of failures difficult, which was further exacerbated by blocks having multiple builds going on in parallel (default and cover_reg_top).  

THis implementation takes a slightly simpler approach by making build randomization opt-in instead, via `--build-seed <optional-seed>` switch. If this switch is not passed, no build randomization is performed whatsoever. If it is, then users can wire up 'pre_build_cmds` to the build_seed` mode in their simulation cfg hjson file to invoke external tools to enable the build randomization. The `--build-seed` switch will be enabled in the nightly regressions. Failures can then be easily reproduced by running the failing tests locally, passing the same build seed value (reflected in the nightly dashboard).

The first commit is an emergency fix for xcelium (compile failure), The second commit enables the "new" build seed behavior, The third commit updates the chip and otp ctrl testbenches to perform build randomizations as provisioned by the second commit.  

 