### PR TITLE
[spi_device] Add WREN/WRDI CSRs to CMD_INFO

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -975,6 +975,40 @@
         } // f: opcode
       ]
     } // R: CMD_INFO_EX4B
+    { name: "CMD_INFO_WREN"
+      swaccess: "rw"
+      hwaccess: "hro"
+      desc: '''Opcode for Write Enable (WREN)
+        '''
+      fields: [
+        { bits: "31"
+          name: "valid"
+          desc: "If 1, opcode affects"
+        } // f: valid
+        { bits: "7:0"
+          name: "opcode"
+          desc: "WREN opcode"
+          // Leave default value 0 to be consistent
+        } // f: opcode
+      ]
+    } // R: CMD_INFO_WREN
+    { name: "CMD_INFO_WRDI"
+      swaccess: "rw"
+      hwaccess: "hro"
+      desc: '''Opcode for Write Disable (WRDI)
+        '''
+      fields: [
+        { bits: "31"
+          name: "valid"
+          desc: "If 1, opcode affects"
+        } // f: valid
+        { bits: "7:0"
+          name: "opcode"
+          desc: "WRDI opcode"
+          // Leave default value 0 to be consistent
+        } // f: opcode
+      ]
+    } // R: CMD_INFO_WRDI
 
     //===============================================================
     // TPM registers

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -783,6 +783,9 @@ module spi_device
 
   end
 
