### PR TITLE
[adc_ctrl/dv] Enhanced coverage and moved collection to scoreboard

### DIFF
--- a/hw/ip/adc_ctrl/dv/cov/adc_ctrl_core_cov_if.sv
+++ b/hw/ip/adc_ctrl/dv/cov/adc_ctrl_core_cov_if.sv
@@ -5,14 +5,14 @@
 // Implements functional coverage for ADC_CTRL FSM
 
 interface adc_ctrl_fsm_cov_if
-// import adc_ctrl_pkg::*;
-(
+  import adc_ctrl_pkg::*;
+  (
   input logic clk_aon_i,
   input logic rst_aon_ni,
   input logic cfg_fsm_rst_i,
   input logic [15:0] np_sample_cnt_q,
   input logic [7:0] lp_sample_cnt_q,
-  input logic [4:0] fsm_state_q
+  input fsm_state_e fsm_state_q
 );
   `include "dv_fcov_macros.svh"
   localparam int NpSampleCntWidth = $bits(np_sample_cnt_q);

--- a/hw/ip/adc_ctrl/dv/cov/adc_ctrl_cov.core
+++ b/hw/ip/adc_ctrl/dv/cov/adc_ctrl_cov.core
@@ -3,11 +3,11 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:dv:adc_ctrl_cov"
-description: "LC_CTRL functional coverage and bind files"
+description: "ADC_CTRL functional coverage and bind files"
 filesets:
   files_rtl:
     depend:
-      - lowrisc:ip:lc_ctrl
+      - lowrisc:ip:adc_ctrl
 
   files_dv:
     depend:

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cfg.sv
@@ -81,6 +81,10 @@ class adc_ctrl_env_cfg extends cip_base_env_cfg #(
         num_interrupts = ral.intr_state.get_n_used_bits();
       end
     end
+
+    // only support 1 outstanding TL item
+    m_tl_agent_cfg.max_outstanding_req = 1;
+
   endfunction
 
   // Constraints

--- a/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
+++ b/hw/ip/adc_ctrl/dv/env/adc_ctrl_env_cov.sv
@@ -15,31 +15,39 @@ class adc_ctrl_filter_cg_wrapper #(
   // Number of values bins to create
   int NUMBER_VALUES = 10
 );
-  // Sampling event
-  event sample_ev;
-  adc_ctrl_env_cfg cfg;
 
   // Filter configuration one instance per filter
-  covergroup adc_ctrl_filter_cg(int channel, int filter) @(sample_ev);
+  covergroup adc_ctrl_filter_cg(
+      int channel, int filter
+  ) with function sample (
+      adc_ctrl_filter_cfg_t cfg, bit is_interrupt = 0, bit is_wakeup = 0, bit clk_gate = 0
+  );
     option.name = $sformatf("adc_ctrl_filter_cg_%0d_%0d", channel, filter);
     option.per_instance = 1;
-    cond_cp: coverpoint cfg.filter_cfg[channel][filter].cond;
-    min_v_cp: coverpoint cfg.filter_cfg[channel][filter].min_v {
+
+    cond_cp: coverpoint cfg.cond;
+    min_v_cp: coverpoint cfg.min_v {
       bins minimum = {0};
       bins values[NUMBER_VALUES] = {[1 : (2 ** FILTER_WIDTH - 2)]};
       bins maximum = {2 ** FILTER_WIDTH - 1};
     }
-    max_v_cp: coverpoint cfg.filter_cfg[channel][filter].max_v {
+    max_v_cp: coverpoint cfg.max_v {
       bins minimum = {0};
       bins values[NUMBER_VALUES] = {[1 : (2 ** FILTER_WIDTH - 2)]};
       bins maximum = {2 ** FILTER_WIDTH - 1};
     }
-    en_cp: coverpoint cfg.filter_cfg[channel][filter].en;
+    en_cp: coverpoint cfg.en;
+    interrupt_cp: coverpoint is_interrupt;
+    wakeup_cp: coverpoint is_wakeup;
+    clk_gate_cp: coverpoint clk_gate;
+    intr_min_v_cond_xp: cross interrupt_cp, min_v_cp, cond_cp;
+    intr_max_v_cond_xp: cross interrupt_cp, max_v_cp, cond_cp;
+    wakeup_min_v_cond_xp: cross wakeup_cp, min_v_cp, cond_cp;
+    wakeup_max_v_cond_xp: cross wakeup_cp, max_v_cp, cond_cp;
+    wakeup_gated_xp : cross wakeup_cp, clk_gate_cp;
   endgroup
 
-  function new(int channel, int filter, adc_ctrl_env_cfg cfg, event sample_ev);
-    this.sample_ev = sample_ev;
-    this.cfg = cfg;
+  function new(int channel, int filter);
     adc_ctrl_filter_cg = new(channel, filter);
   endfunction
 endclass
@@ -48,29 +56,51 @@ class adc_ctrl_env_cov extends cip_base_env_cov #(
   .CFG_T(adc_ctrl_env_cfg)
 );
   `uvm_component_utils(adc_ctrl_env_cov)
-  `uvm_component_new
 
   // Sample configuration
   event sample_cfg_ev;
 
   // covergroups
 
+  // Modes of operation - sampled when adc_en_ctl is written to start the ADC_CTRL
+  covergroup adc_ctrl_testmode_cg with function sample (adc_ctrl_testmode_e testmode);
+    testmode_cp: coverpoint testmode {
+      bins testmodes[] = {AdcCtrlTestmodeOneShot, AdcCtrlTestmodeNormal, AdcCtrlTestmodeLowpower};
+
+      bins transitions[] = ( AdcCtrlTestmodeOneShot, AdcCtrlTestmodeNormal,
+      AdcCtrlTestmodeLowpower => AdcCtrlTestmodeOneShot, AdcCtrlTestmodeNormal,
+      AdcCtrlTestmodeLowpower );
+    }
+  endgroup
+
+
+  // These are sampled on configuration when adc_en_ctl is written to start the ADC_CTRL
+  // They are also sampled when an interrupt or wakeup event occurs
+  // There is one per filter
   adc_ctrl_filter_cg_wrapper adc_ctrl_filter_cg_wrapper_insts
       [ADC_CTRL_CHANNELS] [ADC_CTRL_NUM_FILTERS];
+
+
+  function new(string name = "adc_ctrl_env_cov", uvm_component parent = null);
+    super.new(name, parent);
+    adc_ctrl_testmode_cg = new();
+  endfunction
 
   virtual function void build_phase(uvm_phase phase);
     super.build_phase(phase);
     for (int channel = 0; channel < ADC_CTRL_CHANNELS; channel++) begin
       for (int filter = 0; filter < ADC_CTRL_NUM_FILTERS; filter++) begin
-        adc_ctrl_filter_cg_wrapper_insts[channel][filter] =
-            new(.channel(channel), .filter(filter), .cfg(cfg), .sample_ev(sample_cfg_ev));
+        adc_ctrl_filter_cg_wrapper_insts[channel][filter] = new(.channel(channel), .filter(filter));
       end
     end
   endfunction : build_phase
 
-  // Sample the coverage
-  virtual function void sample_cfg_cov();
-    ->sample_cfg_ev;
+  // Sample filter coverage
+  virtual function void sample_filter_cov(int channel, int filter, adc_ctrl_filter_cfg_t cfg,
+                                          bit is_interrupt = 0, bit is_wakeup = 0,
+                                          bit clk_gate = 0);
+    adc_ctrl_filter_cg_wrapper_insts[channel][filter].adc_ctrl_filter_cg.sample(cfg, is_interrupt,
+                                                                                is_wakeup);
   endfunction
 
 endclass

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_polled_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_filters_polled_vseq.sv
@@ -34,11 +34,6 @@ class adc_ctrl_filters_polled_vseq extends adc_ctrl_base_vseq;
       // Make sure ADC is off
       csr_wr(ral.adc_en_ctl, 'h0);
 
-      // Sample coverage
-      if (cfg.en_cov) begin
-        cov.sample_cfg_cov();
-      end
-
       // Set up the adc_ctrl registers
       configure_adc_ctrl();
 

--- a/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
+++ b/hw/ip/adc_ctrl/dv/env/seq_lib/adc_ctrl_fsm_reset_vseq.sv
@@ -77,6 +77,8 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
     `DV_ASSERT_CTRL_REQ("PwrupTime_A_CTRL", 0)
     // Disable enter low power assertion
     `DV_ASSERT_CTRL_REQ("EnterLowPower_A_CTRL", 0)
+    // Disable FSM assertions - need this due to counter preloads
+    `DV_ASSERT_CTRL_REQ("ADC_CTRL_FSM_A_CTRL", 0)
   endtask
 
   virtual task post_start();
@@ -84,7 +86,8 @@ class adc_ctrl_fsm_reset_vseq extends adc_ctrl_base_vseq;
     // Reenable assertions
     `DV_ASSERT_CTRL_REQ("ADC_IF_A_CTRL", 1)
     `DV_ASSERT_CTRL_REQ("PwrupTime_A_CTRL", 1)
-    `DV_ASSERT_CTRL_REQ("EnterLowPower_A_CTRL", 0)
+    `DV_ASSERT_CTRL_REQ("EnterLowPower_A_CTRL", 1)
+    `DV_ASSERT_CTRL_REQ("ADC_CTRL_FSM_A_CTRL", 1)
   endtask
 
 

--- a/hw/ip/adc_ctrl/dv/sva/adc_ctrl_fsm_sva.sv
+++ b/hw/ip/adc_ctrl/dv/sva/adc_ctrl_fsm_sva.sv
@@ -2,20 +2,22 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 // System verilog assertions for the adc_ctrl_fsm module
-module adc_ctrl_fsm_sva (
+module adc_ctrl_fsm_sva
+  import adc_ctrl_pkg::*;
+  (
   // adc_ctrl_fsm ports
   input logic clk_aon_i,
   input logic rst_aon_ni,
   input logic cfg_fsm_rst_i,
   // adc_ctrl_fsm signals
-  input logic [4:0] fsm_state_q,
+  input fsm_state_e fsm_state_q,
   input logic [3:0] pwrup_timer_cnt_q,
   input logic [23:0] wakeup_timer_cnt_q,
   input logic [15:0] np_sample_cnt_q,
   input logic [7:0] lp_sample_cnt_q
 );
 
-  localparam logic [4:0] FsmResetState = 0;
+  localparam fsm_state_e FsmResetState = PWRDN;
 
   // FSM software reset
   `ASSERT(FsmStateSwReset_A, cfg_fsm_rst_i |=> fsm_state_q == FsmResetState, clk_aon_i, !rst_aon_ni)

--- a/hw/ip/adc_ctrl/dv/sva/adc_ctrl_sva.core
+++ b/hw/ip/adc_ctrl/dv/sva/adc_ctrl_sva.core
@@ -3,12 +3,13 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:dv:adc_ctrl_sva:0.1"
-description: "DCD assertion modules and bind file."
+description: "ADC_CTRL assertion modules and bind file."
 filesets:
   files_dv:
     depend:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
+      - lowrisc:ip:adc_ctrl
     files:
       - adc_ctrl_fsm_sva.sv
       - adc_ctrl_bind.sv


### PR DESCRIPTION
- Moved coverage collection to scoreboard
- Added interrupt and wakeup coverage collection
- Added test mode coverage
- Updated m_tl_agent_cfg.max_outstanding_req in config object to
solve issue with tl_agent_pkg::max_outstanding_cg
- Fixed adc_ctrl_fsm_reset by disabling RTL assertion which was triggering due
to backdoor preloading of the counters.
- Importing adc_ctrl_pkg and using adc_ctrl_pkg::fsm_state_e for
SVA and coverage

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>