### PR TITLE
[style] Codify assembly style norms

### DIFF
--- a/sw/device/lib/crt/crt.S
+++ b/sw/device/lib/crt/crt.S
@@ -8,89 +8,97 @@
  * Utility functions written in assembly that can be used before the C
  * runtime has been initialized. These functions should not be used once
  * the C runtime has been initialized.
+ *
+ * The name of this library is historical. In many toolchains, a file called
+ * "crt0.o" is linked into each executable, which does something similar to
+ * what these functions 
  */
 
   // NOTE: The "ax" flag below is necessary to ensure that this section
   // is allocated space in ROM by the linker.
   .section .crt, "ax", @progbits
 
-/**
- * Write zeros into the section bounded by the start and end pointers.
- * The section must be word (4 byte) aligned. It is valid for the section
- * to have a length of 0 (i.e. the start and end pointers may be equal).
- *
- * This function follows the standard ILP32 calling convention for arguments
- * but does not require a valid stack pointer, thread pointer or global
- * pointer.
- *
- * Clobbers a0 and t0.
- *
- * @param a0 pointer to start of section to clear (inclusive).
- * @param a1 pointer to end of section to clear (exclusive).
- */
-crt_section_clear:
-  .globl crt_section_clear
+  /**
+   * Write zeros into the section bounded by the start and end pointers.
+   * The section must be word (4 byte) aligned. It is valid for the section
+   * to have a length of 0 (i.e. the start and end pointers may be equal).
+   *
+   * This function follows the standard ILP32 calling convention for arguments
+   * but does not require a valid stack pointer, thread pointer or global
+   * pointer.
+   *
+   * Clobbers a0 and t0.
+   *
+   * @param a0 pointer to start of section to clear (inclusive).
+   * @param a1 pointer to end of section to clear (exclusive).
+   */
+  .balign 4
+  .global crt_section_clear
   .type crt_section_clear, @function
+crt_section_clear:
 
   // Check that start is before end.
-  bgeu a0, a1, L_clear_nothing
+  bgeu a0, a1, .L_clear_nothing
 
   // Check that start and end are word aligned.
   or   t0, a0, a1
   andi t0, t0, 0x3
-  bnez t0, L_clear_error
+  bnez t0, .L_clear_error
 
-L_clear_loop:
+.L_clear_loop:
   // Write zero into section memory word-by-word.
   // TODO: unroll
   sw   zero, 0(a0)
   addi a0, a0, 4
-  bltu a0, a1, L_clear_loop
+  bltu a0, a1, .L_clear_loop
   ret
 
-L_clear_nothing:
+.L_clear_nothing:
   // If section length is 0 just return. Otherwise end is before start
   // which is invalid so trigger an error.
-  bne a0, a1, L_clear_error
+  bne a0, a1, .L_clear_error
   ret
 
-L_clear_error:
+.L_clear_error:
   unimp
 
   // Set function size to allow disassembly.
   .size crt_section_clear, .-crt_section_clear
 
-/**
- * Copy data from the given source into the section bounded by the start and
- * end pointers. Both the section and the source must be word (4 byte) aligned.
- * It is valid for the section to have a length of 0 (i.e. the start and end
- * pointers may be equal). The source is assumed to have the same length as the
- * target section.
- *
- * The destination section and the source must not overlap.
- *
- * This function follows the standard ILP32 calling convention for arguments
- * but does not require a valid stack pointer, thread pointer or global
- * pointer.
- *
- * Clobbers a0, a2, t0 and t1.
- *
- * @param a0 pointer to start of destination section (inclusive).
- * @param a1 pointer to end of destination section (exclusive).
- * @param a2 pointer to source data (inclusive).
- */
-crt_section_copy:
+// -----------------------------------------------------------------------------
+
+  /**
+   * Copy data from the given source into the section bounded by the start and
+   * end pointers. Both the section and the source must be word (4 byte) aligned.
+   * It is valid for the section to have a length of 0 (i.e. the start and end
+   * pointers may be equal). The source is assumed to have the same length as the
+   * target section.
+   *
+   * The destination section and the source must not overlap.
+   *
+   * This function follows the standard ILP32 calling convention for arguments
+   * but does not require a valid stack pointer, thread pointer or global
+   * pointer.
+   *
+   * Clobbers a0, a2, t0 and t1.
+   *
+   * @param a0 pointer to start of destination section (inclusive).
+   * @param a1 pointer to end of destination section (exclusive).
+   * @param a2 pointer to source data (inclusive).
+   */
+  .balign 4
   .global crt_section_copy
   .type crt_section_copy, @function
+crt_section_copy:
 
   // Check that start is before end.
-  bgeu a0, a1, L_copy_nothing
+  bgeu a0, a1, .L_copy_nothing
 
   // Check that start, end and src are word aligned.
   or   t0, a0, a1
   or   t0, t0, a2
   andi t0, t0, 0x3
-  bnez t0, L_copy_error
+  bnez t0, .L_copy_error
 
   // Check that source does not destructively overlap destination
   // (assuming a forwards copy).
@@ -109,26 +117,24 @@ crt_section_copy:
   // TODO: disallow all overlap since it indicates API misuse?
   sub  t0, a0, a2           // (start - src) mod 2**32
   sub  t1, a1, a0           // end - start
-  bltu t0, t1, L_copy_error
+  bltu t0, t1, .L_copy_error
 
-L_copy_loop:
+.L_copy_loop:
   // Copy data from src into section word-by-word.
   // TODO: unroll
   lw   t0, 0(a2)
   addi a2, a2, 4
   sw   t0, 0(a0)
   addi a0, a0, 4
