### PR TITLE
[bazel] Clean up the WORKSPACE file

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,6 +9,7 @@ load("@lowrisc_lint//rules:rules.bzl", "licence_check")
 package(default_visibility = ["//visibility:public"])
 
 unbuildify = [
+    "./WORKSPACE",  # Prevent Buildifier from inserting unnecessary newlines.
     "./**/vendor/**",
     "./util/lowrisc_misc-linters/**",
 ]

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,201 +2,60 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+workspace(name = "lowrisc_opentitan")
 
-################################################################################
-# Bazel Embedded
-#
-# Contains rules that support building SW for embedded targets. Specifically, we
-# maintain a fork to build for RISCV32I.
-################################################################################
-git_repository(
-    name = "bazel_embedded",
-    commit = "fe65a8aca35ae0bae563efd6a29cc14fcb15140d",
-    remote = "https://github.com/lowRISC/bazel-embedded.git",
-    shallow_since = "1639417565 -0800",
-)
-
-load("@bazel_embedded//:bazel_embedded_deps.bzl", "bazel_embedded_deps")
-
+# Bazel Embedded; Bazel platform configuration for embedded environments.
+load("//third_party/bazel_embedded:repos.bzl", "bazel_embedded_repos")
+bazel_embedded_repos()
+load("//third_party/bazel_embedded:deps.bzl", "bazel_embedded_deps")
 bazel_embedded_deps()
 
-load("@bazel_embedded//platforms:execution_platforms.bzl", "register_platforms")
+# The lowRISC LLVM Toolchain
+load("//third_party/lowrisc_toolchain:repos.bzl", "lowrisc_toolchain_repos")
+lowrisc_toolchain_repos()
+load("//third_party/lowrisc_toolchain:deps.bzl", "lowrisc_toolchain_deps")
+lowrisc_toolchain_deps()
 
-register_platforms()
+# C/C++ Library Dependencies
+load("//third_party/cc:repos.bzl", "cc_repos")
+cc_repos()
 
-load(
-    "@bazel_embedded//toolchains/compilers/lowrisc_toolchain_rv32imc:lowrisc_toolchain_rv32imc_repository.bzl",
-    "lowrisc_toolchain_rv32imc_compiler",
-)
+# Go Toolchain
+load("//third_party/go:repos.bzl", "go_repos")
+go_repos()
+load("//third_party/go:deps.bzl", "go_deps")
+go_deps()
 
-lowrisc_toolchain_rv32imc_compiler()
+# Python Toolchain + PIP Dependencies
+load("//third_party/python:repos.bzl", "python_repos")
+python_repos()
+load("//third_party/python:deps.bzl", "python_deps")
+python_deps()
+load("//third_party/python:pip.bzl", "pip_deps")
+pip_deps()
 
-load(
-    "@bazel_embedded//toolchains/lowrisc_toolchain_rv32imc:lowrisc_toolchain_rv32imc.bzl",
-    "register_lowrisc_toolchain_rv32imc_toolchain",
-)
+# Rust Toolchain + crates.io Dependencies
+load("//third_party/rust:repos.bzl", "rust_repos")
+rust_repos()
+load("//third_party/rust:deps.bzl", "rust_deps")
+rust_deps()
 
