### PR TITLE
[flash_ctrl] Add checks for unexpected acks

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -1868,6 +1868,12 @@
               The flash macro encountered a storage integrity ECC error.
             '''
           },
+          { bits: "10",
+            name: "spurious_ack",
+            desc: '''
+              The flash emitted an unexpected acknowledgement.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -1343,6 +1343,12 @@
               The flash macro encountered a storage integrity ECC error.
             '''
           },
+          { bits: "10",
+            name: "spurious_ack",
+            desc: '''
+              The flash emitted an unexpected acknowledgement.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -1022,6 +1022,7 @@ module flash_ctrl
   assign hw2reg.fault_status.seed_err.d         = 1'b1;
   assign hw2reg.fault_status.phy_relbl_err.d    = 1'b1;
   assign hw2reg.fault_status.phy_storage_err.d  = 1'b1;
+  assign hw2reg.fault_status.spurious_ack.d     = 1'b1;
   assign hw2reg.fault_status.mp_err.de          = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de          = hw_err.rd_err;
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
@@ -1031,6 +1032,7 @@ module flash_ctrl
   assign hw2reg.fault_status.seed_err.de        = seed_err;
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;
+  assign hw2reg.fault_status.spurious_ack.de    = flash_phy_rsp.spurious_ack;
 
   // standard faults
   assign hw2reg.std_fault_status.reg_intg_err.d    = 1'b1;

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -430,6 +430,7 @@ package flash_ctrl_pkg;
     logic                    storage_relbl_err;
     logic                    storage_intg_err;
     logic                    fsm_err;
+    logic                    spurious_ack;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -448,7 +449,8 @@ package flash_ctrl_pkg;
     prog_intg_err:      '0,
     storage_relbl_err:  '0,
     storage_intg_err:   '0,
-    fsm_err:            '0
+    fsm_err:            '0,
+    spurious_ack:       '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/flash_ctrl.core
+++ b/hw/ip/flash_ctrl/flash_ctrl.core
@@ -13,6 +13,7 @@ filesets:
       - lowrisc:prim:count
       - lowrisc:prim:edge_detector
       - lowrisc:prim:flash
+      - lowrisc:prim:flop_2sync
       - lowrisc:prim:gf_mult
       - lowrisc:prim:lc_sync
       - lowrisc:prim:lfsr

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1023,6 +1023,7 @@ module flash_ctrl
   assign hw2reg.fault_status.seed_err.d         = 1'b1;
   assign hw2reg.fault_status.phy_relbl_err.d    = 1'b1;
   assign hw2reg.fault_status.phy_storage_err.d  = 1'b1;
+  assign hw2reg.fault_status.spurious_ack.d     = 1'b1;
   assign hw2reg.fault_status.mp_err.de          = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de          = hw_err.rd_err;
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
@@ -1032,6 +1033,7 @@ module flash_ctrl
   assign hw2reg.fault_status.seed_err.de        = seed_err;
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;
+  assign hw2reg.fault_status.spurious_ack.de    = flash_phy_rsp.spurious_ack;
 
   // standard faults
   assign hw2reg.std_fault_status.reg_intg_err.d    = 1'b1;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -965,6 +965,7 @@ module flash_ctrl_core_reg_top (
   logic fault_status_seed_err_qs;
   logic fault_status_phy_relbl_err_qs;
   logic fault_status_phy_storage_err_qs;
+  logic fault_status_spurious_ack_qs;
   logic [19:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
@@ -10247,6 +10248,31 @@ module flash_ctrl_core_reg_top (
     .qs     (fault_status_phy_storage_err_qs)
   );
 
+  //   F[spurious_ack]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_spurious_ack (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.spurious_ack.de),
+    .d      (hw2reg.fault_status.spurious_ack.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.spurious_ack.q),
+
+    // to register interface (read)
+    .qs     (fault_status_spurious_ack_qs)
+  );
+
 
   // R[err_addr]: V(False)
   prim_subreg #(
@@ -12321,6 +12347,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[7] = fault_status_seed_err_qs;
         reg_rdata_next[8] = fault_status_phy_relbl_err_qs;
         reg_rdata_next[9] = fault_status_phy_storage_err_qs;
+        reg_rdata_next[10] = fault_status_spurious_ack_qs;
       end
 
       addr_hit[96]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -430,6 +430,7 @@ package flash_ctrl_pkg;
     logic                    storage_relbl_err;
     logic                    storage_intg_err;
     logic                    fsm_err;
+    logic                    spurious_ack;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -448,7 +449,8 @@ package flash_ctrl_pkg;
     prog_intg_err:      '0,
     storage_relbl_err:  '0,
     storage_intg_err:   '0,
