### PR TITLE
[sw/silicon_creator] Add SPI Flash based bootstrap

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -578,18 +578,33 @@ opentitan_functest(
     ],
 )
 
-cc_library(
+dual_cc_library(
     name = "spi_device",
-    srcs = ["spi_device.c"],
-    hdrs = ["spi_device.h"],
-    deps = [
-        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
-        "//hw/ip/spi_device/data:spi_device_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:abs_mmio",
-        "//sw/device/lib/base:memory",
-        "//sw/device/silicon_creator/lib:error",
-    ],
+    srcs = dual_inputs(
+        device = ["spi_device.c"],
+        host = ["mock_spi_device.cc"],
+    ),
+    hdrs = dual_inputs(
+        host = ["mock_spi_device.h"],
+        shared = ["spi_device.h"],
+    ),
+    deps = dual_inputs(
+        device = [
+            "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+            "//hw/ip/spi_device/data:spi_device_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        ],
+        host = [
+            "//sw/device/lib/base/testing:global_mock",
+            "//sw/device/silicon_creator/testing:mask_rom_test",
+            "@googletest//:gtest",
+        ],
+        shared = [
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:memory",
+            "//sw/device/silicon_creator/lib:error",
+        ],
+    ),
 )
 
 cc_test(
@@ -598,7 +613,7 @@ cc_test(
         "spi_device_unittest.cc",
     ],
     deps = [
-        ":spi_device",
+        dual_cc_device_library_of(":spi_device"),
         "//hw/ip/spi_device/data:spi_device_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -447,27 +447,42 @@ opentitan_functest(
     ],
 )
 
-cc_library(
+dual_cc_library(
     name = "rstmgr",
-    srcs = ["rstmgr.c"],
-    hdrs = ["rstmgr.h"],
-    deps = [
-        "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:bitfield",
-        "//sw/device/lib/base:macros",
-        "//sw/device/lib/base:multibits",
-        "//sw/device/lib/runtime:hart",
-        "//sw/device/silicon_creator/lib:error",
-        "//sw/device/silicon_creator/lib/base:sec_mmio",
-    ],
+    srcs = dual_inputs(
+        device = ["rstmgr.c"],
+        host = ["mock_rstmgr.cc"],
+    ),
+    hdrs = dual_inputs(
+        host = ["mock_rstmgr.h"],
+        shared = ["rstmgr.h"],
+    ),
+    deps = dual_inputs(
+        device = [
+            "//hw/top_earlgrey/ip/rstmgr/data/autogen:rstmgr_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        ],
+        host = [
+            "//sw/device/lib/base/testing:global_mock",
+            "//sw/device/silicon_creator/testing:mask_rom_test",
+            "@googletest//:gtest",
+        ],
+        shared = [
+            "//sw/device/lib/base:bitfield",
+            "//sw/device/lib/base:macros",
+            "//sw/device/lib/base:multibits",
+            "//sw/device/lib/runtime:hart",
+            "//sw/device/silicon_creator/lib:error",
+            "//sw/device/silicon_creator/lib/base:sec_mmio",
+        ],
+    ),
 )
 
 cc_test(
     name = "rstmgr_unittest",
     srcs = ["rstmgr_unittest.cc"],
     deps = [
-        ":rstmgr",
+        dual_cc_device_library_of(":rstmgr"),
         "//sw/device/silicon_creator/testing:mask_rom_test",
         "@googletest//:gtest_main",
     ],

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -67,30 +67,45 @@ opentitan_functest(
     ],
 )
 
-cc_library(
+dual_cc_library(
     name = "flash_ctrl",
-    srcs = ["flash_ctrl.c"],
-    hdrs = ["flash_ctrl.h"],
-    deps = [
-        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
-        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
-        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
-        "//sw/device/lib/base:abs_mmio",
-        "//sw/device/lib/base:bitfield",
-        "//sw/device/lib/base:hardened",
-        "//sw/device/lib/base:memory",
-        "//sw/device/lib/base:multibits",
-        "//sw/device/silicon_creator/lib:error",
-        "//sw/device/silicon_creator/lib/base:sec_mmio",
-        "//sw/device/silicon_creator/lib/drivers:otp",
-    ],
+    srcs = dual_inputs(
+        device = ["flash_ctrl.c"],
+        host = ["mock_flash_ctrl.cc"],
+    ),
+    hdrs = dual_inputs(
+        host = ["mock_flash_ctrl.h"],
+        shared = ["flash_ctrl.h"],
+    ),
+    deps = dual_inputs(
+        device = [
+            "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+            "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+            "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        ],
+        host = [
+            "//sw/device/lib/base/testing:global_mock",
+            "//sw/device/silicon_creator/testing:mask_rom_test",
+            "@googletest//:gtest",
+        ],
+        shared = [
+            "//sw/device/lib/base:abs_mmio",
+            "//sw/device/lib/base:bitfield",
+            "//sw/device/lib/base:hardened",
+            "//sw/device/lib/base:memory",
+            "//sw/device/lib/base:multibits",
+            "//sw/device/silicon_creator/lib:error",
+            "//sw/device/silicon_creator/lib/base:sec_mmio",
+            "//sw/device/silicon_creator/lib/drivers:otp",
+        ],
+    ),
 )
 
 cc_test(
     name = "flash_ctrl_unittest",
     srcs = ["flash_ctrl_unittest.cc"],
     deps = [
-        ":flash_ctrl",
+        dual_cc_device_library_of(":flash_ctrl"),
         "@googletest//:gtest_main",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
@@ -1,0 +1,82 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h"
+
+namespace mask_rom_test {
+extern "C" {
+
+void flash_ctrl_init(void) { MockFlashCtrl::Instance().Init(); }
+
+void flash_ctrl_status_get(flash_ctrl_status_t *status) {
+  MockFlashCtrl::Instance().StatusGet(status);
+}
+
+rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
+                                 void *data) {
+  return MockFlashCtrl::Instance().DataRead(addr, word_count, data);
+}
+
+rom_error_t flash_ctrl_info_read(flash_ctrl_info_page_t info_page,
+                                 uint32_t offset, uint32_t word_count,
+                                 void *data) {
+  return MockFlashCtrl::Instance().InfoRead(info_page, offset, word_count,
+                                            data);
+}
+
+rom_error_t flash_ctrl_data_write(uint32_t addr, uint32_t word_count,
+                                  const void *data) {
+  return MockFlashCtrl::Instance().DataWrite(addr, word_count, data);
+}
+
+rom_error_t flash_ctrl_info_write(flash_ctrl_info_page_t info_page,
+                                  uint32_t offset, uint32_t word_count,
+                                  const void *data) {
+  return MockFlashCtrl::Instance().InfoWrite(info_page, offset, word_count,
+                                             data);
+}
+
+rom_error_t flash_ctrl_data_erase(uint32_t addr,
+                                  flash_ctrl_erase_type_t erase_type) {
+  return MockFlashCtrl::Instance().DataErase(addr, erase_type);
+}
+
+rom_error_t flash_ctrl_data_erase_verify(uint32_t addr,
+                                         flash_ctrl_erase_type_t erase_type) {
+  return MockFlashCtrl::Instance().DataEraseVerify(addr, erase_type);
+}
+
+rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
+                                  flash_ctrl_erase_type_t erase_type) {
+  return MockFlashCtrl::Instance().InfoErase(info_page, erase_type);
+}
+
+void flash_ctrl_data_default_perms_set(flash_ctrl_perms_t perms) {
+  MockFlashCtrl::Instance().DataDefaultPermsSet(perms);
+}
+
+void flash_ctrl_info_perms_set(flash_ctrl_info_page_t info_page,
+                               flash_ctrl_perms_t perms) {
+  MockFlashCtrl::Instance().InfoPermsSet(info_page, perms);
+}
+
+void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg) {
+  MockFlashCtrl::Instance().DataDefaultCfgSet(cfg);
+}
+
+void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page,
+                             flash_ctrl_cfg_t cfg) {
+  MockFlashCtrl::Instance().InfoCfgSet(info_page, cfg);
+}
+
+void flash_ctrl_exec_set(uint32_t exec_val) {
+  MockFlashCtrl::Instance().ExecSet(exec_val);
+}
+
+void flash_ctrl_creator_info_pages_lockdown(void) {
+  MockFlashCtrl::Instance().CreatorInfoPagesLockdown();
+}
+
+}  // extern "C"
+}  // namespace mask_rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_FLASH_CTRL_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_FLASH_CTRL_H_
+
+#include "sw/device/lib/base/testing/global_mock.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for flash_ctrl.
+ */
+class MockFlashCtrl : public global_mock::GlobalMock<MockFlashCtrl> {
+ public:
+  MOCK_METHOD(void, Init, ());
+  MOCK_METHOD(void, StatusGet, (flash_ctrl_status_t *));
+  MOCK_METHOD(rom_error_t, DataRead, (uint32_t, uint32_t, void *));
+  MOCK_METHOD(rom_error_t, InfoRead,
+              (flash_ctrl_info_page_t, uint32_t, uint32_t, void *));
+  MOCK_METHOD(rom_error_t, DataWrite, (uint32_t, uint32_t, const void *));
+  MOCK_METHOD(rom_error_t, InfoWrite,
+              (flash_ctrl_info_page_t, uint32_t, uint32_t, const void *));
+  MOCK_METHOD(rom_error_t, DataErase, (uint32_t, flash_ctrl_erase_type_t));
+  MOCK_METHOD(rom_error_t, DataEraseVerify,
+              (uint32_t, flash_ctrl_erase_type_t));
+  MOCK_METHOD(rom_error_t, InfoErase,
+              (flash_ctrl_info_page_t, flash_ctrl_erase_type_t));
+  MOCK_METHOD(void, DataDefaultPermsSet, (flash_ctrl_perms_t));
+  MOCK_METHOD(void, InfoPermsSet, (flash_ctrl_info_page_t, flash_ctrl_perms_t));
+  MOCK_METHOD(void, DataDefaultCfgSet, (flash_ctrl_cfg_t));
+  MOCK_METHOD(void, InfoCfgSet, (flash_ctrl_info_page_t, flash_ctrl_cfg_t));
+  MOCK_METHOD(void, ExecSet, (uint32_t));
+  MOCK_METHOD(void, CreatorInfoPagesLockdown, ());
+};
+
+}  // namespace internal
+
+using MockFlashCtrl = testing::StrictMock<internal::MockFlashCtrl>;
+
+#ifdef IS_MESON_FOR_MIGRATIONS_ONLY
+extern "C" {
+
+void flash_ctrl_init(void) { MockFlashCtrl::Instance().Init(); }
+
+void flash_ctrl_status_get(flash_ctrl_status_t *status) {
+  MockFlashCtrl::Instance().StatusGet(status);
+}
+
+rom_error_t flash_ctrl_data_read(uint32_t addr, uint32_t word_count,
+                                 void *data) {
+  return MockFlashCtrl::Instance().DataRead(addr, word_count, data);
+}
+
+rom_error_t flash_ctrl_info_read(flash_ctrl_info_page_t info_page,
+                                 uint32_t offset, uint32_t word_count,
+                                 void *data) {
+  return MockFlashCtrl::Instance().InfoRead(info_page, offset, word_count,
+                                            data);
+}
+
+rom_error_t flash_ctrl_data_write(uint32_t addr, uint32_t word_count,
+                                  const void *data) {
+  return MockFlashCtrl::Instance().DataWrite(addr, word_count, data);
+}
+
+rom_error_t flash_ctrl_info_write(flash_ctrl_info_page_t info_page,
+                                  uint32_t offset, uint32_t word_count,
+                                  const void *data) {
+  return MockFlashCtrl::Instance().InfoWrite(info_page, offset, word_count,
+                                             data);
+}
+
+rom_error_t flash_ctrl_data_erase(uint32_t addr,
+                                  flash_ctrl_erase_type_t erase_type) {
+  return MockFlashCtrl::Instance().DataErase(addr, erase_type);
+}
+
+rom_error_t flash_ctrl_data_erase_verify(uint32_t addr,
+                                         flash_ctrl_erase_type_t erase_type) {
+  return MockFlashCtrl::Instance().DataEraseVerify(addr, erase_type);
+}
+
+rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
+                                  flash_ctrl_erase_type_t erase_type) {
+  return MockFlashCtrl::Instance().InfoErase(info_page, erase_type);
+}
+
+void flash_ctrl_data_default_perms_set(flash_ctrl_perms_t perms) {
+  MockFlashCtrl::Instance().DataDefaultPermsSet(perms);
+}
+
+void flash_ctrl_info_perms_set(flash_ctrl_info_page_t info_page,
+                               flash_ctrl_perms_t perms) {
+  MockFlashCtrl::Instance().InfoPermsSet(info_page, perms);
+}
+
+void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg) {
+  MockFlashCtrl::Instance().DataDefaultCfgSet(cfg);
+}
+
+void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page,
+                             flash_ctrl_cfg_t cfg) {
+  MockFlashCtrl::Instance().InfoCfgSet(info_page, cfg);
+}
+
+void flash_ctrl_exec_set(uint32_t exec_val) {
+  MockFlashCtrl::Instance().ExecSet(exec_val);
+}
+
+void flash_ctrl_creator_info_pages_lockdown(void) {
+  MockFlashCtrl::Instance().CreatorInfoPagesLockdown();
+}
+
+}  // extern "C"
+#endif
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_FLASH_CTRL_H_

