### PR TITLE
[sysrst_ctrl] improve interrupt synchronization scheme

### DIFF
--- a/hw/ip/sysrst_ctrl/sysrst_ctrl.core
+++ b/hw/ip/sysrst_ctrl/sysrst_ctrl.core
@@ -9,7 +9,6 @@ filesets:
     depend:
       - lowrisc:constants:top_pkg
       - lowrisc:prim:all
-      - lowrisc:prim:edge_detector
       - lowrisc:ip:tlul
     files:
       - rtl/sysrst_ctrl_reg_pkg.sv


### PR DESCRIPTION
This follows a similar solution introduced for adc_ctrl here: #11904
to make sure that subsequent interrupt requests that occur with the
main bus clock gated do not get lost.

Signed-off-by: Michael Schaffner <msf@opentitan.org>