### PR TITLE
[cleanup] Fix license checker after #11851

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 

--- a/sw/device/examples/BUILD
+++ b/sw/device/examples/BUILD
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 cc_library(

--- a/sw/device/lib/crt/BUILD
+++ b/sw/device/lib/crt/BUILD
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 package(default_visibility = ["//visibility:public"])
 
 load("//rules:opentitan.bzl", "OPENTITAN_CPU")

--- a/util/device_sw_utils/BUILD
+++ b/util/device_sw_utils/BUILD
@@ -1,3 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 load("@rules_python//python:defs.bzl", "py_binary")
 load("@ot_python_deps//:requirements.bzl", "requirement")
 

--- a/util/licence-checker.hjson
+++ b/util/licence-checker.hjson
@@ -10,6 +10,7 @@
     ''',
   exclude_paths: [
     # Exclude anything in vendored directories
+    'third_party/**',
     '*/vendor/*/*',
     'util/lowrisc_misc-linters/*',
 


### PR DESCRIPTION
1. Exclude //third_party from license checks.
2. Add license headers to a few files.

Signed-off-by: Chris Frantz <cfrantz@google.com>