### PR TITLE
[top, dv] Update keymgr key derivation test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
@@ -44,6 +44,13 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     bit [keymgr_pkg::KeyWidth-1:0] OwnerRootSecret;
   } adv_owner_int_data_t;
 
+  typedef struct packed {
+    bit [TL_DW-1:0]      KeyVersion;
+    bit [keymgr_reg_pkg::NumSaltReg-1:0][TL_DW-1:0] Salt;
+    keymgr_pkg::seed_t   KeyID;
+    keymgr_pkg::seed_t   SoftwareExportConstant;
+  } gen_out_data_t;
+
   localparam int KmacDigestBytes = kmac_pkg::AppDigestW / 8;
 
   localparam bit [keymgr_reg_pkg::NumSwBindingReg-1:0][TL_DW-1:0] CreatorSwBinding = {
@@ -62,32 +69,104 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
       32'h4e919d54, 32'h322288d8, 32'h4bd127c7, 32'h9f89bc56,
       32'hb4fb0fdf, 32'h1ca1567b, 32'h13a0e876, 32'ha6521d8f};
 
+  localparam bit [keymgr_reg_pkg::NumSaltReg-1:0][TL_DW-1:0] Salt = {
+      32'hde919d54, 32'h322288d8, 32'h4bd127c7, 32'h9f89bc56,
+      32'hb4fb0fdf, 32'h1ca1567b, 32'h13a0e876, 32'hb6521d8f};
+
+  localparam gen_out_data_t GenSWOutData = '{
+      32'haa, // KeyVersion
+      Salt,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrNoneSeed,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrSoftOutputSeed};
+
+  localparam gen_out_data_t GenKmacOutData = '{
+      32'haa, // KeyVersion
+      Salt,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrKmacSeed,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrHardOutputSeed};
+
+  localparam gen_out_data_t GenAesOutData = '{
+      32'haa, // KeyVersion
+      Salt,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrAesSeed,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrHardOutputSeed};
+
+  localparam gen_out_data_t GenOtbnOutData = '{
+      32'haa, // KeyVersion
+      Salt,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrOtbnSeed,
+      top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrHardOutputSeed};
+
   virtual task body();
     string path_internal_key = "tb.dut.top_earlgrey.u_keymgr.u_ctrl.key_o.key";
+    string path_kmac_key = "tb.dut.top_earlgrey.u_keymgr.kmac_key_o";
+    string path_aes_key = "tb.dut.top_earlgrey.u_keymgr.aes_key_o";
+    string path_otbn_key = "tb.dut.top_earlgrey.u_keymgr.otbn_key_o";
     key_shares_t new_key;
+    keymgr_pkg::hw_key_req_t hw_key;
+    keymgr_pkg::otbn_key_req_t otbn_key;
     bit [keymgr_pkg::KeyWidth-1:0] cur_unmasked_key;
     bit [keymgr_pkg::KeyWidth-1:0] new_unmasked_key;
     super.body();
 
+    // wait and check Keymgr entered CreatorRootKey State
     wait (cfg.sw_logger_vif.printed_log == "Keymgr entered CreatorRootKey State");
-
     cur_unmasked_key = get_unmasked_key(get_otp_root_key());
-
     `DV_CHECK_FATAL(uvm_hdl_check_path(path_internal_key))
     `DV_CHECK_FATAL(uvm_hdl_read(path_internal_key, new_key))
     new_unmasked_key = get_unmasked_key(new_key);
 
     check_internal_key(cur_unmasked_key, get_creator_data(), new_unmasked_key);
 
