### PR TITLE
[bazel] Fixup workspace to ignore files brought in by vendor script

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,5 +1,6 @@
 hw/ip/prim/util/vendor/google_verible_verilog_syntax_py
 sw/vendor/google_googletest
+util/lowrisc_misc-linters
 
 # TODO: once Meson is no longer used, remove the line below.
 build

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
-load("//rules:quality.bzl", "clang_format_check", "html_coverage_report", "license_check")
+load("//rules:quality.bzl", "clang_format_check", "html_coverage_report")
+load("@lowrisc_lint//rules:rules.bzl", "licence_check")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -24,8 +25,14 @@ buildifier(
     mode = "diff",
 )
 
-license_check(
+licence_check(
     name = "license_check",
+    exclude_patterns = [".style.yapf"],
+    licence = """
+    Copyright lowRISC contributors.
+    Licensed under the Apache License, Version 2.0, see LICENSE for details.
+    SPDX-License-Identifier: Apache-2.0
+    """,
 )
 
 clang_format_check(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -7,15 +7,20 @@ load("//rules:quality.bzl", "clang_format_check", "html_coverage_report", "licen
 
 package(default_visibility = ["//visibility:public"])
 
+unbuildify = [
+    "./**/vendor/**",
+    "./util/lowrisc_misc-linters/**",
+]
+
 buildifier(
     name = "buildifier_fix",
-    exclude_patterns = ["./**/vendor/**"],
+    exclude_patterns = unbuildify,
 )
 
 buildifier(
     name = "buildifier_check",
     diff_command = "diff -u",
-    exclude_patterns = ["./**/vendor/**"],
+    exclude_patterns = unbuildify,
     mode = "diff",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -182,3 +182,17 @@ git_repository(
 load("//third_party/freertos:deps.bzl", "freertos_deps")
 
 freertos_deps()
+
+git_repository(
+    name = "lowrisc_lint",
+    commit = "8bca6cff6f5def9ba866a11b7eeb3f4a12f9f516",
+    remote = "https://github.com/lowrisc/misc-linters",
+)
+
+load("@lowrisc_lint//rules:deps.bzl", "lowrisc_misc_linters_dependencies")
+
+lowrisc_misc_linters_dependencies()
+
+load("@lowrisc_lint//rules:pip.bzl", "lowrisc_misc_linters_pip_dependencies")
+
+lowrisc_misc_linters_pip_dependencies()


### PR DESCRIPTION
After Bazel support was added to the misc-linters repository, copying it in broke Bazel until the files could be ignored and because they supported bazel based external dependencies they were brought into bazel that way instead.