### PR TITLE
[conn/clk] Update otbn clk connection

### DIFF
--- a/hw/top_earlgrey/formal/conn_csvs/clkmgr_trans.csv
+++ b/hw/top_earlgrey/formal/conn_csvs/clkmgr_trans.csv
@@ -14,5 +14,5 @@ CONNECTION,CLKMGR_TRANS_HMAC,     top_earlgrey.u_clkmgr_aon, clocks_o.clk_main_h
 CONNECTION,CLKMGR_TRANS_KMAC,     top_earlgrey.u_clkmgr_aon, clocks_o.clk_main_kmac,      top_earlgrey.u_kmac,clk_i
 CONNECTION,CLKMGR_TRANS_KMAC_EDN, top_earlgrey.u_clkmgr_aon, clocks_o.clk_main_kmac,      top_earlgrey.u_kmac,clk_edn_i
 CONNECTION,CLKMGR_TRANS_OTBN,     top_earlgrey.u_clkmgr_aon, clocks_o.clk_main_otbn,      top_earlgrey.u_otbn,clk_i
-CONNECTION,CLKMGR_TRANS_OTBN_EDN, top_earlgrey.u_clkmgr_aon, clocks_o.clk_main_otbn,      top_earlgrey.u_otbn,clk_edn_i
+CONNECTION,CLKMGR_TRANS_OTBN_EDN, top_earlgrey.u_clkmgr_aon, clocks_o.clk_main_secure,    top_earlgrey.u_otbn,clk_edn_i
 CONNECTION,CLKMGR_TRANS_OTBN_OTP, top_earlgrey.u_clkmgr_aon, clocks_o.clk_io_div4_secure, top_earlgrey.u_otbn,clk_otp_i


### PR DESCRIPTION
OTBN EDN clk is updated to connect to `clk_main_secure` from clkmgr.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>