-  bltu a0, a1, L_copy_loop
+  bltu a0, a1, .L_copy_loop
   ret
 
-L_copy_nothing:
+.L_copy_nothing:
   // If section length is 0 just return. Otherwise end is before start
   // which is invalid so trigger an error.
-  bne a0, a1, L_copy_error
+  bne a0, a1, .L_copy_error
   ret
 
-L_copy_error:
+.L_copy_error:
   unimp
-
-  // Set function size to allow disassembly.
   .size crt_section_copy, .-crt_section_copy

--- a/sw/device/lib/testing/test_framework/freertos_port.S
+++ b/sw/device/lib/testing/test_framework/freertos_port.S
@@ -4,18 +4,15 @@
 
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 
-.extern pxCurrentTCB
-
 // -----------------------------------------------------------------------------
 
-/**
- * FreeRTOS, expects this function to exist and uses it to start the first task. 
- */
-.balign 4
-.global xPortStartFirstTask
-.type xPortStartFirstTask, @function
+  /**
+   * FreeRTOS, expects this function to exist and uses it to start the first task. 
+   */
+  .balign 4
+  .global xPortStartFirstTask
+  .type xPortStartFirstTask, @function
 xPortStartFirstTask:
-
   // Load the stack pointer for the current TCB (just going to clobber sp here
   // since we are setting it here anyway).
   lw  sp, pxCurrentTCB
@@ -66,75 +63,72 @@ xPortStartFirstTask:
   addi sp, sp, OTTF_CONTEXT_SIZE
 
   ret
-
-  // Set size so this function can be disassembled.
   .size xPortStartFirstTask, .-xPortStartFirstTask
 
 // -----------------------------------------------------------------------------
 
-/** 
- * The prototype for this function depends on configurations defined in
- * FreeRTOSConfig.h, and is defined in:
- * sw/vendor/freertos_freertos_kernel/include/portable.h
- * 
- * The implementation of this assembly function assumes the prototype for this
- * function looks like:
- * 
- * StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack,
- *                                    TaskFunction_t pxCode,
- *                                    void *pvParameters);
- * 
- * TODO: add some checks to verify this is the configured prototype.
- * TODO: configure to allow use of checking for stack overflows.
- * TODO: configure return address for first (main) task.
- * 
- * As per the standard RISC-V ABI pxTopcOfStack is passed in in a0, pxCode in
- * a1, and pvParameters in a2. The new top of stack is passed out in a0.
- * 
- * The RISC-V context is saved to FreeRTOS tasks in the following stack frame,
- * where the global and thread pointers are currently assumed to be constant,
- * and therefore are not saved:
- * 
- * ---Stack Bottom---
- * ---............---
- * Offset - Reg/Value
- *     29 - mstatus
- *     28 - t6 (x31)
- *     27 - t5 (x30)
- *     26 - t4 (x29)
- *     25 - t3 (x28)
- *     24 - s11 (x27)
- *     23 - s10 (x26)
- *     22 - s9 (x25)
- *     21 - s8 (x24)
- *     20 - s7 (x23)
- *     19 - s6 (x22)
- *     18 - s5 (x21)
- *     17 - s4 (x20)
- *     16 - s3 (x19)
- *     15 - s2 (x18)
- *     14 - a7 (x17)
- *     13 - a6 (x16)
- *     12 - a5 (x15)
- *     11 - a4 (x14)
- *     10 - a3 (x13)
- *      9 - a2 (x12)
- *      8 - a1 (x11)
- *      7 - (pvParameters)
- *      6 - s1 (x9)
- *      5 - s0 (x8)
- *      4 - t2 (x7)
- *      3 - t1 (x6)
- *      2 - t0 (x5)
- *      1 - (return address for main task, 0 for now)
- *      0 - (pxCode)
- * -----Stack Top----
- */
-.balign 4
-.global pxPortInitialiseStack
-.type pxPortInitialiseStack, @function
+  /** 
+   * The prototype for this function depends on configurations defined in
+   * FreeRTOSConfig.h, and is defined in:
+   * sw/vendor/freertos_freertos_kernel/include/portable.h
+   * 
+   * The implementation of this assembly function assumes the prototype for this
+   * function looks like:
+   * 
+   * StackType_t *pxPortInitialiseStack(StackType_t *pxTopOfStack,
+   *                                    TaskFunction_t pxCode,
+   *                                    void *pvParameters);
+   * 
+   * TODO: add some checks to verify this is the configured prototype.
+   * TODO: configure to allow use of checking for stack overflows.
+   * TODO: configure return address for first (main) task.
+   * 
+   * As per the standard RISC-V ABI pxTopcOfStack is passed in in a0, pxCode in
+   * a1, and pvParameters in a2. The new top of stack is passed out in a0.
+   * 
+   * The RISC-V context is saved to FreeRTOS tasks in the following stack frame,
+   * where the global and thread pointers are currently assumed to be constant,
+   * and therefore are not saved:
+   * 
+   * ---Stack Bottom---
+   * ---............---
+   * Offset - Reg/Value
+   *     29 - mstatus
+   *     28 - t6 (x31)
+   *     27 - t5 (x30)
+   *     26 - t4 (x29)
+   *     25 - t3 (x28)
+   *     24 - s11 (x27)
+   *     23 - s10 (x26)
+   *     22 - s9 (x25)
+   *     21 - s8 (x24)
+   *     20 - s7 (x23)
+   *     19 - s6 (x22)
+   *     18 - s5 (x21)
+   *     17 - s4 (x20)
+   *     16 - s3 (x19)
+   *     15 - s2 (x18)
+   *     14 - a7 (x17)
+   *     13 - a6 (x16)
+   *     12 - a5 (x15)
+   *     11 - a4 (x14)
+   *     10 - a3 (x13)
+   *      9 - a2 (x12)
+   *      8 - a1 (x11)
+   *      7 - (pvParameters)
+   *      6 - s1 (x9)
+   *      5 - s0 (x8)
+   *      4 - t2 (x7)
+   *      3 - t1 (x6)
+   *      2 - t0 (x5)
+   *      1 - (return address for main task, 0 for now)
+   *      0 - (pxCode)
+   * -----Stack Top----
+   */
+  .balign 4
+  .global pxPortInitialiseStack
+  .type pxPortInitialiseStack, @function
 pxPortInitialiseStack:
