### PR TITLE
[bazel] add `dv` to `opentitan_functest` so sim_dv-specific artifacts get built

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -143,10 +143,10 @@ load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 gazelle_dependencies()
 
 # Protobuf
-http_archive(
+git_repository(
     name = "com_google_protobuf",
-    strip_prefix = "protobuf-master",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/master.zip"],
+    commit = "520c601c99012101c816b6ccc89e8d6fc28fdbb8",
+    remote = "https://github.com/protocolbuffers/protobuf",
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")

--- a/hw/top_earlgrey/dv/BUILD
+++ b/hw/top_earlgrey/dv/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "config",
+    srcs = [
+        "chip_mask_rom_tests.hjson",
+        "chip_sim_cfg.hjson",
+        "chip_smoketests.hjson",
+    ],
+)

--- a/util/device_sw_utils/BUILD
+++ b/util/device_sw_utils/BUILD
@@ -6,7 +6,8 @@ package(default_visibility = ["//visibility:public"])
 py_binary(
     name = "extract_sw_logs_db",
     srcs = ["extract_sw_logs.py"],
+    main = "extract_sw_logs.py",
     deps = [
-        requirement("elftools"),
+        requirement("pyelftools"),
     ],
 )

--- a/util/dvsim_test_runner.sh
+++ b/util/dvsim_test_runner.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# A shell script for executing dvsim.py as the test harness for functional
+# tests.
+
+set -e
+
+readonly DVSIM="util/dvsim/dvsim.py"
+
+echo "At this time, dvsim.py must be run manually (after building SW) via:
+${DVSIM} $@"


### PR DESCRIPTION
This PR adds a `dv` target to `opentitan_functest` so sim_dv-specific artifacts get built. 

To support transitioning SW builds to bazel, additional rules needed to be added to build sim_dv-specific device artifacts for the test and mask ROMs (to support chip-level test regressions).  These included a sim_dv-specific bootstrap image (#11640) rule, and a sim_dv-specific SW logging database extraction rule (#11755).

While both of these rules have already been added, they were not yet invoked by the main test macro (`opentitan_functest`). The reason is because of how the `opentitan_functest` is structured. Specifically, at a high level, the`opentitan_functest` generates a `test_suite` of `sh_test` rules. The SW artifacts (ROM and flash ELFs, BINs, VMEMs, etc.) are marked as data runfiles of each `sh_test` rule, so they get built when either `bazel build <opentitan_functest name>` or `bazel test <opentitan_functest name>` commands are executed. Since there was no DV sim specific `sh_test` rule (only `verilator` and `cw310` so far) in the `opentitan_functest` `test_suite`, the sim_dv-specific artifacts were not yet built when the prior commands were executed.

To force bazel to build SW artifacts for the DV sim environment, an additional `dv` target was added to the `opentitan_functest` macro. Additionally, an associated "dummy" `sh_test` target was added that runs a simple shell script that echos the proper `dvsim.py` command a user should execute to run the associated test in the DV simulation environment.

The reason the DV `sh_test` does not invoke `dvsim.py` directly for just chip-level tests (which is essentially what an `opentitan_functest` describes), is that doing so would require significant additional work, well outside the scope of this PR (or immediate effort of transitioning ROM builds to bazel for that matter). Moreover, this would be disruptive to the DV team, which is again not the goal of this PR. **_Rather, to reiterate, the goal of this PR is to support building the additional SW artifacts needed for running DV simulations with bazel._** 

Once this PR is merged, the [sim.mk](https://github.com/lowRISC/opentitan/blob/master/hw/dv/tools/dvsim/sim.mk) file that is invoked by `dvsim.py` can be update to invoke bazel instead of meson for building the ROM images.

This fixes #11684.

**_Note: this depends on #11785._**