### PR TITLE
[otbn, dv] Fixes issue in error injection in ISS model

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -18,7 +18,6 @@ from .reg import RegFile
 from .trace import Trace, TracePC
 from .wsr import WSRFile
 
-
 # The number of cycles spent in the 'WIPE' state. This takes constant time in
 # the RTL, mirrored here.
 _WIPE_CYCLES = 98
@@ -431,10 +430,15 @@ class OTBNState:
             self.ext_regs.write('WIPE_START', 1, True)
             self.ext_regs.regs['WIPE_START'].commit()
 
-        # Switch to a 'wiping' state
-        self._next_fsm_state = (FsmState.WIPING_BAD if should_lock
+            # Switch to a 'wiping' state
+            self._next_fsm_state = (FsmState.WIPING_BAD if should_lock
                                 else FsmState.WIPING_GOOD)
-        self.wipe_cycles = (_WIPE_CYCLES if self.secure_wipe_enabled else 2)
+            self.wipe_cycles = (_WIPE_CYCLES if self.secure_wipe_enabled else 2)
+        else:
+            assert should_lock
+            self._next_fsm_state = FsmState.LOCKED
+            next_status = Status.LOCKED
+            self.ext_regs.write('STATUS', next_status, True)
 
         # Clear the "we should stop soon" flag
         self.pending_halt = False


### PR DESCRIPTION
If an error is injected in any state other than FETCH_WAIT and EXEC,
there was an extra clock cycle delay in the status signal being assigned
LOCKED. This commit removes that extra delay.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>