### PR TITLE
[dv/otp_ctrl] Fix assertion error

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_if.sv
@@ -66,7 +66,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   logic lc_prog_err_dly1, lc_prog_no_sta_check;
 
   // Connect push_pull interfaces ack signals for assertion checks.
-  logic otbn_ack;
+  logic otbn_ack, lc_prog_ack;
   logic [1:0] flash_acks;
   logic [NumSramKeyReqSlots-1:0] sram_acks;
 
@@ -314,7 +314,7 @@ interface otp_ctrl_if(input clk_i, input rst_ni);
   `OTP_FATAL_ERR_ASSERT(HwCfgOData_A, otp_hw_cfg_o.data ==
                         PartInvDefault[HwCfgOffset*8+:HwCfgSize*8])
 
-  `OTP_FATAL_ERR_ASSERT(LcProgReq_A, lc_prog_req == 0)
+  `OTP_FATAL_ERR_ASSERT(LcProgAck_A, lc_prog_ack == 0)
   `OTP_FATAL_ERR_ASSERT(FlashAcks_A, flash_acks == 0)
   `OTP_FATAL_ERR_ASSERT(SramAcks_A, sram_acks == 0)
   `OTP_FATAL_ERR_ASSERT(OtbnAck_A, otbn_ack == 0)

--- a/hw/ip/otp_ctrl/dv/tb.sv
+++ b/hw/ip/otp_ctrl/dv/tb.sv
@@ -73,6 +73,7 @@ module tb;
   assign otp_ctrl_if.lc_prog_err = lc_prog_if.d_data;
 
   // Assign to otp_ctrl_if for assertion checks.
+  assign otp_ctrl_if.lc_prog_ack = lc_prog_if.ack;
   assign otp_ctrl_if.flash_acks = flash_data_if.ack;
   assign otp_ctrl_if.otbn_ack  = otbn_if.ack;
 


### PR DESCRIPTION
Fix assertion error because it sampled design input instead of output.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>