### PR TITLE
[dv/otp_ctrl] Improve FSM coverage

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
@@ -20,9 +20,8 @@ class otp_ctrl_check_fail_vseq extends otp_ctrl_dai_lock_vseq;
 
   // 50% chance of having a check timeout
   constraint check_timeout_val_c {
-    ecc_chk_err == OtpNoEccErr   -> check_timeout_val dist {[1 : CHK_TIMEOUT_CYC] :/ 1,
-                                                            [100_000 :'1]         :/ 1};
-    ecc_chk_err == OtpEccCorrErr -> check_timeout_val inside {[100_000 :'1]};
+    check_timeout_val dist {[1 : CHK_TIMEOUT_CYC] :/ 1,
+                            [100_000 :'1]         :/ 1};
   }
 
 endclass

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_common_vseq.sv
@@ -35,6 +35,21 @@ class otp_ctrl_common_vseq extends otp_ctrl_base_vseq;
     run_common_vseq_wrapper(num_trans);
   endtask : body
 
+  virtual task apply_resets_concurrently(int reset_duration_ps = 0);
+    // For stress_all_with_rand_reset test only - backdoor clear OTP memory,
+    // and re-initialize OTP_ctrl after reset.
+    if (common_seq_type == "stress_all_with_rand_reset") begin
+      cfg.otp_ctrl_vif.release_part_access_mubi();
+      cfg.otp_ctrl_vif.drive_lc_escalate_en(lc_ctrl_pkg::Off);
+      otp_ctrl_init();
+      otp_pwr_init();
+      super.apply_resets_concurrently(reset_duration_ps);
+      cfg.en_scb = 1;
+    end else begin
+      super.apply_resets_concurrently(reset_duration_ps);
+    end
+  endtask
+
   virtual task check_sec_cm_fi_resp(sec_cm_base_if_proxy if_proxy);
     bit[TL_DW-1:0] exp_status_val, rdata0, rdata1;
     super.check_sec_cm_fi_resp(if_proxy);

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_smoke_vseq.sv
@@ -68,6 +68,13 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
 
   constraint ecc_chk_err_c {ecc_chk_err == OtpNoEccErr;}
 
+  constraint apply_reset_during_pwr_init_cycles_c {
+    apply_reset_during_pwr_init_cycles dist {
+        [1:5]       :/ 4,
+        [6:2000]    :/ 4,
+        [2001:4000] :/ 2};
+  }
+
   virtual task dut_init(string reset_kind = "HARD");
     if (do_apply_reset) begin
       lc_prog_blocking = 1;
@@ -113,9 +120,7 @@ class otp_ctrl_smoke_vseq extends otp_ctrl_base_vseq;
       // set consistency and integrity checks
       csr_wr(ral.check_regwen, check_regwen_val);
       csr_wr(ral.check_trigger_regwen, check_trigger_regwen_val);
-      if (check_trigger_val && `gmv(ral.check_trigger_regwen)) begin
-        csr_wr(ral.check_timeout, check_timeout_val);
-      end
+      csr_wr(ral.check_timeout, check_timeout_val);
       trigger_checks(.val(check_trigger_val), .wait_done(1), .ecc_err(ecc_chk_err));
 
       if ($urandom_range(0, 1) && access_locked_parts) write_sw_rd_locks();


### PR DESCRIPTION
This PR improves the FSM cov with the following updates:
1). Add support in smoke test to issue reset during pwr_init.
    This targets to hit FSM cov from init states to reset states.
2). Move `apply_resets_concurrently` override to common_vseq because it
    only common tests need this override.
3). Remove the constraints about ECC correctable errors and timeout
    error. I believe scb can handle both cases.
4). Remove the pre-conditions to write ral.check_timeout register.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>