-
   // Setup the MSTATUS register.
   csrr t0, mstatus
   // Ensure interrupts are disabled when the stack is restored within an ISR.
@@ -161,6 +155,4 @@ pxPortInitialiseStack:
   sw a1, 0(a0)
 
   ret
-
-  // Set size so this function can be disassembled.
   .size pxPortInitialiseStack, .-pxPortInitialiseStack

--- a/sw/device/lib/testing/test_framework/ottf_isrs.S
+++ b/sw/device/lib/testing/test_framework/ottf_isrs.S
@@ -4,32 +4,24 @@
 
 #include "sw/device/lib/testing/test_framework/ottf_macros.h"
 
-.extern pxCurrentTCB
-.extern kTestConfig
-.extern ottf_exception_handler
-.extern ottf_software_isr
-.extern ottf_timer_isr
-.extern ottf_external_isr
-
 // -----------------------------------------------------------------------------
 
-/**
- * Compute the MEPC to that will be saved to the stack by the associated ISR
- * handler sub-routine below.
- *
- * This subroutine is only invoked for IRQs that are synchronous. Specifically,
- * this subroutine updates the ISR return address to point to the instruction
- * after the trapped instruction to prevent an endless interrupt cycle.
- *
- * Since we support the RISC-V compressed instructions extension, we need to
- * check if the two least significant bits of the instruction are
- * b11 (0x3), which means that the trapped instruction is not compressed,
- * i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
- * instruction is 16bits = 2bytes.
- */
-
-.balign 4
-.type compute_mepc_on_synchronous_irq, @function
+  /**
+   * Compute the MEPC to that will be saved to the stack by the associated ISR
+   * handler sub-routine below.
+   *
+   * This subroutine is only invoked for IRQs that are synchronous. Specifically,
+   * this subroutine updates the ISR return address to point to the instruction
+   * after the trapped instruction to prevent an endless interrupt cycle.
+   *
+   * Since we support the RISC-V compressed instructions extension, we need to
+   * check if the two least significant bits of the instruction are
+   * b11 (0x3), which means that the trapped instruction is not compressed,
+   * i.e., the trapped instruction is 32bits = 4bytes. Otherwise, the trapped
+   * instruction is 16bits = 2bytes.
+   */
+  .balign 4
+  .type compute_mepc_on_synchronous_irq, @function
 compute_mepc_on_synchronous_irq:
   csrr t0, mepc
   li t1, 0x3
@@ -40,21 +32,19 @@ compute_mepc_on_synchronous_irq:
 .L_32bit_trap_instr:
   addi t0, t0, OTTF_WORD_SIZE
   ret
-
-  // Set size so this function can be disassembled.
   .size compute_mepc_on_synchronous_irq, .-compute_mepc_on_synchronous_irq
 
 // -----------------------------------------------------------------------------
 
-/**
- * Store stack pointer to current Task Control Block (TCB) ONLY if concurrency
- * is enabled for a given test, i.e., the test that triggers an IRQ is running
- * as a FreeRTOS task. This is because for bare-metal tests, the current
- * FreeRTOS TCB pointer (pxCurrentTCB) will be NULL, which will result in an
- * exception, if we attempt to perform a store to said address.
- */
-.balign 4
-.type save_current_sp_to_tcb, @function
+  /**
+   * Store stack pointer to current Task Control Block (TCB) ONLY if concurrency
+   * is enabled for a given test, i.e., the test that triggers an IRQ is running
+   * as a FreeRTOS task. This is because for bare-metal tests, the current
+   * FreeRTOS TCB pointer (pxCurrentTCB) will be NULL, which will result in an
+   * exception, if we attempt to perform a store to said address.
+   */
+  .balign 4
+  .type save_current_sp_to_tcb, @function
 save_current_sp_to_tcb:
   la t0, kTestConfig       // Load the pointer to the test configuration struct.
   beqz t0, .L_skip_sp_save // If the kTestConfig pointer is NULL, we are using
@@ -68,18 +58,16 @@ save_current_sp_to_tcb:
   sw sp, 0(t2)
 .L_skip_sp_save:
   ret
-
-  // Set size so this function can be disassembled.
   .size save_current_sp_to_tcb, .-save_current_sp_to_tcb
 
 // -----------------------------------------------------------------------------
 
-/**
- * Exception handler.
- */
-.balign 4
-.global handler_exception
-.type handler_exception, @function
+  /**
+   * Exception handler.
+   */
+  .balign 4
+  .global handler_exception
+  .type handler_exception, @function
 handler_exception:
   // Save all registers to the stack.
   addi sp, sp, -OTTF_CONTEXT_SIZE
@@ -130,18 +118,16 @@ handler_exception:
 
   // Return from ISR.
   j ottf_isr_exit
