### PR TITLE
[cdc-rand] Enable CDC random delay injection

### DIFF
--- a/hw/dv/tools/dvsim/common_sim_cfg.hjson
+++ b/hw/dv/tools/dvsim/common_sim_cfg.hjson
@@ -70,7 +70,9 @@
                "+define+DUT_HIER={dut_instance}"]
 
   run_opts: ["+UVM_NO_RELNOTES",
-             "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}"]
+             "+UVM_VERBOSITY={expand_uvm_verbosity_{verbosity}}",
+             // TODO: remove once smoke regr passes:
+             "+prim_cdc_rand_delay_mode=disable"]
 
   // Default list of things to export to shell
   exports: [
@@ -116,22 +118,27 @@
       name: smoke
       tests: []
       reseed: 1
-      // Knob used to configure an existing test / vseq to have a shorter runtime.
-      run_opts: ["+smoke_test=1"]
+      run_opts: [// Knob used to configure an existing test / vseq to have a shorter runtime.
+                 "+smoke_test=1",
+                 // Enable CDC random delay once, at the start of the sim.
+                 // TODO: uncomment once smoke regr passes:
+                 // "+prim_cdc_rand_delay_mode=once"
+                ]
     }
-
     {
       name: all
     }
-
     {
       name: all_once
       reseed: 1
     }
-
     {
       name: nightly
       en_sim_modes: ["cov"]
+      run_opts: [// Enable CDC random delay changes every 10 source data changes.
+                 // TODO: Uncomment once nightly regr passes:
+                 // "+prim_cdc_rand_delay_mode=interval", "+prim_cdc_rand_delay_interval=10"
+                ]
     }
   ]
 

--- a/hw/ip/prim/pre_dv/prim_flop_2sync/prim_flop_2sync_sim.core
+++ b/hw/ip/prim/pre_dv/prim_flop_2sync/prim_flop_2sync_sim.core
@@ -1,0 +1,31 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:prim_flop_2sync_sim:0.1"
+description: "prim_flop_2sync_sim sim target"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:prim:flop_2sync
+
+  files_dv:
+    depend:
+      - lowrisc:dv:common_ifs
+      - lowrisc:dv:dv_macros
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_test_status
+    files:
+      - tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim: &sim_target
+    toplevel: tb
+    filesets:
+      - files_rtl
+      - files_dv
+    default_tool: vcs
+
+  lint:
+    <<: *sim_target

--- a/hw/ip/prim/pre_dv/prim_flop_2sync/prim_flop_2sync_sim_cfg.hjson
+++ b/hw/ip/prim/pre_dv/prim_flop_2sync/prim_flop_2sync_sim_cfg.hjson
@@ -1,0 +1,41 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: prim_flop_2sync
+
+  // Top level dut name (sv module).
+  dut: prim_flop_2sync
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Simulator used to sign off this block
+  tool: vcs
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:prim_flop_2sync_sim:0.1
+
+  // Import additional common sim cfg files.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 5
+
+  // List of test specifications.
+  tests: [
+    {
+      name: unit_test
+    }
+  ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: smoke
+      tests: ["unit_test"]
+    }
+  ]
+}

