### PR TITLE
[top, dv] Fix bootstrap test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -194,6 +194,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     spi_host_seq m_spi_host_seq;
     byte sw_byte_q[$];
     uint byte_cnt;
+    uint num_frame;
 
     // wait until spi init is done
     // TODO, in some cases though, we might use UART logger instead of SW logger - need to keep that
@@ -217,14 +218,9 @@ class chip_sw_base_vseq extends chip_base_vseq;
                                      data.size() == SPI_FRAME_BYTE_SIZE;
                                      foreach (data[i]) {data[i] == sw_byte_q[byte_cnt+i];})
       `uvm_send(m_spi_host_seq)
-      if (byte_cnt == 0) begin
-        // SW erase flash after receiving 1st frame
-        wait(cfg.sw_logger_vif.printed_log == "Flash erase successful");
-        // sdo for next frame shouldn't be unknown
-        cfg.m_spi_agent_cfg.en_monitor_checks = 1;
-      end
+      wait (cfg.sw_logger_vif.printed_log == $sformatf("Frame #%0d processed done", num_frame));
+      num_frame++;
 
-      cfg.clk_rst_vif.wait_clks(30_000);
       byte_cnt += SPI_FRAME_BYTE_SIZE;
     end
   endtask

--- a/sw/device/lib/testing/test_rom/bootstrap.c
+++ b/sw/device/lib/testing/test_rom/bootstrap.c
@@ -161,6 +161,7 @@ static int bootstrap_flash(const dif_spi_device_t *spi,
           return E_BS_WRITE;
         }
 
+        LOG_INFO("Frame #%d processed done", expected_frame_num);
         ++expected_frame_num;
         if (SPIFLASH_FRAME_IS_EOF(frame.header.frame_num)) {
           LOG_INFO("Bootstrap: DONE!");


### PR DESCRIPTION
It takes more time to process a frame of data, fixed TB sending SPI data
too fast.
Changed to wait for a message from SW to know the frame processed is
done.
Signed-off-by: Weicai Yang <weicai@google.com>