### PR TITLE
[flash_ctrl] ADD FULL MEMORY ACCESS TEST

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson
@@ -94,11 +94,10 @@
       desc: '''
             Entire memory is accessed by Controller and directly by Host. In addition, Data
             partitions can be directly read by Software(Flash controller) and hardware hosts,
-            while Info partitions can be read only by the Flash controller. Test High Endurance
-            feature.
+            while Info partitions can be read only by the Flash controller.
             '''
       milestone: V2
-      tests: []
+      tests: ["flash_ctrl_full_mem_access"]
     }
     {
       name: rd_buff_eviction

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env.core
@@ -44,6 +44,7 @@ filesets:
       - seq_lib/flash_ctrl_host_ctrl_arb_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_mp_regions_vseq.sv: {is_include_file: true}
       - seq_lib/flash_ctrl_fetch_code_vseq.sv: {is_include_file: true}
+      - seq_lib/flash_ctrl_full_mem_access_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -75,13 +75,15 @@ package flash_ctrl_env_pkg;
   parameter uint FlashFullDataWidth = flash_ctrl_pkg::DataWidth + 4;
 
   // params for words
-  parameter uint NUM_PAGE_WORDS            = 512;
-  parameter uint NUM_BK_DATA_WORDS         = 131072; // 256 pages
-  parameter uint NUM_BK_INFO_WORDS         = 5120;   // 10 pages
+  parameter uint NUM_PAGE_WORDS    = FlashNumBusWordsPerPage;
+  parameter uint NUM_BK_DATA_WORDS = FlashNumBusWordsPerBank;  // 256 pages
+  parameter uint NUM_BK_INFO_WORDS = InfoTypeBusWords[0];      // 10 pages
 
   // params for num of pages
-  parameter uint NUM_PAGE_PART_DATA        = 512;
-  parameter uint NUM_PAGE_PART_INFO0       = 10;
+  parameter uint NUM_PAGE_PART_DATA  = flash_ctrl_pkg::PagesPerBank;
+  parameter uint NUM_PAGE_PART_INFO0 = flash_ctrl_pkg::InfoTypeSize[0];
+  parameter uint NUM_PAGE_PART_INFO1 = flash_ctrl_pkg::InfoTypeSize[1];
+  parameter uint NUM_PAGE_PART_INFO2 = flash_ctrl_pkg::InfoTypeSize[2];
 
   parameter otp_ctrl_pkg::flash_otp_key_rsp_t FLASH_OTP_RSP_DEFAULT = '{
       data_ack: 1'b0,
@@ -137,10 +139,10 @@ package flash_ctrl_env_pkg;
 
   // Partition select for DV
   typedef enum logic [flash_ctrl_pkg::InfoTypes:0] {  // Data partition and all info partitions
-    FlashPartData       = 0,
-    FlashPartInfo       = 1,
-    FlashPartInfo1      = 2,
-    FlashPartInfo2      = 4
+    FlashPartData  = 0,
+    FlashPartInfo  = 1,
+    FlashPartInfo1 = 2,
+    FlashPartInfo2 = 4
   } flash_dv_part_e;
 
   // Special Partitions
@@ -151,6 +153,12 @@ package flash_ctrl_env_pkg;
     FlashData0Part   = 3,
     FlashData1Part   = 4
   } flash_sec_part_e;
