### PR TITLE
[sram, dv] fix smoke test not found error

### DIFF
--- a/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/sram_ctrl/dv/sram_ctrl_base_sim_cfg.hjson
@@ -153,7 +153,7 @@
   regressions: [
     {
       name: smoke
-      tests: ["{variant}_smoke"]
+      tests: ["{name}_smoke"]
     }
   ]
 }


### PR DESCRIPTION
Fixed this error from dvsim
> ERROR: [Modes] Test "sram_ctrl_ret_smoke" added to regression "smoke" not found!

Signed-off-by: Weicai Yang <weicai@google.com>