### PR TITLE
[lc_ctrl/dv] Added MUBI inputs test

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
@@ -131,7 +131,7 @@
         invalid encoding (MANUF.STATE.BKGN_CHK, TRANSITION.CTR.BKGN_CHK).
       '''
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_cm", "lc_ctrl_state_failure"]
     }
     {
       name: sec_cm_main_fsm_global_esc
@@ -142,7 +142,7 @@
       any of the two escalation channels (`esc_scrap_state0/1`) is asserted.
       '''
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_security_escalation"]
     }
     {
       name: sec_cm_main_ctrl_flow_consistency
@@ -191,7 +191,7 @@
       this error occurs.
       '''
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_mubi"]
     }
     {
       name: sec_cm_token_valid_ctrl_mubi
@@ -204,7 +204,7 @@
       error occurs.
       '''
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_mubi"]
     }
     {
       name: sec_cm_token_digest

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -34,6 +34,7 @@ filesets:
       - seq_lib/lc_ctrl_jtag_access_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_jtag_priority_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_regwen_during_op_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_sec_mubi_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cfg.sv
@@ -46,6 +46,7 @@ class lc_ctrl_env_cfg extends cip_base_env_cfg #(
   rand otp_device_id_t otp_manuf_state;
   rand logic [OtpTestCtrlWidth-1:0] otp_vendor_test_ctrl;
   rand logic [OtpTestStatusWidth-1:0] otp_vendor_test_status;
+  lc_tx_t otp_secrets_valid;
 
 
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -99,6 +99,17 @@ package lc_ctrl_env_pkg;
     bit transition_count_err;
     // Randomly assert one or more escalate inputs
     bit security_escalation_err;
+    // Use other than "Off" enum for MUBI input off values
+    // clk_byp_rsp
+    bit clk_byp_rsp_mubi_err;
+    // flash_rma_rsp
+    bit flash_rma_rsp_mubi_err;
+    // OTP secrets valid
+    bit otp_secrets_valid_mubi_err;
+    // OTP test tokens valid
+    bit otp_test_tokens_valid_mubi_err;
+    // OTP RMA token valid
+    bit otp_rma_token_valid_mubi_err;
   } lc_ctrl_err_inj_t;
 
   // Test phase - used to synchronise the scoreboard

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -85,16 +85,24 @@ interface lc_ctrl_if (
   logic mutex_claim_jtag;
   logic mutex_claim_tl;
 
+  // FSM state
+  lc_ctrl_pkg::fsm_state_e lc_ctrl_fsm_state;
+  // Token mux control
+  bit [TokenIdxWidth-1:0] token_idx0;
+  bit [TokenIdxWidth-1:0] token_idx1;
+
+
   // Debug signals
   lc_ctrl_env_pkg::lc_ctrl_err_inj_t err_inj;
   lc_ctrl_env_pkg::lc_ctrl_test_phase_e test_phase;
   bit [79:0][7:0] test_sequence_typename;
 
-  task automatic init(lc_state_e lc_state = LcStRaw, lc_cnt_e lc_cnt = LcCnt0,
-                      lc_tx_t clk_byp_ack = Off, lc_tx_t flash_rma_ack = Off,
-                      logic otp_partition_err = 0, otp_device_id_t otp_device_id = 0,
-                      logic otp_lc_data_i_valid = 1, otp_device_id_t otp_manuf_state = 0,
-                      logic [OtpTestStatusWidth-1:0] otp_vendor_test_status = 0);
+  task automatic init(
+      lc_state_e lc_state = LcStRaw, lc_cnt_e lc_cnt = LcCnt0, lc_tx_t clk_byp_ack = Off,
+      lc_tx_t flash_rma_ack = Off, logic otp_partition_err = 0, otp_device_id_t otp_device_id = 0,
+      logic otp_lc_data_i_valid = 1, otp_device_id_t otp_manuf_state = 0,
+      logic [OtpTestStatusWidth-1:0] otp_vendor_test_status = 0, lc_tx_t otp_secrets_valid = Off,
+      lc_tx_t otp_test_tokens_valid = On, lc_tx_t otp_rma_token_valid = On);
     otp_i.valid             = otp_lc_data_i_valid;
     otp_i.error             = otp_partition_err;
     otp_i.state             = lc_state;
@@ -103,9 +111,9 @@ interface lc_ctrl_if (
     otp_i.test_exit_token   = lc_ctrl_env_pkg::get_random_token();
     otp_i.rma_token         = lc_ctrl_env_pkg::get_random_token();
     // TODO: need to randomize this,
-    otp_i.secrets_valid     = Off;
-    otp_i.test_tokens_valid = On;
-    otp_i.rma_token_valid   = On;
+    otp_i.secrets_valid     = otp_secrets_valid;
+    otp_i.test_tokens_valid = otp_test_tokens_valid;
+    otp_i.rma_token_valid   = otp_rma_token_valid;
 
 
     clk_byp_ack_i           = clk_byp_ack;

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_scoreboard.sv
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-`define gmv32(csr) 32'(`gmv(csr))
+`define GMV32(csr) 32'(`gmv(csr))
 
 class lc_ctrl_scoreboard extends cip_base_scoreboard #(
   .CFG_T(lc_ctrl_env_cfg),
