### PR TITLE
[dv] Enable C/C++ code sourcing with VCS in .core files

### DIFF
--- a/hw/dv/verilator/memutil_dpi.core
+++ b/hw/dv/verilator/memutil_dpi.core
@@ -25,3 +25,8 @@ targets:
   default:
     filesets:
       - files_cpp
+    tools:
+      vcs:
+        vcs_options:
+          - '-CFLAGS -I../../src/lowrisc_dv_verilator_memutil_dpi_0/cpp'
+          - '-lelf'

--- a/hw/dv/verilator/memutil_dpi_scrambled.core
+++ b/hw/dv/verilator/memutil_dpi_scrambled.core
@@ -19,3 +19,8 @@ targets:
   default:
     filesets:
       - files_cpp
+    tools:
+      vcs:
+        vcs_options:
+          - '-CFLAGS -I../../src/lowrisc_dv_verilator_memutil_dpi_scrambled_0/cpp'
+          - '-lelf'

--- a/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_prince_ref.core
+++ b/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_prince_ref.core
@@ -13,3 +13,7 @@ targets:
   default:
     filesets:
       - files_dv
+    tools:
+      vcs:
+        vcs_options:
+          - '-CFLAGS -I../../src/lowrisc_dv_crypto_prince_ref_0.1'

--- a/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.core
+++ b/hw/ip/prim/dv/prim_ram_scr/cpp/scramble_model.core
@@ -18,3 +18,7 @@ targets:
   default:
     filesets:
       - files_cpp
+    tools:
+      vcs:
+        vcs_options:
+          - '-CFLAGS -I../../src/lowrisc_dv_scramble_model_0'

--- a/hw/ip/prim/dv/prim_secded/secded_enc.core
+++ b/hw/ip/prim/dv/prim_secded/secded_enc.core
@@ -16,3 +16,7 @@ targets:
   default:
     filesets:
       - files_dv
+    tools:
+      vcs:
+        vcs_options:
+          - '-CFLAGS -I../../src/lowrisc_dv_secded_enc_0'


### PR DESCRIPTION
Apparently there are some problems with how we handle the C/C++ files while using FuseSoC
Manually adding the generated directories solves the issue.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>