### PR TITLE
[pwrmgr] clarify issues found during pwrmgr v2s review

### DIFF
--- a/doc/rm/comportability_specification/index.md
+++ b/doc/rm/comportability_specification/index.md
@@ -309,6 +309,7 @@ The following standardised countermeasures are defined:
 | LOCAL_ESC      | A local escalation event is triggered when an attack is detected |
 | GLOBAL_ESC     | A global escalation event is triggered when an attack is detected |
 | UNPREDICTABLE  | Behaviour is unpredictable to frustrate repeatable FI attacks |
+| TERMINAL       | The asset goes into a terminal statet that no longer responds to any stimulus |
 | CM             | Catch-all for countermeasures that cannot be further specified. This is a very broad category: avoid if possible and give an instance or net name if not. |
 
 ## Register Handling

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson
@@ -141,7 +141,7 @@
     { name: "FSM.SPARSE",
       desc: "Sparse encoding for slow and fast state machines."
     }
-    { name: "FSM.LOCAL_ESC",
+    { name: "FSM.TERMINAL",
       desc: "When FSMs reach a bad state, escalate directly and force user reset."
     }
     { name: "CTRL_FLOW.GLOBAL_ESC",

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -199,8 +199,11 @@
     { name: "FSM.SPARSE",
       desc: "Sparse encoding for slow and fast state machines."
     }
-    { name: "FSM.LOCAL_ESC",
-      desc: "When FSMs reach a bad state, escalate directly and force user reset."
+    { name: "FSM.TERMINAL",
+      desc: '''
+        When FSMs reach a bad state, go into a terminate state that does not
+        recover without user or external host intervention.
+      '''
     }
     { name: "CTRL_FLOW.GLOBAL_ESC",
       desc: "When global escalation is received, proceed directly to reset."
@@ -638,6 +641,13 @@
           name: "ESC_TIMEOUT",
           desc: '''
             When 1, an escalation clock / reset timeout has occurred.
+          ''',
+        },
+
+        { bits: "2",
+          name: "MAIN_PD_GLITCH",
+          desc: '''
+            When 1, unexpected power glitch was observed on main PD.
           ''',
         },
       ]

--- a/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/ip/pwrmgr/data/pwrmgr_sec_cm_testplan.hjson
@@ -128,8 +128,8 @@
       tests: ["pwrmgr_sec_cm"]
     }
     {
-      name: sec_cm_fsm_local_esc
-      desc: '''Verify the countermeasure(s) FSM.LOCAL_ESC.
+      name: sec_cm_fsm_terminal
+      desc: '''Verify the countermeasure(s) FSM.TERMINAL.
 
             This is caused by any invalid (slow|fast) state.
 

--- a/hw/ip/pwrmgr/doc/_index.md
+++ b/hw/ip/pwrmgr/doc/_index.md
@@ -100,6 +100,9 @@ When this occurs, the slow FSM sends an `invalid` indication to the fast FSM and
 The clocks are kept on however to allow the fast FSM to operate if it is able to receive the `invalid` indication.
 The slow FSM does not recover from this state until the system is reset by POR.
 
+Unlike [escalation resets](#escalation-reset-request), the system does not self reset.
+Instead the system goes into a terminal non-responsive state where a user or host must directly intervene by toggling the power or asserting an external reset input.
+
 ## Fast Clock Domain FSM
 
 The fast clock domain FSM (referred to as fast FSM from here on) resets to `Low Power` state and waits for a power-up request from the slow FSM.

--- a/hw/ip/pwrmgr/rtl/pwrmgr.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr.sv
@@ -258,10 +258,12 @@ module pwrmgr
 
   assign hw2reg.ctrl_cfg_regwen.d = lowpwr_cfg_wen;
 
-  assign hw2reg.fault_status.reg_intg_err.de = reg_intg_err;
-  assign hw2reg.fault_status.reg_intg_err.d  = 1'b1;
-  assign hw2reg.fault_status.esc_timeout.de  = esc_timeout;
-  assign hw2reg.fault_status.esc_timeout.d   = 1'b1;
+  assign hw2reg.fault_status.reg_intg_err.de    = reg_intg_err;
+  assign hw2reg.fault_status.reg_intg_err.d     = 1'b1;
+  assign hw2reg.fault_status.esc_timeout.de     = esc_timeout;
+  assign hw2reg.fault_status.esc_timeout.d      = 1'b1;
+  assign hw2reg.fault_status.main_pd_glitch.de  = peri_reqs_masked.rstreqs[ResetMainPwrIdx];
+  assign hw2reg.fault_status.main_pd_glitch.d   = 1'b1;
 
 
   ////////////////////////////
@@ -278,7 +280,8 @@ module pwrmgr
   };
 
   assign alerts[0] = reg2hw.fault_status.reg_intg_err.q |
-                     reg2hw.fault_status.esc_timeout.q;
+                     reg2hw.fault_status.esc_timeout.q |
+                     reg2hw.fault_status.main_pd_glitch.q;
 
   for (genvar i = 0; i < NumAlerts; i++) begin : gen_alert_tx
     prim_alert_sender #(

--- a/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_fsm.sv
@@ -432,7 +432,7 @@ module pwrmgr_fsm import pwrmgr_pkg::*; import pwrmgr_reg_pkg::*;(
       end
 
       // Terminal state, kill everything
-      // SEC_CM: FSM.LOCAL_ESC
+      // SEC_CM: FSM.TERMINAL
       default: begin
         rst_lc_req_d = {PowerDomains{1'b1}};
         rst_sys_req_d = {PowerDomains{1'b1}};

--- a/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
@@ -253,7 +253,7 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
       // Signal the fast FSM if it somehow is still running.
       // Both FSMs are now permanently out of sync and the device
       // must be rebooted.
-      // SEC_CM: FSM.LOCAL_ESC
+      // SEC_CM: FSM.TERMINAL
       default: begin
         fsm_invalid_d = 1'b1;
         pd_nd         = 1'b0;

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -238,8 +238,11 @@
     { name: "FSM.SPARSE",
       desc: "Sparse encoding for slow and fast state machines."
     }
-    { name: "FSM.LOCAL_ESC",
-      desc: "When FSMs reach a bad state, escalate directly and force user reset."
+    { name: "FSM.TERMINAL",
+      desc: '''
+        When FSMs reach a bad state, go into a terminate state that does not
+        recover without user or external host intervention.
+      '''
     }
     { name: "CTRL_FLOW.GLOBAL_ESC",
       desc: "When global escalation is received, proceed directly to reset."
@@ -677,6 +680,13 @@
           name: "ESC_TIMEOUT",
           desc: '''
             When 1, an escalation clock / reset timeout has occurred.
+          ''',
+        },
+
+        { bits: "2",
+          name: "MAIN_PD_GLITCH",
+          desc: '''
+            When 1, unexpected power glitch was observed on main PD.
           ''',
         },
       ]

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr_sec_cm_testplan.hjson
@@ -129,8 +129,8 @@
       tests: ["pwrmgr_sec_cm"]
     }
     {
-      name: sec_cm_fsm_local_esc
-      desc: '''Verify the countermeasure(s) FSM.LOCAL_ESC.
+      name: sec_cm_fsm_terminal
+      desc: '''Verify the countermeasure(s) FSM.TERMINAL.
 
             This is caused by any invalid (slow|fast) state.
 

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_pkg.sv
@@ -102,6 +102,9 @@ package pwrmgr_reg_pkg;
     struct packed {
       logic        q;
     } esc_timeout;
+    struct packed {
+      logic        q;
+    } main_pd_glitch;
   } pwrmgr_reg2hw_fault_status_reg_t;
 
   typedef struct packed {
@@ -161,34 +164,38 @@ package pwrmgr_reg_pkg;
       logic        d;
       logic        de;
     } esc_timeout;
+    struct packed {
+      logic        d;
+      logic        de;
+    } main_pd_glitch;
   } pwrmgr_hw2reg_fault_status_reg_t;
 
   // Register -> HW type
   typedef struct packed {
-    pwrmgr_reg2hw_intr_state_reg_t intr_state; // [35:35]
-    pwrmgr_reg2hw_intr_enable_reg_t intr_enable; // [34:34]
-    pwrmgr_reg2hw_intr_test_reg_t intr_test; // [33:32]
-    pwrmgr_reg2hw_alert_test_reg_t alert_test; // [31:30]
-    pwrmgr_reg2hw_control_reg_t control; // [29:24]
-    pwrmgr_reg2hw_cfg_cdc_sync_reg_t cfg_cdc_sync; // [23:22]
-    pwrmgr_reg2hw_wakeup_en_mreg_t [5:0] wakeup_en; // [21:16]
-    pwrmgr_reg2hw_reset_en_mreg_t [1:0] reset_en; // [15:14]
-    pwrmgr_reg2hw_wake_info_capture_dis_reg_t wake_info_capture_dis; // [13:13]
-    pwrmgr_reg2hw_wake_info_reg_t wake_info; // [12:2]
-    pwrmgr_reg2hw_fault_status_reg_t fault_status; // [1:0]
+    pwrmgr_reg2hw_intr_state_reg_t intr_state; // [36:36]
+    pwrmgr_reg2hw_intr_enable_reg_t intr_enable; // [35:35]
+    pwrmgr_reg2hw_intr_test_reg_t intr_test; // [34:33]
+    pwrmgr_reg2hw_alert_test_reg_t alert_test; // [32:31]
+    pwrmgr_reg2hw_control_reg_t control; // [30:25]
+    pwrmgr_reg2hw_cfg_cdc_sync_reg_t cfg_cdc_sync; // [24:23]
+    pwrmgr_reg2hw_wakeup_en_mreg_t [5:0] wakeup_en; // [22:17]
+    pwrmgr_reg2hw_reset_en_mreg_t [1:0] reset_en; // [16:15]
+    pwrmgr_reg2hw_wake_info_capture_dis_reg_t wake_info_capture_dis; // [14:14]
+    pwrmgr_reg2hw_wake_info_reg_t wake_info; // [13:3]
+    pwrmgr_reg2hw_fault_status_reg_t fault_status; // [2:0]
   } pwrmgr_reg2hw_t;
 
   // HW -> register type
   typedef struct packed {
-    pwrmgr_hw2reg_intr_state_reg_t intr_state; // [36:35]
-    pwrmgr_hw2reg_ctrl_cfg_regwen_reg_t ctrl_cfg_regwen; // [34:34]
-    pwrmgr_hw2reg_control_reg_t control; // [33:32]
-    pwrmgr_hw2reg_cfg_cdc_sync_reg_t cfg_cdc_sync; // [31:30]
-    pwrmgr_hw2reg_wake_status_mreg_t [5:0] wake_status; // [29:18]
-    pwrmgr_hw2reg_reset_status_mreg_t [1:0] reset_status; // [17:14]
-    pwrmgr_hw2reg_escalate_reset_status_reg_t escalate_reset_status; // [13:12]
-    pwrmgr_hw2reg_wake_info_reg_t wake_info; // [11:4]
-    pwrmgr_hw2reg_fault_status_reg_t fault_status; // [3:0]
+    pwrmgr_hw2reg_intr_state_reg_t intr_state; // [38:37]
+    pwrmgr_hw2reg_ctrl_cfg_regwen_reg_t ctrl_cfg_regwen; // [36:36]
+    pwrmgr_hw2reg_control_reg_t control; // [35:34]
+    pwrmgr_hw2reg_cfg_cdc_sync_reg_t cfg_cdc_sync; // [33:32]
+    pwrmgr_hw2reg_wake_status_mreg_t [5:0] wake_status; // [31:20]
+    pwrmgr_hw2reg_reset_status_mreg_t [1:0] reset_status; // [19:16]
+    pwrmgr_hw2reg_escalate_reset_status_reg_t escalate_reset_status; // [15:14]
+    pwrmgr_hw2reg_wake_info_reg_t wake_info; // [13:6]
+    pwrmgr_hw2reg_fault_status_reg_t fault_status; // [5:0]
   } pwrmgr_hw2reg_t;
 
   // Register offsets

--- a/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
+++ b/hw/top_earlgrey/ip/pwrmgr/rtl/autogen/pwrmgr_reg_top.sv
@@ -182,6 +182,7 @@ module pwrmgr_reg_top (
   logic wake_info_abort_wd;
   logic fault_status_reg_intg_err_qs;
   logic fault_status_esc_timeout_qs;
+  logic fault_status_main_pd_glitch_qs;
 
   // Register instances
   // R[intr_state]: V(False)
@@ -1096,6 +1097,31 @@ module pwrmgr_reg_top (
     .qs     (fault_status_esc_timeout_qs)
   );
 
+  //   F[main_pd_glitch]: 2:2
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_main_pd_glitch (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.main_pd_glitch.de),
+    .d      (hw2reg.fault_status.main_pd_glitch.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.main_pd_glitch.q),
+
+    // to register interface (read)
+    .qs     (fault_status_main_pd_glitch_qs)
+  );
+
 
 
   logic [16:0] addr_hit;
@@ -1298,6 +1324,7 @@ module pwrmgr_reg_top (
       addr_hit[16]: begin
         reg_rdata_next[0] = fault_status_reg_intg_err_qs;
         reg_rdata_next[1] = fault_status_esc_timeout_qs;
+        reg_rdata_next[2] = fault_status_main_pd_glitch_qs;
       end
 
       default: begin

--- a/util/reggen/countermeasure.py
+++ b/util/reggen/countermeasure.py
@@ -59,6 +59,7 @@ CM_TYPES = [
     'LOCAL_ESC',
     'GLOBAL_ESC',
     'UNPREDICTABLE',
+    'TERMINAL',
     'CM'
 ]
 


### PR DESCRIPTION
- fixes #12072
- clarify documentation on terminal vs local_esc
- allow main_pd_glitch to also generate alert for consistency
- this alert is not useful at chip_earlgrey because a reset will also
  wipe out alert_handler, but it makes the block level behavior more consistent
  and easier for integration into different systems in the future.

Signed-off-by: Timothy Chen <timothytim@google.com>