### PR TITLE
[rtl/alert_handler] Fix alert ping enable

### DIFF
--- a/hw/ip_templates/alert_handler/rtl/alert_handler_reg_wrap.sv
+++ b/hw/ip_templates/alert_handler/rtl/alert_handler_reg_wrap.sv
@@ -173,7 +173,7 @@ module alert_handler_reg_wrap import alert_pkg::*; (
   for (genvar k = 0; k < NAlerts; k++) begin : gen_alert_en_class
     // we only ping enabled alerts that are locked
     assign reg2hw_wrap.alert_ping_en[k] = reg2hw.alert_en_shadowed[k].q &
-                                          reg2hw.alert_regwen[k].q;
+                                          ~reg2hw.alert_regwen[k].q;
     assign reg2hw_wrap.alert_en[k]      = reg2hw.alert_en_shadowed[k].q;
     assign reg2hw_wrap.alert_class[k]   = reg2hw.alert_class_shadowed[k].q;
   end

--- a/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_wrap.sv
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/rtl/alert_handler_reg_wrap.sv
@@ -173,7 +173,7 @@ module alert_handler_reg_wrap import alert_pkg::*; (
   for (genvar k = 0; k < NAlerts; k++) begin : gen_alert_en_class
     // we only ping enabled alerts that are locked
     assign reg2hw_wrap.alert_ping_en[k] = reg2hw.alert_en_shadowed[k].q &
-                                          reg2hw.alert_regwen[k].q;
+                                          ~reg2hw.alert_regwen[k].q;
     assign reg2hw_wrap.alert_en[k]      = reg2hw.alert_en_shadowed[k].q;
     assign reg2hw_wrap.alert_class[k]   = reg2hw.alert_class_shadowed[k].q;
   end


### PR DESCRIPTION
Fix the logic to enable alert ping when the regwen is set to 0.
Issue: https://github.com/lowRISC/opentitan/issues/12021

Signed-off-by: Cindy Chen <chencindy@opentitan.org>