### PR TITLE
[flash_ctrl] correct cm label

### DIFF
--- a/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_prog.sv
@@ -159,7 +159,7 @@ module flash_phy_prog import flash_phy_pkg::*; (
   end
 
 
-  // SEC_CM: PHY.FSM.SPARSE
+  // SEC_CM: PHY_PROG.FSM.SPARSE
   `PRIM_FLOP_SPARSE_FSM(u_state_regs, state_d, state_q, state_e, StIdle)
 
   // If the first beat of an incoming transaction is not aligned to word boundary (for example


### PR DESCRIPTION
- there was a cross PR change in label name that was lost during
  rebase.

Signed-off-by: Timothy Chen <timothytim@google.com>