### PR TITLE
[kmac] Ignore entropy refresh requests when running in SW entropy mode

### DIFF
--- a/hw/ip/kmac/rtl/kmac_entropy.sv
+++ b/hw/ip/kmac/rtl/kmac_entropy.sv
@@ -517,7 +517,8 @@ module kmac_entropy
           storage_idx_clear = 1'b 1;
 
           rand_valid_clear = 1'b 1;
-        end else if (entropy_refresh_req_i || threshold_hit_q) begin
+        end else if ((mode_i == EntropyModeEdn) &&
+            (entropy_refresh_req_i || threshold_hit_q)) begin
           st_d = StRandEdn;
 
           // Timer reset


### PR DESCRIPTION
When running in EDN entropy mode, software can manually request the entropy to be refreshed from EDN.

If instead running in SW entropy mode, SW provides the entropy via CSRs. SW is still able to request the entropy to be refreshed. Prior to this commit, the design would then go into the StRandEdn state and request fresh entropy from EDN, but the entropy received from EDN would be ignored. Instead, the LFSR would be reseeded using the value provided by
SW via CSRs. If SW "forgot" to update the CSRs, the LFSR would be reseeded using the same value. This is a bit counter-intuitive and can be exploitet for SCA. It's safer to just ignore these requests when running in SW entropy mode.