### PR TITLE
[bazel,ci] Use Bazel to execute Verilator tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
       sudo apt-get remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
     displayName: Remove existing Clang installation
   - template: ci/install-package-dependencies.yml
+
     ## !!!
     ##
     ##   The steps below here are duplicated in ci/jobs/quick-lint.sh
@@ -52,49 +53,53 @@ jobs:
     ## !!!
   - bash: ci/scripts/show-env.sh
     displayName: Display environment information
+
   - bash: ci/scripts/lint-commits.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check commit metadata
+
   - bash: ci/scripts/check-licence-headers.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check Licence Headers
+
   - bash: ci/scripts/exec-check.sh
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check executable bits
+
   - bash: ci/scripts/check-ascii.sh
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check for non-ASCII characters in source code
+
   - bash: ci/scripts/python-lint.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Run Python lint (flake8)
     continueOnError: true
+
   - bash: ci/scripts/mypy.sh
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Run Python lint (mypy)
+
   - bash: ci/scripts/check-generated.sh
     displayName: Ensure all generated files are clean and up-to-date
+
   - bash: ci/scripts/clang-format.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Use clang-format to check C/C++ coding style
+
   - bash: ci/scripts/include-guard.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check formatting on header guards
+
   - bash: ci/scripts/whitespace.sh $SYSTEM_PULLREQUEST_TARGETBRANCH
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: Check trailing whitespace
-  - bash: ci/scripts/verible-lint.sh rtl
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Style-Lint RTL Verilog source files with Verible
-  - bash: ci/scripts/verible-lint.sh dv
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Style-Lint DV Verilog source files with Verible
-  - bash: ci/scripts/verible-lint.sh fpv
-    condition: eq(variables['Build.Reason'], 'PullRequest')
-    displayName: Style-Lint FPV Verilog source files with Verible
+
   - bash: ci/scripts/build-docs.sh
     displayName: Render documentation
+
   - bash: ci/scripts/build-site.sh
     displayName: Render landing site
+
   - bash: ci/scripts/get-build-type.sh "$SYSTEM_PULLREQUEST_TARGETBRANCH" "$(Build.Reason)"
     displayName: Check what kinds of changes the PR contains
     name: DetermineBuildType
@@ -108,8 +113,21 @@ jobs:
   - template: ci/install-package-dependencies.yml
   - bash: ci/bazelisk.sh run buildifier_check
     displayName: Use buildifier to check Bazel coding style
+
   - bash: ci/scripts/check-vendoring.sh
     displayName: Check vendored directories are up-to-date
+
+  - bash: ci/scripts/verible-lint.sh rtl
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Style-Lint RTL Verilog source files with Verible
+
+  - bash: ci/scripts/verible-lint.sh dv
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Style-Lint DV Verilog source files with Verible
+
+  - bash: ci/scripts/verible-lint.sh fpv
+    condition: eq(variables['Build.Reason'], 'PullRequest')
+    displayName: Style-Lint FPV Verilog source files with Verible
 
 - job: sw_build
   displayName: Build Software for Earl Grey toplevel design
@@ -247,7 +265,8 @@ jobs:
         - "/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator"
 
 - job: execute_verilated_tests
-  displayName: Execute tests on the Verilated system (excl. slow tests)
+  displayName: "Run tests on sim_verilator"
+  dependsOn: lint
   pool: ci-public
   timeoutInMinutes: 120
   dependsOn:
@@ -274,7 +293,8 @@ jobs:
     displayName: Execute tests
 
 - job: execute_verilated_tests_englishbreakfast
-  displayName: Execute tests on the Verilated English Breakfast toplevel design
+  displayName: "Run tests on sim_verilator (top_englishbreakfast)"
+  dependsOn: lint
   pool: ci-public
   dependsOn:
     - chip_englishbreakfast_verilator

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -223,26 +223,6 @@ jobs:
       includePatterns:
         - "/sw/device/***"
 
