### PR TITLE
[prim,rtl] Fix RW collision bug in prim_1p_ram_scr

### DIFF
--- a/hw/ip/prim/rtl/prim_ram_1p_scr.sv
+++ b/hw/ip/prim/rtl/prim_ram_1p_scr.sv
@@ -320,6 +320,8 @@ module prim_ram_1p_scr import prim_ram_1p_pkg::*; #(
         for (int k = 0; k < Width; k++) begin
           if (wmask_q[k]) begin
             rdata_o[k] = wdata_q[k];
+          end else begin
+            rdata_o[k] = rdata[k];
           end
         end
       // regular reads. note that we just return zero in case


### PR DESCRIPTION
When a read collides with buffered write data only the bits that have
been written by a partial write should be forwarded. Otherwise the read
data should come directly from the memory as normal.

Previously prim_ram_1p_scr would forward bits from the buffered write
data if they had been written and otherwise just produce 0 for read
bits that weren't part of a buffered partial write.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>