### PR TITLE
[DIF, KMAC] Add unittests part1

### DIFF
--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -762,3 +762,11 @@ dif_result_t dif_kmac_end(const dif_kmac_t *kmac,
 
   return kDifOk;
 }
+
+dif_result_t dif_kmac_config_is_locked(const dif_kmac_t *kmac,
+                                       bool *is_locked) {
+  uint32_t reg =
+      mmio_region_read32(kmac->base_addr, KMAC_CFG_REGWEN_REG_OFFSET);
+  *is_locked = bitfield_bit32_read(reg, KMAC_CFG_REGWEN_EN_BIT);
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -226,11 +226,6 @@ dif_result_t dif_kmac_mode_sha3_start(
     return kDifBadArg;
   }
 
-  // Hardware must be idle to start an operation.
-  if (!is_state_idle(kmac)) {
-    return kDifError;
-  }
-
   // Set key strength and calculate rate (r) and digest length (d) in 32-bit
   // words.
   uint32_t kstrength;
@@ -262,6 +257,12 @@ dif_result_t dif_kmac_mode_sha3_start(
     default:
       return kDifBadArg;
   }
+
+  // Hardware must be idle to start an operation.
+  if (!is_state_idle(kmac)) {
+    return kDifError;
+  }
+
   operation_state->squeezing = false;
   operation_state->append_d = false;
 

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -373,11 +373,6 @@ dif_result_t dif_kmac_mode_cshake_start(
     }
   }
 
