### PR TITLE
[kmac_app_agent] Support hosts that don't spot constant shares

### DIFF
--- a/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_agent_cfg.sv
@@ -23,6 +23,10 @@ class kmac_app_agent_cfg extends dv_base_agent_cfg;
   // Knob to enable percentage of error response in auto-response sequence.
   int unsigned error_rsp_pct = 0;
 
+  // Knob to control whether an error response can be caused by all zeros or all ones in one of the
+  // shares.
+  bit constant_share_means_error = 1'b1;
+
   // Knob to allow injecting zeros in strb.
   bit inject_zero_in_host_strb = 0;
 

--- a/hw/dv/sv/kmac_app_agent/kmac_app_item.sv
+++ b/hw/dv/sv/kmac_app_agent/kmac_app_item.sv
@@ -4,10 +4,6 @@
 
 class kmac_app_item extends uvm_sequence_item;
 
-  // below 3 cases will trigger KMAC invalid output error
-  `define CALC_KMAC_DATA_INVALID \
-      (rsp_digest_share0 inside {0, '1} || rsp_digest_share1 inside {0, '1})
-
   // random variables
 
   // request data/mask
@@ -20,27 +16,24 @@ class kmac_app_item extends uvm_sequence_item;
   rand bit [kmac_pkg::AppDigestW-1:0] rsp_digest_share1;
   rand bit                            rsp_error;
 
-  rand bit                is_kmac_rsp_err;
   rand int unsigned       rsp_delay;
-
-  constraint is_kmac_rsp_err_c {
-    (`CALC_KMAC_DATA_INVALID || rsp_error) == is_kmac_rsp_err;
-  }
 
   `uvm_object_utils_begin(kmac_app_item)
     `uvm_field_queue_int(byte_data_q, UVM_DEFAULT)
     `uvm_field_int(rsp_digest_share0, UVM_DEFAULT)
     `uvm_field_int(rsp_digest_share1, UVM_DEFAULT)
     `uvm_field_int(rsp_error,         UVM_DEFAULT)
-    `uvm_field_int(is_kmac_rsp_err,   UVM_DEFAULT)
     `uvm_field_int(rsp_delay,         UVM_DEFAULT)
   `uvm_object_utils_end
 
   `uvm_object_new
 
   virtual function bit get_is_kmac_rsp_data_invalid();
-    return `CALC_KMAC_DATA_INVALID;
+    return is_constant_share(rsp_digest_share0) || is_constant_share(rsp_digest_share1);
   endfunction
 
-  `undef CALC_KMAC_DATA_INVALID
+  static function bit is_constant_share(bit [kmac_pkg::AppDigestW-1:0] share);
+    return share inside {'0, '1};
+  endfunction
+
 endclass

--- a/hw/dv/sv/kmac_app_agent/seq_lib/kmac_app_device_seq.sv
+++ b/hw/dv/sv/kmac_app_agent/seq_lib/kmac_app_device_seq.sv
@@ -19,7 +19,7 @@ class kmac_app_device_seq extends kmac_app_base_seq;
   endtask
 
   virtual function void randomize_item(REQ item);
-    kmac_pkg::rsp_digest_t rsp_digest_h; 
+    kmac_pkg::rsp_digest_t rsp_digest_h = '0;
     bit set_share;
     if (cfg.has_user_digest_share()) begin
       set_share = 1;

--- a/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
+++ b/hw/ip/rom_ctrl/dv/env/rom_ctrl_env_cfg.sv
@@ -57,6 +57,7 @@ class rom_ctrl_env_cfg extends cip_base_env_cfg #(.RAL_T(rom_ctrl_regs_reg_block
     m_kmac_agent_cfg = kmac_app_agent_cfg::type_id::create("m_kmac_agent_cfg");
     m_kmac_agent_cfg.if_mode = dv_utils_pkg::Device;
     m_kmac_agent_cfg.start_default_device_seq = 1'b1;
+    m_kmac_agent_cfg.constant_share_means_error = 1'b0;
 
     m_tl_agent_cfgs["rom_ctrl_rom_reg_block"].max_outstanding_req = 2;
 


### PR DESCRIPTION
This code was originally designed for keymgr, which has a check to
make sure that no share is all zeros or all ones. The ROM controller
doesn't have such a check, so we need to tweak the agent slightly.

Without this change, setting `err_rsp_pct` to 100 in the config might
still result in a KMAC response whose `rsp_error` field is zero.
