### PR TITLE
[doc] Add aliases for moved Getting Started pages.

### DIFF
--- a/doc/getting_started/_index.md
+++ b/doc/getting_started/_index.md
@@ -1,5 +1,8 @@
 ---
 title: "Getting Started"
+aliases:
+    - /doc/ug/getting_started
+    - /doc/ug/install_instructions
 ---
 
 Welcome!

--- a/doc/getting_started/build_sw.md
+++ b/doc/getting_started/build_sw.md
@@ -1,5 +1,7 @@
 ---
 title: Building Software
+aliases:
+    - /doc/ug/getting_started_build_sw
 ---
 
 _Before following this guide, make sure you've followed the [dependency installation instructions]({{< relref "getting_started" >}})._

--- a/doc/getting_started/setup_dv.md
+++ b/doc/getting_started/setup_dv.md
@@ -1,5 +1,7 @@
 ---
 title: "Design Verification Setup"
+aliases:
+    - /doc/ug/getting_started_dv
 ---
 
 _Before following this guide, make sure you've followed the [dependency installation and software build instructions]({{< relref "getting_started" >}})._

--- a/doc/getting_started/setup_formal.md
+++ b/doc/getting_started/setup_formal.md
@@ -1,5 +1,7 @@
 ---
 title: "Formal Verification Setup"
+aliases:
+    - /doc/ug/getting_started_formal
 ---
 
 _Before following this guide, make sure you've followed the [dependency installation and software build instructions]({{< relref "getting_started" >}})._

--- a/doc/getting_started/setup_fpga.md
+++ b/doc/getting_started/setup_fpga.md
@@ -1,5 +1,7 @@
 ---
 title: "FPGA Setup"
+aliases:
+    - /doc/ug/getting_started_fpga
 ---
 
 _Before following this guide, make sure you've followed the [dependency installation and software build instructions]({{< relref "getting_started" >}})._

--- a/doc/getting_started/setup_verilator.md
+++ b/doc/getting_started/setup_verilator.md
@@ -1,5 +1,7 @@
 ---
 title: Verilator Setup
+aliases:
+    - /doc/ug/getting_started_verilator
 ---
 
 _Before following this guide, make sure you've followed the [dependency installation and software build instructions]({{< relref "getting_started" >}})._


### PR DESCRIPTION
For search engines and so as not to break links that people already have, adds aliases for pages that were moved in #11582 

See https://github.com/lowRISC/opentitan/pull/11582#issuecomment-1088080999