### PR TITLE
[spi_agent] Config for spi agent monitor have option of decoding cmd

### DIFF
--- a/hw/dv/sv/spi_agent/spi_agent_cfg.sv
+++ b/hw/dv/sv/spi_agent/spi_agent_cfg.sv
@@ -19,6 +19,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
   bit partial_byte;       // Transfering less than byte
   bit [3:0] bits_to_transfer; // Bits to transfer if using less than byte
   bit csb_consecutive;            // Don't deassert CSB
+  bit decode_commands;  // Used in monitor if decoding of commands needed
 
   //-------------------------
   // spi_host regs
@@ -64,6 +65,7 @@ class spi_agent_cfg extends dv_base_agent_cfg;
     `uvm_field_int (csb_sel,        UVM_DEFAULT)
     `uvm_field_int (partial_byte,   UVM_DEFAULT)
     `uvm_field_int (csb_consecutive,    UVM_DEFAULT)
+    `uvm_field_int (decode_commands,    UVM_DEFAULT)
     `uvm_field_int (bits_to_transfer,             UVM_DEFAULT)
     `uvm_field_int (en_extra_dly_btw_sck,         UVM_DEFAULT)
     `uvm_field_int (max_extra_dly_ns_btw_sck,     UVM_DEFAULT)

--- a/hw/dv/sv/spi_agent/spi_monitor.sv
+++ b/hw/dv/sv/spi_agent/spi_monitor.sv
@@ -149,7 +149,7 @@ class spi_monitor extends dv_base_monitor#(
               // sending transactions when collect a word data
               if (host_item.data.size == cfg.num_bytes_per_trans_in_mon &&
                   device_item.data.size == cfg.num_bytes_per_trans_in_mon) begin
-              if (host_item.first_byte == 1 )  begin
+              if (host_item.first_byte == 1 && cfg.decode_commands == 1)  begin
                  cmdtmp = host_byte;
                 `uvm_info(`gfn, $sformatf("spi_monitor: cmdtmp \n%0h", cmdtmp), UVM_DEBUG)
                  end

--- a/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
+++ b/hw/ip/spi_device/dv/env/seq_lib/spi_device_base_vseq.sv
@@ -142,6 +142,7 @@ class spi_device_base_vseq extends cip_base_vseq #(
     cfg.m_spi_agent_cfg.csb_sel = 0;
     cfg.m_spi_agent_cfg.partial_byte = 0;
     cfg.m_spi_agent_cfg.csb_consecutive = 0;
+    cfg.m_spi_agent_cfg.decode_commands = 0;
 
     if (spi_freq_faster) begin
       cfg.spi_device_agent_cfg.sck_period_ps = cfg.clk_rst_vif.clk_period_ps / core_spi_freq_ratio;


### PR DESCRIPTION
Added cfg option for spi agent monitor decoding command. Before it decoding was done on first byte anyway, causing error for epi_device generic mode when we match opcode of dual or quad command.
Configured to 0 for spi device basic tests.
@visbaz please add this cfg enable in spi_host tests where you use it.

Signed-off-by: Kosta Kojdic <kosta.kojdic@ensilica.com>