### PR TITLE
[otbn] Implement end-to-end ECC integrity for ISPRs

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -416,6 +416,7 @@ class OTBNState:
         self.ext_regs.set_bits('INTR_STATE', 1 << 0)
 
         should_lock = (((self._err_bits >> 16) != 0) or
+                       ((self._err_bits >> 10) & 1) or
                        (self._err_bits and self.software_errs_fatal))
         # Make any error bits visible
         self.ext_regs.write('ERR_BITS', self._err_bits, True)

--- a/hw/ip/otbn/dv/uvm/env/otbn_alu_bignum_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_alu_bignum_if.sv
@@ -8,8 +8,38 @@ interface otbn_alu_bignum_if (
   input         clk_i,
   input         rst_ni,
 
-  // Signal names from the otbn_alu_bignum module (where we are bound)
-  input [255:0] mod_q
+  input [otbn_pkg::ExtWLEN-1:0] mod_intg_q,
+  input                         mod_used
 );
+
+  // Force the `mod_intg_q` register to `should_val`.  This function needs to be static because its
+  // argument must live as least as long as the `force` statement is in effect.
+  function static void force_mod_intg_q(input logic [otbn_pkg::ExtWLEN-1:0] should_val);
+    force u_otbn_alu_bignum.mod_intg_q = should_val;
+  endfunction
+
+  // Release the forcing of the `mod_intg_q` register.
+  function automatic void release_mod_intg_q();
+    release u_otbn_alu_bignum.mod_intg_q;
+  endfunction
+
+  // Wait for the `mod_used` signal to be high (outside a reset) or until `max_cycles` clock cycles
+  // have passed.  When this task returns, the `success` output is set to `1'b1` if the `mod_used`
+  // signal was high and to `1'b0` otherwise.
+  task automatic wait_for_mod_used(input int unsigned max_cycles, output bit success);
+    int unsigned cycle_cnt = 0;
+    while (1) begin
+      @(negedge clk_i);
+      if (rst_ni && mod_used) begin
+        success = 1'b1;
+        break;
+      end
+      if (max_cycles != 0 && cycle_cnt >= max_cycles) begin
+        success = 1'b0;
+        break;
+      end
+      cycle_cnt++;
+    end
+  endtask
 
 endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_controller_if.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_controller_if.sv
@@ -1,0 +1,48 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Bound into the otbn_controller and used to help collect ISPR information for coverage.
+
+interface otbn_controller_if
+  import otbn_pkg::*;
+(
+  input         clk_i,
+  input         rst_ni,
+
+  // Signal names from the otbn_controller module (where we are bound)
+  input logic [ExtWLEN-1:0]           ispr_rdata_intg_i,
+  input logic [BaseWordsPerWLEN-1:0]  ispr_rdata_used
+);
+
+  // Force the `ispr_rdata_intg_i` signal to `should_val`.  This function needs to be static because
+  // its argument must live as least as long as the `force` statement is in effect.
+  function static void force_ispr_rdata_intg_i(input logic [ExtWLEN-1:0] should_val);
+    force u_otbn_controller.ispr_rdata_intg_i = should_val;
+  endfunction
+
+  // Release the forcing of the `ispr_rdata_intg_i` signal.
+  function automatic void release_ispr_rdata_intg_i();
+    release u_otbn_controller.ispr_rdata_intg_i;
+  endfunction
+
+  // Wait for the `ispr_rdata_used` signal to be high (outside a reset) or until `max_cycles` clock
+  // cycles have passed.  When this task returns, the `success` output is set to `1'b1` if the
+  // `ispr_rdata_used` signal was high and to `1'b0` otherwise.
+  task automatic wait_for_ispr_rdata_used(input int unsigned max_cycles, output bit success);
+    int unsigned cycle_cnt = 0;
+    while (1) begin
+      @(negedge clk_i);
+      if (rst_ni && |(ispr_rdata_used)) begin
+        success = 1'b1;
+        break;
+      end
+      if (max_cycles != 0 && cycle_cnt >= max_cycles) begin
+        success = 1'b0;
+        break;
+      end
+      cycle_cnt++;
+    end
+  endtask
+
+endinterface

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.core
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.core
@@ -19,6 +19,7 @@ filesets:
       - otbn_env_pkg.sv
       - otbn_loop_if.sv
       - otbn_alu_bignum_if.sv
+      - otbn_controller_if.sv
       - otbn_mac_bignum_if.sv
       - otbn_rf_base_if.sv
       - otbn_insn_cnt_if.sv
@@ -47,6 +48,10 @@ filesets:
       - seq_lib/otbn_zero_state_err_urnd_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_illegal_mem_acc_vseq.sv: {is_include_file: true}
       - seq_lib/otbn_sw_errs_fatal_chk_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_intg_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_alu_bignum_mod_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_controller_ispr_rdata_err_vseq.sv: {is_include_file: true}
+      - seq_lib/otbn_mac_bignum_acc_err_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/otbn/dv/uvm/env/otbn_env.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env.sv
@@ -60,6 +60,10 @@ class otbn_env extends cip_base_env #(
                                                          cfg.alu_bignum_vif)) begin
       `uvm_fatal(`gfn, "failed to get otbn_alu_bignum_if handle from uvm_config_db")
     end
+    if (!uvm_config_db#(virtual otbn_controller_if)::get(this, "", "controller_vif",
+                                                         cfg.controller_vif)) begin
+      `uvm_fatal(`gfn, "failed to get otbn_controller_if handle from uvm_config_db")
+    end
     if (!uvm_config_db#(virtual otbn_mac_bignum_if)::get(this, "", "mac_bignum_vif",
                                                          cfg.mac_bignum_vif)) begin
       `uvm_fatal(`gfn, "failed to get otbn_mac_bignum_if handle from uvm_config_db")

