### PR TITLE
[docgen] Minor HW dashboard updates

### DIFF
--- a/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.prj.hjson
+++ b/hw/top_earlgrey/ip/sensor_ctrl/data/sensor_ctrl.prj.hjson
@@ -12,8 +12,9 @@
         version:            "1.0",
         life_stage:         "L1",
         design_stage:       "D2",
-        verification_stage: "N/A", // block level verification not planned
-        //notes:            ""
+        // block level verification not planned
+        verification_stage: "N/A",
+        notes:              "Verified at the top-level."
       }
     ]
 }

--- a/site/docs/layouts/shortcodes/dashboard.html
+++ b/site/docs/layouts/shortcodes/dashboard.html
@@ -3,7 +3,7 @@
     <tr>
       <th>Design Spec</th>
       <th>DV Document</th>
-      <th><a href="{{ relref . "doc/project/development_stages#versioning" }}">Version</a></th>
+      <th><a href="{{ relref . "doc/project/development_stages#versioning" }}">Spec Version</a></th>
       <th colspan="4"><a href="{{ relref . "doc/project/development_stages#life-stages" }}">Development Stage</a></th>
       <th>Notes</th>
     </tr>

--- a/util/dashboard/gen_dashboard_entry.py
+++ b/util/dashboard/gen_dashboard_entry.py
@@ -45,6 +45,9 @@ STAGE_STRINGS = {
     'S1': 'Functional',
     'S2': 'Complete',
     'S3': 'Stable',
+    # In case certain development stages do not apply
+    # (e.g. verification handled at the top-level).
+    'N/A': 'Not Applicable'
 }
 
 
@@ -102,8 +105,8 @@ def get_linked_checklist(obj, rev, stage, is_latest_rev=True):
 
     url = ""
     in_page_ref = ""
-    if rev[stage] not in ["D0", "V0"]:
-        # if in D0 or V0 stage, there is no in-page reference.
+    # if N/A or in D0/V0 stage, there is no in-page reference.
+    if rev[stage] not in ["D0", "V0", "N/A"]:
         in_page_ref = "#{}".format(html.escape(rev[stage]).lower())
 
     # If the checklist is available, the commit id is available, and it is not


### PR DESCRIPTION
This is a follow-on for #11712 and #11694.

In particular, this makes explicit the fact that the version is with respect to a design spec / feature set.
Also, it updates the `docgen` tool to recognize `N/A` entries in the design stage fields.