--- a/sw/device/silicon_creator/lib/drivers/mock_rstmgr.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_rstmgr.cc
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/mock_rstmgr.h"
+
+namespace mask_rom_test {
+extern "C" {
+uint32_t rstmgr_reason_get(void) { return MockRstmgr::Instance().ReasonGet(); }
+
+void rstmgr_reason_clear(uint32_t reasons) {
+  MockRstmgr::Instance().ReasonClear(reasons);
+}
+
+void rstmgr_alert_info_enable(void) {
+  MockRstmgr::Instance().AlertInfoEnable();
+}
+
+void rstmgr_reset(void) { MockRstmgr::Instance().Reset(); }
+}  // extern "C"
+}  // namespace mask_rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_rstmgr.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_rstmgr.h
@@ -1,0 +1,46 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RSTMGR_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RSTMGR_H_
+
+#include "sw/device/lib/base/testing/global_mock.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for rstmgr.c.
+ */
+class MockRstmgr : public global_mock::GlobalMock<MockRstmgr> {
+ public:
+  MOCK_METHOD(uint32_t, ReasonGet, ());
+  MOCK_METHOD(void, ReasonClear, (uint32_t));
+  MOCK_METHOD(void, AlertInfoEnable, ());
+  MOCK_METHOD(void, Reset, ());
+};
+
+}  // namespace internal
+
+using MockRstmgr = testing::StrictMock<internal::MockRstmgr>;
+
+#ifdef IS_MESON_FOR_MIGRATIONS_ONLY
+extern "C" {
+uint32_t rstmgr_reason_get(void) { return MockRstmgr::Instance().ReasonGet(); }
+
+void rstmgr_reason_clear(uint32_t reasons) {
+  MockRstmgr::Instance().ReasonClear(reasons);
+}
+
+void rstmgr_alert_info_enable(void) {
+  MockRstmgr::Instance().AlertInfoEnable();
+}
+
+void rstmgr_reset(void) { MockRstmgr::Instance().Reset(); }
+}  // extern "C"
+#endif
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_RSTMGR_H_

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
@@ -6,6 +6,7 @@
 
 namespace mask_rom_test {
 extern "C" {
+
 void spi_device_init(void) { MockSpiDevice::Instance().Init(); }
 
 void spi_device_cmd_get(spi_device_cmd_t *cmd) {
@@ -15,5 +16,10 @@ void spi_device_cmd_get(spi_device_cmd_t *cmd) {
 void spi_device_flash_status_clear(void) {
   MockSpiDevice::Instance().FlashStatusClear();
 }
+
+uint32_t spi_device_flash_status_get(void) {
+  return MockSpiDevice::Instance().FlashStatusGet();
+}
+
 }  // extern "C"
 }  // namespace mask_rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
@@ -1,0 +1,19 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/lib/drivers/mock_spi_device.h"
+
+namespace mask_rom_test {
+extern "C" {
+void spi_device_init(void) { MockSpiDevice::Instance().Init(); }
+
+void spi_device_cmd_get(spi_device_cmd_t *cmd) {
+  MockSpiDevice::Instance().CmdGet(cmd);
+}
+
+void spi_device_flash_status_clear(void) {
+  MockSpiDevice::Instance().FlashStatusClear();
+}
+}  // extern "C"
+}  // namespace mask_rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
@@ -19,6 +19,7 @@ class MockSpiDevice : public global_mock::GlobalMock<MockSpiDevice> {
   MOCK_METHOD(void, Init, ());
   MOCK_METHOD(void, CmdGet, (spi_device_cmd_t *));
   MOCK_METHOD(void, FlashStatusClear, ());
+  MOCK_METHOD(uint32_t, FlashStatusGet, ());
 };
 
 }  // namespace internal
@@ -36,6 +37,10 @@ void spi_device_cmd_get(spi_device_cmd_t *cmd) {
 
 void spi_device_flash_status_clear(void) {
   MockSpiDevice::Instance().FlashStatusClear();
+}
+
+uint32_t spi_device_flash_status_get(void) {
+  return MockSpiDevice::Instance().FlashStatusGet();
 }
 
 }  // extern "C"

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_SPI_DEVICE_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_SPI_DEVICE_H_
+
+#include "sw/device/lib/base/testing/global_mock.h"
+#include "sw/device/silicon_creator/lib/drivers/spi_device.h"
+
+namespace mask_rom_test {
+namespace internal {
+
+/**
+ * Mock class for spi_device.c.
+ */
+class MockSpiDevice : public global_mock::GlobalMock<MockSpiDevice> {
+ public:
+  MOCK_METHOD(void, Init, ());
+  MOCK_METHOD(void, CmdGet, (spi_device_cmd_t *));
+  MOCK_METHOD(void, FlashStatusClear, ());
+};
+
+}  // namespace internal
+
+using MockSpiDevice = testing::StrictMock<internal::MockSpiDevice>;
+
+#ifdef IS_MESON_FOR_MIGRATIONS_ONLY
+extern "C" {
+
+void spi_device_init(void) { MockSpiDevice::Instance().Init(); }
+
+void spi_device_cmd_get(spi_device_cmd_t *cmd) {
+  MockSpiDevice::Instance().CmdGet(cmd);
+}
+
+void spi_device_flash_status_clear(void) {
+  MockSpiDevice::Instance().FlashStatusClear();
+}
+
+}  // extern "C"
+#endif
+}  // namespace mask_rom_test
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_LIB_DRIVERS_MOCK_SPI_DEVICE_H_

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -636,3 +636,7 @@ void spi_device_cmd_get(spi_device_cmd_t *cmd) {
 void spi_device_flash_status_clear(void) {
   abs_mmio_write32(kBase + SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0);
 }
+
+uint32_t spi_device_flash_status_get(void) {
+  return abs_mmio_read32(kBase + SPI_DEVICE_FLASH_STATUS_REG_OFFSET);
+}

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -355,7 +355,7 @@ static_assert(kBfptTablePointer % sizeof(uint32_t) == 0,
 /**
  * BFPT 20th Word
  * --------------
- * [31,  0]: Max (8S-8S-8S) (4D-4D-4D) (4S-4S-4S) speed 
+ * [31,  0]: Max (8S-8S-8S) (4D-4D-4D) (4S-4S-4S) speed
  *           (not supported, 0xffffffff)
  */
 #define BFPT_WORD_20(X) \

--- a/sw/device/silicon_creator/lib/drivers/spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.h
@@ -38,7 +38,25 @@ enum {
    * LSB of the 2-byte device ID.
    */
   kSpiDeviceJedecDensity = 0x0a,
-  // TODO(#11740): Auto-generated macros for SFDP offset and size.
+  /**
+   * Size of the JEDEC Basic Flash Parameter Table (BFPT) in words.
+   */
+  kSpiDeviceBfptNumWords = 23,
+  /**
+   * Size of the SFDP table in words.
+   */
+  kSpiDeviceSfdpTableNumWords = 27,
+  /**
+   * Address value used when a command does not have an address.
+   *
+   * Since the spi_device is configured to support only the 3-byte addressing
+   * mode this value is not a valid address.
+   */
+  kSpiDeviceNoAddress = UINT32_MAX,
+};
+
+// TODO(#11740): Auto-generated macros for HW constants.
+enum {
   /**
    * Size of the SFDP area in spi_device buffer in bytes.
    *
@@ -62,22 +80,9 @@ enum {
    */
   kSpiDevicePayloadAreaNumWords = 64,
   /**
-   * Size of the JEDEC Basic Flash Parameter Table (BFPT) in words.
-   *
-   * Note: JESD261F 6.4.1 states that this
+   * Index of the WEL bit in flash status register.
    */
-  kSpiDeviceBfptNumWords = 23,
-  /**
-   * Size of the SFDP table in words.
-   */
-  kSpiDeviceSfdpTableNumWords = 27,
-  /**
-   * Address value used when a command does not have an address.
-   *
-   * Since the spi_device is configured to support only the 3-byte addressing
-   * mode this value is not a valid address.
-   */
-  kSpiDeviceNoAddress = UINT32_MAX,
+  kSpiDeviceWelBit = 1,
 };
 
 /**
@@ -326,6 +331,11 @@ void spi_device_cmd_get(spi_device_cmd_t *cmd);
  * to clear the WIP (busy) and WEL (write enable latch) bits.
  */
 void spi_device_flash_status_clear(void);
+
+/**
+ * Gets the SPI flash status register.
+ */
+uint32_t spi_device_flash_status_get(void);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -165,6 +165,12 @@ TEST_F(SpiDeviceTest, FlashStatusClear) {
   spi_device_flash_status_clear();
 }
 
+TEST_F(SpiDeviceTest, FlashStatusGet) {
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0xa5);
+
+  EXPECT_EQ(0xa5, spi_device_flash_status_get());
+}
+
 struct CmdGetTestCase {
   spi_device_opcode_t opcode;
   uint32_t address;

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -119,6 +119,11 @@ enum module_ {
   X(kErrorBootstrapWrite,             ERROR_(5, kModuleBootstrap, kInternal)), \
   X(kErrorBootstrapGpio,              ERROR_(6, kModuleBootstrap, kInternal)), \
   X(kErrorBootstrapUnknown,           ERROR_(7, kModuleBootstrap, kInternal)), \
+  X(kErrorBootstrapEraseAddress,      ERROR_(8, kModuleBootstrap, kInvalidArgument)), \
+  X(kErrorBootstrapProgramAddress,    ERROR_(9, kModuleBootstrap, kInvalidArgument)), \
+  X(kErrorBootstrapInvalidOpcode,     ERROR_(10, kModuleBootstrap, kInvalidArgument)), \
+  X(kErrorBootstrapInvalidState,      ERROR_(11, kModuleBootstrap, kInvalidArgument)), \
+  X(kErrorBootstrapNotRequested,      ERROR_(12, kModuleBootstrap, kInternal)), \
   X(kErrorLogBadFormatSpecifier,      ERROR_(1, kModuleLog, kInternal)), \
   X(kErrorBootDataNotFound,           ERROR_(1, kModuleBootData, kInternal)), \
   X(kErrorBootDataWriteCheck,         ERROR_(2, kModuleBootData, kInternal)), \

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -240,6 +240,19 @@ cc_library(
     ],
 )
 
+cc_test(
+    name = "bootstrap_unittest",
+    srcs = ["bootstrap_unittest.cc"],
+    deps = [
+        ":bootstrap",
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//hw/ip/gpio/data:gpio_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "@googletest//:gtest_main",
+    ],
+)
+
 dual_cc_library(
     name = "sigverify_keys_ptrs",
     srcs = dual_inputs(

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -220,6 +220,26 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "bootstrap",
+    srcs = ["bootstrap.c"],
+    hdrs = ["bootstrap.h"],
+    deps = [
+        "//hw/ip/flash_ctrl/data:flash_ctrl_regs",
+        "//hw/ip/gpio/data:gpio_regs",
+        "//hw/ip/otp_ctrl/data:otp_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:abs_mmio",
+        "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened",
+        "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/drivers:flash_ctrl",
+        "//sw/device/silicon_creator/lib/drivers:otp",
+        "//sw/device/silicon_creator/lib/drivers:rstmgr",
+        "//sw/device/silicon_creator/lib/drivers:spi_device",
+    ],
+)
+
 dual_cc_library(
     name = "sigverify_keys_ptrs",
     srcs = dual_inputs(

--- a/sw/device/silicon_creator/mask_rom/bootstrap.c
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.c
@@ -1,0 +1,382 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/mask_rom/bootstrap.h"
+
+#include <stdalign.h>
+
+#include "sw/device/lib/base/abs_mmio.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/silicon_creator/lib/drivers/flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
+#include "sw/device/silicon_creator/lib/drivers/rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/spi_device.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#include "flash_ctrl_regs.h"
+#include "gpio_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+
+enum {
+  /*
+   * Maximum flash address, exclusive.
+   */
+  kMaxAddress =
+      FLASH_CTRL_PARAM_BYTES_PER_BANK * FLASH_CTRL_PARAM_REG_NUM_BANKS,
+};
+
+static_assert(FLASH_CTRL_PARAM_REG_NUM_BANKS == 2, "Flash must have 2 banks");
+
+/**
+ * Bootstrap states.
+ *
+ * OpenTitan bootstrap consists of three states between which the chip
+ * transitions sequentially.
+ *
+ * Encoding generated with
+ * $ ./util/design/sparse-fsm-encode.py -d 5 -m 3 -n 32 \
+ *     -s 375382971 --language=c
+ *
+ * Minimum Hamming distance: 17
+ * Maximum Hamming distance: 19
+ * Minimum Hamming weight: 16
+ * Maximum Hamming weight: 19
+ */
+typedef enum bootstrap_state {
+  /**
+   * Initial bootstrap state where the chip waits for a SECTOR_ERASE or
+   * CHIP_ERASE command.
+   */
+  kBootstrapStateErase = 0xd4576543,
+  /**
+   * Second bootstrap state where the chip verifies that all data banks have
+   * been erased.
+   */
+  kBootstrapStateEraseVerify = 0xf3c71bac,
+  /**
+   * Final bootstrap state. This is the main program loop where the chip handles
+   * erase, program, and reset commands.
+   */
+  kBootstrapStateProgram = 0xbdd8ca60,
+} bootstrap_state_t;
+
+/**
+ * Handles access permissions and erases both data banks of the embedded flash.
+ *
+ * @return Result of the operation.
+ */
+static rom_error_t bootstrap_chip_erase(void) {
+  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
+      .read = kMultiBitBool4False,
+      .write = kMultiBitBool4False,
+      .erase = kMultiBitBool4True,
+  });
+  rom_error_t err_0 = flash_ctrl_data_erase(0, kFlashCtrlEraseTypeBank);
+  rom_error_t err_1 = flash_ctrl_data_erase(FLASH_CTRL_PARAM_BYTES_PER_BANK,
+                                            kFlashCtrlEraseTypeBank);
+  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
+      .read = kMultiBitBool4False,
+      .write = kMultiBitBool4False,
+      .erase = kMultiBitBool4False,
+  });
+
+  HARDENED_RETURN_IF_ERROR(err_0);
+  return err_1;
+}
+
+/**
+ * Handles access permissions and erases a 4 KiB region in the data partition of
+ * the embedded flash.
+ *
+ * Since OpenTitan's flash page size is 2 KiB, this function erases two
+ * consecutive pages.
+ *
+ * @param addr Address that falls within the 4 KiB region being deleted.
+ * @return Result of the operation.
+ */
+static rom_error_t bootstrap_sector_erase(uint32_t addr) {
+  static_assert(FLASH_CTRL_PARAM_BYTES_PER_PAGE == 2048,
+                "Page size must be 2 KiB");
+  enum {
+    /**
+     * Mask for truncating `addr` to the lower 4 KiB aligned address.
+     */
+    kPageAddrMask = ~UINT32_C(4096) + 1,
+  };
+
+  if (addr >= kMaxAddress) {
+    return kErrorBootstrapEraseAddress;
+  }
+  addr &= kPageAddrMask;
+
+  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
+      .read = kMultiBitBool4False,
+      .write = kMultiBitBool4False,
+      .erase = kMultiBitBool4True,
+  });
+  rom_error_t err_0 = flash_ctrl_data_erase(addr, kFlashCtrlEraseTypePage);
+  rom_error_t err_1 = flash_ctrl_data_erase(
+      addr + FLASH_CTRL_PARAM_BYTES_PER_PAGE, kFlashCtrlEraseTypePage);
+  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
+      .read = kMultiBitBool4False,
+      .write = kMultiBitBool4False,
+      .erase = kMultiBitBool4False,
+  });
+
+  HARDENED_RETURN_IF_ERROR(err_0);
+  return err_1;
+}
+
+/**
+ * Handles access permissions and programs up to 256 bytes of flash memory
+ * starting at `addr`.
+ *
+ * If `byte_count` is not a multiple of flash word size, it's rounded up to next
+ * flash word and missing bytes in `data` are set to `0xff`.
+ *
+ * @param addr Address to write to, must be flash word aligned.
+ * @param byte_count Number of bytes to write. Rounded up to next flash word if
+ * not a multiple of flash word size. Missing bytes in `data` are set to `0xff`.
+ * @param data Data to write, must be word aligned. If `byte_count` is not a
+ * multiple of flash word size, `data` must have enough space until the next
+ * flash word.
+ * @return Result of the operation.
+ */
+static rom_error_t bootstrap_page_program(uint32_t addr, size_t byte_count,
+                                          uint8_t *data) {
+  static_assert(__builtin_popcount(FLASH_CTRL_PARAM_BYTES_PER_WORD) == 1,
+                "Bytes per flash word must be a power of two.");
+  enum {
+    /**
+     * Mask for checking that `addr` is flash word aligned.
+     */
+    kFlashWordMask = FLASH_CTRL_PARAM_BYTES_PER_WORD - 1,
+    /**
+     * SPI flash programming page size in bytes.
+     */
+    kFlashProgPageSize = 256,
+    /**
+     * Mask for checking whether `addr` is flash programming page aligned.
+     *
+     * Flash programming page size is 256 bytes, writes that start at an `addr`
+     * with a non-zero LSB wrap to the start of the 256 byte region.
+     */
+    kFlashProgPageMask = kFlashProgPageSize - 1,
+  };
+
+  if (addr & kFlashWordMask || addr >= kMaxAddress) {
+    return kErrorBootstrapProgramAddress;
+  }
+
+  // Round up to next flash word and fill missing bytes with `0xff`.
+  size_t flash_word_misalignment = byte_count & kFlashWordMask;
+  if (flash_word_misalignment > 0) {
+    size_t padding_byte_count =
+        FLASH_CTRL_PARAM_BYTES_PER_WORD - flash_word_misalignment;
+    for (size_t i = 0; i < padding_byte_count; ++i) {
+      data[byte_count++] = 0xff;
+    }
+  }
+  size_t rem_word_count = byte_count / sizeof(uint32_t);
+
+  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
+      .read = kMultiBitBool4False,
+      .write = kMultiBitBool4True,
+      .erase = kMultiBitBool4False,
+  });
+  // Wrap to the start of the flash programming page if `addr` is not aligned.
+  rom_error_t err_0 = kErrorOk;
+  size_t prog_page_misalignment = addr & kFlashProgPageMask;
+  if (prog_page_misalignment > 0) {
+    size_t word_count =
+        (kFlashProgPageSize - prog_page_misalignment) / sizeof(uint32_t);
+    err_0 = flash_ctrl_data_write(addr, word_count, data);
+    rem_word_count -= word_count;
+    data += word_count * sizeof(uint32_t);
+    addr &= ~kFlashProgPageMask;
+  }
+  rom_error_t err_1 = kErrorOk;
+  if (rem_word_count > 0) {
+    err_1 = flash_ctrl_data_write(addr, rem_word_count, data);
+  }
+  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
+      .read = kMultiBitBool4False,
+      .write = kMultiBitBool4False,
+      .erase = kMultiBitBool4False,
+  });
+
+  HARDENED_RETURN_IF_ERROR(err_0);
+  return err_1;
+}
+
+/**
+ * Bootstrap state 1: Wait for an erase command and erase the data
+ * partition.
+ *
+ * This function erases both data banks of the flash regardless of the type of
+ * the erase command (CHIP_ERASE or SECTOR_ERASE).
+ *
+ * @param state Bootstrap state.
+ * @return Result of the operation.
+ */
+static rom_error_t bootstrap_handle_erase(bootstrap_state_t *state) {
+  HARDENED_CHECK_EQ(*state, kBootstrapStateErase);
+
+  spi_device_cmd_t cmd;
+  spi_device_cmd_get(&cmd);
+  // Erase requires WREN, ignore if WEL is not set.
+  if (!bitfield_bit32_read(spi_device_flash_status_get(), kSpiDeviceWelBit)) {
+    return kErrorOk;
+  }
+
+  rom_error_t error = kErrorUnknown;
+  switch (cmd.opcode) {
+    case kSpiDeviceOpcodeChipErase:
+    case kSpiDeviceOpcodeSectorErase:
+      error = bootstrap_chip_erase();
+      HARDENED_RETURN_IF_ERROR(error);
+      *state = kBootstrapStateEraseVerify;
+      break;
+    default:
+      // Ignore any other command, e.g. PAGE_PROGRAM, RESET.
+      error = kErrorOk;
+  }
+
+  // Note: We clear WIP and WEN bits in `bootstrap_handle_erase_verify()` after
+  // checking that both data banks have been erased.
+  return error;
+}
+
+/**
+ * Bootstrap state 2: Verify that all data banks have been erased.
+ *
+ * This function also clears the WIP and WEN bits of the flash status register.
+ *
+ * @param state Bootstrap state.
+ * @return Result of the operation.
+ */
+static rom_error_t bootstrap_handle_erase_verify(bootstrap_state_t *state) {
+  HARDENED_CHECK_EQ(*state, kBootstrapStateEraseVerify);
+
+  rom_error_t err_0 = flash_ctrl_data_erase_verify(0, kFlashCtrlEraseTypeBank);
+  rom_error_t err_1 = flash_ctrl_data_erase_verify(
+      FLASH_CTRL_PARAM_BYTES_PER_BANK, kFlashCtrlEraseTypeBank);
+  HARDENED_RETURN_IF_ERROR(err_0);
+  HARDENED_RETURN_IF_ERROR(err_1);
+
+  *state = kBootstrapStateProgram;
+  spi_device_flash_status_clear();
+  return err_0;
+}
+
+/**
+ * Bootstrap state 3: (Erase/)Program loop.
+ *
+ * @param state Bootstrap state.
+ * @return Result of the operation.
+ */
+static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
+  static_assert(alignof(spi_device_cmd_t) >= sizeof(uint32_t) &&
+                    offsetof(spi_device_cmd_t, payload) >= sizeof(uint32_t),
+                "Payload must be word aligned.");
+  static_assert(
+      sizeof((spi_device_cmd_t){0}.payload) % FLASH_CTRL_PARAM_BYTES_PER_WORD ==
+          0,
+      "Payload size must be a multiple of flash word size.");
+
+  HARDENED_CHECK_EQ(*state, kBootstrapStateProgram);
+
+  spi_device_cmd_t cmd;
+  spi_device_cmd_get(&cmd);
+  // Erase and program require WREN, ignore if WEL is not set.
+  if (cmd.opcode != kSpiDeviceOpcodeReset &&
+      !bitfield_bit32_read(spi_device_flash_status_get(), kSpiDeviceWelBit)) {
+    return kErrorOk;
+  }
+
+  rom_error_t error = kErrorUnknown;
+  switch (cmd.opcode) {
+    case kSpiDeviceOpcodeChipErase:
+      error = bootstrap_chip_erase();
+      break;
+    case kSpiDeviceOpcodeSectorErase:
+      error = bootstrap_sector_erase(cmd.address);
+      break;
+    case kSpiDeviceOpcodePageProgram:
+      error = bootstrap_page_program(cmd.address, cmd.payload_byte_count,
+                                     cmd.payload);
+      break;
+    case kSpiDeviceOpcodeReset:
+      rstmgr_reset();
+#ifdef OT_PLATFORM_RV32
+      HARDENED_UNREACHABLE();
+#else
+      // If this is an off-target test, return `kErrorUnknown` to be able to
+      // test without requiring EXPECT_DEATH.
+      error = kErrorUnknown;
+#endif
+      break;
+    default:
+      // We don't expect any other commands.
+      error = kErrorBootstrapInvalidOpcode;
+  }
+  HARDENED_RETURN_IF_ERROR(error);
+
+  spi_device_flash_status_clear();
+  return error;
+}
+
+hardened_bool_t bootstrap_requested(void) {
+  uint32_t res = otp_read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET);
+  if (launder32(res) != kHardenedBoolTrue) {
+    return kHardenedBoolFalse;
+  }
+  HARDENED_CHECK_EQ(res, kHardenedBoolTrue);
+
+  res ^= kBootstrapPinMask;
+  res ^=
+      abs_mmio_read32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET) &
+      kBootstrapPinMask;
+  if (launder32(res) != kHardenedBoolTrue) {
+    return kHardenedBoolFalse;
+  }
+  HARDENED_CHECK_EQ(res, kHardenedBoolTrue);
+  return res;
+}
+
+rom_error_t bootstrap(void) {
+  hardened_bool_t requested = bootstrap_requested();
+  if (launder32(requested) != kHardenedBoolTrue) {
+    return kErrorBootstrapNotRequested;
+  }
+  HARDENED_CHECK_EQ(requested, kHardenedBoolTrue);
+
+  spi_device_init();
+
+  // Bootstrap event loop.
+  bootstrap_state_t state = kBootstrapStateErase;
+  rom_error_t error = kErrorUnknown;
+  while (true) {
+    switch (launder32(state)) {
+      case kBootstrapStateErase:
+        HARDENED_CHECK_EQ(state, kBootstrapStateErase);
+        error = bootstrap_handle_erase(&state);
+        break;
+      case kBootstrapStateEraseVerify:
+        HARDENED_CHECK_EQ(state, kBootstrapStateEraseVerify);
+        error = bootstrap_handle_erase_verify(&state);
+        break;
+      case kBootstrapStateProgram:
+        HARDENED_CHECK_EQ(state, kBootstrapStateProgram);
+        error = bootstrap_handle_program(&state);
+        break;
+      default:
+        error = kErrorBootstrapInvalidState;
+    }
+    HARDENED_RETURN_IF_ERROR(error);
+  }
+  HARDENED_UNREACHABLE();
+}

