### PR TITLE
[flash_ctrl/dv] Change timing of RMA tests to match CS long timing

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -869,7 +869,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
     // Local Variables
     lc_ctrl_pkg::lc_tx_t done;
-    time timeout_ns = 1000_000_000;
+    time timeout = 15s;
     time start_time;
     bit rma_ack_seen;
 
@@ -901,10 +901,10 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
           end
           begin  // Timeout - Unexpected
             `uvm_info(`gfn, "Starting RMA Timeout Check ...", UVM_LOW)
-            #(timeout_ns);
+            #(timeout);
             `uvm_error(`gfn, {
                        "RMA ACK NOT seen within the expected time frame, Timeout - FAIL",
-                       $sformatf("FAIL (%0t)", timeout_ns)
+                       $sformatf(" (%0t)", timeout)
                        })
           end
         join_any

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -89,8 +89,10 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     // Delay
     cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
 
-    // Iterate
-    num_trans = 2;  // Fixed Number of Iterations as Test time is VERY LONG
+    // Iterate fixed Number of iterations as test time is VERY LONG.
+    // Since this test is getting unbearably long in the closed-source, when running in the
+    //  closed-source, this test will do only one iteration.
+    num_trans = `PRIM_DEFAULT_IMPL==prim_pkg::ImplGeneric ? 2 : 1;
     for (int i=0; i<num_trans; i++) begin
 
       `uvm_info(`gfn, $sformatf("Iteration : %0d", i+1), UVM_LOW)

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -107,13 +107,13 @@
     {
       name: flash_ctrl_hw_rma
       uvm_test_seq: flash_ctrl_hw_rma_vseq
-      run_opts: ["+test_timeout_ns=10000000000"]
+      run_opts: ["+test_timeout_ns=15000000000"]
       reseed: 3
     }
     {
       name: flash_ctrl_host_ctrl_arb
       uvm_test_seq: flash_ctrl_host_ctrl_arb_vseq
-      run_opts: ["+zero_delays=1", "+test_timeout_ns=10000000000"]
+      run_opts: ["+zero_delays=1", "+test_timeout_ns=15000000000"]
       reseed: 5
     }
 


### PR DESCRIPTION
Hi,
The RMA entry process is very very long in the closed-source and so the timing of the tests doing this process had to be modified to be possible to run in the closed-source.
Please note that the tests in general are taking much more time then in the OS and so whenever there is a timeout in the tests, please do it either using external knob that can be overriden by CS or by setting the timeout values to be extremely high.
@TimEwins as the author of this test, please let me know what you think.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>