### PR TITLE
[dvsim] Fix looping through old result directories

### DIFF
--- a/util/dvsim/FlowCfg.py
+++ b/util/dvsim/FlowCfg.py
@@ -6,6 +6,7 @@ import datetime
 import logging as log
 import os
 import pprint
+import re
 import subprocess
 import sys
 from shutil import which
@@ -558,7 +559,9 @@ class FlowCfg():
         for rdir in results_dirs:
             dirname = rdir.replace(self.results_server_path, '')
             dirname = dirname.replace('/', '')
-            if dirname == "latest":
+            # Only track history directories with format
+            # "year.month.date_hour.min.sec".
+            if not bool(re.match('[\d*.]*_[\d*.]*', dirname)):
                 continue
             rdirs.append(dirname)
         rdirs.sort(reverse=True)


### PR DESCRIPTION
Currently implemention will list all directories for old result, and
only filter out the ones that is not named `latest`. But we actually
only wants to list all the generated directories with name format:
"year.month.data_hour.min.sec". Because there are other directories such
as `lint`, `latest` ect.
TO avoid listing all these directories in nightly regression history
section, we use a regular expression to find these actual history
directories.

Current regression dashboard:
![image](https://user-images.githubusercontent.com/11466553/161872645-24e7faa4-7a07-4fd0-b0c4-719a72deb280.png)


Signed-off-by: Cindy Chen <chencindy@opentitan.org>