### PR TITLE
[prim,rtl] Pass addr_i in no scrambling case

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -160,7 +160,7 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
       .data_o ( addr_scr       )
     );
   end else begin : gen_no_addr_scr
-    assign addr_scr = addr_mux;
+    assign addr_scr = addr_i;
   end
 
   // We latch the non-scrambled address for error reporting.


### PR DESCRIPTION
Gets rid of circular logic in the case of having NumAddrScrRounds
as 0 by considering addr_i a scrambled addr.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>