### PR TITLE
[dv,pwrmgr] update tb to honor clock enables

### DIFF
--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/README.md
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/README.md
@@ -1,0 +1,3 @@
+# PWRMGR_CLK_CTRL UVM Agent
+
+PWRMGR_CLK_CTRL UVM Agent is extended from DV library agent classes.

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent.core
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent.core
@@ -1,0 +1,29 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:pwrmgr_clk_ctrl_agent:0.1"
+description: "PWRMGR_CLK_CTRL DV UVM agent"
+filesets:
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_lib
+      - lowrisc:ip:pwrmgr_pkg
+    files:
+      - pwrmgr_clk_ctrl_if.sv
+      - pwrmgr_clk_ctrl_agent_pkg.sv
+      - pwrmgr_clk_ctrl_item.sv: {is_include_file: true}
+      - pwrmgr_clk_ctrl_agent_cfg.sv: {is_include_file: true}
+      - pwrmgr_clk_ctrl_agent_cov.sv: {is_include_file: true}
+      - pwrmgr_clk_ctrl_driver.sv: {is_include_file: true}
+      - pwrmgr_clk_ctrl_monitor.sv: {is_include_file: true}
+      - pwrmgr_clk_ctrl_agent.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_clk_ctrl_base_seq.sv: {is_include_file: true}
+      - seq_lib/pwrmgr_clk_ctrl_seq_list.sv: {is_include_file: true}
+    file_type: systemVerilogSource
+
+targets:
+  default:
+    filesets:
+      - files_dv

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent.sv
@@ -1,0 +1,25 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_clk_ctrl_agent extends dv_base_agent #(
+  .CFG_T          (pwrmgr_clk_ctrl_agent_cfg),
+  .DRIVER_T       (pwrmgr_clk_ctrl_driver),
+  .SEQUENCER_T    (pwrmgr_clk_ctrl_sequencer),
+  .MONITOR_T      (pwrmgr_clk_ctrl_monitor),
+  .COV_T          (pwrmgr_clk_ctrl_agent_cov)
+);
+
+  `uvm_component_utils(pwrmgr_clk_ctrl_agent)
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+    // get pwrmgr_clk_ctrl_if handle
+    if (!uvm_config_db#(virtual pwrmgr_clk_ctrl_if)::get(this, "", "vif", cfg.vif)) begin
+      `uvm_fatal(`gfn, "failed to get pwrmgr_clk_ctrl_if handle from uvm_config_db")
+    end
+  endfunction
+
+endclass

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_cfg.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_cfg.sv
@@ -1,0 +1,17 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_clk_ctrl_agent_cfg extends dv_base_agent_cfg;
+
+  bit clk_ctrl_en = 1;
+  // interface handle used by driver, monitor & the sequencer, via cfg handle
+  virtual pwrmgr_clk_ctrl_if vif;
+  virtual clk_rst_if clk_rst_vif;
+  virtual clk_rst_if esc_clk_rst_vif;
+  `uvm_object_utils_begin(pwrmgr_clk_ctrl_agent_cfg)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_cov.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_cov.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_clk_ctrl_agent_cov extends dv_base_agent_cov #(pwrmgr_clk_ctrl_agent_cfg);
+  `uvm_component_utils(pwrmgr_clk_ctrl_agent_cov)
+
+  // the base class provides the following handles for use:
+  // pwrmgr_clk_ctrl_agent_cfg: cfg
+
+  // covergroups
+
+  function new(string name, uvm_component parent);
+    super.new(name, parent);
+    // instantiate all covergroups here
+  endfunction : new
+
+endclass

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_pkg.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_pkg.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+package pwrmgr_clk_ctrl_agent_pkg;
+  // dep packages
+  import uvm_pkg::*;
+  import dv_utils_pkg::*;
+  import dv_lib_pkg::*;
+
+  // macro includes
+  `include "uvm_macros.svh"
+  `include "dv_macros.svh"
+
+  // parameters
+
+  // local types
+  // forward declare classes to allow typedefs below
+  typedef class pwrmgr_clk_ctrl_item;
+  typedef class pwrmgr_clk_ctrl_agent_cfg;
+
+  // reuse dv_base_sequencer as is with the right parameter set
+  typedef dv_base_sequencer #(.ITEM_T(pwrmgr_clk_ctrl_item),
+                              .CFG_T (pwrmgr_clk_ctrl_agent_cfg)) pwrmgr_clk_ctrl_sequencer;
+
+  // functions
+
+  // package sources
+  `include "pwrmgr_clk_ctrl_item.sv"
+  `include "pwrmgr_clk_ctrl_agent_cfg.sv"
+  `include "pwrmgr_clk_ctrl_agent_cov.sv"
+  `include "pwrmgr_clk_ctrl_driver.sv"
+  `include "pwrmgr_clk_ctrl_monitor.sv"
+  `include "pwrmgr_clk_ctrl_agent.sv"
+  `include "pwrmgr_clk_ctrl_seq_list.sv"
+
+endpackage: pwrmgr_clk_ctrl_agent_pkg

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_driver.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_driver.sv
@@ -1,0 +1,38 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_clk_ctrl_driver extends dv_base_driver #(.ITEM_T(pwrmgr_clk_ctrl_item),
+                                              .CFG_T (pwrmgr_clk_ctrl_agent_cfg));
+  `uvm_component_utils(pwrmgr_clk_ctrl_driver)
+
+  // the base class provides the following handles for use:
+  // pwrmgr_clk_ctrl_agent_cfg: cfg
+
+  `uvm_component_new
+
+  virtual task run_phase(uvm_phase phase);
+    // base class forks off reset_signals() and get_and_drive() tasks
+    super.run_phase(phase);
+  endtask
+
+  // reset signals
+  virtual task reset_signals();
+  endtask
+
+  // drive trans received from sequencer
+  virtual task get_and_drive();
+    forever begin
+      seq_item_port.get_next_item(req);
+      $cast(rsp, req.clone());
+      rsp.set_id_info(req);
+      `uvm_info(`gfn, $sformatf("rcvd item:\n%0s", req.sprint()), UVM_HIGH)
+      // TODO: do the driving part
+      //
+      // send rsp back to seq
+      `uvm_info(`gfn, "item sent", UVM_HIGH)
+      seq_item_port.item_done(rsp);
+    end
+  endtask
+
+endclass

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_if.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_if.sv
@@ -1,0 +1,31 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+interface pwrmgr_clk_ctrl_if (
+  input logic clk,
+  input logic rst_n,
+  input logic clk_slow,
+  input logic rst_slow_n
+);
+  import uvm_pkg::*;
+  import pwrmgr_pkg::*;
+
+
+  // interface pins
+  pwrmgr_pkg::pwr_ast_req_t pwr_ast_req;
+  pwrmgr_pkg::pwr_clk_req_t pwr_clk_req;
+
+  clocking cb @(posedge clk);
+  endclocking // cb
+
+  clocking scb @(posedge clk_slow);
+  endclocking // scb
+
+  // wait for rst_n to assert and then deassert
+  task automatic wait_for_reset(bit wait_negedge = 1'b1, bit wait_posedge = 1'b1);
+    if (wait_negedge && ($isunknown(rst_n) || rst_n === 1'b1)) @(negedge rst_n);
+    if (wait_posedge && (rst_n === 1'b0)) @(posedge rst_n);
+  endtask
+
+endinterface

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_item.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_item.sv
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_clk_ctrl_item extends uvm_sequence_item;
+
+  // random variables
+
+  `uvm_object_utils_begin(pwrmgr_clk_ctrl_item)
+  `uvm_object_utils_end
+
+  `uvm_object_new
+
+endclass

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_monitor.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_monitor.sv
@@ -1,0 +1,70 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_clk_ctrl_monitor extends dv_base_monitor #(
+    .ITEM_T (pwrmgr_clk_ctrl_item),
+    .CFG_T  (pwrmgr_clk_ctrl_agent_cfg),
+    .COV_T  (pwrmgr_clk_ctrl_agent_cov)
+  );
+  `uvm_component_utils(pwrmgr_clk_ctrl_monitor)
+
+  // the base class provides the following handles for use:
+  // pwrmgr_clk_ctrl_agent_cfg: cfg
+  // pwrmgr_clk_ctrl_agent_cov: cov
+  // uvm_analysis_port #(pwrmgr_clk_ctrl_item): analysis_port
+
+  `uvm_component_new
+
+  function void build_phase(uvm_phase phase);
+    super.build_phase(phase);
+  endfunction
+
+  task run_phase(uvm_phase phase);
+    super.run_phase(phase);
+  endtask
+
+  // collect transactions forever - already forked in dv_base_monitor::run_phase
+  virtual protected task collect_trans(uvm_phase phase);
+    cfg.vif.wait_for_reset();
+
+    `uvm_info(`gfn, $sformatf("clk_ctrl %s", (cfg.clk_ctrl_en)? "enabled" :
+                              "disabled"), UVM_MEDIUM)
+    if (cfg.clk_ctrl_en) begin
+      fork
+        monitor_pwr_ast_o();
+        monitor_pwr_clk_o();
+      join_none
+    end
+  endtask
+
+  task monitor_pwr_ast_o();
+    forever begin
+      @cfg.vif.cb;
+      if (cfg.vif.pwr_ast_req.io_clk_en == 0) begin
+        cfg.clk_rst_vif.stop_clk();
+        @(posedge cfg.vif.pwr_ast_req.io_clk_en);
+        #($urandom_range(300_000, 5_152_286) * 1ps);
+        cfg.clk_rst_vif.start_clk();
+      end
+    end
+  endtask // monitor_pwr_ast_o
+
+  task monitor_pwr_clk_o();
+    logic ival = cfg.vif.pwr_clk_req.io_ip_clk_en;
+    forever begin
+      @cfg.vif.cb;
+      if (ival) begin
+        @(negedge cfg.vif.pwr_clk_req.io_ip_clk_en);
+        repeat($urandom_range(1, 10)) @cfg.vif.cb;
+        cfg.esc_clk_rst_vif.stop_clk();
+        ival = 0;
+      end else begin
+        @(posedge cfg.vif.pwr_clk_req.io_ip_clk_en);
+        repeat($urandom_range(1, 10)) @cfg.vif.cb;
+        cfg.esc_clk_rst_vif.start_clk();
+        ival = 1;
+      end
+    end
+  endtask // monitor_pwr_clk_o
+endclass

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/seq_lib/pwrmgr_clk_ctrl_base_seq.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/seq_lib/pwrmgr_clk_ctrl_base_seq.sv
@@ -1,0 +1,18 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class pwrmgr_clk_ctrl_base_seq extends dv_base_seq #(
+    .REQ         (pwrmgr_clk_ctrl_item),
+    .CFG_T       (pwrmgr_clk_ctrl_agent_cfg),
+    .SEQUENCER_T (pwrmgr_clk_ctrl_sequencer)
+  );
+  `uvm_object_utils(pwrmgr_clk_ctrl_base_seq)
+
+  `uvm_object_new
+
+  virtual task body();
+    `uvm_fatal(`gtn, "Need to override this when you extend from this class!")
+  endtask
+
+endclass

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/seq_lib/pwrmgr_clk_ctrl_seq_list.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/seq_lib/pwrmgr_clk_ctrl_seq_list.sv
@@ -1,0 +1,5 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+`include "pwrmgr_clk_ctrl_base_seq.sv"

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.core
@@ -9,6 +9,7 @@ filesets:
     depend:
       - lowrisc:dv:ralgen
       - lowrisc:dv:cip_lib
+      - lowrisc:dv:pwrmgr_clk_ctrl_agent
     files:
       - pwrmgr_env_pkg.sv
       - pwrmgr_env_cfg.sv: {is_include_file: true}

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env.sv
@@ -10,8 +10,8 @@ class pwrmgr_env extends cip_base_env #(
 );
   `uvm_component_utils(pwrmgr_env)
 
-  alert_esc_agent m_esc_agent;
-
+  alert_esc_agent       m_esc_agent;
+  pwrmgr_clk_ctrl_agent m_pcc_agent;
   `uvm_component_new
 
   function void build_phase(uvm_phase phase);
@@ -25,6 +25,11 @@ class pwrmgr_env extends cip_base_env #(
             this, "", "esc_clk_rst_vif", cfg.esc_clk_rst_vif
         )) begin
       `uvm_fatal(`gfn, "failed to get esc_clk_rst_vif from uvm_config_db")
+    end
+    if (!uvm_config_db#(virtual clk_rst_if)::get(
+            this, "", "aon_clk_rst_vif", cfg.aon_clk_rst_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get aon_clk_rst_vif from uvm_config_db")
     end
     if (!uvm_config_db#(virtual pwrmgr_if)::get(this, "", "pwrmgr_vif", cfg.pwrmgr_vif)) begin
       `uvm_fatal(`gfn, "failed to get pwrmgr_vif from uvm_config_db")
@@ -48,6 +53,20 @@ class pwrmgr_env extends cip_base_env #(
     m_esc_agent = alert_esc_agent::type_id::create("m_esc_agent", this);
     uvm_config_db#(alert_esc_agent_cfg)::set(this, "m_esc_agent", "cfg", cfg.m_esc_agent_cfg);
     cfg.m_esc_agent_cfg.en_cov = cfg.en_cov;
+
+    m_pcc_agent = pwrmgr_clk_ctrl_agent::type_id::create("m_pcc_agent", this);
+    uvm_config_db#(pwrmgr_clk_ctrl_agent_cfg)::set(this, "m_pcc_agent", "cfg", cfg.m_pcc_agent_cfg);
+    if (!uvm_config_db#(virtual clk_rst_if)::get(
+            this, "", "clk_rst_vif", cfg.m_pcc_agent_cfg.clk_rst_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get clk_rst_vif to cfg.m_pcc_agent_cfg.clk_rst_vif")
+    end
+    if (!uvm_config_db#(virtual clk_rst_if)::get(
+            this, "", "esc_clk_rst_vif", cfg.m_pcc_agent_cfg.esc_clk_rst_vif
+        )) begin
+      `uvm_fatal(`gfn, "failed to get clk_rst_vif to cfg.m_pcc_agent_cfg.esc_clk_rst_vif")
+    end
+
   endfunction
 
   function void connect_phase(uvm_phase phase);

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_cfg.sv
@@ -9,8 +9,8 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
   // disable fault csr read check from scoreboard
   bit disable_csr_rd_chk = 0;
   // ext component cfgs
-  alert_esc_agent_cfg m_esc_agent_cfg;
-
+  alert_esc_agent_cfg        m_esc_agent_cfg;
+  pwrmgr_clk_ctrl_agent_cfg  m_pcc_agent_cfg;
   // set expected alert
   // since pwrmgr has one alert, use single bit q
   bit exp_alert_q[$];
@@ -21,6 +21,7 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
 
   // ext interfaces
   virtual clk_rst_if esc_clk_rst_vif;
+  virtual clk_rst_if aon_clk_rst_vif;
   virtual clk_rst_if slow_clk_rst_vif;
   virtual pwrmgr_if pwrmgr_vif;
   virtual pwrmgr_ast_sva_if pwrmgr_ast_sva_vif;
@@ -46,6 +47,11 @@ class pwrmgr_env_cfg extends cip_base_env_cfg #(
     m_esc_agent_cfg.is_alert = 0;
     // Disable escalation ping coverage.
     m_esc_agent_cfg.en_ping_cov = 0;
+
+    // pwrmgr_clk_ctrl_agent config
+    m_pcc_agent_cfg = pwrmgr_clk_ctrl_agent_cfg::type_id::create("m_pcc_agent_cfg");
+    m_pcc_agent_cfg.is_active = 0;
+    m_pcc_agent_cfg.en_cov = 0;
   endfunction
 
 endclass

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
@@ -20,6 +20,7 @@ package pwrmgr_env_pkg;
   import prim_mubi_pkg::MuBi4True;
   import prim_mubi_pkg::MuBi4Width;
   import sec_cm_pkg::*;
+  import pwrmgr_clk_ctrl_agent_pkg::*;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_base_vseq.sv
@@ -180,13 +180,18 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
       begin
         cfg.esc_clk_rst_vif.apply_reset();
       end
+      begin
+        cfg.aon_clk_rst_vif.apply_reset();
+      end
     join
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
     cfg.slow_clk_rst_vif.drive_rst_pin(0);
     cfg.esc_clk_rst_vif.drive_rst_pin(0);
+    cfg.aon_clk_rst_vif.drive_rst_pin(0);
     super.apply_resets_concurrently(cfg.slow_clk_rst_vif.clk_period_ps);
+    cfg.aon_clk_rst_vif.drive_rst_pin(1);
     cfg.esc_clk_rst_vif.drive_rst_pin(1);
     cfg.slow_clk_rst_vif.drive_rst_pin(1);
   endtask
@@ -203,6 +208,7 @@ class pwrmgr_base_vseq extends cip_base_vseq #(
               cfg.slow_clk_rst_vif.clk_period_ps
               ), UVM_MEDIUM)
     cfg.esc_clk_rst_vif.set_freq_mhz(cfg.clk_rst_vif.clk_freq_mhz);
