### PR TITLE
[doc] Fix underscore with hyphen for install-dir

### DIFF
--- a/doc/getting_started/_index.md
+++ b/doc/getting_started/_index.md
@@ -103,7 +103,7 @@ You can alternatively download the tarball starting with `lowrisc-toolchain-rv32
 Assuming one of the above worked and you have installed to a non-standard location, you will need to set the `TOOLCHAIN_PATH` environment variable to match whatever path you used.
 For example, if I wanted to install to `~/ot_tools/riscv`, then I would use:
 ```console
-$ ./util/get-toolchain.py --install_dir=~/ot_tools/riscv
+$ ./util/get-toolchain.py --install-dir=~/ot_tools/riscv
 $ export TOOLCHAIN_PATH=~/ot_tools/riscv
 ```
 Add the `export` command to your `~/.bashrc` or equivalent to ensure that the `TOOLCHAIN_PATH` variable is set for future sessions.


### PR DESCRIPTION
get-toolchain.py uses `install-dir` instead of `install_dir`.

Signed-off-by: Canberk Topal <ctopal@lowrisc.org>