### PR TITLE
[edn/dv] Remove endpoint_width/genbits_width TODO/constraint

### DIFF
--- a/hw/ip/edn/data/edn_testplan.hjson
+++ b/hw/ip/edn/data/edn_testplan.hjson
@@ -51,8 +51,6 @@
       desc: '''
             Verify genbits input is transferred to endpoint(s) as predicted.
             Verify fips bit(s) are properly transferred to endpoint.
-            // TODO: Implement below in vseq
-            Endpoints request non-multiple of ENDPOINT_BUS_SIZE/GENBITS_BUS_SIZE.
             '''
       milestone: V2
       tests: ["edn_genbits"]

--- a/hw/ip/edn/dv/env/edn_scoreboard.sv
+++ b/hw/ip/edn/dv/env/edn_scoreboard.sv
@@ -185,9 +185,6 @@ class edn_scoreboard extends cip_base_scoreboard #(
   function void check_phase(uvm_phase phase);
     super.check_phase(phase);
 
-    if (endpoint_data_q.size()) begin
-      `uvm_fatal(`gfn, $sformatf("endpoint_data_q.size = %0d at EOT", endpoint_data_q.size()))
-    end
     // TODO: post test checks - ensure that all local fifos and queues are empty
   endfunction
 

--- a/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
+++ b/hw/ip/edn/dv/env/seq_lib/edn_genbits_vseq.sv
@@ -33,10 +33,11 @@ class edn_genbits_vseq extends edn_base_vseq;
     for (int i = 0; i < num_requesters; i++) begin
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(num_ep_reqs,
                                          num_ep_reqs inside
-                                             { [cfg.min_num_ep_reqs:cfg.max_num_ep_reqs] };
-                                         // TODO: Make num_ep_reqs not 4*num_cs_reqs
-                                         num_ep_reqs % 4 == 0;)
+                                             { [cfg.min_num_ep_reqs:cfg.max_num_ep_reqs] };)
       num_cs_reqs += num_ep_reqs/(csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH);
+      if (num_ep_reqs % (csrng_pkg::GENBITS_BUS_WIDTH/ENDPOINT_BUS_WIDTH)) begin
+        num_cs_reqs += 1;
+      end
 
       if (i == extra_requester) begin
         if (cfg.boot_req_mode == MuBi4True) begin


### PR DESCRIPTION
Removed TODO from testplan and associated constraint from vseq @weicaiyang mentioned in PR #11552 

Signed-off-by: Steve Nelson <steve.nelson@wdc.com>