### PR TITLE
[flash, dv] Add -xprop=mmsopt to improve VCS run-time

### DIFF
--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -34,7 +34,19 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"],
 
-  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
+  // TODO, #11245. Remove this when the VCS issue is fixed
+  build_modes: [
+    {
+      name: vcs_ip_build_opts
+      build_opts: ["-xprop=mmsopt"]
+    }
+    {
+      name: xcelium_ip_build_opts
+    }
+  ]
+
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts",
+                   "{tool}_ip_build_opts"]
 
   // Flash references pwrmgr directly, need to reference the top version
   overrides: [


### PR DESCRIPTION
With this opt, run-time drops from 9h+ to 18m for flash RMA test
But this opt can't be enabled in all blocks due to #11245

Signed-off-by: Weicai Yang <weicai@google.com>