### PR TITLE
[test, aes] Aes entropy chip level test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1579,14 +1579,11 @@
             - Write the KEY_IV_DATA_IN_CLEAR and DATA_OUT_CLEAR trigger bits to 1 and wait for it to
               complete by polling the status idle bit.
             - Read back the data out CSRs - they should all read garbage values.
-            - Assertion check verifies that the internal states (data_in, key share and IV are also
-              garbage, i.e. different from the originally written values.
-            - Assertion checks proves that all interfaces are connected across AST RNG, ES, CSRNG,
-              EDN and AES.
-            - Predict the generated entropy bits and check against the observed for correctness.
+            - Assertion check verifies that the IV are also garbage, i.e. different from the originally
+              written values.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_aes_entropy"]
     }
     {
       name: chip_sw_aes_idle

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -533,6 +533,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_aes_entropy
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/aes_entropy_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=15000000"]
+    }
+    {
       name: chip_sw_hmac_enc_irq
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/hmac_enc_irq_test:1"]

--- a/sw/device/lib/testing/hmac_testutils.c
+++ b/sw/device/lib/testing/hmac_testutils.c
@@ -51,7 +51,7 @@ void hmac_testutils_finish_and_check_polled(const dif_hmac_t *hmac,
                                             const dif_hmac_digest_t *expected) {
   dif_hmac_digest_t digest;
   hmac_testutils_finish_polled(hmac, &digest);
-  CHECK_BUFFER(digest.digest, expected, ARRAYSIZE(digest.digest));
+  CHECK_BUFFER_EQ(digest.digest, expected, ARRAYSIZE(digest.digest));
 }
 
 void hmac_testutils_push_message(const dif_hmac_t *hmac, const char *data,

--- a/sw/device/lib/testing/hmac_testutils.h
+++ b/sw/device/lib/testing/hmac_testutils.h
@@ -78,7 +78,7 @@ void hmac_testutils_finish_polled(const dif_hmac_t *hmac,
  * Spins until HMAC has processed the final hash, and compares the digests.
  *
  * Convenience function that combines `hmac_testutils_finish_polled` and
- * and `CHECK_BUFFER`.
+ * and `CHECK_BUFFER_EQ`.
  *
  * @param hmac An HMAC handle.
  * @param expected Expected HMAC final digest.

--- a/sw/device/lib/testing/rstmgr_testutils.c
+++ b/sw/device/lib/testing/rstmgr_testutils.c
@@ -40,7 +40,7 @@ void rstmgr_testutils_compare_alert_info(
   CHECK_DIF_OK(dif_rstmgr_alert_info_dump_read(
       rstmgr, actual_alert_dump, DIF_RSTMGR_ALERT_INFO_MAX_SIZE, &size_read));
   CHECK(dump_size <= size_read);
-  CHECK_BUFFER(actual_alert_dump, expected_alert_dump, dump_size);
+  CHECK_BUFFER_EQ(actual_alert_dump, expected_alert_dump, dump_size);
 }
 
 void rstmgr_testutils_compare_cpu_info(
@@ -57,7 +57,7 @@ void rstmgr_testutils_compare_cpu_info(
   CHECK_DIF_OK(dif_rstmgr_cpu_info_dump_read(
       rstmgr, actual_cpu_dump, DIF_RSTMGR_CPU_INFO_MAX_SIZE, &size_read));
   CHECK(dump_size <= size_read);
-  CHECK_BUFFER(actual_cpu_dump, expected_cpu_dump, dump_size);
+  CHECK_BUFFER_EQ(actual_cpu_dump, expected_cpu_dump, dump_size);
 }
 
 void rstmgr_testutils_pre_reset(const dif_rstmgr_t *rstmgr) {

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -6,6 +6,27 @@ load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 
 opentitan_functest(
+    name = "aes_entropy_test",
+    srcs = ["aes_entropy_test.c"],
+    verilator = verilator_params(
+        tags = [
+            "cpu:4",
+            "failing_verilator",
+        ],
+    ),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:aes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aes_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "aes_idle_test",
     srcs = ["aes_idle_test.c"],
     verilator = verilator_params(

--- a/sw/device/tests/aes_entropy_test.c
+++ b/sw/device/tests/aes_entropy_test.c
@@ -1,0 +1,131 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_aes.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aes_testutils.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+// The following plaintext, key and ciphertext are extracted from Appendix C of
+// the Advanced Encryption Standard (AES) FIPS Publication 197 available at
+// https://www.nist.gov/publications/advanced-encryption-standard-aes
+
+#define TIMEOUT (1000 * 1000)
+
+static const uint32_t kPlainText[] = {
+    0x33221100,
+    0x77665544,
+    0xbbaa9988,
+    0xffeeddcc,
+};
+
+static const uint8_t kKey[] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+    0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15,
+    0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+};
+
+static const uint32_t kCipherTextGold[] = {
+    0x493350e6,
+    0x4a0a5568,
+    0x9d4d4aa1,
+    0xd256e2e0,
+};
+
+static const uint32_t kIv[] = {
+    0x01020304,
+    0x0c0d0e0f,
+    0x1718191a,
+    0x1c1d1e1f,
+};
+
+// The mask share, used to mask kKey. Note that the masking should not be done
+// manually. Software is expected to get the key in two shares right from the
+// beginning.
+static const uint8_t kKeyShare1[] = {
+    0x0f, 0x1f, 0x2f, 0x3f, 0x4f, 0x5f, 0x6f, 0x7f, 0x8f, 0x9f, 0xaf,
+    0xbf, 0xcf, 0xdf, 0xef, 0xff, 0x0a, 0x1a, 0x2a, 0x3a, 0x4a, 0x5a,
+    0x6a, 0x7a, 0x8a, 0x9a, 0xaa, 0xba, 0xca, 0xda, 0xea, 0xfa,
+};
+
+const test_config_t kTestConfig;
+
+bool test_main(void) {
+  dif_aes_t aes;
+
+  // First of all, we need to get the entropy complex up and running.
+  entropy_testutils_boot_mode_init();
+
+  // Initialise AES.
+  CHECK_DIF_OK(
+      dif_aes_init(mmio_region_from_addr(TOP_EARLGREY_AES_BASE_ADDR), &aes));
+  CHECK_DIF_OK(dif_aes_reset(&aes));
+
+  // Mask the key. Note that this should not be done manually. Software is
+  // expected to get the key in two shares right from the beginning.
+  uint8_t key_share0[ARRAYSIZE(kKey)];
+  for (int i = 0; i < ARRAYSIZE(kKey); ++i) {
+    key_share0[i] = kKey[i] ^ kKeyShare1[i];
+  }
+
+  // "Convert" key share byte arrays to `dif_aes_key_share_t`.
+  dif_aes_key_share_t key;
+  memcpy(key.share0, key_share0, ARRAYSIZE(kKey));
+  memcpy(key.share1, kKeyShare1, ARRAYSIZE(kKey));
+
+  // "Convert" iv byte arrays to `dif_aes_iv_t`.
+  dif_aes_iv_t iv;
+  memcpy(iv.iv, kIv, ARRAYSIZE(kIv));
+
+  // Setup CBC encryption transaction.
+  dif_aes_transaction_t transaction = {
+      .operation = kDifAesOperationEncrypt,
+      .mode = kDifAesModeCbc,
+      .key_len = kDifAesKey256,
+      .manual_operation = kDifAesManualOperationManual,
+  };
+
+  // Write the initial key share, IV and data in CSRs (known combinations).
+  CHECK_DIF_OK(dif_aes_start(&aes, &transaction, &key, &iv));
+  dif_aes_data_t in_data_plain;
+  memcpy(in_data_plain.data, kPlainText, ARRAYSIZE(kPlainText));
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusInputReady, true, TIMEOUT);
+  CHECK_DIF_OK(dif_aes_load_data(&aes, in_data_plain));
+
+  // Write the PRNG_RESEED bit to reseed the internal state of the PRNG.
+  CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerPrngReseed));
+
+  // Trigger the AES operation to run and wait for it to complete.
+  CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerStart));
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusOutputValid, true, TIMEOUT);
+
+  // Check the ciphertext against the expected value.
+  dif_aes_data_t out_data;
+  CHECK_DIF_OK(dif_aes_read_output(&aes, &out_data));
+  CHECK_BUFFER_EQ(out_data.data, kCipherTextGold, ARRAYSIZE(kCipherTextGold));
+
+  // Write the KEY_IV_DATA_IN_CLEAR and DATA_OUT_CLEAR trigger bits to 1 and
+  // wait for it to complete by polling the status idle bit.
+  CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerDataOutClear));
+  CHECK_DIF_OK(dif_aes_trigger(&aes, kDifAesTriggerKeyIvDataInClear));
+  AES_TESTUTILS_WAIT_FOR_STATUS(&aes, kDifAesStatusIdle, true, TIMEOUT);
+
+  // Read back the data out CSRs - they should all read garbage values.
+  CHECK(dif_aes_read_output(&aes, &out_data) == kDifError);
+  CHECK(!aes_testutils_get_status(&aes, kDifAesStatusOutputValid));
+
+  // Assertion check verifies that the internal states (data_in, key share and
+  // IV are also garbage, i.e. different from the originally written values.
+  CHECK_DIF_OK(dif_aes_read_iv(&aes, &iv));
+  CHECK_BUFFER_NEQ(iv.iv, kIv, ARRAYSIZE(kIv));
+
+  CHECK_DIF_OK(dif_aes_end(&aes));
+  return true;
+}

