### PR TITLE
[flash_ctrl] Incorporate flash disable into flash_exec

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -87,6 +87,7 @@ package flash_ctrl_pkg;
     LcMgrDisableIdx,
     MpDisableIdx,
     HostDisableIdx,
+    IFetchDisableIdx,
     FlashDisableLast
   } flash_disable_pos_e;
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -270,7 +270,6 @@ module flash_ctrl
 
   // import commonly used routines
   import lc_ctrl_pkg::lc_tx_test_true_strict;
-  import lc_ctrl_pkg::lc_tx_test_true_loose;
 
   // life cycle connections
   lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
@@ -304,7 +303,7 @@ module flash_ctrl
   );
 
   // flash disable declaration
-  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
+  mubi4_t [FlashDisableLast-1:0] flash_disable;
 
   // flash control arbitration between softawre / harware interfaces
   flash_ctrl_arb u_ctrl_arb (
@@ -930,12 +929,12 @@ module flash_ctrl
   // In other words...cowardice.
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
-  prim_mubi_pkg::mubi4_t lc_conv_disable;
-  prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
+  mubi4_t lc_conv_disable;
+  mubi4_t flash_disable_pre_buf;
   assign lc_conv_disable = lc_ctrl_pkg::lc_to_mubi4(lc_disable);
   assign flash_disable_pre_buf = prim_mubi_pkg::mubi4_or_hi(
       lc_conv_disable,
-      prim_mubi_pkg::mubi4_t'(reg2hw.dis.q));
+      mubi4_t'(reg2hw.dis.q));
 
   prim_mubi4_sync #(
     .NumCopies(int'(FlashDisableLast)),
@@ -949,18 +948,26 @@ module flash_ctrl
 
   assign flash_phy_req.flash_disable = flash_disable[PhyDisableIdx];
 
-  prim_mubi_pkg::mubi4_t sw_flash_exec_en;
-  prim_mubi_pkg::mubi4_t flash_exec_en;
+  logic [prim_mubi_pkg::MuBi4Width-1:0] sw_flash_exec_en;
+  mubi4_t flash_exec_en;
 
   // SEC_CM: MEM_EN.CONFIG.REDUN
-  assign sw_flash_exec_en = (reg2hw.exec.q == unsigned'(ExecEn)) ?
-                            prim_mubi_pkg::MuBi4True :
-                            prim_mubi_pkg::MuBi4False;
+  prim_sec_anchor_buf #(
+    .Width(prim_mubi_pkg::MuBi4Width)
+  ) u_exec_en_buf (
+    .in_i(prim_mubi_pkg::mubi4_bool_to_mubi(reg2hw.exec.q == unsigned'(ExecEn))),
+    .out_o(sw_flash_exec_en)
+  );
 
-  assign flash_exec_en = lc_tx_test_true_loose(lc_escalate_en) ?
-                         prim_mubi_pkg::MuBi4False :
-                         sw_flash_exec_en;
+  mubi4_t disable_exec;
+  assign disable_exec = mubi4_t'(~flash_disable[IFetchDisableIdx]);
+  assign flash_exec_en = prim_mubi_pkg::mubi4_and_hi(
+                           disable_exec,
+                           mubi4_t'(sw_flash_exec_en)
+                         );
 
+  // the above statement only works if mubi true/false are fully complement
+  `ASSERT_INIT(MuBiComplCheck_A, prim_mubi_pkg::MuBi4True == ~prim_mubi_pkg::MuBi4False)
 
   //////////////////////////////////////
   // Errors and Interrupts
@@ -1190,9 +1197,7 @@ module flash_ctrl
   logic [flash_ctrl_pkg::BusFullWidth-1:0] flash_host_rdata;
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
 
-  import prim_mubi_pkg::mubi4_test_true_loose;
   lc_ctrl_pkg::lc_tx_t host_enable;
-
 
   // if flash disable is activated, error back from the adapter interface immediately
   assign host_enable = lc_ctrl_pkg::mubi4_to_lc_inv(flash_disable[HostDisableIdx]);

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -87,6 +87,7 @@ package flash_ctrl_pkg;
     LcMgrDisableIdx,
     MpDisableIdx,
     HostDisableIdx,
+    IFetchDisableIdx,
     FlashDisableLast
   } flash_disable_pos_e;
 

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -106,8 +106,10 @@ module tlul_adapter_sram
                            : 1'b0;
 
   // An instruction type transaction is only valid if en_ifetch is enabled
-  assign instr_error = prim_mubi_pkg::mubi4_test_true_strict(tl_i.a_user.instr_type) &
-                       prim_mubi_pkg::mubi4_test_false_loose(en_ifetch_i);
+  // If the instruction type is completely invalid, also considered an instruction error
+  assign instr_error = prim_mubi_pkg::mubi4_test_invalid(tl_i.a_user.instr_type) |
+                       (prim_mubi_pkg::mubi4_test_true_strict(tl_i.a_user.instr_type) &
+                        prim_mubi_pkg::mubi4_test_false_loose(en_ifetch_i));
 
   if (ErrOnWrite == 1) begin : gen_no_writes
     assign wr_vld_error = tl_i.a_opcode != Get;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -276,7 +276,6 @@ module flash_ctrl
 
   // import commonly used routines
   import lc_ctrl_pkg::lc_tx_test_true_strict;
-  import lc_ctrl_pkg::lc_tx_test_true_loose;
 
   // life cycle connections
   lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
@@ -310,7 +309,7 @@ module flash_ctrl
   );
 
   // flash disable declaration
-  prim_mubi_pkg::mubi4_t [FlashDisableLast-1:0] flash_disable;
+  mubi4_t [FlashDisableLast-1:0] flash_disable;
 
   // flash control arbitration between softawre / harware interfaces
   flash_ctrl_arb u_ctrl_arb (
@@ -936,12 +935,12 @@ module flash_ctrl
   // In other words...cowardice.
   // SEC_CM: MEM.CTRL.GLOBAL_ESC
   // SEC_CM: MEM_DISABLE.CONFIG.MUBI
-  prim_mubi_pkg::mubi4_t lc_conv_disable;
-  prim_mubi_pkg::mubi4_t flash_disable_pre_buf;
+  mubi4_t lc_conv_disable;
+  mubi4_t flash_disable_pre_buf;
   assign lc_conv_disable = lc_ctrl_pkg::lc_to_mubi4(lc_disable);
   assign flash_disable_pre_buf = prim_mubi_pkg::mubi4_or_hi(
       lc_conv_disable,
-      prim_mubi_pkg::mubi4_t'(reg2hw.dis.q));
+      mubi4_t'(reg2hw.dis.q));
 
   prim_mubi4_sync #(
     .NumCopies(int'(FlashDisableLast)),
@@ -955,18 +954,26 @@ module flash_ctrl
 
   assign flash_phy_req.flash_disable = flash_disable[PhyDisableIdx];
 
-  prim_mubi_pkg::mubi4_t sw_flash_exec_en;
-  prim_mubi_pkg::mubi4_t flash_exec_en;
+  logic [prim_mubi_pkg::MuBi4Width-1:0] sw_flash_exec_en;
+  mubi4_t flash_exec_en;
 
   // SEC_CM: MEM_EN.CONFIG.REDUN
-  assign sw_flash_exec_en = (reg2hw.exec.q == unsigned'(ExecEn)) ?
-                            prim_mubi_pkg::MuBi4True :
-                            prim_mubi_pkg::MuBi4False;
+  prim_sec_anchor_buf #(
+    .Width(prim_mubi_pkg::MuBi4Width)
+  ) u_exec_en_buf (
+    .in_i(prim_mubi_pkg::mubi4_bool_to_mubi(reg2hw.exec.q == unsigned'(ExecEn))),
+    .out_o(sw_flash_exec_en)
+  );
 
-  assign flash_exec_en = lc_tx_test_true_loose(lc_escalate_en) ?
-                         prim_mubi_pkg::MuBi4False :
-                         sw_flash_exec_en;
+  mubi4_t disable_exec;
+  assign disable_exec = mubi4_t'(~flash_disable[IFetchDisableIdx]);
+  assign flash_exec_en = prim_mubi_pkg::mubi4_and_hi(
+                           disable_exec,
+                           mubi4_t'(sw_flash_exec_en)
+                         );
 
+  // the above statement only works if mubi true/false are fully complement
+  `ASSERT_INIT(MuBiComplCheck_A, prim_mubi_pkg::MuBi4True == ~prim_mubi_pkg::MuBi4False)
 
   //////////////////////////////////////
   // Errors and Interrupts
@@ -1196,9 +1203,7 @@ module flash_ctrl
   logic [flash_ctrl_pkg::BusFullWidth-1:0] flash_host_rdata;
   logic [flash_ctrl_pkg::BusAddrW-1:0] flash_host_addr;
 
-  import prim_mubi_pkg::mubi4_test_true_loose;
   lc_ctrl_pkg::lc_tx_t host_enable;
-
 
   // if flash disable is activated, error back from the adapter interface immediately
   assign host_enable = lc_ctrl_pkg::mubi4_to_lc_inv(flash_disable[HostDisableIdx]);

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -93,6 +93,7 @@ package flash_ctrl_pkg;
     LcMgrDisableIdx,
     MpDisableIdx,
     HostDisableIdx,
+    IFetchDisableIdx,
     FlashDisableLast
   } flash_disable_pos_e;
 


### PR DESCRIPTION
- also add handling for what happens if instr_type is invalid
  This was previously handled as part of transmission integrity, but
  it does not hurt to make it more explicit.

- fixes #11883

Signed-off-by: Timothy Chen <timothytim@google.com>