### PR TITLE
[pwrmgr,dv] v2s_review_ready

### DIFF
--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_pkg.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_agent_pkg.sv
@@ -13,7 +13,10 @@ package pwrmgr_clk_ctrl_agent_pkg;
   `include "dv_macros.svh"
 
   // parameters
-
+  parameter uint MAIN_CLK_DELAY_MIN = 15;  // cycle of aon clk
+  parameter uint MAIN_CLK_DELAY_MAX = 258; // cycle of aon clk
+  parameter uint ESC_CLK_DELAY_MIN = 1;    // cycle of aon clk
+  parameter uint ESC_CLK_DELAY_MAX = 10;   // cycle of aon clk
   // local types
   // forward declare classes to allow typedefs below
   typedef class pwrmgr_clk_ctrl_item;

--- a/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_monitor.sv
+++ b/hw/dv/sv/pwrmgr_clk_ctrl_agent/pwrmgr_clk_ctrl_monitor.sv
@@ -44,7 +44,7 @@ class pwrmgr_clk_ctrl_monitor extends dv_base_monitor #(
       if (cfg.vif.pwr_ast_req.io_clk_en == 0) begin
         cfg.clk_rst_vif.stop_clk();
         @(posedge cfg.vif.pwr_ast_req.io_clk_en);
-        #($urandom_range(300_000, 5_152_286) * 1ps);
+        repeat ($urandom_range(MAIN_CLK_DELAY_MIN, MAIN_CLK_DELAY_MAX)) @cfg.vif.cb;
         cfg.clk_rst_vif.start_clk();
       end
     end
@@ -56,12 +56,12 @@ class pwrmgr_clk_ctrl_monitor extends dv_base_monitor #(
       @cfg.vif.cb;
       if (ival) begin
         @(negedge cfg.vif.pwr_clk_req.io_ip_clk_en);
-        repeat($urandom_range(1, 10)) @cfg.vif.cb;
+        repeat($urandom_range(ESC_CLK_DELAY_MIN, ESC_CLK_DELAY_MAX)) @cfg.vif.cb;
         cfg.esc_clk_rst_vif.stop_clk();
         ival = 0;
       end else begin
         @(posedge cfg.vif.pwr_clk_req.io_ip_clk_en);
-        repeat($urandom_range(1, 10)) @cfg.vif.cb;
+        repeat($urandom_range(ESC_CLK_DELAY_MIN, ESC_CLK_DELAY_MAX)) @cfg.vif.cb;
         cfg.esc_clk_rst_vif.start_clk();
         ival = 1;
       end

--- a/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
+++ b/hw/ip/pwrmgr/dv/env/pwrmgr_env_pkg.sv
@@ -28,6 +28,12 @@ package pwrmgr_env_pkg;
   // parameters
   parameter int NUM_INTERRUPTS = 1;
 
+  // clk enable disable delay
+  parameter uint MAIN_CLK_DELAY_MIN = pwrmgr_clk_ctrl_agent_pkg::MAIN_CLK_DELAY_MIN;
+  parameter uint MAIN_CLK_DELAY_MAX = pwrmgr_clk_ctrl_agent_pkg::MAIN_CLK_DELAY_MAX;
+  parameter uint ESC_CLK_DELAY_MIN = pwrmgr_clk_ctrl_agent_pkg::ESC_CLK_DELAY_MIN;
+  parameter uint ESC_CLK_DELAY_MAX = pwrmgr_clk_ctrl_agent_pkg::ESC_CLK_DELAY_MAX;
+
   // alerts
   parameter uint NUM_ALERTS = 1;
   parameter string LIST_OF_ALERTS[] = {"fatal_fault"};

--- a/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_glitch_vseq.sv
+++ b/hw/ip/pwrmgr/dv/env/seq_lib/pwrmgr_glitch_vseq.sv
@@ -15,15 +15,23 @@ class pwrmgr_glitch_vseq extends pwrmgr_base_vseq;
   virtual task body();
     for (int i = 0; i < num_trans; ++i) begin
       wait_for_fast_fsm_active();
-      cfg.pwrmgr_vif.glitch_power_reset();
+
+      fork
+        cfg.pwrmgr_vif.glitch_power_reset();
+        begin
+          cfg.pwrmgr_vif.update_ast_main_pok(0);
+          cfg.slow_clk_rst_vif.wait_clks(2);
+          cfg.pwrmgr_vif.update_ast_main_pok(1);
+        end
+      join
       cfg.clk_rst_vif.wait_clks(cycles_before_reset);
       `DV_SPINWAIT(wait(cfg.pwrmgr_vif.fast_state == pwrmgr_pkg::FastPwrStateResetPrep &&
-                        cfg.pwrmgr_vif.pwr_rst_req.rstreqs[2] == 1);
-                   dut_init();,
+                        cfg.pwrmgr_vif.pwr_rst_req.rstreqs[2] == 1);,
                    $sformatf("checker timeout : fast_state %s, pwr_rst_req 0x%x",
                              cfg.pwrmgr_vif.fast_state.name,
                              cfg.pwrmgr_vif.pwr_rst_req.rstreqs),
                    10000)
