### PR TITLE
[clkmgr] Fix build with Xcelium

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -220,6 +220,12 @@ from topgen.lib import Name
   // Clock bypass request
   ////////////////////////////////////////////////////
 
+  mubi4_t extclk_ctrl_sel;
+  mubi4_t extclk_ctrl_hi_speed_sel;
+
+  assign extclk_ctrl_sel = mubi4_t'(reg2hw.extclk_ctrl.sel.q);
+  assign extclk_ctrl_hi_speed_sel = mubi4_t'(reg2hw.extclk_ctrl.hi_speed_sel.q);
+
   clkmgr_byp #(
     .NumDivClks(${len(clocks.derived_srcs)})
   ) u_clkmgr_byp (
@@ -228,8 +234,8 @@ from topgen.lib import Name
     .en_i(lc_hw_debug_en_i),
     .lc_clk_byp_req_i,
     .lc_clk_byp_ack_o,
-    .byp_req_i(mubi4_t'(reg2hw.extclk_ctrl.sel.q)),
-    .hi_speed_sel_i(mubi4_t'(reg2hw.extclk_ctrl.hi_speed_sel.q)),
+    .byp_req_i(extclk_ctrl_sel),
+    .hi_speed_sel_i(extclk_ctrl_hi_speed_sel),
     .all_clk_byp_req_o,
     .all_clk_byp_ack_i,
     .io_clk_byp_req_o,

--- a/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
+++ b/hw/ip/clkmgr/dv/sva/clkmgr_bind.sv
@@ -100,8 +100,8 @@ module clkmgr_bind;
   bind clkmgr clkmgr_extclk_sva_if clkmgr_extclk_sva_if (
     .clk_i,
     .rst_ni,
-    .extclk_ctrl_sel(mubi4_t'(reg2hw.extclk_ctrl.sel.q)),
-    .extclk_ctrl_hi_speed_sel(mubi4_t'(reg2hw.extclk_ctrl.hi_speed_sel.q)),
+    .extclk_ctrl_sel,
+    .extclk_ctrl_hi_speed_sel,
     .lc_hw_debug_en_i,
     .lc_clk_byp_req_i,
     .io_clk_byp_req_o,

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -253,6 +253,12 @@
   // Clock bypass request
   ////////////////////////////////////////////////////
 
+  mubi4_t extclk_ctrl_sel;
+  mubi4_t extclk_ctrl_hi_speed_sel;
+
+  assign extclk_ctrl_sel = mubi4_t'(reg2hw.extclk_ctrl.sel.q);
+  assign extclk_ctrl_hi_speed_sel = mubi4_t'(reg2hw.extclk_ctrl.hi_speed_sel.q);
+
   clkmgr_byp #(
     .NumDivClks(2)
   ) u_clkmgr_byp (
@@ -261,8 +267,8 @@
     .en_i(lc_hw_debug_en_i),
     .lc_clk_byp_req_i,
     .lc_clk_byp_ack_o,
-    .byp_req_i(mubi4_t'(reg2hw.extclk_ctrl.sel.q)),
-    .hi_speed_sel_i(mubi4_t'(reg2hw.extclk_ctrl.hi_speed_sel.q)),
+    .byp_req_i(extclk_ctrl_sel),
+    .hi_speed_sel_i(extclk_ctrl_hi_speed_sel),
     .all_clk_byp_req_o,
     .all_clk_byp_ack_i,
     .io_clk_byp_req_o,


### PR DESCRIPTION
It turns out that Xcelium (at least version 21.09-s006) doesn't
support static casts in bind ports. A rather strange restriction,
given you can put all sorts of other expressions in them! Ho hum.

Anyway, tweak the RTL to do some existing casts into variables that
can then be picked up by the bound-in interfaces.

Found when trying to debug #11816.