### PR TITLE
[otbn, dv] Enables secure wipe

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_trace_checker.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.cc
@@ -246,10 +246,12 @@ bool OtbnTraceChecker::MatchPair() {
     return false;
   }
 
-  // We've got a matching pair. Move the ISS data out of the (now defunct)
-  // iss_entry_ and into last_data_.
-  last_data_ = std::move(iss_entry_.data_);
-  last_data_vld_ = true;
+  // We've got a matching pair of entries. Move the ISS data out of the (now
+  // defunct) iss_entry_ and into last_data_.
+  if (rtl_entry_.trace_type() == OtbnTraceEntry::Exec) {
+    last_data_ = std::move(iss_entry_.data_);
+    last_data_vld_ = true;
+  }
 
   return true;
 }

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -344,19 +344,15 @@ class OTBNState:
             return
 
         self.gprs.commit()
-
-        # If we're stalled, there's nothing more to do: we only commit the rest
-        # of the architectural state when we finish our stall cycles.
-        if sim_stalled:
-            return
-
         self.dmem.commit()
-        self.pc = self.get_next_pc()
-        self._pc_next_override = None
         self.loop_stack.commit()
         self.wsrs.commit()
         self.csrs.flags.commit()
         self.wdrs.commit()
+
+        if not sim_stalled:
+            self.pc = self.get_next_pc()
+            self._pc_next_override = None
 
     def _abort(self) -> None:
         '''Abort any pending state changes'''
@@ -432,7 +428,7 @@ class OTBNState:
 
             # Switch to a 'wiping' state
             self._next_fsm_state = (FsmState.WIPING_BAD if should_lock
-                                else FsmState.WIPING_GOOD)
+                                    else FsmState.WIPING_GOOD)
             self.wipe_cycles = (_WIPE_CYCLES if self.secure_wipe_enabled else 2)
         else:
             assert should_lock

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_imem_err_vseq.sv
@@ -45,11 +45,9 @@ class otbn_imem_err_vseq extends otbn_base_vseq;
     cfg.model_agent_cfg.vif.invalidate_imem();
 
     // If we were unlucky, we might have injected the errors while OTBN was executing an instruction
-    // that was already causing it to stop. To allow for this specific case, we wait three cycles to
-    // let that instruction flush through. We need this much time to handle things like branches
-    // that might take until the second cycle before realising that something failed and then one
-    // more cycle to clean up.
-    repeat (3) @(cfg.clk_rst_vif.cbn);
+    // that was already causing it to stop. To allow for this specific case, we wait 100 cycles to
+    // let that instruction flush through and secure wiping to finish.
+    repeat (100) @(cfg.clk_rst_vif.cbn);
     // If OTBN is now idle, we hit this exact window and the test didn't do anything useful. Ho
     // hum... Note that we don't need to apply a reset in this case.
     if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusIdle) begin

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -254,7 +254,7 @@ name:
       tests: [
         "otbn_smoke", "otbn_single", "otbn_multi", "otbn_reset",
          "otbn_multi_err", "otbn_imem_err", "otbn_dmem_err",
-         "otbn_stress_all"
+         "otbn_stress_all", "otbn_escalate"
       ]
     }
   ]

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -25,7 +25,7 @@ module tb;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // Configure internal secure wipe
-  localparam bit SecWipeEn  = 1'b0;
+  localparam bit SecWipeEn  = 1'b1;
 
   // interfaces
   clk_rst_if                    clk_rst_if  (.clk(clk), .rst_n(rst_n));


### PR DESCRIPTION
This commit adds necessary changes to enable security wipe and fixes the
wdr register commit issue when secure wipe is done. It also fixes rtl
and iss trace entry mismatch during coverage collection.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>