### PR TITLE
[flash_ctrl] Reconnect command integrity error

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -110,6 +110,7 @@ module flash_ctrl
   logic storage_err;
   logic update_err;
   logic intg_err;
+  logic eflash_cmd_intg_err;
 
   // SEC_CM: BUS.INTEGRITY
   // SEC_CM: CTRL.CONFIG.REGWEN
@@ -1040,7 +1041,7 @@ module flash_ctrl
   assign hw2reg.std_fault_status.storage_err.d     = 1'b1;
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
-  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err;
+  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
   assign hw2reg.std_fault_status.lcmgr_intg_err.de = lcmgr_intg_err;
@@ -1252,7 +1253,7 @@ module flash_ctrl
     .addr_o      (flash_host_addr),
     .wdata_o     (),
     .wmask_o     (),
-    .intg_error_o(),
+    .intg_error_o(eflash_cmd_intg_err),
     .rdata_i     (flash_host_rdata),
     .rvalid_i    (flash_host_req_done),
     .rerror_i    ({flash_host_rderr,1'b0})

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -110,6 +110,7 @@ module flash_ctrl
   logic storage_err;
   logic update_err;
   logic intg_err;
+  logic eflash_cmd_intg_err;
 
   // SEC_CM: BUS.INTEGRITY
   // SEC_CM: CTRL.CONFIG.REGWEN
@@ -1041,7 +1042,7 @@ module flash_ctrl
   assign hw2reg.std_fault_status.storage_err.d     = 1'b1;
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
-  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err;
+  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
   assign hw2reg.std_fault_status.lcmgr_intg_err.de = lcmgr_intg_err;
@@ -1253,7 +1254,7 @@ module flash_ctrl
     .addr_o      (flash_host_addr),
     .wdata_o     (),
     .wmask_o     (),
-    .intg_error_o(),
+    .intg_error_o(eflash_cmd_intg_err),
     .rdata_i     (flash_host_rdata),
     .rvalid_i    (flash_host_req_done),
     .rerror_i    ({flash_host_rderr,1'b0})

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -192,8 +192,11 @@ module flash_phy_core
   assign host_req_rdy_o = rd_stage_rdy & (arb_cnt < ArbCnt[CntWidth-1:0]) & ~ctrl_gnt;
   assign host_req_done_o = ~ctrl_gnt & rd_stage_data_valid;
 
-  localparam int OutStandingRdWidth = $clog2(RspOrderDepth+1);
-  logic [OutStandingRdWidth-1:0] host_outstanding;
+  // oustanding width is slightly larger to ensure a faulty increment is able to reach
+  // the higher value. For example if RspOrderDepth were 3, a clog2 of 3 would still be 2
+  // and not allow the counter to increment to 4.
+  localparam int OutstandingRdWidth = $clog2(RspOrderDepth+2);
+  logic [OutstandingRdWidth-1:0] host_outstanding;
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       host_outstanding <= '0;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -116,6 +116,7 @@ module flash_ctrl
   logic storage_err;
   logic update_err;
   logic intg_err;
+  logic eflash_cmd_intg_err;
 
   // SEC_CM: BUS.INTEGRITY
   // SEC_CM: CTRL.CONFIG.REGWEN
@@ -1047,7 +1048,7 @@ module flash_ctrl
   assign hw2reg.std_fault_status.storage_err.d     = 1'b1;
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
-  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err;
+  assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
   assign hw2reg.std_fault_status.lcmgr_intg_err.de = lcmgr_intg_err;
@@ -1259,7 +1260,7 @@ module flash_ctrl
     .addr_o      (flash_host_addr),
     .wdata_o     (),
     .wmask_o     (),
-    .intg_error_o(),
+    .intg_error_o(eflash_cmd_intg_err),
     .rdata_i     (flash_host_rdata),
     .rvalid_i    (flash_host_req_done),
     .rerror_i    ({flash_host_rderr,1'b0})


### PR DESCRIPTION
- the host direct access interface accidentally had its command integrity
  dropped from fatal alert generation.  This commit adds it back.

The first commit will be rebased away in #12056 