+    wait (cfg.sw_logger_vif.printed_log == "Keymgr generated identity at CreatorRootKey State");
+    check_gen_id(new_unmasked_key, top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrCreatorIdentitySeed);
+
+    // wait and check Keymgr entered OwnerIntKey State
     wait (cfg.sw_logger_vif.printed_log == "Keymgr entered OwnerIntKey State");
     cur_unmasked_key = new_unmasked_key;
     `DV_CHECK_FATAL(uvm_hdl_read(path_internal_key, new_key))
     new_unmasked_key = get_unmasked_key(new_key);
 
     check_internal_key(cur_unmasked_key, get_owner_int_data(), new_unmasked_key);
-    // TODO
-    // 1. check SW output
-    // 2. check 3 sideload interfaces
+
+    wait (cfg.sw_logger_vif.printed_log == "Keymgr generated identity at OwnerIntKey State");
+    check_gen_id(new_unmasked_key, top_earlgrey_rnd_cnst_pkg::RndCnstKeymgrOwnerIntIdentitySeed);
+
+    wait (cfg.sw_logger_vif.printed_log == "Keymgr generated SW output at OwnerIntKey State");
+    check_gen_out(new_unmasked_key, GenSWOutData);
+
+    // check 3 sideload interfaces
+    wait (cfg.sw_logger_vif.printed_log ==
+          "Keymgr generated HW output for Kmac at OwnerIntKey State");
+    `DV_CHECK_FATAL(uvm_hdl_check_path(path_kmac_key))
+    `DV_CHECK_FATAL(uvm_hdl_read(path_kmac_key, hw_key))
+    `DV_CHECK_EQ(hw_key.valid, 1)
+    check_gen_out(new_unmasked_key, GenKmacOutData, get_unmasked_key(hw_key.key));
+
+    wait (cfg.sw_logger_vif.printed_log ==
+          "Keymgr generated HW output for Aes at OwnerIntKey State");
+    `DV_CHECK_FATAL(uvm_hdl_check_path(path_aes_key))
+    `DV_CHECK_FATAL(uvm_hdl_read(path_aes_key, hw_key))
+    `DV_CHECK_EQ(hw_key.valid, 1)
+    check_gen_out(new_unmasked_key, GenAesOutData, get_unmasked_key(hw_key.key));
+
+    // otbn sideload key is 384 bit, so it's treated a bit differently
+    begin
+      bit [7:0] data_arr[];
+      bit [kmac_pkg::AppDigestW-1:0] unmask_act_key, unmask_exp_key;
+      wait (cfg.sw_logger_vif.printed_log ==
+            "Keymgr generated HW output for Otbn at OwnerIntKey State");
+      `DV_CHECK_FATAL(uvm_hdl_check_path(path_otbn_key))
+      `DV_CHECK_FATAL(uvm_hdl_read(path_otbn_key, otbn_key))
+      `DV_CHECK_EQ(otbn_key.valid, 1)
+
+      unmask_act_key = otbn_key.key[0] ^ otbn_key.key[1];
+
+      {<< byte {data_arr}} = GenOtbnOutData;
+      unmask_exp_key = get_kmac_digest(new_unmasked_key, data_arr);
+
+      `DV_CHECK_EQ(unmask_act_key, unmask_exp_key)
+    end
   endtask
 
   virtual function bit [keymgr_pkg::KeyWidth-1:0] get_unmasked_key(key_shares_t two_share_key);
@@ -158,25 +237,15 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     return otp_root_key;
   endfunction
 
-  virtual function void check_internal_key(
+  // a generic kmac digest check function, allow to enter with any length of kmac data
+  virtual function void check_kmac_digest(
       bit [keymgr_pkg::KeyWidth-1:0]     kmac_key,
-      bit [keymgr_pkg::AdvDataWidth-1:0] kmac_data,
+      bit [7:0]                          data_arr[],
       bit [keymgr_pkg::KeyWidth-1:0]     act_digest);
-    bit [7:0] data_arr[];
-    bit [7:0] key_arr[];
-    string custom_str = ""; // Just use empty string for top-level tests
-    bit [7:0] digest_arr[KmacDigestBytes];
     bit [kmac_pkg::AppDigestW-1:0] digest;
     bit [keymgr_pkg::KeyWidth-1:0] exp_digest;
 
-    {<< byte {key_arr}}  = kmac_key;
-    {<< byte {data_arr}} = kmac_data;
-
-    digestpp_dpi_pkg::c_dpi_kmac256(data_arr, data_arr.size(),
-                                    key_arr, key_arr.size(),
-                                    custom_str,
-                                    KmacDigestBytes, digest_arr);
-    digest  = {<< byte {digest_arr}};
+    digest  = get_kmac_digest(kmac_key, data_arr);
 
     // truncate to 256 bits
     exp_digest = keymgr_pkg::KeyWidth'(digest);
@@ -184,4 +253,69 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
     `DV_CHECK_EQ(act_digest, exp_digest)
   endfunction
 
