### PR TITLE
[ci] Latency optimizations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -110,8 +110,7 @@ jobs:
   displayName: Build Software for Earl Grey toplevel design
   dependsOn: lint
   condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool:
-    vmImage: ubuntu-18.04
+  pool: ci-public
   steps:
   - template: ci/install-package-dependencies.yml
   - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -618,7 +618,7 @@ jobs:
 - job: execute_fpga_tests_cw310
   displayName: Execute tests on ChipWhisperer CW310 FPGA board
   pool: FPGA
-  timeoutInMinutes: 30
+  timeoutInMinutes: 8
   dependsOn:
     - chip_earlgrey_cw310
     - sw_build


### PR DESCRIPTION
This PR:
- Reduces the FPGA test runtime from 30 minutes to 8 to fail faster when the FPGA agent fails
- Moves the `sw_build` job from Azure runners to ci-public