### PR TITLE
[dv/otp] Increase FSM coverage

### DIFF
--- a/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
+++ b/hw/ip/otp_ctrl/dv/env/otp_ctrl_env_pkg.sv
@@ -182,6 +182,15 @@ package otp_ctrl_env_pkg;
     bit write_lock;
   } otp_part_access_lock_t;
 
+  // OTP conditions when driving specific port.
+  typedef enum bit [2:0] {
+    DuringOTPInit,
+    DuringOTPDaiBusy,
+    DuringOTPDaiDigest,
+    DuringOTPRead,
+    DriveRandomly
+  } port_drive_condition_e;
+
   typedef virtual otp_ctrl_if otp_ctrl_vif;
 
   parameter otp_err_code_e OTP_TERMINAL_ERRS[4] = {OtpMacroEccUncorrError,

--- a/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
+++ b/hw/ip/otp_ctrl/dv/env/seq_lib/otp_ctrl_check_fail_vseq.sv
@@ -11,6 +11,10 @@ class otp_ctrl_check_fail_vseq extends otp_ctrl_dai_lock_vseq;
 
   `uvm_object_new
 
+  constraint ecc_otp_err_c {
+    ecc_otp_err inside {OtpEccCorrErr, OtpNoEccErr};
+  }
+
   constraint ecc_chk_err_c {
     // TODO: currently only max to 1 error bits, once implemetned ECC in mem_bkdr_util, we can
     // fully randomize num of error bits

--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -151,6 +151,11 @@
       name: otp_ctrl_test_access
       uvm_test_seq: otp_ctrl_test_access_vseq
     }
+
+    {
+      name: otp_ctrl_stress_all_with_rand_reset
+      reseed: 100
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR increases the FSM cov by:
1). Add an enum to control random timing to issue reset or lc_esc.
2). Add some flags to mark specific FSM states: such as digests cal,
  init, etc.
3). Enhance some randomizations in existing tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>