+      dut_init();
     end
   endtask : body
 endclass

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_bind.sv
@@ -57,7 +57,10 @@ module pwrmgr_bind;
     .clk_i,
     .rst_ni,
     .rom_intg_chk_dis(u_fsm.rom_intg_chk_dis),
+    .rom_intg_chk_ok(u_fsm.rom_intg_chk_ok),
     .lc_dft_en_i,
-    .lc_hw_debug_en_i
+    .lc_hw_debug_en_i,
+    .rom_ctrl_done_i(u_fsm.rom_ctrl_done_i),
+    .rom_ctrl_good_i(u_fsm.rom_ctrl_good_i)
   );
 endmodule

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.core
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_rstmgr_sva_if.core
@@ -8,6 +8,7 @@ filesets:
   files_dv:
     depend:
       - lowrisc:ip:pwrmgr_pkg
+      - lowrisc:dv:pwrmgr_clk_ctrl_agent
     files:
       - pwrmgr_rstmgr_sva_if.sv
     file_type: systemVerilogSource

--- a/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
+++ b/hw/ip/pwrmgr/dv/sva/pwrmgr_sec_cm_checker_assert.sv
@@ -7,8 +7,11 @@ module pwrmgr_sec_cm_checker_assert (
   input clk_i,
   input rst_ni,
   input prim_mubi_pkg::mubi4_t rom_intg_chk_dis,
+  input prim_mubi_pkg::mubi4_t rom_intg_chk_ok,
   input lc_ctrl_pkg::lc_tx_t lc_dft_en_i,
-  input lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i
+  input lc_ctrl_pkg::lc_tx_t lc_hw_debug_en_i,
+  input prim_mubi_pkg::mubi4_t rom_ctrl_done_i,
+  input prim_mubi_pkg::mubi4_t rom_ctrl_good_i
 );
 
   bit   disable_sva;
