### PR TITLE
[bazel] cleanup opentitan_functest to promote code-reuse

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -216,13 +216,6 @@ def _format_list(param_name, list1, datadict, **kwargs):
     """
     return [x.format(**kwargs) for x in list1 + datadict.pop(param_name, [])]
 
-def _unique_deps(*deplists):
-    uniq = {}
-    for deplist in deplists:
-        for dep in deplist:
-            uniq[dep] = True
-    return uniq.keys()
-
 def opentitan_functest(
         name,
         targets = ["dv", "verilator", "cw310"],
@@ -271,7 +264,7 @@ def opentitan_functest(
     """
 
     # Generate flash artifacts for test.
-    deps = _unique_deps(kwargs.pop("deps", []), ottf)
+    deps = depset(direct = kwargs.pop("deps", []) + ottf).to_list()
     if test_in_rom:
         opentitan_rom_binary(
             name = name + "_rom_prog",

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -288,9 +288,7 @@ BOOT_FAILURE_MSG = "BFV_[0-9a-z]{{8}}\nLCV_[0-9a-z]{{8}}\n"
 
 opentitan_functest(
     name = "e2e_bootup_success",
-    srcs = [
-        "mask_rom_test.c",
-    ],
+    srcs = ["mask_rom_test.c"],
     signed = True,
     targets = [
         "verilator",
@@ -308,13 +306,11 @@ opentitan_functest(
 # TODO: Add verilator test
 opentitan_functest(
     name = "e2e_bootup_no_rom_ext_signature",
-    srcs = [
-        "mask_rom_test.c",
-    ],
+    srcs = ["mask_rom_test.c"],
     cw310 = cw310_params(
         args = [
             "--exec=\"console -q -t0\"",
-            "--exec=\"bootstrap $(location {test_bin})\"",
+            "--exec=\"bootstrap $(location {flash})\"",
             "console",
             "--timeout=3600",
             "--exit-success='{}'".format(BOOT_FAILURE_MSG),


### PR DESCRIPTION
A review comment in #11787 suggested the `opentitan_functest` rule could benefit from some refactoring to promote code reuse. This does so, and fixes #11805.

**_Note: this depends on #11835._**