+  // a generic kmac digest check function, allow to enter with any length of kmac data
+  virtual function bit[kmac_pkg::AppDigestW-1:0] get_kmac_digest(
+      bit [keymgr_pkg::KeyWidth-1:0]     kmac_key,
+      bit [7:0]                          data_arr[]);
+    bit [7:0] key_arr[];
+    string custom_str = ""; // Just use empty string for top-level tests
+    bit [7:0] digest_arr[KmacDigestBytes];
+    bit [kmac_pkg::AppDigestW-1:0] digest;
+
+    {<< byte {key_arr}}  = kmac_key;
+
+    digestpp_dpi_pkg::c_dpi_kmac256(data_arr, data_arr.size(),
+                                    key_arr, key_arr.size(),
+                                    custom_str,
+                                    KmacDigestBytes, digest_arr);
+    digest  = {<< byte {digest_arr}};
+
+    return digest;
+  endfunction
+
+  virtual function void check_internal_key(
+      bit [keymgr_pkg::KeyWidth-1:0]     kmac_key,
+      bit [keymgr_pkg::AdvDataWidth-1:0] kmac_data,
+      bit [keymgr_pkg::KeyWidth-1:0]     act_digest);
+    bit [7:0] data_arr[];
+    {<< byte {data_arr}} = kmac_data;
+
+    check_kmac_digest(kmac_key, data_arr, act_digest);
+  endfunction
+
+  virtual function void check_gen_id(
+      bit [keymgr_pkg::KeyWidth-1:0]     kmac_key,
+      bit [keymgr_pkg::IdDataWidth-1:0]  kmac_data);
+    bit [7:0] data_arr[];
+    {<< byte {data_arr}} = kmac_data;
+
+    check_kmac_digest(kmac_key, data_arr, get_sw_shares());
+  endfunction
+
+  virtual function void check_gen_out(
+      bit [keymgr_pkg::KeyWidth-1:0]     kmac_key,
+      bit [keymgr_pkg::GenDataWidth-1:0] kmac_data,
+      bit [keymgr_pkg::KeyWidth-1:0]     exp_digest = get_sw_shares());
+    bit [7:0] data_arr[];
+    {<< byte {data_arr}} = kmac_data;
+
+    check_kmac_digest(kmac_key, data_arr, exp_digest);
+  endfunction
+
+  virtual function bit [keymgr_pkg::KeyWidth-1:0] get_sw_shares();
+    key_shares_t key_shares;
+    for (int i = 0; i < keymgr_pkg::KeyWidth / TL_DW; i++) begin
+      bit [TL_DW-1:0] rdata;
+      csr_peek(ral.keymgr.sw_share0_output[i], rdata);
+      key_shares[0][TL_DW * i +: TL_DW] = rdata;
+    end
+    for (int i = 0; i < keymgr_pkg::KeyWidth / TL_DW; i++) begin
+      bit [TL_DW-1:0] rdata;
+      csr_peek(ral.keymgr.sw_share1_output[i], rdata);
+      key_shares[1][TL_DW * i +: TL_DW] = rdata;
+    end
+    `uvm_info(`gfn, $sformatf("Read SW shares 0x%0h, 0x%0h", key_shares[0], key_shares[1]),
+              UVM_LOW)
+    return get_unmasked_key(key_shares);
+  endfunction
 endclass : chip_sw_keymgr_key_derivation_vseq

