### PR TITLE
[fpv/tcl] Add macro defines to fpv tcl file

### DIFF
--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -2,14 +2,16 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 {
-  sub_flow:    fpv
+  sub_flow: fpv
   import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_formal_cfg.hjson"]
   stopats: ""
   task: ""
+  defines: ""
 
   // Optional vars that need to exported to the env
   exports: [
     {STOPATS: '{stopats}'},
-    {TASK:    '{task}'}
+    {TASK:    '{task}'},
+    {FPV_DEFINES:  '{defines}'},
   ]
 }

--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -10,6 +10,7 @@
 # DUT_TOP: string to indicate the top-level module name.
 # STOPATS: string to indicate the name of the signal to insert `stopat`.
 # TASK: string to collect and prove a subset of assertions that contains these string.
+# FPV_DEFINES: string to add additional macro defines during anaylze phase.
 
 # clear previous settings
 clear -all
@@ -29,18 +30,18 @@ if {$env(COV) == 1} {
 if {$env(TASK) == "FpvSecCm"} {
   analyze -sv09 \
     +define+FPV_ON \
-    +define+FPV_SEC_CM_ON+FPV_ALERT_NO_SIGINT_ERR \
+    +define+FPV_SEC_CM_ON+FPV_ALERT_NO_SIGINT_ERR+$env(FPV_DEFINES) \
     -bbox_m prim_count \
     -bbox_m prim_double_lfsr \
     -f [glob *.scr]
 } elseif {$env(DUT_TOP) == "pinmux_tb"} {
   analyze -sv09 \
-    +define+FPV_ON+FPV_ALERT_NO_SIGINT_ERR \
+    +define+FPV_ON+$env(FPV_DEFINES) \
     -bbox_m usbdev_aon_wake \
     -f [glob *.scr]
 } else {
   analyze -sv09 \
-    +define+FPV_ON \
+    +define+FPV_ON+$env(FPV_DEFINES) \
     -f [glob *.scr]
 }
 

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -355,6 +355,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/ip/pinmux/{sub_flow}/{tool}"
                cov: true
+               defines: "FPV_ALERT_NO_SIGINT_ERR"
              }
              {
                // Use chip_eargrey_asic parameters.
@@ -364,6 +365,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                rel_path: "hw/top_earlgrey/ip/pinmux/{sub_flow}/{tool}"
                cov: true
+               defines: "FPV_ALERT_NO_SIGINT_ERR"
                overrides: [
                  {
                    name:  design_level


### PR DESCRIPTION
This PR adds an env variable in FPV tcl file to set macro defines from
fpv_cfg.hjson file.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>