### PR TITLE
[otbn, dv] Fixed regression issue in otbn_stress_all_with_rand_reset

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_single_vseq.sv
@@ -27,7 +27,10 @@ class otbn_single_vseq extends otbn_base_vseq;
       load_elf(elf_path, do_backdoor_load);
       cfg_interrupts(enable_interrupts);
     join
-
+    if (cfg.under_reset) begin
+        `uvm_info(`gfn, "under reset", UVM_LOW)
+        cfg.clk_rst_vif.wait_for_reset(.wait_negedge(1'b0), .wait_posedge(1'b1));
+    end
     // We've loaded the binary. Run the processor to see what happens!
     run_otbn();
   endtask : body


### PR DESCRIPTION
If a reset is asserted when elf file is getting loaded, the sequence
waits for reset to get de-asserted before executing run_otbn task.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>