+
+  typedef enum {
+    AllOnes,       // All 1s
+    AllZeros,      // All 0s
+    CustomVal      // Custom Value
+  } flash_scb_wr_e;
 
   typedef struct packed {
     mubi4_t  en;           // enable this region
@@ -184,8 +192,12 @@ package flash_ctrl_env_pkg;
 
   // Data queue for flash transactions
   typedef logic [TL_DW-1:0] data_q_t[$];
+  typedef bit [TL_DW-1:0] data_b_t[$];
   typedef bit [TL_DW-1:0] data_t;
   typedef bit [TL_AW-1:0] addr_t;
+
+  parameter uint ALL_ZEROS = 32'h0000_0000;
+  parameter uint ALL_ONES  = 32'hffff_ffff;
 
   // Parameter for Probing into the DUT RMA FSM
   parameter string PRB_RMA_FSM = "tb.dut.u_flash_hw_if.state_q";

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_base_vseq.sv
@@ -29,6 +29,8 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
   // rand data for program
   rand data_q_t flash_program_data;
 
+  constraint flash_program_data_c {flash_program_data.size == 16;}
+
   // default region cfg
   flash_mp_region_cfg_t default_region_cfg = '{
       default: MuBi4True,
@@ -147,12 +149,12 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
                                              mubi4_t he_en       = MuBi4False);
     uvm_reg_data_t data;
     data = get_csr_val_with_updated_field(ral.default_region.rd_en, data, read_en);
-    data = data | get_csr_val_with_updated_field(ral.default_region.prog_en, data,
-                                                 program_en);
-    data = data | get_csr_val_with_updated_field(ral.default_region.erase_en, data,
-                                                 erase_en);
-    data = data | get_csr_val_with_updated_field(ral.default_region.scramble_en, data,
-                                                 scramble_en);
+    data = data |
+        get_csr_val_with_updated_field(ral.default_region.prog_en, data, program_en);
+    data = data |
+        get_csr_val_with_updated_field(ral.default_region.erase_en, data, erase_en);
+    data = data |
+        get_csr_val_with_updated_field(ral.default_region.scramble_en, data, scramble_en);
     data = data | get_csr_val_with_updated_field(ral.default_region.ecc_en, data, ecc_en);
     data = data | get_csr_val_with_updated_field(ral.default_region.he_en, data, he_en);
     csr_wr(.ptr(ral.default_region), .value(data));
@@ -175,18 +177,18 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     end
     csr = ral.get_reg_by_name(csr_name);
     data = get_csr_val_with_updated_field(csr.get_field_by_name("en"), data, page_cfg.en);
-    data = data | get_csr_val_with_updated_field(csr.get_field_by_name("rd_en"), data,
-                                                 page_cfg.read_en);
-    data = data | get_csr_val_with_updated_field(csr.get_field_by_name("prog_en"), data,
-                                                 page_cfg.program_en);
-    data = data | get_csr_val_with_updated_field(csr.get_field_by_name("erase_en"), data,
-                                                 page_cfg.erase_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("rd_en"), data, page_cfg.read_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("prog_en"), data, page_cfg.program_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("erase_en"), data, page_cfg.erase_en);
     data = data | get_csr_val_with_updated_field(csr.get_field_by_name("scramble_en"), data,
                                                  page_cfg.scramble_en);
-    data = data | get_csr_val_with_updated_field(csr.get_field_by_name("ecc_en"), data,
-                                                 page_cfg.ecc_en);
-    data = data | get_csr_val_with_updated_field(csr.get_field_by_name("he_en"), data,
-                                                 page_cfg.he_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("ecc_en"), data, page_cfg.ecc_en);
+    data = data |
+        get_csr_val_with_updated_field(csr.get_field_by_name("he_en"), data, page_cfg.he_en);
     csr_wr(.ptr(csr), .value(data));
   endtask : flash_ctrl_mp_info_page_cfg
 
@@ -338,11 +340,11 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     flash_op_t        flash_op;
 
     // Flash Operation Assignments
-    flash_op.op         = op;
-    flash_op.partition  = FlashPartInfo;
-    flash_op.erase_type = FlashErasePage;
-    flash_op.num_words  = FlashSecretPartWords;
-    poll_fifo_status    = 1;
+    flash_op.op                         = op;
+    flash_op.partition                  = FlashPartInfo;
+    flash_op.erase_type                 = FlashErasePage;
+    flash_op.num_words                  = FlashSecretPartWords;
+    poll_fifo_status                    = 1;
 
     // Disable HW Access to Secret Partition from Life Cycle Controller Interface (Write/Read/Erase)
     cfg.flash_ctrl_vif.lc_seed_hw_rd_en = lc_ctrl_pkg::Off;  // Disable Secret Partition HW Access
