### PR TITLE
[otbn] Pass lc_escalate as lc_tx_t to consumer FSMs

### DIFF
--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -232,7 +232,7 @@ module tb;
     .cmd_i        (model_if.cmd_q),
     .cmd_en_i     (model_if.cmd_qe),
 
-    .lc_escalate_en_i (escalate_if.enable == lc_ctrl_pkg::On),
+    .lc_escalate_en_i (escalate_if.enable != lc_ctrl_pkg::Off),
 
     .err_bits_o   (model_if.err_bits),
 

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -72,53 +72,53 @@ module otbn_top_sim (
     .DmemSizeByte ( DmemSizeByte ),
     .SecWipeEn    ( SecWipeEn    )
   ) u_otbn_core (
-    .clk_i                       ( IO_CLK              ),
-    .rst_ni                      ( IO_RST_N            ),
+    .clk_i                       ( IO_CLK                     ),
+    .rst_ni                      ( IO_RST_N                   ),
 
-    .start_i                     ( otbn_start          ),
-    .done_o                      ( otbn_done           ),
-    .locked_o                    (                     ),
+    .start_i                     ( otbn_start                 ),
+    .done_o                      ( otbn_done                  ),
+    .locked_o                    (                            ),
 
-    .err_bits_o                  ( core_err_bits       ),
-    .recoverable_err_o           (                     ),
+    .err_bits_o                  ( core_err_bits              ),
+    .recoverable_err_o           (                            ),
 
-    .imem_req_o                  ( imem_req            ),
-    .imem_addr_o                 ( imem_addr           ),
-    .imem_rdata_i                ( imem_rdata          ),
-    .imem_rvalid_i               ( imem_rvalid         ),
+    .imem_req_o                  ( imem_req                   ),
+    .imem_addr_o                 ( imem_addr                  ),
+    .imem_rdata_i                ( imem_rdata                 ),
+    .imem_rvalid_i               ( imem_rvalid                ),
 
-    .dmem_req_o                  ( dmem_req            ),
-    .dmem_write_o                ( dmem_write          ),
-    .dmem_addr_o                 ( dmem_addr           ),
-    .dmem_wdata_o                ( dmem_wdata          ),
-    .dmem_wmask_o                ( dmem_wmask          ),
+    .dmem_req_o                  ( dmem_req                   ),
+    .dmem_write_o                ( dmem_write                 ),
+    .dmem_addr_o                 ( dmem_addr                  ),
+    .dmem_wdata_o                ( dmem_wdata                 ),
+    .dmem_wmask_o                ( dmem_wmask                 ),
     .dmem_rmask_o                ( ),
-    .dmem_rdata_i                ( dmem_rdata          ),
-    .dmem_rvalid_i               ( dmem_rvalid         ),
-    .dmem_rerror_i               ( dmem_rerror         ),
+    .dmem_rdata_i                ( dmem_rdata                 ),
+    .dmem_rvalid_i               ( dmem_rvalid                ),
+    .dmem_rerror_i               ( dmem_rerror                ),
 
-    .edn_rnd_req_o               ( edn_rnd_req         ),
-    .edn_rnd_ack_i               ( edn_rnd_ack         ),
-    .edn_rnd_data_i              ( edn_rnd_data        ),
+    .edn_rnd_req_o               ( edn_rnd_req                ),
+    .edn_rnd_ack_i               ( edn_rnd_ack                ),
+    .edn_rnd_data_i              ( edn_rnd_data               ),
 
-    .edn_urnd_req_o              ( edn_urnd_req        ),
-    .edn_urnd_ack_i              ( edn_urnd_ack        ),
-    .edn_urnd_data_i             ( edn_urnd_data       ),
+    .edn_urnd_req_o              ( edn_urnd_req               ),
+    .edn_urnd_ack_i              ( edn_urnd_ack               ),
+    .edn_urnd_data_i             ( edn_urnd_data              ),
 
-    .insn_cnt_o                  ( insn_cnt            ),
-    .insn_cnt_clear_i            ( 1'b0                ),
+    .insn_cnt_o                  ( insn_cnt                   ),
+    .insn_cnt_clear_i            ( 1'b0                       ),
 
-    .mems_sec_wipe_o             (                     ),
-    .dmem_sec_wipe_urnd_key_o    (                     ),
-    .imem_sec_wipe_urnd_key_o    (                     ),
-    .req_sec_wipe_urnd_keys_i    ( 1'b0                ),
+    .mems_sec_wipe_o             (                            ),
+    .dmem_sec_wipe_urnd_key_o    (                            ),
+    .imem_sec_wipe_urnd_key_o    (                            ),
+    .req_sec_wipe_urnd_keys_i    ( 1'b0                       ),
 
-    .escalate_en_i               ( 1'b0                ),
+    .escalate_en_i               ( prim_mubi_pkg::MuBi4False  ),
 
-    .software_errs_fatal_i       ( 1'b0                ),
+    .software_errs_fatal_i       ( 1'b0                       ),
 
-    .sideload_key_shares_i       ( sideload_key_shares ),
-    .sideload_key_shares_valid_i ( 2'b11               )
+    .sideload_key_shares_i       ( sideload_key_shares        ),
+    .sideload_key_shares_valid_i ( 2'b11                      )
   );
 
   localparam logic [WLEN-1:0] FixedEdnVal = {{(WLEN / 4){4'h9}}};

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -66,6 +66,7 @@ module otbn
   input keymgr_pkg::otbn_key_req_t keymgr_key_i
 );
 
+  import prim_mubi_pkg::*;
   import prim_util_pkg::vbits;
 
   logic rst_n;
@@ -102,7 +103,7 @@ module otbn
   logic [127:0] dmem_sec_wipe_urnd_key, imem_sec_wipe_urnd_key;
 
   logic core_recoverable_err, recoverable_err_d, recoverable_err_q;
-  logic core_escalate_en;
+  mubi4_t core_escalate_en;
   core_err_bits_t core_err_bits;
   err_bits_t err_bits, err_bits_d, err_bits_q;
   logic err_bits_en;
@@ -150,7 +151,7 @@ module otbn
 
   // Note: This is not the same thing as STATUS == IDLE. For example, we want to allow clock gating
   // when locked.
-  assign idle_o = prim_mubi_pkg::mubi4_bool_to_mubi(is_not_running_r);
+  assign idle_o = mubi4_bool_to_mubi(is_not_running_r);
 
   // Lifecycle ==================================================================
 
@@ -322,7 +323,6 @@ module otbn
   // Always grant to bus accesses, when OTBN is running a dummy response is returned
   assign imem_gnt_bus = imem_req_bus;
 
-  import prim_mubi_pkg::MuBi4False;
   tlul_adapter_sram #(
     .SramAw          (ImemIndexWidth),
     .SramDw          (32),
@@ -984,9 +984,9 @@ module otbn
   };
 
   // An error signal going down into the core to show that it should locally escalate
-  assign core_escalate_en = |{illegal_bus_access_q,
-                              otbn_scramble_state_error,
-                              bus_intg_violation};
+  assign core_escalate_en = mubi4_bool_to_mubi(
+      |{illegal_bus_access_q, otbn_scramble_state_error, bus_intg_violation}
+  );
 
   // We're idle if we're neither busy executing something nor locked
   assign idle = ~(busy_execute_q | locked | otbn_dmem_scramble_key_req_busy |
@@ -1022,7 +1022,7 @@ module otbn
 
   // Error handling: if we pass an error signal down to the core then we should also be setting an
   // error flag.
-  `ASSERT(ErrBitIfEscalate_A, core_escalate_en |=> |err_bits_q)
+  `ASSERT(ErrBitIfEscalate_A, mubi4_test_true_loose(core_escalate_en) |=> |err_bits_q)
 
   // Constraint from package, check here as we cannot have `ASSERT_INIT in package
   `ASSERT_INIT(WsrESizeMatchesParameter_A, $bits(wsr_e) == WsrNumWidth)

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -955,7 +955,6 @@ module otbn
     .imem_sec_wipe_urnd_key_o    (imem_sec_wipe_urnd_key),
     .req_sec_wipe_urnd_keys_i    (req_sec_wipe_urnd_keys),
 
-    .lc_escalate_en_i            (lc_escalate_en[1]),
     .escalate_en_i               (core_escalate_en),
 
     .software_errs_fatal_i       (software_errs_fatal_q),
@@ -984,8 +983,9 @@ module otbn
   };
 
   // An error signal going down into the core to show that it should locally escalate
-  assign core_escalate_en = mubi4_bool_to_mubi(
-      |{illegal_bus_access_q, otbn_scramble_state_error, bus_intg_violation}
+  assign core_escalate_en = mubi4_or_hi(
+      mubi4_bool_to_mubi(|{illegal_bus_access_q, otbn_scramble_state_error, bus_intg_violation}),
+      lc_ctrl_pkg::lc_to_mubi4(lc_escalate_en[1])
   );
 
   // We're idle if we're neither busy executing something nor locked

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -24,7 +24,6 @@ module otbn_controller
   input  logic start_i,  // start the processing at address zero
   output logic locked_o, // OTBN in locked state and must be reset to perform any further actions
 
-  input lc_ctrl_pkg::lc_tx_t   lc_escalate_en_i,
   input prim_mubi_pkg::mubi4_t escalate_en_i,
   output controller_err_bits_t err_bits_o,
   output logic                 recoverable_err_o,
@@ -477,7 +476,6 @@ module otbn_controller
   assign fatal_err = |{fatal_software_err,
                        bad_internal_state_err,
                        reg_intg_violation_err,
-                       lc_escalate_en_i != lc_ctrl_pkg::Off,
                        mubi4_test_true_loose(escalate_en_i)};
 
   assign recoverable_err_o = software_err & ~software_errs_fatal_i;
@@ -489,7 +487,7 @@ module otbn_controller
   assign insn_executing = insn_valid_i & ~err;
 
   `ASSERT(ErrBitSetOnErr,
-      err & ~(mubi4_test_true_loose(escalate_en_i) | (lc_escalate_en_i != lc_ctrl_pkg::Off)) |=> err_bits_o)
+      err & mubi4_test_false_strict(escalate_en_i) |=> err_bits_o)
   `ASSERT(ErrSetOnFatalErr, fatal_err |-> err)
   `ASSERT(SoftwareErrIfNonInsnAddrSoftwareErr, non_insn_addr_software_err |-> software_err)
 

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -25,7 +25,7 @@ module otbn_controller
   output logic locked_o, // OTBN in locked state and must be reset to perform any further actions
 
   input lc_ctrl_pkg::lc_tx_t   lc_escalate_en_i,
-  input logic                  escalate_en_i,
+  input prim_mubi_pkg::mubi4_t escalate_en_i,
   output controller_err_bits_t err_bits_o,
   output logic                 recoverable_err_o,
 
@@ -142,6 +142,8 @@ module otbn_controller
   output logic [ImemAddrWidth:0]   prefetch_loop_end_addr_o,
   output logic [ImemAddrWidth-1:0] prefetch_loop_jump_addr_o
 );
+  import prim_mubi_pkg::*;
+
   otbn_state_e state_q, state_d;
 
 
@@ -476,7 +478,7 @@ module otbn_controller
                        bad_internal_state_err,
                        reg_intg_violation_err,
                        lc_escalate_en_i != lc_ctrl_pkg::Off,
-                       escalate_en_i};
+                       mubi4_test_true_loose(escalate_en_i)};
 
   assign recoverable_err_o = software_err & ~software_errs_fatal_i;
   assign mems_sec_wipe_o   = (state_d == OtbnStateLocked) & (state_q != OtbnStateLocked);
@@ -487,7 +489,7 @@ module otbn_controller
   assign insn_executing = insn_valid_i & ~err;
 
   `ASSERT(ErrBitSetOnErr,
-      err & ~(escalate_en_i | (lc_escalate_en_i != lc_ctrl_pkg::Off)) |=> err_bits_o)
+      err & ~(mubi4_test_true_loose(escalate_en_i) | (lc_escalate_en_i != lc_ctrl_pkg::Off)) |=> err_bits_o)
   `ASSERT(ErrSetOnFatalErr, fatal_err |-> err)
   `ASSERT(SoftwareErrIfNonInsnAddrSoftwareErr, non_insn_addr_software_err |-> software_err)
 

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -74,9 +74,6 @@ module otbn_core
   output logic [127:0] dmem_sec_wipe_urnd_key_o, // URND bits to give temporary dmem scramble key
   output logic [127:0] imem_sec_wipe_urnd_key_o, // URND bits to give temporary imem scramble key
 
-  // Lifecycle interface
-  input lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
-
   // Indicates an incoming escalation from some fatal error at the level above.
   input prim_mubi_pkg::mubi4_t escalate_en_i,
 
@@ -328,7 +325,6 @@ module otbn_core
     .start_i      (controller_start),
     .locked_o,
 
-    .lc_escalate_en_i,
     .escalate_en_i(controller_escalate_en),
     .err_bits_o   (controller_err_bits),
     .recoverable_err_o,

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -74,8 +74,10 @@ module otbn_core
   output logic [127:0] dmem_sec_wipe_urnd_key_o, // URND bits to give temporary dmem scramble key
   output logic [127:0] imem_sec_wipe_urnd_key_o, // URND bits to give temporary imem scramble key
 
-  // Indicates an incoming escalation from the life cycle manager or some other fatal error at the
-  // level above.
+  // Lifecycle interface
+  input lc_ctrl_pkg::lc_tx_t lc_escalate_en_i,
+
+  // Indicates an incoming escalation from some fatal error at the level above.
   input logic escalate_en_i,
 
   // When set software errors become fatal errors.
@@ -324,6 +326,7 @@ module otbn_core
     .start_i      (controller_start),
     .locked_o,
 
+    .lc_escalate_en_i,
     .escalate_en_i(controller_escalate_en),
     .err_bits_o   (controller_err_bits),
     .recoverable_err_o,


### PR DESCRIPTION
Create copies of `lc_escalate_en_i` using `prim_lc_sync` and pass the signal as `lc_tx_t` (i.e., with differential encoding) to the consumer FSM.

This is part of the work on #11019.

The tests `otbn_sec_cm`, `otbn_tl_intg_err`, and `otbn_escalate` fail, but they also fail on `master`. Maybe it is worth fixing `otbn_escalate` before merging this, to make sure no bug gets masked?