+  logic  unused_wrendi;
+  assign unused_wrendi = ^{reg2hw.cmd_info_wren, reg2hw.cmd_info_wrdi};
+
   //////////////////////////////
   // // Clock & reset control //
   //////////////////////////////

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -375,6 +375,24 @@ package spi_device_reg_pkg;
 
   typedef struct packed {
     struct packed {
+      logic [7:0]  q;
+    } opcode;
+    struct packed {
+      logic        q;
+    } valid;
+  } spi_device_reg2hw_cmd_info_wren_reg_t;
+
+  typedef struct packed {
+    struct packed {
+      logic [7:0]  q;
+    } opcode;
+    struct packed {
+      logic        q;
+    } valid;
+  } spi_device_reg2hw_cmd_info_wrdi_reg_t;
+
+  typedef struct packed {
+    struct packed {
       logic        q;
     } en;
     struct packed {
@@ -654,33 +672,35 @@ package spi_device_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    spi_device_reg2hw_intr_state_reg_t intr_state; // [1629:1618]
-    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1617:1606]
-    spi_device_reg2hw_intr_test_reg_t intr_test; // [1605:1582]
-    spi_device_reg2hw_alert_test_reg_t alert_test; // [1581:1580]
-    spi_device_reg2hw_control_reg_t control; // [1579:1574]
-    spi_device_reg2hw_cfg_reg_t cfg; // [1573:1560]
-    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1559:1528]
-    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1527:1512]
-    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1511:1496]
-    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1495:1464]
-    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1463:1432]
-    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1431:1428]
-    spi_device_reg2hw_flash_status_reg_t flash_status; // [1427:1402]
-    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1401:1386]
-    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1385:1362]
-    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1361:1352]
-    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1351:1320]
-    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1319:1311]
-    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1310:1278]
-    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1277:1022]
-    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1021:990]
-    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [989:958]
-    spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [957:926]
-    spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [925:894]
-    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [893:294]
-    spi_device_reg2hw_cmd_info_en4b_reg_t cmd_info_en4b; // [293:285]
-    spi_device_reg2hw_cmd_info_ex4b_reg_t cmd_info_ex4b; // [284:276]
+    spi_device_reg2hw_intr_state_reg_t intr_state; // [1647:1636]
+    spi_device_reg2hw_intr_enable_reg_t intr_enable; // [1635:1624]
+    spi_device_reg2hw_intr_test_reg_t intr_test; // [1623:1600]
+    spi_device_reg2hw_alert_test_reg_t alert_test; // [1599:1598]
+    spi_device_reg2hw_control_reg_t control; // [1597:1592]
+    spi_device_reg2hw_cfg_reg_t cfg; // [1591:1578]
+    spi_device_reg2hw_fifo_level_reg_t fifo_level; // [1577:1546]
+    spi_device_reg2hw_rxf_ptr_reg_t rxf_ptr; // [1545:1530]
+    spi_device_reg2hw_txf_ptr_reg_t txf_ptr; // [1529:1514]
+    spi_device_reg2hw_rxf_addr_reg_t rxf_addr; // [1513:1482]
+    spi_device_reg2hw_txf_addr_reg_t txf_addr; // [1481:1450]
+    spi_device_reg2hw_intercept_en_reg_t intercept_en; // [1449:1446]
+    spi_device_reg2hw_flash_status_reg_t flash_status; // [1445:1420]
+    spi_device_reg2hw_jedec_cc_reg_t jedec_cc; // [1419:1404]
+    spi_device_reg2hw_jedec_id_reg_t jedec_id; // [1403:1380]
+    spi_device_reg2hw_read_threshold_reg_t read_threshold; // [1379:1370]
+    spi_device_reg2hw_mailbox_addr_reg_t mailbox_addr; // [1369:1338]
+    spi_device_reg2hw_upload_cmdfifo_reg_t upload_cmdfifo; // [1337:1329]
+    spi_device_reg2hw_upload_addrfifo_reg_t upload_addrfifo; // [1328:1296]
+    spi_device_reg2hw_cmd_filter_mreg_t [255:0] cmd_filter; // [1295:1040]
+    spi_device_reg2hw_addr_swap_mask_reg_t addr_swap_mask; // [1039:1008]
+    spi_device_reg2hw_addr_swap_data_reg_t addr_swap_data; // [1007:976]
+    spi_device_reg2hw_payload_swap_mask_reg_t payload_swap_mask; // [975:944]
+    spi_device_reg2hw_payload_swap_data_reg_t payload_swap_data; // [943:912]
+    spi_device_reg2hw_cmd_info_mreg_t [23:0] cmd_info; // [911:312]
+    spi_device_reg2hw_cmd_info_en4b_reg_t cmd_info_en4b; // [311:303]
+    spi_device_reg2hw_cmd_info_ex4b_reg_t cmd_info_ex4b; // [302:294]
+    spi_device_reg2hw_cmd_info_wren_reg_t cmd_info_wren; // [293:285]
+    spi_device_reg2hw_cmd_info_wrdi_reg_t cmd_info_wrdi; // [284:276]
     spi_device_reg2hw_tpm_cfg_reg_t tpm_cfg; // [275:271]
     spi_device_reg2hw_tpm_access_mreg_t [4:0] tpm_access; // [270:231]
     spi_device_reg2hw_tpm_sts_reg_t tpm_sts; // [230:199]
@@ -778,6 +798,8 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h ec;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EN4B_OFFSET = 13'h f0;
   parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EX4B_OFFSET = 13'h f4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_WREN_OFFSET = 13'h f8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_WRDI_OFFSET = 13'h fc;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -892,6 +914,8 @@ package spi_device_reg_pkg;
     SPI_DEVICE_CMD_INFO_23,
     SPI_DEVICE_CMD_INFO_EN4B,
     SPI_DEVICE_CMD_INFO_EX4B,
+    SPI_DEVICE_CMD_INFO_WREN,
+    SPI_DEVICE_CMD_INFO_WRDI,
     SPI_DEVICE_TPM_CAP,
     SPI_DEVICE_TPM_CFG,
     SPI_DEVICE_TPM_STATUS,
@@ -910,7 +934,7 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [77] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [79] = '{
     4'b 0011, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0011, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0011, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -973,21 +997,23 @@ package spi_device_reg_pkg;
     4'b 1111, // index[59] SPI_DEVICE_CMD_INFO_23
     4'b 1111, // index[60] SPI_DEVICE_CMD_INFO_EN4B
     4'b 1111, // index[61] SPI_DEVICE_CMD_INFO_EX4B
