### PR TITLE
[sw/silicon_creator] Configure the bootstrap pin only if enabled in OTP

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_rma.hjson
@@ -52,6 +52,12 @@
                     value: "0x0",
                 },
                 {
+                    name: "ROM_BOOTSTRAP_EN",
+                    // Enable bootstrap. See `hardened_bool_t` in
+                    // sw/device/lib/base/hardened.h.
+                    value: "0x739",
+                },
+                {
                     name: "ROM_ALERT_CLASS_EN"
                     // Set the enables to kAlertEnableNone.
                     // See `alert_enable_t`

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -306,10 +306,13 @@ cc_library(
     srcs = ["pinmux.c"],
     hdrs = ["pinmux.h"],
     deps = [
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
         "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:macros",
+        "//sw/device/silicon_creator/lib/drivers:otp",
     ],
 )
 

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -417,10 +417,13 @@ sw_silicon_creator_lib_driver_pinmux = declare_dependency(
     'sw_silicon_creator_lib_driver_pinmux',
     sources: [
       hw_top_earlgrey_pinmux_reg_h,
+      hw_ip_otp_ctrl_reg_h,
       'pinmux.c',
     ],
     dependencies: [
       sw_lib_abs_mmio,
+      sw_lib_hardened,
+      sw_silicon_creator_lib_driver_otp,
     ],
   ),
 )
@@ -430,11 +433,13 @@ test('sw_silicon_creator_lib_driver_pinmux_unittest', executable(
     sources: [
       'pinmux_unittest.cc',
       hw_top_earlgrey_pinmux_reg_h,
+      hw_ip_otp_ctrl_reg_h,
       'pinmux.c',
     ],
     dependencies: [
       sw_vendor_gtest,
       sw_lib_testing_mock_abs_mmio,
+      sw_lib_testing_hardened,
     ],
     native: true,
     c_args: ['-DMOCK_ABS_MMIO'],

--- a/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/pinmux_unittest.cc
@@ -7,17 +7,22 @@
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
-#include "pinmux_regs.h"  // Generated.
+#include "otp_ctrl_regs.h"
+#include "pinmux_regs.h"
 
 namespace pinmux_unittest {
 namespace {
+using ::testing::Return;
+
 class PinmuxTest : public mask_rom_test::MaskRomTest {
  protected:
   uint32_t base_ = TOP_EARLGREY_PINMUX_AON_BASE_ADDR;
   mask_rom_test::MockAbsMmio mmio_;
+  mask_rom_test::MockOtp otp_;
 };
 
 class InitTest : public PinmuxTest {
@@ -59,10 +64,26 @@ class InitTest : public PinmuxTest {
   };
 };
 
-TEST_F(InitTest, Initialize) {
+TEST_F(InitTest, WithBootstrap) {
   // The inputs that will be configured.
+  EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
+      .WillOnce(Return(kHardenedBoolTrue));
   EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInGpioGpio17),
                      kTopEarlgreyPinmuxInselIob8)
+  EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInUart0Rx),
+                     kTopEarlgreyPinmuxInselIoc3);
+
+  // The outputs that will be configured.
+  EXPECT_ABS_WRITE32(RegOut(kTopEarlgreyPinmuxMioOutIoc4),
+                     kTopEarlgreyPinmuxOutselUart0Tx);
+
+  pinmux_init();
+}
+
+TEST_F(InitTest, WithoutBootstrap) {
+  // The inputs that will be configured.
+  EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
+      .WillOnce(Return(kHardenedBoolFalse));
   EXPECT_ABS_WRITE32(RegIn(kTopEarlgreyPinmuxPeripheralInUart0Rx),
                      kTopEarlgreyPinmuxInselIoc3);
 


### PR DESCRIPTION
This PR sets the value of `ROM_BOOTSTRAP_EN` in the RMA OTP image to `kHardenedBoolTrue` and updates the pinmux driver to configure the bootstrap pin only if enabled in OTP.