### PR TITLE
[sw/test_rom] Init SRAM for non-sim_dv devices

### DIFF
--- a/hw/top_englishbreakfast/util/sw_sources.patch
+++ b/hw/top_englishbreakfast/util/sw_sources.patch
@@ -30,10 +30,10 @@ index 643e44b49..a07e286e1 100644
    reg32 =
        mmio_region_from_addr(PINMUX0_BASE_ADDR + PINMUX_MIO_OUTSEL_0_REG_OFFSET);
 diff --git a/sw/device/lib/testing/test_rom/test_rom_start.S b/sw/device/lib/testing/test_rom/test_rom_start.S
-index 7092c858a..101d3bc7e 100644
+index 960cd0c62..f7b4c100b 100644
 --- a/sw/device/lib/testing/test_rom/test_rom_start.S
 +++ b/sw/device/lib/testing/test_rom/test_rom_start.S
-@@ -146,47 +146,6 @@ _start:
+@@ -147,47 +147,6 @@ _start:
    li   t0, CLKMGR_CLK_HINTS_REG_RESVAL
    sw   t0, CLKMGR_CLK_HINTS_REG_OFFSET(a0)
 
@@ -78,11 +78,11 @@ index 7092c858a..101d3bc7e 100644
 -  li   t0, 0x55aa
 -  sw   t0, EDN_CTRL_REG_OFFSET(a0)
 -
-   // Remove address space protections by configuring entry 15 as
-   // read-write-execute for the entire address space and then clearing
-   // all other entries.
+   // Scramble and initialize main memory (main SRAM).
+   // Memory accesses will stall until initialization is complete.
+   // Skip SRAM initialization for DV sim device type, as the testbench handles
 diff --git a/sw/device/sca/aes_serial.c b/sw/device/sca/aes_serial.c
-index aee8a61f3..b910e1c34 100644
+index e8f59855b..25cb412f2 100644
 --- a/sw/device/sca/aes_serial.c
 +++ b/sw/device/sca/aes_serial.c
 @@ -199,18 +199,13 @@ int main(void) {
@@ -118,7 +118,7 @@ index 3a613b2b8..fa939775a 100644
        sw_lib_mmio,
        sw_lib_pinmux,
 diff --git a/sw/device/sca/lib/sca.c b/sw/device/sca/lib/sca.c
-index 3c0c86f26..7354aa9cb 100644
+index 26110265f..7354aa9cb 100644
 --- a/sw/device/sca/lib/sca.c
 +++ b/sw/device/sca/lib/sca.c
 @@ -7,8 +7,6 @@
@@ -222,7 +222,7 @@ index 3c0c86f26..7354aa9cb 100644
    if (disable & kScaPeripheralUsb) {
      IGNORE_RESULT(dif_clkmgr_gateable_clock_set_enabled(
          &clkmgr, CLKMGR_CLK_ENABLES_CLK_USB_PERI_EN_BIT, kDifToggleDisabled));
-@@ -221,8 +167,6 @@ void sca_init(sca_trigger_source_t trigger, sca_peripherals_t enable) {
+@@ -218,8 +167,6 @@ void sca_init(sca_trigger_source_t trigger, sca_peripherals_t enable) {
    sca_init_uart();
    sca_init_gpio(trigger);
    sca_init_timer();
@@ -232,7 +232,7 @@ index 3c0c86f26..7354aa9cb 100644
  }
 
 diff --git a/sw/device/tests/aes_smoketest.c b/sw/device/tests/aes_smoketest.c
-index 4667a550a..bea5d3bf5 100644
+index 1286e47c0..308aab5a4 100644
 --- a/sw/device/tests/aes_smoketest.c
 +++ b/sw/device/tests/aes_smoketest.c
 @@ -7,7 +7,6 @@
@@ -254,10 +254,10 @@ index 4667a550a..bea5d3bf5 100644
    CHECK_DIF_OK(
        dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
 diff --git a/sw/device/tests/meson.build b/sw/device/tests/meson.build
-index 2e822c5f3..2da8fc3be 100644
+index 0cb0e09c3..32274f359 100644
 --- a/sw/device/tests/meson.build
 +++ b/sw/device/tests/meson.build
-@@ -248,7 +248,6 @@ aes_smoketest_lib = declare_dependency(
+@@ -277,7 +277,6 @@ aes_smoketest_lib = declare_dependency(
        sw_lib_dif_aes,
        sw_lib_mmio,
        sw_lib_runtime_log,

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -28,23 +28,27 @@
 typedef enum device_type {
   /**
    * Represents "DV", i.e. running th test in a DV simulation testbench.
+   *
+   * DISCLAIMER: it is important this value remains assigned to 0, as it is
+   * implicitly checked in the `test_rom_start.S` assembly code to determine
+   * whether or not to initialize SRAM.
    */
-  kDeviceSimDV,
+  kDeviceSimDV = 0,
   /**
    * Represents the "Verilator" device, i.e., a synthesis of the OpenTitan
    * design by Verilator into C++.
    */
-  kDeviceSimVerilator,
+  kDeviceSimVerilator = 1,
   /**
    * Represents the "ChipWhisperer CW310 FPGA" device, i.e., the particular
    * FPGA board blessed for OpenTitan development, containing a Xilinx FPGA.
    */
-  kDeviceFpgaCw310,
+  kDeviceFpgaCw310 = 2,
   /**
    * Represents the "Nexys Video FPGA" device, i.e., the previous main FPGA
    * development board for OpenTitan, containing a Xilinx FPGA.
    */
-  kDeviceFpgaNexysVideo,
+  kDeviceFpgaNexysVideo = 3,
 } device_type_t;
 
 /**

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -78,6 +78,7 @@ _test_rom_interrupt_vector:
 
   .extern crt_section_clear
   .extern crt_section_copy
+  .extern kDeviceType
 
 /**
  * Entry point after reset. This symbol is jumped to from the handler
@@ -187,6 +188,17 @@ _start:
   li   t0, 0x55aa
   sw   t0, EDN_CTRL_REG_OFFSET(a0)
 
+  // Scramble and initialize main memory (main SRAM).
+  // Memory accesses will stall until initialization is complete.
+  // Skip SRAM initialization for DV sim device type, as the testbench handles
+  // this to optimize test run times.
+  lw    t0, kDeviceType
+  beqz  t0, .L_sram_init_skip
+  li    a0, TOP_EARLGREY_SRAM_CTRL_MAIN_REGS_BASE_ADDR
+  li    t0, (1 << SRAM_CTRL_CTRL_INIT_BIT)
+  sw    t0, SRAM_CTRL_CTRL_REG_OFFSET(a0)
+
+.L_sram_init_skip:
   // Remove address space protections by configuring entry 15 as
   // read-write-execute for the entire address space and then clearing
   // all other entries.


### PR DESCRIPTION
In DV sim, the testbench handles the SRAM init via backdoor loading to
optimize test run time. However, in Verilator and FPGA, this is not the
case. Therefore to prevent this from causing a bus integrity error, we
initialize SRAM for Verilator and FPGA devices.

This fixes #11854.

Signed-off-by: Timothy Trippel <ttrippel@google.com>