--- a/sw/device/silicon_creator/mask_rom/bootstrap.h
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.h
@@ -1,0 +1,55 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+#ifndef OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOTSTRAP_H_
+#define OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOTSTRAP_H_
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/silicon_creator/lib/error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+  /**
+   * Mask for the bootstrap pin.
+   *
+   * TODO(#11934): The actual chip will have 3 strapping pins.
+   */
+  kBootstrapPinMask = 0x00020000,
+};
+
+/**
+ * Checks whether bootstrap is requested.
+ *
+ * The return value of this function also depends on the `ROM_BOOTSTRAP_EN` OTP
+ * item.
+ *
+ * @return Whether bootstrap is requested.
+ */
+hardened_bool_t bootstrap_requested(void);
+
+/**
+ * Bootstraps the data partition of the embedded flash with data received by the
+ * spi_device.
+ *
+ * OpenTitan bootstrap uses the typical SPI flash EEPROM commands. A typical
+ * bootstrap session involves:
+ * - Asserting bootstrap pins to enter bootstrap mode,
+ * - Erasing the chip (WREN, CHIP_ERASE, busy loop ...),
+ * - Programming the chip (WREN, PAGE_PROGRAM, busy loop ...), and
+ * - Resetting the chip (RESET).
+ *
+ * This function only returns on error since a successful bootstrap ends with a
+ * chip reset.
+ *
+ * @return Result of the operation.
+ */
+rom_error_t bootstrap(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // OPENTITAN_SW_DEVICE_SILICON_CREATOR_MASK_ROM_BOOTSTRAP_H_

--- a/sw/device/silicon_creator/mask_rom/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/bootstrap_unittest.cc
@@ -1,0 +1,622 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/silicon_creator/mask_rom/bootstrap.h"
+
+#include <cstring>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_otp.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_rstmgr.h"
+#include "sw/device/silicon_creator/lib/drivers/mock_spi_device.h"
+#include "sw/device/silicon_creator/testing/mask_rom_test.h"
+
+#include "flash_ctrl_regs.h"
+#include "gpio_regs.h"
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
+
+bool operator==(flash_ctrl_perms_t lhs, flash_ctrl_perms_t rhs) {
+  return std::memcmp(&lhs, &rhs, sizeof(flash_ctrl_perms_t)) == 0;
+}
+
+namespace bootstrap_unittest {
+namespace {
+
+using ::testing::NotNull;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+MATCHER_P(HasBytes, bytes, "") {
+  return std::memcmp(arg, bytes.data(), bytes.size()) == 0;
+}
+
+class BootstrapTest : public mask_rom_test::MaskRomTest {
+ protected:
+  /**
+   * Sets an expectation for a bootstrap request check.
+   *
+   * @param requested Whether bootstrap is requested.
+   */
+  void ExpectBootstrapRequestCheck(bool requested) {
+    EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
+        .WillOnce(Return(kHardenedBoolTrue));
+    uint32_t pins = kBootstrapPinMask;
+    if (!requested) {
+      pins = ~pins;
+    }
+    EXPECT_ABS_READ32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET,
+                      pins);
+  }
+
+  /**
+   * Sets an expectation for a spi flash command.
+   *
+   * @param cmd Command struct to output.
+   */
+  void ExpectSpiCmd(spi_device_cmd_t cmd) {
+    EXPECT_CALL(spi_device_, CmdGet(NotNull())).WillOnce(SetArgPointee<0>(cmd));
+  }
+
+  /**
+   * Sets an expectation for getting the SPI flash status register.
+   *
+   * @param wel Value of the WEL bit.
+   */
+  void ExpectSpiFlashStatusGet(bool wel) {
+    EXPECT_CALL(spi_device_, FlashStatusGet())
+        .WillOnce(Return(wel << kSpiDeviceWelBit));
+  }
+
+  /**
+   * Sets an expectation for enabling erase for the data partition.
+   */
+  void ExpectFlashCtrlEraseEnable() {
+    EXPECT_CALL(flash_ctrl_, DataDefaultPermsSet((flash_ctrl_perms_t){
+                                 .read = kMultiBitBool4False,
+                                 .write = kMultiBitBool4False,
+                                 .erase = kMultiBitBool4True,
+                             }));
+  }
+
+  /**
+   * Sets an expectation for enabling write for the data partition.
+   */
+  void ExpectFlashCtrlWriteEnable() {
+    EXPECT_CALL(flash_ctrl_, DataDefaultPermsSet((flash_ctrl_perms_t){
+                                 .read = kMultiBitBool4False,
+                                 .write = kMultiBitBool4True,
+                                 .erase = kMultiBitBool4False,
+                             }));
+  }
+
+  /**
+   * Sets an expectation for disabling all permissions for the data partition.
+   */
+  void ExpectFlashCtrlAllDisable() {
+    EXPECT_CALL(flash_ctrl_, DataDefaultPermsSet((flash_ctrl_perms_t){
+                                 .read = kMultiBitBool4False,
+                                 .write = kMultiBitBool4False,
+                                 .erase = kMultiBitBool4False,
+                             }));
+  }
+
+  /**
+   * Sets expectations for a chip erase.
+   *
+   * @param err0 Result of erase for the first bank.
+   * @param err1 Result of erase for the second bank.
+   */
+  void ExpectFlashCtrlChipErase(rom_error_t err0, rom_error_t err1) {
+    ExpectFlashCtrlEraseEnable();
+    EXPECT_CALL(flash_ctrl_, DataErase(0, kFlashCtrlEraseTypeBank))
+        .WillOnce(Return(err0));
+    EXPECT_CALL(flash_ctrl_, DataErase(FLASH_CTRL_PARAM_BYTES_PER_BANK,
+                                       kFlashCtrlEraseTypeBank))
+        .WillOnce(Return(err1));
+    ExpectFlashCtrlAllDisable();
+  }
+
+  /**
+   * Sets expectations for a sector erase.
+   *
+   * @param err0 Result of erase for the first page.
+   * @param err1 Result of erase for the second page.
+   * @param addr Erase start address.
+   */
+  void ExpectFlashCtrlSectorErase(rom_error_t err0, rom_error_t err1,
+                                  uint32_t addr) {
+    ExpectFlashCtrlEraseEnable();
+    EXPECT_CALL(flash_ctrl_, DataErase(addr, kFlashCtrlEraseTypePage))
+        .WillOnce(Return(err0));
+    EXPECT_CALL(flash_ctrl_, DataErase(addr + FLASH_CTRL_PARAM_BYTES_PER_PAGE,
+                                       kFlashCtrlEraseTypePage))
+        .WillOnce(Return(err1));
+    ExpectFlashCtrlAllDisable();
+  }
+
+  /**
+   * Sets expectations for a chip erase verification.
+   *
+   * @param err0 Result of erase verification for the first bank.
+   * @param err1 Result of erase verification for the second bank.
+   */
+  void ExpectFlashCtrlEraseVerify(rom_error_t err0, rom_error_t err1) {
+    EXPECT_CALL(flash_ctrl_, DataEraseVerify(0, kFlashCtrlEraseTypeBank))
+        .WillOnce(Return(err0));
+    EXPECT_CALL(flash_ctrl_, DataEraseVerify(FLASH_CTRL_PARAM_BYTES_PER_BANK,
+                                             kFlashCtrlEraseTypeBank))
+        .WillOnce(Return(err1));
+  }
+
+  mask_rom_test::MockAbsMmio mmio_;
+  mask_rom_test::MockFlashCtrl flash_ctrl_;
+  mask_rom_test::MockOtp otp_;
+  mask_rom_test::MockRstmgr rstmgr_;
+  mask_rom_test::MockSpiDevice spi_device_;
+};
+
+TEST_F(BootstrapTest, RequestedDisabled) {
+  EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
+      .WillOnce(Return(kHardenedBoolFalse));
+
+  EXPECT_EQ(bootstrap_requested(), kHardenedBoolFalse);
+}
+
+TEST_F(BootstrapTest, RequestedEnabled) {
+  EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
+      .WillOnce(Return(kHardenedBoolTrue));
+  EXPECT_ABS_READ32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET,
+                    kBootstrapPinMask);
+  EXPECT_EQ(bootstrap_requested(), kHardenedBoolTrue);
+
+  EXPECT_CALL(otp_, read32(OTP_CTRL_PARAM_ROM_BOOTSTRAP_EN_OFFSET))
+      .WillOnce(Return(kHardenedBoolTrue));
+  EXPECT_ABS_READ32(TOP_EARLGREY_GPIO_BASE_ADDR + GPIO_DATA_IN_REG_OFFSET,
+                    ~kBootstrapPinMask);
+  EXPECT_EQ(bootstrap_requested(), kHardenedBoolFalse);
+}
+
+/**
+ * Returns a struct that represents a CHIP_ERASE command.
+ *
+ * @return A `spi_device_cmd_t` that represents a CHIP_ERASE command.
+ */
+spi_device_cmd_t ChipEraseCmd() {
+  return {
+      .opcode = kSpiDeviceOpcodeChipErase,
+      .address = kSpiDeviceNoAddress,
+      .payload_byte_count = 0,
+      .payload = {},
+  };
+}
+
+/**
+ * Returns a struct that represents a SECTOR_ERASE command.
+ *
+ * @param address Address field of the command.
+ * @return A `spi_device_cmd_t` that represents a SECTOR_ERASE command.
+ */
+spi_device_cmd_t SectorEraseCmd(uint32_t address) {
+  return {
+      .opcode = kSpiDeviceOpcodeSectorErase,
+      .address = address,
+      .payload_byte_count = 0,
+      .payload = {},
+  };
+}
+
+/**
+ * Returns a struct that represents a PAGE_PROGRAM command.
+ *
+ * @param address Address field of the command.
+ * @param payload_byte_count Payload size in bytes.
+ * @return A `spi_device_cmd_t` that represents a PAGE_PROGRAM command.
+ */
+spi_device_cmd_t PageProgramCmd(uint32_t address, size_t payload_byte_count) {
+  spi_device_cmd_t cmd{
+      .opcode = kSpiDeviceOpcodePageProgram,
+      .address = address,
+      .payload_byte_count = payload_byte_count,
+  };
+  EXPECT_LE(payload_byte_count, kSpiDevicePayloadAreaNumBytes);
+  for (size_t i = 0; i < payload_byte_count; ++i) {
+    cmd.payload[i] = static_cast<uint8_t>(i);
+  }
+
+  return cmd;
+}
+
+spi_device_cmd_t ResetCmd() {
+  return {
+      .opcode = kSpiDeviceOpcodeReset,
+      .address = kSpiDeviceNoAddress,
+      .payload_byte_count = 0,
+      .payload = {},
+  };
+}
+
+TEST_F(BootstrapTest, BootstrapSimple) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(0, 16);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes(cmd.payload,
+                                   cmd.payload + cmd.payload_byte_count);
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_, DataWrite(0, 4, HasBytes(flash_bytes)))
+      .WillOnce(Return(kErrorOk));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, BootstrapOddPayload) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(0, 17);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes(cmd.payload,
+                                   cmd.payload + cmd.payload_byte_count);
+  for (size_t i = 0; i < 7; ++i) {
+    flash_bytes.push_back(0xff);
+  }
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_, DataWrite(cmd.address, 6, HasBytes(flash_bytes)))
+      .WillOnce(Return(kErrorOk));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, BootstrapMisalignedAddr) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(0xfff0, 256);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes_0(cmd.payload, cmd.payload + 16);
+  std::vector<uint8_t> flash_bytes_1(cmd.payload + 16,
+                                     cmd.payload + cmd.payload_byte_count);
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_, DataWrite(0xfff0, 4, HasBytes(flash_bytes_0)))
+      .WillOnce(Return(kErrorOk));
+  EXPECT_CALL(flash_ctrl_, DataWrite(0xff00, 60, HasBytes(flash_bytes_1)))
+      .WillOnce(Return(kErrorOk));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, BootstrapStartWithSectorErase) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(SectorEraseCmd(0));
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(0, 16);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes(cmd.payload,
+                                   cmd.payload + cmd.payload_byte_count);
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_,
+              DataWrite(cmd.address, cmd.payload_byte_count / sizeof(uint32_t),
+                        HasBytes(flash_bytes)))
+      .WillOnce(Return(kErrorOk));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, BootstrapProgramWithErase) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(0, 16);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes(cmd.payload,
+                                   cmd.payload + cmd.payload_byte_count);
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_,
+              DataWrite(cmd.address, cmd.payload_byte_count / sizeof(uint32_t),
+                        HasBytes(flash_bytes)))
+      .WillOnce(Return(kErrorOk));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Chip erase
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Sector erase
+  ExpectSpiCmd(SectorEraseCmd(0));
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlSectorErase(kErrorOk, kErrorOk, 0);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, MisalignedEraseAddress) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Erase with misaligned and aligned addresses
+  ExpectSpiCmd(SectorEraseCmd(5));
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlSectorErase(kErrorOk, kErrorOk, 0);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+
+  ExpectSpiCmd(SectorEraseCmd(4096));
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlSectorErase(kErrorOk, kErrorOk, 4096);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+
+  ExpectSpiCmd(SectorEraseCmd(8195));
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlSectorErase(kErrorOk, kErrorOk, 8192);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, IgnoredCommands) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());  // Ignored, missing WREN.
+  ExpectSpiFlashStatusGet(false);
+  ExpectSpiCmd(ResetCmd());  // Ignored, not supported.
+  ExpectSpiFlashStatusGet(true);
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Erase/Program
+  ExpectSpiCmd(SectorEraseCmd(0));
+  ExpectSpiFlashStatusGet(false);
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(false);
+  ExpectSpiCmd(PageProgramCmd(0, 16));
+  ExpectSpiFlashStatusGet(false);
+  // Reset
+  ExpectSpiCmd(ResetCmd());
+  EXPECT_CALL(rstmgr_, Reset());
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, EraseBank0Error) {
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorUnknown, kErrorOk);
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, EraseBank1Error) {
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorUnknown);
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, EraseVerifyBank0Error) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorUnknown, kErrorOk);
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, EraseVerifyBank1Error) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorUnknown);
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, DataWriteError) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(0, 16);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes(cmd.payload,
+                                   cmd.payload + cmd.payload_byte_count);
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_,
+              DataWrite(cmd.address, cmd.payload_byte_count / sizeof(uint32_t),
+                        HasBytes(flash_bytes)))
+      .WillOnce(Return(kErrorUnknown));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, DataWriteErrorMisalignedAddr) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto cmd = PageProgramCmd(0xf0, 16);
+  ExpectSpiCmd(cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  std::vector<uint8_t> flash_bytes(cmd.payload,
+                                   cmd.payload + cmd.payload_byte_count);
+
+  ExpectFlashCtrlWriteEnable();
+  EXPECT_CALL(flash_ctrl_, DataWrite(0xf0, 4, HasBytes(flash_bytes)))
+      .WillOnce(Return(kErrorUnknown));
+  ExpectFlashCtrlAllDisable();
+
+  EXPECT_EQ(bootstrap(), kErrorUnknown);
+}
+
+TEST_F(BootstrapTest, BadProgramAddress) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Program
+  auto page_program_cmd = PageProgramCmd(3, 16);
+  ExpectSpiCmd(page_program_cmd);
+  ExpectSpiFlashStatusGet(true);
+
+  EXPECT_EQ(bootstrap(), kErrorBootstrapProgramAddress);
+}
+
+TEST_F(BootstrapTest, BadEraseAddress) {
+  // Erase
+  ExpectBootstrapRequestCheck(true);
+  EXPECT_CALL(spi_device_, Init());
+  ExpectSpiCmd(ChipEraseCmd());
+  ExpectSpiFlashStatusGet(true);
+  ExpectFlashCtrlChipErase(kErrorOk, kErrorOk);
+  // Verify
+  ExpectFlashCtrlEraseVerify(kErrorOk, kErrorOk);
+  EXPECT_CALL(spi_device_, FlashStatusClear());
+  // Erase
+  ExpectSpiCmd(SectorEraseCmd(FLASH_CTRL_PARAM_BYTES_PER_BANK *
+                              FLASH_CTRL_PARAM_REG_NUM_BANKS));
+  ExpectSpiFlashStatusGet(true);
+
+  EXPECT_EQ(bootstrap(), kErrorBootstrapEraseAddress);
+}
+
+TEST_F(BootstrapTest, NotRequested) {
+  ExpectBootstrapRequestCheck(false);
+
+  EXPECT_EQ(bootstrap(), kErrorBootstrapNotRequested);
+}
+
+}  // namespace
+}  // namespace bootstrap_unittest

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -207,6 +207,27 @@ sw_silicon_creator_mask_rom_bootstrap = declare_dependency(
   ),
 )
 