-- job: chip_earlgrey_verilator
-  displayName: Build Verilator simulation of the Earl Grey toplevel design
-  dependsOn: lint
-  condition: and(succeeded(), eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'))
-  pool: ci-public
-  steps:
-  - template: ci/install-package-dependencies.yml
-  - bash: |
-      python3 --version
-      fusesoc --version
-      verilator --version
-      verible-verilog-lint --version
-    displayName: Display environment
-  - bash: ci/scripts/build-chip-verilator.sh earlgrey
-    displayName: Build simulation with Verilator
-  - template: ci/upload-artifacts-template.yml
-    parameters:
-      includePatterns:
-        - "/hw/top_earlgrey/Vchip_earlgrey_verilator"
-
 - job: chip_englishbreakfast_verilator
   displayName: Build Verilator simulation of the English Breakfast toplevel design
   dependsOn: lint
@@ -265,58 +245,74 @@ jobs:
         - "/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator"
 
 - job: execute_verilated_tests
-  displayName: "Run tests on sim_verilator"
+  displayName: "Build and run tests on sim_verilator"
   dependsOn: lint
   pool: ci-public
-  timeoutInMinutes: 120
-  dependsOn:
-    - chip_earlgrey_verilator
-    - sw_build
+  timeoutInMinutes: 180
   steps:
   - template: ci/install-package-dependencies.yml
-  - template: ci/download-artifacts-template.yml
-    parameters:
-      downloadPartialBuildBinFrom:
-        - chip_earlgrey_verilator
-        - sw_build
   - bash: |
-      # Install an additional pytest dependency for result upload.
-      pip3 install pytest-azurepipelines
-
+      # Because Verilator is incredibly slow in CI, we make two
+      # changes to make sure tests complete:
+      #
+      # --test_timeout is used to upgrade all short and medium tests time
+      # out after ten minutes.
+      ci/bazelisk.sh test \
+        --build_tests_only=true \
+        --test_timeout=600,600,-1,-1 \
+        --local_test_jobs=4 \
+        --test_tag_filters=-broken,verilator_in_ci \
+        //...
+    displayName: Build and execute tests
+  - bash: |
       . util/build_consts.sh
-      pytest --version
-      pytest test/systemtest/earlgrey/test_sim_verilator.py \
-        -m "not slow" \
-        --log-cli-level=DEBUG \
-        --test-run-title="Run system tests with Verilator simulation (excl. slow tests)" \
-        --napoleon-docstrings
-    displayName: Execute tests
+      mkdir -p "$BIN_DIR/hw/top_earlgrey/"
+      cp $(find bazel-out/* -name Vchip_sim_tb) \
+        "$BIN_DIR/hw/top_earlgrey/Vchip_earlgrey_verilator"
+    displayName: "Copy //hw:verilator to legacy $BIN_DIR location"
+  - template: ci/upload-artifacts-template.yml
+    parameters:
+      includePatterns:
+        - "/hw/top_earlgrey/Vchip_earlgrey_verilator"
 
 - job: execute_verilated_tests_englishbreakfast
   displayName: "Run tests on sim_verilator (top_englishbreakfast)"
-  dependsOn: lint
   pool: ci-public
   dependsOn:
     - chip_englishbreakfast_verilator
-    - sw_build_englishbreakfast
   steps:
   - template: ci/install-package-dependencies.yml
   - template: ci/download-artifacts-template.yml
     parameters:
       downloadPartialBuildBinFrom:
         - chip_englishbreakfast_verilator
-        - sw_build_englishbreakfast
   - bash: |
-      # Install an additional pytest dependency for result upload.
-      pip3 install pytest-azurepipelines
-
+      # Only a single test is supported on EB. Currently Bazel cannot build
+      # EB Verilator, so we only build the test with Bazel and then use ottool
+      # directly.
+      set -e
       . util/build_consts.sh
-      pytest --version
-      pytest test/systemtest/englishbreakfast/test_sim_verilator.py \
-        -m "not slow" \
-        --log-cli-level=DEBUG \
-        --test-run-title="Run English Breakfast system tests with Verilator simulation" \
-        --napoleon-docstrings
+
+      # Build the modified EB software.
+      ./hw/top_englishbreakfast/util/prepare_sw.py --bazel -b
+
+      # Build some other things we'll need.
+      ci/bazelisk.sh build //sw/host/opentitantool //hw/ip/otp_ctrl/data:rma_image_verilator
+
+      # Run the one test.
+      bazel-bin/sw/host/opentitantool/opentitantool \
+        --rcfile="" \
+        --logging=info \
+        --interface=verilator \
+        --conf=sw/host/opentitantool/config/opentitan_verilator.json \
+        --verilator-bin=$BIN_DIR/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator \
+        --verilator-rom=$(find bazel-out/* -name 'test_rom_sim_verilator.scr.39.vmem') \
+        --verilator-flash=$(find bazel-out/* -name 'aes_smoketest_prog_sim_verilator.64.scr.vmem') \
+        --verilator-otp=bazel-bin/hw/ip/otp_ctrl/data/rma_image_verilator.vmem \
+        console \
+        --exit-failure="(FAIL|FAULT).*\n" \
+        --exit-success="PASS.*\n" \
+        --timeout=3600s
     displayName: Execute tests
 
 - job: otbn_standalone_tests
@@ -489,7 +485,7 @@ jobs:
   dependsOn:
     - lint
     - sw_build
-    - chip_earlgrey_verilator
+    - execute_verilated_tests
     - chip_earlgrey_cw310
   condition: and(eq(dependencies.lint.outputs['DetermineBuildType.onlyDocChanges'], '0'), eq(dependencies.lint.outputs['DetermineBuildType.onlyDvChanges'], '0'))
   steps:
@@ -524,7 +520,6 @@ jobs:
       assets: |
           $(Build.ArtifactStagingDirectory)/dist-final/*
 
-
 - job: build_docker_containers
   displayName: "Build Docker Containers"
   pool:
@@ -556,8 +551,7 @@ jobs:
   displayName: Bazel Software Build and Test
   timeoutInMinutes: 120
   dependsOn: lint
-  pool:
-    vmImage: ubuntu-18.04
+  pool: ci-public
   variables:
   - name: bazelCacheGcpKeyPath
     value: ''

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -6,12 +6,8 @@ load("//rules:fusesoc.bzl", "fusesoc_build")
 
 fusesoc_build(
     name = "verilator_real",
-    srcs = [
-        ":all_files",
-    ],
-    cores = [
-        "//:cores",
-    ],
+    srcs = [":all_files"],
+    cores = ["//:cores"],
     data = ["//hw/ip/otbn:all_files"],
     systems = ["lowrisc:dv:chip_verilator_sim"],
     target = "sim",

--- a/hw/top_englishbreakfast/util/prepare_sw.py
+++ b/hw/top_englishbreakfast/util/prepare_sw.py
@@ -29,9 +29,9 @@ BINARIES = [
 ]
 
 BAZEL_BINARIES = [
-    '//sw/device/lib/testing/test_rom',
+    '//sw/device/lib/testing/test_rom:test_rom',
     '//sw/device/sca:aes_serial',
-    '//sw/device/tests:aes_smoketest',
+    '//sw/device/tests:aes_smoketest_prog',
     '//sw/device/examples/hello_world',
 ]
 
@@ -142,7 +142,7 @@ def main():
     # Build the software including test_rom to enable the FPGA build.
     if args.bazel:
         shell_out([
-            'bazel', 'build',
+            REPO_TOP / 'bazelisk.sh', 'build',
             '--copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_',
         ] + BAZEL_BINARIES)
     else:

--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -45,6 +45,7 @@ opentitan_functest(
     srcs = ["boot_data_functest.c"],
     verilator = verilator_params(
         timeout = "eternal",
+        tags = ["verilator_in_ci"],
     ),
     deps = [
         ":boot_data",
@@ -137,6 +138,10 @@ cc_library(
 opentitan_functest(
     name = "irq_asm_functest",
     srcs = ["irq_asm_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+        tags = ["verilator_in_ci"],
+    ),
     deps = [
         ":error",
         ":irq_asm",

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -52,6 +52,10 @@ cc_test(
 opentitan_functest(
     name = "alert_functest",
     srcs = ["alert_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+        tags = ["verilator_in_ci"],
+    ),
     deps = [
         ":alert",
         ":rstmgr",
@@ -143,6 +147,7 @@ cc_test(
 opentitan_functest(
     name = "hmac_functest",
     srcs = ["hmac_functest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         ":hmac",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -376,6 +381,7 @@ opentitan_functest(
     srcs = ["retention_sram_functest.c"],
     verilator = verilator_params(
         timeout = "long",
+        tags = ["verilator_in_ci"],
     ),
     deps = [
         ":retention_sram",
@@ -488,6 +494,7 @@ cc_test(
 opentitan_functest(
     name = "uart_functest",
     srcs = ["uart_functest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         ":uart",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -534,6 +541,7 @@ opentitan_functest(
     srcs = ["watchdog_functest.c"],
     verilator = verilator_params(
         timeout = "long",
+        tags = ["verilator_in_ci"],
     ),
     deps = [
         ":retention_sram",

--- a/sw/device/silicon_creator/lib/sigverify/BUILD
+++ b/sw/device/silicon_creator/lib/sigverify/BUILD
@@ -63,10 +63,7 @@ opentitan_functest(
     srcs = ["mod_exp_ibex_functest.c"],
     verilator = verilator_params(
         timeout = "long",
-        tags = [
-            "cpu:4",
-            "manual",
-        ],
+        tags = ["manual"],
     ),
     deps = [
         ":mod_exp_ibex",
@@ -117,10 +114,7 @@ opentitan_functest(
     srcs = ["mod_exp_otbn_functest.c"],
     verilator = verilator_params(
         timeout = "long",
-        tags = [
-            "cpu:4",
-            "manual",
-        ],
+        tags = ["manual"],
     ),
     deps = [
         ":mod_exp_otbn",
@@ -191,8 +185,8 @@ opentitan_functest(
     verilator = verilator_params(
         timeout = "long",
         tags = [
-            "cpu:4",
             "manual",
+            "verilator_in_ci",
         ],
     ),
     deps = [
@@ -208,10 +202,7 @@ opentitan_functest(
     srcs = ["sigverify_dynamic_functest.c"],
     verilator = verilator_params(
         timeout = "long",
-        tags = [
-            "cpu:4",
-            "manual",
-        ],
+        tags = ["manual"],
     ),
     deps = [
         ":sigverify",

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -293,10 +293,7 @@ opentitan_functest(
     ],
     verilator = verilator_params(
         rom = ":mask_rom_sim_verilator_scr_vmem",
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
+        tags = ["broken"],
     ),
     deps = [
         "//sw/device/lib/testing/test_framework:ottf_main",

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -8,12 +8,7 @@ load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 opentitan_functest(
     name = "aes_idle_test",
     srcs = ["aes_idle_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
@@ -55,6 +50,7 @@ alias(
 opentitan_functest(
     name = "aes_smoketest",
     srcs = ["aes_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         ":aes_smoketest_entropy_testutils",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
@@ -89,6 +85,7 @@ opentitan_functest(
 opentitan_functest(
     name = "aon_timer_smoketest",
     srcs = ["aon_timer_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:aon_timer",
@@ -102,12 +99,7 @@ opentitan_functest(
 opentitan_functest(
     name = "aon_timer_wdog_bite_reset_test",
     srcs = ["aon_timer_wdog_bite_reset_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:math",
@@ -165,12 +157,7 @@ cc_library(
 opentitan_functest(
     name = "clkmgr_external_clk_src_for_sw_fast_test",
     srcs = ["clkmgr_external_clk_src_for_sw_fast_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         ":clkmgr_external_clk_src_for_sw_impl",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -180,12 +167,7 @@ opentitan_functest(
 opentitan_functest(
     name = "clkmgr_external_clk_src_for_sw_slow_test",
     srcs = ["clkmgr_external_clk_src_for_sw_slow_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         ":clkmgr_external_clk_src_for_sw_impl",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -226,6 +208,7 @@ opentitan_functest(
 opentitan_functest(
     name = "clkmgr_smoketest",
     srcs = ["clkmgr_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
@@ -251,6 +234,7 @@ opentitan_functest(
 opentitan_functest(
     name = "crt_test",
     srcs = ["crt_test.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -268,12 +252,7 @@ opentitan_functest(
 opentitan_functest(
     name = "csrng_smoketest",
     srcs = ["csrng_smoketest.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:mmio",
@@ -286,12 +265,7 @@ opentitan_functest(
 opentitan_functest(
     name = "entropy_src_fw_ovr_test",
     srcs = ["entropy_src_fw_ovr_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
@@ -355,12 +329,7 @@ opentitan_functest(
 opentitan_functest(
     name = "flash_ctrl_idle_low_power_test",
     srcs = ["flash_ctrl_idle_low_power_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
@@ -400,6 +369,7 @@ opentitan_functest(
 opentitan_functest(
     name = "flash_ctrl_test",
     srcs = ["flash_ctrl_test.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:macros",
@@ -415,19 +385,7 @@ opentitan_functest(
 opentitan_functest(
     name = "gpio_smoketest",
     srcs = ["gpio_smoketest.c"],
-    verilator = verilator_params(
-        args = [
-            "--verilator-args=--trace",
-            "console",
-            "--timeout=3600s",
-            "--exit-failure=FAIL",
-            "--exit-success=PASS",
-        ],
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/testing/test_framework:ottf_main",
@@ -437,12 +395,7 @@ opentitan_functest(
 opentitan_functest(
     name = "hmac_enc_irq_test",
     srcs = ["hmac_enc_irq_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = ["broken"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
@@ -513,6 +466,7 @@ opentitan_functest(
 opentitan_functest(
     name = "kmac_mode_cshake_test",
     srcs = ["kmac_mode_cshake_test.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -527,6 +481,7 @@ opentitan_functest(
 opentitan_functest(
     name = "kmac_mode_kmac_test",
     srcs = ["kmac_mode_kmac_test.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -541,6 +496,7 @@ opentitan_functest(
 opentitan_functest(
     name = "kmac_smoketest",
     srcs = ["kmac_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -590,6 +546,7 @@ opentitan_functest(
 opentitan_functest(
     name = "otbn_irq_test",
     srcs = ["otbn_irq_test.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
@@ -601,6 +558,26 @@ opentitan_functest(
         "//sw/device/lib/testing:entropy_testutils",
         "//sw/device/lib/testing/test_framework:ottf_main",
         "//sw/otbn/code-snippets:err_test",
+    ],
+)
+
+opentitan_functest(
+    name = "otbn_randomness_test",
+    srcs = ["otbn_randomness_test.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/dif:base",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:otbn",
+        "//sw/device/lib/runtime:ibex",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:otbn",
+        "//sw/device/lib/testing:clkmgr_testutils",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "//sw/otbn/code-snippets:randomness",
     ],
 )
 
@@ -639,6 +616,7 @@ opentitan_functest(
 opentitan_functest(
     name = "otbn_smoketest",
     srcs = ["otbn_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/dif:otbn",
@@ -655,6 +633,7 @@ opentitan_functest(
 opentitan_functest(
     name = "otp_ctrl_smoketest",
     srcs = ["otp_ctrl_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
@@ -670,12 +649,10 @@ opentitan_functest(
 opentitan_functest(
     name = "pmp_smoketest_napot",
     srcs = ["pmp_smoketest_napot.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = [
+        "broken",
+        "verilator_in_ci",
+    ]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
@@ -689,12 +666,10 @@ opentitan_functest(
 opentitan_functest(
     name = "pmp_smoketest_tor",
     srcs = ["pmp_smoketest_tor.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+    verilator = verilator_params(tags = [
+        "broken",
+        "verilator_in_ci",
+    ]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
@@ -708,6 +683,7 @@ opentitan_functest(
 opentitan_functest(
     name = "pwrmgr_smoketest",
     srcs = ["pwrmgr_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -739,6 +715,7 @@ opentitan_functest(
 opentitan_functest(
     name = "rstmgr_smoketest",
     srcs = ["rstmgr_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:mmio",
@@ -786,6 +763,7 @@ opentitan_functest(
 opentitan_functest(
     name = "rv_plic_smoketest",
     srcs = ["rv_plic_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
@@ -802,6 +780,7 @@ opentitan_functest(
 opentitan_functest(
     name = "rv_timer_smoketest",
     srcs = ["rv_timer_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:irq",
@@ -904,6 +883,7 @@ opentitan_functest(
 opentitan_functest(
     name = "sram_ctrl_execution_test_ret",
     srcs = ["sram_ctrl_execution_test_ret.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:macros",
@@ -949,6 +929,7 @@ opentitan_functest(
 opentitan_functest(
     name = "uart_smoketest",
     srcs = ["uart_smoketest.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
@@ -962,6 +943,7 @@ opentitan_functest(
 opentitan_functest(
     name = "usbdev_test",
     srcs = ["usbdev_test.c"],
+    verilator = verilator_params(tags = ["verilator_in_ci"]),
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib:usb",

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -2,13 +2,16 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:opentitan_test.bzl", "opentitan_functest")
+load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 
 package(default_visibility = ["//visibility:public"])
 
 opentitan_functest(
     name = "ecdsa_p256_functest",
     srcs = ["ecdsa_p256_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         "//sw/device/lib/crypto:otbn_util",
         "//sw/device/lib/crypto/drivers:hmac",
@@ -28,6 +31,9 @@ cc_library(
 opentitan_functest(
     name = "ecdsa_p256_verify_functest",
     srcs = ["ecdsa_p256_verify_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         ":ecdsa_p256_verify_testvectors",
         "//sw/device/lib/crypto:otbn_util",
@@ -47,6 +53,9 @@ cc_library(
 opentitan_functest(
     name = "rsa_3072_verify_functest",
     srcs = ["rsa_3072_verify_functest.c"],
+    verilator = verilator_params(
+        timeout = "long",
+    ),
     deps = [
         ":rsa_3072_verify_testvectors",
         "//sw/device/lib/crypto:otbn_util",

--- a/third_party/riscv-compliance/BUILD
+++ b/third_party/riscv-compliance/BUILD
@@ -6,4 +6,19 @@ load(":defs.bzl", "TESTS", "rv_compliance_test")
 
 package(default_visibility = ["//visibility:public"])
 
+cc_library(
+    name = "compliance_main",
+    srcs = [
+        "compliance_main.S",
+        "compliance_main.c",
+    ],
+    linkopts = ["-Wl,--no-relax"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+        "@riscv-compliance//:riscv-test-env",
+    ],
+    alwayslink = True,
+)
+
 [[rv_compliance_test(test, arch) for test in tests] for arch, tests in TESTS.items()]

--- a/third_party/riscv-compliance/defs.bzl
+++ b/third_party/riscv-compliance/defs.bzl
@@ -29,16 +29,14 @@ def rv_compliance_test(name, arch):
         srcs = [
             test_file,
             expected_signature,
-            "compliance_main.c",
-            "compliance_main.S",
         ],
         verilator = verilator_params(
             timeout = "long",
+            tags = ["verilator_rv_compliance"],
         ),
-        linkopts = ["-Wl,--no-relax"],
         deps = [
             "//sw/device/lib/testing/test_framework:ottf_main",
-            "@riscv-compliance//:riscv-test-env",
+            "//third_party/riscv-compliance:compliance_main",
         ],
     )
 


### PR DESCRIPTION
Because `execute_verilated_tests` includes RISC-V compliance, we can get rid of that separate CI step (it was separated out because Meson had no idea how to build them; Bazel, on the other hand, does!).

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>