--- a/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_cfg.sv
@@ -21,6 +21,7 @@ class otbn_env_cfg extends cip_base_env_cfg #(.RAL_T(otbn_reg_block));
   virtual otbn_trace_if      trace_vif;
   virtual otbn_loop_if       loop_vif;
   virtual otbn_alu_bignum_if alu_bignum_vif;
+  virtual otbn_controller_if controller_vif;
   virtual otbn_mac_bignum_if mac_bignum_vif;
   virtual otbn_rf_base_if    rf_base_vif;
   virtual otbn_escalate_if   escalate_vif;

--- a/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_trace_monitor.sv
@@ -55,7 +55,9 @@ class otbn_trace_monitor extends dv_base_monitor #(
             item.has_sideload_key = cfg.keymgr_sideload_agent_cfg.vif.sideload_key.valid;
             item.current_loop_end = cfg.loop_vif.current_loop_end;
             item.at_current_loop_end_insn = cfg.loop_vif.at_current_loop_end_insn;
-            item.mod = cfg.alu_bignum_vif.mod_q;
+            for (int unsigned i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin
+              item.mod[i_word*32+:32] = cfg.alu_bignum_vif.mod_intg_q[i_word*39+:32];
+            end
             item.new_acc_extended = cfg.mac_bignum_vif.get_sum_value();
 
             item_valid = 1'b1;

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_alu_bignum_mod_err_vseq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program multiple times and corrupts the `mod_intg_q` register of
+// `otbn_alu_bignum` while OTBN is still running.
+
+class otbn_alu_bignum_mod_err_vseq extends otbn_intg_err_vseq;
+  `uvm_object_utils(otbn_alu_bignum_mod_err_vseq)
+
+  `uvm_object_new
+
+  task await_use(output bit used);
+    used = 1'b0;
+    `uvm_info(`gfn, "Waiting for `mod_intg_q` to be used", UVM_LOW)
+    cfg.alu_bignum_vif.wait_for_mod_used(200, used);
+  endtask
+
+  task inject_errors(output bit corrupted);
+    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.alu_bignum_vif.mod_intg_q, 50,
+                                                        corrupted);
+    if (corrupted) begin
+      `uvm_info(`gfn, "Injecting errors into `mod_intg_q` of `otbn_alu_bignum`", UVM_LOW)
+      cfg.alu_bignum_vif.force_mod_intg_q(new_data);
+    end else begin
+      `uvm_info(`gfn, "Randomization decided to not inject any errors.", UVM_LOW)
+    end
+  endtask
+
+  task release_force();
+    cfg.alu_bignum_vif.release_mod_intg_q();
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_controller_ispr_rdata_err_vseq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program multiple times and corrupts the `ispr_rdata_intg_i` signal of
+// `otbn_controller` while OTBN is still running.
+
+class otbn_controller_ispr_rdata_err_vseq extends otbn_intg_err_vseq;
+  `uvm_object_utils(otbn_controller_ispr_rdata_err_vseq)
+
+  `uvm_object_new
+
+  task await_use(output bit used);
+    used = 1'b0;
+    `uvm_info(`gfn, "Waiting for `ispr_rdata_intg` to be used", UVM_LOW)
+    cfg.controller_vif.wait_for_ispr_rdata_used(200, used);
+  endtask
+
+  task inject_errors(output bit corrupted);
+    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.controller_vif.ispr_rdata_intg_i, 50,
+                                                        corrupted);
+    if (corrupted) begin
+      `uvm_info(`gfn, "Injecting errors into `ispr_rdata_intg_i` of `otbn_controller`", UVM_LOW)
+      cfg.controller_vif.force_ispr_rdata_intg_i(new_data);
+    end else begin
+      `uvm_info(`gfn, "Randomization decided to not inject any errors.", UVM_LOW)
+    end
+  endtask
+
+  task release_force();
+    cfg.controller_vif.release_ispr_rdata_intg_i();
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_intg_err_vseq.sv
@@ -1,0 +1,118 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program multiple times and corrupts an integrity-checked signal while OTBN
+// is still running.
+
+class otbn_intg_err_vseq extends otbn_base_vseq;
+
+  `uvm_object_utils(otbn_intg_err_vseq)
+
+  `uvm_object_new
+
+  // Wait until the integrity-checked signal is used (otherwise an injected error would not have any
+  // consequences) or an internal timeout expires.  The `used` output indicates whether the signal
+  // was used during the call of this task.
+  protected virtual task await_use(output bit used);
+  endtask
+
+  // Probabilistically corrupt 1 to 2 bits of each word of `orig_data`, with a probability of
+  // `corrupt_word_pct` (in percent) per word.  The `corrupted` output indicates if any word was
+  // corrupted.
+  protected function bit [otbn_pkg::ExtWLEN-1:0] corrupt_data(
+      input bit [otbn_pkg::ExtWLEN-1:0] orig_data,
+      input int unsigned corrupt_word_pct,
+      output bit corrupted
+    );
+    bit [otbn_pkg::ExtWLEN-1:0] new_data;
+    corrupted = 1'b0;
+    for (int i_word = 0; i_word < otbn_pkg::BaseWordsPerWLEN; i_word++) begin
+      bit [BaseIntgWidth-1:0] orig_word = orig_data[i_word*39+:39];
+      bit corrupt_word = $urandom_range(100) < corrupt_word_pct;
+      if (corrupt_word) begin
+        bit [BaseIntgWidth-1:0] good_word = cfg.fix_integrity_32(orig_word);
+        bit [BaseIntgWidth-1:0] mask;
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(mask, $countones(mask) inside {[1:2]};)
+        new_data[i_word*39+:39] = good_word ^ mask;
+        corrupted = 1'b1;
+      end else begin
+        new_data[i_word*39+:39] = orig_word;
+      end
+    end
+    return new_data;
+  endfunction
+
+  // Inject errors into the integrity-checked signal by `force`ing it.
+  protected virtual task inject_errors(output bit corrupted);
+  endtask
+
+  // Release the `force`ing of the integrity-checked signal.
+  protected virtual task release_force();
+  endtask
+
+  task body();
+    uvm_reg_data_t    act_val;
+    string            elf_path;
+    bit               used;
+    bit               corrupted;
+    bit [ExtWLEN-1:0] new_data;
+
+    elf_path = pick_elf_path();
+    `uvm_info(`gfn, $sformatf("Loading OTBN binary from `%0s'", elf_path), UVM_LOW)
+    load_elf(elf_path, 1'b1);
+
+    // Start running OTBN. When this task returns, we'll be in the middle of a run.
+    start_running_otbn(.check_end_addr(1'b0));
+
+    // Wait until the register containing the integrity-checked value is being used.
+    await_use(used);
+
+    // If the binary we are running does not use the integrity-checked register, there is no point
+    // in continuing this sequence.
+    if (!used) begin
+      `uvm_info(`gfn,
+          {"Skipping test: we happened to run a binary that does not use ",
+          "the register into which we want to inject an integrity error."},
+          UVM_LOW)
+      return;
+    end
+
+    inject_errors(corrupted);
+
+    // Notify the model about the integrity violation error.
+    if (corrupted) begin
+      otbn_pkg::err_bits_t err_bits;
+      err_bits = '{reg_intg_violation: 1'b1, default: 1'b0};
+      cfg.model_agent_cfg.vif.send_err_escalation(err_bits);
+    end
+
+    @(cfg.clk_rst_vif.cbn);
+    release_force();
+
+    // OTBN should now do a secure wipe. Give it some cycles to do so.
+    repeat (100) @(cfg.clk_rst_vif.cbn);
+
+    // We should now be in a locked state after the secure wipe.
+    `DV_CHECK_FATAL(cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked);
+
+    // The scoreboard will have seen the transition to locked state and inferred that it should see
+    // a fatal alert. However, it doesn't really have a way to ensure that we keep generating them.
+    // Wait for 3 fatal alerts and also read STATUS, ERR_BITS and FATAL_ALERT_CAUSE in parallel.
+    fork
+      begin
+        csr_utils_pkg::csr_rd(.ptr(ral.status), .value(act_val));
+        csr_utils_pkg::csr_rd(.ptr(ral.err_bits), .value(act_val));
+        csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
+      end
+      begin
+        repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
+      end
+    join
+
+    // Reset and finish sequence.
+    do_apply_reset = 1'b1;
+    dut_init("HARD");
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_mac_bignum_acc_err_vseq.sv
@@ -1,0 +1,34 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// A sequence that runs a program multiple times and corrupts the `acc_intg_q` register of
+// `otbn_mac_bignum` while OTBN is still running.
+
+class otbn_mac_bignum_acc_err_vseq extends otbn_intg_err_vseq;
+  `uvm_object_utils(otbn_mac_bignum_acc_err_vseq)
+
+  `uvm_object_new
+
+  task await_use(output bit used);
+    used = 1'b0;
+    `uvm_info(`gfn, "Waiting for `acc_intg_q` to be used", UVM_LOW)
+    cfg.mac_bignum_vif.wait_for_acc_used(200, used);
+  endtask
+
+  task inject_errors(output bit corrupted);
+    bit [otbn_pkg::ExtWLEN-1:0] new_data = corrupt_data(cfg.mac_bignum_vif.acc_intg_q, 50,
+                                                        corrupted);
+    if (corrupted) begin
+      `uvm_info(`gfn, "Injecting errors into `acc_intg_q` of `otbn_mac_bignum`", UVM_LOW)
+      cfg.mac_bignum_vif.force_acc_intg_q(new_data);
+    end else begin
+      `uvm_info(`gfn, "Randomization decided to not inject any errors.", UVM_LOW)
+    end
+  endtask
+
+  task release_force();
+    cfg.mac_bignum_vif.release_acc_intg_q();
+  endtask
+
+endclass

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_vseq_list.sv
@@ -16,3 +16,7 @@
 `include "otbn_zero_state_err_urnd_vseq.sv"
 `include "otbn_illegal_mem_acc_vseq.sv"
 `include "otbn_sw_errs_fatal_chk_vseq.sv"
+`include "otbn_intg_err_vseq.sv"
+`include "otbn_alu_bignum_mod_err_vseq.sv"
+`include "otbn_controller_ispr_rdata_err_vseq.sv"
+`include "otbn_mac_bignum_acc_err_vseq.sv"

--- a/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
+++ b/hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson
@@ -223,6 +223,27 @@ name:
       reseed: 5
     }
 
+    {
+      name: "otbn_alu_bignum_mod_err"
+      uvm_test_seq: "otbn_alu_bignum_mod_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "otbn_controller_ispr_rdata_err"
+      uvm_test_seq: "otbn_controller_ispr_rdata_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
+    {
+      name: "otbn_mac_bignum_acc_err"
+      uvm_test_seq: "otbn_mac_bignum_acc_err_vseq"
+      en_run_modes: ["build_otbn_rig_binary_mode"]
+      reseed: 5
+    }
+
     // This test runs several sequences back-to-back. Unlike otbn_multi, these
     // sequences can include imem or dmem error sequences. We shouldn't need
     // many seeds here because each test runs several operations.

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -203,6 +203,7 @@ module tb;
     );
 
   bind dut.u_otbn_core.u_otbn_alu_bignum otbn_alu_bignum_if i_otbn_alu_bignum_if (.*);
+  bind dut.u_otbn_core.u_otbn_controller otbn_controller_if i_otbn_controller_if (.*);
   bind dut.u_otbn_core.u_otbn_mac_bignum otbn_mac_bignum_if i_otbn_mac_bignum_if (.*);
   bind dut.u_otbn_core.u_otbn_rf_base otbn_rf_base_if i_otbn_rf_base_if (.*);
 
@@ -331,6 +332,9 @@ module tb;
     uvm_config_db#(virtual otbn_alu_bignum_if)::set(
       null, "*.env", "alu_bignum_vif",
       dut.u_otbn_core.u_otbn_alu_bignum.i_otbn_alu_bignum_if);
+    uvm_config_db#(virtual otbn_controller_if)::set(
+      null, "*.env", "controller_vif",
+      dut.u_otbn_core.u_otbn_controller.i_otbn_controller_if);
     uvm_config_db#(virtual otbn_mac_bignum_if)::set(
       null, "*.env", "mac_bignum_vif",
       dut.u_otbn_core.u_otbn_mac_bignum.i_otbn_mac_bignum_if);

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -81,6 +81,7 @@ module otbn_alu_bignum
   input logic rst_ni,
 
   input  alu_bignum_operation_t operation_i,
+  input  logic                  operation_valid_i,
   input  logic                  operation_commit_i,
   output logic [WLEN-1:0]       operation_result_o,
   output logic                  selection_flag_o,

--- a/hw/ip/otbn/rtl/otbn_alu_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_alu_bignum.sv
@@ -92,16 +92,18 @@ module otbn_alu_bignum
   input  ispr_e                       ispr_addr_i,
   input  logic [31:0]                 ispr_base_wdata_i,
   input  logic [BaseWordsPerWLEN-1:0] ispr_base_wr_en_i,
-  input  logic [WLEN-1:0]             ispr_bignum_wdata_i,
+  input  logic [ExtWLEN-1:0]          ispr_bignum_wdata_intg_i,
   input  logic                        ispr_bignum_wr_en_i,
   input  logic                        ispr_wr_commit_i,
   input  logic                        ispr_init_i,
-  output logic [WLEN-1:0]             ispr_rdata_o,
+  output logic [ExtWLEN-1:0]          ispr_rdata_intg_o,
   input  logic                        ispr_rd_en_i,
 
-  input  logic [WLEN-1:0]             ispr_acc_i,
-  output logic [WLEN-1:0]             ispr_acc_wr_data_o,
+  input  logic [ExtWLEN-1:0]          ispr_acc_intg_i,
+  output logic [ExtWLEN-1:0]          ispr_acc_wr_data_intg_o,
   output logic                        ispr_acc_wr_en_o,
+
+  output logic                        reg_intg_violation_err_o,
 
   input logic                         sec_wipe_mod_urnd_i,
   input logic                         sec_wipe_zero_i,
@@ -134,7 +136,8 @@ module otbn_alu_bignum
   flags_t                              mac_update_flags;
   logic                                mac_update_flags_en;
   logic                                ispr_update_flags_en;
-  logic   [WLEN-1:0]                   ispr_rdata_mux_in [NIspr];
+  logic   [ExtWLEN-1:0]                ispr_rdata_intg_mux_in [NIspr];
+  logic   [WLEN-1:0]                   ispr_rdata_no_intg_mux_in [NIspr];
 
   logic [NIspr-1:0] expected_ispr_rd_en_onehot;
   logic [NIspr-1:0] expected_ispr_wr_en_onehot;
@@ -199,40 +202,70 @@ module otbn_alu_bignum
   end
 
 
-  logic [WLEN-1:0]             mod_q;
-  logic [WLEN-1:0]             mod_d;
+  logic [ExtWLEN-1:0]          mod_intg_q;
+  logic [ExtWLEN-1:0]          mod_intg_d;
   logic [BaseWordsPerWLEN-1:0] mod_ispr_wr_en;
   logic [BaseWordsPerWLEN-1:0] mod_wr_en;
 
-  logic [WLEN-1:0] ispr_mod_bignum_wdata_blanked;
+  logic [ExtWLEN-1:0] ispr_mod_bignum_wdata_intg_blanked;
 
   // SEC_CM: DATA_REG_SW.SCA
-  prim_blanker #(.Width(WLEN)) u_ispr_mod_bignum_wdata_blanker (
-    .in_i (ispr_bignum_wdata_i),
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_mod_bignum_wdata_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
     .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprMod]),
