### PR TITLE
[rom_ctrl,rtl] Tighten up expression for counter_data_rdy

### DIFF
--- a/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
+++ b/hw/ip/rom_ctrl/rtl/rom_ctrl_fsm.sv
@@ -271,7 +271,7 @@ module rom_ctrl_fsm
     end
   end
 
-  assign counter_data_rdy = kmac_rom_rdy_i | (state_q != ReadingLow);
+  assign counter_data_rdy = kmac_rom_rdy_i | (state_q inside {ReadingHigh, KmacAhead});
   assign kmac_rom_vld_o = kmac_rom_vld_q;
   assign kmac_rom_last_o = counter_lnt;
 


### PR DESCRIPTION
This signal is used to tell the counter that it can increment on this
cycle. Usually, that would be because we'd managed to pass a packet of
data to KMAC (when state is `ReadingLow`).

Once we've finished passing things to KMAC, we want to race through
the last 8 words with no back pressure. This was implemented by the
"`state_q != ReadingLow`" term. Unfortunately, an injected error on
`state_q` when we're in the `ReadingLow` state caused us to spuriously
increment the ROM index which, in turn, meant that the data we were
presenting to KMAC changed.

This isn't a big deal (the chip is already going to deadlock), but it
causes an assertion failure. Rather than messing around with
assertions, let's just tighten up the expression so that we control
the "race ahead" behaviour more explicitly. `ReadingHigh` and `KmacAhead`
are the two FSM states where we've finished passing data to KMAC but
haven't yet finished reading the top of the ROM.

@prajwalaputtappa: FYI, this fixes most of the error injection failures we were seeing. I've got a local run that seems to have generated another unrelated issue, which I'm looking into now.