### PR TITLE
[lib] Switch memory.c to defining weak symbols

### DIFF
--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -72,7 +72,9 @@ cc_library(
     # This library defines memcpy(), so we can't have LLVM rewriting memcpy
     # into a call to itself.
     copts = ["-fno-builtin"],
-    deps = [":macros"],
+    deps = [
+        ":macros",
+    ],
 )
 
 cc_library(

--- a/sw/device/lib/base/memory.c
+++ b/sw/device/lib/base/memory.c
@@ -4,17 +4,12 @@
 
 #include "sw/device/lib/base/memory.h"
 
-// Some symbols below are only defined for device builds. For host builds, we
-// their implementations will be provided by the host's libc implementation.
-//
-// If you are getting missing symbol linker errors for these symbols, it's
-// likely because you have specified `-nostdlib` for a host build. Host builds
-// must be linked against the system libc.
-//
-// This approach is used so that DIFs can depend on `memory.h`, but also be
-// built for host-side software.
+#include "sw/device/lib/base/macros.h"
 
-#if !defined(HOST_BUILD)
+// The symbols below are all provided by the host libc. To avoid linker clashes,
+// they are all marked as `OT_WEAK`.
+
+OT_WEAK
 void *memcpy(void *restrict dest, const void *restrict src, size_t len) {
   uint8_t *dest8 = (uint8_t *)dest;
   uint8_t *src8 = (uint8_t *)src;
@@ -23,9 +18,8 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t len) {
   }
   return dest;
 }
-#endif  // !defined(HOST_BUILD)
 
-#if !defined(HOST_BUILD)
+OT_WEAK
 void *memset(void *dest, int value, size_t len) {
   uint8_t *dest8 = (uint8_t *)dest;
   uint8_t value8 = (uint8_t)value;
@@ -34,7 +28,6 @@ void *memset(void *dest, int value, size_t len) {
   }
   return dest;
 }
-#endif  // !defined(HOST_BUILD)
 
 enum {
   kMemCmpEq = 0,
@@ -42,7 +35,7 @@ enum {
   kMemCmpGt = 42,
 };
 
-#if !defined(HOST_BUILD)
+OT_WEAK
 int memcmp(const void *lhs, const void *rhs, size_t len) {
   const uint8_t *lhs8 = (uint8_t *)lhs;
   const uint8_t *rhs8 = (uint8_t *)rhs;
@@ -55,8 +48,8 @@ int memcmp(const void *lhs, const void *rhs, size_t len) {
   }
   return kMemCmpEq;
 }
-#endif  // !defined(HOST_BUILD)
 
+OT_WEAK
 int memrcmp(const void *lhs, const void *rhs, size_t len) {
   const uint8_t *lhs8 = (uint8_t *)lhs;
   const uint8_t *rhs8 = (uint8_t *)rhs;
@@ -72,7 +65,7 @@ int memrcmp(const void *lhs, const void *rhs, size_t len) {
   return kMemCmpEq;
 }
 
-#if !defined(HOST_BUILD)
+OT_WEAK
 void *memchr(const void *ptr, int value, size_t len) {
   uint8_t *ptr8 = (uint8_t *)ptr;
   uint8_t value8 = (uint8_t)value;
@@ -83,8 +76,8 @@ void *memchr(const void *ptr, int value, size_t len) {
   }
   return NULL;
 }
-#endif  // !defined(HOST_BUILD)
 
+OT_WEAK
 void *memrchr(const void *ptr, int value, size_t len) {
   uint8_t *ptr8 = (uint8_t *)ptr;
   uint8_t value8 = (uint8_t)value;


### PR DESCRIPTION
This removes the comparatively fussy do-it-with-a-macro behavior, so that we don't really have to think about how this gets linked in too hard.