### PR TITLE
[dv/dv_base_reg] Remove duplicated `get_map_by_name` method

### DIFF
--- a/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
+++ b/hw/dv/sv/dv_base_reg/dv_base_reg_block.sv
@@ -378,12 +378,4 @@ class dv_base_reg_block extends uvm_reg_block;
     foreach (subblks[i]) subblks[i].set_default_map_w_subblks_by_name(map_name);
   endfunction
 
-  function uvm_reg_map get_map_by_name(string name);
-    uvm_reg_map maps[$];
-    this.get_maps(maps);
-    foreach (maps[i]) begin
-      if (maps[i].get_name() == name) return maps[i];
-    end
-    return null;
-  endfunction
 endclass


### PR DESCRIPTION
This PR removes the duplicated method `get_map_by_name` which is already
declared in uvm codebase.
Thanks @rasmus-madsen for finding this issue, and @rswarbrick @sriyerg for chime
in and provide quick support.
This fixes issue: https://github.com/lowRISC/opentitan/issues/11788 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>