### PR TITLE
[mask_rom] Add a separate library for .static_critical symbols

### DIFF
--- a/sw/device/silicon_creator/lib/base/BUILD
+++ b/sw/device/silicon_creator/lib/base/BUILD
@@ -50,6 +50,19 @@ cc_test(
     ],
 )
 
+cc_library(
+    name = "static_critical_sec_mmio",
+    srcs = ["static_critical_sec_mmio.c"],
+    deps = [
+        ":sec_mmio",
+        "//sw/device/lib/base:macros",
+    ],
+    # This library provides a special symbol that the linker will find.
+    # We want this to be a linker input to ensure the weak version in
+    # sec_mmio.c is overriden.
+    alwayslink = True,
+)
+
 ld_library(
     name = "static_critical_sections",
     fragments = ["static_critical.ld"],

--- a/sw/device/silicon_creator/lib/base/sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/sec_mmio.c
@@ -12,7 +12,7 @@
 
 // The context is declared as weak so that the mask ROM and ROM_EXT may
 // override its location.
-__attribute__((weak)) volatile sec_mmio_ctx_t sec_mmio_ctx;
+OT_WEAK volatile sec_mmio_ctx_t sec_mmio_ctx;
 
 enum {
   // Value with good hamming weight used to mask the stored expected value.

--- a/sw/device/silicon_creator/lib/base/static_critical.ld
+++ b/sw/device/silicon_creator/lib/base/static_critical.ld
@@ -5,10 +5,19 @@
 /**
  * Variables stored in the .static_critical section of RAM.
  *
- * This should be included into a NOLOAD .static_critical section located at
- * the origin of main RAM.
+ * This file should be included inside of a `SECTIONS` block where a
+ * `ram_main` memory is defined, and should come before all other main
+ * memory sections.
  */
-ASSERT(. == ORIGIN(ram_main), "Error: .static_critical section not at the base address of main RAM.");
-ASSERT(. - ADDR(.static_critical) == 0, "Error: .static_critical.sec_mmio_ctx section offset has changed.");
-KEEP(*(.static_critical.sec_mmio_ctx))
-ASSERT(. - ADDR(.static_critical) == 1616, "Error: .static_critical.sec_mmio_ctx section size has changed");
+
+.static_critical ORIGIN(ram_main) (NOLOAD) : ALIGN(4) {
+  ASSERT(
+    . == ORIGIN(ram_main),
+    "Error: .static_critical section not at the base address of main RAM.");
+
+  KEEP(*(.static_critical.sec_mmio_ctx))
+  
+  ASSERT(
+    . - ADDR(.static_critical) == 1616,
+    "Error: .static_critical.sec_mmio_ctx section size has changed");
+} > ram_main

--- a/sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c
+++ b/sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c
@@ -1,0 +1,13 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
+
+// Secure MMIO context.
+//
+// This is placed at a fixed location in memory within the .static_critical
+// section. It will be populated by the mask ROM before the jump to ROM_EXT.
+OT_SECTION(".static_critical.sec_mmio_ctx")
+volatile sec_mmio_ctx_t sec_mmio_ctx;

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -55,13 +55,6 @@
 // Define counters and constant values required by the CFI counter macros.
 CFI_DEFINE_COUNTERS(rom_counters, ROM_CFI_FUNC_COUNTERS_TABLE);
 
-// Secure MMIO context.
-//
-// This is placed at a fixed location in memory within the .static_critical
-// section. The location of this data is known to ROM_EXT.
-__attribute__((section(".static_critical.sec_mmio_ctx")))
-volatile sec_mmio_ctx_t sec_mmio_ctx;
-
 // In-memory copy of the ePMP register configuration.
 epmp_state_t epmp;
 // Life cycle state of the chip.
@@ -297,8 +290,8 @@ void mask_rom_interrupt_handler(void) {
 // We only need a single handler for all mask ROM interrupts, but we want to
 // keep distinct symbols to make writing tests easier.  In the mask ROM,
 // alias all interrupt handler symbols to the single handler.
-void mask_rom_exception_handler(void)
-    __attribute__((alias("mask_rom_interrupt_handler")));
+OT_ALIAS("mask_rom_interrupt_handler")
+void mask_rom_exception_handler(void);
 
-void mask_rom_nmi_handler(void)
-    __attribute__((alias("mask_rom_interrupt_handler")));
+OT_ALIAS("mask_rom_interrupt_handler")
+void mask_rom_nmi_handler(void);

--- a/sw/device/silicon_creator/mask_rom/mask_rom.ld
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.ld
@@ -130,16 +130,8 @@ SECTIONS {
   /**
    * Critical static data that is accessible by both the mask ROM and the ROM
    * extension.
-   *
-   * Each variable added to .static_critical must be in its own subsection
-   * named after the variable.
-   *
-   * This data is not initialized during CRT (hence NOLOAD). The mask ROM must
-   * initialize this data explicitly.
    */
-  .static_critical ORIGIN(ram_main) (NOLOAD) : ALIGN(4) {
-    INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
-  } > ram_main
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
 
   /**
    * Mutable data section. This will be initialized from rom at runtime by the

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -200,6 +200,7 @@ mask_rom_lib = declare_dependency(
     hw_ip_sensor_ctrl_reg_h,
     hw_ip_sram_ctrl_reg_h,
     'mask_rom_start.S',
+    meson.project_source_root() / 'sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c',
   ],
     link_args: rom_link_args,
     dependencies: [

--- a/sw/device/silicon_creator/rom_ext/BUILD
+++ b/sw/device/silicon_creator/rom_ext/BUILD
@@ -108,6 +108,7 @@ cc_library(
         "//sw/device/silicon_creator/lib:manifest",
         "//sw/device/silicon_creator/lib:shutdown",
         "//sw/device/silicon_creator/lib/base:sec_mmio",
+        "//sw/device/silicon_creator/lib/base:static_critical_sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
         "//sw/device/silicon_creator/lib/drivers:hmac",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",

--- a/sw/device/silicon_creator/rom_ext/meson.build
+++ b/sw/device/silicon_creator/rom_ext/meson.build
@@ -85,6 +85,7 @@ foreach slot, slot_link_args : rom_ext_link_info
     slot: declare_dependency(
       sources: [
         'rom_ext_start.S',
+        meson.project_source_root() / 'sw/device/silicon_creator/lib/base/static_critical_sec_mmio.c',
       ],
       link_args: slot_link_args[0],
       dependencies: [

--- a/sw/device/silicon_creator/rom_ext/rom_ext.c
+++ b/sw/device/silicon_creator/rom_ext/rom_ext.c
@@ -26,19 +26,12 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
 
-// Secure MMIO context.
-//
-// This is placed at a fixed location in memory within the .static_critical
-// section. It will be populated by the ROM_EXT before the jump to ROM_EXT.
-__attribute__((section(".static_critical.sec_mmio_ctx")))  //
-volatile sec_mmio_ctx_t sec_mmio_ctx;
-
 // In-memory copy of the ePMP register configuration.
 epmp_state_t epmp;
 // Life cycle state of the chip.
 lifecycle_state_t lc_state = kLcStateProd;
 
-static inline rom_error_t rom_ext_irq_error(void) {
+static rom_error_t rom_ext_irq_error(void) {
   uint32_t mcause;
   CSR_READ(CSR_REG_MCAUSE, &mcause);
   // Shuffle the mcause bits into the uppermost byte of the word and report
@@ -139,8 +132,8 @@ void rom_ext_interrupt_handler(void) { shutdown_finalize(rom_ext_irq_error()); }
 // We only need a single handler for all ROM_EXT interrupts, but we want to
 // keep distinct symbols to make writing tests easier.  In the ROM_EXT,
 // alias all interrupt handler symbols to the single handler.
-void rom_ext_exception_handler(void)
-    __attribute__((alias("rom_ext_interrupt_handler")));
+OT_ALIAS("rom_ext_interrupt_handler")
+void rom_ext_exception_handler(void);
 
-void rom_ext_nmi_handler(void)
-    __attribute__((alias("rom_ext_interrupt_handler")));
+OT_ALIAS("rom_ext_interrupt_handler")
+void rom_ext_nmi_handler(void);

--- a/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
+++ b/sw/device/silicon_creator/rom_ext/rom_ext_common.ld
@@ -94,16 +94,8 @@ SECTIONS {
   /**
    * Critical static data that is accessible by both the mask ROM and the ROM
    * extension.
-   *
-   * Each variable added to .static_critical must be in its own subsection
-   * named after the variable.
-   *
-   * This data is not initialized during CRT (hence NOLOAD). Instead it will
-   * be initialized by the mask ROM.
    */
-  .static_critical ORIGIN(ram_main) (NOLOAD) : ALIGN(4) {
-    INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
-  } > ram_main
+  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
 
   /**
    * Mutable data section, at the bottom of ram_main. This will be initialized


### PR DESCRIPTION
This is a cleanup to centralize where static_critical stuff is defined. @alphan I'd expecially like to hear your thoughts on this cleanup.