### PR TITLE
[bazel] fix aes_testutils target

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -45,6 +45,11 @@ cc_library(
     srcs = ["aes_testutils.c"],
     hdrs = ["aes_testutils.h"],
     target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/dif:aes",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/testing/test_framework",
+    ],
 )
 
 cc_library(

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -9,6 +9,7 @@ opentitan_functest(
     srcs = ["aes_smoketest.c"],
     deps = [
         "//sw/device/lib/dif:aes",
+        "//sw/device/lib/testing:aes_testutils",
         "//sw/device/lib/testing:entropy_testutils",
     ],
 )


### PR DESCRIPTION
The AES testutils target was failing to build with bazel, therefore
causing `bazel build //...` to fail. This fixes the AES testutils target
to build properly.

Signed-off-by: Timothy Trippel <ttrippel@google.com>