### PR TITLE
[fpv/pinmux] Add tl integrity error check

### DIFF
--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -25,16 +25,17 @@ if {$env(COV) == 1} {
 # read design
 #-------------------------------------------------------------------------
 
+# TODO: better way to handle macro define. Consider use it as an input for sim_cfg.
 if {$env(TASK) == "FpvSecCm"} {
   analyze -sv09 \
     +define+FPV_ON \
-    +define+FPV_SEC_CM_ON \
+    +define+FPV_SEC_CM_ON+FPV_ALERT_NO_SIGINT_ERR \
     -bbox_m prim_count \
     -bbox_m prim_double_lfsr \
     -f [glob *.scr]
 } elseif {$env(DUT_TOP) == "pinmux_tb"} {
   analyze -sv09 \
-    +define+FPV_ON \
+    +define+FPV_ON+FPV_ALERT_NO_SIGINT_ERR \
     -bbox_m usbdev_aon_wake \
     -f [glob *.scr]
 } else {

--- a/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
+++ b/hw/ip/pinmux/fpv/vip/pinmux_assert_fpv.sv
@@ -718,4 +718,9 @@ module pinmux_assert_fpv
   `ASSERT(UsbStateDebugO_A, ##1 usb_state_debug_o <->
           u_usbdev_aon_wake.bus_debug_o, clk_aon_i, !rst_aon_ni)
 
+  // Fatal alert related assertions
+  `ASSUME(TriggerAfterAlertInit_S, $stable(rst_ni) == 0 |->
+          pinmux.u_reg.u_chk.intg_err_o == 0 [*10])
+  `ASSERT(TlIntgFatalAlert_A, pinmux.u_reg.intg_err_o |-> (##[0:7] (alert_tx_o[0].alert_p)) [*2])
+
 endmodule : pinmux_assert_fpv

--- a/hw/ip/prim/rtl/prim_alert_sender.sv
+++ b/hw/ip/prim/rtl/prim_alert_sender.sv
@@ -304,12 +304,16 @@ module prim_alert_sender
     sequence AckSigInt_S;
       alert_rx_i.ping_p == alert_rx_i.ping_n [*2];
     endsequence
+
+  `ifndef FPV_ALERT_NO_SIGINT_ERR
     // check propagation of sigint issues to output within three cycles
     // shift sequence to the right to avoid reset effects.
     `ASSERT(SigIntPing_A, ##1 PingSigInt_S |->
         ##3 alert_tx_o.alert_p == alert_tx_o.alert_n)
     `ASSERT(SigIntAck_A, ##1 AckSigInt_S |->
         ##3 alert_tx_o.alert_p == alert_tx_o.alert_n)
+  `endif
+
     // Test in-band FSM reset request (via signal integrity error)
     `ASSERT(InBandInitFsm_A, PingSigInt_S or AckSigInt_S |-> ##3 state_q == Idle)
     `ASSERT(InBandInitPing_A, PingSigInt_S or AckSigInt_S |-> ##3 !ping_set_q)
@@ -332,11 +336,15 @@ module prim_alert_sender
     sequence AckSigInt_S;
       alert_rx_i.ping_p == alert_rx_i.ping_n;
     endsequence
+
+  `ifndef FPV_ALERT_NO_SIGINT_ERR
     // check propagation of sigint issues to output within one cycle
     `ASSERT(SigIntPing_A, PingSigInt_S |=>
         alert_tx_o.alert_p == alert_tx_o.alert_n)
     `ASSERT(SigIntAck_A,  AckSigInt_S |=>
         alert_tx_o.alert_p == alert_tx_o.alert_n)
+  `endif
+
     // Test in-band FSM reset request (via signal integrity error)
     `ASSERT(InBandInitFsm_A, PingSigInt_S or AckSigInt_S |=> state_q == Idle)
     `ASSERT(InBandInitPing_A, PingSigInt_S or AckSigInt_S |=> !ping_set_q)
@@ -374,7 +382,7 @@ module prim_alert_sender
       clk_i, !rst_ni || (alert_tx_o.alert_p == alert_tx_o.alert_n))
 `endif
 
-`ifdef FPV_SEC_CM_ON
+`ifdef FPV_ALERT_NO_SIGINT_ERR
   // Assumptions for FPV security countermeasures to ensure the alert protocol functions collectly.
   `ASSUME_FPV(AckPFollowsAlertP_S, alert_rx_i.ack_p == $past(alert_tx_o.alert_p))
   `ASSUME_FPV(AckNFollowsAlertN_S, alert_rx_i.ack_n == $past(alert_tx_o.alert_n))

--- a/hw/ip/prim/rtl/prim_diff_decode.sv
+++ b/hw/ip/prim/rtl/prim_diff_decode.sv
@@ -233,6 +233,7 @@ module prim_diff_decode #(
       end
     end
 
+  `ifndef FPV_ALERT_NO_SIGINT_ERR
     // correctly detect sigint issue (only one transition cycle of permissible due to skew)
     `ASSERT(SigintCheck0_A, hlp_diff_pq == hlp_diff_nq [*2] |-> ##[0:1] sigint_o)
     // the synchronizer adds 2 cycles of latency with respect to input signals.
@@ -256,6 +257,8 @@ module prim_diff_decode #(
         $fell(hlp_diff_nq) && $stable(hlp_diff_pq) ##1 $stable(hlp_diff_nq) && $rose(hlp_diff_pq)
         |->
         ##1 rise_o)
+  `endif
+
     // correctly detect edges
     `ASSERT(RiseCheck_A,  ##1 $rose(hlp_diff_pq)     && (hlp_diff_pq ^ hlp_diff_nq) |->
         ##[1:2] rise_o,  clk_i, !rst_ni || sigint_o)
@@ -270,8 +273,12 @@ module prim_diff_decode #(
 `endif
   end else begin : gen_sync_assert
     // assertions for synchronous case
+
+  `ifndef FPV_ALERT_NO_SIGINT_ERR
     // correctly detect sigint issue
     `ASSERT(SigintCheck_A, diff_pi == diff_ni |-> sigint_o)
+  `endif
+
     // correctly detect edges
     `ASSERT(RiseCheck_A,  ##1 $rose(diff_pi)    && (diff_pi ^ diff_ni) |->  rise_o)
     `ASSERT(FallCheck_A,  ##1 $fell(diff_pi)    && (diff_pi ^ diff_ni) |->  fall_o)


### PR DESCRIPTION
This PR adds check for TL integrity error to trigger fatal alert.
To accomplish this, we need to ensure the alert receiver end returns
alert handshake signal correctly.
Because this requirement is shared for FPV security countermeasures, I
create a new macro define `FPV_ALERT_NO_SIGINT_ERR`, and disable some
build-in signal integrity assertions from alert_sender and diff_decode
block.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>