### PR TITLE
[ci] Store old versions of bitstream on GCP

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -467,16 +467,6 @@ jobs:
     parameters:
       includePatterns:
         - "/hw/***"
-  - ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
-    - template: ci/gcp-upload-template.yml
-      parameters:
-        parentDir: "$BIN_DIR/hw/top_earlgrey"
-        includeFiles:
-          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit"
-          - "rom.mmi"
-        archiveName: "latest-bitstreams.tar.gz"
-        gcpKeyFile: "gcpkey.json"
-        bucketURI: "gs://opentitan-bitstreams/master/latest"
   - publish: "$(Build.ArtifactStagingDirectory)"
     artifact: chip_earlgrey_cw310-build-out
     displayName: Upload all Vivado artifacts for CW310
@@ -510,6 +500,15 @@ jobs:
     parameters:
       includePatterns:
         - "/hw/***"
+  - ${{ if eq(variables['Build.SourceBranchName'], 'master') }}:
+    - template: ci/gcp-upload-bitstream-template.yml
+      parameters:
+        parentDir: "$BIN_DIR/hw/top_earlgrey"
+        includeFiles:
+          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig"
+          - "lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice"
+        gcpKeyFile: "gcpkey.json"
+        bucketURI: "gs://opentitan-bitstreams/master"
   - publish: "$(Build.ArtifactStagingDirectory)"
     artifact: chip_earlgrey_cw310-splice-mask-rom-build-out
     displayName: Upload all Vivado artifacts for CW310

--- a/ci/gcp-upload-bitstream-template.yml
+++ b/ci/gcp-upload-bitstream-template.yml
@@ -22,9 +22,6 @@ parameters:
   - name: includeFiles
     type: object
     default: []
-  - name: archiveName
-    type: string
-    default: ""
   - name: gcpKeyFile
     type: string
     default: ""
@@ -53,13 +50,16 @@ steps:
 
       . util/build_consts.sh
       printf "$(date -u +%Y-%m-%dT%H:%M:%S)\n$(Build.SourceVersion)" > latest.txt
-      printf  "${{ join('\n', parameters.includeFiles) }}" > include_files.txt
-      tar -C ${{ parameters.parentDir }} -zcvf ${{ parameters.archiveName }} -T include_files.txt
+      printf "${{ join('\n', parameters.includeFiles) }}" > include_files.txt
+      tar -C ${{ parameters.parentDir }} -zcvf bitstream-latest.tar.gz -T include_files.txt
 
       gsutil -o Credentials:gs_service_key_file=$(gcpkey.secureFilePath) \
         cp latest.txt ${{ parameters.bucketURI }}/latest.txt
       gsutil -o Credentials:gs_service_key_file=$(gcpkey.secureFilePath) \
-        cp -r ${{ parameters.archiveName }} ${{ parameters.bucketURI }}/${{ parameters.archiveName }}
+        cp -r bitstream-latest.tar.gz ${{ parameters.bucketURI }}/bitstream-latest.tar.gz
+      gsutil -o Credentials:gs_service_key_file=$(gcpkey.secureFilePath) \
+        cp -r ${{ parameters.bucketURI }}/bitstream-latest.tar.gz ${{ parameters.bucketURI }}/bitstream-$(Build.SourceVersion).tar.gz
     condition: succeeded()
-    displayName: Upload artifacts to GCP bucket
+    continueOnError: true
+    displayName: Upload bitstreams to GCP bucket
 


### PR DESCRIPTION
This commit allows storing old versions of the bitstream instead of
always overwriting the latest bitstream.
- Each new PR merge into master gets stored as `bitstream-{hash}.tar.gz`
- `bitstream-latest.tar.gz` always points to the latest bitstream
- `latest.txt` continues to contain the datetime of the upload and the
  commit hash of the latest bitstream version
- Both the bitstreams with the Test ROM and Mask ROM are included

Signed-off-by: Miles Dai <milesdai@google.com>