### PR TITLE
[ottf] Regularize OTTF exception outputs.

### DIFF
--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("//rules:opentitan.bzl", "opentitan_flash_binary", "opentitan_rom_binary")
+load("@bazel_skylib//lib:shell.bzl", "shell")
+
+_EXIT_SUCCESS = r"PASS.*\n"
+_EXIT_FAILURE = r"(FAIL|FAULT).*\n"
 
 _BASE_PARAMS = {
     "args": [],
@@ -89,8 +93,8 @@ def verilator_params(
         # Base Parameters
         args = _BASE_PARAMS["args"] + [
             "console",
-            "--exit-failure=FAIL",
-            "--exit-success=PASS",
+            "--exit-failure=" + shell.quote(_EXIT_FAILURE),
+            "--exit-success=" + shell.quote(_EXIT_SUCCESS),
             "--timeout=3600",
         ],
         data = _BASE_PARAMS["data"],
@@ -149,8 +153,8 @@ def cw310_params(
             "--exec=\"console -q -t0\"",
             "--exec=\"bootstrap $(location {flash})\"",
             "console",
-            "--exit-failure=FAIL",
-            "--exit-success=PASS",
+            "--exit-failure=" + shell.quote(_EXIT_FAILURE),
+            "--exit-success=" + shell.quote(_EXIT_SUCCESS),
             "--timeout=3600",
         ],
         data = _BASE_PARAMS["data"],

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -10,6 +10,56 @@
 #include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 
+// Fault reasons from
+// https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf
+static const char *exception_reason[] = {
+    "Instruction Misaligned",
+    "Instruction Access",
+    "Illegial Instruction",
+    "Breakpoint",
+    "Load Address Misaligned",
+    "Load Access Fault",
+    "Store Address Misaligned",
+    "Store Access Fault",
+    "U-mode Ecall",
+    "S-mode Ecall",
+    "Reserved",
+    "M-mode Ecall",
+    "Instruction Page Fault",
+    "Load Page Fault",
+    "Reserved",
+    "Store Page Fault",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+    "Reserved",
+};
+
+static void generic_fault_print(const char *reason, uint32_t mcause) {
+  uint32_t mepc = ibex_mepc_read();
+  uint32_t mtval = ibex_mtval_read();
+  LOG_ERROR("FAULT: %s. MCAUSE=%08x MEPC=%08x MTVAL=%08x", reason, mcause, mepc,
+            mtval);
+}
+
+static void generic_fault_handler(void) {
+  uint32_t mcause = ibex_mcause_read();
+  generic_fault_print(exception_reason[mcause & kIdMax], mcause);
+  abort();
+}
+
 /**
  * These weak symbols (pxCurrentTCB and kTestConfig) enable the OTTF ISRs to be
  * used without the OTTF itself. This enables us to maintain one set of default
@@ -51,72 +101,52 @@ void ottf_exception_handler(void) {
       ottf_user_ecall_handler();
       break;
     default:
-      LOG_INFO("Unknown exception triggered!");
-      abort();
+      generic_fault_handler();
   }
 }
 
 OT_WEAK
-void ottf_instr_misaligned_fault_handler(void) {
-  LOG_INFO("Misaligned instruction, mtval holds the fault address.");
-  LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
-  abort();
-}
+OT_ALIAS("generic_fault_handler")
+void ottf_instr_misaligned_fault_handler(void);
 
 OT_WEAK
-void ottf_instr_access_fault_handler(void) {
-  LOG_INFO("Instruction access fault, mtval holds the fault address.");
-  LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
-  abort();
-}
+OT_ALIAS("generic_fault_handler")
+void ottf_instr_access_fault_handler(void);
 
 OT_WEAK
-void ottf_illegal_instr_fault_handler(void) {
-  LOG_INFO("Illegal instruction fault, mtval shows the faulting instruction.");
-  LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
-  abort();
-}
+OT_ALIAS("generic_fault_handler")
+void ottf_illegal_instr_fault_handler(void);
 
 OT_WEAK
-void ottf_breakpoint_handler(void) {
-  LOG_INFO("Breakpoint triggered, mtval holds the breakpoint address.");
-  LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
-  abort();
-}
+OT_ALIAS("generic_fault_handler")
+void ottf_breakpoint_handler(void);
 
 OT_WEAK
-void ottf_load_store_fault_handler(void) {
-  LOG_INFO("Load/Store fault, mtval holds the fault address.");
-  LOG_INFO("MTVAL value is 0x%x", ibex_mtval_read());
-  abort();
-}
+OT_ALIAS("generic_fault_handler")
+void ottf_load_store_fault_handler(void);
 
 OT_WEAK
-void ottf_machine_ecall_handler(void) {
-  LOG_INFO("Machine-mode environment call (syscall).");
-  abort();
-}
+OT_ALIAS("generic_fault_handler")
+void ottf_machine_ecall_handler(void);
 
 OT_WEAK
-void ottf_user_ecall_handler(void) {
-  LOG_INFO("User-mode environment call (syscall).");
-  abort();
-}
+OT_ALIAS("generic_fault_handler")
+void ottf_user_ecall_handler(void);
 
 OT_WEAK
 void ottf_software_isr(void) {
-  LOG_INFO("Software IRQ triggered!");
+  generic_fault_print("Software IRQ", ibex_mcause_read());
   abort();
 }
 
 OT_WEAK
 void ottf_timer_isr(void) {
-  LOG_INFO("Timer IRQ triggered!");
+  generic_fault_print("Timer IRQ", ibex_mcause_read());
   abort();
 }
 
 OT_WEAK
 void ottf_external_isr(void) {
-  LOG_INFO("External IRQ triggered!");
+  generic_fault_print("External IRQ", ibex_mcause_read());
   abort();
 }


### PR DESCRIPTION
1. Regularize the OTTF exception outputs.
2. Recognize FAIL or FAULT as a test failure condition.

Signed-off-by: Chris Frantz <cfrantz@google.com>