@@ -704,9 +706,9 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     data_q_t                 data_copy;
 
     // Calculate Number of Complete Cycles and Partial Cycle Words
-    num      = data.size();
-    num_full = num / FIFO_DEPTH;
-    num_part = num % FIFO_DEPTH;
+    num           = data.size();
+    num_full      = num / FIFO_DEPTH;
+    num_part      = num % FIFO_DEPTH;
 
     // Other
     partition_sel = |flash_op.partition;
@@ -813,7 +815,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     flash_addr    = flash_op.addr;
 
     // If num_full > 0
-    idx = 0;
+    idx           = 0;
     for (int cycle = 0; cycle < num_full; cycle++) begin
 
       `uvm_info(`gfn, $sformatf("Read Cycle : %0d, flash_addr = 0x%0x", cycle, flash_addr),
@@ -926,7 +928,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
 
   // Task to Enable/Disable the 'Info' Partitions, Creator, Owner and Isolated, via the Lifetime
   // Controller Interface
-  virtual task en_sw_rw_part_info (input flash_op_t flash_op, input lc_ctrl_pkg::lc_tx_t val);
+  virtual task en_sw_rw_part_info(input flash_op_t flash_op, input lc_ctrl_pkg::lc_tx_t val);
     if (flash_op.partition == FlashPartInfo) begin
       cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = val;
       cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = val;
@@ -946,7 +948,7 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
       flash_ctrl_start_op(flash_op_r);
       flash_ctrl_read(flash_op_r.num_words, flash_read_data, poll_fifo_status);
       wait_flash_op_done();
-      flash_op_r.addr = flash_op_r.addr + 64; //64B was read, 16 words
+      flash_op_r.addr = flash_op_r.addr + 64;  //64B was read, 16 words
     end
   endtask : controller_read_page
 
@@ -959,38 +961,15 @@ class flash_ctrl_base_vseq extends cip_base_vseq #(
     for (int i = 0; i < 32; i++) begin
       `uvm_info(`gfn, $sformatf("PROGRAM ADDRESS: 0x%0h", flash_op_p.addr), UVM_HIGH)
       // Randomize Write Data
