### PR TITLE
[mask_rom] Switch the compiler to clang

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,7 +13,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 ################################################################################
 git_repository(
     name = "bazel_embedded",
-    commit = "b4faaec60b07b11fe3d1fc6b40f22baf31a54690",
+    commit = "fe65a8aca35ae0bae563efd6a29cc14fcb15140d",
     remote = "https://github.com/lowRISC/bazel-embedded.git",
     shallow_since = "1639417565 -0800",
 )

--- a/sw/device/lib/testing/test_framework/ottf_isrs.c
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.c
@@ -15,7 +15,7 @@
 static const char *exception_reason[] = {
     "Instruction Misaligned",
     "Instruction Access",
-    "Illegial Instruction",
+    "Illegal Instruction",
     "Breakpoint",
     "Load Address Misaligned",
     "Load Access Fault",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -182,6 +182,9 @@ opentitan_functest(
     # FIXME: currently, the FPGA doesn't wake up from low-power mode.
     # For now, run the test only in verilator.
     targets = ["verilator"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         ":keymgr",
         ":lifecycle",
@@ -354,6 +357,9 @@ cc_test(
 opentitan_functest(
     name = "retention_sram_functest",
     srcs = ["retention_sram_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         ":retention_sram",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -122,7 +122,7 @@ void otbn_zero_dmem(void) {
   for (; launder32(i) < kOtbnDMemSizeBytes; i += sizeof(uint32_t)) {
     abs_mmio_write32(kBase + OTBN_DMEM_REG_OFFSET + i, 0u);
   }
-  HARDENED_CHECK_EQ(i, kOtbnDMemSizeBytes / sizeof(uint32_t));
+  HARDENED_CHECK_EQ(i, kOtbnDMemSizeBytes);
 }
 
 rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {


### PR DESCRIPTION
1. Use the latest commit on lowRISC/bazel-embedded:riscv32 as it configures
   clang as the default compiler.
2. Lengthen a couple of test times to accomodate the fact that tests are not
   built under the `opt` profile.

Signed-off-by: Chris Frantz <cfrantz@google.com>