### PR TITLE
[mask_rom, cleanup] Fix mask_rom link error

### DIFF
--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -217,6 +217,7 @@ dual_cc_library(
     name = "sigverify_keys_ptrs",
     srcs = dual_inputs(
         host = ["mock_sigverify_keys_ptrs.cc"],
+        device = ["sigverify_keys_ptrs.c"],
     ),
     hdrs = dual_inputs(
         host = ["mock_sigverify_keys_ptrs.h"],

--- a/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.c
+++ b/sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.c
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/mask_rom/sigverify_keys_ptrs.h"
+
+extern const sigverify_mask_rom_key_t *sigverify_rsa_keys_ptr_get(void);
+extern size_t sigverify_num_rsa_keys_get(void);
+extern size_t sigverify_rsa_keys_step_get(void);


### PR DESCRIPTION
1. Realize symbols from sigverify_keys_ptrs.h.

Signed-off-by: Chris Frantz <cfrantz@google.com>