-
-  // Set size so this function can be disassembled.
   .size handler_exception, .-handler_exception
 
 // -----------------------------------------------------------------------------
 
-/**
- * Software IRQ handler.
- */
-.balign 4
-.global handler_irq_software
-.type handler_irq_software, @function
+  /**
+   * Software IRQ handler.
+   */
+  .balign 4
+  .global handler_irq_software
+  .type handler_irq_software, @function
 handler_irq_software:
   // Save all registers to the stack.
   addi sp, sp, -OTTF_CONTEXT_SIZE
@@ -192,18 +178,16 @@ handler_irq_software:
 
   // Return from ISR.
   j ottf_isr_exit
-
-  // Set size so this function can be disassembled.
   .size handler_irq_software, .-handler_irq_software
 
 // -----------------------------------------------------------------------------
 
-/**
- * Timer IRQ handler.
- */
-.balign 4
-.global handler_irq_timer
-.type handler_irq_timer, @function
+  /**
+   * Timer IRQ handler.
+   */
+  .balign 4
+  .global handler_irq_timer
+  .type handler_irq_timer, @function
 handler_irq_timer:
   // Save all registers to the stack.
   addi sp, sp, -OTTF_CONTEXT_SIZE
@@ -254,18 +238,16 @@ handler_irq_timer:
 
   // Return from ISR.
   j ottf_isr_exit
-
-  // Set size so this function can be disassembled.
   .size handler_irq_timer, .-handler_irq_timer
 
 // -----------------------------------------------------------------------------
 
-/**
- * External IRQ handler.
- */
-.balign 4
-.global handler_irq_external
-.type handler_irq_external, @function
+  /**
+   * External IRQ handler.
+   */
+  .balign 4
+  .global handler_irq_external
+  .type handler_irq_external, @function
 handler_irq_external:
   // Save all registers to the stack.
   addi sp, sp, -OTTF_CONTEXT_SIZE
@@ -316,18 +298,16 @@ handler_irq_external:
 
   // Return from ISR.
   j ottf_isr_exit
-
-  // Set size so this function can be disassembled.
   .size handler_irq_external, .-handler_irq_external
 
 // -----------------------------------------------------------------------------
 
-/**
- * ISR exit sub-routine restores registers from the stack.
- */
-.balign 4
-.global ottf_isr_exit
-.type ottf_isr_exit, @function
+  /**
+   * ISR exit sub-routine restores registers from the stack.
+   */
+  .balign 4
+  .global ottf_isr_exit
+  .type ottf_isr_exit, @function
 ottf_isr_exit:
   // Load the stack pointer for the current task control block (TCB), only if
   // the `enable_concurrency` flag is set in the test configuration struct,
@@ -388,6 +368,4 @@ ottf_isr_exit:
   // This exits the ISR completely, and does not return control flow to the ISR
   // that called this sub-routine.
   mret
-
-  // Set size so this function can be disassembled.
   .size ottf_isr_exit, .-ottf_isr_exit

--- a/sw/device/lib/testing/test_framework/ottf_start.S
+++ b/sw/device/lib/testing/test_framework/ottf_start.S
@@ -2,25 +2,27 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Manifest for boot stages stored in flash.
- *
- * Note, we set the default entry point field (which is the last field in the
- * manifest struct) to `_ottf_start`. We do this to enable running unsigned test
- * images with the test ROM, since these images will not be processed by our
- * signing tool which would otherwise populate this entry point field.
- */
+#include "sw/device/silicon_creator/lib/manifest_size.h"
 
-  #include "sw/device/silicon_creator/lib/manifest_size.h"
-
+  /**
+   * Manifest for boot stages stored in flash.
+   *
+   * Note, we set the default entry point field (which is the last field in the
+   * manifest struct) to `_ottf_start`. We do this to enable running unsigned test
+   * images with the test ROM, since these images will not be processed by our
+   * signing tool which would otherwise populate this entry point field.
+   */
   .section .manifest, "a"
   .global kManifest
-
+  .type kManifest, @object
 kManifest:
   .rept MANIFEST_SIZE - 4
   .byte 0x0
   .endr
   .4byte _ottf_start
+  .size kManifest, .-kManifest
+
+// -----------------------------------------------------------------------------
 
 /**
  * OTTF Interrupt Vector.
@@ -37,33 +39,27 @@ kManifest:
   // link-time, which we also really don't want.
   .option norelax
 
-  // These symbols are declared in `ottf_isrs.S`.
-  .extern handler_exception
-  .extern handler_irq_software
-  .extern handler_irq_timer
-  .extern handler_irq_external
-
-/**
- * `_ottf_interrupt_vector` is an ibex-compatible interrupt vector.
- *
- * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts. The
- * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
- *
- * Only the following will be used by Ibex:
- * - Exception Handler (Entry 0)
- * - Machine Software Interrupt Handler (Entry 3)
- * - Machine Timer Interrupt Handler (Entry 7)
- * - Machine External Interrupt Handler (Entry 11)
- * - Vendor Interrupt Handlers (Entries 16-31)
- *
- * More information about Ibex's interrupts can be found here:
- *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
- */
+  /**
+   * `_ottf_interrupt_vector` is an ibex-compatible interrupt vector.
+   *
+   * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts.
+   * The vector must be 256-byte aligned, as Ibex's vectoring mechanism requires
+   * that.
+   *
+   * Only the following will be used by Ibex:
+   * - Exception Handler (Entry 0)
+   * - Machine Software Interrupt Handler (Entry 3)
+   * - Machine Timer Interrupt Handler (Entry 7)
+   * - Machine External Interrupt Handler (Entry 11)
+   * - Vendor Interrupt Handlers (Entries 16-31)
+   *
+   * More information about Ibex's interrupts can be found here:
+   *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+   */
   .balign 256
   .global _ottf_interrupt_vector
   .type _ottf_interrupt_vector, @function
 _ottf_interrupt_vector:
