### PR TITLE
[host,test] Fix broken test in host tools.

### DIFF
--- a/sw/host/rom_ext_image_tools/signer/image/src/image.rs
+++ b/sw/host/rom_ext_image_tools/signer/image/src/image.rs
@@ -89,6 +89,7 @@ impl DerefMut for ManifestBuffer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use memoffset::offset_of;
 
     #[test]
     fn test_set_manifest_field() -> Result<(), ImageError> {
@@ -98,7 +99,10 @@ mod tests {
         let identifier: u32 = 0x01020304;
         image.manifest.identifier = identifier;
         for i in 0..4 {
-            assert_eq!(manifest_buffer[i], identifier.to_le_bytes()[i]);
+            assert_eq!(
+                manifest_buffer[offset_of!(Manifest, identifier) + i],
+                identifier.to_le_bytes()[i]
+            );
         }
         Ok(())
     }


### PR DESCRIPTION
When trying to test out a new change I found that this test was actually broken on master; it's a pretty straightforward fix. The test was assuming the identifier field is at the start of the manifest; filling in the identifier field's actual offset fixed the test. After this change, `bazel test //sw/host/...` passes.