### PR TITLE
[spi_device] Payload Start Index (CSR + Logic)

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -656,13 +656,35 @@
           name: "addrfifo_notempty"
           desc: "Upload Address FIFO Not Empty"
         } // f: addrfifo_notempty
-        { bits: "24:16"
+      ]
+    } // R: UPLOAD_STATUS
+    { name: "UPLOAD_STATUS2"
+      desc: '''Upload module status 2 register.
+
+        This register contains payload related status. payload_depth indicates
+        the payload size (from 0 to 256 bytes).
+
+        payload_start_idx indicates the start of the 256B. This stays 0
+        usually. However, when the SPI host system issues more than 256B of
+        payload in a command, this field may not be 0. For example, if the
+        system issues 258B payload, the payload_depth is 256 (as the IP only
+        holds 256B of payload), the payload_start_idx is 2. SW should read from
+        2 to 255 then 0 and 1.
+        '''
+      swaccess: "ro"
+      hwaccess: "hwo"
+      fields: [
+        { bits: "8:0"
           name: "payload_depth"
           desc: '''Payload buffer depth
             '''
         } // f: payload_depth
+        { bits: "23:16"
+          name: "payload_start_idx"
+          desc: '''Payload Start Index'''
+        } // f: payload_start_idx
       ]
-    } // R: UPLOAD_STATUS
+    } // R: UPLOAD_STATUS2
     { name: "UPLOAD_CMDFIFO"
       desc: '''Command Fifo Read Port.
         '''

--- a/hw/ip/spi_device/pre_dv/tb/spid_upload_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_upload_tb.sv
@@ -142,7 +142,7 @@ module spid_upload_tb;
   logic [           $clog2(SramCmdFifoDepth+1)-1:0] cmdfifo_depth;
   logic [          $clog2(SramAddrFifoDepth+1)-1:0] addrfifo_depth;
   logic [$clog2(SramPayloadDepth*(SramDw/8)+1)-1:0] payload_depth;
-  logic [$clog2(SramPayloadDepth*(SramDw/8)+1)-1:0] last_written_payload_idx;
+  logic [  $clog2(SramPayloadDepth*(SramDw/8))-1:0] payload_start_idx;
 
   // Upload module signals
   logic cfg_addr_4b_en;
@@ -404,10 +404,10 @@ module spid_upload_tb;
     .sys_addrfifo_full_o     (), // not used
     .sys_payload_overflow_o  (payload_overflow),
 
-    .sys_cmdfifo_depth_o            (cmdfifo_depth),
-    .sys_addrfifo_depth_o           (addrfifo_depth),
-    .sys_payload_depth_o            (payload_depth),
-    .sys_last_written_payload_idx_o (last_written_payload_idx),
+    .sys_cmdfifo_depth_o     (cmdfifo_depth),
+    .sys_addrfifo_depth_o    (addrfifo_depth),
+    .sys_payload_depth_o     (payload_depth),
+    .sys_payload_start_idx_o (payload_start_idx),
   );
 
   spi_cmdparse cmdparse (

--- a/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_pkg.sv
@@ -584,11 +584,18 @@ package spi_device_reg_pkg;
       logic        d;
       logic        de;
     } addrfifo_notempty;
+  } spi_device_hw2reg_upload_status_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic [8:0]  d;
       logic        de;
     } payload_depth;
-  } spi_device_hw2reg_upload_status_reg_t;
+    struct packed {
+      logic [7:0]  d;
+      logic        de;
+    } payload_start_idx;
+  } spi_device_hw2reg_upload_status2_reg_t;
 
   typedef struct packed {
     logic [7:0]  d;
@@ -690,15 +697,16 @@ package spi_device_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
-    spi_device_hw2reg_intr_state_reg_t intr_state; // [270:247]
-    spi_device_hw2reg_cfg_reg_t cfg; // [246:245]
-    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [244:229]
-    spi_device_hw2reg_status_reg_t status; // [228:223]
-    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [222:206]
-    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [205:189]
-    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [188:157]
-    spi_device_hw2reg_flash_status_reg_t flash_status; // [156:133]
-    spi_device_hw2reg_upload_status_reg_t upload_status; // [132:107]
+    spi_device_hw2reg_intr_state_reg_t intr_state; // [279:256]
+    spi_device_hw2reg_cfg_reg_t cfg; // [255:254]
+    spi_device_hw2reg_async_fifo_level_reg_t async_fifo_level; // [253:238]
+    spi_device_hw2reg_status_reg_t status; // [237:232]
+    spi_device_hw2reg_rxf_ptr_reg_t rxf_ptr; // [231:215]
+    spi_device_hw2reg_txf_ptr_reg_t txf_ptr; // [214:198]
+    spi_device_hw2reg_last_read_addr_reg_t last_read_addr; // [197:166]
+    spi_device_hw2reg_flash_status_reg_t flash_status; // [165:142]
+    spi_device_hw2reg_upload_status_reg_t upload_status; // [141:126]
+    spi_device_hw2reg_upload_status2_reg_t upload_status2; // [125:107]
     spi_device_hw2reg_upload_cmdfifo_reg_t upload_cmdfifo; // [106:99]
     spi_device_hw2reg_upload_addrfifo_reg_t upload_addrfifo; // [98:67]
     spi_device_hw2reg_tpm_cap_reg_t tpm_cap; // [66:52]
@@ -729,46 +737,47 @@ package spi_device_reg_pkg;
   parameter logic [BlockAw-1:0] SPI_DEVICE_READ_THRESHOLD_OFFSET = 13'h 48;
   parameter logic [BlockAw-1:0] SPI_DEVICE_MAILBOX_ADDR_OFFSET = 13'h 4c;
   parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS_OFFSET = 13'h 50;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 54;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 58;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 5c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 60;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 64;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 68;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 6c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 70;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 74;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 78;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 7c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 80;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 84;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 88;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 8c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 90;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 94;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 98;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h 9c;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h a0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h a4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h a8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h ac;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h b0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h b4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h b8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h bc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h c0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h c4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h c8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h cc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h d0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h d4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h d8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h dc;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h e0;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h e4;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h e8;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EN4B_OFFSET = 13'h ec;
-  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EX4B_OFFSET = 13'h f0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_STATUS2_OFFSET = 13'h 54;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET = 13'h 58;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET = 13'h 5c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_0_OFFSET = 13'h 60;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_1_OFFSET = 13'h 64;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_2_OFFSET = 13'h 68;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_3_OFFSET = 13'h 6c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_4_OFFSET = 13'h 70;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_5_OFFSET = 13'h 74;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_6_OFFSET = 13'h 78;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_FILTER_7_OFFSET = 13'h 7c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_MASK_OFFSET = 13'h 80;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_ADDR_SWAP_DATA_OFFSET = 13'h 84;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET = 13'h 88;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET = 13'h 8c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_0_OFFSET = 13'h 90;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_1_OFFSET = 13'h 94;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_2_OFFSET = 13'h 98;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_3_OFFSET = 13'h 9c;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_4_OFFSET = 13'h a0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_5_OFFSET = 13'h a4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_6_OFFSET = 13'h a8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_7_OFFSET = 13'h ac;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_8_OFFSET = 13'h b0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_9_OFFSET = 13'h b4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_10_OFFSET = 13'h b8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_11_OFFSET = 13'h bc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_12_OFFSET = 13'h c0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_13_OFFSET = 13'h c4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_14_OFFSET = 13'h c8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_15_OFFSET = 13'h cc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_16_OFFSET = 13'h d0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_17_OFFSET = 13'h d4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_18_OFFSET = 13'h d8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_19_OFFSET = 13'h dc;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_20_OFFSET = 13'h e0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_21_OFFSET = 13'h e4;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_22_OFFSET = 13'h e8;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_23_OFFSET = 13'h ec;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EN4B_OFFSET = 13'h f0;
+  parameter logic [BlockAw-1:0] SPI_DEVICE_CMD_INFO_EX4B_OFFSET = 13'h f4;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CAP_OFFSET = 13'h 800;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_CFG_OFFSET = 13'h 804;
   parameter logic [BlockAw-1:0] SPI_DEVICE_TPM_STATUS_OFFSET = 13'h 808;
@@ -842,6 +851,7 @@ package spi_device_reg_pkg;
     SPI_DEVICE_READ_THRESHOLD,
     SPI_DEVICE_MAILBOX_ADDR,
     SPI_DEVICE_UPLOAD_STATUS,
+    SPI_DEVICE_UPLOAD_STATUS2,
     SPI_DEVICE_UPLOAD_CMDFIFO,
     SPI_DEVICE_UPLOAD_ADDRFIFO,
     SPI_DEVICE_CMD_FILTER_0,
@@ -900,7 +910,7 @@ package spi_device_reg_pkg;
   } spi_device_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] SPI_DEVICE_PERMIT [76] = '{
