### PR TITLE
[entropy_src/dv] Minor updates to support more use cases

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -120,7 +120,7 @@
     }
     {
       name: short_run
-      run_opts: ["+test_timeout_ns=1000000"]
+      run_opts: ["+test_timeout_ns=5000000"]
     }
   ]
 }

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_pkg.sv
@@ -165,7 +165,7 @@ package entropy_src_env_pkg;
 
     phase = convert_seed_idx_to_phase(seed_idx, fips_enable, fw_ov_insert);
 
-    return (phase == BOOT) ? entropy_src_pkg::CSRNG_BUS_WIDTH : fips_window_size;
+    return (phase == BOOT || phase == HALTED) ? entropy_src_pkg::CSRNG_BUS_WIDTH : fips_window_size;
 
   endfunction
 

--- a/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
+++ b/hw/ip/entropy_src/dv/tests/entropy_src_rng_test.sv
@@ -16,7 +16,7 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.fips_window_size            = 2048;
     cfg.bypass_window_size          = 384;
     cfg.boot_mode_retry_limit       = 10;
-    cfg.sim_duration                = 10ms;
+    cfg.sim_duration                = 20ms;
     cfg.hard_mtbf                   = 100s;
     cfg.soft_mtbf                   = 7500us;
     // Apply standards ranging from strict to relaxed
@@ -27,25 +27,27 @@ class entropy_src_rng_test extends entropy_src_base_test;
     cfg.markov_sigma_min            = 1.0;
     cfg.markov_sigma_max            = 6.0;
 
-    // TODO: Randomize (Ideally @50%)
-    cfg.entropy_data_reg_enable_pct = 100;
-    // TODO: Randomize@50% (requires vseq update)
-    cfg.route_software_pct          = 0;
-    // TODO: Randomize@50%
-    cfg.type_bypass_pct             = 0;
+    // TODO: Randomize
+    // (Also requires some scoreboarding checks)
+    cfg.sw_regupd_pct               = 100;
+
+    cfg.entropy_data_reg_enable_pct = 50;
+    cfg.route_software_pct          = 50;
+    cfg.otp_en_es_fw_read_pct       = 50;
+    cfg.otp_en_es_fw_over_pct       = 50;
+
+    cfg.type_bypass_pct             = 50;
     cfg.default_ht_thresholds_pct   = 100;
 
     // Sometimes read data from the Observe FIFO (but always take entropy from RNG)
     cfg.fw_read_pct                 = 50;
     cfg.fw_over_pct                 = 0;
     // Sometimes inject data, even if not configured
-    cfg.spurious_inject_entropy_pct = 100;
+    cfg.spurious_inject_entropy_pct = 50;
 
-    // TODO: Randomize@50%
-    cfg.rng_bit_enable_pct          = 0;
+    cfg.rng_bit_enable_pct          = 50;
 
-    // TODO: Randomize@50%
-    cfg.fips_enable_pct             = 100;
+    cfg.fips_enable_pct             = 50;
     cfg.module_enable_pct           = 100;
     `DV_CHECK_RANDOMIZE_FATAL(cfg)
 


### PR DESCRIPTION
The RNG Vseq and scoreboard have been updated to better support various entropy_src configurations:

- Properly handles OTP flags for FW reads, and FW override modes
- An interrupt handler has been added to fetch data from the ENTOPY_DATA CSR
- Minor bugfixes have been added to recognize bypass-mode data when
  ENTROPY_CONTROL.ES_TYPE is set to MuBi4True.
- When in bypass mode, the interrupt handler also reinitializes
  The DUT after reading a word, to prompt the production of more
  seeds.  (The DUT itself halts after making one seed.)

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>