### PR TITLE
[top, dv] Fix rom backdoor symbol overwrite

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
@@ -15,6 +15,8 @@ filesets:
       - lowrisc:prim:cipher_pkg:0.1
       - lowrisc:prim:secded:0.1
       - lowrisc:ip:otp_ctrl_pkg:0.1
+      - lowrisc:dv:digestpp_dpi
+      - lowrisc:ip:kmac_pkg
     files:
       - otp_scrambler_pkg.sv
       - sram_scrambler_pkg.sv

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
@@ -138,14 +138,11 @@ virtual function void rom_encrypt_write8(bit [bus_params_pkg::BUS_AW-1:0] addr,
                                          logic [SRAM_KEY_WIDTH-1:0]       key,
                                          logic [SRAM_BLOCK_WIDTH-1:0]     nonce,
                                          bit                              scramble_data = 1);
-  uint32_t byte_idx;
   bit [bus_params_pkg::BUS_AW-1:0] aligned_addr = (addr >> addr_lsb) << addr_lsb;
   int byte_offset = addr % bytes_per_word;
   bit [31:0] rw_data = 32'(rom_encrypt_read32(addr, key, nonce, scramble_data));
 
-  byte_idx = addr - aligned_addr;
-  rw_data[byte_idx * 8 +: 8] = data;
-
+  rw_data[byte_offset * 8 +: 8] = data;
   rom_encrypt_write32_integ(aligned_addr, rw_data, key, nonce, scramble_data);
 endfunction
 

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__rom.sv
@@ -122,3 +122,59 @@ virtual function void rom_encrypt_write32_integ(logic [bus_params_pkg::BUS_AW-1:
   // Write the scrambled data to memory
   write39integ(bus_addr, scrambled_data);
 endfunction
+
+virtual function bit [7:0] rom_encrypt_read8(bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                             logic [SRAM_KEY_WIDTH-1:0]       key,
+                                             logic [SRAM_BLOCK_WIDTH-1:0]     nonce,
+                                             bit                              unscramble_data = 1);
+  int byte_offset = addr % bytes_per_word;
+  bit [bus_params_pkg::BUS_AW-1:0] aligned_addr = (addr >> addr_lsb) << addr_lsb;
+  bit [38:0] data = rom_encrypt_read32(aligned_addr, key, nonce, unscramble_data);
+  return (data >> (byte_offset * byte_width)) & 8'hff;
+endfunction
+
+virtual function void rom_encrypt_write8(bit [bus_params_pkg::BUS_AW-1:0] addr,
+                                         logic [7:0]                      data,
+                                         logic [SRAM_KEY_WIDTH-1:0]       key,
+                                         logic [SRAM_BLOCK_WIDTH-1:0]     nonce,
+                                         bit                              scramble_data = 1);
+  uint32_t byte_idx;
+  bit [bus_params_pkg::BUS_AW-1:0] aligned_addr = (addr >> addr_lsb) << addr_lsb;
+  int byte_offset = addr % bytes_per_word;
+  bit [31:0] rw_data = 32'(rom_encrypt_read32(addr, key, nonce, scramble_data));
+
+  byte_idx = addr - aligned_addr;
+  rw_data[byte_idx * 8 +: 8] = data;
+
+  rom_encrypt_write32_integ(aligned_addr, rw_data, key, nonce, scramble_data);
+endfunction
+
+virtual function void update_rom_digest(logic [SRAM_KEY_WIDTH-1:0]   key,
+                                        logic [SRAM_BLOCK_WIDTH-1:0] nonce);
+  bit [63:0] kmac_data[$];
+  bit [7:0] kmac_data_arr[];
+  bit [7:0] dpi_digest[kmac_pkg::AppDigestW / 8];
+  int kmac_data_bytes = size_bytes - ROM_DIGEST_BYTES;
+  int digest_start_addr = kmac_data_bytes;
+  bit scramble_data = 0; // digest and kmac data aren't scrambled
+
+  // kmac data is twice of kmac_data_bytes as we use 64 bit bus to send 32 bit data + 7 intg
+  kmac_data_arr = new[kmac_data_bytes * 2];
+
+  for (int i = 0; i < kmac_data_bytes; i += 4) begin
+    bit [63:0] data64;
+
+    // it returns 39 bits, including integrity. and the 39 bits data will be sent to 64 bits bus to
+    // the kmac
+    data64 = 64'(rom_encrypt_read32(i, key, nonce, scramble_data));
+    for (int j = 0; j < 8; j++) begin
+      kmac_data_arr[i * 2 + j] = data64[j * 8 +: 8];
+    end
+  end
+  digestpp_dpi_pkg::c_dpi_cshake256(kmac_data_arr, "", "ROM_CTRL", kmac_data_arr.size,
+                                    kmac_pkg::AppDigestW / 8, dpi_digest);
+
+  for (int i = 0; i < ROM_DIGEST_BYTES; i++) begin
+    rom_encrypt_write8(digest_start_addr + i, dpi_digest[i], key, nonce, scramble_data);
+  end
+endfunction

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util_pkg.sv
@@ -39,6 +39,8 @@ package mem_bkdr_util_pkg;
     ParityOdd
   } err_detection_e;
 
+  parameter int ROM_DIGEST_SIZE = 256;
+  parameter int ROM_DIGEST_BYTES = ROM_DIGEST_SIZE / 8;
   // macro includes
   `include "uvm_macros.svh"
   `include "dv_macros.svh"

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_rma_unlocked_vseq.sv
@@ -26,27 +26,7 @@ class chip_sw_flash_rma_unlocked_vseq extends chip_sw_base_vseq;
   bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0] sram_ret_nonce;
   bit [sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0] sram_ret_key;
 