-    .out_o(ispr_mod_bignum_wdata_blanked)
+    .out_o(ispr_mod_bignum_wdata_intg_blanked)
   );
+  // If the blanker is enabled, the output will not carry the correct ECC bits.  This is not
+  // a problem because a blanked value should never be written to the register.  If the blanked
+  // value is written to the register nonetheless, an integrity error arises.
 
+  logic [WLEN-1:0]                mod_no_intg_d;
+  logic [WLEN-1:0]                mod_no_intg_q;
+  logic [ExtWLEN-1:0]             mod_intg_calc;
+  logic [2*BaseWordsPerWLEN-1:0]  mod_intg_err;
   for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : g_mod_words
+    prim_secded_inv_39_32_enc i_secded_enc (
+      .data_i (mod_no_intg_d[i_word*32+:32]),
+      .data_o (mod_intg_calc[i_word*39+:39])
+    );
+    prim_secded_inv_39_32_dec i_secded_dec (
+      .data_i     (mod_intg_q[i_word*39+:39]),
+      .data_o     (/* unused because we abort on any integrity error */),
+      .syndrome_o (/* unused */),
+      .err_o      (mod_intg_err[i_word*2+:2])
+    );
+    assign mod_no_intg_q[i_word*32+:32] = mod_intg_q[i_word*39+:32];
+
     always_ff @(posedge clk_i or negedge rst_ni) begin
       if (!rst_ni) begin
