### PR TITLE
[prim_onehot_check] Add prim_onehot_check

### DIFF
--- a/hw/ip/prim/prim_onehot_check.core
+++ b/hw/ip/prim/prim_onehot_check.core
@@ -3,15 +3,14 @@ CAPI=2:
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: "lowrisc:prim:onehot"
-description: "Utilities for working with one-hot encoding"
+name: "lowrisc:prim:onehot_check"
+description: "One-hot encoding checker"
 filesets:
   files_rtl:
     depend:
       - lowrisc:prim:util
     files:
-      - rtl/prim_onehot_enc.sv
-      - rtl/prim_onehot_mux.sv
+      - rtl/prim_onehot_check.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:
@@ -19,7 +18,7 @@ filesets:
       # common waivers
       - lowrisc:lint:common
     #files:
-    #  - lint/prim_onehot.vlt
+    #  - lint/prim_onehot_check.vlt
     file_type: vlt
 
   files_ascentlint_waiver:
@@ -27,7 +26,7 @@ filesets:
       # common waivers
       - lowrisc:lint:common
     #files:
-    #  - lint/prim_onehot.waiver
+    #  - lint/prim_onehot_check.waiver
     file_type: waiver
 
   files_veriblelint_waiver:
@@ -42,3 +41,8 @@ targets:
       - tool_ascentlint  ? (files_ascentlint_waiver)
       - tool_veriblelint ? (files_veriblelint_waiver)
       - files_rtl
+
+  formal:
+    filesets:
+      - files_rtl
+    toplevel: prim_onehot_check

--- a/hw/ip/prim/rtl/prim_onehot_check.sv
+++ b/hw/ip/prim/rtl/prim_onehot_check.sv
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Onehot checker.
+// Checks whether the onehot property is true and outputs an error otherwise.
+// Specifically, it expects exactly one oh_i bit to be 1 when en_i is 1, and
+// when en_i is zero it expects the oh_i vector to be all zeroes.
+
+module prim_onehot_check #(
+  parameter int unsigned OneHotWidth = 32
+) (
+  // The module is combinational - the clock and reset are only used for assertions.
+  input                          clk_i,
+  input                          rst_ni,
+
+  input  logic [OneHotWidth-1:0] oh_i,
+  input  logic                   en_i,
+
+  output logic                   err_o
+);
+
+  ///////////////////////
+  // Binary tree logic //
+  ///////////////////////
+
+  // This only works with 2 or more sources.
+  `ASSERT_INIT(NumSources_A, OneHotWidth >= 2)
+
+  // Align to powers of 2 for simplicity.
+  // A full binary tree with N levels has 2**N + 2**N-1 nodes.
+  localparam int NumLevels = $clog2(OneHotWidth);
+  logic [2**(NumLevels+1)-2:0] or_tree;
+  logic [2**(NumLevels+1)-2:0] err_tree;
+
+  for (genvar level = 0; level < NumLevels+1; level++) begin : gen_tree
+    //
+    // level+1   C0   C1   <- "Base1" points to the first node on "level+1",
+    //            \  /         these nodes are the children of the nodes one level below
+    // level       Pa      <- "Base0", points to the first node on "level",
+    //                         these nodes are the parents of the nodes one level above
+    //
+    // hence we have the following indices for the paPa, C0, C1 nodes:
+    // Pa = 2**level     - 1 + offset       = Base0 + offset
+    // C0 = 2**(level+1) - 1 + 2*offset     = Base1 + 2*offset
+    // C1 = 2**(level+1) - 1 + 2*offset + 1 = Base1 + 2*offset + 1
+    //
+    localparam int Base0 = (2**level)-1;
+    localparam int Base1 = (2**(level+1))-1;
+
+    for (genvar offset = 0; offset < 2**level; offset++) begin : gen_level
+      localparam int Pa = Base0 + offset;
+      localparam int C0 = Base1 + 2*offset;
+      localparam int C1 = Base1 + 2*offset + 1;
+
+      // This assigns the input values, their corresponding IDs and valid signals to the tree leafs.
+      if (level == NumLevels) begin : gen_leafs
+        if (offset < OneHotWidth) begin : gen_assign
+          assign or_tree[Pa] = oh_i[offset];
+        end else begin : gen_tie_off
+          assign or_tree[Pa] = 1'b0;
+        end
+        assign err_tree[Pa] = 1'b0;
+      // This creates the node assignments.
+      end else begin : gen_nodes
+        // Local helper variables
+        assign or_tree[Pa]  = or_tree[C0] || or_tree[C1];
+        assign err_tree[Pa] = (or_tree[C0] && or_tree[C1]) || err_tree[C0] || err_tree[C1];
+      end
+    end : gen_level
+  end : gen_tree
+
+  // Check whether:
+  // 1) more than 1 bit is set in the vector
+  // 2) whether en_i agrees with (|oh_i)
+  assign err_o = err_tree[0] || or_tree[0] ^ en_i;
+
+  `ASSERT(Onehot0_A, !$onehot0(oh_i) |-> err_o )
+  `ASSERT(Crosscheck_A, err_o === ($countones(oh_i) != en_i))
+
+endmodule : prim_onehot_check

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -392,6 +392,20 @@
                rel_path: "hw/ip/prim/prim_max_tree/{sub_flow}/{tool}"
                cov: true
              }
+             { name: prim_sum_tree
+               dut: prim_sum_tree
+               fusesoc_core: lowrisc:prim:sum_tree
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_sum_tree/{sub_flow}/{tool}"
+               cov: true
+             }
+             { name: prim_onehot_check
+               dut: prim_onehot_check
+               fusesoc_core: lowrisc:prim:onehot_check
+               import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
+               rel_path: "hw/ip/prim/prim_onehot_check/{sub_flow}/{tool}"
+               cov: true
+             }
              // Below are IPs that already has a DV testbench,
              // FPV only verifies the security countermeasure assertions,
              // so will not collect FPV coverage.


### PR DESCRIPTION
Adds a checker module that can be used to check the onehot0 property of
a vector. This is useful for checks such as spurious write-enable
detection on CSR and register file blocks (for triggering alerts).

Signed-off-by: Michael Schaffner <msf@google.com>