### PR TITLE
[entropy_src/dv] Coverage for entropy_data reads

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src_testplan.hjson
+++ b/hw/ip/entropy_src/data/entropy_src_testplan.hjson
@@ -141,9 +141,53 @@
             '''
     }
     {
-      name: seed_output_cg
+      name: seed_output_hw_cg
       desc: '''
-            Covers that data output is observed at the csrng, entropy_src, and fw_ov interfaces for
+            Covers that data output is observed at the CSRNG HW interface for
+            all possible modes of operation, including:
+            - CONF.FIPS_ENABLE (True and False)
+            - CONF.ENTROPY_DATA_REG_ENABLE (True and False)
+            - CONF.THRESHOLD_SCOPE (True and False)
+            - CONF.RNG_BIT_ENABLE (True and False)
+            - CONF.RNG_BIT_SEL (0 to 3)
+            - ENTROPY_CONTROL.ES_TYPE (True and False)
+            - FW_OV_MODE (True or False)
+            - FW_OV_ENTROPY_INSERT (True or False)
+            In addition to the above, the following settings are illegal when sampling on
+            this covergroup, and merit the creation of illegal_bins
+            - ENTROPY_CONTROL.ES_ROUTE = True
+
+            Since the scoreboard permits data to be dropped or rejected by the entropy source we
+            must explicitly confirm that the data is observed at the outputs for all possible
+            configurations.
+            '''
+    }
+    {
+      name: seed_output_entropy_data_cg
+      desc: '''
+            Covers that data output is observed at the entropy_data CSR interfaces for
+            all possible modes of operation, including:
+            - CONF.FIPS_ENABLE (True and False)
+            - CONF.THRESHOLD_SCOPE (True and False)
+            - CONF.RNG_BIT_ENABLE (True and False)
+            - CONF.RNG_BIT_SEL (0 to 3)
+            - ENTROPY_CONTROL.ES_TYPE (True and False)
+            - FW_OV_MODE (True or False)
+            - FW_OV_ENTROPY_INSERT (True or False)
+            In addition to the above, the following settings are illegal when sampling on the
+            this covergroup, and merit the creation of illegal_bins
+            - ENTROPY_CONTROL.ES_ROUTE = False
+            - CONF.ENTROPY_DATA_REG_ENABLE = False
+
+            Since the scoreboard permits data to be dropped or rejected by the entropy source we
+            must explicitly confirm that the data is observed at the outputs for all possible
+            configurations.
+            '''
+    }
+    {
+      name: fw_ov_output_cg
+      desc: '''
+            Covers that data output is observed at the fw_ov_rd_data CSE interface for
             all possible modes of operation, including:
             - CONF.FIPS_ENABLE (True and False)
             - CONF.ENTROPY_DATA_REG_ENABLE (True and False)
@@ -155,8 +199,8 @@
             - ENTROPY_CONTROL.ES_TYPE (True and False)
             - FW_OV_MODE (True or False)
             - FW_OV_ENTROPY_INSERT (True or False)
