### PR TITLE
[dv] Add instr_type error cases in tl_err test

### DIFF
--- a/hw/dv/sv/cip_lib/cip_base_env_cov.sv
+++ b/hw/dv/sv/cip_lib/cip_base_env_cov.sv
@@ -88,7 +88,9 @@ class tl_errors_cg_wrap;
                            bit mem_byte_access_err,
                            bit mem_wo_err,
                            bit mem_ro_err,
-                           bit tl_protocol_err);
+                           bit tl_protocol_err,
+                           bit write_w_instr_type_err,
+                           bit instr_type_err);
     option.per_instance = 1;
     option.name = name;
 
@@ -105,6 +107,9 @@ class tl_errors_cg_wrap;
     cp_tl_protocol_err: coverpoint tl_protocol_err {
       bins covered = {1};
     }
+
+    cp_write_w_instr_type_err: coverpoint write_w_instr_type_err;
+    cp_instr_type_err: coverpoint instr_type_err;
   endgroup
 
   // Function: new
@@ -118,9 +123,11 @@ class tl_errors_cg_wrap;
                        bit mem_byte_access_err,
                        bit mem_wo_err,
                        bit mem_ro_err,
-                       bit tl_protocol_err);
-    tl_errors_cg.sample(unmapped_err, csr_size_err, mem_byte_access_err,
-                        mem_wo_err, mem_ro_err, tl_protocol_err);
+                       bit tl_protocol_err,
+                       bit write_w_instr_type_err,
+                       bit instr_type_err);
+    tl_errors_cg.sample(unmapped_err, csr_size_err, mem_byte_access_err, mem_wo_err,
+                        mem_ro_err, tl_protocol_err, write_w_instr_type_err, instr_type_err);
   endfunction : sample
 
 endclass

--- a/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
+++ b/hw/dv/sv/cip_lib/cip_base_scoreboard.sv
@@ -358,7 +358,7 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     cip_tl_seq_item cip_item;
     tl_intg_err_e tl_intg_err_type;
     uint num_cmd_err_bits, num_data_err_bits;
-    bit write_w_instr_type_err;
+    bit write_w_instr_type_err, instr_type_err;
 
     unmapped_err = !is_tl_access_mapped_addr(item, ral_name);
     if (unmapped_err) begin
@@ -386,11 +386,12 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
     tl_item_err = item.get_exp_d_error();
     `downcast(cip_item, item)
     cip_item.get_a_chan_err_info(tl_intg_err_type, num_cmd_err_bits, num_data_err_bits,
-                                 write_w_instr_type_err);
-    exp_d_error |= byte_wr_err | bus_intg_err | csr_size_err | tl_item_err | write_w_instr_type_err;
+                                 write_w_instr_type_err, instr_type_err);
+    exp_d_error |= byte_wr_err | bus_intg_err | csr_size_err | tl_item_err |
+                   write_w_instr_type_err | instr_type_err;
 
     invalid_access = unmapped_err | mem_access_err | bus_intg_err | csr_size_err | tl_item_err |
-                     write_w_instr_type_err;
+                     write_w_instr_type_err | instr_type_err;
 
     if (channel == DataChannel) begin
       // integrity at d_user is from DUT, which should be always correct, except data integrity for
@@ -434,7 +435,9 @@ class cip_base_scoreboard #(type RAL_T = dv_base_reg_block,
                                             .mem_byte_access_err(mem_byte_access_err),
                                             .mem_wo_err(mem_wo_err),
                                             .mem_ro_err(mem_ro_err),
-                                            .tl_protocol_err(tl_item_err));
+                                            .tl_protocol_err(tl_item_err),
+                                            .write_w_instr_type_err(write_w_instr_type_err),
+                                            .instr_type_err(instr_type_err));
       end
 
     end

--- a/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_tl_seq_item.sv
@@ -230,7 +230,8 @@ class cip_tl_seq_item extends tl_seq_item;
   virtual function void get_a_chan_err_info(output tl_intg_err_e tl_intg_err_type,
                                             output uint num_cmd_err_bits,
                                             output uint num_data_err_bits,
-                                            output bit write_w_instr_type_err);
+                                            output bit write_w_instr_type_err,
+                                            output bit instr_type_err);
     tl_a_user_t exp_a_user = compute_a_user();
     tl_a_user_t act_a_user = tl_a_user_t'(a_user);
     bit         is_cmd_ok  = (act_a_user.cmd_intg == exp_a_user.cmd_intg);
@@ -243,6 +244,7 @@ class cip_tl_seq_item extends tl_seq_item;
     // d_error will be set if it's a write with instr_type=True
     write_w_instr_type_err = a_opcode inside {PutFullData, PutPartialData} &&
                              act_a_user.instr_type == MuBi4True;
+    instr_type_err = !(act_a_user.instr_type inside {MuBi4True, MuBi4False});
   endfunction : get_a_chan_err_info
 
   virtual function void get_d_chan_err_info(output tl_intg_err_e tl_intg_err_type,


### PR DESCRIPTION
Aligned with design update #12109
Add driving and checking invalid instr_type triggers d_error

This also fixed sram exec test.

Signed-off-by: Weicai Yang <weicai@google.com>