-
   // RISC-V Standard (Vectored) Interrupt Handlers:
 
   // Exception and User Software Interrupt Handler.
@@ -114,6 +110,8 @@ _ottf_interrupt_vector:
 
   .option pop
 
+// -----------------------------------------------------------------------------
+
 /**
  * OTTF runtime initialization code.
  */
@@ -124,16 +122,16 @@ _ottf_interrupt_vector:
    */
   .section .crt, "ax"
 
-/**
- * Entry point.
- *
- * This symbol is jumped to from the test ROM or mask ROM using the
- * `entry_point` field of the manifest.
- */
-  .globl _ottf_start
+  /**
+   * Entry point.
+   *
+   * This symbol is jumped to from the test ROM or mask ROM using the
+   * `entry_point` field of the manifest.
+   */
+  .balign 4
+  .global _ottf_start
   .type _ottf_start, @function
 _ottf_start:
-
   /**
    * Set up the stack pointer.
    *
@@ -165,7 +163,6 @@ _ottf_start:
   la   a0, _data_start
   la   a1, _data_end
   la   a2, _data_init_start
-  .extern crt_section_copy
   call crt_section_copy
 
   /**
@@ -176,7 +173,6 @@ _ottf_start:
    */
   la   a0, _bss_start
   la   a1, _bss_end
-  .extern crt_section_clear
   call crt_section_clear
 
   /**
@@ -218,8 +214,5 @@ init_array_loop_end:
   */
   li   a0, 0x0  // argc = 0
   li   a1, 0x0  // argv = NULL
-  .extern main
   tail main
-
-  // Set size so this function can be disassembled.
   .size _ottf_start, .-_ottf_start

--- a/sw/device/lib/testing/test_rom/test_rom_start.S
+++ b/sw/device/lib/testing/test_rom/test_rom_start.S
@@ -46,7 +46,7 @@
   // is allocated executable space in ROM by the linker.
   .section .vectors, "ax"
   .balign 256
-  .globl _test_rom_interrupt_vector
+  .global _test_rom_interrupt_vector
   .type _test_rom_interrupt_vector, @function
 _test_rom_interrupt_vector:
 
@@ -68,6 +68,8 @@ _test_rom_interrupt_vector:
   // Re-enable compressed instructions, linker relaxation.
   .option pop
 
+// -----------------------------------------------------------------------------
+
 /**
  * Test ROM runtime initialization code.
  */
@@ -76,16 +78,14 @@ _test_rom_interrupt_vector:
   // is allocated executable space in ROM by the linker.
   .section .crt, "ax"
 
-  .extern crt_section_clear
-  .extern crt_section_copy
-  .extern kDeviceType
-
-/**
- * Entry point after reset. This symbol is jumped to from the handler
- * for IRQ 0x80.
- */
+  /**
+   * Entry point after reset. This symbol is jumped to from the handler
+   * for IRQ 0x80.
+   */
+  .balign 4
+  .global _reset_start
+  .type _reset_start, @function
 _reset_start:
-  .globl _reset_start
   // Clobber all writeable registers.
   li  x1, 0x0
   li  x2, 0x0
@@ -130,16 +130,20 @@ _reset_start:
   .option pop
 
   // Explicit fall-through to `_start`.
+  .size _reset_start, .-_reset_start
 
-/**
- * Callable entry point for the boot rom.
- *
- * Currently, this zeroes the `.bss` section, copies initial data to
- * `.data`, and then jumps to the program entry point.
- */
+// -----------------------------------------------------------------------------
+
+  /**
+   * Callable entry point for the boot rom.
+   *
+   * Currently, this zeroes the `.bss` section, copies initial data to
+   * `.data`, and then jumps to the program entry point.
+   */
+  .balign 4
+  .global _start
+  .type _start, @function
 _start:
-  .globl _start
-
   // Re-enable all SW gateable clocks in case the clkmgr was not reset.
   li   a0, TOP_EARLGREY_CLKMGR_AON_BASE_ADDR
   li   t0, CLKMGR_CLK_ENABLES_REG_RESVAL
@@ -247,14 +251,18 @@ _start:
 .L_wfi_loop:
   wfi
   j   .L_wfi_loop
+  .size _start, .-_start
 
-/**
- * Test ROM IRQ/exception handler; loops forever.
- */
+// -----------------------------------------------------------------------------
 
-  // Put this handler in the code section.
- .section .text
-
+  /**
+   * Test ROM IRQ/exception handler; loops forever.
+   */
+  .balign 4
+  .section .text
+  .global _test_rom_irq_handler
+  .type _test_rom_irq_handler, @function
 _test_rom_irq_handler:
   wfi
   j _test_rom_irq_handler
+  .size _test_rom_irq_handler, .-_test_rom_irq_handler

--- a/sw/device/silicon_creator/lib/irq_asm.S
+++ b/sw/device/silicon_creator/lib/irq_asm.S
@@ -14,13 +14,14 @@
   // is allocated executable space in ROM by the linker.
   .section .shutdown, "ax"
 