-    4'b 0111, // index[62] SPI_DEVICE_TPM_CAP
-    4'b 0001, // index[63] SPI_DEVICE_TPM_CFG
-    4'b 0011, // index[64] SPI_DEVICE_TPM_STATUS
-    4'b 1111, // index[65] SPI_DEVICE_TPM_ACCESS_0
-    4'b 0001, // index[66] SPI_DEVICE_TPM_ACCESS_1
-    4'b 1111, // index[67] SPI_DEVICE_TPM_STS
-    4'b 1111, // index[68] SPI_DEVICE_TPM_INTF_CAPABILITY
-    4'b 1111, // index[69] SPI_DEVICE_TPM_INT_ENABLE
-    4'b 0001, // index[70] SPI_DEVICE_TPM_INT_VECTOR
-    4'b 1111, // index[71] SPI_DEVICE_TPM_INT_STATUS
-    4'b 1111, // index[72] SPI_DEVICE_TPM_DID_VID
-    4'b 0001, // index[73] SPI_DEVICE_TPM_RID
-    4'b 1111, // index[74] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 0001, // index[75] SPI_DEVICE_TPM_READ_FIFO
-    4'b 0001  // index[76] SPI_DEVICE_TPM_WRITE_FIFO
+    4'b 1111, // index[62] SPI_DEVICE_CMD_INFO_WREN
+    4'b 1111, // index[63] SPI_DEVICE_CMD_INFO_WRDI
+    4'b 0111, // index[64] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[65] SPI_DEVICE_TPM_CFG
+    4'b 0011, // index[66] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[67] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[68] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[69] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[70] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[71] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[72] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[73] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[74] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[75] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[76] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 0001, // index[77] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[78] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -1471,6 +1471,16 @@ module spi_device_reg_top (
   logic [7:0] cmd_info_ex4b_opcode_wd;
   logic cmd_info_ex4b_valid_qs;
   logic cmd_info_ex4b_valid_wd;
+  logic cmd_info_wren_we;
+  logic [7:0] cmd_info_wren_opcode_qs;
+  logic [7:0] cmd_info_wren_opcode_wd;
+  logic cmd_info_wren_valid_qs;
+  logic cmd_info_wren_valid_wd;
+  logic cmd_info_wrdi_we;
+  logic [7:0] cmd_info_wrdi_opcode_qs;
+  logic [7:0] cmd_info_wrdi_opcode_wd;
+  logic cmd_info_wrdi_valid_qs;
+  logic cmd_info_wrdi_valid_wd;
   logic [7:0] tpm_cap_rev_qs;
   logic tpm_cap_locality_qs;
   logic [2:0] tpm_cap_max_xfer_size_qs;
@@ -17417,6 +17427,110 @@ module spi_device_reg_top (
   );
 
 
+  // R[cmd_info_wren]: V(False)
+  //   F[opcode]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_cmd_info_wren_opcode (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_wren_we),
+    .wd     (cmd_info_wren_opcode_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_wren.opcode.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_wren_opcode_qs)
+  );
+
+  //   F[valid]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_wren_valid (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_wren_we),
+    .wd     (cmd_info_wren_valid_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_wren.valid.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_wren_valid_qs)
+  );
+
+
+  // R[cmd_info_wrdi]: V(False)
+  //   F[opcode]: 7:0
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (8'h0)
+  ) u_cmd_info_wrdi_opcode (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_wrdi_we),
+    .wd     (cmd_info_wrdi_opcode_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_wrdi.opcode.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_wrdi_opcode_qs)
+  );
+
+  //   F[valid]: 31:31
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (1'h0)
+  ) u_cmd_info_wrdi_valid (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (cmd_info_wrdi_we),
+    .wd     (cmd_info_wrdi_valid_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.cmd_info_wrdi.valid.q),
+
+    // to register interface (read)
+    .qs     (cmd_info_wrdi_valid_qs)
+  );
+
+
   // R[tpm_cap]: V(False)
   //   F[rev]: 7:0
   prim_subreg #(