-    fsm_err:            '0
+    fsm_err:            '0,
+    spurious_ack:       '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -428,6 +428,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } phy_storage_err;
+    struct packed {
+      logic        q;
+    } spurious_ack;
   } flash_ctrl_reg2hw_fault_status_reg_t;
 
   typedef struct packed {
@@ -640,6 +643,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } phy_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } spurious_ack;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -683,29 +690,29 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1317:1312]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1311:1306]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1305:1294]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1293:1288]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [1287:1284]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [1283:1252]
-    flash_ctrl_reg2hw_init_reg_t init; // [1251:1251]
-    flash_ctrl_reg2hw_control_reg_t control; // [1250:1231]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [1230:1211]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1210:1209]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1208:1208]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1207:984]
-    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [983:832]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [831:808]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [807:528]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [527:500]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [499:444]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [443:164]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [163:136]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [135:80]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [79:78]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [77:70]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [69:61]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1318:1313]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1312:1307]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1306:1295]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1294:1289]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [1288:1285]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [1284:1253]
+    flash_ctrl_reg2hw_init_reg_t init; // [1252:1252]
+    flash_ctrl_reg2hw_control_reg_t control; // [1251:1232]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [1231:1212]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1211:1210]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1209:1209]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1208:985]
+    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [984:833]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [832:809]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [808:529]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [528:501]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [500:445]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [444:165]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [164:137]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [136:81]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [80:79]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [78:71]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
@@ -715,15 +722,15 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [175:164]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [163:163]
-    flash_ctrl_hw2reg_control_reg_t control; // [162:161]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [160:159]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [158:155]
-    flash_ctrl_hw2reg_status_reg_t status; // [154:145]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [144:131]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [130:115]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [114:97]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [177:166]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [165:165]
+    flash_ctrl_hw2reg_control_reg_t control; // [164:163]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [162:161]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [160:157]
+    flash_ctrl_hw2reg_status_reg_t status; // [156:147]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [146:133]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [132:117]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [116:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [75:58]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [57:16]

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -91,6 +91,7 @@ module flash_phy
   // common interface
   logic [BusFullWidth-1:0] rd_data [NumBanks];
   logic [NumBanks-1:0] rd_err;
+  logic [NumBanks-1:0] spurious_acks;
 
   // fsm error per bank
   logic [NumBanks-1:0] fsm_err;
@@ -124,6 +125,7 @@ module flash_phy
   assign flash_ctrl_o.storage_relbl_err = |relbl_ecc_err;
   assign flash_ctrl_o.storage_intg_err = |intg_ecc_err;
   assign flash_ctrl_o.fsm_err = |fsm_err;
+  assign flash_ctrl_o.spurious_ack = |spurious_acks;
 
   // This fifo holds the expected return order
   prim_fifo_sync #(
@@ -270,7 +272,8 @@ module flash_phy
       .fsm_err_o(fsm_err[bank]),
       .prog_intg_err_o(prog_intg_err[bank]),
       .relbl_ecc_err_o(relbl_ecc_err[bank]),
-      .intg_ecc_err_o(intg_ecc_err[bank])
+      .intg_ecc_err_o(intg_ecc_err[bank]),
+      .spurious_ack_o(spurious_acks[bank])
     );
   end // block: gen_flash_banks
 

--- a/hw/ip/prim/prim_cdc_rand_delay.core
+++ b/hw/ip/prim/prim_cdc_rand_delay.core
@@ -26,7 +26,7 @@ filesets:
       # common waivers
       - lowrisc:lint:common
     files:
-      #- lint/prim_cdc_rand_delay.waiver
+      - lint/prim_cdc_rand_delay.waiver
     file_type: waiver
 
   files_veriblelint_waiver:

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -331,7 +331,7 @@ module prim_generic_flash_bank #(
 
       StErase: begin
         // Actual erasing of the page
