### PR TITLE
[bazel] cleanup `verilator_params()` in `opentitan_functests()`

### DIFF
--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -64,8 +64,8 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
+            "cpu:4",
             "manual",
-            "verilator",
         ],
     ),
     deps = [
@@ -117,8 +117,8 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
+            "cpu:4",
             "manual",
-            "verilator",
         ],
     ),
     deps = [
@@ -190,8 +190,8 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
+            "cpu:4",
             "manual",
-            "verilator",
         ],
     ),
     deps = [
@@ -207,8 +207,8 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
+            "cpu:4",
             "manual",
-            "verilator",
         ],
     ),
     deps = [


### PR DESCRIPTION
The `verilator_params()` macro was refactored in a prior commit, but its
invocations in `opentitan_functest()` rules were not. This cleans these
up to remove un-needed (required) tags.

Signed-off-by: Timothy Trippel <ttrippel@google.com>