### PR TITLE
[python] Bump fusesoc/edalize versions

### DIFF
--- a/python-requirements.txt
+++ b/python-requirements.txt
@@ -42,10 +42,10 @@ types-pyyaml
 types-tabulate
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/fusesoc.git@ot-0.1
+git+https://github.com/lowRISC/fusesoc.git@ot-0.2
 
 # Development version with OT-specific changes
-git+https://github.com/lowRISC/edalize.git@ot-0.1
+git+https://github.com/lowRISC/edalize.git@ot-0.2
 
 # Development version of ChipWhisperer toolchain
 # Use a development version until support for the CW310 board works in a


### PR DESCRIPTION
These don't really introduce new functionality. The ot-0.2 release of
fusesoc is essentially the same as ot-0.1, but rebased onto a more
recent upstream fusesoc release.

We don't need a specific "ot" edalize at the moment: all the patches
we were carrying have been upstreamed (yippee!)
