### PR TITLE
[rom_ctrl,dv] Wait for the right time before predicting an alert

### DIFF
--- a/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
+++ b/hw/ip/rom_ctrl/dv/env/seq_lib/rom_ctrl_kmac_err_chk_vseq.sv
@@ -12,15 +12,18 @@ class rom_ctrl_kmac_err_chk_vseq extends rom_ctrl_base_vseq;
     uvm_reg_data_t act_val;
 
     cfg.m_kmac_agent_cfg.error_rsp_pct = 100;
-    cfg.scoreboard.set_exp_alert("fatal", .is_fatal(1'b1), .max_delay(1000000));
+
+    wait(cfg.m_kmac_agent_cfg.vif.mon_cb.rsp_done);
+
+    cfg.scoreboard.set_exp_alert("fatal", .is_fatal(1'b1));
     fork
       begin
         ral.fatal_alert_cause.predict(.value('b1), .kind(UVM_PREDICT_READ), .be(4'hF));
-        wait_alert_trigger ("fatal", .max_wait_cycle(1000000), .wait_complete(1));
+        wait_alert_trigger ("fatal", .wait_complete(1));
         csr_utils_pkg::csr_rd(.ptr(ral.fatal_alert_cause), .value(act_val));
       end
       begin
-        repeat(3) wait_alert_trigger ("fatal", .max_wait_cycle(1000000), .wait_complete(1));
+        repeat(3) wait_alert_trigger ("fatal", .wait_complete(1));
       end
     join
     uvm_hdl_read("tb.dut.gen_fsm_scramble_enabled.u_checker_fsm.state_q", rdata_state);


### PR DESCRIPTION
Doing it this way means that the wait time doesn't include all the
time we spend sending data to KMAC. As such, we can use the default (7
cycle) delay.

No functional change, but failing tests will fail much quicker, rather
than having to simulate several milliseconds of run time before
deciding something went wrong.