-/**
- * Exception handler that is safe to call before the C runtime has been
- * initialized. It must not use the stack or global pointer.
- *
- * The exception handler will use the reset manager to trigger a reset.
- */
-  .globl _asm_exception_handler
+  /**
+   * Exception handler that is safe to call before the C runtime has been
+   * initialized. It must not use the stack or global pointer.
+   *
+   * The exception handler will use the reset manager to trigger a reset.
+   */
+  .balign 4
+  .global _asm_exception_handler
   .type _asm_exception_handler, @function
 _asm_exception_handler:
 .L_exception_loop:
@@ -38,6 +39,4 @@ _asm_exception_handler:
 
   wfi
   j   .L_exception_loop
-
-  // Set size so this function can be disassembled.
   .size _asm_exception_handler, .-_asm_exception_handler

--- a/sw/device/silicon_creator/lib/manifest_section.S
+++ b/sw/device/silicon_creator/lib/manifest_section.S
@@ -2,16 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-/**
- * Manifest for boot stages stored in flash.
- */
+#include "sw/device/silicon_creator/lib/manifest_size.h"
 
-  #include "sw/device/silicon_creator/lib/manifest_size.h"
-
+  /**
+   * Manifest for boot stages stored in flash.
+   */
   .section .manifest, "a"
-  .globl kManifest
-
+  .balign 4
+  .global kManifest
+  .type kManifest, @object
 kManifest:
-  .rept MANIFEST_SIZE
-  .byte 0x0
-  .endr
+  .zero MANIFEST_SIZE
+  .size kManifest, .-kManifest

--- a/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_epmp.S
@@ -28,24 +28,26 @@
  */
 #define NAPOT(addr, len) (((addr) >> 2) | (((len) - 1) >> 3))
 
-/**
- * The "ax" flag below is necessary to ensure that this section
- * is allocated space in ROM by the linker.
- */
-.section .crt, "ax", @progbits
+// -----------------------------------------------------------------------------
 
-/**
- * Configure the CPU's Enhanced Physical Memory Protection (ePMP) feature.
- *
- * This function follows the standard ILP32 calling convention but does not
- * require a valid stack pointer, thread pointer or global pointer.
- *
- * May clobber temporary registers (t0-t6).
- */
-mask_rom_epmp_init:
-  .globl mask_rom_epmp_init
+  /**
+   * The "ax" flag below is necessary to ensure that this section
+   * is allocated space in ROM by the linker.
+   */
+  .section .crt, "ax", @progbits
+
+  /**
+   * Configure the CPU's Enhanced Physical Memory Protection (ePMP) feature.
+   *
+   * This function follows the standard ILP32 calling convention but does not
+   * require a valid stack pointer, thread pointer or global pointer.
+   *
+   * May clobber temporary registers (t0-t6).
+   */
+  .balign 4
+  .global mask_rom_epmp_init
   .type mask_rom_epmp_init, @function
-
+mask_rom_epmp_init:
   // Pre-encoded addresses defined in linker script.
   .extern _epmp_text_tor_lo
   .extern _epmp_text_tor_hi
@@ -104,6 +106,4 @@ mask_rom_epmp_init:
   csrw pmpcfg3, t3
 
   ret
-
-  // Set function size to allow disassembly.
   .size mask_rom_epmp_init, .-mask_rom_epmp_init

--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -29,75 +29,67 @@
   // link-time, which we also really don't want.
   .option norelax
 
-/**
- * Initial RISC-V vectored exception/interrupt handlers.
- *
- * After reset all interrupts are disabled. Only exceptions (interrupt 0) and
- * non-maskable interrupts (interrupt 31) are possible. For simplicity however
- * we just set all interrupt handlers to the same exception handler.
- *
- * Since the C runtime is not initialized immediately after reset the initial
- * interrupt vector must only call functions written in assembly. Once the C
- * runtime is intialized the interrupt vector should be replaced.
- *
- * If the hardware is operating correctly the assembly interrupt handlers
- * should never be called.
- *
- * Note that the Ibex reset handler (entry point) immediately follows this
- * interrupt vector and can be thought of as an extra entry.
- *
- * More information about Ibex's interrupts can be found here:
- *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
- *
- * TODO(lowRISC/ibex#1419): if direct mode support is added to Ibex it probably
- * makes sense to use it instead of vectored mode in the mask ROM.
- */
+  /**
+   * Initial RISC-V vectored exception/interrupt handlers.
+   *
+   * After reset all interrupts are disabled. Only exceptions (interrupt 0) and
+   * non-maskable interrupts (interrupt 31) are possible. For simplicity however
+   * we just set all interrupt handlers to the same exception handler.
+   *
+   * Since the C runtime is not initialized immediately after reset the initial
+   * interrupt vector must only call functions written in assembly. Once the C
+   * runtime is intialized the interrupt vector should be replaced.
+   *
+   * If the hardware is operating correctly the assembly interrupt handlers
+   * should never be called.
+   *
+   * Note that the Ibex reset handler (entry point) immediately follows this
+   * interrupt vector and can be thought of as an extra entry.
+   *
+   * More information about Ibex's interrupts can be found here:
+   *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+   *
+   * TODO(lowRISC/ibex#1419): if direct mode support is added to Ibex it probably
+   * makes sense to use it instead of vectored mode in the mask ROM.
+   */
   .section .vectors, "ax"
   .balign 256
-  .globl _mask_rom_interrupt_vector_asm
+  .global _mask_rom_interrupt_vector_asm
   .type _mask_rom_interrupt_vector_asm, @function
 _mask_rom_interrupt_vector_asm:
-
   // Each jump instruction must be exactly 4 bytes in order to ensure that the
   // entries are properly located.
-  .extern _asm_exception_handler
   .rept 32
   j _asm_exception_handler
   .endr
 
   // Ibex Reset Handler:
   j _mask_rom_start_boot