+  parameter logic [3:0] SPI_DEVICE_PERMIT [77] = '{
     4'b 0011, // index[ 0] SPI_DEVICE_INTR_STATE
     4'b 0011, // index[ 1] SPI_DEVICE_INTR_ENABLE
     4'b 0011, // index[ 2] SPI_DEVICE_INTR_TEST
@@ -921,62 +931,63 @@ package spi_device_reg_pkg;
     4'b 0111, // index[17] SPI_DEVICE_JEDEC_ID
     4'b 0011, // index[18] SPI_DEVICE_READ_THRESHOLD
     4'b 1111, // index[19] SPI_DEVICE_MAILBOX_ADDR
-    4'b 1111, // index[20] SPI_DEVICE_UPLOAD_STATUS
-    4'b 0001, // index[21] SPI_DEVICE_UPLOAD_CMDFIFO
-    4'b 1111, // index[22] SPI_DEVICE_UPLOAD_ADDRFIFO
-    4'b 1111, // index[23] SPI_DEVICE_CMD_FILTER_0
-    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_1
-    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_2
-    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_3
-    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_4
-    4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_5
-    4'b 1111, // index[29] SPI_DEVICE_CMD_FILTER_6
-    4'b 1111, // index[30] SPI_DEVICE_CMD_FILTER_7
-    4'b 1111, // index[31] SPI_DEVICE_ADDR_SWAP_MASK
-    4'b 1111, // index[32] SPI_DEVICE_ADDR_SWAP_DATA
-    4'b 1111, // index[33] SPI_DEVICE_PAYLOAD_SWAP_MASK
-    4'b 1111, // index[34] SPI_DEVICE_PAYLOAD_SWAP_DATA
-    4'b 1111, // index[35] SPI_DEVICE_CMD_INFO_0
-    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_1
-    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_2
-    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_3
-    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_4
-    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_5
-    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_6
-    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_7
-    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_8
-    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_9
-    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_10
-    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_11
-    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_12
-    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_13
-    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_14
-    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_15
-    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_16
-    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_17
-    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_18
-    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_19
-    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_20
-    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_21
-    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_22
-    4'b 1111, // index[58] SPI_DEVICE_CMD_INFO_23
-    4'b 1111, // index[59] SPI_DEVICE_CMD_INFO_EN4B
-    4'b 1111, // index[60] SPI_DEVICE_CMD_INFO_EX4B
-    4'b 0111, // index[61] SPI_DEVICE_TPM_CAP
-    4'b 0001, // index[62] SPI_DEVICE_TPM_CFG
-    4'b 0011, // index[63] SPI_DEVICE_TPM_STATUS
-    4'b 1111, // index[64] SPI_DEVICE_TPM_ACCESS_0
-    4'b 0001, // index[65] SPI_DEVICE_TPM_ACCESS_1
-    4'b 1111, // index[66] SPI_DEVICE_TPM_STS
-    4'b 1111, // index[67] SPI_DEVICE_TPM_INTF_CAPABILITY
-    4'b 1111, // index[68] SPI_DEVICE_TPM_INT_ENABLE
-    4'b 0001, // index[69] SPI_DEVICE_TPM_INT_VECTOR
-    4'b 1111, // index[70] SPI_DEVICE_TPM_INT_STATUS
-    4'b 1111, // index[71] SPI_DEVICE_TPM_DID_VID
-    4'b 0001, // index[72] SPI_DEVICE_TPM_RID
-    4'b 1111, // index[73] SPI_DEVICE_TPM_CMD_ADDR
-    4'b 0001, // index[74] SPI_DEVICE_TPM_READ_FIFO
-    4'b 0001  // index[75] SPI_DEVICE_TPM_WRITE_FIFO
+    4'b 0011, // index[20] SPI_DEVICE_UPLOAD_STATUS
+    4'b 0111, // index[21] SPI_DEVICE_UPLOAD_STATUS2
+    4'b 0001, // index[22] SPI_DEVICE_UPLOAD_CMDFIFO
+    4'b 1111, // index[23] SPI_DEVICE_UPLOAD_ADDRFIFO
+    4'b 1111, // index[24] SPI_DEVICE_CMD_FILTER_0
+    4'b 1111, // index[25] SPI_DEVICE_CMD_FILTER_1
+    4'b 1111, // index[26] SPI_DEVICE_CMD_FILTER_2
+    4'b 1111, // index[27] SPI_DEVICE_CMD_FILTER_3
+    4'b 1111, // index[28] SPI_DEVICE_CMD_FILTER_4
+    4'b 1111, // index[29] SPI_DEVICE_CMD_FILTER_5
+    4'b 1111, // index[30] SPI_DEVICE_CMD_FILTER_6
+    4'b 1111, // index[31] SPI_DEVICE_CMD_FILTER_7
+    4'b 1111, // index[32] SPI_DEVICE_ADDR_SWAP_MASK
+    4'b 1111, // index[33] SPI_DEVICE_ADDR_SWAP_DATA
+    4'b 1111, // index[34] SPI_DEVICE_PAYLOAD_SWAP_MASK
+    4'b 1111, // index[35] SPI_DEVICE_PAYLOAD_SWAP_DATA
+    4'b 1111, // index[36] SPI_DEVICE_CMD_INFO_0
+    4'b 1111, // index[37] SPI_DEVICE_CMD_INFO_1
+    4'b 1111, // index[38] SPI_DEVICE_CMD_INFO_2
+    4'b 1111, // index[39] SPI_DEVICE_CMD_INFO_3
+    4'b 1111, // index[40] SPI_DEVICE_CMD_INFO_4
+    4'b 1111, // index[41] SPI_DEVICE_CMD_INFO_5
+    4'b 1111, // index[42] SPI_DEVICE_CMD_INFO_6
+    4'b 1111, // index[43] SPI_DEVICE_CMD_INFO_7
+    4'b 1111, // index[44] SPI_DEVICE_CMD_INFO_8
+    4'b 1111, // index[45] SPI_DEVICE_CMD_INFO_9
+    4'b 1111, // index[46] SPI_DEVICE_CMD_INFO_10
+    4'b 1111, // index[47] SPI_DEVICE_CMD_INFO_11
+    4'b 1111, // index[48] SPI_DEVICE_CMD_INFO_12
+    4'b 1111, // index[49] SPI_DEVICE_CMD_INFO_13
+    4'b 1111, // index[50] SPI_DEVICE_CMD_INFO_14
+    4'b 1111, // index[51] SPI_DEVICE_CMD_INFO_15
+    4'b 1111, // index[52] SPI_DEVICE_CMD_INFO_16
+    4'b 1111, // index[53] SPI_DEVICE_CMD_INFO_17
+    4'b 1111, // index[54] SPI_DEVICE_CMD_INFO_18
+    4'b 1111, // index[55] SPI_DEVICE_CMD_INFO_19
+    4'b 1111, // index[56] SPI_DEVICE_CMD_INFO_20
+    4'b 1111, // index[57] SPI_DEVICE_CMD_INFO_21
+    4'b 1111, // index[58] SPI_DEVICE_CMD_INFO_22
+    4'b 1111, // index[59] SPI_DEVICE_CMD_INFO_23
+    4'b 1111, // index[60] SPI_DEVICE_CMD_INFO_EN4B
+    4'b 1111, // index[61] SPI_DEVICE_CMD_INFO_EX4B
+    4'b 0111, // index[62] SPI_DEVICE_TPM_CAP
+    4'b 0001, // index[63] SPI_DEVICE_TPM_CFG
+    4'b 0011, // index[64] SPI_DEVICE_TPM_STATUS
+    4'b 1111, // index[65] SPI_DEVICE_TPM_ACCESS_0
+    4'b 0001, // index[66] SPI_DEVICE_TPM_ACCESS_1
+    4'b 1111, // index[67] SPI_DEVICE_TPM_STS
+    4'b 1111, // index[68] SPI_DEVICE_TPM_INTF_CAPABILITY
+    4'b 1111, // index[69] SPI_DEVICE_TPM_INT_ENABLE
+    4'b 0001, // index[70] SPI_DEVICE_TPM_INT_VECTOR
+    4'b 1111, // index[71] SPI_DEVICE_TPM_INT_STATUS
+    4'b 1111, // index[72] SPI_DEVICE_TPM_DID_VID
+    4'b 0001, // index[73] SPI_DEVICE_TPM_RID
+    4'b 1111, // index[74] SPI_DEVICE_TPM_CMD_ADDR
+    4'b 0001, // index[75] SPI_DEVICE_TPM_READ_FIFO
+    4'b 0001  // index[76] SPI_DEVICE_TPM_WRITE_FIFO
   };
 
 endpackage

