### PR TITLE
[dv/otp_ctrl] Add assertions to check fatal alert outputs

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_scoreboard.sv
@@ -145,6 +145,7 @@ class otp_ctrl_scoreboard #(type CFG_T = otp_ctrl_env_cfg)
             exp_hwcfg_data = cfg.otp_ctrl_vif.under_error_states() ?
                              otp_ctrl_part_pkg::PartInvDefault[HwCfgOffset*8 +: HwCfgSize*8] :
                              otp_hw_cfg_data_t'({<<32 {otp_a[HwCfgOffset/4 +: HwCfgSize/4]}});
+            `DV_CHECK_EQ(cfg.otp_ctrl_vif.otp_hw_cfg_o.valid, lc_ctrl_pkg::On)
             `DV_CHECK_EQ(cfg.otp_ctrl_vif.otp_hw_cfg_o.data, exp_hwcfg_data)
 
             if (!cfg.otp_ctrl_vif.under_error_states() && cfg.en_scb) begin

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -71,6 +71,11 @@ module tb;
 
   assign otp_ctrl_if.lc_prog_req = lc_prog_if.req;
   assign otp_ctrl_if.lc_prog_err = lc_prog_if.d_data;
+
+  // Assign to otp_ctrl_if for assertion checks.
+  assign otp_ctrl_if.flash_acks = flash_data_if.ack;
+  assign otp_ctrl_if.otbn_ack  = otbn_if.ack;
+
   // This signal probes design's alert request to avoid additional logic for triggering alert and
   // disable assertions.
   // Alert checkings are done independently in otp_ctrl's scb.
@@ -144,9 +149,10 @@ module tb;
   );
 
   for (genvar i = 0; i < NumSramKeyReqSlots; i++) begin : gen_sram_pull_if
-    assign sram_req[i]       = sram_if[i].req;
-    assign sram_if[i].ack    = sram_rsp[i].ack;
-    assign sram_if[i].d_data = {sram_rsp[i].key, sram_rsp[i].nonce, sram_rsp[i].seed_valid};
+    assign sram_req[i]              = sram_if[i].req;
+    assign sram_if[i].ack           = sram_rsp[i].ack;
+    assign sram_if[i].d_data        = {sram_rsp[i].key, sram_rsp[i].nonce, sram_rsp[i].seed_valid};
+    assign otp_ctrl_if.sram_acks[i] = sram_rsp[i].ack;
     initial begin
       uvm_config_db#(virtual push_pull_if#(.DeviceDataWidth(SRAM_DATA_SIZE)))::set(null,
                      $sformatf("*env.m_sram_pull_agent[%0d]*", i), "vif", sram_if[i]);


### PR DESCRIPTION
This PR adds assertions to check after fatal alert, if all outputs are
reverted back to default value.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>