-      `DV_CHECK_MEMBER_RANDOMIZE_WITH_FATAL(flash_program_data,
-                                            flash_program_data.size == flash_op_p.num_words;)
+      for (int j = 0; j < 16; j++) begin
+        flash_program_data[j] = $urandom();
+      end
       cfg.flash_mem_bkdr_write(.flash_op(flash_op_p), .scheme(FlashMemInitSet));
       flash_ctrl_start_op(flash_op_p);
       flash_ctrl_write(flash_program_data, poll_fifo_status);
       wait_flash_op_done(.timeout_ns(cfg.seq_cfg.prog_timeout_ns));
-      flash_op_p.addr = flash_op_p.addr + 64; //64B was written, 16 words
+      flash_op_p.addr = flash_op_p.addr + 64;  //64B was written, 16 words
     end
   endtask : controller_program_page
-
-  // Task for set scb memory
-  virtual task set_scb_mem(int bkd_num_words,flash_dv_part_e bkd_partition,
-                         bit [TL_AW-1:0] write_bkd_addr,bit [TL_DW-1:0] set_bkd_val);
-    bit [TL_AW-1:0] wr_bkd_addr;
-    `uvm_info(`gfn, $sformatf("SET SCB MEM TEST part: %0s addr:%0h data:0x%0h num: %0d",
-                             bkd_partition.name,write_bkd_addr,set_bkd_val,bkd_num_words),UVM_HIGH)
-    wr_bkd_addr = {write_bkd_addr[TL_AW-1:2], 2'b00};
-    `uvm_info(`gfn, $sformatf("SET SCB MEM ADDR:%0h", wr_bkd_addr), UVM_HIGH)
-    for (int i=0; i < bkd_num_words; i++) begin
-      `uvm_info(`gfn, $sformatf("SET SCB MEM part: %0s addr:%0h data:0x%0h num: %0d",
-                bkd_partition.name,wr_bkd_addr,set_bkd_val,bkd_num_words),UVM_HIGH)
-      cfg.write_data_all_part(bkd_partition, wr_bkd_addr, set_bkd_val);
-      wr_bkd_addr = wr_bkd_addr + 4;
-    end
-  endtask : set_scb_mem
-
-  // Task for clean scb memory
-  virtual task scb_del_mem();
-        cfg.scb_flash_data.delete();
-        cfg.scb_flash_info.delete();
-        cfg.scb_flash_info1.delete();
-        cfg.scb_flash_info2.delete();
-  endtask : scb_del_mem
 
 endclass : flash_ctrl_base_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_full_mem_access_vseq.sv
@@ -1,0 +1,197 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Full memory access test. First flash is first programmed and than read back
+// by controller. Second direct reads are invoked.
+class flash_ctrl_full_mem_access_vseq extends flash_ctrl_base_vseq;
+  `uvm_object_utils(flash_ctrl_full_mem_access_vseq)
+
+  `uvm_object_new
+
+  // Configure sequence knobs to tailor it to smoke seq.
+  virtual function void configure_vseq();
+
+    // enable high endurance
+    cfg.seq_cfg.mp_region_he_en_pc      = 50;
+    cfg.seq_cfg.default_region_he_en_pc = 50;
+
+  endfunction
+
+  rand flash_op_t flash_op;
+  rand bit        selected_bank;
+  bit [TL_AW-1:0] bank_start_addr;
+
+  // Memory protection regions settings.
+  flash_mp_region_cfg_t mp_regions[flash_ctrl_pkg::MpRegions];
+
+  // Information partitions memory protection pages settings.
+  rand flash_bank_mp_info_page_cfg_t
+             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+
+  constraint mp_info_pages_c {
+    foreach (mp_info_pages[i, j]) {
+      mp_info_pages[i][j].size() == flash_ctrl_pkg::InfoTypeSize[j];
+      foreach (mp_info_pages[i][j][k]) {
+        mp_info_pages[i][j][k].en == MuBi4True;
+        mp_info_pages[i][j][k].read_en == MuBi4True;
+        mp_info_pages[i][j][k].program_en == MuBi4True;
+        mp_info_pages[i][j][k].erase_en == MuBi4True;
+        mp_info_pages[i][j][k].scramble_en == MuBi4False;
+        mp_info_pages[i][j][k].ecc_en == MuBi4False;
+        mp_info_pages[i][j][k].he_en dist {
+          MuBi4False :/ (100 - cfg.seq_cfg.mp_region_he_en_pc),
+          MuBi4True :/ cfg.seq_cfg.mp_region_he_en_pc
+        };
+      }
+    }
+  }
+
+  // Default flash ctrl region settings.
+  rand mubi4_t default_region_read_en;
+  rand mubi4_t default_region_program_en;
+  rand mubi4_t default_region_erase_en;
+  rand mubi4_t default_region_he_en;
+  mubi4_t default_region_scramble_en;
+  mubi4_t default_region_ecc_en;
+
+  // Bank erasability.
+  rand bit [flash_ctrl_pkg::NumBanks-1:0] bank_erase_en;
+
+  constraint default_region_he_en_c {
+    default_region_he_en dist {
+      MuBi4True :/ cfg.seq_cfg.default_region_he_en_pc,
+      MuBi4False :/ (100 - cfg.seq_cfg.default_region_he_en_pc)
+    };
+  }
+
+  virtual task body();
+    cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
+    cfg.scb_check                               = 1;
+
+    `DV_CHECK_RANDOMIZE_FATAL(this)
+    bank_start_addr = selected_bank * BytesPerBank;
+    `uvm_info(`gfn, $sformatf("SW PROGRAM AND READ DATA FROM BANK %0d", selected_bank), UVM_LOW)
+    do_sw_rw();
+    `uvm_info(`gfn, $sformatf("DIRECT READ DATA FROM BANK %0d", selected_bank), UVM_LOW)
+    do_direct_rd();
+
+  endtask : body
+
+  virtual task do_sw_rw();
+    flash_op_t flash_op_sw_rw;
+    // Default region settings
+    default_region_read_en     = MuBi4True;
+    default_region_program_en  = MuBi4True;
+    default_region_erase_en    = MuBi4True;
+    default_region_ecc_en      = MuBi4False;
+    default_region_scramble_en = MuBi4False;
+    flash_ctrl_default_region_cfg(
+        .read_en(default_region_read_en), .program_en(default_region_program_en),
+        .erase_en(default_region_erase_en), .scramble_en(default_region_scramble_en),
+        .ecc_en(default_region_ecc_en), .he_en(default_region_he_en));
+
+    // No Protection
+    foreach (mp_regions[i]) begin
+      mp_regions[i].en = MuBi4False;
+    end
+    foreach (mp_regions[k]) begin
+      flash_ctrl_mp_region_cfg(k, mp_regions[k]);
+      `uvm_info(`gfn, $sformatf("MP regions values %p", mp_regions[k]), UVM_HIGH)
+    end
+
+    foreach (mp_info_pages[i, j, k]) begin
+      flash_ctrl_mp_info_page_cfg(i, j, k, mp_info_pages[i][j][k]);
+      `uvm_info(`gfn, $sformatf("MP INFO regions values %p", mp_info_pages[i][j][k]), UVM_HIGH)
+    end
+    //Enable Bank erase
+    flash_ctrl_bank_erase_cfg(.bank_erase_en(bank_erase_en));
+
+    flash_op_sw_rw.partition  = FlashPartData;
+    flash_op_sw_rw.erase_type = flash_ctrl_pkg::FlashEraseBank;
+    flash_op_sw_rw.op         = flash_ctrl_pkg::FlashOpProgram;
+    flash_op_sw_rw.num_words  = 16;
+    flash_op_sw_rw.addr       = bank_start_addr;
+
+    `uvm_info(`gfn, $sformatf("PROGRAM DATA PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_DATA; i++) begin
+      controller_program_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+
+    flash_op_sw_rw.partition = FlashPartInfo;
+    flash_op_sw_rw.addr = bank_start_addr;
+    `uvm_info(`gfn, $sformatf("PROGRAM INFO PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_INFO0; i++) begin
+      controller_program_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+
+    flash_op_sw_rw.partition = FlashPartInfo1;
+    flash_op_sw_rw.addr = bank_start_addr;
+    `uvm_info(`gfn, $sformatf("PROGRAM INFO1 PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_INFO1; i++) begin
+      controller_program_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+
+    flash_op_sw_rw.partition = FlashPartInfo2;
+    flash_op_sw_rw.addr = bank_start_addr;
+    `uvm_info(`gfn, $sformatf("PROGRAM INFO2 PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_INFO2; i++) begin
+      controller_program_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+
+    flash_op_sw_rw.partition = FlashPartData;
+    flash_op_sw_rw.addr = bank_start_addr;
+    `uvm_info(`gfn, $sformatf("READ DATA PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_DATA; i++) begin
+      controller_read_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+
+    flash_op_sw_rw.partition = FlashPartInfo;
+    flash_op_sw_rw.addr = bank_start_addr;
+    `uvm_info(`gfn, $sformatf("READ INFO PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_INFO0; i++) begin
+      controller_read_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+
+    flash_op_sw_rw.partition = FlashPartInfo1;
+    flash_op_sw_rw.addr = bank_start_addr;
+    `uvm_info(`gfn, $sformatf("READ INFO1 PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_INFO1; i++) begin
+      controller_read_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+
+    flash_op_sw_rw.partition = FlashPartInfo2;
+    flash_op_sw_rw.addr = bank_start_addr;
+    `uvm_info(`gfn, $sformatf("READ INFO2 PART %p", flash_op_sw_rw), UVM_LOW)
+    for (int i = 0; i < NUM_PAGE_PART_INFO2; i++) begin
+      controller_read_page(flash_op_sw_rw);
+      flash_op_sw_rw.addr = flash_op_sw_rw.addr + BytesPerPage;
+    end
+  endtask : do_sw_rw
+
+  virtual task do_direct_rd();
+    bit   [TL_AW-1:0] read_addr;
+    bit   [TL_AW-1:0] start_addr;
+    logic [TL_DW-1:0] rdata;
+    start_addr = bank_start_addr;
+    cfg.dir_rd_in_progress = 1'b1;
+    for (int i = 0; i < NUM_BK_DATA_WORDS; i++) begin
+      read_addr = start_addr + 4 * i;
+      `uvm_info(`gfn, $sformatf("Direct read address 0x%0h", read_addr), UVM_HIGH)
+      do_direct_read(.addr(read_addr), .mask('1), .blocking(1), .check_rdata(0), .rdata(rdata));
+    end
+    csr_utils_pkg::wait_no_outstanding_access();
+    cfg.dir_rd_in_progress = 1'b0;
+  endtask : do_direct_rd
+
+endclass : flash_ctrl_full_mem_access_vseq

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_mp_regions_vseq.sv
@@ -13,11 +13,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   virtual function void configure_vseq();
 
     // set page erase as default
-    cfg.seq_cfg.op_erase_type_bank_pc   = 0;
+    cfg.seq_cfg.op_erase_type_bank_pc          = 0;
 
     // enable high endurance
-    cfg.seq_cfg.mp_region_he_en_pc      = 50;
-    cfg.seq_cfg.default_region_he_en_pc = 50;
+    cfg.seq_cfg.mp_region_he_en_pc             = 50;
+    cfg.seq_cfg.default_region_he_en_pc        = 50;
 
     // info1 partition is not read only
     cfg.seq_cfg.op_readonly_on_info1_partition = 0;
@@ -27,7 +27,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   flash_op_t      flash_op_pg_erase;
   flash_op_t      flash_op_bk_erase;
 
-  localparam bit [TL_DW-1:0] ALL_ONES = {TL_DW{1'b1}};
+  data_b_t set_val;
 
   bit poll_fifo_status;
 
@@ -41,11 +41,11 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   }
 
   constraint flash_op_c {
-    flash_op.op inside {FlashOpRead, FlashOpProgram,FlashOpErase};
+    flash_op.op inside {FlashOpRead, FlashOpProgram, FlashOpErase};
     flash_op.addr inside {[0 : FlashSizeBytes - 1]};
     // Bank erase is supported only for data & 1st info partitions
     flash_op.partition != FlashPartData && flash_op.partition != FlashPartInfo ->
-      flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
+    flash_op.erase_type == flash_ctrl_pkg::FlashErasePage;
 
     flash_op.erase_type dist {
       flash_ctrl_pkg::FlashErasePage :/ (100 - cfg.seq_cfg.op_erase_type_bank_pc),
@@ -76,9 +76,9 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       };
 
       mp_regions[i].start_page dist {
-        0                   :/ 10,
-        [1:FlashNumPages-2] :/ 80,
-        FlashNumPages-1     :/ 10
+        0                       :/ 10,
+        [1 : FlashNumPages - 2] :/ 80,
+        FlashNumPages - 1       :/ 10
       };
       mp_regions[i].num_pages inside {[1 : FlashNumPages - mp_regions[i].start_page]};
       mp_regions[i].num_pages <= cfg.seq_cfg.mp_region_max_pages;
@@ -86,8 +86,9 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
   }
 
   // Information partitions memory protection pages settings.
-  rand flash_bank_mp_info_page_cfg_t
-             mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
+  rand
+  flash_bank_mp_info_page_cfg_t
+  mp_info_pages[flash_ctrl_pkg::NumBanks][flash_ctrl_pkg::InfoTypes][$];
 
   constraint mp_info_pages_c {
 
@@ -151,9 +152,9 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
-    cfg.scb_check              = 1;
-    cfg.scb_set_exp_alert      = 1;
-    cfg.alert_max_delay        = 100_000_000;
+    cfg.scb_check                               = 1;
+    cfg.scb_set_exp_alert                       = 1;
+    cfg.alert_max_delay                         = 100_000_000;
     repeat (num_trans) begin
       `DV_CHECK_RANDOMIZE_FATAL(this)
       do_mp_reg();
@@ -161,9 +162,9 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
 
     if (cfg.bank_erase_enable) begin
       //clean scb mem
-      scb_del_mem();
+      cfg.reset_scb_mem();
       `DV_CHECK_RANDOMIZE_WITH_FATAL(this,
-                                    flash_op.partition inside {FlashPartData,FlashPartInfo};)
+                                     flash_op.partition inside {FlashPartData, FlashPartInfo};)
       `uvm_info(`gfn, $sformatf("BANK ERASE PART %0p", flash_op), UVM_LOW)
       do_bank_erase();
     end
@@ -200,7 +201,6 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     if (flash_op.op != flash_ctrl_pkg::FlashOpErase) begin
       //prepare for program op
       cfg.flash_mem_bkdr_write(.flash_op(flash_op), .scheme(FlashMemInitSet));
-      set_scb_mem(flash_op.num_words,flash_op.partition,flash_op.addr,ALL_ONES);
       // FLASH Program Operation
       flash_op.op = flash_ctrl_pkg::FlashOpProgram;
       flash_ctrl_start_op(flash_op);
@@ -224,19 +224,19 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       // FLASH Erase Page Operation of previous programmed data
       `uvm_info(`gfn, $sformatf("PROGRAM OP %p", flash_op_pg_erase), UVM_HIGH)
       for (int i = 0; i < 32; i++) begin
-        set_scb_mem(flash_op_pg_erase.num_words,flash_op_pg_erase.partition,
-                    flash_op_pg_erase.addr,ALL_ONES);
-        flash_op_pg_erase.addr = flash_op_pg_erase.addr + 64; //64B was written, 16 words
+        cfg.set_scb_mem(flash_op_pg_erase.num_words, flash_op_pg_erase.partition,
+                        flash_op_pg_erase.addr, AllOnes, set_val);
+        flash_op_pg_erase.addr = flash_op_pg_erase.addr + 64;  //64B was written, 16 words
       end
-      flash_op_pg_erase.addr       = {flash_op.addr[19:11], {11{1'b0}}};
+      flash_op_pg_erase.addr = {flash_op.addr[19:11], {11{1'b0}}};
       controller_program_page(flash_op_pg_erase);
-      flash_op_pg_erase.op = flash_ctrl_pkg::FlashOpErase;
-      flash_op_pg_erase.addr       = {flash_op.addr[19:11], {11{1'b0}}};
-      `uvm_info(`gfn, $sformatf("ERASE OP %p", flash_op_pg_erase), UVM_LOW)
+      flash_op_pg_erase.op   = flash_ctrl_pkg::FlashOpErase;
+      flash_op_pg_erase.addr = {flash_op.addr[19:11], {11{1'b0}}};
+      `uvm_info(`gfn, $sformatf("ERASE OP %p", flash_op_pg_erase), UVM_HIGH)
       flash_ctrl_start_op(flash_op_pg_erase);
       wait_flash_op_done(.timeout_ns(cfg.seq_cfg.erase_timeout_ns));
-      `uvm_info(`gfn, $sformatf("READ OP %p", flash_op_pg_erase), UVM_LOW)
-      flash_op_pg_erase.addr       = {flash_op.addr[19:11], {11{1'b0}}};
+      `uvm_info(`gfn, $sformatf("READ OP %p", flash_op_pg_erase), UVM_HIGH)
+      flash_op_pg_erase.addr = {flash_op.addr[19:11], {11{1'b0}}};
       controller_read_page(flash_op_pg_erase);
     end
 
@@ -299,7 +299,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     flash_op_bk_erase.addr       = {flash_op.addr[19], {19{1'b0}}};
 
     `uvm_info(`gfn, $sformatf("PROGRAM OP %p", flash_op_bk_erase), UVM_LOW)
-    for (int i=0; i < NUM_PAGE_PART_DATA; i++ ) begin
+    for (int i = 0; i < NUM_PAGE_PART_DATA; i++) begin
       controller_program_page(flash_op_bk_erase);
       flash_op_bk_erase.addr = flash_op_bk_erase.addr + BytesPerPage;
     end
@@ -308,13 +308,13 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       flash_op_bk_erase.partition = FlashPartInfo;
       flash_op_bk_erase.addr = {flash_op.addr[19], {19{1'b0}}};
       `uvm_info(`gfn, $sformatf("PROGRAM OP %p", flash_op_bk_erase), UVM_LOW)
-      for (int i=0; i < NUM_PAGE_PART_INFO0; i++ ) begin
+      for (int i = 0; i < NUM_PAGE_PART_INFO0; i++) begin
         controller_program_page(flash_op_bk_erase);
         flash_op_bk_erase.addr = flash_op_bk_erase.addr + BytesPerPage;
       end
     end
 
-    flash_op_bk_erase.op = flash_ctrl_pkg::FlashOpErase;
+    flash_op_bk_erase.op   = flash_ctrl_pkg::FlashOpErase;
     flash_op_bk_erase.addr = flash_op.addr;
     `uvm_info(`gfn, $sformatf("ERASE OP %p", flash_op_bk_erase), UVM_LOW)
     flash_ctrl_start_op(flash_op_bk_erase);
@@ -323,8 +323,8 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
     flash_op_bk_erase.partition = FlashPartData;
     flash_op_bk_erase.addr = {flash_op.addr[19], {19{1'b0}}};
     `uvm_info(`gfn, $sformatf("READ OP %p", flash_op_bk_erase), UVM_LOW)
-    for (int i=0; i < NUM_PAGE_PART_DATA; i++ ) begin
-       controller_read_page(flash_op_bk_erase);
+    for (int i = 0; i < NUM_PAGE_PART_DATA; i++) begin
+      controller_read_page(flash_op_bk_erase);
       flash_op_bk_erase.addr = flash_op_bk_erase.addr + BytesPerPage;
     end
 
@@ -332,7 +332,7 @@ class flash_ctrl_mp_regions_vseq extends flash_ctrl_base_vseq;
       flash_op_bk_erase.partition = FlashPartInfo;
       flash_op_bk_erase.addr = {flash_op.addr[19], {19{1'b0}}};
       `uvm_info(`gfn, $sformatf("READ OP %p", flash_op_bk_erase), UVM_LOW)
-      for (int i=0; i < NUM_PAGE_PART_INFO0; i++ ) begin
+      for (int i = 0; i < NUM_PAGE_PART_INFO0; i++) begin
         controller_read_page(flash_op_bk_erase);
         flash_op_bk_erase.addr = flash_op_bk_erase.addr + BytesPerPage;
       end

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_vseq_list.sv
@@ -19,3 +19,4 @@
 `include "flash_ctrl_host_ctrl_arb_vseq.sv"
 `include "flash_ctrl_mp_regions_vseq.sv"
 `include "flash_ctrl_fetch_code_vseq.sv"
+`include "flash_ctrl_full_mem_access_vseq.sv"

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -139,7 +139,12 @@
       uvm_test_seq: flash_ctrl_fetch_code_vseq
       reseed: 5
     }
-  
+    {
+      name: flash_ctrl_full_mem_access
+      uvm_test_seq: flash_ctrl_full_mem_access_vseq
+      run_opts: ["+test_timeout_ns=300000000000"]
+      reseed: 5
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
Add full memory access test. Add support for direct read checks in
the scoreboard. Move tasks set_scb_mem and reset_scb_mem to cfg.

Signed-off-by: Nikola Miladinovic <nikola.miladinovic@ensilica.com>