-  // TODO(lowRISC/opentitan:#11795): replace with SW symbol backdoor write
-  // when this is fixed for ROM.
-  // Currently a fixed unlock token which will match in software.
-  bit [7:0] rma_unlock_token[TokenWidthByte] = '{
-      8'h00,
-      8'h01,
-      8'h02,
-      8'h03,
-      8'h04,
-      8'h05,
-      8'h06,
-      8'h07,
-      8'h08,
-      8'h09,
-      8'h0a,
-      8'h0b,
-      8'h0c,
-      8'h0d,
-      8'h0e,
-      8'h0f
-  };
+  rand bit [7:0] rma_unlock_token[TokenWidthByte];
 
   rand bit [7:0] creator_root_key0[KeyWidthByte];
   rand bit [7:0] creator_root_key1[KeyWidthByte];
@@ -109,9 +89,10 @@ class chip_sw_flash_rma_unlocked_vseq extends chip_sw_base_vseq;
     super.dut_init(reset_kind);
     // Override the LC partition to Dev state.
     cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStDev);
-    // TODO(lowRISC/opentitan:#11795): replace with SW symbol backdoor write
-    // when this is fixed for ROM.
-    // The following overwrite does not yet work.
+  endtask
+
+  virtual task cpu_init();
+    super.cpu_init();
     sw_symbol_backdoor_overwrite("kLcRmaUnlockToken", rma_unlock_token, Rom, SwTypeRom);
   endtask
 

--- a/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
+++ b/sw/device/tests/sim_dv/flash_rma_unlocked_test.c
@@ -78,9 +78,6 @@ static const uint32_t kRandomData[7][kDataSize] = {
      0x733bf534, 0xc4914b4b, 0x64487458, 0x9d0fa332}};
 
 // RMA unlock token value for LC state transition.
-// TODO(lowRISC/opentitan:#11795): when the sw_symbol_backdoor_overwrite
-// is fixed for ROM, this can be overriden by the testbench as a SW variable.
-// Currently hardcoded to match the token written in the testbench.
 static volatile const uint8_t kLcRmaUnlockToken[LC_TOKEN_SIZE] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,


### PR DESCRIPTION
2 commits in the PR

[top, dv] Fix rom backdoor symbol overwrite
Fix 2 issues
1. used correct backdoor read/write functions for rom
2. re-generated and updated rom digest after backdoor overwrite, rom
   digest check can't pass

[flash, dv] Fix RMA test backdoor symbol overwrite
Changed to randomize the data and moved the overwrite function invocation to `cpu_init`

Signed-off-by: Weicai Yang <weicai@google.com>