-
-  // Set size so this vector can be disassembled.
   .size _mask_rom_interrupt_vector_asm, .-_mask_rom_interrupt_vector_asm
 
-/**
- * Post C runtime initialization RISC-V vectored exception/interrupt handlers.
- *
- * This vector is placed into the .crt section so that .vectors doesn't need to
- * be padded to a 256 byte boundary.
- */
+// -----------------------------------------------------------------------------
+
+  /**
+   * Post C runtime initialization RISC-V vectored exception/interrupt handlers.
+   *
+   * This vector is placed into the .crt section so that .vectors doesn't need to
+   * be padded to a 256 byte boundary.
+   */
   .section .crt, "ax"
   .balign 256
-  .globl _mask_rom_interrupt_vector_c
+  .global _mask_rom_interrupt_vector_c
   .type _mask_rom_interrupt_vector_c, @function
 _mask_rom_interrupt_vector_c:
-
   // Entry 0: exception handler.
-  .extern mask_rom_exception_handler
   j mask_rom_exception_handler
 
   // Entries 1-30: interrupt handlers.
-  .extern mask_rom_interrupt_handler
   .rept 30
   j mask_rom_interrupt_handler
   .endr
 
   // Entry 31: non-maskable interrupt handler.
-  .extern mask_rom_nmi_handler
   j mask_rom_nmi_handler
-
-  // Set size so this vector can be disassembled.
   .size _mask_rom_interrupt_vector_c, .-_mask_rom_interrupt_vector_c
 
   // Pop Mask ROM interrupt vector options.
@@ -105,16 +97,18 @@ _mask_rom_interrupt_vector_c:
   // Re-enable compressed instructions, linker relaxation.
   .option pop
 
-/**
- * Mask ROM shadow stack.
- */
-
-  .bss
-  .globl _mask_rom_shadow_stack
-  .align 4
+  /**
+   * Mask ROM shadow stack.
+   */
+  .section .bss
+  .balign 4
+  .global _mask_rom_shadow_stack
+  .type _mask_rom_shadow_stack, @object
 _mask_rom_shadow_stack:
-  .space 256*4
+  .zero 256 * 4
   .size _mask_rom_shadow_stack, .-_mask_rom_shadow_stack
+
+// -----------------------------------------------------------------------------
 
 /**
  * Mask ROM runtime initialization code.
@@ -130,10 +124,11 @@ _mask_rom_shadow_stack:
   .option push
   .option norelax
 
-/**
- * Entry point after reset.
- */
-  .globl _mask_rom_start_boot
+  /**
+   * Entry point after reset.
+   */
+  .balign 4
+  .global _mask_rom_start_boot
   .type _mask_rom_start_boot, @function
 _mask_rom_start_boot:
 
@@ -267,7 +262,6 @@ _mask_rom_start_boot:
   li x31, 0x0
 
   // Must be called prior to any Main RAM access.
-  .extern mask_rom_epmp_init
   call mask_rom_epmp_init
 
   /**
@@ -278,13 +272,11 @@ _mask_rom_start_boot:
   la   a0, _data_start
   la   a1, _data_end
   la   a2, _data_init_start
-  .extern crt_section_copy
   call crt_section_copy
 
   // Initialize the `.bss` section.
   la   a0, _bss_start
   la   a1, _bss_end
-  .extern crt_section_clear
   call crt_section_clear
 
   // Set up stack pointer.
@@ -322,10 +314,7 @@ _mask_rom_start_boot:
   /**
    * Jump to C Code
    */
-  .extern mask_rom_main
   tail mask_rom_main
-
-  // Set size so this function can be disassembled.
   .size _mask_rom_start_boot, .-_mask_rom_start_boot
 
   // Re-enable linker relaxation.

--- a/sw/device/silicon_creator/rom_ext/rom_ext_start.S
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_start.S
@@ -18,27 +18,27 @@
   // link-time, which we also really don't want.
   .option norelax
 
-/**
- * `_rom_ext_interrupt_vector` is an ibex-compatible interrupt vector.
- *
- * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts. The
- * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
- *
- * Only the following will be used by Ibex:
- * - Exception Handler (Entry 0)
- * - Machine Software Interrupt Handler (Entry 3)
- * - Machine Timer Interrupt Handler (Entry 7)
- * - Machine External Interrupt Handler (Entry 11)
- * - Vendor Interrupt Handlers (Entries 16-31)
- *
- * More information about Ibex's interrupts can be found here:
- *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
- */
+  /**
+   * `_rom_ext_interrupt_vector` is an ibex-compatible interrupt vector.
+   *
+   * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts.
+   * The vector must be 256-byte aligned, as Ibex's vectoring mechanism
+   * requires that.
+   *
+   * Only the following will be used by Ibex:
+   * - Exception Handler (Entry 0)
+   * - Machine Software Interrupt Handler (Entry 3)
+   * - Machine Timer Interrupt Handler (Entry 7)
+   * - Machine External Interrupt Handler (Entry 11)
+   * - Vendor Interrupt Handlers (Entries 16-31)
+   *
+   * More information about Ibex's interrupts can be found here:
+   *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+   */
   .balign 256
-  .globl _rom_ext_interrupt_vector
+  .global _rom_ext_interrupt_vector
   .type _rom_ext_interrupt_vector, @function
 _rom_ext_interrupt_vector:
-
   // RISC-V Standard (Vectored) Interrupt Handlers:
 
   // Exception and User Software Interrupt Handler.
