### PR TITLE
[sysrst_ctrl,dv] Added register reads to fill coverage holes

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_auto_blk_key_output_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_auto_blk_key_output_vseq.sv
@@ -41,6 +41,8 @@ class sysrst_ctrl_auto_blk_key_output_vseq extends sysrst_ctrl_base_vseq;
 
     bit enable_key0_out_sel, enable_key1_out_sel, enable_key2_out_sel;
     bit override_key0_out_value, override_key1_out_value, override_key2_out_value;
+    uvm_reg_data_t rdata;
+    uint16_t get_timer_value;
 
     `uvm_info(`gfn, "Starting the body from auto_blk_key_output_vseq", UVM_LOW)
 
@@ -68,15 +70,18 @@ class sysrst_ctrl_auto_blk_key_output_vseq extends sysrst_ctrl_base_vseq;
 
       `uvm_info(`gfn, $sformatf("Value of cycles:%0d", cycles), UVM_LOW)
 
-      enable_key0_out_sel = `gmv(ral.auto_block_out_ctl.key0_out_sel);
-      enable_key1_out_sel = `gmv(ral.auto_block_out_ctl.key1_out_sel);
-      enable_key2_out_sel = `gmv(ral.auto_block_out_ctl.key2_out_sel);
+      csr_rd(ral.auto_block_out_ctl, rdata);
+      enable_key0_out_sel = get_field_val(ral.auto_block_out_ctl.key0_out_sel, rdata);
+      enable_key1_out_sel = get_field_val(ral.auto_block_out_ctl.key1_out_sel, rdata);
+      enable_key2_out_sel = get_field_val(ral.auto_block_out_ctl.key2_out_sel, rdata);
 
-      override_key0_out_value = `gmv(ral.auto_block_out_ctl.key0_out_value);
-      override_key1_out_value = `gmv(ral.auto_block_out_ctl.key1_out_value);
-      override_key2_out_value = `gmv(ral.auto_block_out_ctl.key2_out_value);
+      override_key0_out_value = get_field_val(ral.auto_block_out_ctl.key0_out_value, rdata);
+      override_key1_out_value = get_field_val(ral.auto_block_out_ctl.key1_out_value, rdata);
+      override_key2_out_value = get_field_val(ral.auto_block_out_ctl.key2_out_value, rdata);
 
-      if (en_auto == 1 && cycles >= set_timer) begin
+      csr_rd(ral.auto_block_debounce_ctl, rdata);
+      get_timer_value = get_field_val(ral.auto_block_debounce_ctl.debounce_timer, rdata);
+      if (en_auto == 1 && cycles >= get_timer_value) begin
         cfg.clk_aon_rst_vif.wait_clks(1);
         if(enable_key0_out_sel == 1) begin
           `DV_CHECK_EQ(override_key0_out_value, cfg.vif.key0_out);

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ec_pwr_on_rst_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ec_pwr_on_rst_vseq.sv
@@ -21,6 +21,7 @@ class sysrst_ctrl_ec_pwr_on_rst_vseq extends sysrst_ctrl_base_vseq;
     }
 
    task body();
+    uint16_t get_ec_rst_timer;
 
     `uvm_info(`gfn, "Starting the body from ec_pwr_on_rst_vseq", UVM_LOW)
 
@@ -32,8 +33,11 @@ class sysrst_ctrl_ec_pwr_on_rst_vseq extends sysrst_ctrl_base_vseq;
     // Configure the EC_RST_CTL register to stretch the EC rst
     csr_wr(ral.ec_rst_ctl, set_ec_rst_timer);
 
+    // Get the ec_rst timer value
+    csr_rd(ral.ec_rst_ctl, get_ec_rst_timer);
+
     // check ec_rst_l asserts for ec_rst_timer cycles after reset
-    monitor_ec_rst_low(set_ec_rst_timer);
+    monitor_ec_rst_low(get_ec_rst_timer);
 
     repeat ($urandom_range(2, 4)) begin
       cfg.clk_aon_rst_vif.wait_clks(10);
@@ -43,10 +47,10 @@ class sysrst_ctrl_ec_pwr_on_rst_vseq extends sysrst_ctrl_base_vseq;
 
       fork
         begin
-          driver_ec_rst_l_in($urandom_range(1, set_ec_rst_timer * 2));
+          driver_ec_rst_l_in($urandom_range(1, get_ec_rst_timer * 2));
         end
         begin
-          monitor_ec_rst_low(set_ec_rst_timer);
+          monitor_ec_rst_low(get_ec_rst_timer);
         end
       join
     end

--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_ultra_low_pwr_vseq.sv
@@ -73,6 +73,8 @@ class sysrst_ctrl_ultra_low_pwr_vseq extends sysrst_ctrl_base_vseq;
    task body();
 
     uvm_reg_data_t rdata;
+    uint16_t get_ac_timer, get_pwrb_timer, get_lid_timer;
+    bit enable_ulp;
 
     `uvm_info(`gfn, "Starting the body from ultra_low_pwr_vseq", UVM_LOW)
 
@@ -115,8 +117,13 @@ class sysrst_ctrl_ultra_low_pwr_vseq extends sysrst_ctrl_base_vseq;
      // Enable the bus clock to read the status register
      cfg.clk_rst_vif.start_clk();
 
-     if (en_ulp == 1 && (pwrb_cycles >= set_pwrb_timer || ac_cycles >= set_ac_timer ||
-            lid_cycles >= set_lid_timer)) begin
+     csr_rd(ral.ulp_ac_debounce_ctl, get_ac_timer);
+     csr_rd(ral.ulp_pwrb_debounce_ctl, get_pwrb_timer);
+     csr_rd(ral.ulp_lid_debounce_ctl, get_lid_timer);
+     csr_rd(ral.ulp_ctl, rdata);
+     enable_ulp = get_field_val(ral.ulp_ctl.ulp_enable, rdata);
+     if (enable_ulp == 1 && (pwrb_cycles >= get_pwrb_timer || ac_cycles >= get_ac_timer ||
+            lid_cycles >= get_lid_timer)) begin
        cfg.clk_aon_rst_vif.wait_clks(1);
        `DV_CHECK_EQ(cfg.vif.z3_wakeup, 1);
        csr_rd_check(ral.wkup_status, .compare_value(1));


### PR DESCRIPTION
Few register reads are added in the functional tests to fill
in the assert coverage holes from sysrst_ctrl_csr_assert module.

Signed-off-by: Madhuri Patel <madhuri.patel@ensilica.com>