### PR TITLE
[spi_device] Change `addr_latched` to a pulse signal

### DIFF
--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -392,7 +392,23 @@ module spi_readcmd
   assign addr_ready_in_word     = (addr_cnt_d == 5'd 2);
   assign addr_ready_in_halfword = (addr_cnt_d == 5'd 1);
 
-  assign addr_latched = (addr_cnt_d == 5'd 0);
+  // addr_latched should be a pulse to be used in spid_readsram
+  logic  addr_latched_d;
+  assign addr_latched_d = (addr_cnt_d == 5'd 0);
+
+  prim_edge_detector #(
+    .Width      (1),
+    .ResetValue (1'b 0),
+    .EnSync     (1'b 0)
+  ) u_addr_latch_pulse (
+    .clk_i,
+    .rst_ni,
+
+    .d_i               (addr_latched_d),
+    .q_sync_o          (              ),
+    .q_posedge_pulse_o (addr_latched  ),
+    .q_negedge_pulse_o (              )
+  );
 
   assign cmdinfo_addr_mode = get_addr_mode(cmd_info_i, addr_4b_en_i);
 

--- a/hw/ip/spi_device/rtl/spid_readsram.sv
+++ b/hw/ip/spi_device/rtl/spid_readsram.sv
@@ -351,4 +351,7 @@ module spid_readsram
   // strb_set is asserted together with sram_req or follows the req
   `ASSUME(ReqStrbRelation_M, sram_read_req_i |-> ##[0:2] addr_latched_i)
 
+  // Address latched signal is a pulse signal
+  `ASSUME(AddrLatchedPulse_M, addr_latched_i |=> !addr_latched_i)
+
 endmodule : spid_readsram


### PR DESCRIPTION
Problem:

    `addr_latched_i` in `spid_readsram` module is expected to be a pulse
    signal. The `spi_readcmd` module generates the signal as a level by
    comparing `addr_cnt_d` with all zero value.

    As a result, the `strb` register in `spid_readsram` follows the
    current address, which is increased by when a byte is sent to the
    host system. However, the `spid_readsram` logic pushes the data into
    the FIFO already. As the FIFO depth is 2, one more entry has been
    added to the FIFO, which results the host system sees the a byte has
    been shifted.

Resolution:

    Revised the `addr_latched` logic to be a pulse. Either `addr_cnt_d`
    or `addr_latched` can be revised. I chose the latter. Latching the
    latched signal and generated a pulse.

This PR contains #11829  Please review the last commit only. I will rebase once the PR is merged