--- a/hw/ip/prim/pre_dv/prim_flop_2sync/tb.sv
+++ b/hw/ip/prim/pre_dv/prim_flop_2sync/tb.sv
@@ -1,0 +1,85 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Basic testbench for prim_flop_2sync with CDC random delay enabled.
+module tb;
+  `include "dv_macros.svh"
+
+  localparam string MsgId = $sformatf("%m");
+
+  logic [31:0] src_d, src_q;
+  wire clk, rst_n;
+
+  clk_rst_if clk_rst_if(.clk, .rst_n);
+
+  prim_flop_2sync #(.Width(32)) dut (
+    // source clock domain
+    .d_i    (src_d),
+    // destination clock domain
+    .clk_i  (clk),
+    .rst_ni (rst_n),
+    .q_o    (src_q)
+  );
+
+  initial begin
+    clk_rst_if.set_active();
+    clk_rst_if.apply_reset(.reset_width_clks(10));
+
+    $display("Using prim_cdc_rand_delay_mode slow");
+    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(1);
+    repeat (100) begin
+      src_d <= $urandom();
+      clk_rst_if.wait_clks($urandom_range(1, 20));
+    end
+    clk_rst_if.wait_clks(200);
+
+    $display("Using prim_cdc_rand_delay_mode once");
+    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(2);
+    repeat (100) begin
+      src_d <= $urandom();
+      clk_rst_if.wait_clks($urandom_range(1, 20));
+    end
+    clk_rst_if.wait_clks(200);
+
+    $display("Using prim_cdc_rand_delay_mode interval = 10");
+    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_mode(3);
+    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(10);
+    repeat (100) begin
+      src_d <= $urandom();
+      clk_rst_if.wait_clks($urandom_range(1, 20));
+    end
+    clk_rst_if.wait_clks(200);
+
+    $display("Using prim_cdc_rand_delay_mode interval = 1");
+    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(1);
+    repeat (100) begin
+      src_d <= $urandom();
+      clk_rst_if.wait_clks($urandom_range(1, 20));
+    end
+    clk_rst_if.wait_clks(200);
+
+    $display("Using prim_cdc_rand_delay_mode interval = 0");
+    dut.u_prim_cdc_rand_delay.set_prim_cdc_rand_delay_interval(0);
+    repeat (100) begin
+      src_d <= $urandom();
+      clk_rst_if.wait_clks($urandom_range(1, 20));
+    end
+    clk_rst_if.wait_clks(200);
+
+    // TODO: Add more checks.
+    dv_test_status_pkg::dv_test_status(.passed(1));
+    `DV_CHECK(!src_d_q.size(), , , MsgId)
+    $finish;
+  end
+
+  // Verify src_d to src_q consistency.
+  logic [31:0] src_d_q[$];
+  initial begin
+    fork
+      forever @src_d if (rst_n) src_d_q.push_back(src_d);
+      forever @src_q `DV_CHECK_EQ(src_q, src_d_q.pop_front(), , , MsgId)
+    join_none
+  end
+
+endmodule

--- a/hw/ip/prim/prim_flop_2sync.core
+++ b/hw/ip/prim/prim_flop_2sync.core
@@ -12,6 +12,7 @@ filesets:
       # Needed because the generic prim_flop_2sync has a
       # dependency on prim:flop.
       - lowrisc:prim:flop
+      - lowrisc:prim:cdc_rand_delay
     files:
       - rtl/prim_flop_2sync.sv
     file_type: systemVerilogSource

--- a/hw/ip/prim/rtl/prim_flop_2sync.sv
+++ b/hw/ip/prim/rtl/prim_flop_2sync.sv
@@ -8,7 +8,9 @@
 
 module prim_flop_2sync #(
   parameter int               Width      = 16,
-  parameter logic [Width-1:0] ResetValue = '0
+  parameter logic [Width-1:0] ResetValue = '0,
+  parameter int               CdcLatencyPs = 1000,
+  parameter int               CdcJitterPs = 1000
 ) (
   input                    clk_i,
   input                    rst_ni,
@@ -16,7 +18,19 @@ module prim_flop_2sync #(
   output logic [Width-1:0] q_o
 );
 
-  // TODO(#10432): Add CDC instrumentation for simulations
+  logic [Width-1:0] d_o;
+
+  prim_cdc_rand_delay #(
+    .DataWidth(Width),
+    .UseSourceClock(0),
+    .LatencyPs(CdcLatencyPs),
+    .JitterPs(CdcJitterPs)
+  ) u_prim_cdc_rand_delay (
+    .src_clk(),
+    .src_data(d_i),
+    .dst_clk(clk_i),
+    .dst_data(d_o)
+  );
 
   logic [Width-1:0] intq;
 
@@ -26,7 +40,7 @@ module prim_flop_2sync #(
   ) u_sync_1 (
     .clk_i,
     .rst_ni,
-    .d_i,
+    .d_i(d_o),
     .q_o(intq)
   );
 


### PR DESCRIPTION
This commit builds upon the work by @udinator and instantiates the CDC random
delay model within the prim_flop_2sync module. It injects delays into the incoming
source data before it passes through the 2 flop synchronizer.

It also comes with its mini testbench, which currently lacks any checks, but
serves as a way to view waves and check the behavior via visual inspection.

The delay insertion is currently disabled due to smoke regr failures.

Signed-off-by: Srikrishna Iyer <sriyer@google.com>