+test('sw_silicon_creator_mask_rom_bootstrap_unittest', executable(
+    'sw_silicon_creator_mask_rom_bootstrap_unittest',
+    sources: [
+      'bootstrap_unittest.cc',
+      'bootstrap.c',
+      hw_ip_gpio_reg_h,
+      hw_ip_flash_ctrl_reg_h,
+      hw_ip_otp_ctrl_reg_h,
+    ],
+    dependencies: [
+      sw_vendor_gtest,
+      sw_lib_testing_bitfield,
+      sw_lib_testing_hardened,
+    ],
+    native: true,
+    c_args: ['-DOT_OFF_TARGET_TEST'],
+    cpp_args: ['-DOT_OFF_TARGET_TEST'],
+  ),
+  suite: 'mask_rom',
+)
+
 # MaskROM library.
 mask_rom_lib = declare_dependency(
   sources: [

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -189,6 +189,24 @@ primitive_bootstrap_lib = declare_dependency(
   ),
 )
 
+sw_silicon_creator_mask_rom_bootstrap = declare_dependency(
+  link_with: static_library (
+    'sw_silicon_creator_mask_rom_bootstrap',
+    sources: [
+      'bootstrap.c',
+      hw_ip_gpio_reg_h,
+      hw_ip_flash_ctrl_reg_h,
+      hw_ip_otp_ctrl_reg_h,
+    ],
+    dependencies: [
+      sw_silicon_creator_lib_driver_flash_ctrl,
+      sw_silicon_creator_lib_driver_otp,
+      sw_silicon_creator_lib_driver_rstmgr,
+      sw_silicon_creator_lib_driver_spi_device,
+    ],
+  ),
+)
+
 # MaskROM library.
 mask_rom_lib = declare_dependency(
   sources: [


### PR DESCRIPTION
This PR adds the new bootstrap implementation that uses typical SPI flash EEPROM commands.

I've split the changes into multiple commits for ease of review: First three commits adds mocks for flash_ctrl, rstmgr, and spi_device drivers, while the last two commits add the new bootstrap implementation and unit tests.

Please see the following docs for more details: [1](https://docs.google.com/document/d/16NRCDkNss_IbcyEkIjOFwQ7pKxdpGr6V3gqfwOElRek/edit#heading=h.iwftp5ejxamb), [2](https://docs.google.com/document/d/1X_x7f62IrPeHRLGBzybhDu9TsvsSCb6_1uKOjQO_fI4/edit?resourcekey=0-vLsVqyrt1F2mGwLrz73uwA).