-  // Hardware must be idle to start an operation.
-  if (!is_state_idle(kmac)) {
-    return kDifError;
-  }
-
   // Set key strength and calculate rate (r).
   uint32_t kstrength;
   switch (mode) {
@@ -391,6 +386,11 @@ dif_result_t dif_kmac_mode_cshake_start(
       break;
     default:
       return kDifBadArg;
+  }
+
+  // Hardware must be idle to start an operation.
+  if (!is_state_idle(kmac)) {
+    return kDifError;
   }
   operation_state->squeezing = false;
   operation_state->append_d = false;
@@ -409,8 +409,8 @@ dif_result_t dif_kmac_mode_cshake_start(
 
   // Calculate PREFIX register values.
   uint32_t prefix_regs[11] = {0};
-  uint8_t *prefix_data = (void *)prefix_regs;
-  if (n == NULL) {
+  uint8_t *prefix_data = (uint8_t *)prefix_regs;
+  if (n == NULL || n->length < 3) {
     // Append left encoded empty string.
     prefix_data[0] = 1;
     prefix_data[1] = 0;
@@ -419,7 +419,7 @@ dif_result_t dif_kmac_mode_cshake_start(
     memcpy(prefix_data, n->buffer, n->length);
     prefix_data += n->length;
   }
-  if (s == NULL) {
+  if (s == NULL || s->length == 0) {
     // Append left encoded empty string.
     prefix_data[0] = 1;
     prefix_data[1] = 0;

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -299,11 +299,6 @@ dif_result_t dif_kmac_mode_shake_start(
     return kDifBadArg;
   }
 
-  // Hardware must be idle to start an operation.
-  if (!is_state_idle(kmac)) {
-    return kDifError;
-  }
-
   // Set key strength and calculate rate (r).
   uint32_t kstrength;
   switch (mode) {
@@ -317,6 +312,11 @@ dif_result_t dif_kmac_mode_shake_start(
       break;
     default:
       return kDifBadArg;
+  }
+
+  // Hardware must be idle to start an operation.
+  if (!is_state_idle(kmac)) {
+    return kDifError;
   }
   operation_state->squeezing = false;
   operation_state->append_d = false;

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -465,11 +465,6 @@ dif_result_t dif_kmac_mode_kmac_start(
     return kDifBadArg;
   }
 
-  // Hardware must be idle to start an operation.
-  if (!is_state_idle(kmac)) {
-    return kDifError;
-  }
-
   // Set key strength and calculate rate (r).
   uint32_t kstrength;
   switch (mode) {
@@ -510,6 +505,10 @@ dif_result_t dif_kmac_mode_kmac_start(
       return kDifBadArg;
   }
 
+  // Hardware must be idle to start an operation.
+  if (!is_state_idle(kmac)) {
+    return kDifError;
+  }
   // Set key length and shares.
   mmio_region_write32(kmac->base_addr, KMAC_KEY_LEN_REG_OFFSET, key_len);
   for (int i = 0; i < ARRAYSIZE(k->share0); ++i) {

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -169,4 +169,22 @@ TEST_F(AbsorbalignmentMessage, Success) {
         dif_kmac_absorb(&kmac_, &op_state_, pMsg, kMsg_.size(), NULL));
   }
 }
+
+class ConfigLock : public KmacTest {};
+
+TEST_F(ConfigLock, Locked) {
+  EXPECT_READ32(KMAC_CFG_REGWEN_REG_OFFSET, true);
+
+  bool lock = false;
+  EXPECT_EQ(dif_kmac_config_is_locked(&kmac_, &lock), kDifOk);
+  EXPECT_TRUE(lock);
+}
+
+TEST_F(ConfigLock, Unlocked) {
+  EXPECT_READ32(KMAC_CFG_REGWEN_REG_OFFSET, false);
+
+  bool lock = true;
+  EXPECT_EQ(dif_kmac_config_is_locked(&kmac_, &lock), kDifOk);
+  EXPECT_FALSE(lock);
+}
 }  // namespace dif_kmac_unittest

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -300,6 +300,44 @@ TEST_F(Kmac256Test, StartError) {
             kDifError);
 }
 
+class Sha3_224Test : public KmacTest {
+ protected:
+  dif_kmac_mode_sha3_t mode_ = kDifKmacModeSha3Len224;
+
+  Sha3_224Test() {
+    config_reg_.mode = KMAC_CFG_SHADOWED_MODE_VALUE_SHA3;
+    config_reg_.key_strength = KMAC_CFG_SHADOWED_KSTRENGTH_VALUE_L224;
+  }
+};
+
+TEST_F(Sha3_224Test, StartSuccess) {
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_IDLE_BIT, true}});
+  EXPECT_READ32(KMAC_CFG_SHADOWED_REG_OFFSET,
+                {{KMAC_CFG_SHADOWED_KMAC_EN_BIT, false}});
+  ExpectConfig();
+  EXPECT_WRITE32(KMAC_CMD_REG_OFFSET,
+                 {{KMAC_CMD_CMD_OFFSET, KMAC_CMD_CMD_VALUE_START}});
+  EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_ABSORB_BIT, true}});
+
+  EXPECT_DIF_OK(dif_kmac_mode_sha3_start(&kmac_, &op_state_, mode_));
+}
+
+TEST_F(Sha3_224Test, StartBadArg) {
+  EXPECT_DIF_BADARG(dif_kmac_mode_sha3_start(NULL, &op_state_, mode_));
+
+  EXPECT_DIF_BADARG(dif_kmac_mode_sha3_start(&kmac_, NULL, mode_));
+
+  EXPECT_DIF_BADARG(
+      dif_kmac_mode_sha3_start(&kmac_, &op_state_, (dif_kmac_mode_sha3_t)0xff));
+}
+
+TEST_F(Sha3_224Test, StartError) {
+  {
+    EXPECT_READ32(KMAC_STATUS_REG_OFFSET, {{KMAC_STATUS_SHA3_IDLE_BIT, false}});
+    EXPECT_EQ(dif_kmac_mode_sha3_start(&kmac_, &op_state_, mode_), kDifError);
+  }
+}
+
 constexpr std::array<uint8_t, 17> KmacTest::kMsg_;
 
 class AbsorbalignmentMessage : public KmacTest {};


### PR DESCRIPTION
# This PR is part of a serie of PRs to bring the kmac DIF to S2.
## This PR implements a portion of the necessary unittests for kmac:
- Register CFG_REGWEN
- Start function
- kmac_sha3
- kmac_mode_shake
- kmac_mode_cshake
- kmac_end