### PR TITLE
[dv/build_seed] Fix build seed errors

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -44,7 +44,7 @@
     // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
     {
       name: build_seed
-      pre_build_cmds: ["cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}"]
+      pre_build_cmds: ["cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {build_seed}"]
       is_sim_mode: 1
     }
   ]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -119,14 +119,13 @@
     }
     // Sim mode that enables build randomization. See the `build_seed` mode
     // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
-    // TODO: enable the following pre_build_cmds once the otp init error is fixed
-    // "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}"
     {
       name: build_seed
       pre_build_cmds: [
         '''cd {proj_root} && ./util/topgen.py -t {ral_spec} \
-               -o hw/top_earlgrey --rnd_cnst_seed {seed}
-        '''
+               -o hw/top_earlgrey --rnd_cnst_seed {build_seed}
+        ''',
+        "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {build_seed}"
       ]
       is_sim_mode: 1
     }
@@ -141,7 +140,7 @@
   // Setup for generating OTP images.
   gen_otp_images_cfg_dir: "{proj_root}/hw/ip/otp_ctrl/data"
   gen_otp_images_cmd: "{proj_root}/util/design/gen-otp-img.py"
-  gen_otp_images_cmd_opts: ["--quiet", "--seed {seed}"]
+  gen_otp_images_cmd_opts: ["--quiet", "--img-seed {seed}", "--otp-seed {build_seed}"]
 
   // Add run modes.
   run_modes: [

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -299,6 +299,7 @@ class CompileSim(Deploy):
     def __init__(self, build_mode, sim_cfg):
         self.build_mode_obj = build_mode
         self.seed = sim_cfg.build_seed
+        self.build_seed = sim_cfg.build_seed
         super().__init__(sim_cfg)
 
     def _define_attrs(self):
@@ -405,6 +406,7 @@ class RunTest(Deploy):
         self.test_obj = test
         self.index = index
         self.seed = RunTest.get_seed()
+        self.build_seed = sim_cfg.build_seed
         super().__init__(sim_cfg)
 
         if build_job is not None:

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -60,7 +60,7 @@ class SimCfg(FlowCfg):
     # TODO: Find a way to set these in sim cfg instead
     ignored_wildcards = [
         "build_mode", "index", "test", "seed", "uvm_test", "uvm_test_seq",
-        "cov_db_dirs", "sw_images", "sw_build_device"
+        "cov_db_dirs", "sw_images", "sw_build_device", "build_seed"
     ]
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
@@ -108,6 +108,11 @@ class SimCfg(FlowCfg):
             self.en_build_modes.append("xprop")
         if self.build_seed:
             self.en_build_modes.append("build_seed")
+        else:
+            # TODO: when build_seed mode is not enabled, the script should not
+            # pass `--otp-seed` args. Temp support this by providing default
+            # build seed value.
+            self.build_seed = 10556718629619452145
 
         # Options built from cfg_file files
         self.project = ""


### PR DESCRIPTION
1). Fix regression error that should use `otp-seed` instead of `seed`
  when generate OTP image.
2). Because the keyword `seed` and `build_seed` are both used in run
  phase: `seed` for SV rand seed, and `build_seed` for build time random
  script input. So we need to create a variable for `build_seed`,
  otherwise the `build_seed` will be override by `seed`.
3). This is a temp solution, will need further support. If `build_seed`
  mode is not enabled, we should not pass the `--otp-seed` args. But
  current structure does not have a good way to handle this. In this PR,
  I manually added the default seed number to generate OTP image.
  Further support should be able to not pass the `otp-seed` args when it
  is not under `build_seed` mode.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>