@@ -18135,7 +18249,7 @@ module spi_device_reg_top (
 
 
 
-  logic [76:0] addr_hit;
+  logic [78:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -18200,21 +18314,23 @@ module spi_device_reg_top (
     addr_hit[59] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
     addr_hit[60] = (reg_addr == SPI_DEVICE_CMD_INFO_EN4B_OFFSET);
     addr_hit[61] = (reg_addr == SPI_DEVICE_CMD_INFO_EX4B_OFFSET);
-    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
-    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
-    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
-    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
-    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
-    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
-    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
-    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
-    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
-    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
-    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
-    addr_hit[73] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
-    addr_hit[74] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
-    addr_hit[75] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
-    addr_hit[76] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_CMD_INFO_WREN_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_CMD_INFO_WRDI_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[73] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[74] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[75] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[76] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[77] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[78] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -18298,7 +18414,9 @@ module spi_device_reg_top (
                (addr_hit[73] & (|(SPI_DEVICE_PERMIT[73] & ~reg_be))) |
                (addr_hit[74] & (|(SPI_DEVICE_PERMIT[74] & ~reg_be))) |
                (addr_hit[75] & (|(SPI_DEVICE_PERMIT[75] & ~reg_be))) |
-               (addr_hit[76] & (|(SPI_DEVICE_PERMIT[76] & ~reg_be)))));
+               (addr_hit[76] & (|(SPI_DEVICE_PERMIT[76] & ~reg_be))) |
+               (addr_hit[77] & (|(SPI_DEVICE_PERMIT[77] & ~reg_be))) |
+               (addr_hit[78] & (|(SPI_DEVICE_PERMIT[78] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -19603,7 +19721,17 @@ module spi_device_reg_top (
   assign cmd_info_ex4b_opcode_wd = reg_wdata[7:0];
 
   assign cmd_info_ex4b_valid_wd = reg_wdata[31];
-  assign tpm_cfg_we = addr_hit[63] & reg_we & !reg_error;
+  assign cmd_info_wren_we = addr_hit[62] & reg_we & !reg_error;
+
+  assign cmd_info_wren_opcode_wd = reg_wdata[7:0];
+
+  assign cmd_info_wren_valid_wd = reg_wdata[31];
+  assign cmd_info_wrdi_we = addr_hit[63] & reg_we & !reg_error;
+
+  assign cmd_info_wrdi_opcode_wd = reg_wdata[7:0];
+
+  assign cmd_info_wrdi_valid_wd = reg_wdata[31];
+  assign tpm_cfg_we = addr_hit[65] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
 
@@ -19614,7 +19742,7 @@ module spi_device_reg_top (
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_access_0_we = addr_hit[65] & reg_we & !reg_error;
+  assign tpm_access_0_we = addr_hit[67] & reg_we & !reg_error;
 
   assign tpm_access_0_access_0_wd = reg_wdata[7:0];
 
@@ -19623,37 +19751,37 @@ module spi_device_reg_top (
   assign tpm_access_0_access_2_wd = reg_wdata[23:16];
 
   assign tpm_access_0_access_3_wd = reg_wdata[31:24];
-  assign tpm_access_1_we = addr_hit[66] & reg_we & !reg_error;
+  assign tpm_access_1_we = addr_hit[68] & reg_we & !reg_error;
 
   assign tpm_access_1_wd = reg_wdata[7:0];
-  assign tpm_sts_we = addr_hit[67] & reg_we & !reg_error;
+  assign tpm_sts_we = addr_hit[69] & reg_we & !reg_error;
 
   assign tpm_sts_wd = reg_wdata[31:0];
-  assign tpm_intf_capability_we = addr_hit[68] & reg_we & !reg_error;
+  assign tpm_intf_capability_we = addr_hit[70] & reg_we & !reg_error;
 
   assign tpm_intf_capability_wd = reg_wdata[31:0];
-  assign tpm_int_enable_we = addr_hit[69] & reg_we & !reg_error;
+  assign tpm_int_enable_we = addr_hit[71] & reg_we & !reg_error;
 
   assign tpm_int_enable_wd = reg_wdata[31:0];
-  assign tpm_int_vector_we = addr_hit[70] & reg_we & !reg_error;
+  assign tpm_int_vector_we = addr_hit[72] & reg_we & !reg_error;
 
   assign tpm_int_vector_wd = reg_wdata[7:0];
-  assign tpm_int_status_we = addr_hit[71] & reg_we & !reg_error;
+  assign tpm_int_status_we = addr_hit[73] & reg_we & !reg_error;
 
   assign tpm_int_status_wd = reg_wdata[31:0];
-  assign tpm_did_vid_we = addr_hit[72] & reg_we & !reg_error;
+  assign tpm_did_vid_we = addr_hit[74] & reg_we & !reg_error;
 
   assign tpm_did_vid_vid_wd = reg_wdata[15:0];
 
   assign tpm_did_vid_did_wd = reg_wdata[31:16];
-  assign tpm_rid_we = addr_hit[73] & reg_we & !reg_error;
+  assign tpm_rid_we = addr_hit[75] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = addr_hit[74] & reg_re & !reg_error;
-  assign tpm_read_fifo_we = addr_hit[75] & reg_we & !reg_error;
+  assign tpm_cmd_addr_re = addr_hit[76] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[77] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[7:0];
-  assign tpm_write_fifo_re = addr_hit[76] & reg_re & !reg_error;
+  assign tpm_write_fifo_re = addr_hit[78] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -20486,12 +20614,22 @@ module spi_device_reg_top (
       end
 
       addr_hit[62]: begin
+        reg_rdata_next[7:0] = cmd_info_wren_opcode_qs;
+        reg_rdata_next[31] = cmd_info_wren_valid_qs;
+      end
+
+      addr_hit[63]: begin
+        reg_rdata_next[7:0] = cmd_info_wrdi_opcode_qs;
+        reg_rdata_next[31] = cmd_info_wrdi_valid_qs;
+      end
+
+      addr_hit[64]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
         reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[65]: begin
         reg_rdata_next[0] = tpm_cfg_en_qs;
         reg_rdata_next[1] = tpm_cfg_tpm_mode_qs;
         reg_rdata_next[2] = tpm_cfg_hw_reg_dis_qs;
@@ -20499,63 +20637,63 @@ module spi_device_reg_top (
         reg_rdata_next[4] = tpm_cfg_invalid_locality_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[66]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
         reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[67]: begin
         reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
         reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
         reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
         reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[68]: begin
         reg_rdata_next[7:0] = tpm_access_1_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[69]: begin
         reg_rdata_next[31:0] = tpm_sts_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[70]: begin
         reg_rdata_next[31:0] = tpm_intf_capability_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[71]: begin
         reg_rdata_next[31:0] = tpm_int_enable_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[72]: begin
         reg_rdata_next[7:0] = tpm_int_vector_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[73]: begin
         reg_rdata_next[31:0] = tpm_int_status_qs;
       end
 
-      addr_hit[72]: begin
+      addr_hit[74]: begin
         reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
         reg_rdata_next[31:16] = tpm_did_vid_did_qs;
       end
 
-      addr_hit[73]: begin
+      addr_hit[75]: begin
         reg_rdata_next[7:0] = tpm_rid_qs;
       end
 
-      addr_hit[74]: begin
+      addr_hit[76]: begin
         reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
         reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
       end
 
-      addr_hit[75]: begin
+      addr_hit[77]: begin
         reg_rdata_next[7:0] = '0;
       end
 
-      addr_hit[76]: begin
+      addr_hit[78]: begin
         reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 


### PR DESCRIPTION

As discussed in #11869 , WREN/ WRDI are better to be processed in HW.
This commit defines WREN/ WRDI opcode CSRs for the cmdparse module to
parse the command correctly.