--- a/hw/ip/spi_device/rtl/spi_device_reg_top.sv
+++ b/hw/ip/spi_device/rtl/spi_device_reg_top.sv
@@ -323,7 +323,8 @@ module spi_device_reg_top (
   logic upload_status_cmdfifo_notempty_qs;
   logic [4:0] upload_status_addrfifo_depth_qs;
   logic upload_status_addrfifo_notempty_qs;
-  logic [8:0] upload_status_payload_depth_qs;
+  logic [8:0] upload_status2_payload_depth_qs;
+  logic [7:0] upload_status2_payload_start_idx_qs;
   logic upload_cmdfifo_re;
   logic [7:0] upload_cmdfifo_qs;
   logic upload_addrfifo_re;
@@ -3429,12 +3430,14 @@ module spi_device_reg_top (
     .qs     (upload_status_addrfifo_notempty_qs)
   );
 
-  //   F[payload_depth]: 24:16
+
+  // R[upload_status2]: V(False)
+  //   F[payload_depth]: 8:0
   prim_subreg #(
     .DW      (9),
     .SwAccess(prim_subreg_pkg::SwAccessRO),
     .RESVAL  (9'h0)
-  ) u_upload_status_payload_depth (
+  ) u_upload_status2_payload_depth (
     .clk_i   (clk_i),
     .rst_ni  (rst_ni),
 
@@ -3443,15 +3446,40 @@ module spi_device_reg_top (
     .wd     ('0),
 
     // from internal hardware
-    .de     (hw2reg.upload_status.payload_depth.de),
-    .d      (hw2reg.upload_status.payload_depth.d),
+    .de     (hw2reg.upload_status2.payload_depth.de),
+    .d      (hw2reg.upload_status2.payload_depth.d),
 
     // to internal hardware
     .qe     (),
     .q      (),
 
     // to register interface (read)
-    .qs     (upload_status_payload_depth_qs)
+    .qs     (upload_status2_payload_depth_qs)
+  );
+
+  //   F[payload_start_idx]: 23:16
+  prim_subreg #(
+    .DW      (8),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (8'h0)
+  ) u_upload_status2_payload_start_idx (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.upload_status2.payload_start_idx.de),
+    .d      (hw2reg.upload_status2.payload_start_idx.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (),
+
+    // to register interface (read)
+    .qs     (upload_status2_payload_start_idx_qs)
   );
 
 
@@ -18107,7 +18135,7 @@ module spi_device_reg_top (
 
 
 
-  logic [75:0] addr_hit;
+  logic [76:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == SPI_DEVICE_INTR_STATE_OFFSET);
@@ -18131,61 +18159,62 @@ module spi_device_reg_top (
     addr_hit[18] = (reg_addr == SPI_DEVICE_READ_THRESHOLD_OFFSET);
     addr_hit[19] = (reg_addr == SPI_DEVICE_MAILBOX_ADDR_OFFSET);
     addr_hit[20] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS_OFFSET);
-    addr_hit[21] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
-    addr_hit[22] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
-    addr_hit[23] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
-    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
-    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
-    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
-    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
-    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
-    addr_hit[29] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
-    addr_hit[30] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
-    addr_hit[31] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
-    addr_hit[32] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
-    addr_hit[33] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
-    addr_hit[34] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
-    addr_hit[35] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
-    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
-    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
-    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
-    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
-    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
-    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
-    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
-    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
-    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
-    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
-    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
-    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
-    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
-    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
-    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
-    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
-    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
-    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
-    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
-    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
-    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
-    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
-    addr_hit[58] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
-    addr_hit[59] = (reg_addr == SPI_DEVICE_CMD_INFO_EN4B_OFFSET);
-    addr_hit[60] = (reg_addr == SPI_DEVICE_CMD_INFO_EX4B_OFFSET);
-    addr_hit[61] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
-    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
-    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
-    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
-    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
-    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
-    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
-    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
-    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
-    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
-    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
-    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
-    addr_hit[73] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
-    addr_hit[74] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
-    addr_hit[75] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
+    addr_hit[21] = (reg_addr == SPI_DEVICE_UPLOAD_STATUS2_OFFSET);
+    addr_hit[22] = (reg_addr == SPI_DEVICE_UPLOAD_CMDFIFO_OFFSET);
+    addr_hit[23] = (reg_addr == SPI_DEVICE_UPLOAD_ADDRFIFO_OFFSET);
+    addr_hit[24] = (reg_addr == SPI_DEVICE_CMD_FILTER_0_OFFSET);
+    addr_hit[25] = (reg_addr == SPI_DEVICE_CMD_FILTER_1_OFFSET);
+    addr_hit[26] = (reg_addr == SPI_DEVICE_CMD_FILTER_2_OFFSET);
+    addr_hit[27] = (reg_addr == SPI_DEVICE_CMD_FILTER_3_OFFSET);
+    addr_hit[28] = (reg_addr == SPI_DEVICE_CMD_FILTER_4_OFFSET);
+    addr_hit[29] = (reg_addr == SPI_DEVICE_CMD_FILTER_5_OFFSET);
+    addr_hit[30] = (reg_addr == SPI_DEVICE_CMD_FILTER_6_OFFSET);
+    addr_hit[31] = (reg_addr == SPI_DEVICE_CMD_FILTER_7_OFFSET);
+    addr_hit[32] = (reg_addr == SPI_DEVICE_ADDR_SWAP_MASK_OFFSET);
+    addr_hit[33] = (reg_addr == SPI_DEVICE_ADDR_SWAP_DATA_OFFSET);
+    addr_hit[34] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_MASK_OFFSET);
+    addr_hit[35] = (reg_addr == SPI_DEVICE_PAYLOAD_SWAP_DATA_OFFSET);
+    addr_hit[36] = (reg_addr == SPI_DEVICE_CMD_INFO_0_OFFSET);
+    addr_hit[37] = (reg_addr == SPI_DEVICE_CMD_INFO_1_OFFSET);
+    addr_hit[38] = (reg_addr == SPI_DEVICE_CMD_INFO_2_OFFSET);
+    addr_hit[39] = (reg_addr == SPI_DEVICE_CMD_INFO_3_OFFSET);
+    addr_hit[40] = (reg_addr == SPI_DEVICE_CMD_INFO_4_OFFSET);
+    addr_hit[41] = (reg_addr == SPI_DEVICE_CMD_INFO_5_OFFSET);
+    addr_hit[42] = (reg_addr == SPI_DEVICE_CMD_INFO_6_OFFSET);
+    addr_hit[43] = (reg_addr == SPI_DEVICE_CMD_INFO_7_OFFSET);
+    addr_hit[44] = (reg_addr == SPI_DEVICE_CMD_INFO_8_OFFSET);
+    addr_hit[45] = (reg_addr == SPI_DEVICE_CMD_INFO_9_OFFSET);
+    addr_hit[46] = (reg_addr == SPI_DEVICE_CMD_INFO_10_OFFSET);
+    addr_hit[47] = (reg_addr == SPI_DEVICE_CMD_INFO_11_OFFSET);
+    addr_hit[48] = (reg_addr == SPI_DEVICE_CMD_INFO_12_OFFSET);
+    addr_hit[49] = (reg_addr == SPI_DEVICE_CMD_INFO_13_OFFSET);
+    addr_hit[50] = (reg_addr == SPI_DEVICE_CMD_INFO_14_OFFSET);
+    addr_hit[51] = (reg_addr == SPI_DEVICE_CMD_INFO_15_OFFSET);
+    addr_hit[52] = (reg_addr == SPI_DEVICE_CMD_INFO_16_OFFSET);
+    addr_hit[53] = (reg_addr == SPI_DEVICE_CMD_INFO_17_OFFSET);
+    addr_hit[54] = (reg_addr == SPI_DEVICE_CMD_INFO_18_OFFSET);
+    addr_hit[55] = (reg_addr == SPI_DEVICE_CMD_INFO_19_OFFSET);
+    addr_hit[56] = (reg_addr == SPI_DEVICE_CMD_INFO_20_OFFSET);
+    addr_hit[57] = (reg_addr == SPI_DEVICE_CMD_INFO_21_OFFSET);
+    addr_hit[58] = (reg_addr == SPI_DEVICE_CMD_INFO_22_OFFSET);
+    addr_hit[59] = (reg_addr == SPI_DEVICE_CMD_INFO_23_OFFSET);
+    addr_hit[60] = (reg_addr == SPI_DEVICE_CMD_INFO_EN4B_OFFSET);
+    addr_hit[61] = (reg_addr == SPI_DEVICE_CMD_INFO_EX4B_OFFSET);
+    addr_hit[62] = (reg_addr == SPI_DEVICE_TPM_CAP_OFFSET);
+    addr_hit[63] = (reg_addr == SPI_DEVICE_TPM_CFG_OFFSET);
+    addr_hit[64] = (reg_addr == SPI_DEVICE_TPM_STATUS_OFFSET);
+    addr_hit[65] = (reg_addr == SPI_DEVICE_TPM_ACCESS_0_OFFSET);
+    addr_hit[66] = (reg_addr == SPI_DEVICE_TPM_ACCESS_1_OFFSET);
+    addr_hit[67] = (reg_addr == SPI_DEVICE_TPM_STS_OFFSET);
+    addr_hit[68] = (reg_addr == SPI_DEVICE_TPM_INTF_CAPABILITY_OFFSET);
+    addr_hit[69] = (reg_addr == SPI_DEVICE_TPM_INT_ENABLE_OFFSET);
+    addr_hit[70] = (reg_addr == SPI_DEVICE_TPM_INT_VECTOR_OFFSET);
+    addr_hit[71] = (reg_addr == SPI_DEVICE_TPM_INT_STATUS_OFFSET);
+    addr_hit[72] = (reg_addr == SPI_DEVICE_TPM_DID_VID_OFFSET);
+    addr_hit[73] = (reg_addr == SPI_DEVICE_TPM_RID_OFFSET);
+    addr_hit[74] = (reg_addr == SPI_DEVICE_TPM_CMD_ADDR_OFFSET);
+    addr_hit[75] = (reg_addr == SPI_DEVICE_TPM_READ_FIFO_OFFSET);
+    addr_hit[76] = (reg_addr == SPI_DEVICE_TPM_WRITE_FIFO_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -18268,7 +18297,8 @@ module spi_device_reg_top (
                (addr_hit[72] & (|(SPI_DEVICE_PERMIT[72] & ~reg_be))) |
                (addr_hit[73] & (|(SPI_DEVICE_PERMIT[73] & ~reg_be))) |
                (addr_hit[74] & (|(SPI_DEVICE_PERMIT[74] & ~reg_be))) |
-               (addr_hit[75] & (|(SPI_DEVICE_PERMIT[75] & ~reg_be)))));
+               (addr_hit[75] & (|(SPI_DEVICE_PERMIT[75] & ~reg_be))) |
+               (addr_hit[76] & (|(SPI_DEVICE_PERMIT[76] & ~reg_be)))));
   end
   assign intr_state_we = addr_hit[0] & reg_we & !reg_error;
 
@@ -18429,9 +18459,9 @@ module spi_device_reg_top (
   assign mailbox_addr_we = addr_hit[19] & reg_we & !reg_error;
 
   assign mailbox_addr_wd = reg_wdata[31:0];
-  assign upload_cmdfifo_re = addr_hit[21] & reg_re & !reg_error;
-  assign upload_addrfifo_re = addr_hit[22] & reg_re & !reg_error;
-  assign cmd_filter_0_we = addr_hit[23] & reg_we & !reg_error;
+  assign upload_cmdfifo_re = addr_hit[22] & reg_re & !reg_error;
+  assign upload_addrfifo_re = addr_hit[23] & reg_re & !reg_error;
+  assign cmd_filter_0_we = addr_hit[24] & reg_we & !reg_error;
 
   assign cmd_filter_0_filter_0_wd = reg_wdata[0];
 
@@ -18496,7 +18526,7 @@ module spi_device_reg_top (
   assign cmd_filter_0_filter_30_wd = reg_wdata[30];
 
   assign cmd_filter_0_filter_31_wd = reg_wdata[31];
-  assign cmd_filter_1_we = addr_hit[24] & reg_we & !reg_error;
+  assign cmd_filter_1_we = addr_hit[25] & reg_we & !reg_error;
 
   assign cmd_filter_1_filter_32_wd = reg_wdata[0];
 
@@ -18561,7 +18591,7 @@ module spi_device_reg_top (
   assign cmd_filter_1_filter_62_wd = reg_wdata[30];
 
   assign cmd_filter_1_filter_63_wd = reg_wdata[31];
-  assign cmd_filter_2_we = addr_hit[25] & reg_we & !reg_error;
+  assign cmd_filter_2_we = addr_hit[26] & reg_we & !reg_error;
 
   assign cmd_filter_2_filter_64_wd = reg_wdata[0];
 
@@ -18626,7 +18656,7 @@ module spi_device_reg_top (
   assign cmd_filter_2_filter_94_wd = reg_wdata[30];
 
   assign cmd_filter_2_filter_95_wd = reg_wdata[31];
-  assign cmd_filter_3_we = addr_hit[26] & reg_we & !reg_error;
+  assign cmd_filter_3_we = addr_hit[27] & reg_we & !reg_error;
 
   assign cmd_filter_3_filter_96_wd = reg_wdata[0];
 
@@ -18691,7 +18721,7 @@ module spi_device_reg_top (
   assign cmd_filter_3_filter_126_wd = reg_wdata[30];
 
   assign cmd_filter_3_filter_127_wd = reg_wdata[31];
-  assign cmd_filter_4_we = addr_hit[27] & reg_we & !reg_error;
+  assign cmd_filter_4_we = addr_hit[28] & reg_we & !reg_error;
 
   assign cmd_filter_4_filter_128_wd = reg_wdata[0];
 
@@ -18756,7 +18786,7 @@ module spi_device_reg_top (
   assign cmd_filter_4_filter_158_wd = reg_wdata[30];
 
   assign cmd_filter_4_filter_159_wd = reg_wdata[31];
-  assign cmd_filter_5_we = addr_hit[28] & reg_we & !reg_error;
+  assign cmd_filter_5_we = addr_hit[29] & reg_we & !reg_error;
 
   assign cmd_filter_5_filter_160_wd = reg_wdata[0];
 
@@ -18821,7 +18851,7 @@ module spi_device_reg_top (
   assign cmd_filter_5_filter_190_wd = reg_wdata[30];
 
   assign cmd_filter_5_filter_191_wd = reg_wdata[31];
-  assign cmd_filter_6_we = addr_hit[29] & reg_we & !reg_error;
+  assign cmd_filter_6_we = addr_hit[30] & reg_we & !reg_error;
 
   assign cmd_filter_6_filter_192_wd = reg_wdata[0];
 
@@ -18886,7 +18916,7 @@ module spi_device_reg_top (
   assign cmd_filter_6_filter_222_wd = reg_wdata[30];
 
   assign cmd_filter_6_filter_223_wd = reg_wdata[31];
-  assign cmd_filter_7_we = addr_hit[30] & reg_we & !reg_error;
+  assign cmd_filter_7_we = addr_hit[31] & reg_we & !reg_error;
 
   assign cmd_filter_7_filter_224_wd = reg_wdata[0];
 
@@ -18951,19 +18981,19 @@ module spi_device_reg_top (
   assign cmd_filter_7_filter_254_wd = reg_wdata[30];
 
   assign cmd_filter_7_filter_255_wd = reg_wdata[31];
-  assign addr_swap_mask_we = addr_hit[31] & reg_we & !reg_error;
+  assign addr_swap_mask_we = addr_hit[32] & reg_we & !reg_error;
 
   assign addr_swap_mask_wd = reg_wdata[31:0];
-  assign addr_swap_data_we = addr_hit[32] & reg_we & !reg_error;
+  assign addr_swap_data_we = addr_hit[33] & reg_we & !reg_error;
 
   assign addr_swap_data_wd = reg_wdata[31:0];
-  assign payload_swap_mask_we = addr_hit[33] & reg_we & !reg_error;
+  assign payload_swap_mask_we = addr_hit[34] & reg_we & !reg_error;
 
   assign payload_swap_mask_wd = reg_wdata[31:0];
-  assign payload_swap_data_we = addr_hit[34] & reg_we & !reg_error;
+  assign payload_swap_data_we = addr_hit[35] & reg_we & !reg_error;
 
   assign payload_swap_data_wd = reg_wdata[31:0];
-  assign cmd_info_0_we = addr_hit[35] & reg_we & !reg_error;
+  assign cmd_info_0_we = addr_hit[36] & reg_we & !reg_error;
 
   assign cmd_info_0_opcode_0_wd = reg_wdata[7:0];
 
@@ -18988,7 +19018,7 @@ module spi_device_reg_top (
   assign cmd_info_0_busy_0_wd = reg_wdata[25];
 
   assign cmd_info_0_valid_0_wd = reg_wdata[31];
-  assign cmd_info_1_we = addr_hit[36] & reg_we & !reg_error;
+  assign cmd_info_1_we = addr_hit[37] & reg_we & !reg_error;
 
   assign cmd_info_1_opcode_1_wd = reg_wdata[7:0];
 
@@ -19013,7 +19043,7 @@ module spi_device_reg_top (
   assign cmd_info_1_busy_1_wd = reg_wdata[25];
 
   assign cmd_info_1_valid_1_wd = reg_wdata[31];
-  assign cmd_info_2_we = addr_hit[37] & reg_we & !reg_error;
+  assign cmd_info_2_we = addr_hit[38] & reg_we & !reg_error;
 
   assign cmd_info_2_opcode_2_wd = reg_wdata[7:0];
 
@@ -19038,7 +19068,7 @@ module spi_device_reg_top (
   assign cmd_info_2_busy_2_wd = reg_wdata[25];
 
   assign cmd_info_2_valid_2_wd = reg_wdata[31];
-  assign cmd_info_3_we = addr_hit[38] & reg_we & !reg_error;
+  assign cmd_info_3_we = addr_hit[39] & reg_we & !reg_error;
 
   assign cmd_info_3_opcode_3_wd = reg_wdata[7:0];
 
@@ -19063,7 +19093,7 @@ module spi_device_reg_top (
   assign cmd_info_3_busy_3_wd = reg_wdata[25];
 
   assign cmd_info_3_valid_3_wd = reg_wdata[31];
-  assign cmd_info_4_we = addr_hit[39] & reg_we & !reg_error;
+  assign cmd_info_4_we = addr_hit[40] & reg_we & !reg_error;
 
   assign cmd_info_4_opcode_4_wd = reg_wdata[7:0];
 
@@ -19088,7 +19118,7 @@ module spi_device_reg_top (
   assign cmd_info_4_busy_4_wd = reg_wdata[25];
 
   assign cmd_info_4_valid_4_wd = reg_wdata[31];
-  assign cmd_info_5_we = addr_hit[40] & reg_we & !reg_error;
+  assign cmd_info_5_we = addr_hit[41] & reg_we & !reg_error;
 
   assign cmd_info_5_opcode_5_wd = reg_wdata[7:0];
 
@@ -19113,7 +19143,7 @@ module spi_device_reg_top (
   assign cmd_info_5_busy_5_wd = reg_wdata[25];
 
   assign cmd_info_5_valid_5_wd = reg_wdata[31];
-  assign cmd_info_6_we = addr_hit[41] & reg_we & !reg_error;
+  assign cmd_info_6_we = addr_hit[42] & reg_we & !reg_error;
 
   assign cmd_info_6_opcode_6_wd = reg_wdata[7:0];
 
@@ -19138,7 +19168,7 @@ module spi_device_reg_top (
   assign cmd_info_6_busy_6_wd = reg_wdata[25];
 
   assign cmd_info_6_valid_6_wd = reg_wdata[31];
-  assign cmd_info_7_we = addr_hit[42] & reg_we & !reg_error;
+  assign cmd_info_7_we = addr_hit[43] & reg_we & !reg_error;
 
   assign cmd_info_7_opcode_7_wd = reg_wdata[7:0];
 
@@ -19163,7 +19193,7 @@ module spi_device_reg_top (
   assign cmd_info_7_busy_7_wd = reg_wdata[25];
 
   assign cmd_info_7_valid_7_wd = reg_wdata[31];
-  assign cmd_info_8_we = addr_hit[43] & reg_we & !reg_error;
+  assign cmd_info_8_we = addr_hit[44] & reg_we & !reg_error;
 
   assign cmd_info_8_opcode_8_wd = reg_wdata[7:0];
 
@@ -19188,7 +19218,7 @@ module spi_device_reg_top (
   assign cmd_info_8_busy_8_wd = reg_wdata[25];
 
   assign cmd_info_8_valid_8_wd = reg_wdata[31];
-  assign cmd_info_9_we = addr_hit[44] & reg_we & !reg_error;
+  assign cmd_info_9_we = addr_hit[45] & reg_we & !reg_error;
 
   assign cmd_info_9_opcode_9_wd = reg_wdata[7:0];
 
@@ -19213,7 +19243,7 @@ module spi_device_reg_top (
   assign cmd_info_9_busy_9_wd = reg_wdata[25];
 
   assign cmd_info_9_valid_9_wd = reg_wdata[31];
-  assign cmd_info_10_we = addr_hit[45] & reg_we & !reg_error;
+  assign cmd_info_10_we = addr_hit[46] & reg_we & !reg_error;
 
   assign cmd_info_10_opcode_10_wd = reg_wdata[7:0];
 
@@ -19238,7 +19268,7 @@ module spi_device_reg_top (
   assign cmd_info_10_busy_10_wd = reg_wdata[25];
 
   assign cmd_info_10_valid_10_wd = reg_wdata[31];
-  assign cmd_info_11_we = addr_hit[46] & reg_we & !reg_error;
+  assign cmd_info_11_we = addr_hit[47] & reg_we & !reg_error;
 
   assign cmd_info_11_opcode_11_wd = reg_wdata[7:0];
 
@@ -19263,7 +19293,7 @@ module spi_device_reg_top (
   assign cmd_info_11_busy_11_wd = reg_wdata[25];
 
   assign cmd_info_11_valid_11_wd = reg_wdata[31];
-  assign cmd_info_12_we = addr_hit[47] & reg_we & !reg_error;
+  assign cmd_info_12_we = addr_hit[48] & reg_we & !reg_error;
 
   assign cmd_info_12_opcode_12_wd = reg_wdata[7:0];
 
@@ -19288,7 +19318,7 @@ module spi_device_reg_top (
   assign cmd_info_12_busy_12_wd = reg_wdata[25];
 
   assign cmd_info_12_valid_12_wd = reg_wdata[31];
-  assign cmd_info_13_we = addr_hit[48] & reg_we & !reg_error;
+  assign cmd_info_13_we = addr_hit[49] & reg_we & !reg_error;
 
   assign cmd_info_13_opcode_13_wd = reg_wdata[7:0];
 
@@ -19313,7 +19343,7 @@ module spi_device_reg_top (
   assign cmd_info_13_busy_13_wd = reg_wdata[25];
 
   assign cmd_info_13_valid_13_wd = reg_wdata[31];
-  assign cmd_info_14_we = addr_hit[49] & reg_we & !reg_error;
+  assign cmd_info_14_we = addr_hit[50] & reg_we & !reg_error;
 
   assign cmd_info_14_opcode_14_wd = reg_wdata[7:0];
 
@@ -19338,7 +19368,7 @@ module spi_device_reg_top (
   assign cmd_info_14_busy_14_wd = reg_wdata[25];
 
   assign cmd_info_14_valid_14_wd = reg_wdata[31];
-  assign cmd_info_15_we = addr_hit[50] & reg_we & !reg_error;
+  assign cmd_info_15_we = addr_hit[51] & reg_we & !reg_error;
 
   assign cmd_info_15_opcode_15_wd = reg_wdata[7:0];
 
@@ -19363,7 +19393,7 @@ module spi_device_reg_top (
   assign cmd_info_15_busy_15_wd = reg_wdata[25];
 
   assign cmd_info_15_valid_15_wd = reg_wdata[31];
-  assign cmd_info_16_we = addr_hit[51] & reg_we & !reg_error;
+  assign cmd_info_16_we = addr_hit[52] & reg_we & !reg_error;
 
   assign cmd_info_16_opcode_16_wd = reg_wdata[7:0];
 
@@ -19388,7 +19418,7 @@ module spi_device_reg_top (
   assign cmd_info_16_busy_16_wd = reg_wdata[25];
 
   assign cmd_info_16_valid_16_wd = reg_wdata[31];
-  assign cmd_info_17_we = addr_hit[52] & reg_we & !reg_error;
+  assign cmd_info_17_we = addr_hit[53] & reg_we & !reg_error;
 
   assign cmd_info_17_opcode_17_wd = reg_wdata[7:0];
 
@@ -19413,7 +19443,7 @@ module spi_device_reg_top (
   assign cmd_info_17_busy_17_wd = reg_wdata[25];
 
   assign cmd_info_17_valid_17_wd = reg_wdata[31];
-  assign cmd_info_18_we = addr_hit[53] & reg_we & !reg_error;
+  assign cmd_info_18_we = addr_hit[54] & reg_we & !reg_error;
 
   assign cmd_info_18_opcode_18_wd = reg_wdata[7:0];
 
@@ -19438,7 +19468,7 @@ module spi_device_reg_top (
   assign cmd_info_18_busy_18_wd = reg_wdata[25];
 
   assign cmd_info_18_valid_18_wd = reg_wdata[31];
-  assign cmd_info_19_we = addr_hit[54] & reg_we & !reg_error;
+  assign cmd_info_19_we = addr_hit[55] & reg_we & !reg_error;
 
   assign cmd_info_19_opcode_19_wd = reg_wdata[7:0];
 
@@ -19463,7 +19493,7 @@ module spi_device_reg_top (
   assign cmd_info_19_busy_19_wd = reg_wdata[25];
 
   assign cmd_info_19_valid_19_wd = reg_wdata[31];
-  assign cmd_info_20_we = addr_hit[55] & reg_we & !reg_error;
+  assign cmd_info_20_we = addr_hit[56] & reg_we & !reg_error;
 
   assign cmd_info_20_opcode_20_wd = reg_wdata[7:0];
 
@@ -19488,7 +19518,7 @@ module spi_device_reg_top (
   assign cmd_info_20_busy_20_wd = reg_wdata[25];
 
   assign cmd_info_20_valid_20_wd = reg_wdata[31];
-  assign cmd_info_21_we = addr_hit[56] & reg_we & !reg_error;
+  assign cmd_info_21_we = addr_hit[57] & reg_we & !reg_error;
 
   assign cmd_info_21_opcode_21_wd = reg_wdata[7:0];
 
@@ -19513,7 +19543,7 @@ module spi_device_reg_top (
   assign cmd_info_21_busy_21_wd = reg_wdata[25];
 
   assign cmd_info_21_valid_21_wd = reg_wdata[31];
-  assign cmd_info_22_we = addr_hit[57] & reg_we & !reg_error;
+  assign cmd_info_22_we = addr_hit[58] & reg_we & !reg_error;
 
   assign cmd_info_22_opcode_22_wd = reg_wdata[7:0];
 
@@ -19538,7 +19568,7 @@ module spi_device_reg_top (
   assign cmd_info_22_busy_22_wd = reg_wdata[25];
 
   assign cmd_info_22_valid_22_wd = reg_wdata[31];
-  assign cmd_info_23_we = addr_hit[58] & reg_we & !reg_error;
+  assign cmd_info_23_we = addr_hit[59] & reg_we & !reg_error;
 
   assign cmd_info_23_opcode_23_wd = reg_wdata[7:0];
 
@@ -19563,17 +19593,17 @@ module spi_device_reg_top (
   assign cmd_info_23_busy_23_wd = reg_wdata[25];
 
   assign cmd_info_23_valid_23_wd = reg_wdata[31];
-  assign cmd_info_en4b_we = addr_hit[59] & reg_we & !reg_error;
+  assign cmd_info_en4b_we = addr_hit[60] & reg_we & !reg_error;
 
   assign cmd_info_en4b_opcode_wd = reg_wdata[7:0];
 
   assign cmd_info_en4b_valid_wd = reg_wdata[31];
-  assign cmd_info_ex4b_we = addr_hit[60] & reg_we & !reg_error;
+  assign cmd_info_ex4b_we = addr_hit[61] & reg_we & !reg_error;
 
   assign cmd_info_ex4b_opcode_wd = reg_wdata[7:0];
 
   assign cmd_info_ex4b_valid_wd = reg_wdata[31];
-  assign tpm_cfg_we = addr_hit[62] & reg_we & !reg_error;
+  assign tpm_cfg_we = addr_hit[63] & reg_we & !reg_error;
 
   assign tpm_cfg_en_wd = reg_wdata[0];
 
@@ -19584,7 +19614,7 @@ module spi_device_reg_top (
   assign tpm_cfg_tpm_reg_chk_dis_wd = reg_wdata[3];
 
   assign tpm_cfg_invalid_locality_wd = reg_wdata[4];
-  assign tpm_access_0_we = addr_hit[64] & reg_we & !reg_error;
+  assign tpm_access_0_we = addr_hit[65] & reg_we & !reg_error;
 
   assign tpm_access_0_access_0_wd = reg_wdata[7:0];
 
@@ -19593,37 +19623,37 @@ module spi_device_reg_top (
   assign tpm_access_0_access_2_wd = reg_wdata[23:16];
 
   assign tpm_access_0_access_3_wd = reg_wdata[31:24];
-  assign tpm_access_1_we = addr_hit[65] & reg_we & !reg_error;
+  assign tpm_access_1_we = addr_hit[66] & reg_we & !reg_error;
 
   assign tpm_access_1_wd = reg_wdata[7:0];
-  assign tpm_sts_we = addr_hit[66] & reg_we & !reg_error;
+  assign tpm_sts_we = addr_hit[67] & reg_we & !reg_error;
 
   assign tpm_sts_wd = reg_wdata[31:0];
-  assign tpm_intf_capability_we = addr_hit[67] & reg_we & !reg_error;
+  assign tpm_intf_capability_we = addr_hit[68] & reg_we & !reg_error;
 
   assign tpm_intf_capability_wd = reg_wdata[31:0];
-  assign tpm_int_enable_we = addr_hit[68] & reg_we & !reg_error;
+  assign tpm_int_enable_we = addr_hit[69] & reg_we & !reg_error;
 
   assign tpm_int_enable_wd = reg_wdata[31:0];
-  assign tpm_int_vector_we = addr_hit[69] & reg_we & !reg_error;
+  assign tpm_int_vector_we = addr_hit[70] & reg_we & !reg_error;
 
   assign tpm_int_vector_wd = reg_wdata[7:0];
-  assign tpm_int_status_we = addr_hit[70] & reg_we & !reg_error;
+  assign tpm_int_status_we = addr_hit[71] & reg_we & !reg_error;
 
   assign tpm_int_status_wd = reg_wdata[31:0];
-  assign tpm_did_vid_we = addr_hit[71] & reg_we & !reg_error;
+  assign tpm_did_vid_we = addr_hit[72] & reg_we & !reg_error;
 
   assign tpm_did_vid_vid_wd = reg_wdata[15:0];
 
   assign tpm_did_vid_did_wd = reg_wdata[31:16];
-  assign tpm_rid_we = addr_hit[72] & reg_we & !reg_error;
+  assign tpm_rid_we = addr_hit[73] & reg_we & !reg_error;
 
   assign tpm_rid_wd = reg_wdata[7:0];
-  assign tpm_cmd_addr_re = addr_hit[73] & reg_re & !reg_error;
-  assign tpm_read_fifo_we = addr_hit[74] & reg_we & !reg_error;
+  assign tpm_cmd_addr_re = addr_hit[74] & reg_re & !reg_error;
+  assign tpm_read_fifo_we = addr_hit[75] & reg_we & !reg_error;
 
   assign tpm_read_fifo_wd = reg_wdata[7:0];
-  assign tpm_write_fifo_re = addr_hit[75] & reg_re & !reg_error;
+  assign tpm_write_fifo_re = addr_hit[76] & reg_re & !reg_error;
 
   // Read data return
   always_comb begin
@@ -19774,18 +19804,22 @@ module spi_device_reg_top (
         reg_rdata_next[7] = upload_status_cmdfifo_notempty_qs;
         reg_rdata_next[12:8] = upload_status_addrfifo_depth_qs;
         reg_rdata_next[15] = upload_status_addrfifo_notempty_qs;
-        reg_rdata_next[24:16] = upload_status_payload_depth_qs;
       end
 
       addr_hit[21]: begin
-        reg_rdata_next[7:0] = upload_cmdfifo_qs;
+        reg_rdata_next[8:0] = upload_status2_payload_depth_qs;
+        reg_rdata_next[23:16] = upload_status2_payload_start_idx_qs;
       end
 
       addr_hit[22]: begin
-        reg_rdata_next[31:0] = upload_addrfifo_qs;
+        reg_rdata_next[7:0] = upload_cmdfifo_qs;
       end
 
       addr_hit[23]: begin
+        reg_rdata_next[31:0] = upload_addrfifo_qs;
+      end
+
+      addr_hit[24]: begin
         reg_rdata_next[0] = cmd_filter_0_filter_0_qs;
         reg_rdata_next[1] = cmd_filter_0_filter_1_qs;
         reg_rdata_next[2] = cmd_filter_0_filter_2_qs;
@@ -19820,7 +19854,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_0_filter_31_qs;
       end
 
-      addr_hit[24]: begin
+      addr_hit[25]: begin
         reg_rdata_next[0] = cmd_filter_1_filter_32_qs;
         reg_rdata_next[1] = cmd_filter_1_filter_33_qs;
         reg_rdata_next[2] = cmd_filter_1_filter_34_qs;
@@ -19855,7 +19889,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_1_filter_63_qs;
       end
 
-      addr_hit[25]: begin
+      addr_hit[26]: begin
         reg_rdata_next[0] = cmd_filter_2_filter_64_qs;
         reg_rdata_next[1] = cmd_filter_2_filter_65_qs;
         reg_rdata_next[2] = cmd_filter_2_filter_66_qs;
@@ -19890,7 +19924,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_2_filter_95_qs;
       end
 
-      addr_hit[26]: begin
+      addr_hit[27]: begin
         reg_rdata_next[0] = cmd_filter_3_filter_96_qs;
         reg_rdata_next[1] = cmd_filter_3_filter_97_qs;
         reg_rdata_next[2] = cmd_filter_3_filter_98_qs;
@@ -19925,7 +19959,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_3_filter_127_qs;
       end
 
-      addr_hit[27]: begin
+      addr_hit[28]: begin
         reg_rdata_next[0] = cmd_filter_4_filter_128_qs;
         reg_rdata_next[1] = cmd_filter_4_filter_129_qs;
         reg_rdata_next[2] = cmd_filter_4_filter_130_qs;
@@ -19960,7 +19994,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_4_filter_159_qs;
       end
 
-      addr_hit[28]: begin
+      addr_hit[29]: begin
         reg_rdata_next[0] = cmd_filter_5_filter_160_qs;
         reg_rdata_next[1] = cmd_filter_5_filter_161_qs;
         reg_rdata_next[2] = cmd_filter_5_filter_162_qs;
@@ -19995,7 +20029,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_5_filter_191_qs;
       end
 
-      addr_hit[29]: begin
+      addr_hit[30]: begin
         reg_rdata_next[0] = cmd_filter_6_filter_192_qs;
         reg_rdata_next[1] = cmd_filter_6_filter_193_qs;
         reg_rdata_next[2] = cmd_filter_6_filter_194_qs;
@@ -20030,7 +20064,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_6_filter_223_qs;
       end
 
-      addr_hit[30]: begin
+      addr_hit[31]: begin
         reg_rdata_next[0] = cmd_filter_7_filter_224_qs;
         reg_rdata_next[1] = cmd_filter_7_filter_225_qs;
         reg_rdata_next[2] = cmd_filter_7_filter_226_qs;
@@ -20065,23 +20099,23 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_filter_7_filter_255_qs;
       end
 
-      addr_hit[31]: begin
+      addr_hit[32]: begin
         reg_rdata_next[31:0] = addr_swap_mask_qs;
       end
 
-      addr_hit[32]: begin
+      addr_hit[33]: begin
         reg_rdata_next[31:0] = addr_swap_data_qs;
       end
 
-      addr_hit[33]: begin
+      addr_hit[34]: begin
         reg_rdata_next[31:0] = payload_swap_mask_qs;
       end
 
-      addr_hit[34]: begin
+      addr_hit[35]: begin
         reg_rdata_next[31:0] = payload_swap_data_qs;
       end
 
-      addr_hit[35]: begin
+      addr_hit[36]: begin
         reg_rdata_next[7:0] = cmd_info_0_opcode_0_qs;
         reg_rdata_next[9:8] = cmd_info_0_addr_mode_0_qs;
         reg_rdata_next[10] = cmd_info_0_addr_swap_en_0_qs;
@@ -20096,7 +20130,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_0_valid_0_qs;
       end
 
-      addr_hit[36]: begin
+      addr_hit[37]: begin
         reg_rdata_next[7:0] = cmd_info_1_opcode_1_qs;
         reg_rdata_next[9:8] = cmd_info_1_addr_mode_1_qs;
         reg_rdata_next[10] = cmd_info_1_addr_swap_en_1_qs;
@@ -20111,7 +20145,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_1_valid_1_qs;
       end
 
-      addr_hit[37]: begin
+      addr_hit[38]: begin
         reg_rdata_next[7:0] = cmd_info_2_opcode_2_qs;
         reg_rdata_next[9:8] = cmd_info_2_addr_mode_2_qs;
         reg_rdata_next[10] = cmd_info_2_addr_swap_en_2_qs;
@@ -20126,7 +20160,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_2_valid_2_qs;
       end
 
-      addr_hit[38]: begin
+      addr_hit[39]: begin
         reg_rdata_next[7:0] = cmd_info_3_opcode_3_qs;
         reg_rdata_next[9:8] = cmd_info_3_addr_mode_3_qs;
         reg_rdata_next[10] = cmd_info_3_addr_swap_en_3_qs;
@@ -20141,7 +20175,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_3_valid_3_qs;
       end
 
-      addr_hit[39]: begin
+      addr_hit[40]: begin
         reg_rdata_next[7:0] = cmd_info_4_opcode_4_qs;
         reg_rdata_next[9:8] = cmd_info_4_addr_mode_4_qs;
         reg_rdata_next[10] = cmd_info_4_addr_swap_en_4_qs;
@@ -20156,7 +20190,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_4_valid_4_qs;
       end
 
-      addr_hit[40]: begin
+      addr_hit[41]: begin
         reg_rdata_next[7:0] = cmd_info_5_opcode_5_qs;
         reg_rdata_next[9:8] = cmd_info_5_addr_mode_5_qs;
         reg_rdata_next[10] = cmd_info_5_addr_swap_en_5_qs;
@@ -20171,7 +20205,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_5_valid_5_qs;
       end
 
-      addr_hit[41]: begin
+      addr_hit[42]: begin
         reg_rdata_next[7:0] = cmd_info_6_opcode_6_qs;
         reg_rdata_next[9:8] = cmd_info_6_addr_mode_6_qs;
         reg_rdata_next[10] = cmd_info_6_addr_swap_en_6_qs;
@@ -20186,7 +20220,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_6_valid_6_qs;
       end
 
-      addr_hit[42]: begin
+      addr_hit[43]: begin
         reg_rdata_next[7:0] = cmd_info_7_opcode_7_qs;
         reg_rdata_next[9:8] = cmd_info_7_addr_mode_7_qs;
         reg_rdata_next[10] = cmd_info_7_addr_swap_en_7_qs;
@@ -20201,7 +20235,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_7_valid_7_qs;
       end
 
-      addr_hit[43]: begin
+      addr_hit[44]: begin
         reg_rdata_next[7:0] = cmd_info_8_opcode_8_qs;
         reg_rdata_next[9:8] = cmd_info_8_addr_mode_8_qs;
         reg_rdata_next[10] = cmd_info_8_addr_swap_en_8_qs;
@@ -20216,7 +20250,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_8_valid_8_qs;
       end
 
-      addr_hit[44]: begin
+      addr_hit[45]: begin
         reg_rdata_next[7:0] = cmd_info_9_opcode_9_qs;
         reg_rdata_next[9:8] = cmd_info_9_addr_mode_9_qs;
         reg_rdata_next[10] = cmd_info_9_addr_swap_en_9_qs;
@@ -20231,7 +20265,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_9_valid_9_qs;
       end
 
-      addr_hit[45]: begin
+      addr_hit[46]: begin
         reg_rdata_next[7:0] = cmd_info_10_opcode_10_qs;
         reg_rdata_next[9:8] = cmd_info_10_addr_mode_10_qs;
         reg_rdata_next[10] = cmd_info_10_addr_swap_en_10_qs;
@@ -20246,7 +20280,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_10_valid_10_qs;
       end
 
-      addr_hit[46]: begin
+      addr_hit[47]: begin
         reg_rdata_next[7:0] = cmd_info_11_opcode_11_qs;
         reg_rdata_next[9:8] = cmd_info_11_addr_mode_11_qs;
         reg_rdata_next[10] = cmd_info_11_addr_swap_en_11_qs;
@@ -20261,7 +20295,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_11_valid_11_qs;
       end
 
-      addr_hit[47]: begin
+      addr_hit[48]: begin
         reg_rdata_next[7:0] = cmd_info_12_opcode_12_qs;
         reg_rdata_next[9:8] = cmd_info_12_addr_mode_12_qs;
         reg_rdata_next[10] = cmd_info_12_addr_swap_en_12_qs;
@@ -20276,7 +20310,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_12_valid_12_qs;
       end
 
-      addr_hit[48]: begin
+      addr_hit[49]: begin
         reg_rdata_next[7:0] = cmd_info_13_opcode_13_qs;
         reg_rdata_next[9:8] = cmd_info_13_addr_mode_13_qs;
         reg_rdata_next[10] = cmd_info_13_addr_swap_en_13_qs;
@@ -20291,7 +20325,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_13_valid_13_qs;
       end
 
-      addr_hit[49]: begin
+      addr_hit[50]: begin
         reg_rdata_next[7:0] = cmd_info_14_opcode_14_qs;
         reg_rdata_next[9:8] = cmd_info_14_addr_mode_14_qs;
         reg_rdata_next[10] = cmd_info_14_addr_swap_en_14_qs;
@@ -20306,7 +20340,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_14_valid_14_qs;
       end
 
-      addr_hit[50]: begin
+      addr_hit[51]: begin
         reg_rdata_next[7:0] = cmd_info_15_opcode_15_qs;
         reg_rdata_next[9:8] = cmd_info_15_addr_mode_15_qs;
         reg_rdata_next[10] = cmd_info_15_addr_swap_en_15_qs;
@@ -20321,7 +20355,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_15_valid_15_qs;
       end
 
-      addr_hit[51]: begin
+      addr_hit[52]: begin
         reg_rdata_next[7:0] = cmd_info_16_opcode_16_qs;
         reg_rdata_next[9:8] = cmd_info_16_addr_mode_16_qs;
         reg_rdata_next[10] = cmd_info_16_addr_swap_en_16_qs;
@@ -20336,7 +20370,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_16_valid_16_qs;
       end
 
-      addr_hit[52]: begin
+      addr_hit[53]: begin
         reg_rdata_next[7:0] = cmd_info_17_opcode_17_qs;
         reg_rdata_next[9:8] = cmd_info_17_addr_mode_17_qs;
         reg_rdata_next[10] = cmd_info_17_addr_swap_en_17_qs;
@@ -20351,7 +20385,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_17_valid_17_qs;
       end
 
-      addr_hit[53]: begin
+      addr_hit[54]: begin
         reg_rdata_next[7:0] = cmd_info_18_opcode_18_qs;
         reg_rdata_next[9:8] = cmd_info_18_addr_mode_18_qs;
         reg_rdata_next[10] = cmd_info_18_addr_swap_en_18_qs;
@@ -20366,7 +20400,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_18_valid_18_qs;
       end
 
-      addr_hit[54]: begin
+      addr_hit[55]: begin
         reg_rdata_next[7:0] = cmd_info_19_opcode_19_qs;
         reg_rdata_next[9:8] = cmd_info_19_addr_mode_19_qs;
         reg_rdata_next[10] = cmd_info_19_addr_swap_en_19_qs;
@@ -20381,7 +20415,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_19_valid_19_qs;
       end
 
-      addr_hit[55]: begin
+      addr_hit[56]: begin
         reg_rdata_next[7:0] = cmd_info_20_opcode_20_qs;
         reg_rdata_next[9:8] = cmd_info_20_addr_mode_20_qs;
         reg_rdata_next[10] = cmd_info_20_addr_swap_en_20_qs;
@@ -20396,7 +20430,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_20_valid_20_qs;
       end
 
-      addr_hit[56]: begin
+      addr_hit[57]: begin
         reg_rdata_next[7:0] = cmd_info_21_opcode_21_qs;
         reg_rdata_next[9:8] = cmd_info_21_addr_mode_21_qs;
         reg_rdata_next[10] = cmd_info_21_addr_swap_en_21_qs;
@@ -20411,7 +20445,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_21_valid_21_qs;
       end
 
-      addr_hit[57]: begin
+      addr_hit[58]: begin
         reg_rdata_next[7:0] = cmd_info_22_opcode_22_qs;
         reg_rdata_next[9:8] = cmd_info_22_addr_mode_22_qs;
         reg_rdata_next[10] = cmd_info_22_addr_swap_en_22_qs;
@@ -20426,7 +20460,7 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_22_valid_22_qs;
       end
 
-      addr_hit[58]: begin
+      addr_hit[59]: begin
         reg_rdata_next[7:0] = cmd_info_23_opcode_23_qs;
         reg_rdata_next[9:8] = cmd_info_23_addr_mode_23_qs;
         reg_rdata_next[10] = cmd_info_23_addr_swap_en_23_qs;
@@ -20441,23 +20475,23 @@ module spi_device_reg_top (
         reg_rdata_next[31] = cmd_info_23_valid_23_qs;
       end
 
-      addr_hit[59]: begin
+      addr_hit[60]: begin
         reg_rdata_next[7:0] = cmd_info_en4b_opcode_qs;
         reg_rdata_next[31] = cmd_info_en4b_valid_qs;
       end
 
-      addr_hit[60]: begin
+      addr_hit[61]: begin
         reg_rdata_next[7:0] = cmd_info_ex4b_opcode_qs;
         reg_rdata_next[31] = cmd_info_ex4b_valid_qs;
       end
 
-      addr_hit[61]: begin
+      addr_hit[62]: begin
         reg_rdata_next[7:0] = tpm_cap_rev_qs;
         reg_rdata_next[8] = tpm_cap_locality_qs;
         reg_rdata_next[18:16] = tpm_cap_max_xfer_size_qs;
       end
 
-      addr_hit[62]: begin
+      addr_hit[63]: begin
         reg_rdata_next[0] = tpm_cfg_en_qs;
         reg_rdata_next[1] = tpm_cfg_tpm_mode_qs;
         reg_rdata_next[2] = tpm_cfg_hw_reg_dis_qs;
@@ -20465,63 +20499,63 @@ module spi_device_reg_top (
         reg_rdata_next[4] = tpm_cfg_invalid_locality_qs;
       end
 
-      addr_hit[63]: begin
+      addr_hit[64]: begin
         reg_rdata_next[0] = tpm_status_cmdaddr_notempty_qs;
         reg_rdata_next[1] = tpm_status_rdfifo_notempty_qs;
         reg_rdata_next[6:4] = tpm_status_rdfifo_depth_qs;
         reg_rdata_next[10:8] = tpm_status_wrfifo_depth_qs;
       end
 
-      addr_hit[64]: begin
+      addr_hit[65]: begin
         reg_rdata_next[7:0] = tpm_access_0_access_0_qs;
         reg_rdata_next[15:8] = tpm_access_0_access_1_qs;
         reg_rdata_next[23:16] = tpm_access_0_access_2_qs;
         reg_rdata_next[31:24] = tpm_access_0_access_3_qs;
       end
 
-      addr_hit[65]: begin
+      addr_hit[66]: begin
         reg_rdata_next[7:0] = tpm_access_1_qs;
       end
 
-      addr_hit[66]: begin
+      addr_hit[67]: begin
         reg_rdata_next[31:0] = tpm_sts_qs;
       end
 
-      addr_hit[67]: begin
+      addr_hit[68]: begin
         reg_rdata_next[31:0] = tpm_intf_capability_qs;
       end
 
-      addr_hit[68]: begin
+      addr_hit[69]: begin
         reg_rdata_next[31:0] = tpm_int_enable_qs;
       end
 
-      addr_hit[69]: begin
+      addr_hit[70]: begin
         reg_rdata_next[7:0] = tpm_int_vector_qs;
       end
 
-      addr_hit[70]: begin
+      addr_hit[71]: begin
         reg_rdata_next[31:0] = tpm_int_status_qs;
       end
 
-      addr_hit[71]: begin
+      addr_hit[72]: begin
         reg_rdata_next[15:0] = tpm_did_vid_vid_qs;
         reg_rdata_next[31:16] = tpm_did_vid_did_qs;
       end
 
-      addr_hit[72]: begin
+      addr_hit[73]: begin
         reg_rdata_next[7:0] = tpm_rid_qs;
       end
 
-      addr_hit[73]: begin
+      addr_hit[74]: begin
         reg_rdata_next[23:0] = tpm_cmd_addr_addr_qs;
         reg_rdata_next[31:24] = tpm_cmd_addr_cmd_qs;
       end
 
-      addr_hit[74]: begin
+      addr_hit[75]: begin
         reg_rdata_next[7:0] = '0;
       end
 
-      addr_hit[75]: begin
+      addr_hit[76]: begin
         reg_rdata_next[7:0] = tpm_write_fifo_qs;
       end
 

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -622,8 +622,9 @@ void spi_device_cmd_get(spi_device_cmd_t *cmd) {
         abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_ADDRFIFO_REG_OFFSET);
   }
 
+  // TODO: Handle the case of non-zero PAYLOAD_START_IDX.
   cmd->payload_byte_count =
-      bitfield_field32_read(reg, SPI_DEVICE_UPLOAD_STATUS_PAYLOAD_DEPTH_FIELD);
+      abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_STATUS2_REG_OFFSET);
   uint32_t src =
       kBase + SPI_DEVICE_BUFFER_REG_OFFSET + kSpiDevicePayloadAreaOffset;
   char *dest = (char *)&cmd->payload;

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -183,8 +183,6 @@ TEST_P(CmdGetTest, CmdGet) {
       {
           {SPI_DEVICE_UPLOAD_STATUS_CMDFIFO_NOTEMPTY_BIT, 1},
           {SPI_DEVICE_UPLOAD_STATUS_ADDRFIFO_NOTEMPTY_BIT, has_address},
-          {SPI_DEVICE_UPLOAD_STATUS_PAYLOAD_DEPTH_OFFSET,
-           GetParam().payload.size()},
       });
   EXPECT_ABS_READ32(base_ + SPI_DEVICE_UPLOAD_CMDFIFO_REG_OFFSET,
                     GetParam().opcode);
@@ -198,6 +196,8 @@ TEST_P(CmdGetTest, CmdGet) {
                                      std::numeric_limits<uint32_t>::max());
   std::memcpy(payload_area.data(), GetParam().payload.data(),
               GetParam().payload.size());
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_UPLOAD_STATUS2_REG_OFFSET,
+                    GetParam().payload.size());
   uint32_t offset =
       base_ + SPI_DEVICE_BUFFER_REG_OFFSET + kSpiDevicePayloadAreaOffset;
   for (size_t i = 0; i < GetParam().payload.size(); i += sizeof(uint32_t)) {


### PR DESCRIPTION
This commit revised the last_written_payload_idx to payload_start_idx.

The payload_start_idx indicates the first pointer of the written
payload. It usually shows 0. If the attached SPI host system issues more
than 256B, this may show the non-zero value. SW should read from
start_idx to get the correct value in that case.



Note: Please review last three commits. first 8 commits are for overflow event PR.