### PR TITLE
[otbn] Move .start into .text section in OTBN linker script.

### DIFF
--- a/hw/ip/otbn/data/otbn.ld.tpl
+++ b/hw/ip/otbn/data/otbn.ld.tpl
@@ -29,14 +29,10 @@ MEMORY
 
 SECTIONS
 {
-    .start ORIGIN(imem) : ALIGN(4)
+    .text ORIGIN(imem) : ALIGN(4)
     {
         _imem_start = .;
         KEEP(*(.text.start*))
-    } >imem AT>imem_load
-
-    .text : ALIGN(4)
-    {
         *(.text*)
 
         /* Align section end. Shouldn't really matter, but might make binary


### PR DESCRIPTION
Sven brought to my attention a strange-looking issue with OTBN symbols in `.rv32embed.o` files, in which the "local"-prefixed symbols appeared to assume the `.text.start` section was twice as long as it actually was. The OTBN drivers raise errors if the `.text.start` section is larger than 250 instructions, for instance, because they think the IMEM size of 2 kiB (500 instructions) was exceeded. The `.elf` and `.o` files were not affected; this issue appeared to be introduced during the [objcopy process in otbn_build.py](https://github.com/lowRISC/opentitan/blob/b1caf36b28699afbac303b48dcfb6d0d72a012ad/util/otbn_build.py#L268).

I think/guess that the problem was being caused by the objcopy somehow thinking `.text.start` was both in `.text` and `.start`, and therefore leaving space for it in `.text` where it didn't exist. This change moves `.text.start` into the linker script's `.text` section and removes the dedicated `.start` section; I've tested it out and it appears to preserve the property that you can pass `.o` files to `otbn-ld` in any order and expect `.text.start` to always come first.

Detailed walkthough:

Everything below will use a simple test file with a `.text.start` section that calls out to a subroutine in a `.text` section:
```shell
$ cat test.s
.section .text

.globl foo
foo:
  bn.add  w31, w31, w31
  bn.add  w31, w31, w31
  bn.add  w31, w31, w31
  bn.add  w31, w31, w31
  bn.add  w31, w31, w31
  bn.add  w31, w31, w31
  ret

.section .text.start

.globl main
main:
  bn.xor  w31, w31, w31
  bn.xor  w31, w31, w31
  bn.xor  w31, w31, w31
  bn.xor  w31, w31, w31
  jal  x1, foo
  ecall
```

On master, we get the code for the `foo` subroutine starting at `0x18`, while the label `otbn_local_app_test_foo` is actually at `0x30`.
```shell
$ util/otbn_build.py test.s
$ /tools/riscv/bin/riscv32-unknown-elf-objdump -D test.rv32embed.o

test.rv32embed.o:     file format elf32-littleriscv

Disassembly of section .rodata.otbn.start:

00000000 <_otbn_local_app_test__imem_start>:
   0:   01ffeffb                0x1ffeffb
   4:   01ffeffb                0x1ffeffb
   8:   01ffeffb                0x1ffeffb
   c:   01ffeffb                0x1ffeffb
  10:   008000ef                jal     ra,18 <_otbn_remote_app_test_foo>
  14:   00000073                ecall

Disassembly of section .rodata.otbn.text:

00000018 <_otbn_local_app_test_foo-0x18>:
  18:   01ff8fab                0x1ff8fab
  1c:   01ff8fab                0x1ff8fab
  20:   01ff8fab                0x1ff8fab
  24:   01ff8fab                0x1ff8fab
  28:   01ff8fab                0x1ff8fab
  2c:   01ff8fab                0x1ff8fab

00000030 <_otbn_local_app_test_foo>:
  30:   00008067                ret
```

This leads to a miscalculation of the `otbn_local_app__imem_end`, which in the usual case of a small `.text.start` section just makes the OTBN driver copy extra zeroes into IMEM, but in the case of a large `.start` section can cause the OTBN driver to think the IMEM size is exceeded.
```shell
$ /tools/riscv/bin/riscv32-unknown-elf-objdump -t test.rv32embed.o | grep imem
0000004c g       .rodata.otbn.text      00000000 _otbn_local_app_test__imem_end
00000000 g       .rodata.otbn.start     00000000 _otbn_local_app_test__imem_start
00000034 g       *ABS*  00000000 _otbn_remote_app_test__imem_end
00000000 g       *ABS*  00000000 _otbn_remote_app_test__imem_start
```

This change fixes the problem; with the same `test.s` file, we now get correct symbols:
```shell
$ /tools/riscv/bin/riscv32-unknown-elf-objdump -D test.rv32embed.o

test.rv32embed.o:     file format elf32-littleriscv

Disassembly of section .rodata.otbn.text:

00000000 <_otbn_local_app_test__imem_start>:
   0:   01ffeffb                0x1ffeffb
   4:   01ffeffb                0x1ffeffb
   8:   01ffeffb                0x1ffeffb
   c:   01ffeffb                0x1ffeffb
  10:   008000ef                jal     ra,18 <_otbn_local_app_test_foo>
  14:   00000073                ecall

00000018 <_otbn_local_app_test_foo>:
  18:   01ff8fab                0x1ff8fab
  1c:   01ff8fab                0x1ff8fab
  20:   01ff8fab                0x1ff8fab
  24:   01ff8fab                0x1ff8fab
  28:   01ff8fab                0x1ff8fab
  2c:   01ff8fab                0x1ff8fab
  30:   00008067                ret

$ /tools/riscv/bin/riscv32-unknown-elf-objdump -t test.rv32embed.o | grep imem
00000034 g       .rodata.otbn.text      00000000 _otbn_local_app_test__imem_end
00000000 g       .rodata.otbn.text      00000000 _otbn_local_app_test__imem_start
00000034 g       *ABS*  00000000 _otbn_remote_app_test__imem_end
00000000 g       *ABS*  00000000 _otbn_remote_app_test__imem_start
```