-        mod_q[i_word*32+:32] <= '0;
+        mod_intg_q[i_word*39+:39] <= EccZeroWord;
       end else if (mod_wr_en[i_word]) begin
-        mod_q[i_word*32+:32] <= mod_d[i_word*32+:32];
+        mod_intg_q[i_word*39+:39] <= mod_intg_d[i_word*39+:39];
       end
     end
 
     always_comb begin
-
+      mod_no_intg_d[i_word*32+:32] = '0;
       unique case (1'b1)
-        sec_wipe_mod_urnd_i: mod_d[i_word*32+:32] = urnd_data_i[i_word*32+:32];
-        sec_wipe_zero_i:     mod_d[i_word*32+:32] = 32'd0;
-        default:             mod_d[i_word*32+:32] = ispr_mod_bignum_wdata_blanked[i_word*32+:32];
+        // Non-encoded inputs have to be encoded before writing to the register.
+        sec_wipe_mod_urnd_i: begin
+          // In a secure wipe, `urnd_data_i` is written to the register before the zero word.  The
+          // ECC bits should not matter between the two writes, but nonetheless we encode
+          // `urnd_data_i` so there is no spurious integrity error.
+          mod_no_intg_d[i_word*32+:32] = urnd_data_i[i_word*32+:32];
+          mod_intg_d[i_word*39+:39]  = mod_intg_calc[i_word*39+:39];
+        end
+        // Pre-encoded inputs can directly be written to the register.
+        sec_wipe_zero_i: mod_intg_d[i_word*39+:39] = EccZeroWord;
+        default: mod_intg_d[i_word*39+:39] = ispr_mod_bignum_wdata_intg_blanked[i_word*39+:39];
       endcase
 
       unique case (1'b1)
-        ispr_init_i:               mod_d[i_word*32+:32] = '0;
-        ispr_base_wr_en_i[i_word]: mod_d[i_word*32+:32] = ispr_base_wdata_i;
+        ispr_init_i: mod_intg_d[i_word*39+:39] = EccZeroWord;
+        ispr_base_wr_en_i[i_word]: begin
+          mod_no_intg_d[i_word*32+:32] = ispr_base_wdata_i;
+          mod_intg_d[i_word*39+:39] = mod_intg_calc[i_word*39+:39];
+        end
         default: ;
       endcase
     end
@@ -253,39 +286,76 @@ module otbn_alu_bignum
   assign ispr_acc_wr_en_o   =
     ((ispr_addr_i == IsprAcc) & ispr_bignum_wr_en_i & ispr_wr_commit_i) | ispr_init_i;
 
-  logic [WLEN-1:0] ispr_acc_bignum_wdata_blanked;
+  logic [WLEN-1:0]    ispr_rdata_no_intg;
+  logic [ExtWLEN-1:0] ispr_rdata_intg_calc;
+  for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : g_rdata_enc
+    prim_secded_inv_39_32_enc i_secded_enc (
+      .data_i(ispr_rdata_no_intg[i_word * 32 +: 32]),
+      .data_o(ispr_rdata_intg_calc[i_word * 39 +: 39])
+    );
+  end
+
+  logic [ExtWLEN-1:0] ispr_acc_bignum_wdata_intg_blanked;
 
   // SEC_CM: DATA_REG_SW.SCA
-  prim_blanker #(.Width(WLEN)) u_ispr_acc_bignum_wdata_blanker (
-    .in_i (ispr_bignum_wdata_i),
+  prim_blanker #(.Width(ExtWLEN)) u_ispr_acc_bignum_wdata_intg_blanker (
+    .in_i (ispr_bignum_wdata_intg_i),
     .en_i (ispr_predec_bignum_i.ispr_wr_en[IsprAcc]),
-    .out_o(ispr_acc_bignum_wdata_blanked)
+    .out_o(ispr_acc_bignum_wdata_intg_blanked)
   );
+  // If the blanker is enabled, the output will not carry the correct ECC bits.  This is not
+  // a problem because a blanked value should never be used.  If the blanked value is used
+  // nonetheless, an integrity error arises.
 
-  assign ispr_acc_wr_data_o = ispr_init_i ? '0 : ispr_acc_bignum_wdata_blanked;
+  assign ispr_acc_wr_data_intg_o = ispr_init_i ? EccWideZeroWord
+                                               : ispr_acc_bignum_wdata_intg_blanked;
 
-  assign ispr_rdata_mux_in[IsprMod]  = mod_q;
-  assign ispr_rdata_mux_in[IsprRnd]  = rnd_data_i;
-  assign ispr_rdata_mux_in[IsprUrnd] = urnd_data_i;
-  assign ispr_rdata_mux_in[IsprAcc]  = ispr_acc_i;
-  assign ispr_rdata_mux_in[IsprFlags] = {{(WLEN - (NFlagGroups * FlagsWidth)){1'b0}},
-                                         flags_flattened};
-  assign ispr_rdata_mux_in[IsprKeyS0L] = sideload_key_shares_i[0][255:0];
-  assign ispr_rdata_mux_in[IsprKeyS0H] = {{(WLEN - (SideloadKeyWidth - 256)){1'b0}},
-                                          sideload_key_shares_i[0][SideloadKeyWidth-1:256]};
-  assign ispr_rdata_mux_in[IsprKeyS1L] = sideload_key_shares_i[1][255:0];
-  assign ispr_rdata_mux_in[IsprKeyS1H] = {{(WLEN - (SideloadKeyWidth - 256)){1'b0}},
-                                          sideload_key_shares_i[1][SideloadKeyWidth-1:256]};
+  // Pre-encoded values directly go through the mux that selects among ECC-coded signals.
+  assign ispr_rdata_intg_mux_in[IsprMod] = mod_intg_q;
+  assign ispr_rdata_intg_mux_in[IsprAcc] = ispr_acc_intg_i;
+  assign ispr_rdata_no_intg_mux_in[IsprMod] = 'x; // This value must not be used!
+  assign ispr_rdata_no_intg_mux_in[IsprAcc] = 'x; // This value must not be used!
+
+  // Non-encoded values have to be encoded before going to the mux that selects among ECC-coded
+  // signals.
+  assign ispr_rdata_no_intg_mux_in[IsprRnd]    = rnd_data_i;
+  assign ispr_rdata_no_intg_mux_in[IsprUrnd]   = urnd_data_i;
+  assign ispr_rdata_no_intg_mux_in[IsprFlags]  = {{(WLEN - (NFlagGroups * FlagsWidth)){1'b0}},
+                                                 flags_flattened};
+  assign ispr_rdata_no_intg_mux_in[IsprKeyS0L] = sideload_key_shares_i[0][255:0];
+  assign ispr_rdata_no_intg_mux_in[IsprKeyS0H] = {{(WLEN - (SideloadKeyWidth - 256)){1'b0}},
+                                                  sideload_key_shares_i[0][SideloadKeyWidth-1:256]};
+  assign ispr_rdata_no_intg_mux_in[IsprKeyS1L] = sideload_key_shares_i[1][255:0];
+  assign ispr_rdata_no_intg_mux_in[IsprKeyS1H] = {{(WLEN - (SideloadKeyWidth - 256)){1'b0}},
+                                                  sideload_key_shares_i[1][SideloadKeyWidth-1:256]};
+  assign ispr_rdata_intg_mux_in[IsprRnd]    = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprUrnd]   = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprFlags]  = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprKeyS0L] = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprKeyS0H] = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprKeyS1L] = ispr_rdata_intg_calc;
+  assign ispr_rdata_intg_mux_in[IsprKeyS1H] = ispr_rdata_intg_calc;
 
   prim_onehot_mux #(
     .Width  (WLEN),
     .Inputs (NIspr)
+  ) u_ispr_rd_no_intg_mux (
+    .clk_i,
+    .rst_ni,
+    .in_i  (ispr_rdata_no_intg_mux_in),
+    .sel_i (ispr_predec_bignum_i.ispr_rd_en),
+    .out_o (ispr_rdata_no_intg)
+  );
+
+  prim_onehot_mux #(
+    .Width  (ExtWLEN),
+    .Inputs (NIspr)
   ) u_ispr_rd_mux (
     .clk_i,
     .rst_ni,
-    .in_i  (ispr_rdata_mux_in),
+    .in_i  (ispr_rdata_intg_mux_in),
     .sel_i (ispr_predec_bignum_i.ispr_rd_en),
-    .out_o (ispr_rdata_o)
+    .out_o (ispr_rdata_intg_o)
   );
 
   prim_onehot_enc #(
@@ -415,7 +485,7 @@ module otbn_alu_bignum
     .out_o(adder_y_op_shifter_res_blanked)
   );
 
-  assign shift_mod_mux_out = shift_mod_sel ? adder_y_op_shifter_res_blanked : mod_q;
+  assign shift_mod_mux_out = shift_mod_sel ? adder_y_op_shifter_res_blanked : mod_no_intg_q;
 
   assign adder_y_op_a = {x_res_operand_a_mux_out, 1'b1};
   assign adder_y_op_b = {adder_y_op_b_invert ? ~shift_mod_mux_out : shift_mod_mux_out,
@@ -651,8 +721,10 @@ module otbn_alu_bignum
   // Output multiplexer //
   ////////////////////////
 
+  logic adder_y_res_used;
   always_comb begin
     operation_result_o = adder_y_res[WLEN:1];
+    adder_y_res_used = 1'b1;
 
     unique case(operation_i.op)
       AluOpBignumAdd,
@@ -660,6 +732,7 @@ module otbn_alu_bignum
       AluOpBignumSub,
       AluOpBignumSubb: begin
         operation_result_o = adder_y_res[WLEN:1];
+        adder_y_res_used = 1'b1;
       end
 
       // For pseudo-mod operations the result depends upon initial a + b / a - b result that is
@@ -675,8 +748,10 @@ module otbn_alu_bignum
       AluOpBignumAddm: begin
         if (adder_x_res[WLEN+1] || adder_y_res[WLEN+1]) begin
           operation_result_o = adder_y_res[WLEN:1];
+          adder_y_res_used = 1'b1;
         end else begin
           operation_result_o = adder_x_res[WLEN:1];
+          adder_y_res_used = 1'b0;
         end
       end
 
@@ -686,13 +761,16 @@ module otbn_alu_bignum
       AluOpBignumSubm: begin
         if (adder_x_res[WLEN+1]) begin
           operation_result_o = adder_x_res[WLEN:1];
+          adder_y_res_used = 1'b0;
         end else begin
           operation_result_o = adder_y_res[WLEN:1];
+          adder_y_res_used = 1'b1;
         end
       end
 
       AluOpBignumRshi: begin
         operation_result_o = shifter_res[WLEN-1:0];
+          adder_y_res_used = 1'b0;
       end
 
       AluOpBignumXor,
@@ -700,8 +778,24 @@ module otbn_alu_bignum
       AluOpBignumAnd,
       AluOpBignumNot: begin
         operation_result_o = logical_res;
+        adder_y_res_used = 1'b0;
       end
       default: ;
     endcase
   end
+
+  // Determine if `mod_intg_q` is used.  The control signals are only valid if `operation_i.op` is
+  // not none. If `shift_mod_sel` is low, `mod_intg_q` flows into `adder_y_op_b` and from there
+  // into `adder_y_res`.  In this case, `mod_intg_q` is used iff  `adder_y_res` flows into
+  // `operation_result_o`.
+  logic mod_used;
+  assign mod_used = operation_valid_i & (operation_i.op != AluOpBignumNone)
+                    & !shift_mod_sel & adder_y_res_used;
+  `ASSERT_KNOWN(ModUsed_A, mod_used)
+
+  // Raise a register integrity violation error iff `mod_intg_q` is used and (at least partially)
+  // invalid.
+  assign reg_intg_violation_err_o = mod_used & |(mod_intg_err);
+  `ASSERT_KNOWN(RegIntgErrKnown_A, reg_intg_violation_err_o)
+
 endmodule

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -95,6 +95,7 @@ module otbn_controller
 
   // Bignum ALU
   output alu_bignum_operation_t alu_bignum_operation_o,
+  output logic                  alu_bignum_operation_valid_o,
   output logic                  alu_bignum_operation_commit_o,
   input  logic [WLEN-1:0]       alu_bignum_operation_result_i,
   input  logic                  alu_bignum_selection_flag_i,
@@ -827,6 +828,7 @@ module otbn_controller
   assign alu_bignum_operation_o.alu_flag_en = insn_dec_bignum_i.alu_flag_en & insn_valid_i;
   assign alu_bignum_operation_o.mac_flag_en = insn_dec_bignum_i.mac_flag_en & insn_valid_i;
 
+  assign alu_bignum_operation_valid_o  = insn_valid_i;
   assign alu_bignum_operation_commit_o = insn_executing;
 
   assign mac_bignum_operation_o.operand_a         = rf_bignum_rd_data_a_no_intg;

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -175,6 +175,7 @@ module otbn_core
   logic               rf_bignum_rf_err;
 
   alu_bignum_operation_t alu_bignum_operation;
+  logic                  alu_bignum_operation_valid;
   logic                  alu_bignum_operation_commit;
   logic [WLEN-1:0]       alu_bignum_operation_result;
   logic                  alu_bignum_selection_flag;
@@ -445,6 +446,7 @@ module otbn_core
 
     // To/from bignum ALU
     .alu_bignum_operation_o       (alu_bignum_operation),
+    .alu_bignum_operation_valid_o (alu_bignum_operation_valid),
     .alu_bignum_operation_commit_o(alu_bignum_operation_commit),
     .alu_bignum_operation_result_i(alu_bignum_operation_result),
     .alu_bignum_selection_flag_i  (alu_bignum_selection_flag),
@@ -723,6 +725,7 @@ module otbn_core
     .rst_ni,
 
     .operation_i       (alu_bignum_operation),
+    .operation_valid_i (alu_bignum_operation_valid),
     .operation_commit_i(alu_bignum_operation_commit),
     .operation_result_o(alu_bignum_operation_result),
     .selection_flag_o  (alu_bignum_selection_flag),

--- a/hw/ip/otbn/rtl/otbn_mac_bignum.sv
+++ b/hw/ip/otbn/rtl/otbn_mac_bignum.sv
@@ -17,6 +17,7 @@ module otbn_mac_bignum
   output logic [WLEN-1:0] operation_result_o,
   output flags_t          operation_flags_o,
   output flags_t          operation_flags_en_o,
+  output logic            operation_intg_violation_err_o,
 
   input  mac_predec_bignum_t mac_predec_bignum_i,
   output logic               predec_error_o,
@@ -25,9 +26,9 @@ module otbn_mac_bignum
   input logic            sec_wipe_acc_urnd_i,
   input logic            sec_wipe_zero_i,
 
-  output logic [WLEN-1:0] ispr_acc_o,
-  input  logic [WLEN-1:0] ispr_acc_wr_data_i,
-  input  logic            ispr_acc_wr_en_i
+  output logic [ExtWLEN-1:0] ispr_acc_intg_o,
+  input  logic [ExtWLEN-1:0] ispr_acc_wr_data_intg_i,
+  input  logic               ispr_acc_wr_en_i
 );
   // The MAC operates on quarter-words, QWLEN gives the number of bits in a quarter-word.
   localparam int unsigned QWLEN = WLEN / 4;
@@ -42,10 +43,10 @@ module otbn_mac_bignum
   logic [WLEN/2-1:0] mul_res;
   logic [WLEN-1:0]   mul_res_shifted;
 
-  logic [WLEN-1:0] acc_d;
-  logic [WLEN-1:0] acc_q;
-  logic [WLEN-1:0] acc_blanked;
-  logic            acc_en;
+  logic [ExtWLEN-1:0] acc_intg_d;
+  logic [ExtWLEN-1:0] acc_intg_q;
+  logic [WLEN-1:0]    acc_blanked;
+  logic               acc_en;
 
   logic [WLEN-1:0] operand_a_blanked, operand_b_blanked;
 
@@ -109,12 +110,38 @@ module otbn_mac_bignum
 
   `ASSERT_KNOWN_IF(PreAccShiftImmKnown, operation_i.pre_acc_shift_imm, mac_en_i)
 
+  // ECC encode and decode of accumulator register
+  logic [WLEN-1:0]                acc_no_intg_d;
+  logic [WLEN-1:0]                acc_no_intg_q;
+  logic [ExtWLEN-1:0]             acc_intg_calc;
+  logic [2*BaseWordsPerWLEN-1:0]  acc_intg_err;
+  for (genvar i_word = 0; i_word < BaseWordsPerWLEN; i_word++) begin : g_acc_words
+    prim_secded_inv_39_32_enc i_secded_enc (
+      .data_i (acc_no_intg_d[i_word*32+:32]),
+      .data_o (acc_intg_calc[i_word*39+:39])
+    );
+    prim_secded_inv_39_32_dec i_secded_dec (
+      .data_i     (acc_intg_q[i_word*39+:39]),
+      .data_o     (/* unused because we abort on any integrity error */),
+      .syndrome_o (/* unused */),
+      .err_o      (acc_intg_err[i_word*2+:2])
+    );
+    assign acc_no_intg_q[i_word*32+:32] = acc_intg_q[i_word*39+:32];
+  end
+
+  // Propagate integrity error only if accumulator register is used: `acc_intg_q` flows into
+  // `operation_result_o` via `acc`, `adder_op_b`, and `adder_result` iff the MAC is enabled and the
+  // current operation does not zero the accumulation register.
+  logic acc_used;
+  assign acc_used = mac_en_i & ~operation_i.zero_acc;
+  assign operation_intg_violation_err_o = acc_used & |(acc_intg_err);
+
   // Accumulator logic
 
   // SEC_CM: DATA_REG_SW.SCA
   // acc_rd_en is so if .Z set in MULQACC (zero_acc) so accumulator reads as 0
   prim_blanker #(.Width(WLEN)) u_acc_blanker (
-    .in_i (acc_q),
+    .in_i (acc_no_intg_q),
     .en_i (mac_predec_bignum_i.acc_rd_en),
     .out_o(acc_blanked)
   );
@@ -158,15 +185,27 @@ module otbn_mac_bignum
   assign operation_flags_en_o.C = 1'b0;
 
   always_comb begin
+    acc_no_intg_d = '0;
     unique case (1'b1)
-    sec_wipe_acc_urnd_i: acc_d = urnd_data_i;
-    sec_wipe_zero_i:     acc_d = '0;
-    // If performing an ACC ISPR write the next accumulator value is taken from the ISPR write data,
-    // otherwise it is drawn from the adder result. The new accumulator can be optionally shifted
-    // right by one half-word (shift_acc).
-    default:  acc_d = ispr_acc_wr_en_i      ? ispr_acc_wr_data_i                                :
-                      operation_i.shift_acc ? {{QWLEN*2{1'b0}}, adder_result[QWLEN*2+:QWLEN*2]} :
-                                              adder_result;
+      // Non-encoded inputs have to be encoded before writing to the register.
+      sec_wipe_acc_urnd_i: begin
+        acc_no_intg_d = urnd_data_i;
+        acc_intg_d = acc_intg_calc;
+      end
+      // Pre-encoded values can be written directly to the register.
+      sec_wipe_zero_i: acc_intg_d = EccWideZeroWord;
+      default: begin
+        // If performing an ACC ISPR write the next accumulator value is taken from the ISPR write
+        // data, otherwise it is drawn from the adder result. The new accumulator can be optionally
+        // shifted right by one half-word (shift_acc).
+        if (ispr_acc_wr_en_i) begin
+          acc_intg_d = ispr_acc_wr_data_intg_i;
+        end else begin
+          acc_no_intg_d = operation_i.shift_acc ? {{QWLEN*2{1'b0}}, adder_result[QWLEN*2+:QWLEN*2]}
+                                                : adder_result;
+          acc_intg_d = acc_intg_calc;
+        end
+      end
     endcase
   end
 
@@ -177,13 +216,13 @@ module otbn_mac_bignum
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      acc_q <= '0;
+      acc_intg_q <= EccWideZeroWord;
     end else if (acc_en) begin
-      acc_q <= acc_d;
+      acc_intg_q <= acc_intg_d;
     end
   end
 
-  assign ispr_acc_o = acc_q;
+  assign ispr_acc_intg_o = acc_intg_q;
 
   // The operation result is taken directly from the adder, shift_acc only applies to the new value
   // written to the accumulator.


### PR DESCRIPTION
Implement end-to-end ECC integrity checks for OTBN ISPRs.

This is part of the work on https://github.com/lowRISC/opentitan/issues/11019.

## TODO
- [x] In `otbn_controller`, decoding errors may only conditionally be raised as integrity errors. Find the correct control flow and change the existing conditions.
- [x] In `otbn_alu_bignum`, decoding errors may also only conditionally be raised as integrity errors. However, the current condition is wrong as it leads to X propagation. Find the correct condition.
- [x] Add simple verification sequences, each of which injects an error in one of the ISPRs and ensures that a corresponding integrity violation error is raised.
- [x] Rebase on #10824 once it is merged and replace the signal that indicates if `alu_bignum` is active (driven by `otbn_decoder`) by using the `None` instruction added in that PR.