### PR TITLE
[sw/tests] fix missing symbols in tests that run from ROM

### DIFF
--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -1235,7 +1235,7 @@ foreach sw_test_name, sw_test_info : sw_tests
           sw_lib_testing_test_status,
           shared_test_deps,
           sw_lib_crt,
-          sw_test_info['library'],
+          sw_test_info['library'].as_link_whole(),
         ],
       )
     else


### PR DESCRIPTION
As noted in #12128, symbols were completely missing from tests that run
entirely in ROM. This adds a meson flag to fix this in interim, until we
switch to bazel, where this is not an issue.

This fixes #12128.

Signed-off-by: Timothy Trippel <ttrippel@google.com>