-            Since the scoreboard permits data to be dropped or rejected by the intropy source we
-            must explicitly confirm that the data is observed at the outputs for all possible
+            Since the scoreboard permits data to be dropped by the entropy source we
+            must explicitly confirm that the data is observed at this output for all possible
             configurations.
             '''
     }

--- a/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
+++ b/hw/ip/entropy_src/dv/cov/entropy_src_cov_if.sv
@@ -9,6 +9,7 @@ interface entropy_src_cov_if (
 
   import uvm_pkg::*;
   import dv_utils_pkg::*;
+  import prim_mubi_pkg::*;
   import entropy_src_pkg::*;
   import entropy_src_env_pkg::*;
   `include "dv_fcov_macros.svh"
@@ -20,18 +21,111 @@ interface entropy_src_cov_if (
   bit en_intg_cov_loc;
   assign en_intg_cov_loc = en_full_cov | en_intg_cov;
 
-  covergroup entropy_src_cfg_cg with function sample(prim_mubi_pkg::mubi4_t   route_software);
-    option.name         = "entropy_src_cfg_cg";
+  // Covergroup to confirm that the entropy_data CSR interface works
+  // for all configurations
+  covergroup entropy_src_seed_output_csr_cg with function sample(mubi4_t   fips_enable,
+                                                                 mubi4_t   threshold_scope,
+                                                                 mubi4_t   rng_bit_enable,
+                                                                 bit [1:0] rng_bit_sel,
+                                                                 mubi4_t   es_route,
+                                                                 mubi4_t   es_type,
+                                                                 mubi4_t   entropy_data_reg_enable,
+                                                                 mubi8_t   otp_en_es_fw_read,
+                                                                 mubi4_t   fw_ov_mode,
+                                                                 mubi4_t   entropy_insert,
+                                                                 bit       full_seed);
+
+    option.name         = "entropy_src_seed_output_csr_cg";
     option.per_instance = 1;
 
-    cp_route_software: coverpoint route_software;
-  endgroup : entropy_src_cfg_cg
+    // For the purposes of this CG, ignore coverage of invalid MuBi values
+    cp_fips_enable: coverpoint fips_enable iff(full_seed) {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
 
-  `DV_FCOV_INSTANTIATE_CG(entropy_src_cfg_cg, en_full_cov)
+    cp_threshold_scope: coverpoint threshold_scope iff(full_seed) {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_rng_bit_enable: coverpoint rng_bit_enable iff(full_seed) {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_rng_bit_sel: coverpoint rng_bit_sel iff(full_seed);
+
+    // Signal an error if data is observed when es_route is false.
+    // Sample this even if we don't have a full seed, to detect partial seed
+    // leakage.
+    cp_es_route: coverpoint es_route {
+      bins         mubi_true  = { MuBi4True };
+      illegal_bins mubi_false = { MuBi4False };
+    }
+
+    cp_es_type: coverpoint es_type iff(full_seed) {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    // Signal an error if data is observed when entropy_data_reg_enable is false
+    // Sample this even if we don't have a full seed, to detect partial seed
+    // leakage.
+    cp_entropy_data_reg_enable: coverpoint entropy_data_reg_enable {
+      bins         mubi_true  = { MuBi4True };
+      illegal_bins mubi_false = { MuBi4False };
+    }
+
+    // Signal an error if data is observed when otp_en_es_fw_read is false.
+    // Sample this even if we don't have a full seed, to detect partial seed
+    // leakage.
+    cp_otp_en_es_fw_read: coverpoint otp_en_es_fw_read {
+      bins         mubi_true  = { MuBi8True };
+      illegal_bins mubi_false = { MuBi8False };
+    }
+
+    // Sample the FW_OV parameters, just to be sure that they
+    // don't interfere with the entropy_data interface.
+    cp_fw_ov_mode: coverpoint fw_ov_mode {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    cp_entropy_insert: coverpoint entropy_insert {
+      bins        mubi_true  = { MuBi4True };
+      bins        mubi_false = { MuBi4False };
+    }
+
+    // Cross coverage points
+
+    // Entropy data interface is tested with all valid configurations
+    cr_config: cross cp_fips_enable, cp_threshold_scope, cp_rng_bit_enable,
+        cp_rng_bit_sel, cp_es_type;
+
+    // Entropy data interface functions despite any changes to the fw_ov settings
+    cr_fw_ov: cross cp_fw_ov_mode, cp_entropy_insert;
+
+  endgroup : entropy_src_seed_output_csr_cg;
+
+  `DV_FCOV_INSTANTIATE_CG(entropy_src_seed_output_csr_cg, en_full_cov)
 
   // Sample functions needed for xcelium
-  function automatic void cg_cfg_sample(entropy_src_env_cfg cfg);
-    entropy_src_cfg_cg_inst.sample(cfg.route_software);
+  function automatic void cg_seed_output_csr_sample(mubi4_t   fips_enable,
+                                                    mubi4_t   threshold_scope,
+                                                    mubi4_t   rng_bit_enable,
+                                                    bit [1:0] rng_bit_sel,
+                                                    mubi4_t   es_route,
+                                                    mubi4_t   es_type,
+                                                    mubi4_t   entropy_data_reg_enable,
+                                                    mubi8_t   otp_en_es_fw_read,
+                                                    mubi4_t   fw_ov_mode,
+                                                    mubi4_t   entropy_insert,
+                                                    bit       full_seed);
+    entropy_src_seed_output_csr_cg_inst.sample(fips_enable, threshold_scope, rng_bit_enable,
+                                               rng_bit_sel, es_route, es_type,
+                                               entropy_data_reg_enable, otp_en_es_fw_read,
+                                               fw_ov_mode, entropy_insert, full_seed);
   endfunction
 
 endinterface : entropy_src_cov_if

--- a/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
+++ b/hw/ip/entropy_src/dv/env/seq_lib/entropy_src_base_vseq.sv
@@ -28,8 +28,6 @@ class entropy_src_base_vseq extends cip_base_vseq #(
         (null, "*.env" , "entropy_src_cov_if", cov_vif)) begin
       `uvm_fatal(`gfn, $sformatf("Failed to get entropy_src_cov_if from uvm_config_db"))
     end
-
-    cov_vif.cg_cfg_sample(.cfg(cfg));
   endtask
 
   virtual task dut_init(string reset_kind = "HARD");


### PR DESCRIPTION
- Updates test plan to reflect the fact that the cover groups for
  entropy_data seeds, CSRNG HW IF seeds, and observe FIFO data
  all need separate CG's as they must be sampled at different
  events
- Removes old placeholder CG for env_cfg structure (not in current
  test plan)  The configuration parameters will still be covered
  though under different coverpoints, and sampled once the
  configuration yeilds functional outputs.
- Creates seed_output_csr_cg and adds sampling in scoreboard

Signed-off-by: Martin Lueker-Boden <martin.lueker-boden@wdc.com>