@@ -77,20 +77,28 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
           exp_lc_o.lc_seed_hw_rd_en_o = lc_ctrl_pkg::Off;
         end
 
+        // lc_seed_hw_rd_en copies otp_secrets_valid in certain states
+        if (cfg.err_inj.otp_secrets_valid_mubi_err && lc_state_e'(cfg.lc_ctrl_vif.otp_i.state)
+            inside {LcStProd, LcStProdEnd, LcStDev}) begin
+          exp_lc_o.lc_seed_hw_rd_en_o = cfg.otp_secrets_valid;
+          exp_lc_o.lc_creator_seed_sw_rw_en_o = ~cfg.otp_secrets_valid;
+        end
+
         ->check_lc_output_ev;
         check_lc_outputs(exp_lc_o, {$sformatf("Called from line: %0d, ", `__LINE__), err_msg});
-
 
         if (cfg.err_inj.state_err || cfg.err_inj.count_err ||
             cfg.err_inj.state_backdoor_err || cfg.err_inj.count_backdoor_err ||
             cfg.err_inj.count_illegal_err || cfg.err_inj.state_illegal_err ||
-            cfg.err_inj.lc_fsm_backdoor_err || cfg.err_inj.kmac_fsm_backdoor_err
+            cfg.err_inj.lc_fsm_backdoor_err || cfg.err_inj.kmac_fsm_backdoor_err ||
+            cfg.err_inj.clk_byp_rsp_mubi_err || cfg.err_inj.otp_secrets_valid_mubi_err
             ) begin // State/count error expected
           set_exp_alert(.alert_name("fatal_state_error"), .is_fatal(1),
                         .max_delay(cfg.alert_max_delay));
         end
 
-        if (cfg.err_inj.otp_prog_err || cfg.err_inj.clk_byp_error_rsp) begin
+        if (cfg.err_inj.otp_prog_err || cfg.err_inj.clk_byp_error_rsp ||
+            cfg.err_inj.clk_byp_rsp_mubi_err) begin
           // OTP program error expected
           set_exp_alert(.alert_name("fatal_prog_error"), .is_fatal(1),
                         .max_delay(cfg.alert_max_delay));
@@ -164,10 +172,10 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
       `uvm_info(`gfn, $sformatf("process_kmac_app_req: token received %h", token_data), UVM_MEDIUM)
 
       if (cfg.en_scb) begin
-        `DV_CHECK_EQ(token_data, {`gmv32(ral.transition_token[3]),
-                                  `gmv32(ral.transition_token[2]),
-                                  `gmv32(ral.transition_token[1]),
-                                  `gmv32(ral.transition_token[0])})
+        `DV_CHECK_EQ(token_data, {`GMV32(ral.transition_token[3]),
+                                  `GMV32(ral.transition_token[2]),
+                                  `GMV32(ral.transition_token[1]),
+                                  `GMV32(ral.transition_token[0])})
       end
     end
   endtask
@@ -359,10 +367,12 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     bit state_err_exp = cfg.err_inj.state_err || cfg.err_inj.count_err ||
         cfg.err_inj.state_illegal_err || cfg.err_inj.count_illegal_err ||
         cfg.err_inj.count_backdoor_err ||  cfg.err_inj.state_backdoor_err ||
-        cfg.err_inj.lc_fsm_backdoor_err || cfg.err_inj.kmac_fsm_backdoor_err;
+        cfg.err_inj.lc_fsm_backdoor_err || cfg.err_inj.kmac_fsm_backdoor_err ||
+        cfg.err_inj.otp_secrets_valid_mubi_err;
 
     // OTP program error is expected
-    bit prog_err_exp = cfg.err_inj.otp_prog_err || cfg.err_inj.clk_byp_error_rsp;
+    bit prog_err_exp = cfg.err_inj.otp_prog_err || cfg.err_inj.clk_byp_error_rsp ||
+        cfg.err_inj.clk_byp_rsp_mubi_err;
 
 
     // Exceptions to default
@@ -425,7 +435,8 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     // State error of some kind expected
     bit state_err_exp = cfg.err_inj.state_err || cfg.err_inj.count_err ||
         cfg.err_inj.state_illegal_err || cfg.err_inj.count_illegal_err ||
-        cfg.err_inj.count_backdoor_err || cfg.err_inj.lc_fsm_backdoor_err;
+        cfg.err_inj.count_backdoor_err || cfg.err_inj.lc_fsm_backdoor_err ||
+        cfg.err_inj.clk_byp_rsp_mubi_err || cfg.err_inj.otp_secrets_valid_mubi_err;
 
     // Exceptions to default expected lc_transition_count
     unique case (cfg.test_phase)
@@ -502,7 +513,8 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     // Reflects otp_vendor_test_status_i in these states otherwise 0
     if ((LcStateIn inside {LC_CTRL_OTP_TEST_REG_ENABLED_STATES}) &&
         (LcCntIn inside {LC_CTRL_OTP_TEST_REG_ENABLED_COUNTS}) &&
-        (cfg.test_phase < LcCtrlPostTransition)) begin
+        (cfg.test_phase < LcCtrlPostTransition) &&
+        !cfg.err_inj.otp_secrets_valid_mubi_err) begin
       return cfg.otp_vendor_test_status;
     end else return 0;
   endfunction
@@ -558,6 +570,6 @@ class lc_ctrl_scoreboard extends cip_base_scoreboard #(
     // post test checks - ensure that all local fifos and queues are empty
   endfunction
 
-`undef gmv32
+  `undef GMV32
 
 endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -101,42 +101,38 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
     super.read_and_check_all_csrs_after_reset();
   endtask
 
-  virtual task run_clk_byp_rsp_nonblocking(bit has_err = 0);
-    fork
-      forever begin
-        lc_ctrl_pkg::lc_tx_t rsp;
-        wait(cfg.lc_ctrl_vif.clk_byp_req_o == lc_ctrl_pkg::On);
-        rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
-            lc_ctrl_pkg::On;
-        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
-        cfg.lc_ctrl_vif.set_clk_byp_ack(rsp);
+  virtual task run_clk_byp_rsp(bit has_err = 0);
+    forever begin
+      lc_ctrl_pkg::lc_tx_t rsp;
+      wait(cfg.lc_ctrl_vif.clk_byp_req_o == lc_ctrl_pkg::On);
+      rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
+          lc_ctrl_pkg::On;
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+      cfg.lc_ctrl_vif.set_clk_byp_ack(rsp);
 
-        wait(cfg.lc_ctrl_vif.clk_byp_req_o != lc_ctrl_pkg::On);
-        rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
-            lc_ctrl_pkg::Off;
-        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
-        cfg.lc_ctrl_vif.set_clk_byp_ack(rsp);
-      end
-    join_none
+      wait(cfg.lc_ctrl_vif.clk_byp_req_o != lc_ctrl_pkg::On);
+      rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
+          lc_ctrl_pkg::Off;
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+      cfg.lc_ctrl_vif.set_clk_byp_ack(rsp);
+    end
   endtask
 
-  virtual task run_flash_rma_rsp_nonblocking(bit has_err = 0);
-    fork
-      forever begin
-        lc_ctrl_pkg::lc_tx_t rsp;
-        wait(cfg.lc_ctrl_vif.flash_rma_req_o == lc_ctrl_pkg::On);
-        rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
-            lc_ctrl_pkg::On;
-        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
-        cfg.lc_ctrl_vif.set_flash_rma_ack(rsp);
+  virtual task run_flash_rma_rsp(bit has_err = 0);
+    forever begin
+      lc_ctrl_pkg::lc_tx_t rsp;
+      wait(cfg.lc_ctrl_vif.flash_rma_req_o == lc_ctrl_pkg::On);
+      rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
+          lc_ctrl_pkg::On;
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+      cfg.lc_ctrl_vif.set_flash_rma_ack(rsp);
 
-        wait(cfg.lc_ctrl_vif.flash_rma_req_o != lc_ctrl_pkg::On);
-        rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
-            lc_ctrl_pkg::Off;
-        cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
-        cfg.lc_ctrl_vif.set_flash_rma_ack(rsp);
-      end
-    join_none
+      wait(cfg.lc_ctrl_vif.flash_rma_req_o != lc_ctrl_pkg::On);
+      rsp = (has_err) ? ($urandom_range(0, 1) ? lc_ctrl_pkg::On : lc_ctrl_pkg::Off) :
+          lc_ctrl_pkg::Off;
+      cfg.clk_rst_vif.wait_clks($urandom_range(0, 20));
+      cfg.lc_ctrl_vif.set_flash_rma_ack(rsp);
+    end
   endtask
 
   virtual task sw_transition_req(bit [TL_DW-1:0] next_lc_state, bit [TL_DW*4-1:0] token_val);
@@ -220,6 +216,31 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
     while (cfg.m_kmac_app_agent_cfg.has_user_digest_share()) begin
       void'(cfg.m_kmac_app_agent_cfg.get_user_digest_share());
     end
+  endfunction
+
+  // Does this transition require a test unlock or test exit token
+  virtual function bit has_test_token(input dec_lc_state_e dec_lc_state,
+                                      input dec_lc_state_e next_lc_state);
+    has_test_token = (TransTokenIdxMatrix[dec_lc_state][next_lc_state] inside {
+        TestUnlockTokenIdx, TestExitTokenIdx});
+    `uvm_info(`gfn, $sformatf(
+              "has_test_token: checking state %s -> %s result %0b",
+              dec_lc_state.name(),
+              next_lc_state.name(),
+              has_test_token
+              ), UVM_MEDIUM)
+  endfunction
+
+  // Does this transition require an RMA token
+  virtual function bit has_rma_token(input dec_lc_state_e dec_lc_state,
+                                     input dec_lc_state_e next_lc_state);
+    has_rma_token = (TransTokenIdxMatrix[dec_lc_state][next_lc_state] inside {RmaTokenIdx});
+    `uvm_info(`gfn, $sformatf(
+              "has_rma_token: checking state %s -> %s result %0b",
+              dec_lc_state.name(),
+              next_lc_state.name(),
+              has_rma_token
+              ), UVM_MEDIUM)
   endfunction
 
 endclass : lc_ctrl_base_vseq

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_sec_mubi_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_sec_mubi_vseq.sv
@@ -1,0 +1,26 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// MUBI inputs error injection test
+
+class lc_ctrl_sec_mubi_vseq extends lc_ctrl_errors_vseq;
+
+  `uvm_object_utils(lc_ctrl_sec_mubi_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[50 : 100]};}
+
+  constraint mubi_err_inj_c {
+    $onehot(
+        {
+          err_inj.clk_byp_rsp_mubi_err,
+          err_inj.flash_rma_rsp_mubi_err,
+          err_inj.otp_secrets_valid_mubi_err,
+          err_inj.otp_test_tokens_valid_mubi_err,
+          err_inj.otp_rma_token_valid_mubi_err
+        }
+    );
+  }
+
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_smoke_vseq.sv
@@ -31,14 +31,17 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
 
   virtual task post_start();
     // Kill sub processes
-    disable run_clk_byp_rsp_nonblocking;
-    disable run_flash_rma_rsp_nonblocking;
+    disable run_clk_byp_rsp;
+    disable run_flash_rma_rsp;
     super.post_start();
   endtask
 
   task body();
-    run_clk_byp_rsp_nonblocking(clk_byp_error_rsp);
-    run_flash_rma_rsp_nonblocking(flash_rma_error_rsp);
+
+    fork
+      run_clk_byp_rsp(clk_byp_error_rsp);
+      run_flash_rma_rsp(flash_rma_error_rsp);
+    join_none
 
     //
     // Check OTP read only regs (static ones)
@@ -133,4 +136,6 @@ class lc_ctrl_smoke_vseq extends lc_ctrl_base_vseq;
     clear_kmac_user_digest_share();
     cfg.m_kmac_app_agent_cfg.add_user_digest_share(kmac_digest);
   endfunction
+
 endclass : lc_ctrl_smoke_vseq
+

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -14,6 +14,7 @@
 `include "lc_ctrl_jtag_access_vseq.sv"
 `include "lc_ctrl_jtag_priority_vseq.sv"
 `include "lc_ctrl_regwen_during_op_vseq.sv"
+`include "lc_ctrl_sec_mubi_vseq.sv"
 `include "lc_ctrl_stress_all_vseq.sv"
 
 

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -226,6 +226,12 @@
     }
 
     {
+      name: "lc_ctrl_sec_mubi"
+      uvm_test_seq: lc_ctrl_sec_mubi_vseq
+      run_opts: ["+create_jtag_riscv_map=1"]
+    }
+
+    {
       name: "lc_ctrl_stress_all"
       uvm_test_seq: lc_ctrl_stress_all_vseq
       run_opts: ["+create_jtag_riscv_map=1"]

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -177,10 +177,18 @@ module tb;
       dut.sw_claim_transition_if_q
   );
 
+  // FSM State
+  assign #1ps lc_ctrl_if.lc_ctrl_fsm_state = dut.u_lc_ctrl_fsm.fsm_state_q;
+  // Token mux control
+  assign lc_ctrl_if.token_idx0 = dut.u_lc_ctrl_fsm.token_idx0;
+  assign lc_ctrl_if.token_idx1 = dut.u_lc_ctrl_fsm.token_idx1;
 
   initial begin
-    static lc_ctrl_parameters_cfg parameters_cfg =
-        lc_ctrl_parameters_cfg::type_id::create("parameters_cfg");
+    static
+    lc_ctrl_parameters_cfg
+    parameters_cfg = lc_ctrl_parameters_cfg::type_id::create(
+        "parameters_cfg"
+    );
 
     // drive clk and rst_n from clk_if
     clk_rst_if.set_active();
@@ -231,5 +239,9 @@ module tb;
   `DV_ASSERT_CTRL("KmacIfSyncReqAckAckNeedsReq",
                   kmac_app_if.req_data_if.H_DataStableWhenValidAndNotReady_A)
   `DV_ASSERT_CTRL("KmacIfSyncReqAckAckNeedsReq", kmac_app_if.req_data_if.ValidHighUntilReady_A)
+  `DV_ASSERT_CTRL("FsmClkBypAckSync", dut.u_lc_ctrl_fsm.u_prim_lc_sync_clk_byp_ack)
+  `DV_ASSERT_CTRL("FsmClkFlashRmaAckSync", dut.u_lc_ctrl_fsm.u_prim_lc_sync_flash_rma_ack)
+  `DV_ASSERT_CTRL("FsmOtpTestTokensValidSync", dut.u_lc_ctrl_fsm.u_prim_lc_sync_test_token_valid)
+  `DV_ASSERT_CTRL("FsmOtpRmaTokenValidSync", dut.u_lc_ctrl_fsm.u_prim_lc_sync_rma_token_valid)
 
 endmodule


### PR DESCRIPTION
- Added tests
  - lc_ctrl_sec_mubi
- Added test sequences
  - lc_ctrl_sec_mubi_vseq
- Updated lc_ctrl_errors_vseq to inject mubi errors
- Updated error injection structure added entries
  - clk_byp_rsp_mubi_err
  - flash_rma_rsp_mubi_err
  - otp_secrets_valid_mubi_err
  - otp_test_tokens_valid_mubi_err
  - otp_rma_token_valid_mubi_err
- Added whitebox signals to lc_ctrl_if to enable error injection to
be timed to FSM state.
- Renamed run_clk_byp_rsp_nonblocking to run_clk_byp_rsp and
run_flash_rma_rsp_nonblocking to run_flash_rma_rsp after moving the
fork outside of the task