-        if (erase_suspend_req_i && ack_o) begin
+        if (erase_suspend_req_i) begin
           st_d = StErSuspend;
         end else if (index_cnt < index_limit_q || time_cnt < time_limit_q) begin
           mem_req = 1'b1;

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -1874,6 +1874,12 @@
               The flash macro encountered a storage integrity ECC error.
             '''
           },
+          { bits: "10",
+            name: "spurious_ack",
+            desc: '''
+              The flash emitted an unexpected acknowledgement.
+            '''
+          },
         ]
       },
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1029,6 +1029,7 @@ module flash_ctrl
   assign hw2reg.fault_status.seed_err.d         = 1'b1;
   assign hw2reg.fault_status.phy_relbl_err.d    = 1'b1;
   assign hw2reg.fault_status.phy_storage_err.d  = 1'b1;
+  assign hw2reg.fault_status.spurious_ack.d     = 1'b1;
   assign hw2reg.fault_status.mp_err.de          = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de          = hw_err.rd_err;
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
@@ -1038,6 +1039,7 @@ module flash_ctrl
   assign hw2reg.fault_status.seed_err.de        = seed_err;
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;
+  assign hw2reg.fault_status.spurious_ack.de    = flash_phy_rsp.spurious_ack;
 
   // standard faults
   assign hw2reg.std_fault_status.reg_intg_err.d    = 1'b1;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -965,6 +965,7 @@ module flash_ctrl_core_reg_top (
   logic fault_status_seed_err_qs;
   logic fault_status_phy_relbl_err_qs;
   logic fault_status_phy_storage_err_qs;
+  logic fault_status_spurious_ack_qs;
   logic [19:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
@@ -10247,6 +10248,31 @@ module flash_ctrl_core_reg_top (
     .qs     (fault_status_phy_storage_err_qs)
   );
 
+  //   F[spurious_ack]: 10:10
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_spurious_ack (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.spurious_ack.de),
+    .d      (hw2reg.fault_status.spurious_ack.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.spurious_ack.q),
+
+    // to register interface (read)
+    .qs     (fault_status_spurious_ack_qs)
+  );
+
 
   // R[err_addr]: V(False)
   prim_subreg #(
@@ -12321,6 +12347,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[7] = fault_status_seed_err_qs;
         reg_rdata_next[8] = fault_status_phy_relbl_err_qs;
         reg_rdata_next[9] = fault_status_phy_storage_err_qs;
+        reg_rdata_next[10] = fault_status_spurious_ack_qs;
       end
 
       addr_hit[96]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -436,6 +436,7 @@ package flash_ctrl_pkg;
     logic                    storage_relbl_err;
     logic                    storage_intg_err;
     logic                    fsm_err;
+    logic                    spurious_ack;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -454,7 +455,8 @@ package flash_ctrl_pkg;
     prog_intg_err:      '0,
     storage_relbl_err:  '0,
     storage_intg_err:   '0,
-    fsm_err:            '0
+    fsm_err:            '0,
+    spurious_ack:       '0
   };
 
   // RMA entries

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -428,6 +428,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } phy_storage_err;
+    struct packed {
+      logic        q;
+    } spurious_ack;
   } flash_ctrl_reg2hw_fault_status_reg_t;
 
   typedef struct packed {
@@ -640,6 +643,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } phy_storage_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } spurious_ack;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -683,29 +690,29 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1317:1312]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1311:1306]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1305:1294]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1293:1288]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [1287:1284]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [1283:1252]
-    flash_ctrl_reg2hw_init_reg_t init; // [1251:1251]
-    flash_ctrl_reg2hw_control_reg_t control; // [1250:1231]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [1230:1211]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1210:1209]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1208:1208]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1207:984]
-    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [983:832]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [831:808]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [807:528]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [527:500]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [499:444]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [443:164]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [163:136]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [135:80]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [79:78]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [77:70]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [69:61]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1318:1313]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1312:1307]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1306:1295]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1294:1289]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [1288:1285]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [1284:1253]
+    flash_ctrl_reg2hw_init_reg_t init; // [1252:1252]
+    flash_ctrl_reg2hw_control_reg_t control; // [1251:1232]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [1231:1212]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1211:1210]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1209:1209]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1208:985]
+    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [984:833]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [832:809]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [808:529]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [528:501]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [500:445]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [444:165]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [164:137]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [136:81]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [80:79]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [78:71]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
@@ -715,15 +722,15 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [175:164]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [163:163]
-    flash_ctrl_hw2reg_control_reg_t control; // [162:161]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [160:159]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [158:155]
-    flash_ctrl_hw2reg_status_reg_t status; // [154:145]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [144:131]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [130:115]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [114:97]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [177:166]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [165:165]
+    flash_ctrl_hw2reg_control_reg_t control; // [164:163]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [162:161]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [160:157]
+    flash_ctrl_hw2reg_status_reg_t status; // [156:147]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [146:133]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [132:117]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [116:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [75:58]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [57:16]


### PR DESCRIPTION
- d2s item

Unexpeted acks are checked in two places, the controller access
path and the host access path.

For the controller access path, the accesses are fsm controlled,
so whenever the fsm is idle it should not see an ack.

For the host access path, a small amount of logic is added to track
the number of outstanding host transactions. When there are no
outstanding transactions, a response is not expected and would constitute a
spurious ack.