### PR TITLE
Remove git repo from workspace[bazel] remove `git_repository()` repo rules

### DIFF
--- a/sw/vendor/patches/mundane/build_with_bazel.patch
+++ b/sw/vendor/patches/mundane/build_with_bazel.patch
@@ -66,10 +66,9 @@ new file mode 100644
 index 0000000..4b7301c
 --- /dev/null
 +++ b/WORKSPACE.bazel
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,25 @@
 +workspace(name = "mundane")
 +
-+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 +load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 +
 +http_archive(
@@ -89,11 +88,9 @@ index 0000000..4b7301c
 +    version = "1.53.0",
 +)
 +
-+# boringssl `main-with-bazel` branch as of 2021-11-09.
-+git_repository(
++http_archive(
 +    name = "boringssl",
-+    commit = "4fb158925f7753d80fb858cb0239dff893ef9f15",
-+    remote = "https://boringssl.googlesource.com/boringssl",
++    url = "https://boringssl.googlesource.com/boringssl/+archive/4fb158925f7753d80fb858cb0239dff893ef9f15.tar.gz",
 +)
 diff --git a/boringssl/BUILD.bazel b/boringssl/BUILD.bazel
 new file mode 100644

--- a/third_party/bazel_embedded/repos.bzl
+++ b/third_party/bazel_embedded/repos.bzl
@@ -2,14 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def bazel_embedded_repos():
     # Contains rules that support building SW for embedded targets. Specifically, we
     # maintain a fork to build for RISCV32I.
-    git_repository(
+    http_archive(
         name = "bazel_embedded",
-        commit = "fe65a8aca35ae0bae563efd6a29cc14fcb15140d",
-        remote = "https://github.com/lowRISC/bazel-embedded.git",
-        shallow_since = "1639417565 -0800",
+        sha256 = "ee828762c3b7ea6f4513a57bf39b530671822503be924d3fe29e48390ca41bca",
+        strip_prefix = "bazel-embedded-fe65a8aca35ae0bae563efd6a29cc14fcb15140d",
+        url = "https://github.com/lowRISC/bazel-embedded/archive/fe65a8aca35ae0bae563efd6a29cc14fcb15140d.tar.gz",
     )

--- a/third_party/cc/repos.bzl
+++ b/third_party/cc/repos.bzl
@@ -3,20 +3,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def cc_repos():
-    git_repository(
+    http_archive(
         name = "rules_cc",
-        commit = "a636005ba28c0344da5110bd8532184c74b6ffdf",
-        remote = "https://github.com/bazelbuild/rules_cc.git",
-        shallow_since = "1583316607 -0800",
+        sha256 = "123ababe4be661f2fc9189d3b24deabc003926e87d991832cd46b6ae59f7b3c8",
+        strip_prefix = "rules_cc-a636005ba28c0344da5110bd8532184c74b6ffdf",
+        url = "https://github.com/bazelbuild/rules_cc/archive/a636005ba28c0344da5110bd8532184c74b6ffdf.tar.gz",
     )
 
     http_archive(
         name = "com_google_absl",
-        strip_prefix = "abseil-cpp-master",
-        urls = ["https://github.com/abseil/abseil-cpp/archive/master.zip"],
+        strip_prefix = "abseil-cpp-e854df09dfcb35056c1d42420028648ee0ebebaf",
+        url = "https://github.com/abseil/abseil-cpp/archive/e854df09dfcb35056c1d42420028648ee0ebebaf.tar.gz",
     )
 
     native.local_repository(

--- a/third_party/freertos/repos.bzl
+++ b/third_party/freertos/repos.bzl
@@ -2,15 +2,17 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def freertos_repos():
-    new_git_repository(
+    http_archive(
         name = "freertos",
         build_file = Label("//third_party/freertos:BUILD.freertos.bazel"),
-        remote = "https://github.com/FreeRTOS/FreeRTOS-Kernel.git",
-        commit = "0b1e9d79c82c1bf00e93142f9d5b1b7b62446995",
-        shallow_since = "1628817357 -0700",
+        sha256 = "c4c29136071b84841c3f00675da35f5e61e83c1fa18ac43841c478f99190dd7d",
+        strip_prefix = "FreeRTOS-Kernel-0b1e9d79c82c1bf00e93142f9d5b1b7b62446995",
+        urls = [
+            "https://github.com/FreeRTOS/FreeRTOS-Kernel/archive/0b1e9d79c82c1bf00e93142f9d5b1b7b62446995.tar.gz",
+        ],
         patches = [
             Label("//third_party/freertos:0001-Remove-mtime-address-macros.patch"),
             Label("//third_party/freertos:0002-Remove-references-to-stdlib.h.patch"),

--- a/third_party/lint/repos.bzl
+++ b/third_party/lint/repos.bzl
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def lint_repos():
     # We have a 'vendored' copy of the google_verible_verilog_syntax_py repo
@@ -18,8 +17,9 @@ def lint_repos():
         url = "https://github.com/bazelbuild/buildtools/archive/main.zip",
     )
 
-    git_repository(
+    http_archive(
         name = "lowrisc_lint",
-        commit = "8bca6cff6f5def9ba866a11b7eeb3f4a12f9f516",
-        remote = "https://github.com/lowrisc/misc-linters",
+        sha256 = "2cf2badc52b212445d7ed6eb4d99a925d9736b06daacf9ad3b783953fb3ccaee",
+        strip_prefix = "misc-linters-8bca6cff6f5def9ba866a11b7eeb3f4a12f9f516",
+        url = "https://github.com/lowrisc/misc-linters/archive/8bca6cff6f5def9ba866a11b7eeb3f4a12f9f516.tar.gz",
     )

--- a/third_party/protobuf/repos.bzl
+++ b/third_party/protobuf/repos.bzl
@@ -2,11 +2,12 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def protobuf_repos():
-    git_repository(
+    http_archive(
         name = "com_google_protobuf",
-        commit = "520c601c99012101c816b6ccc89e8d6fc28fdbb8",
-        remote = "https://github.com/protocolbuffers/protobuf",
+        sha256 = "e661431858c1c7672a77446a7732d397dc5ae422eddfe07d02ed2c0619ae5d2b",
+        strip_prefix = "protobuf-520c601c99012101c816b6ccc89e8d6fc28fdbb8",
+        url = "https://github.com/protocolbuffers/protobuf/archive/520c601c99012101c816b6ccc89e8d6fc28fdbb8.tar.gz",
     )

--- a/third_party/riscv-compliance/repos.bzl
+++ b/third_party/riscv-compliance/repos.bzl
@@ -2,8 +2,6 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
-
 def riscv_compliance_repos():
     #new_git_repository(
     #    name = "riscv-compliance",
@@ -19,7 +17,10 @@ def riscv_compliance_repos():
 
     # TODO(lowRISC/opentitan#11877)
     # For the time being, use a local repo, but it should really be replaced with
-    # the git repo defined above.
+    # the an http_archive version of the git repo defined above. Note, we avoid using
+    # git repos in order to support offline (airgapped) builds, which require building
+    # the repository cache offline (which only works with http_archive). See
+    # https://docs.bazel.build/versions/3.4.0/external.html#repository-rules
     #
     # Everything else in this directory is set up so that we can uncomment the above
     # without any other changes.

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -3,31 +3,24 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 def rust_repos():
     http_archive(
         name = "rules_rust",
         sha256 = "531bdd470728b61ce41cf7604dc4f9a115983e455d46ac1d0c1632f613ab9fc3",
         strip_prefix = "rules_rust-d8238877c0e552639d3e057aadd6bfcf37592408",
-        urls = [
-            # `main` branch as of 2021-08-23
-            "https://github.com/bazelbuild/rules_rust/archive/d8238877c0e552639d3e057aadd6bfcf37592408.tar.gz",
-        ],
+        url = "https://github.com/bazelbuild/rules_rust/archive/d8238877c0e552639d3e057aadd6bfcf37592408.tar.gz",
     )
 
     # Boring is only used to build Mundane.
-    git_repository(
+    http_archive(
         name = "boringssl",
-        # boringssl `main-with-bazel` branch as of 2021-11-09.
-        commit = "4fb158925f7753d80fb858cb0239dff893ef9f15",
-        remote = "https://boringssl.googlesource.com/boringssl",
+        url = "https://boringssl.googlesource.com/boringssl/+archive/4fb158925f7753d80fb858cb0239dff893ef9f15.tar.gz",
     )
 
-    git_repository(
+    http_archive(
         name = "mundane",
-        commit = "f516499751b45969ac5a95091b1f68cf5ec23f04",
+        url = "https://fuchsia.googlesource.com/mundane/+archive/f516499751b45969ac5a95091b1f68cf5ec23f04.tar.gz",
         patch_args = ["-p1"],
         patches = ["//sw/vendor/patches/mundane:build_with_bazel.patch"],
-        remote = "https://fuchsia.googlesource.com/mundane",
     )

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -141,7 +141,7 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @local_config_cc_toolchains//... \
     @local_config_platform//... \
     @local_config_sh//... \
-    @python3_9_toolchains//... \
+    @python3_toolchains//... \
     @riscv-compliance//... \
     @rust_darwin_aarch64_toolchains//... \
     @rust_darwin_x86_64_toolchains//... \


### PR DESCRIPTION
In order to support offline bazel builds on airgapped machines, we must be able to prepare a repository cache with all external dependencies on a machine connected to the internet, and then move this cache to the airgapped machine and build with `bazel build --repository_cache=<cache> <label>`. However, according to the bazel documentation (see https://docs.bazel.build/versions/3.4.0/external.html#repository-rules) only `http_archive` works with the repository cache, not `git_repository` rules. Therefore, this commit removes all `git_repository` rules from the workspace, and uses `http_archive` rules instead.

Signed-off-by: Timothy Trippel <ttrippel@google.com>