### PR TITLE
[bazel, clang] Update to the latest bazel-embedded

### DIFF
--- a/third_party/bazel_embedded/repos.bzl
+++ b/third_party/bazel_embedded/repos.bzl
@@ -4,12 +4,18 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def bazel_embedded_repos():
+def bazel_embedded_repos(local=None):
     # Contains rules that support building SW for embedded targets. Specifically, we
     # maintain a fork to build for RISCV32I.
-    http_archive(
-        name = "bazel_embedded",
-        sha256 = "ee828762c3b7ea6f4513a57bf39b530671822503be924d3fe29e48390ca41bca",
-        strip_prefix = "bazel-embedded-fe65a8aca35ae0bae563efd6a29cc14fcb15140d",
-        url = "https://github.com/lowRISC/bazel-embedded/archive/fe65a8aca35ae0bae563efd6a29cc14fcb15140d.tar.gz",
-    )
+    if local:
+        native.local_repository(
+            name = "bazel_embedded",
+            path = local,
+        )
+    else:
+        http_archive(
+            name = "bazel_embedded",
+            sha256 = "ef976ed293199f4c072812c951883b223867a4ef6793b3a795bddbc197b53d4f",
+            strip_prefix = "bazel-embedded-09618f3535d90f8130ffdc27df311039f62ae872",
+            url = "https://github.com/lowRISC/bazel-embedded/archive/09618f3535d90f8130ffdc27df311039f62ae872.tar.gz",
+        )


### PR DESCRIPTION
1. Downloads resources as http archives (for airgapped builds).
2. Fixes the compiler configuration to not find the system compiler.

Fixes: #12016
Signed-off-by: Chris Frantz <cfrantz@google.com>