@@ -83,13 +83,12 @@ _rom_ext_interrupt_vector:
 
   // On Ibex interrupt id 31 is for non-maskable interrupts.
   unimp
-
-  // Set size so this vector can be disassembled.
   .size _rom_ext_interrupt_vector, .-_rom_ext_interrupt_vector
 
   // Re-enable compressed instructions, linker relaxation.
   .option pop
 
+// -----------------------------------------------------------------------------
 
 /**
  * ROM_EXT runtime initialization code.
@@ -109,16 +108,16 @@ _rom_ext_interrupt_vector:
   .option push
   .option norelax
 
-/**
- * Entry point.
- *
- * This symbol is jumped to from `mask_rom_boot` using the `entry_point` field
- * of the manifest.
- */
-  .globl _rom_ext_start_boot
+  /**
+   * Entry point.
+   *
+   * This symbol is jumped to from `mask_rom_boot` using the `entry_point` field
+   * of the manifest.
+   */
+  .balign 4
+  .global _rom_ext_start_boot
   .type _rom_ext_start_boot, @function
 _rom_ext_start_boot:
-
   /**
    * Disable Interrupts.
    *
@@ -167,7 +166,6 @@ _rom_ext_start_boot:
   la   a0, _data_start
   la   a1, _data_end
   la   a2, _data_init_start
-  .extern crt_section_copy
   call crt_section_copy
 
   /**
@@ -178,7 +176,6 @@ _rom_ext_start_boot:
    */
   la   a0, _bss_start
   la   a1, _bss_end
-  .extern crt_section_clear
   call crt_section_clear
 
   // Re-clobber all of the temporary registers.
@@ -214,8 +211,5 @@ _rom_ext_start_boot:
   /**
    * Jump to C Code
    */
-  .extern rom_ext_main
   tail rom_ext_main
-
-  // Set size so this function can be disassembled.
   .size _rom_ext_start_boot, .-_rom_ext_start_boot

--- a/sw/device/silicon_owner/bare_metal/bare_metal_start.S
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_start.S
@@ -18,27 +18,27 @@
   // link-time, which we also really don't want.
   .option norelax
 
-/**
- * `_interrupt_vector` is an ibex-compatible interrupt vector.
- *
- * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts. The
- * vector must be 256-byte aligned, as Ibex's vectoring mechanism requires that.
- *
- * Only the following will be used by Ibex:
- * - Exception Handler (Entry 0)
- * - Machine Software Interrupt Handler (Entry 3)
- * - Machine Timer Interrupt Handler (Entry 7)
- * - Machine External Interrupt Handler (Entry 11)
- * - Vendor Interrupt Handlers (Entries 16-31)
- *
- * More information about Ibex's interrupts can be found here:
- *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
- */
+  /**
+   * `_interrupt_vector` is an ibex-compatible interrupt vector.
+   *
+   * Interrupt vectors in Ibex have 32 4-byte entries for 32 possible interrupts.
+   * The vector must be 256-byte aligned, as Ibex's vectoring mechanism requires
+   * that.
+   *
+   * Only the following will be used by Ibex:
+   * - Exception Handler (Entry 0)
+   * - Machine Software Interrupt Handler (Entry 3)
+   * - Machine Timer Interrupt Handler (Entry 7)
+   * - Machine External Interrupt Handler (Entry 11)
+   * - Vendor Interrupt Handlers (Entries 16-31)
+   *
+   * More information about Ibex's interrupts can be found here:
+   *   https://ibex-core.readthedocs.io/en/latest/03_reference/exception_interrupts.html
+   */
   .balign 256
-  .globl _interrupt_vector
+  .global _interrupt_vector
   .type _interrupt_vector, @function
 _interrupt_vector:
-
   // RISC-V Standard (Vectored) Interrupt Handlers:
 
   // Exception and User Software Interrupt Handler.
@@ -83,13 +83,12 @@ _interrupt_vector:
 
   // On Ibex interrupt id 31 is for non-maskable interrupts.
   unimp
-
-  // Set size so this vector can be disassembled.
   .size _interrupt_vector, .-_interrupt_vector
 
   // Re-enable compressed instructions, linker relaxation.
   .option pop
 
+// -----------------------------------------------------------------------------
 
 /**
  * Runtime initialization code.
@@ -109,13 +108,13 @@ _interrupt_vector:
   .option push
   .option norelax
 
-/**
- * Entry point.
- */
-  .globl _start_boot
+  /**
+   * Entry point.
+   */
+  .balign 4
+  .global _start_boot
   .type _start_boot, @function
 _start_boot:
-
   /**
    * Disable Interrupts.
    *
@@ -164,7 +163,6 @@ _start_boot:
   la   a0, _data_start
   la   a1, _data_end
   la   a2, _data_init_start
-  .extern crt_section_copy
   call crt_section_copy
 
   /**
@@ -175,7 +173,6 @@ _start_boot:
    */
   la   a0, _bss_start
   la   a1, _bss_end
-  .extern crt_section_clear
   call crt_section_clear
 
   // Re-clobber all of the temporary registers.
@@ -211,8 +208,5 @@ _start_boot:
   /**
    * Jump to C Code
    */
-  .extern bare_metal_main
   tail bare_metal_main
-
-  // Set size so this function can be disassembled.
   .size _start_boot, .-_start_boot


### PR DESCRIPTION
This PR has two parts:
1. Fix several inconsistencies in our assembly files, favoring the most explicit existing practice.
2. Document the style choices in the style guide.

The latter captures all of the changes I made in the former. This PR is in response to a chat Michael and I had about some style nits in one of my own assembly PRs. :)