### PR TITLE
[bazel] add `pip_wheel` repository rule

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -80,3 +80,5 @@ filegroup(
         "topgen-reg-only.core",
     ],
 )
+
+exports_files(["python-requirements.txt"])

--- a/third_party/python/BUILD
+++ b/third_party/python/BUILD
@@ -1,3 +1,9 @@
 # Copyright lowRISC contributors.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "gen_requirements.sh",
+])

--- a/third_party/python/gen_requirements.sh
+++ b/third_party/python/gen_requirements.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+#
+# A shell script for building a python-requirements.txt file based on a
+# directory of wheels that have been pre-downloaded.
+
+set -e
+
+WHEEL_DIR="./"
+OUTPUT_FILE="sanitized_requirements.txt"
+
+for wheel in $(ls -1 ${WHEEL_DIR}/*.whl); do
+  wheel_basename=$(echo ${wheel} | tr '\n' '\0' | xargs -0 -n 1 basename)
+  IFS='-' read -ra WHEEL_NAME_ARRAY <<< ${wheel_basename}
+  PACKAGE_NAME=${WHEEL_NAME_ARRAY[0]}
+  PACKAGE_VERSION=${WHEEL_NAME_ARRAY[1]}
+  echo "${PACKAGE_NAME}==${PACKAGE_VERSION}" >> ${OUTPUT_FILE}
+done

--- a/third_party/python/pip.bzl
+++ b/third_party/python/pip.bzl
@@ -5,9 +5,121 @@
 load("@rules_python//python:pip.bzl", "pip_install")
 load("@python3//:defs.bzl", "interpreter")
 
+_WHEEL_BUILD_FILE_CONTENTS = """\
+package(default_visibility = ["//visibility:public"])
+
+exports_files([
+    "sanitized_requirements.txt",
+])
+
+filegroup(
+    name = "all_wheels",
+    srcs = glob(["**/*.whl"])
+)
+"""
+
+def _pip_wheel_impl(rctx):
+    # First, we install the Python wheel package so we can build other wheels.
+    args = [
+        rctx.path(rctx.attr.python_interpreter),
+        "-m",
+        "pip",
+        "install",
+        "wheel",
+    ]
+    progress_message = "Installing the Python wheel package"
+    rctx.report_progress(progress_message)
+    result = rctx.execute(
+        args,
+        timeout = rctx.attr.timeout,
+        quiet = rctx.attr.quiet,
+    )
+    if result.return_code:
+        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
+
+    # Next, we download/build all the Python wheels for each requirement.
+    args = [
+        rctx.path(rctx.attr.python_interpreter),
+        "-m",
+        "pip",
+        "wheel",
+        "-r",
+        rctx.path(rctx.attr.requirements),
+        "-w",
+        "./",
+    ]
+    progress_message = "Pre-building Python wheels"
+    rctx.report_progress(progress_message)
+    result = rctx.execute(
+        args,
+        timeout = rctx.attr.timeout,
+        quiet = rctx.attr.quiet,
+    )
+    if result.return_code:
+        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
+
+    # Last, we generate a new Python requirements file that does not contain any
+    # VCS links. We avoid just patching the existing python_requirements.txt
+    # file, and instead generate a requirements file based on the wheels that
+    # were built above. This enables us to make changes to the main
+    # python_requirements.txt file without impacting this step.
+    args = [rctx.path(rctx.attr._gen_requirements_script)]
+    progress_message = "Generating sanitzed requirements file"
+    rctx.report_progress(progress_message)
+    result = rctx.execute(
+        args,
+        timeout = rctx.attr.timeout,
+        quiet = rctx.attr.quiet,
+        working_directory = "./",
+    )
+    if result.return_code:
+        fail("pip_wheel failed: {} ({})".format(result.stdout, result.stderr))
+
+    # We need a BUILD file to load the downloaded Python packages.
+    rctx.file(
+        "BUILD.bazel",
+        _WHEEL_BUILD_FILE_CONTENTS,
+    )
+
+pip_wheel = repository_rule(
+    implementation = _pip_wheel_impl,
+    attrs = {
+        "python_interpreter": attr.label(
+            default = interpreter,
+            allow_single_file = True,
+            doc = "Python interpreter to use.",
+        ),
+        "requirements": attr.label(
+            default = "//:python-requirements.txt",
+            allow_single_file = True,
+            doc = "Python requirements file describing package dependencies.",
+        ),
+        "quiet": attr.bool(
+            default = True,
+            doc = "If True, suppress printing stdout/stderr to the terminal.",
+        ),
+        "timeout": attr.int(
+            default = 300,
+            doc = "Timeout (in seconds) on the rule's execution duration.",
+        ),
+        "_gen_requirements_script": attr.label(
+            default = "//third_party/python:gen_requirements.sh",
+            allow_single_file = True,
+            doc = "Shell script that generates a requirements file without VCS links.",
+            executable = True,
+            cfg = "host",
+        ),
+    },
+)
+
 def pip_deps():
+    pip_wheel(
+        name = "ot_python_wheels",
+    )
     pip_install(
         name = "ot_python_deps",
         python_interpreter_target = interpreter,
-        requirements = "//:python-requirements.txt",
+        requirements = "@ot_python_wheels//:sanitized_requirements.txt",
+        find_links = "@ot_python_wheels//:all_wheels",
+        extra_pip_args = ["--no-index"],
     )

--- a/third_party/python/repos.bzl
+++ b/third_party/python/repos.bzl
@@ -7,7 +7,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def python_repos():
     http_archive(
         name = "rules_python",
-        sha256 = "9fcf91dbcc31fde6d1edb15f117246d912c33c36f44cf681976bd886538deba6",
-        strip_prefix = "rules_python-0.8.0",
-        url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.0.tar.gz",
+        sha256 = "9e9a58cff49f80afd1c9fcc7137b719531f7a7427cce4fda1d30ca27b4a46a8a",
+        strip_prefix = "rules_python-07c3f8547abbd5b97839a48af226a0fbcfaa5e7c",
+        url = "https://github.com/lowRISC/rules_python/archive/07c3f8547abbd5b97839a48af226a0fbcfaa5e7c.tar.gz",
     )

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 : "${BAZEL_AIRGAPPED_DIR:=bazel-airgapped}"
 : "${BAZEL_DISTDIR:=bazel-distdir}"
 : "${BAZEL_CACHEDIR:=bazel-cache}"
+: "${BAZEL_PYTHON_WHEEL_REPO:=ot_python_wheels}"
 
 LINE_SEP="====================================================================="
 
@@ -149,6 +150,8 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @rust_linux_aarch64_toolchains//... \
     @rust_linux_x86_64_toolchains//... \
     @rust_windows_x86_64_toolchains//...
+  cp -R $(${BAZELISK} info output_base)/external/${BAZEL_PYTHON_WHEEL_REPO} \
+    ${BAZEL_AIRGAPPED_DIR}/
   echo "Done."
 fi
 


### PR DESCRIPTION
Currently, Bazel python rules install python packages by invoking `pip
wheel` to download and build Python wheel archives for all package
dependencies. Unfortunately, this mechanism does not result in the wheel
archives being cached in the bazel `repository_cache`, like other
repository dependencies.

In order to support airgapped bazel builds (#12090), we need to be able to
pre-fetch all external dependencies and copy them over to the airgapped
environment. This includes Python dependencies (wheels).

The `pip` package manager does provide both: 1) a mechanism to pre-download
python package archives (in their distributed form) using `pip download`,
and 2) a way to use these pre-downloaded archives in subsequent invocations
of `pip wheel`, with the `--find-links` flag, which is already invoked by
the `pip_install` Python bazel rule.

Unfortunately, if you use VCS URLs in your `requirements.txt` file,
`pip` will still attempt to grab these from the internet using the
corresponding VCS tool (e.g., `git` in our case, since fusesoc, edalize,
and chipwhisperer packges are all specified with `git` urls in our
`python-requirements.txt` file) in subsequent invocations of `pip wheel`
or `pip install`, even if they have been pre-downloaded with `pip download`,
and you have specified their location on your system with the
`--find-links` opt.

To overcome this, `pip` also provides a `wheel` subcommand that will
both pre-download python package archives, AND, build a wheel for those
packages that are not already distributed in wheel form. We can take
advantage of this, and both pre-download existing wheels for packages
that provide them, and build wheels for packages that do not, i.e. those
specified via VCS URLs. Then, we can generate a new `requirements.txt`
file on the fly that does not contain any VCS URLs, so that future
invocations of `pip wheel` or `pip install` will hit our
pre-downloaded/built wheel cache.

This commit accomplishes the above by:

1. adding a custom bazel repository rule to:
   a. pre-download/build all Python packages (specified by the project's
      `python-requirements.txt` file) in wheel form,
   b. generate a VCS-URL-free requirements.txt file on the fly that
      describes only those dependencies specified in the original
      `python-requirements.txt` file whose wheels were downloaded/built
      in (a),
2. re-vendoring of a forked version of the Python bazel rules
   (`rules_python`) that contains a patch to support passing the location
   of the pre-downloaded Python wheels to the `pip_install` rule, to further
   pass to it's underlying invocation of the `pip wheel` command along with
   the `--find-links` opt.
3. updating the `prep-bazel-airgapped-build.sh` script to copy over the
   pre-built python wheel repo to the airgapped prep directory.

This fixes #12090.

Signed-off-by: Timothy Trippel <ttrippel@google.com>