+    cfg.aon_clk_rst_vif.set_freq_mhz(cfg.clk_rst_vif.clk_freq_mhz);
     control_assertions(0);
   endtask
 

--- a/hw/ip/pwrmgr/dv/tb.sv
+++ b/hw/ip/pwrmgr/dv/tb.sv
@@ -16,6 +16,7 @@ module tb;
   wire clk, rst_n;
   wire clk_esc, rst_esc_n;
   wire clk_slow, rst_slow_n;
+  wire aon_clk, aon_rst_n;
   wire devmode;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
@@ -27,6 +28,10 @@ module tb;
   clk_rst_if esc_clk_rst_if (
     .clk  (clk_esc),
     .rst_n(rst_esc_n)
+  );
+  clk_rst_if aon_clk_rst_if (
+    .clk  (aon_clk),
+    .rst_n(aon_rst_n)
   );
   clk_rst_if slow_clk_rst_if (
     .clk  (clk_slow),
@@ -51,6 +56,16 @@ module tb;
     .clk_slow,
     .rst_slow_n
   );
+
+  pwrmgr_clk_ctrl_if pcc_if(
+    .clk (aon_clk),
+    .rst_n,
+    .clk_slow,
+    .rst_slow_n
+  );
+
+  assign pcc_if.pwr_ast_req = pwrmgr_if.pwr_ast_req;
+  assign pcc_if.pwr_clk_req = pwrmgr_if.pwr_clk_req;
 
   `DV_ALERT_IF_CONNECT
 
@@ -113,9 +128,11 @@ module tb;
     clk_rst_if.set_active();
     esc_clk_rst_if.set_active();
     slow_clk_rst_if.set_active();
+    aon_clk_rst_if.set_active();
 
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "esc_clk_rst_vif", esc_clk_rst_if);
+    uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "aon_clk_rst_vif", aon_clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "slow_clk_rst_vif", slow_clk_rst_if);
     uvm_config_db#(devmode_vif)::set(null, "*.env", "devmode_vif", devmode_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
@@ -129,6 +146,7 @@ module tb;
         null, "*.env", "pwrmgr_clock_enables_sva_vif", dut.pwrmgr_clock_enables_sva_if);
     uvm_config_db#(virtual pwrmgr_rstmgr_sva_if)::set(null, "*.env", "pwrmgr_rstmgr_sva_vif",
                                                       dut.pwrmgr_rstmgr_sva_if);
+    uvm_config_db#(virtual pwrmgr_clk_ctrl_if)::set(null, "*.env.m_pcc_agent*", "vif", pcc_if);
     $timeformat(-12, 0, " ps", 12);
     run_test();
   end


### PR DESCRIPTION
 - add a new agent to monitor two ports pwr_ast_o, pwr_clk_o
 - agent control two clocks inputs clk_i, esc_clk_i
   following monitored ouputs
 - pass full regression

Signed-off-by: Jaedon Kim <jdonjdon@google.com>