-register_lowrisc_toolchain_rv32imc_toolchain()
-
-################################################################################
-# Go Rules
-################################################################################
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
-    urls = [
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
-    ],
-)
-
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains()
-
-################################################################################
-# Python Rules
-################################################################################
-http_archive(
-    name = "rules_python",
-    sha256 = "9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6",
-    strip_prefix = "rules_python-0.8.0",
-    url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
-)
-
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
-load("@rules_python//python:pip.bzl", "pip_install")
-
-python_register_toolchains(
-    name = "python3_9",
-    python_version = "3.9",
-)
-
-load("@python3_9//:defs.bzl", "interpreter")
-
-pip_install(
-    name = "ot_python_deps",
-    python_interpreter_target = interpreter,
-    requirements = "//:python-requirements.txt",
-)
-
-################################################################################
-# Rust Rules
-################################################################################
-http_archive(
-    name = "rules_rust",
-    sha256 = "531bdd470728b61ce41cf7604dc4f9a115983e455d46ac1d0c1632f613ab9fc3",
-    strip_prefix = "rules_rust-d8238877c0e552639d3e057aadd6bfcf37592408",
-    urls = [
-        # `main` branch as of 2021-08-23
-        "https://github.com/bazelbuild/rules_rust/archive/d8238877c0e552639d3e057aadd6bfcf37592408.tar.gz",
-    ],
-)
-
-load("@rules_rust//rust:repositories.bzl", "rust_repositories")
-
-rust_repositories(
-    edition = "2018",
-    version = "1.58.0",
-)
-
-load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")
-
-raze_fetch_remote_crates()
-
-################################################################################
-# Vendored SW
-################################################################################
-# We have a 'vendored' copy of the googletest repo in our repository.
-# In the future, we may want to change this to a git repo or http archive.
-local_repository(
-    name = "googletest",
-    path = "sw/vendor/google_googletest",
-)
-
-# We have a 'vendored' copy of the google_verible_verilog_syntax_py repo
-local_repository(
-    name = "google_verible_verilog_syntax_py",
-    path = "hw/ip/prim/util/vendor/google_verible_verilog_syntax_py",
-)
-
-################################################################################
-# Third Party SW
-################################################################################
-# Abseil is required by googletest.
-http_archive(
-    name = "com_google_absl",
-    strip_prefix = "abseil-cpp-master",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
-)
-
-# Bazel Gazelle
-http_archive(
-    name = "bazel_gazelle",
-    sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
-    urls = [
-        "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
-    ],
-)
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-gazelle_dependencies()
-
-# Protobuf
-git_repository(
-    name = "com_google_protobuf",
-    commit = "520c601c99012101c816b6ccc89e8d6fc28fdbb8",
-    remote = "https://github.com/protocolbuffers/protobuf",
-)
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
+# Protobuf Toolchain
+load("//third_party/protobuf:repos.bzl", "protobuf_repos")
+protobuf_repos()
+load("//third_party/protobuf:deps.bzl", "protobuf_deps")
 protobuf_deps()
 
-# Buildifier (linting tool for our WORKSPACE and BUILD files)
-http_archive(
-    name = "com_github_bazelbuild_buildtools",
-    strip_prefix = "buildtools-main",
-    url = "https://github.com/bazelbuild/buildtools/archive/main.zip",
-)
+# Various linters
+load("//third_party/lint:repos.bzl", "lint_repos")
+lint_repos()
+load("//third_party/lint:deps.bzl", "lint_deps")
+lint_deps()
 
-# boringssl `main-with-bazel` branch as of 2021-11-09.
-git_repository(
-    name = "boringssl",
-    commit = "4fb158925f7753d80fb858cb0239dff893ef9f15",
-    remote = "https://boringssl.googlesource.com/boringssl",
-)
+# FreeRTOS; used by the OTTF
+load("//third_party/freertos:repos.bzl", "freertos_repos")
+freertos_repos()
 
-git_repository(
-    name = "mundane",
-    commit = "f516499751b45969ac5a95091b1f68cf5ec23f04",
-    patch_args = ["-p1"],
-    patches = ["//sw/vendor/patches/mundane:build_with_bazel.patch"],
-    remote = "https://fuchsia.googlesource.com/mundane",
-)
-
-load("//third_party/freertos:deps.bzl", "freertos_deps")
-
-freertos_deps()
-
-git_repository(
-    name = "lowrisc_lint",
-    commit = "8bca6cff6f5def9ba866a11b7eeb3f4a12f9f516",
-    remote = "https://github.com/lowrisc/misc-linters",
-)
-
-load("@lowrisc_lint//rules:deps.bzl", "lowrisc_misc_linters_dependencies")
-
-lowrisc_misc_linters_dependencies()
-
-load("@lowrisc_lint//rules:pip.bzl", "lowrisc_misc_linters_pip_dependencies")
-
-lowrisc_misc_linters_pip_dependencies()
-
-load("//third_party/riscv-compliance:deps.bzl", "riscv_compliance_deps")
-
-riscv_compliance_deps()
+# RISC-V Compliance Tests
+load("//third_party/riscv-compliance:repos.bzl", "riscv_compliance_repos")
+riscv_compliance_repos()