--- a/sw/device/tests/aes_idle_test.c
+++ b/sw/device/tests/aes_idle_test.c
@@ -156,8 +156,8 @@ bool test_main(void) {
   // Finish the ECB encryption transaction.
   CHECK_DIF_OK(dif_aes_end(&aes));
 
-  CHECK_BUFFER(out_data_cipher.data, kCipherTextGold,
-               ARRAYSIZE(kCipherTextGold));
+  CHECK_BUFFER_EQ(out_data_cipher.data, kCipherTextGold,
+                  ARRAYSIZE(kCipherTextGold));
 
   return true;
 }

--- a/sw/device/tests/aes_smoketest.c
+++ b/sw/device/tests/aes_smoketest.c
@@ -110,7 +110,7 @@ bool test_main(void) {
   // Finish the ECB encryption transaction.
   CHECK_DIF_OK(dif_aes_end(&aes));
 
-  CHECK_BUFFER(out_data_cipher.data, kCipherTextGold, TEXT_LENGTH_IN_WORDS);
+  CHECK_BUFFER_EQ(out_data_cipher.data, kCipherTextGold, TEXT_LENGTH_IN_WORDS);
 
   // Setup ECB decryption transaction.
   transaction.operation = kDifAesOperationDecrypt;
@@ -128,7 +128,7 @@ bool test_main(void) {
   // Finish the ECB encryption transaction.
   CHECK_DIF_OK(dif_aes_end(&aes));
 
-  CHECK_BUFFER(out_data_plain.data, kPlainText, TEXT_LENGTH_IN_WORDS);
+  CHECK_BUFFER_EQ(out_data_plain.data, kPlainText, TEXT_LENGTH_IN_WORDS);
 
   return true;
 }

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -46,11 +46,11 @@ static void check_internal_state(const dif_csrng_t *csrng,
   CHECK(got.reseed_counter == expected->reseed_counter);
   CHECK(got.fips_compliance == expected->fips_compliance);
 
-  CHECK_BUFFER(got.v, expected->v, ARRAYSIZE(expected->v),
-               "CSRNG internal V buffer mismatch.");
+  CHECK_BUFFER_EQ(got.v, expected->v, ARRAYSIZE(expected->v),
+                  "CSRNG internal V buffer mismatch.");
 
-  CHECK_BUFFER(got.key, expected->key, ARRAYSIZE(expected->key),
-               "CSRNG internal K buffer mismatch.");
+  CHECK_BUFFER_EQ(got.key, expected->key, ARRAYSIZE(expected->key),
+                  "CSRNG internal K buffer mismatch.");
 }
 
 /**
@@ -124,8 +124,8 @@ static void fips_generate_kat(const dif_csrng_t *csrng) {
       0x2581f391, 0x80b1dc2f, 0xdf82ab22, 0x771c619b, 0xd40fccb1, 0x87189e99,
       0xe48bb8cb, 0x1012c84c, 0x5af8a7f1, 0xd1c07cd9};
 
-  CHECK_BUFFER(got, kExpectedOutput, kExpectedOutputLen,
-               "Generate command KAT output mismatch");
+  CHECK_BUFFER_EQ(got, kExpectedOutput, kExpectedOutputLen,
+                  "Generate command KAT output mismatch");
 }
 
 /**

--- a/sw/device/tests/flash_ctrl_clock_freqs_test.c
+++ b/sw/device/tests/flash_ctrl_clock_freqs_test.c
@@ -47,7 +47,7 @@ static void read_and_check_host_if(uint32_t addr, const uint32_t *check_data) {
   for (int i = 0; i < kDataSize; ++i) {
     host_data[i] = mmio_region_read32(flash_addr, i * sizeof(uint32_t));
   }
-  CHECK_BUFFER(host_data, check_data, kDataSize);
+  CHECK_BUFFER_EQ(host_data, check_data, kDataSize);
 }
 
 /**
@@ -74,7 +74,7 @@ static void do_info_partition_test(uint32_t partition_number) {
       &flash_state, address, kPartitionId, readback_data,
       kDifFlashCtrlPartitionTypeInfo, kDataSize, 0));
 
-  CHECK_BUFFER(readback_data, test_data, kDataSize);
+  CHECK_BUFFER_EQ(readback_data, test_data, kDataSize);
 }
 
 /**
@@ -116,7 +116,7 @@ static void do_data_partition_test(uint32_t bank_number) {
           &flash_state, address, kPartitionId, readback_data,
           kDifFlashCtrlPartitionTypeData, kDataSize, 1));
       read_and_check_host_if(kPageSize * page_index, test_data);
-      CHECK_BUFFER(readback_data, test_data, kDataSize);
+      CHECK_BUFFER_EQ(readback_data, test_data, kDataSize);
     }
   } else {
     LOG_ERROR("Unexpected bank number, only 0 and 1 are valid.");

--- a/sw/device/tests/flash_ctrl_idle_low_power_test.c
+++ b/sw/device/tests/flash_ctrl_idle_low_power_test.c
@@ -117,7 +117,7 @@ bool test_main(void) {
     CHECK(flash_ctrl_testutils_read(
               &flash, address, kPartitionId, readback_data,
               kDifFlashCtrlPartitionTypeData, kNumWords, 0) == 0);
-    CHECK_BUFFER(data, readback_data, kNumWords);
+    CHECK_BUFFER_EQ(data, readback_data, kNumWords);
 
     // Setting up low power hint and starting watchdog timer followed by
     // a flash operation (page erase) and WFI. This will create a bite
@@ -155,7 +155,7 @@ bool test_main(void) {
               kDifFlashCtrlPartitionTypeData, kNumWords, 0) == 0);
     uint32_t expected_data[kNumWords];
     memset(expected_data, 0xff, sizeof(expected_data));
-    CHECK_BUFFER(readback_data, expected_data, kNumWords);
+    CHECK_BUFFER_EQ(readback_data, expected_data, kNumWords);
 
     CHECK_DIF_OK(dif_rstmgr_reset_info_clear(&rstmgr));
   } else {

--- a/sw/device/tests/flash_ctrl_ops_test.c
+++ b/sw/device/tests/flash_ctrl_ops_test.c
@@ -151,7 +151,7 @@ static void read_and_check_host_if(uint32_t addr, const uint32_t *check_data) {
   for (int i = 0; i < kDataSize; ++i) {
     host_data[i] = mmio_region_read32(flash_addr, i * sizeof(uint32_t));
   }
-  CHECK_BUFFER(host_data, check_data, kDataSize);
+  CHECK_BUFFER_EQ(host_data, check_data, kDataSize);
 }
 
 /**
@@ -193,7 +193,7 @@ static void do_info_partition_test(uint32_t partition_number,
 
   compare_and_clear_irq_variables();
 
-  CHECK_BUFFER(readback_data, test_data, kInfoSize);
+  CHECK_BUFFER_EQ(readback_data, test_data, kInfoSize);
 }
 
 /**
@@ -275,7 +275,7 @@ static void do_bank1_data_partition_test(void) {
     compare_and_clear_irq_variables();
 
     read_and_check_host_if(kPageSize * page_index, test_data);
-    CHECK_BUFFER(readback_data, test_data, kDataSize);
+    CHECK_BUFFER_EQ(readback_data, test_data, kDataSize);
   }
 
   // Erasing the whole of bank 1.
@@ -319,7 +319,7 @@ static void do_bank1_data_partition_test(void) {
     memset(expected_data, 0xff, sizeof(expected_data));
 
     read_and_check_host_if(kPageSize * page_index, expected_data);
-    CHECK_BUFFER(readback_data, expected_data, kDataSize);
+    CHECK_BUFFER_EQ(readback_data, expected_data, kDataSize);
   }
 }
 

--- a/sw/device/tests/hmac_enc_test.c
+++ b/sw/device/tests/hmac_enc_test.c
@@ -92,8 +92,8 @@ bool test_main() {
   CHECK_DIF_OK(dif_hmac_process(&hmac));
   dif_hmac_digest_t key_digest;
   hmac_testutils_finish_polled(&hmac, &key_digest);
-  CHECK_BUFFER(key_digest.digest, kExpectedShaDigest.digest,
-               ARRAYSIZE(key_digest.digest));
+  CHECK_BUFFER_EQ(key_digest.digest, kExpectedShaDigest.digest,
+                  ARRAYSIZE(key_digest.digest));
 
   // Generate HMAC final digest, using the resulted SHA256 digest over the
   // `kHmacLongKey`.

--- a/sw/device/tests/kmac_app_rom_test.c
+++ b/sw/device/tests/kmac_app_rom_test.c
@@ -26,9 +26,9 @@ bool test_main(void) {
   // get computed and expected digests and check that they match
   CHECK_DIF_OK(dif_rom_ctrl_get_digest(&rom_ctrl, &computed_digest));
   CHECK_DIF_OK(dif_rom_ctrl_get_expected_digest(&rom_ctrl, &expected_digest));
-  CHECK_BUFFER(computed_digest.digest, expected_digest.digest,
-               ROM_CTRL_DIGEST_MULTIREG_COUNT,
-               "Mismatch between computed and expected digest.");
+  CHECK_BUFFER_EQ(computed_digest.digest, expected_digest.digest,
+                  ROM_CTRL_DIGEST_MULTIREG_COUNT,
+                  "Mismatch between computed and expected digest.");
 
   return true;
 }

--- a/sw/device/tests/kmac_idle_test.c
+++ b/sw/device/tests/kmac_idle_test.c
@@ -82,8 +82,8 @@ static void do_sha3_test(void) {
   check_clock_state(kDifToggleDisabled);
 
   // Check the result to be sure the SHA3 operation completed correctly.
-  CHECK_BUFFER(out, sha3_256_test.digest, sha3_256_test.digest_len,
-               "Digest mismatch for test SHA3 256.");
+  CHECK_BUFFER_EQ(out, sha3_256_test.digest, sha3_256_test.digest_len,
+                  "Digest mismatch for test SHA3 256.");
 
   // Set hint to enabled again to check that clock can be re-enabled.
   CHECK_DIF_OK(dif_clkmgr_hintable_clock_set_hint(&clkmgr, kmac_clock,

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -376,6 +376,27 @@ sw_tests += {
   }
 }
 
+aes_entropy_test_lib = declare_dependency(
+  link_with: static_library(
+    'aes_entropy_test_lib',
+    sources: ['aes_entropy_test.c'],
+    dependencies: [
+      sw_lib_dif_aes,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+      sw_lib_testing_entropy_testutils,
+      sw_lib_testing_aes_testutils,
+      sw_lib_testing_clkmgr_testutils,
+      sw_lib_testing_test_status,
+    ],
+  ),
+)
+sw_tests += {
+  'aes_entropy_test': {
+    'library': aes_entropy_test_lib,
+  }
+}
+
 clkmgr_smoketest_lib = declare_dependency(
   link_with: static_library(
     'clkmgr_smoketest_lib',

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -53,7 +53,7 @@ static void otbn_check_mem(otbn_t *ctx, const uint8_t *addr, size_t mem_size,
     CHECK_DIF_OK(otbn_read(&ctx->dif, offset, local_buf, remainder));
     if (match_expected) {
       CHECK(!has_exception_fired, "Unexpected exception");
-      CHECK_BUFFER(addr + offset, local_buf, remainder);
+      CHECK_BUFFER_EQ(addr + offset, local_buf, remainder);
     } else {
       CHECK(has_exception_fired, "Expected exception haven't fired");
       break;

--- a/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
+++ b/sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test.c
@@ -88,7 +88,7 @@ static bool access_partitions(bool do_write, bool do_read, int page_id,
         flash_ctrl_testutils_read(&flash, address, kPartitionId, readback_data,
                                   kDifFlashCtrlPartitionTypeInfo, size, 0);
     if (retval == false) {
-      CHECK_BUFFER(data, readback_data, size);
+      CHECK_BUFFER_EQ(data, readback_data, size);
     }
   }
   return (!retval);
@@ -157,7 +157,8 @@ bool test_main(void) {
                                            kDifKeymgrStateCreatorRootKey);
 
   if (curr_state == kDifLcCtrlStateDev) {
-    CHECK_BUFFER(access_checks, kDevExpectedAccess, ARRAYSIZE(access_checks));
+    CHECK_BUFFER_EQ(access_checks, kDevExpectedAccess,
+                    ARRAYSIZE(access_checks));
 
     CHECK_DIF_OK(dif_otp_ctrl_dai_digest(&otp, kDifOtpCtrlPartitionSecret2, 0));
     dif_otp_ctrl_status_t otp_status;
@@ -166,7 +167,8 @@ bool test_main(void) {
     } while (
         !(bitfield_bit32_read(otp_status.codes, kDifOtpCtrlStatusCodeDaiIdle)));
   } else if (curr_state == kDifLcCtrlStateProd) {
-    CHECK_BUFFER(access_checks, kProdExpectedAccess, ARRAYSIZE(access_checks));
+    CHECK_BUFFER_EQ(access_checks, kProdExpectedAccess,
+                    ARRAYSIZE(access_checks));
   }
 
   test_status_set(kTestStatusInWfi);

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -112,9 +112,9 @@ static void read_and_check_info_page_scrambled(bool is_equal,
       &flash_state, address, kPartitionId, readback_data,
       kDifFlashCtrlPartitionTypeInfo, kDataSize, 0));
   if (is_equal) {
-    CHECK_BUFFER(readback_data, data, kDataSize);
+    CHECK_BUFFER_EQ(readback_data, data, kDataSize);
   } else {
-    CHECK_BUFFER_NOT_EQ(readback_data, data, kDataSize);
+    CHECK_BUFFER_NEQ(readback_data, data, kDataSize);
   }
 }
 
@@ -130,9 +130,9 @@ static void read_and_check_data_page_scrambled(bool is_equal,
       &flash_state, address, kPartitionId, readback_data,
       kDifFlashCtrlPartitionTypeData, kDataSize, 0));
   if (is_equal) {
-    CHECK_BUFFER(readback_data, data, kDataSize);
+    CHECK_BUFFER_EQ(readback_data, data, kDataSize);
   } else {
-    CHECK_BUFFER_NOT_EQ(readback_data, data, kDataSize);
+    CHECK_BUFFER_NEQ(readback_data, data, kDataSize);
   }
 }
 

--- a/sw/device/tests/sim_dv/keymgr_key_derivation.c
+++ b/sw/device/tests/sim_dv/keymgr_key_derivation.c
@@ -114,7 +114,7 @@ static void write_info_page(dif_flash_ctrl_state_t *flash, uint32_t page_id,
   CHECK(flash_ctrl_testutils_read(flash, address, kFlashInfoPartitionId,
                                   readback_data, kDifFlashCtrlPartitionTypeInfo,
                                   kSecretWordSize, 0) == 0);
-  CHECK_BUFFER(data, readback_data, kSecretWordSize);
+  CHECK_BUFFER_EQ(data, readback_data, kSecretWordSize);
 }
 
 static void init_flash(void) {

--- a/third_party/riscv-compliance/compliance_main.c
+++ b/third_party/riscv-compliance/compliance_main.c
@@ -24,7 +24,7 @@ bool test_main(void) {
   run_rvc_test();
 
   ptrdiff_t words = end_signature - begin_signature;
-  CHECK_BUFFER(begin_signature, kExpectedSignature, (size_t)words);
+  CHECK_BUFFER_EQbegin_signature, kExpectedSignature, (size_t)words);
 
   return true;
 }


### PR DESCRIPTION
## Fist commit

- Refactor the `CHECK_BUFFER` macro
- Add the macors `CHECK_BUFFER_EQ` and `CHECK_BUFFER_NEQ`

## Second commit

- Add the chip level test `chip_sw_aes_entropy`.
- Changes the test description since it is not possible to read the keys from the registers.
