### PR TITLE
[dv,tcl] Merge Coverage Databases with union_all

### DIFF
--- a/hw/dv/tools/xcelium/cov_merge.tcl
+++ b/hw/dv/tools/xcelium/cov_merge.tcl
@@ -18,7 +18,7 @@ puts "Output directory for merged coverage:"
 set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
 
 # Run the merge command.
-merge $cov_db_dirs -out $cov_merge_db_dir -overwrite
+merge $cov_db_dirs -out $cov_merge_db_dir -overwrite -initial_model union_all
 
 # Create a file with the path to the cover dirs
 set filepointer [open "$cov_merge_db_dir/runs.txt" w]


### PR DESCRIPTION
This argument enables to merge different coverage databases with
different testbench structures to tie together as a single coverage
database. Necessary for Ibex DV because we want to see the numbers
for both riscv-dv and core_ibex coverage databases.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>