### PR TITLE
[entropy_src/dv] Proper prediction of FIFO Read CSRs

### DIFF
--- a/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
+++ b/hw/ip/entropy_src/dv/entropy_src_sim_cfg.hjson
@@ -120,7 +120,7 @@
     }
     {
       name: short_run
-      run_opts: ["+test_timeout_ns=5000000"]
+      run_opts: ["+test_timeout_ns=10000000"]
     }
   ]
 }

--- a/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
+++ b/hw/ip/entropy_src/dv/env/entropy_src_env_cfg.sv
@@ -118,7 +118,8 @@ class entropy_src_env_cfg extends cip_base_env_cfg #(.RAL_T(entropy_src_reg_bloc
   // Number of clock cycles between a TLUL disable signal, and deassertion
   // of enable on the RNG bus.
 
-  int tlul2rng_disable_delay = 1;
+  int tlul_to_rng_disable_delay = 1;
+  int tlul_to_fifo_clr_delay    = 5;
 
   // When expecting an alert, the cip scoreboarding routines expect a to see the
   // alert within alert_max_delay clock cycles.


### PR DESCRIPTION
- New scoreboard timing adjustment to predict entropy_data and observe
  FIFO clear events 3 cycles after DUT disablement
- Predict fatal errors when these CSR-attached FIFOs have been cleared
  before a read event.
- Meanwhile, the RNG Vseq prevents attempts to read FIFOs from a disabled
  DUT.  This is done by moving all DUT enable and disable commands to
  the interrupt handler thread, which is responsible for FIFO reads.

Fixes #11951

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>