### PR TITLE
[bazel] fix build for sim_dv device

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -60,6 +60,9 @@ opentitan_rom_binary(
         "mask_rom.h",
         "mask_rom_start.S",
     ],
+    # Mask ROM does not permit the DV simulation backdoor logging mechanism that
+    # test ROM does, for obvious security reasons.
+    extract_sw_logs_db = False,
     linkopts = [
         "-T $(location mask_rom.ld)",
     ],
@@ -283,6 +286,10 @@ opentitan_functest(
         "mask_rom_test.c",
     ],
     signed = True,
+    targets = [
+        "verilator",
+        "cw310",
+    ],
     verilator = verilator_params(
         rom = ":mask_rom_sim_verilator_scr_vmem",
         tags = [


### PR DESCRIPTION
Originally, #11787 added a "dv" target to the "opentitan_functest" rule
so that sim_dv-specific SW artifacts (such as the backdoor SW logging
database files) would get built/generated when `bazel build ...` was
invoked. However, #11787 did not consider the fact that the mask ROM
does not support the backdoor logging interface (specifically, the
linker script does not include the proper symbols in the proper section)
for obvious security reasons. Therefore, #11787 broke the bazel build for
mask ROM E2E tests.

This fixes the build for said tests by only running the SW backdoor logs
database extraction rule for test ROM (not mask ROM) and related tests
that use the mask ROM.

This is the more permanent solution version of #11803. #11803 will be closed.
Signed-off-by: Timothy Trippel <ttrippel@google.com>