### PR TITLE
[dv/top] Fix padring coverage issue

### DIFF
--- a/hw/top_earlgrey/dv/cov/chip_cover.cfg
+++ b/hw/top_earlgrey/dv/cov/chip_cover.cfg
@@ -8,7 +8,7 @@
 begin tgl(portsonly)
   +module chip_earlgrey_asic
   +module ast
-  +module padring
+  +moduletree padring
   +moduletree top_earlgrey 2
   +moduletree rv_core_ibex 2
 end


### PR DESCRIPTION
Issue #12043 currently only collects assertion coverage for padring.
This PR fixes the issue and now collects all coverages.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>