### PR TITLE
[otbn, dv] Checks secure wiping writes random data before wrting zeroes

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_trace_checker.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.cc
@@ -235,7 +235,7 @@ bool OtbnTraceChecker::MatchPair() {
   rtl_pending_ = false;
   iss_pending_ = false;
   iss_started_ = false;
-  if (!(rtl_entry_ == iss_entry_)) {
+  if (!(rtl_entry_.compare_rtl_iss_entries(iss_entry_))) {
     std::cerr
         << ("ERROR: Mismatch between RTL and ISS trace entries.\n"
             "  RTL entry is:\n");

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -54,7 +54,7 @@ class OtbnTraceEntry {
   // message to stderr and return false.
   bool from_rtl_trace(const std::string &trace);
 
-  bool operator==(const OtbnTraceEntry &other) const;
+  bool compare_rtl_iss_entries(const OtbnTraceEntry &other) const;
   void print(const std::string &indent, std::ostream &os) const;
 
   void take_writes(const OtbnTraceEntry &other);
@@ -71,13 +71,18 @@ class OtbnTraceEntry {
   // True if this entry is "final" (Exec or WipeComplete)
   bool is_final() const;
 
+  static bool check_entries_compatible(
+      trace_type_t type, const std::string &key,
+      const std::vector<OtbnTraceBodyLine> &rtl_lines,
+      const std::vector<OtbnTraceBodyLine> &iss_lines);
+
  protected:
   static trace_type_t hdr_to_trace_type(const std::string &hdr);
 
   trace_type_t trace_type_;
   std::string hdr_;
   // The register writes for this trace entry, keyed by destination
-  std::map<std::string, OtbnTraceBodyLine> writes_;
+  std::map<std::string, std::vector<OtbnTraceBodyLine>> writes_;
 };
 
 class OtbnIssTraceEntry : public OtbnTraceEntry {


### PR DESCRIPTION
This commit adds check to ensure that random data is written to memory
before zeroes are written when secure wiping is done.

Fixes #10547

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>