### PR TITLE
[bazel] detect airgapped mode in `pip_wheel` repo rule

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sensor_ctrl",
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/dif:spi_host",
         "//sw/device/lib/dif:sysrst_ctrl",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -633,6 +633,7 @@ opentitan_functest(
         "//sw/device/lib/dif:pwrmgr",
         "//sw/device/lib/dif:rv_plic",
         "//sw/device/lib/dif:rv_timer",
+        "//sw/device/lib/dif:sensor_ctrl",
         "//sw/device/lib/dif:spi_device",
         "//sw/device/lib/dif:spi_host",
         "//sw/device/lib/dif:sysrst_ctrl",


### PR DESCRIPTION
In #12091, a custom bazel repository rule was setup to pre-download / build python wheels to transport them to an airgapped machine so the`pip_install` rule does not attempt to go to the internet. This commit enables the custom bazel repository rule previously added to detect if it is executing in airgapped mode (via an environment variable), and if so, use the pre-built/local Python wheels repo.

This fixes #12090.

Signed-off-by: Timothy Trippel <ttrippel@google.com>