### PR TITLE
[dif, Kmac] Bring KMAC to S2 part 2

### DIFF
--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -779,3 +779,29 @@ dif_result_t dif_kmac_config_is_locked(const dif_kmac_t *kmac,
   *is_locked = bitfield_bit32_read(reg, KMAC_CFG_REGWEN_EN_BIT);
   return kDifOk;
 }
+
+dif_result_t dif_kmac_get_status(const dif_kmac_t *kmac,
+                                 dif_kmac_status_t *kmac_status) {
+  if (kmac == NULL || kmac_status == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t reg = mmio_region_read32(kmac->base_addr, KMAC_STATUS_REG_OFFSET);
+
+  kmac_status->sha3_state = bitfield_field32_read(
+      reg,
+      (bitfield_field32_t){.mask = 0x07, .index = KMAC_STATUS_SHA3_IDLE_BIT});
+
+  kmac_status->fifo_depth =
+      bitfield_field32_read(reg, KMAC_STATUS_FIFO_DEPTH_FIELD);
+
+  kmac_status->fifo_state = bitfield_field32_read(
+      reg,
+      (bitfield_field32_t){.mask = 0x03, .index = KMAC_STATUS_FIFO_EMPTY_BIT});
+
+  kmac_status->faults = bitfield_field32_read(
+      reg, (bitfield_field32_t){.mask = 0x03,
+                                .index = KMAC_STATUS_ALERT_FATAL_FAULT_BIT});
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -184,8 +184,12 @@ dif_result_t dif_kmac_configure(dif_kmac_t *kmac, dif_kmac_config_t config) {
                                  config.sideload);
   cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_ENTROPY_READY_BIT,
                                  entropy_ready);
-  mmio_region_write32(kmac->base_addr, KMAC_CFG_SHADOWED_REG_OFFSET, cfg_reg);
-  mmio_region_write32(kmac->base_addr, KMAC_CFG_SHADOWED_REG_OFFSET, cfg_reg);
+
+  cfg_reg = bitfield_bit32_write(cfg_reg, KMAC_CFG_SHADOWED_MSG_MASK_BIT,
+                                 config.msg_mask);
+
+  mmio_region_write32_shadowed(kmac->base_addr, KMAC_CFG_SHADOWED_REG_OFFSET,
+                               cfg_reg);
 
   // Write entropy period register.
   uint32_t entropy_period_reg = 0;
@@ -195,6 +199,7 @@ dif_result_t dif_kmac_configure(dif_kmac_t *kmac, dif_kmac_config_t config) {
   mmio_region_write32(kmac->base_addr, KMAC_ENTROPY_PERIOD_REG_OFFSET,
                       entropy_period_reg);
 
+  // Write entropy seed registers.
   // Write entropy seed registers.
   mmio_region_write32(kmac->base_addr, KMAC_ENTROPY_SEED_LOWER_REG_OFFSET,
                       (uint32_t)config.entropy_seed);

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -770,6 +770,10 @@ dif_result_t dif_kmac_end(const dif_kmac_t *kmac,
 
 dif_result_t dif_kmac_config_is_locked(const dif_kmac_t *kmac,
                                        bool *is_locked) {
+  if (kmac == NULL || is_locked == NULL) {
+    return kDifBadArg;
+  }
+
   uint32_t reg =
       mmio_region_read32(kmac->base_addr, KMAC_CFG_REGWEN_REG_OFFSET);
   *is_locked = bitfield_bit32_read(reg, KMAC_CFG_REGWEN_EN_BIT);

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -380,15 +380,87 @@ typedef enum dif_kmac_error {
 
 /**
  * The state of the message FIFO used to buffer absorbed data.
+ *
+ * The hardware defined these status in different bit fields, however they work
+ * better in the same field. i.e the fifo can't be empty and full at the same
+ * time. That said, the values chosen for this enum allow the conversion from
+ * the register bits to this enum without branches.
  */
 typedef enum dif_kmac_fifo_state {
-  /** The message FIFO is empty. */
-  kDifKmacFifoStateEmpty,
   /** The message FIFO is not empty or full. */
-  kDifKmacFifoStatePartial,
+  kDifKmacFifoStatePartial = 0,
+  /** The message FIFO is empty. */
+  kDifKmacFifoStateEmpty = 1 << 0,
   /** The message FIFO is full. Further writes will block. */
-  kDifKmacFifoStateFull,
+  kDifKmacFifoStateFull = 1 << 1,
 } dif_kmac_fifo_state_t;
+
+typedef enum dif_kmac_sha3_state {
+  /**
+   * SHA3 hashing engine is in idle state.
+   */
+  kDifKmacSha3StateIdle = 1 << 0,
+
+  /**
+   * SHA3 is receiving message stream and processing it.
+   */
+  kDifKmacSha3StateAbsorbing = 1 << 1,
+
+  /**
+   * SHA3 completes sponge absorbing stage. In this stage, SW can manually run
+   * the hashing engine.
+   */
+  kDifKmacSha3StateSqueezing = 1 << 2,
+} dif_kmac_sha3_state_t;
+
+/**
+ * The kmac error faults.
+ *
+ * The hardware defined these status in different bit fields, however they work
+ * better in the same field. Then the values chosen for this enum allow the
+ * conversion from the register bits to this enum without branches.
+ */
+typedef enum dif_kmac_alert_faults {
+  /**
+   * Neither errors nor fault has occurred.
+   */
+  kDifKmacAlertNone = 0,
+  /**
+   * A fatal fault has occurred and the KMAC unit needs to be reset (1),
+   * Examples for such faults include i) TL-UL bus integrity fault ii)
+   * storage errors in the shadow registers iii) errors in the message,
+   * round, or key counter iv) any internal FSM entering an invalid state v)
+   * an error in the redundant lfsr.
+   */
+  kDifKmacAlertFatalFault = 1 << 0,
+  /**
+   * An update error has occurred in the shadowed Control Register. KMAC
+   * operation needs to be restarted by re-writing the Control Register.
+   */
+  kDifKmacAlertRecovCtrlUpdate = 1 << 1,
+} dif_kmac_alert_faults_t;
+
+typedef struct dif_kmac_status {
+  /**
+   * Sha3 state.
+   */
+  dif_kmac_sha3_state_t sha3_state;
+
+  /**
+   * Message FIFO entry count.
+   */
+  uint32_t fifo_depth;
+
+  /**
+   * Kmac fifo state.
+   */
+  dif_kmac_fifo_state_t fifo_state;
+
+  /**
+   * Kmac faults and errors state.
+   */
+  dif_kmac_alert_faults_t faults;
+} dif_kmac_status_t;
 
 /**
  * Configures KMAC with runtime information.
@@ -616,14 +688,12 @@ dif_result_t dif_kmac_reset(const dif_kmac_t *kmac,
  * Fetch the current status of the message FIFO used to buffer absorbed data.
  *
  * @param kmac A KMAC handle.
- * @param[out] state The state of the FIFO (empty, partially full or full).
- * @param[out] depth The current depth of the FIFO (optional).
+ * @param[out] kmac_status The kmac status struct.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_kmac_get_fifo_state(const dif_kmac_t *kmac,
-                                     dif_kmac_fifo_state_t *fifo_state,
-                                     uint32_t *depth);
+dif_result_t dif_kmac_get_status(const dif_kmac_t *kmac,
+                                 dif_kmac_status_t *kmac_status);
 
 /**
  * Reports whether or not the KMAC configuration register is locked.

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -133,6 +133,13 @@ typedef struct dif_kmac_config {
    */
   bool sideload;
 
+  /**
+   * Message Masking with PRNG.
+   * If true, KMAC applies PRNG to the input messages to the Keccak module when
+   * KMAC mode is on.
+   */
+  bool msg_mask;
+
 } dif_kmac_config_t;
 
 /**

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -602,6 +602,7 @@ class KmacConfigureTest : public KmacTest {
       .message_big_endian = false,
       .output_big_endian = false,
       .sideload = false,
+      .msg_mask = true,
   };
   KmacConfigureTest() {
     config_reg_.msg_big_endian = kmac_config_.message_big_endian;
@@ -611,6 +612,7 @@ class KmacConfigureTest : public KmacTest {
     config_reg_.sideload = kmac_config_.sideload;
     config_reg_.key_strength = 0;
     config_reg_.mode = 0;
+    config_reg_.msg_mask = kmac_config_.msg_mask;
   }
 };
 

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -561,6 +561,12 @@ TEST_F(ConfigLock, Unlocked) {
   EXPECT_FALSE(lock);
 }
 
+TEST_F(ConfigLock, BadArg) {
+  bool locked;
+  EXPECT_DIF_BADARG(dif_kmac_config_is_locked(nullptr, &locked));
+  EXPECT_DIF_BADARG(dif_kmac_config_is_locked(&kmac_, nullptr));
+}
+
 class KmacEndTest : public KmacTest {
  protected:
   KmacEndTest() { op_state_.squeezing = true; }


### PR DESCRIPTION
# This PR:

- Add unit test for `dif_kmac_configure`.
- Add the option to control de `msg_mask` config.
- Refactor the funciton `dif_kmac_config_is_locked`.
- Add the function dif_kmac_get_status.