### PR TITLE
[top, dv] Test keymgr disable

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1852,8 +1852,6 @@
               keymgr.
             - Read keymgr CSRs `SW_SHARE*` and verify the return values.
             - Advance to `Disabled` and verify keymgr enters the state successfully.
-            - Generate identity / SW output and ensure these are neither all 1s/0s nor any valid
-              key value, which proves secrets are wiped by entropy value from EDN.
 
             - For each operation, wait for the interrupt `op_done` to be triggered and check CSR
               `op_status` is `DONE_SUCCESS`.
@@ -1869,19 +1867,6 @@
             '''
       milestone: V2
       tests: ["chip_sw_keymgr_key_derivation"]
-    }
-    {
-      name: chip_sw_keymgr_lc_disable
-      desc: '''Verify that the keymgr is disabled on LC escalation.
-
-            - Configure the keymgr and advance to `CreatorRootKey`.
-            - Transition life cycle to `ESCALATION` state, which should disable keymgr.
-            - Verify keymgr enters the `Disabled` state successfully.
-
-            X-ref'ed with life cycle test.
-            '''
-      milestone: V2
-      tests: []
     }
     {
       name: chip_sw_keymgr_sideload_kmac

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_keymgr_key_derivation_vseq.sv
@@ -167,6 +167,9 @@ class chip_sw_keymgr_key_derivation_vseq extends chip_sw_base_vseq;
 
       `DV_CHECK_EQ(unmask_act_key, unmask_exp_key)
     end
+
+    // The next operation is disable, and key will be wiped and changed every cycle.
+    $assertoff(0, "tb.dut.top_earlgrey.u_kmac.u_kmac_core.KeyDataStable_M");
   endtask
 
   virtual function bit [keymgr_pkg::KeyWidth-1:0] get_unmasked_key(key_shares_t two_share_key);

--- a/sw/device/lib/testing/keymgr_testutils.h
+++ b/sw/device/lib/testing/keymgr_testutils.h
@@ -9,25 +9,49 @@
 
 /**
  * Issues a keymgr advance operation and wait for it to complete
+ *
+ * @param keymgr A key manager handle.
+ * @param params The binding and max key version value for the next state.
  */
 void keymgr_testutils_advance_state(const dif_keymgr_t *keymgr,
                                     const dif_keymgr_state_params_t *params);
 
 /**
  * Checks if the current keymgr state matches the expected state
+ *
+ * @param keymgr A key manager handle.
+ * @param exp_state The expected key manager state.
  */
 void keymgr_testutils_check_state(const dif_keymgr_t *keymgr,
                                   const dif_keymgr_state_t exp_state);
 
 /**
  * Issues a keymgr identity generation and wait for it to complete
+ *
+ * @param keymgr A key manager handle.
  */
 void keymgr_testutils_generate_identity(const dif_keymgr_t *keymgr);
 
 /**
  * Issues a keymgr HW/SW versioned key generation and wait for it to complete
+ *
+ * @param keymgr A key manager handle.
+ * @param params Key generation parameters.
  */
 void keymgr_testutils_generate_versioned_key(
     const dif_keymgr_t *keymgr, const dif_keymgr_versioned_key_params_t params);
+
+/**
+ * Issues a keymgr disable and wait for it to complete
+ */
+void keymgr_testutils_disable(const dif_keymgr_t *keymgr);
+
+/**
+ * Polling keymgr status until it becomes idle.
+ * Fail the test if the status code indicates any error.
+ *
+ * @param keymgr A key manager handle.
+ */
+void keymgr_testutils_wait_for_operation_done(const dif_keymgr_t *keymgr);
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_KEYMGR_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/keymgr_key_derivation.c
+++ b/sw/device/tests/sim_dv/keymgr_key_derivation.c
@@ -221,6 +221,10 @@ bool test_main(void) {
     keymgr_testutils_generate_versioned_key(&keymgr, sideload_params);
     LOG_INFO("Keymgr generated HW output for Otbn at OwnerIntKey State");
 
+    keymgr_testutils_disable(&keymgr);
+    keymgr_testutils_check_state(&keymgr, kDifKeymgrStateDisabled);
+    LOG_INFO("Keymgr entered Disabled state");
+
     return true;
   } else {
     LOG_FATAL("Unexpected reset reason unexpected: %0x", info);


### PR DESCRIPTION
1. Added testing keymgr disable in keymgr_key_derivation test
2. Updated keymgr_testutils to add
   `keymgr_testutils_wait_for_operation_done`, in order to reduce
   repetitive code
3. Removed keymgr lc_disable test as it's done by conn test
Signed-off-by: Weicai Yang <weicai@google.com>