### PR TITLE
[xcelium] Pass cov_merge_db_dir through to cov_report.tcl

### DIFF
--- a/hw/dv/tools/xcelium/cov_report.tcl
+++ b/hw/dv/tools/xcelium/cov_report.tcl
@@ -12,6 +12,10 @@
 # The supplied env var may have quotes or spaces that needs to be trimmed.
 set cov_report_dir [string trim $::env(cov_report_dir) " \"'"]
 
+# Set the input merged coverage database directory using the env var 'cov_merge_db_dir'.
+# The supplied env var may have quotes or spaces that needs to be trimmed.
+set cov_merge_db_dir [string trim $::env(cov_merge_db_dir) " \"'"]
+
 # Set the DUT name.
 set dut [string trim $::env(DUT_TOP)]
 set dut_uc [string toupper $dut]


### PR DESCRIPTION
This was removed by 6e5fc98, which changed the script to not use the
variable any more. Unfortunately, that commit was closely followed by
0012ec3 which used the variable. (Looking at the dates, I think this
was probably merge skew from a slow PR review)

Put it back!