--- a/sw/device/lib/dif/dif_keymgr.c
+++ b/sw/device/lib/dif/dif_keymgr.c
@@ -25,20 +25,18 @@ static_assert(KEYMGR_SEALING_SW_BINDING_2_REG_OFFSET ==
 static_assert(KEYMGR_SEALING_SW_BINDING_3_REG_OFFSET ==
                   KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 12,
               "SEALING_SW_BINDING_N registers must be contiguous.");
-// TODO: Uncomment when lowRISC/opentitan#5194 is completed.
-// TODO: Consider defining a macro once all assertions are enabled.
-// static_assert(KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET ==
-//                   KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 16,
-//               "SEALING_SW_BINDING_N registers must be contiguous.");
-// static_assert(KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET ==
-//                   KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 20,
-//               "SEALING_SW_BINDING_N registers must be contiguous.");
-// static_assert(KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET ==
-//                   KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 24,
-//               "SEALING_SW_BINDING_N registers must be contiguous.");
-// static_assert(KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET ==
-//                   KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 28,
-//               "SEALING_SW_BINDING_N registers must be contiguous.");
+static_assert(KEYMGR_SEALING_SW_BINDING_4_REG_OFFSET ==
+                  KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 16,
+              "SEALING_SW_BINDING_N registers must be contiguous.");
+static_assert(KEYMGR_SEALING_SW_BINDING_5_REG_OFFSET ==
+                  KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 20,
+              "SEALING_SW_BINDING_N registers must be contiguous.");
+static_assert(KEYMGR_SEALING_SW_BINDING_6_REG_OFFSET ==
+                  KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 24,
+              "SEALING_SW_BINDING_N registers must be contiguous.");
+static_assert(KEYMGR_SEALING_SW_BINDING_7_REG_OFFSET ==
+                  KEYMGR_SEALING_SW_BINDING_0_REG_OFFSET + 28,
+              "SEALING_SW_BINDING_N registers must be contiguous.");
 
 static_assert(KEYMGR_SALT_1_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 4,
               "SALT_N registers must be contiguous.");
@@ -46,19 +44,14 @@ static_assert(KEYMGR_SALT_2_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 8,
               "SALT_N registers must be contiguous.");
 static_assert(KEYMGR_SALT_3_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 12,
               "SALT_N registers must be contiguous.");
-// TODO: Uncomment when lowRISC/opentitan#5194 is completed.
-// static_assert(KEYMGR_SALT_4_REG_OFFSET ==
-//                   KEYMGR_SALT_0_REG_OFFSET + 16,
-//               "SALT_N registers must be contiguous.");
-// static_assert(KEYMGR_SALT_5_REG_OFFSET ==
-//                   KEYMGR_SALT_0_REG_OFFSET + 20,
-//               "SALT_N registers must be contiguous.");
-// static_assert(KEYMGR_SALT_6_REG_OFFSET ==
-//                   KEYMGR_SALT_0_REG_OFFSET + 24,
-//               "SALT_N registers must be contiguous.");
-// static_assert(KEYMGR_SALT_7_REG_OFFSET ==
-//                   KEYMGR_SALT_0_REG_OFFSET + 28,
-//               "SALT_N registers must be contiguous.");
+static_assert(KEYMGR_SALT_4_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 16,
+              "SALT_N registers must be contiguous.");
+static_assert(KEYMGR_SALT_5_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 20,
+              "SALT_N registers must be contiguous.");
+static_assert(KEYMGR_SALT_6_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 24,
+              "SALT_N registers must be contiguous.");
+static_assert(KEYMGR_SALT_7_REG_OFFSET == KEYMGR_SALT_0_REG_OFFSET + 28,
+              "SALT_N registers must be contiguous.");
 
 static_assert(KEYMGR_SW_SHARE0_OUTPUT_1_REG_OFFSET ==
                   KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET + 4,
@@ -472,6 +465,12 @@ dif_result_t dif_keymgr_generate_versioned_key(
     case kDifKeymgrVersionedKeyDestKmac:
       hw_op_params = (start_operation_params_t){
           .dest = KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_KMAC,
+          .op = KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_HW_OUTPUT,
+      };
+      break;
+    case kDifKeymgrVersionedKeyDestOtbn:
+      hw_op_params = (start_operation_params_t){
+          .dest = KEYMGR_CONTROL_SHADOWED_DEST_SEL_VALUE_OTBN,
           .op = KEYMGR_CONTROL_SHADOWED_OPERATION_VALUE_GENERATE_HW_OUTPUT,
       };
       break;

--- a/sw/device/lib/dif/dif_keymgr.h
+++ b/sw/device/lib/dif/dif_keymgr.h
@@ -344,9 +344,13 @@ typedef enum dif_keymgr_versioned_key_dest {
    */
   kDifKeymgrVersionedKeyDestKmac,
   /**
+   * Sideload the generated versioned key to Otbn device.
+   */
+  kDifKeymgrVersionedKeyDestOtbn,
+  /**
    * \internal Last key destination.
    */
-  kDifKeymgrVersionedKeyDestLast = kDifKeymgrVersionedKeyDestKmac,
+  kDifKeymgrVersionedKeyDestLast = kDifKeymgrVersionedKeyDestOtbn,
 } dif_keymgr_versioned_key_dest_t;
 
 /**

--- a/sw/device/lib/testing/keymgr_testutils.c
+++ b/sw/device/lib/testing/keymgr_testutils.c
@@ -37,3 +37,35 @@ void keymgr_testutils_check_state(const dif_keymgr_t *keymgr,
              exp_state);
   }
 }
+
+void keymgr_testutils_generate_identity(const dif_keymgr_t *keymgr) {
+  CHECK_DIF_OK(dif_keymgr_generate_identity_seed(keymgr));
+
+  dif_keymgr_status_codes_t status;
+  do {
+    CHECK_DIF_OK(dif_keymgr_get_status_codes(keymgr, &status));
+    if (status == 0) {
+      LOG_INFO("Generating identity seed");
+    } else if (status > kDifKeymgrStatusCodeIdle) {
+      LOG_ERROR("Unexpected status: %0x", status);
+      break;
+    }
+  } while (status != kDifKeymgrStatusCodeIdle);
+}
+
+void keymgr_testutils_generate_versioned_key(
+    const dif_keymgr_t *keymgr,
+    const dif_keymgr_versioned_key_params_t params) {
+  CHECK_DIF_OK(dif_keymgr_generate_versioned_key(keymgr, params));
+
+  dif_keymgr_status_codes_t status;
+  do {
+    CHECK_DIF_OK(dif_keymgr_get_status_codes(keymgr, &status));
+    if (status == 0) {
+      LOG_INFO("Generating versioned key for dest: 0x%0x", params.dest);
+    } else if (status > kDifKeymgrStatusCodeIdle) {
+      LOG_ERROR("Unexpected status: %0x", status);
+      break;
+    }
+  } while (status != kDifKeymgrStatusCodeIdle);
+}

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -19,4 +19,15 @@ void keymgr_testutils_advance_state(const dif_keymgr_t *keymgr,
 void keymgr_testutils_check_state(const dif_keymgr_t *keymgr,
                                   const dif_keymgr_state_t exp_state);
 
+/**
+ * Issues a keymgr identity generation and wait for it to complete
+ */
+void keymgr_testutils_generate_identity(const dif_keymgr_t *keymgr);
+
+/**
+ * Issues a keymgr HW/SW versioned key generation and wait for it to complete
+ */
+void keymgr_testutils_generate_versioned_key(
+    const dif_keymgr_t *keymgr, const dif_keymgr_versioned_key_params_t params);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_TESTUTILS_H_


### PR DESCRIPTION
2 commits:
[dif] Update keymgr dif
1. Uncommented some code and removed a TODO
2. Added Otbn sideload

[top, dv] Update keymgr key derivation test
1. added generating identity and SW data as well as checking them at SV
2. added generating sideload key for all interfaces and check them via
   backdoor

Signed-off-by: Weicai Yang <weicai@google.com>