--- a/rules/cc_side_outputs.bzl
+++ b/rules/cc_side_outputs.bzl
@@ -90,7 +90,7 @@ def _cc_compile_different_output(name, target, ctx, extension, flags, process_al
 
         # C files are treated specially, and have different flags applied
         # (e.g. --std=c11).
-        # 
+        #
         # Things that are neither C or C++ TU files don't get any flags.
         opts = ctx.fragments.cpp.copts + ctx.rule.attr.copts
         if source_file.extension == "c":

--- a/rules/linker.bzl
+++ b/rules/linker.bzl
@@ -10,22 +10,22 @@ def _ld_library_impl(ctx):
     if ctx.file.script:
         files += ctx.files.script
         user_link_flags += [
-          "-Wl,-T,{}".format(ctx.file.script.path),
+            "-Wl,-T,{}".format(ctx.file.script.path),
         ]
 
     return [
-      cc_common.merge_cc_infos(
-        direct_cc_infos = [CcInfo(
-            linking_context = cc_common.create_linking_context(
-                linker_inputs = depset([cc_common.create_linker_input(
-                    owner = ctx.label,
-                    additional_inputs = depset(files),
-                    user_link_flags = depset(user_link_flags),
-                )]),
-            ),
-        )],
-        cc_infos = [dep[CcInfo] for dep in ctx.attr.deps],
-      ),
+        cc_common.merge_cc_infos(
+            direct_cc_infos = [CcInfo(
+                linking_context = cc_common.create_linking_context(
+                    linker_inputs = depset([cc_common.create_linker_input(
+                        owner = ctx.label,
+                        additional_inputs = depset(files),
+                        user_link_flags = depset(user_link_flags),
+                    )]),
+                ),
+            )],
+            cc_infos = [dep[CcInfo] for dep in ctx.attr.deps],
+        ),
     ]
 
 ld_library = rule(

--- a/sw/device/lib/base/BUILD
+++ b/sw/device/lib/base/BUILD
@@ -127,7 +127,6 @@ cc_test(
     ],
 )
 
-
 # TODO: Until Meson is removed, these files need to stay in a different
 # directory, but eventually they will be hoisted to live alongside the
 # targets they mock.

--- a/third_party/bazel_embedded/BUILD
+++ b/third_party/bazel_embedded/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/bazel_embedded/deps.bzl
+++ b/third_party/bazel_embedded/deps.bzl
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_embedded//:bazel_embedded_deps.bzl", _bazel_embedded_deps = "bazel_embedded_deps")
+load("@bazel_embedded//platforms:execution_platforms.bzl", "register_platforms")
+
+def bazel_embedded_deps():
+    _bazel_embedded_deps()
+    register_platforms()

--- a/third_party/bazel_embedded/repos.bzl
+++ b/third_party/bazel_embedded/repos.bzl
@@ -1,0 +1,15 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def bazel_embedded_repos():
+    # Contains rules that support building SW for embedded targets. Specifically, we
+    # maintain a fork to build for RISCV32I.
+    git_repository(
+        name = "bazel_embedded",
+        commit = "fe65a8aca35ae0bae563efd6a29cc14fcb15140d",
+        remote = "https://github.com/lowRISC/bazel-embedded.git",
+        shallow_since = "1639417565 -0800",
+    )

--- a/third_party/cc/BUILD
+++ b/third_party/cc/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/cc/repos.bzl
+++ b/third_party/cc/repos.bzl
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def cc_repos():
+    git_repository(
+        name = "rules_cc",
+        commit = "a636005ba28c0344da5110bd8532184c74b6ffdf",
+        remote = "https://github.com/bazelbuild/rules_cc.git",
+        shallow_since = "1583316607 -0800",
+    )
+
+    http_archive(
+        name = "com_google_absl",
+        strip_prefix = "abseil-cpp-master",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
+    )
+
+    native.local_repository(
+        name = "googletest",
+        path = "sw/vendor/google_googletest",
+    )

--- a/third_party/freertos/repos.bzl
+++ b/third_party/freertos/repos.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
-def freertos_deps():
+def freertos_repos():
     new_git_repository(
         name = "freertos",
         build_file = Label("//third_party/freertos:BUILD.freertos.bazel"),

--- a/third_party/go/BUILD
+++ b/third_party/go/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/go/deps.bzl
+++ b/third_party/go/deps.bzl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+
+def go_deps():
+    go_rules_dependencies()
+    go_register_toolchains()
+    gazelle_dependencies()

--- a/third_party/go/repos.bzl
+++ b/third_party/go/repos.bzl
@@ -1,0 +1,21 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def go_repos():
+    http_archive(
+        name = "io_bazel_rules_go",
+        sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+        urls = [
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+        ],
+    )
+    http_archive(
+        name = "bazel_gazelle",
+        sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
+        urls = [
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.22.2/bazel-gazelle-v0.22.2.tar.gz",
+        ],
+    )

--- a/third_party/lint/BUILD
+++ b/third_party/lint/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/lint/deps.bzl
+++ b/third_party/lint/deps.bzl
@@ -1,0 +1,10 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@lowrisc_lint//rules:deps.bzl", "lowrisc_misc_linters_dependencies")
+load("@lowrisc_lint//rules:pip.bzl", "lowrisc_misc_linters_pip_dependencies")
+
+def lint_deps():
+    lowrisc_misc_linters_dependencies()
+    lowrisc_misc_linters_pip_dependencies()

--- a/third_party/lint/repos.bzl
+++ b/third_party/lint/repos.bzl
@@ -1,0 +1,25 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def lint_repos():
+    # We have a 'vendored' copy of the google_verible_verilog_syntax_py repo
+    native.local_repository(
+        name = "google_verible_verilog_syntax_py",
+        path = "hw/ip/prim/util/vendor/google_verible_verilog_syntax_py",
+    )
+
+    http_archive(
+        name = "com_github_bazelbuild_buildtools",
+        strip_prefix = "buildtools-main",
+        url = "https://github.com/bazelbuild/buildtools/archive/main.zip",
+    )
+
+    git_repository(
+        name = "lowrisc_lint",
+        commit = "8bca6cff6f5def9ba866a11b7eeb3f4a12f9f516",
+        remote = "https://github.com/lowrisc/misc-linters",
+    )

--- a/third_party/lowrisc_toolchain/BUILD
+++ b/third_party/lowrisc_toolchain/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/lowrisc_toolchain/deps.bzl
+++ b/third_party/lowrisc_toolchain/deps.bzl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "@bazel_embedded//toolchains/lowrisc_toolchain_rv32imc:lowrisc_toolchain_rv32imc.bzl",
+    "register_lowrisc_toolchain_rv32imc_toolchain",
+)
+
+def lowrisc_toolchain_deps():
+    register_lowrisc_toolchain_rv32imc_toolchain()

--- a/third_party/lowrisc_toolchain/repos.bzl
+++ b/third_party/lowrisc_toolchain/repos.bzl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load(
+    "@bazel_embedded//toolchains/compilers/lowrisc_toolchain_rv32imc:lowrisc_toolchain_rv32imc_repository.bzl",
+    "lowrisc_toolchain_rv32imc_compiler",
+)
+
+def lowrisc_toolchain_repos():
+    lowrisc_toolchain_rv32imc_compiler()

--- a/third_party/protobuf/BUILD
+++ b/third_party/protobuf/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/protobuf/deps.bzl
+++ b/third_party/protobuf/deps.bzl
@@ -1,0 +1,8 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@com_google_protobuf//:protobuf_deps.bzl", _protobuf_deps = "protobuf_deps")
+
+def protobuf_deps():
+    _protobuf_deps()

--- a/third_party/protobuf/repos.bzl
+++ b/third_party/protobuf/repos.bzl
@@ -1,0 +1,12 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def protobuf_repos():
+    git_repository(
+        name = "com_google_protobuf",
+        commit = "520c601c99012101c816b6ccc89e8d6fc28fdbb8",
+        remote = "https://github.com/protocolbuffers/protobuf",
+    )

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/python/deps.bzl
+++ b/third_party/python/deps.bzl
@@ -1,0 +1,11 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+
+def python_deps():
+    python_register_toolchains(
+        name = "python3",
+        python_version = "3.9",
+    )

--- a/third_party/python/pip.bzl
+++ b/third_party/python/pip.bzl
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:pip.bzl", "pip_install")
+load("@python3//:defs.bzl", "interpreter")
+
+def pip_deps():
+    pip_install(
+        name = "ot_python_deps",
+        python_interpreter_target = interpreter,
+        requirements = "//:python-requirements.txt",
+    )

--- a/third_party/python/repos.bzl
+++ b/third_party/python/repos.bzl
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def python_repos():
+    http_archive(
+        name = "rules_python",
+        sha256 = "9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6",
+        strip_prefix = "rules_python-0.8.0",
+        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
+    )

--- a/third_party/riscv-compliance/repos.bzl
+++ b/third_party/riscv-compliance/repos.bzl
@@ -4,7 +4,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 
-def riscv_compliance_deps():
+def riscv_compliance_repos():
     #new_git_repository(
     #    name = "riscv-compliance",
     #    build_file = Label("//third_party/riscv-compliance:BUILD.riscv-compliance.bazel"),

--- a/third_party/rust/BUILD
+++ b/third_party/rust/BUILD
@@ -1,0 +1,3 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0

--- a/third_party/rust/deps.bzl
+++ b/third_party/rust/deps.bzl
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:repositories.bzl", "rust_repositories")
+load("//third_party/cargo:crates.bzl", "raze_fetch_remote_crates")
+
+def rust_deps():
+    rust_repositories(
+        edition = "2018",
+        version = "1.58.0",
+    )
+    raze_fetch_remote_crates()

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -1,0 +1,33 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+def rust_repos():
+    http_archive(
+        name = "rules_rust",
+        sha256 = "531bdd470728b61ce41cf7604dc4f9a115983e455d46ac1d0c1632f613ab9fc3",
+        strip_prefix = "rules_rust-d8238877c0e552639d3e057aadd6bfcf37592408",
+        urls = [
+            # `main` branch as of 2021-08-23
+            "https://github.com/bazelbuild/rules_rust/archive/d8238877c0e552639d3e057aadd6bfcf37592408.tar.gz",
+        ],
+    )
+
+    # Boring is only used to build Mundane.
+    git_repository(
+        name = "boringssl",
+        # boringssl `main-with-bazel` branch as of 2021-11-09.
+        commit = "4fb158925f7753d80fb858cb0239dff893ef9f15",
+        remote = "https://boringssl.googlesource.com/boringssl",
+    )
+
+    git_repository(
+        name = "mundane",
+        commit = "f516499751b45969ac5a95091b1f68cf5ec23f04",
+        patch_args = ["-p1"],
+        patches = ["//sw/vendor/patches/mundane:build_with_bazel.patch"],
+        remote = "https://fuchsia.googlesource.com/mundane",
+    )


### PR DESCRIPTION
This PR proposes the following organizational structure for remote deps:
1. Dependencies are roughly grouped into directories in //third_party.
2. Each //third_party directory exports a repos.bzl and deps.bzl with
   contents approximately like those in this PR.
3. The WORKSPACE file consists exclusively of loading a repos.bzl, using
   it to instantiate remote dependencies, and then loading and using
   deps.bzl to run any initialization required by that dependency.

Because buildifier wants to place a newline between every single
statement in the WORKSPACE file, which results in a bit of an unreadable
mess, buildifier formatting is disabled for it.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>