@@ -16,15 +19,44 @@ module pwrmgr_sec_cm_checker_assert (
 
   always_comb reset_or_disable = !rst_ni || disable_sva;
 
+`define ASYNC_ASSERT(_name, _prop, _sigs, _rst) \
+  _name: assert property (@(_sigs) disable iff ((_rst) !== '0) (_prop)) \
+         else begin\
+           `ASSERT_ERROR(_name)\
+         end
 
   // Assuming lc_dft_en_i and lc_hw_debug_en_i are asynchronous
-  `ASSERT(RomIntgChkDisTrue_A,
-          rom_intg_chk_dis == prim_mubi_pkg::MuBi4True |=>
-          (lc_dft_en_i == lc_ctrl_pkg::On && lc_hw_debug_en_i == lc_ctrl_pkg::On),
-          rom_intg_chk_dis, reset_or_disable)
+  // rom_intg_chk_dis only allows two states.
+  `ASYNC_ASSERT(RomIntgChkDisTrue_A,
+                rom_intg_chk_dis == prim_mubi_pkg::MuBi4True |->
+                (lc_dft_en_i == lc_ctrl_pkg::On && lc_hw_debug_en_i == lc_ctrl_pkg::On),
+                rom_intg_chk_dis or lc_dft_en_i or lc_hw_debug_en_i, reset_or_disable)
 
-  `ASSERT(RomIntgChkDisFalse_A,
-          rom_intg_chk_dis == prim_mubi_pkg::MuBi4False |=>
-          (lc_dft_en_i != lc_ctrl_pkg::On || lc_hw_debug_en_i != lc_ctrl_pkg::On),
-          rom_intg_chk_dis, reset_or_disable)
+  `ASYNC_ASSERT(RomIntgChkDisFalse_A,
+                rom_intg_chk_dis == prim_mubi_pkg::MuBi4False |->
+                (lc_dft_en_i != lc_ctrl_pkg::On || lc_hw_debug_en_i != lc_ctrl_pkg::On),
+                rom_intg_chk_dis or lc_dft_en_i or lc_hw_debug_en_i, reset_or_disable)
+
+  // check rom_intg_chk_ok
+  // rom_ctrl_i go through cdc. So use synchronous assertion.
+  // rom_intg_chk_ok can be any values.
+  `ASYNC_ASSERT(RomIntgChkOkTrue_A,
+                rom_intg_chk_ok == prim_mubi_pkg::MuBi4True |->
+                (rom_intg_chk_dis == prim_mubi_pkg::MuBi4True &&
+                 rom_ctrl_done_i == prim_mubi_pkg::MuBi4True) ||
+                (rom_ctrl_done_i == prim_mubi_pkg::MuBi4True &&
+                 rom_ctrl_good_i == prim_mubi_pkg::MuBi4True),
+                rom_intg_chk_ok or rom_intg_chk_dis or rom_ctrl_done_i or rom_ctrl_good_i,
+                reset_or_disable)
+
+  `ASYNC_ASSERT(RomIntgChkOkFalse_A,
+                rom_intg_chk_ok != prim_mubi_pkg::MuBi4True |->
+                (rom_intg_chk_dis == prim_mubi_pkg::MuBi4False ||
+                 rom_ctrl_done_i != prim_mubi_pkg::MuBi4True) &&
+                (rom_ctrl_done_i != prim_mubi_pkg::MuBi4True ||
+                 rom_ctrl_good_i != prim_mubi_pkg::MuBi4True),
+                rom_intg_chk_ok or rom_intg_chk_dis or rom_ctrl_done_i or rom_ctrl_good_i,
+                reset_or_disable)
+
+`undef ASYNC_ASSERT
 endmodule // pwrmgr_sec_cm_checker_assert

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
@@ -78,7 +78,8 @@
             - Drive tb.dut.sw_rst_req_i with mixed valid and invalid values
 
             **Check**:
-            - See sw rst only happens when dut gets valid value.
+            - See sw rst only happens when dut gets valid value by
+              probing fast fsm state. The state has to move low power state.
             - Collect coverage by binding cip_mubi_cov_if to
               tb.dut.sw_rst_req_i
             '''
@@ -136,8 +137,8 @@
             **Check**:
             If slow state is invalid, fast state becomes FastPwrStateInvalid,
             pwr_ast_o.pwr_clamp =1 and pwr_ast_o.main_pd_n = 0.
-            If fast state is invalid, pwr_rst_o.rst_lc_req = 3,
-            pwr_rst_o.rst_sys_req = 3 and pwr_clk_o = 0.
+            If fast state is invalid, pwr_rst_o.rst_lc_req is all one,
+            pwr_rst_o.rst_sys_req is all one  and pwr_clk_o = 0.
             Dut should be recovered by asserting rst_n = 0.
             '''
       milestone: V2S
@@ -162,7 +163,8 @@
       desc: '''Verify the countermeasure(s) MAIN_PD.RST.LOCAL_ESC.
 
             **Stimulus**:
-            - Create power reset glitch by setting 'tb.dut.rst_main_ni' to 0.
+            - Create power reset glitch by setting tb.dut.rst_main_ni
+              and tb.dut.pwr_ast_i.main_pok  to 0.
 
             **Check**:
             - Check fast state transition to FastPwrStateResetPrep
@@ -184,7 +186,7 @@
             **Check**:
             - After the csr update under PWRMGR.CTRL_CFG_REGWEN = 0,
               read back and check the value is not updated by
-              the csr udate attempt.
+              the csr update attempt.
             '''
       milestone: V2S
       tests: ["pwrmgr_sec_cm_ctrl_config_regwen"]


### PR DESCRIPTION
- convert clk ctrl agent delay to clock cycles
- update env to accommodate clock gating event
-  add async assertion
- add designers' feedback to sec_cm test plan


Signed-off-by: Jaedon Kim <jdonjdon@google.com>