### PR TITLE
[opentitantool] Refactor proxy error handling

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -42,6 +42,7 @@ rust_library(
         "src/otp/otp_img.rs",
         "src/otp/otp_mmap.rs",
         "src/otp/vmem_serialize.rs",
+        "src/proxy/errors.rs",
         "src/proxy/handler.rs",
         "src/proxy/mod.rs",
         "src/proxy/protocol.rs",

--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -37,12 +37,14 @@ sha2 = "0.10.1"
 humantime = "2.1.0"
 mio = { version = "0.7.0", features = ["os-poll", "net", "os-ext"] }
 mio-signals = "0.1.5" # mio-signals 0.2.0 exists, but requires mio 0.8.0
+rand = "0.8.4"
 
 serde = { version="1", features=["serde_derive"] }
 serde_json = "1"
 deser-hjson = "1.0.2"
-rand = "0.8.4"
 erased-serde = "0.3.12"
+typetag = "0.1"
+
 opentitantool_derive = {path = "opentitantool_derive"}
 
 [package.metadata.raze.crates.libudev-sys.'0.1.4']

--- a/sw/host/opentitanlib/src/app/mod.rs
+++ b/sw/host/opentitanlib/src/app/mod.rs
@@ -11,7 +11,8 @@ use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::io::i2c::Bus;
 use crate::io::spi::Target;
 use crate::io::uart::Uart;
-use crate::transport::{ProxyOps, Result, Transport, TransportError};
+use crate::transport::{ProxyOps, Transport, TransportError};
+use anyhow::Result;
 
 use erased_serde::Serialize;
 use std::any::Any;
@@ -149,9 +150,7 @@ impl TransportWrapper {
         if let Some(strapping_conf_map) = self.strapping_conf_map.get(strapping_name) {
             self.apply_pin_configurations(&strapping_conf_map)
         } else {
-            Err(TransportError::InvalidStrappingName(
-                strapping_name.to_string(),
-            ))
+            Err(TransportError::InvalidStrappingName(strapping_name.to_string()).into())
         }
     }
 
@@ -167,9 +166,7 @@ impl TransportWrapper {
             }
             Ok(())
         } else {
-            Err(TransportError::InvalidStrappingName(
-                strapping_name.to_string(),
-            ))
+            Err(TransportError::InvalidStrappingName(strapping_name.to_string()).into())
         }
     }
 
@@ -204,7 +201,7 @@ impl TransportWrapper {
         }
     }
 
-    pub fn add_configuration_file(&mut self, file: conf::ConfigurationFile) -> anyhow::Result<()> {
+    pub fn add_configuration_file(&mut self, file: conf::ConfigurationFile) -> Result<()> {
         // Merge content of configuration file into pin_map and other
         // members.
         for pin_conf in file.pins {

--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use mundane::hash::{Digest, Hasher, Sha256};
 use std::time::Duration;
 use thiserror::Error;
@@ -9,8 +10,9 @@ use zerocopy::AsBytes;
 
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, BootstrapOptions, UpdateProtocol};
+use crate::impl_serializable_error;
 use crate::io::spi::Transfer;
-use crate::transport::{Capability, Result};
+use crate::transport::Capability;
 
 #[derive(AsBytes, Debug, Default)]
 #[repr(C)]
@@ -178,6 +180,7 @@ pub enum LegacyBootstrapError {
     #[error("Repeated errors communicating with boot rom")]
     RepeatedErrors,
 }
+impl_serializable_error!(LegacyBootstrapError);
 
 impl From<u8> for LegacyBootstrapError {
     fn from(value: u8) -> LegacyBootstrapError {

--- a/sw/host/opentitanlib/src/bootstrap/mod.rs
+++ b/sw/host/opentitanlib/src/bootstrap/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use humantime::parse_duration;
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
@@ -11,10 +12,11 @@ use structopt::StructOpt;
 use thiserror::Error;
 
 use crate::app::TransportWrapper;
+use crate::impl_serializable_error;
 use crate::io::gpio::GpioPin;
 use crate::io::spi::SpiParams;
 use crate::io::uart::UartParams;
-use crate::transport::{Capability, Result};
+use crate::transport::Capability;
 
 mod legacy;
 mod primitive;
@@ -28,6 +30,7 @@ pub enum BootstrapError {
     #[error("Invalid hash length: {0}")]
     InvalidHashLength(usize),
 }
+impl_serializable_error!(BootstrapError);
 
 arg_enum! {
     /// `BootstrapProtocol` describes the supported types of bootstrap.

--- a/sw/host/opentitanlib/src/bootstrap/primitive.rs
+++ b/sw/host/opentitanlib/src/bootstrap/primitive.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use mundane::hash::{Digest, Hasher, Sha256};
 use std::time::Duration;
 use zerocopy::AsBytes;
@@ -9,7 +10,7 @@ use zerocopy::AsBytes;
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, BootstrapOptions, UpdateProtocol};
 use crate::io::spi::Transfer;
-use crate::transport::{Capability, Result};
+use crate::transport::Capability;
 
 #[derive(AsBytes, Debug, Default)]
 #[repr(C)]

--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, ensure, Result};
 use mundane::hash::{Digest, Hasher, Sha256};
 use std::time::{Duration, Instant};
 use thiserror::Error;
@@ -9,9 +10,9 @@ use zerocopy::AsBytes;
 
 use crate::app::TransportWrapper;
 use crate::bootstrap::{Bootstrap, BootstrapOptions, UpdateProtocol};
+use crate::impl_serializable_error;
 use crate::io::uart::Uart;
-use crate::transport::{Capability, Result};
-use crate::{bail, ensure};
+use crate::transport::Capability;
 
 #[derive(AsBytes, Debug, Default)]
 #[repr(C)]
@@ -158,6 +159,7 @@ pub enum RescueError {
     #[error("Repeated errors communicating with boot rom")]
     RepeatedErrors,
 }
+impl_serializable_error!(RescueError);
 
 /// Implements the UART rescue protocol of Google Ti50 firmware.
 pub struct Rescue {}
@@ -272,7 +274,7 @@ impl Rescue {
             }
             eprintln!(" Failed to enter rescue mode.");
         }
-        bail!(RescueError::RepeatedErrors);
+        Err(RescueError::RepeatedErrors.into())
     }
 }
 

--- a/sw/host/opentitanlib/src/io/emu.rs
+++ b/sw/host/opentitanlib/src/io/emu.rs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transport::Result;
+use crate::impl_serializable_error;
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use thiserror::Error;
 
-/// Error related to the `Emulator` trait. These error messages will be printed in the context of
-/// a TransportError::EmuError, that is "Emulator error: {}".  So including the words "error" or
-/// "Emulator" in texts below will probably be redundant.
+/// Error related to the `Emulator` trait.
 #[derive(Error, Debug, Serialize, Deserialize)]
 pub enum EmuError {
     #[error("Invalid argument name {0}")]
@@ -25,6 +24,7 @@ pub enum EmuError {
     #[error("Runtime error {0}")]
     RuntimeError(String),
 }
+impl_serializable_error!(EmuError);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum EmuValue {

--- a/sw/host/opentitanlib/src/io/gpio.rs
+++ b/sw/host/opentitanlib/src/io/gpio.rs
@@ -2,15 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use structopt::clap::arg_enum;
 use thiserror::Error;
 
-use crate::transport::Result;
+use crate::impl_serializable_error;
 
-/// Errors related to the GPIO interface.  These error messages will be printed in the context of
-/// a TransportError::GpioError, that is "GPIO error: {}".  So including the words "error" or
-/// "gpio" in texts below will probably be redundant.
+/// Errors related to the GPIO interface.
 #[derive(Debug, Error, Serialize, Deserialize)]
 pub enum GpioError {
     #[error("Invalid pin name {0}")]
@@ -28,6 +27,7 @@ pub enum GpioError {
     #[error("Unsupported pull mode {0} requested")]
     UnsupportedPullMode(PullMode),
 }
+impl_serializable_error!(GpioError);
 
 arg_enum! {
     /// Mode of I/O pins.

--- a/sw/host/opentitanlib/src/io/i2c.rs
+++ b/sw/host/opentitanlib/src/io/i2c.rs
@@ -2,13 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 use structopt::StructOpt;
 use thiserror::Error;
 
 use crate::app::TransportWrapper;
-use crate::transport::Result;
+use crate::impl_serializable_error;
 
 #[derive(Debug, StructOpt)]
 pub struct I2cParams {
@@ -23,9 +24,7 @@ impl I2cParams {
     }
 }
 
-/// Errors related to the I2C interface and I2C transactions.  These error messages will be
-/// printed in the context of a TransportError::I2cError, that is "I2C error: {}".  So
-/// including the words "error" or "i2c" in texts below will probably be redundant.
+/// Errors related to the I2C interface and I2C transactions.
 #[derive(Error, Debug, Deserialize, Serialize)]
 pub enum I2cError {
     #[error("Invalid data length: {0}")]
@@ -35,6 +34,7 @@ pub enum I2cError {
     #[error("Bus busy")]
     Busy,
 }
+impl_serializable_error!(I2cError);
 
 /// Represents a I2C transfer.
 pub enum Transfer<'rd, 'wr> {

--- a/sw/host/opentitanlib/src/io/spi.rs
+++ b/sw/host/opentitanlib/src/io/spi.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 use std::str::FromStr;
@@ -9,7 +10,7 @@ use structopt::StructOpt;
 use thiserror::Error;
 
 use crate::app::TransportWrapper;
-use crate::transport::Result;
+use crate::impl_serializable_error;
 use crate::util::voltage::Voltage;
 
 #[derive(Clone, Debug, StructOpt, Serialize, Deserialize)]
@@ -43,9 +44,7 @@ impl SpiParams {
     }
 }
 
-/// Errors related to the SPI interface and SPI transactions.  These error messages will be
-/// printed in the context of a TransportError::SpiError, that is "SPI error: {}".  So including
-/// the words "error" or "spi" in texts below will probably be redundant.
+/// Errors related to the SPI interface and SPI transactions.
 #[derive(Error, Debug, Serialize, Deserialize)]
 pub enum SpiError {
     #[error("Invalid option: {0}")]
@@ -61,6 +60,7 @@ pub enum SpiError {
     #[error("Invalid transfer mode: {0}")]
     InvalidTransferMode(String),
 }
+impl_serializable_error!(SpiError);
 
 /// Represents the SPI transfer mode.
 /// See https://en.wikipedia.org/wiki/Serial_Peripheral_Interface#Clock_polarity_and_phase

--- a/sw/host/opentitanlib/src/io/uart.rs
+++ b/sw/host/opentitanlib/src/io/uart.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
 use std::time::Duration;
@@ -9,7 +10,7 @@ use structopt::StructOpt;
 use thiserror::Error;
 
 use crate::app::TransportWrapper;
-use crate::transport::Result;
+use crate::impl_serializable_error;
 
 #[derive(Clone, Debug, StructOpt, Serialize, Deserialize)]
 pub struct UartParams {
@@ -51,9 +52,7 @@ pub trait Uart {
     fn write(&self, buf: &[u8]) -> Result<()>;
 }
 
-/// Errors related to the UART interface.  These error messages will be printed in the context
-/// of a TransportError::UartError, that is "UART error: {}".  So including the words "error" or
-/// "serial" in texts below will probably be redundant.
+/// Errors related to the UART interface.
 #[derive(Error, Debug, Serialize, Deserialize)]
 pub enum UartError {
     #[error("Enumerating: {0}")]
@@ -71,3 +70,4 @@ pub enum UartError {
     #[error("{0}")]
     GenericError(String),
 }
+impl_serializable_error!(UartError);

--- a/sw/host/opentitanlib/src/proxy/errors.rs
+++ b/sw/host/opentitanlib/src/proxy/errors.rs
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use erased_serde::Serialize;
+
+/// `SerializableError` is a trait which represents an error type that can
+/// be sent over the wire by the proxy protocol.
+#[typetag::serde(tag = "error_type")]
+pub trait SerializableError: Serialize + std::error::Error + std::fmt::Debug + Send + Sync {
+    fn as_anyhow_error(self: Box<Self>) -> anyhow::Error;
+}
+
+/// `impl_serializable_error` needs to be invoked for every error type
+/// that can be sent over the wire.
+#[macro_export]
+macro_rules! impl_serializable_error {
+    ($t:ty) => {
+        const _: () = {
+            use $crate::proxy::errors::SerializableError;
+            #[typetag::serde]
+            impl SerializableError for $t {
+                fn as_anyhow_error(self: Box<$t>) -> anyhow::Error {
+                    self.into()
+                }
+            }
+        };
+    };
+}
+
+/// `SerializedError` is the wire form of errors that can be sent through the proxy.
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
+pub struct SerializedError {
+    pub description: String,
+    pub backtrace: String,
+    pub error: Option<Box<dyn SerializableError>>,
+}
+
+// Helper macro for building the `From` implementation that converts
+// native error types into their serialized form. This is a recursive
+// macro.
+macro_rules! to_serialized_error {
+    // This is the terminal state for this macro: only one type to convert.
+    // Parameters:
+    //   error - The error object.
+    //   msg - The error message (e.g. `to_string()`).
+    //   bt - The error backtrace.
+    //   box - A function which can box the error if needed.
+    //   t - The error type to convert.
+    ($error:expr, $msg:expr, $bt:expr, $box:expr, $t:ty $(,)?) => {{
+        match $error.downcast::<$t>() {
+            Ok(e) => return SerializedError {
+                description: $msg,
+                backtrace: $bt,
+                error: Some($box(e)),
+            },
+
+            Err(_) => return SerializedError {
+                description: $msg,
+                backtrace: $bt,
+                error: None,
+            },
+        }
+    }};
+
+    // This is the non-terminal state for this macro: many types to convert.
+    // Parameters:
+    //   error - The error object.
+    //   msg - The error message (e.g. `to_string()`).
+    //   bt - The error backtrace.
+    //   box - A function which can box the error if needed.
+    //   t:ts - The error types to convert.
+    ($error:expr, $msg:expr, $bt:expr, $box:expr, $t:ty, $($ts:ty),+ $(,)?) => {{
+        let e2 = match $error.downcast::<$t>() {
+            Ok(e) => return SerializedError {
+                description: $msg,
+                backtrace: $bt,
+                error: Some($box(e)),
+            },
+            Err(e) => e,
+        };
+        to_serialized_error!(e2, $msg, $bt, $box, $($ts,)*);
+    }};
+}
+
+/// Converts a `SerializedError` back into a real error type.
+impl From<SerializedError> for anyhow::Error {
+    fn from(ser: SerializedError) -> anyhow::Error {
+        let error = if let Some(error) = ser.error {
+            error.as_anyhow_error()
+        } else {
+            anyhow::Error::msg(ser.description)
+        };
+        if ser.backtrace == "<disabled>" {
+            error
+        } else {
+            error.context(format!("Server Error.\nRemote {}", ser.backtrace))
+        }
+    }
+}
+
+/// Converts any error into a `SerializedError`.
+impl From<anyhow::Error> for SerializedError {
+    fn from(error: anyhow::Error) -> SerializedError {
+        let msg = error.to_string();
+        let bt = format!("{:#?}", error.backtrace());
+        to_serialized_error!(
+            error,
+            msg,
+            bt,
+            Box::new,
+            crate::bootstrap::BootstrapError,
+            crate::bootstrap::LegacyBootstrapError,
+            crate::bootstrap::RescueError,
+            crate::io::emu::EmuError,
+            crate::io::gpio::GpioError,
+            crate::io::i2c::I2cError,
+            crate::io::spi::SpiError,
+            crate::io::uart::UartError,
+            crate::transport::TransportError,
+            crate::transport::proxy::ProxyError,
+        );
+    }
+}

--- a/sw/host/opentitanlib/src/proxy/mod.rs
+++ b/sw/host/opentitanlib/src/proxy/mod.rs
@@ -11,6 +11,7 @@ use std::net::SocketAddr;
 
 use crate::app::TransportWrapper;
 
+pub mod errors;
 mod handler;
 pub mod protocol;
 mod socket_server;

--- a/sw/host/opentitanlib/src/proxy/protocol.rs
+++ b/sw/host/opentitanlib/src/proxy/protocol.rs
@@ -9,13 +9,14 @@ use crate::bootstrap::BootstrapOptions;
 use crate::io::emu::{EmuState, EmuValue};
 use crate::io::gpio::{PinMode, PullMode};
 use crate::io::spi::TransferMode;
-use crate::transport::{Capabilities, TransportError};
+use crate::proxy::errors::SerializedError;
+use crate::transport::Capabilities;
 use crate::util::voltage::Voltage;
 
 #[derive(Serialize, Deserialize)]
 pub enum Message {
     Req(Request),
-    Res(Result<Response, TransportError>),
+    Res(Result<Response, SerializedError>),
 }
 
 #[derive(Serialize, Deserialize)]

--- a/sw/host/opentitanlib/src/transport/common/uart.rs
+++ b/sw/host/opentitanlib/src/transport/common/uart.rs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{Context, Result};
 use serialport::SerialPort;
 use std::cell::RefCell;
 use std::io::ErrorKind;
 use std::time::Duration;
 
 use crate::io::uart::{Uart, UartError};
-use crate::transport::{Result, WrapInTransportError};
 
 /// Implementation of the `Uart` trait on top of a serial device, such as `/dev/ttyUSB0`.
 pub struct SerialPortUart {
@@ -29,7 +29,7 @@ impl SerialPortUart {
             port: RefCell::new(
                 serialport::new(port_name, 115200)
                     .open()
-                    .wrap(UartError::OpenError)?,
+                    .map_err(|e| UartError::OpenError(e.to_string()))?,
             ),
         })
     }
@@ -38,7 +38,7 @@ impl SerialPortUart {
 impl Uart for SerialPortUart {
     /// Returns the UART baudrate.  May return zero for virtual UARTs.
     fn get_baudrate(&self) -> Result<u32> {
-        self.port.borrow().baud_rate().wrap(UartError::GenericError)
+        self.port.borrow().baud_rate().context("getting baudrate")
     }
 
     /// Sets the UART baudrate.  May do nothing for virtual UARTs.
@@ -46,7 +46,7 @@ impl Uart for SerialPortUart {
         self.port
             .borrow_mut()
             .set_baud_rate(baudrate)
-            .wrap(|_| UartError::InvalidSpeed(baudrate))?;
+            .map_err(|_| UartError::InvalidSpeed(baudrate))?;
         Ok(())
     }
 
@@ -57,21 +57,21 @@ impl Uart for SerialPortUart {
             .port
             .borrow_mut()
             .read(buf)
-            .wrap(UartError::ReadError)?)
+            .context("UART read error")?)
     }
 
     /// Reads UART receive data into `buf`, returning the number of bytes read.
     /// The `timeout` may be used to specify a duration to wait for data.
     fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
         let mut port = self.port.borrow_mut();
-        port.set_timeout(timeout).wrap(UartError::ReadError)?;
+        port.set_timeout(timeout).context("UART read error")?;
         let result = port.read(buf);
         let len = match result {
             Err(ioerr) if ioerr.kind() == ErrorKind::TimedOut => Ok(0),
             _ => result,
         };
-        port.set_timeout(Self::FOREVER).wrap(UartError::ReadError)?;
-        Ok(len.wrap(UartError::ReadError)?)
+        port.set_timeout(Self::FOREVER).context("UART read error")?;
+        Ok(len.context("UART read error")?)
     }
 
     /// Writes data from `buf` to the UART.
@@ -81,7 +81,7 @@ impl Uart for SerialPortUart {
                 .port
                 .borrow_mut()
                 .write(buf)
-                .wrap(UartError::WriteError)?;
+                .context("UART write error")?;
             buf = &buf[written..];
         }
         Ok(())

--- a/sw/host/opentitanlib/src/transport/cw310/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/gpio.rs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::io::gpio::{GpioError, GpioPin, PinMode, PullMode};
 use crate::transport::cw310::usb::Backend;
-use crate::transport::Result;
 
 pub struct CW310GpioPin {
     device: Rc<RefCell<Backend>>,

--- a/sw/host/opentitanlib/src/transport/cw310/spi.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/spi.rs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use log;
+use anyhow::Result;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 use crate::io::spi::{SpiError, Target, Transfer, TransferMode};
 use crate::transport::cw310::usb::Backend;
 use crate::transport::cw310::CW310;
-use crate::transport::Result;
 
 pub struct CW310Spi {
     device: Rc<RefCell<Backend>>,

--- a/sw/host/opentitanlib/src/transport/cw310/usb.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/usb.rs
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{ensure, Context, Result};
 use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::collection;
-use crate::ensure;
 use crate::io::gpio::GpioError;
 use crate::io::spi::SpiError;
-use crate::transport::{Result, TransportError, TransportInterfaceType, WrapInTransportError};
+use crate::transport::{TransportError, TransportInterfaceType};
 use crate::util::parse_int::ParseInt;
 use crate::util::usb::UsbBackend;
 
@@ -147,7 +147,7 @@ impl Backend {
         })? as u16;
         let mut buf = [0u8; 1];
         self.read_ctrl(Backend::CMD_FPGAIO_UTIL, pinnum, &mut buf)
-            .wrap(TransportError::UsbGenericError)?;
+            .context("USB error")?;
         Ok(buf[0])
     }
 

--- a/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/c2d2.rs
@@ -2,12 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, Result};
 use std::rc::Rc;
 
-use crate::bail;
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::transport::hyperdebug::{Flavor, Inner, StandardFlavor, VID_GOOGLE};
-use crate::transport::{Result, TransportError};
+use crate::transport::TransportError;
 
 /// The C2D2 (Case Closed Debugging Debugger) is used to bring up GSC and EC chips sitting
 /// inside a Chrome OS devices, such that those GSC chips can provide Case Closed Debugging
@@ -52,9 +52,8 @@ impl C2d2ResetPin {
 impl GpioPin for C2d2ResetPin {
     /// Reads the value of the the reset pin.
     fn read(&self) -> Result<bool> {
-        let mut result: Result<bool> = Err(TransportError::CommunicationError(
-            "No output from gpioget".to_string(),
-        ));
+        let mut result: Result<bool> =
+            Err(TransportError::CommunicationError("No output from gpioget".to_string()).into());
         self.inner
             .execute_command("gpioget SPIVREF_RSVD_H1VREF_H1_RST_ODL", |line| {
                 result = Ok(line.trim_start().starts_with("1"))

--- a/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/gpio.rs
@@ -2,11 +2,12 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use std::rc::Rc;
 
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::transport::hyperdebug::Inner;
-use crate::transport::{Result, TransportError};
+use crate::transport::TransportError;
 
 pub struct HyperdebugGpioPin {
     inner: Rc<Inner>,
@@ -26,9 +27,8 @@ impl HyperdebugGpioPin {
 impl GpioPin for HyperdebugGpioPin {
     /// Reads the value of the the GPIO pin `id`.
     fn read(&self) -> Result<bool> {
-        let mut result: Result<bool> = Err(TransportError::CommunicationError(
-            "No output from gpioget".to_string(),
-        ));
+        let mut result: Result<bool> =
+            Err(TransportError::CommunicationError("No output from gpioget".to_string()).into());
         self.inner
             .execute_command(&format!("gpioget {}", &self.pinname), |line| {
                 result = Ok(line.trim_start().starts_with("1"))

--- a/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/i2c.rs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, ensure, Result};
 use std::cmp;
 use std::rc::Rc;
 use zerocopy::{AsBytes, FromBytes};
 
 use crate::io::i2c::{Bus, I2cError, Transfer};
 use crate::transport::hyperdebug::{BulkInterface, Inner};
-use crate::transport::{Result, TransportError};
-use crate::{bail, ensure};
+use crate::transport::TransportError;
 
 pub struct HyperdebugI2cBus {
     inner: Rc<Inner>,

--- a/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
+++ b/sw/host/opentitanlib/src/transport/hyperdebug/spi.rs
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{ensure, Result};
 use rusb::{Direction, Recipient, RequestType};
 use std::mem::size_of;
 use std::rc::Rc;
 use zerocopy::{AsBytes, FromBytes};
 
-use crate::ensure;
 use crate::io::spi::{SpiError, Target, Transfer, TransferMode};
 use crate::transport::hyperdebug::{BulkInterface, Inner};
-use crate::transport::{Result, TransportError};
+use crate::transport::TransportError;
 
 pub struct HyperdebugSpiTarget {
     inner: Rc<Inner>,

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
@@ -24,7 +25,7 @@ pub mod verilator;
 
 // Export custom error types
 mod errors;
-pub use errors::{Result, TransportError, TransportInterfaceType, WrapInTransportError};
+pub use errors::{TransportError, TransportInterfaceType};
 
 bitflags! {
     /// A bitmap of capabilities which may be provided by a transport.
@@ -78,10 +79,7 @@ impl NeededCapabilities {
     /// Checks that the requested capabilities are provided.
     pub fn ok(&self) -> Result<()> {
         if self.capabilities & self.needed != self.needed {
-            Err(TransportError::MissingCapabilities(
-                self.needed,
-                self.capabilities,
-            ))
+            Err(TransportError::MissingCapabilities(self.needed, self.capabilities).into())
         } else {
             Ok(())
         }
@@ -97,45 +95,33 @@ pub trait Transport {
 
     /// Returns a SPI [`Target`] implementation.
     fn spi(&self, _instance: &str) -> Result<Rc<dyn Target>> {
-        Err(TransportError::InvalidInterface(
-            TransportInterfaceType::Spi,
-        ))
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Spi).into())
     }
     /// Returns a I2C [`Bus`] implementation.
     fn i2c(&self, _instance: &str) -> Result<Rc<dyn Bus>> {
-        Err(TransportError::InvalidInterface(
-            TransportInterfaceType::I2c,
-        ))
+        Err(TransportError::InvalidInterface(TransportInterfaceType::I2c).into())
     }
     /// Returns a [`Uart`] implementation.
     fn uart(&self, _instance: &str) -> Result<Rc<dyn Uart>> {
-        Err(TransportError::InvalidInterface(
-            TransportInterfaceType::Uart,
-        ))
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Uart).into())
     }
     /// Returns a [`GpioPin`] implementation.
     fn gpio_pin(&self, _instance: &str) -> Result<Rc<dyn GpioPin>> {
-        Err(TransportError::InvalidInterface(
-            TransportInterfaceType::Gpio,
-        ))
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Gpio).into())
     }
     /// Returns a [`Emulator`] implementation.
     fn emulator(&self) -> Result<Rc<dyn Emulator>> {
-        Err(TransportError::InvalidInterface(
-            TransportInterfaceType::Emulator,
-        ))
+        Err(TransportError::InvalidInterface(TransportInterfaceType::Emulator).into())
     }
 
     /// Methods available only on Proxy implementation.
     fn proxy_ops(&self) -> Result<Rc<dyn ProxyOps>> {
-        Err(TransportError::InvalidInterface(
-            TransportInterfaceType::ProxyOps,
-        ))
+        Err(TransportError::InvalidInterface(TransportInterfaceType::ProxyOps).into())
     }
 
     /// Invoke non-standard functionality of some Transport implementations.
     fn dispatch(&self, _action: &dyn Any) -> Result<Option<Box<dyn erased_serde::Serialize>>> {
-        Err(TransportError::UnsupportedOperation)
+        Err(TransportError::UnsupportedOperation.into())
     }
 }
 

--- a/sw/host/opentitanlib/src/transport/proxy/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/gpio.rs
@@ -2,13 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, Result};
 use std::rc::Rc;
 
 use super::ProxyError;
-use crate::bail;
 use crate::io::gpio::{GpioPin, PinMode, PullMode};
 use crate::proxy::protocol::{GpioRequest, GpioResponse, Request, Response};
-use crate::transport::proxy::{Inner, Proxy, Result};
+use crate::transport::proxy::{Inner, Proxy};
 
 pub struct ProxyGpioPin {
     inner: Rc<Inner>,

--- a/sw/host/opentitanlib/src/transport/proxy/i2c.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/i2c.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, ensure, Result};
 use std::rc::Rc;
 
 use super::ProxyError;
@@ -9,8 +10,7 @@ use crate::io::i2c::{Bus, Transfer};
 use crate::proxy::protocol::{
     I2cRequest, I2cResponse, I2cTransferRequest, I2cTransferResponse, Request, Response,
 };
-use crate::transport::proxy::{Inner, Proxy, Result};
-use crate::{bail, ensure};
+use crate::transport::proxy::{Inner, Proxy};
 
 pub struct ProxyI2c {
     inner: Rc<Inner>,

--- a/sw/host/opentitanlib/src/transport/proxy/spi.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/spi.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, ensure, Result};
 use std::rc::Rc;
 
 use super::ProxyError;
@@ -9,9 +10,8 @@ use crate::io::spi::{SpiError, Target, Transfer, TransferMode};
 use crate::proxy::protocol::{
     Request, Response, SpiRequest, SpiResponse, SpiTransferRequest, SpiTransferResponse,
 };
-use crate::transport::proxy::{Inner, Proxy, Result};
+use crate::transport::proxy::{Inner, Proxy};
 use crate::util::voltage::Voltage;
-use crate::{bail, ensure};
 
 pub struct ProxySpi {
     inner: Rc<Inner>,

--- a/sw/host/opentitanlib/src/transport/proxy/uart.rs
+++ b/sw/host/opentitanlib/src/transport/proxy/uart.rs
@@ -2,14 +2,14 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{bail, Result};
 use std::rc::Rc;
 use std::time::Duration;
 
 use super::ProxyError;
-use crate::bail;
 use crate::io::uart::Uart;
 use crate::proxy::protocol::{Request, Response, UartRequest, UartResponse};
-use crate::transport::proxy::{Inner, Proxy, Result};
+use crate::transport::proxy::{Inner, Proxy};
 
 pub struct ProxyUart {
     inner: Rc<Inner>,

--- a/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/gpio.rs
@@ -2,18 +2,18 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{ensure, Context, Result};
 use lazy_static::lazy_static;
 use safe_ftdi as ftdi;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::rc::Rc;
 
+use crate::collection;
 use crate::io::gpio::{GpioError, GpioPin, PinMode, PullMode};
 use crate::transport::ultradebug::mpsse;
 use crate::transport::ultradebug::Ultradebug;
-use crate::transport::{Result, TransportError, WrapInTransportError};
 use crate::util::parse_int::ParseInt;
-use crate::{collection, ensure};
 
 /// Represents the Ultradebug GPIO pins.
 pub struct UltradebugGpio {
@@ -73,11 +73,7 @@ pub struct UltradebugGpioPin {
 impl GpioPin for UltradebugGpioPin {
     /// Reads the value of the the GPIO pin `id`.
     fn read(&self) -> Result<bool> {
-        let bits = self
-            .device
-            .borrow_mut()
-            .gpio_get()
-            .wrap(TransportError::FtdiError)?;
+        let bits = self.device.borrow_mut().gpio_get().context("FTDI error")?;
         Ok(bits & (1 << self.pin_id) != 0)
     }
 
@@ -86,7 +82,7 @@ impl GpioPin for UltradebugGpioPin {
         self.device
             .borrow_mut()
             .gpio_set(self.pin_id, value)
-            .wrap(TransportError::FtdiError)?;
+            .context("FTDI error")?;
         Ok(())
     }
 
@@ -100,7 +96,7 @@ impl GpioPin for UltradebugGpioPin {
         self.device
             .borrow_mut()
             .gpio_set_direction(self.pin_id, direction)
-            .wrap(TransportError::FtdiError)?;
+            .context("FTDI error")?;
         Ok(())
     }
 

--- a/sw/host/opentitanlib/src/transport/ultradebug/mpsse.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/mpsse.rs
@@ -2,14 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use bitflags::bitflags;
 use log;
 use safe_ftdi as ftdi;
 use std::time::{Duration, Instant};
 use thiserror::Error;
 
-use crate::bail;
 use crate::io::gpio::GpioError;
 use crate::io::spi::SpiError;
 

--- a/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
+++ b/sw/host/opentitanlib/src/transport/ultradebug/uart.rs
@@ -2,15 +2,15 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{Context, Result};
 use safe_ftdi as ftdi;
 use std::cell::RefCell;
 use std::cmp;
 use std::thread;
 use std::time::{Duration, Instant};
 
-use crate::io::uart::{Uart, UartError};
+use crate::io::uart::Uart;
 use crate::transport::ultradebug::Ultradebug;
-use crate::transport::{Result, TransportError, WrapInTransportError};
 
 pub struct Inner {
     device: ftdi::Device,
@@ -26,13 +26,11 @@ impl UltradebugUart {
     pub fn open(ultradebug: &Ultradebug) -> Result<Self> {
         let device = ultradebug
             .from_interface(ftdi::Interface::C)
-            .wrap(TransportError::FtdiError)?;
+            .context("FTDI error")?;
         device
             .set_bitmode(0, ftdi::BitMode::Reset)
-            .wrap(TransportError::FtdiError)?;
-        device
-            .set_baudrate(115200)
-            .wrap(TransportError::FtdiError)?;
+            .context("FTDI error")?;
+        device.set_baudrate(115200).context("FTDI error")?;
         // Read and write timeouts:
         device.set_timeouts(5000, 5000);
         Ok(UltradebugUart {
@@ -51,24 +49,21 @@ impl Uart for UltradebugUart {
 
     fn set_baudrate(&self, baudrate: u32) -> Result<()> {
         let mut inner = self.inner.borrow_mut();
-        inner
-            .device
-            .set_baudrate(baudrate)
-            .wrap(TransportError::FtdiError)?;
+        inner.device.set_baudrate(baudrate).context("FTDI error")?;
         inner.baudrate = baudrate;
         Ok(())
     }
 
     fn read_timeout(&self, buf: &mut [u8], timeout: Duration) -> Result<usize> {
         let now = Instant::now();
-        let count = self.read(buf).wrap(UartError::ReadError)?;
+        let count = self.read(buf).context("UART read error")?;
         if count > 0 {
             return Ok(count);
         }
         let short_delay = cmp::min(timeout.mul_f32(0.1), Duration::from_millis(20));
         while now.elapsed() < timeout {
             thread::sleep(short_delay);
-            let count = self.read(buf).wrap(UartError::ReadError)?;
+            let count = self.read(buf).context("UART read error")?;
             if count > 0 {
                 return Ok(count);
             }
@@ -82,14 +77,14 @@ impl Uart for UltradebugUart {
             .borrow()
             .device
             .read_data(buf)
-            .wrap(UartError::ReadError)?;
+            .context("UART read error")?;
         Ok(n as usize)
     }
 
     fn write(&self, mut buf: &[u8]) -> Result<()> {
         let inner = self.inner.borrow();
         while buf.len() > 0 {
-            let n = inner.device.write_data(buf).wrap(UartError::WriteError)?;
+            let n = inner.device.write_data(buf).context("UART write error")?;
             buf = &buf[n as usize..];
         }
         Ok(())

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{ensure, Result};
 use lazy_static::lazy_static;
 use log::info;
 use regex::Regex;
@@ -9,12 +10,11 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::time::Duration;
 
-use crate::ensure;
 use crate::io::uart::Uart;
 use crate::transport::verilator::subprocess::{Options, Subprocess};
 use crate::transport::verilator::uart::VerilatorUart;
 use crate::transport::{
-    Capabilities, Capability, Result, Transport, TransportError, TransportInterfaceType,
+    Capabilities, Capability, Transport, TransportError, TransportInterfaceType,
 };
 
 #[derive(Default)]
@@ -35,7 +35,7 @@ pub struct Verilator {
 
 impl Verilator {
     /// Creates a verilator subprocess-hosting transport from [`options`].
-    pub fn from_options(options: Options) -> anyhow::Result<Self> {
+    pub fn from_options(options: Options) -> Result<Self> {
         lazy_static! {
             static ref UART: Regex = Regex::new("UART: Created ([^ ]+) for uart0").unwrap();
             static ref SPI: Regex = Regex::new("SPI: Created ([^ ]+) for spi0").unwrap();
@@ -67,7 +67,7 @@ impl Verilator {
     }
 
     /// Shuts down the verilator subprocess.
-    pub fn shutdown(&mut self) -> anyhow::Result<()> {
+    pub fn shutdown(&mut self) -> Result<()> {
         if let Some(mut subprocess) = self.subprocess.take() {
             subprocess.kill()
         } else {

--- a/third_party/cargo/crates.bzl
+++ b/third_party/cargo/crates.bzl
@@ -38,6 +38,7 @@ _DEPENDENCIES = {
         "sha2": "@raze__sha2__0_10_2//:sha2",
         "structopt": "@raze__structopt__0_3_25//:structopt",
         "thiserror": "@raze__thiserror__1_0_30//:thiserror",
+        "typetag": "@raze__typetag__0_1_8//:typetag",
         "zerocopy": "@raze__zerocopy__0_5_0//:zerocopy",
     },
     "sw/host/opentitanlib/opentitantool_derive": {
@@ -490,6 +491,15 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
+        name = "raze__ctor__0_1_22",
+        url = "https://crates.io/api/v1/crates/ctor/0.1.22/download",
+        type = "tar.gz",
+        strip_prefix = "ctor-0.1.22",
+        build_file = Label("//third_party/cargo/remote:BUILD.ctor-0.1.22.bazel"),
+    )
+
+    maybe(
+        http_archive,
         name = "raze__derivative__2_2_0",
         url = "https://crates.io/api/v1/crates/derivative/2.2.0/download",
         type = "tar.gz",
@@ -578,11 +588,11 @@ def raze_fetch_remote_crates():
 
     maybe(
         http_archive,
-        name = "raze__flate2__1_0_22",
-        url = "https://crates.io/api/v1/crates/flate2/1.0.22/download",
+        name = "raze__flate2__1_0_23",
+        url = "https://crates.io/api/v1/crates/flate2/1.0.23/download",
         type = "tar.gz",
-        strip_prefix = "flate2-1.0.22",
-        build_file = Label("//third_party/cargo/remote:BUILD.flate2-1.0.22.bazel"),
+        strip_prefix = "flate2-1.0.23",
+        build_file = Label("//third_party/cargo/remote:BUILD.flate2-1.0.23.bazel"),
     )
 
     maybe(
@@ -602,6 +612,15 @@ def raze_fetch_remote_crates():
         sha256 = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753",
         strip_prefix = "getrandom-0.2.3",
         build_file = Label("//third_party/cargo/remote:BUILD.getrandom-0.2.3.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__ghost__0_1_2",
+        url = "https://crates.io/api/v1/crates/ghost/0.1.2/download",
+        type = "tar.gz",
+        strip_prefix = "ghost-0.1.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.ghost-0.1.2.bazel"),
     )
 
     maybe(
@@ -661,6 +680,15 @@ def raze_fetch_remote_crates():
         sha256 = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b",
         strip_prefix = "indicatif-0.16.2",
         build_file = Label("//third_party/cargo/remote:BUILD.indicatif-0.16.2.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__inventory__0_2_2",
+        url = "https://crates.io/api/v1/crates/inventory/0.2.2/download",
+        type = "tar.gz",
+        strip_prefix = "inventory-0.2.2",
+        build_file = Label("//third_party/cargo/remote:BUILD.inventory-0.2.2.bazel"),
     )
 
     maybe(
@@ -804,6 +832,15 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         strip_prefix = "miniz_oxide-0.4.4",
         build_file = Label("//third_party/cargo/remote:BUILD.miniz_oxide-0.4.4.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__miniz_oxide__0_5_1",
+        url = "https://crates.io/api/v1/crates/miniz_oxide/0.5.1/download",
+        type = "tar.gz",
+        strip_prefix = "miniz_oxide-0.5.1",
+        build_file = Label("//third_party/cargo/remote:BUILD.miniz_oxide-0.5.1.bazel"),
     )
 
     maybe(
@@ -1394,6 +1431,24 @@ def raze_fetch_remote_crates():
         type = "tar.gz",
         strip_prefix = "typenum-1.15.0",
         build_file = Label("//third_party/cargo/remote:BUILD.typenum-1.15.0.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__typetag__0_1_8",
+        url = "https://crates.io/api/v1/crates/typetag/0.1.8/download",
+        type = "tar.gz",
+        strip_prefix = "typetag-0.1.8",
+        build_file = Label("//third_party/cargo/remote:BUILD.typetag-0.1.8.bazel"),
+    )
+
+    maybe(
+        http_archive,
+        name = "raze__typetag_impl__0_1_8",
+        url = "https://crates.io/api/v1/crates/typetag-impl/0.1.8/download",
+        type = "tar.gz",
+        strip_prefix = "typetag-impl-0.1.8",
+        build_file = Label("//third_party/cargo/remote:BUILD.typetag-impl-0.1.8.bazel"),
     )
 
     maybe(

--- a/third_party/cargo/remote/BUILD.ctor-0.1.22.bazel
+++ b/third_party/cargo/remote/BUILD.ctor-0.1.22.bazel
@@ -31,36 +31,12 @@ licenses([
 
 # Generated Targets
 
-# Unsupported target "ar" with type "example" omitted
+# Unsupported target "example" with type "example" omitted
 
-# Unsupported target "dyldcachedump" with type "example" omitted
-
-# Unsupported target "nm" with type "example" omitted
-
-# Unsupported target "objcopy" with type "example" omitted
-
-# Unsupported target "objdump" with type "example" omitted
-
-# Unsupported target "objectmap" with type "example" omitted
-
-# Unsupported target "readobj" with type "example" omitted
-
-rust_library(
-    name = "object",
+rust_proc_macro(
+    name = "ctor",
     srcs = glob(["**/*.rs"]),
     crate_features = [
-        "archive",
-        "coff",
-        "compression",
-        "default",
-        "elf",
-        "flate2",
-        "macho",
-        "pe",
-        "read",
-        "read_core",
-        "std",
-        "unaligned",
     ],
     crate_root = "src/lib.rs",
     data = [],
@@ -70,17 +46,13 @@ rust_library(
     ],
     tags = [
         "cargo-raze",
-        "crate-name=object",
+        "crate-name=ctor",
         "manual",
     ],
-    version = "0.25.3",
+    version = "0.1.22",
     # buildifier: leave-alone
     deps = [
-        "@raze__flate2__1_0_23//:flate2",
-        "@raze__memchr__2_4_1//:memchr",
+        "@raze__quote__1_0_10//:quote",
+        "@raze__syn__1_0_81//:syn",
     ],
 )
-
-# Unsupported target "integration" with type "test" omitted
-
-# Unsupported target "parse_self" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.flate2-1.0.23.bazel
+++ b/third_party/cargo/remote/BUILD.flate2-1.0.23.bazel
@@ -94,24 +94,20 @@ rust_library(
         "crate-name=flate2",
         "manual",
     ],
-    version = "1.0.22",
+    version = "1.0.23",
     # buildifier: leave-alone
     deps = [
         "@raze__cfg_if__1_0_0//:cfg_if",
         "@raze__crc32fast__1_3_2//:crc32fast",
         "@raze__libc__0_2_107//:libc",
-        "@raze__miniz_oxide__0_4_4//:miniz_oxide",
+        "@raze__miniz_oxide__0_5_1//:miniz_oxide",
     ],
 )
-
-# Unsupported target "async-reader" with type "test" omitted
 
 # Unsupported target "early-flush" with type "test" omitted
 
 # Unsupported target "empty-read" with type "test" omitted
 
 # Unsupported target "gunzip" with type "test" omitted
-
-# Unsupported target "tokio" with type "test" omitted
 
 # Unsupported target "zero-write" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.ghost-0.1.2.bazel
+++ b/third_party/cargo/remote/BUILD.ghost-0.1.2.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_proc_macro(
+    name = "ghost",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=ghost",
+        "manual",
+    ],
+    version = "0.1.2",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_32//:proc_macro2",
+        "@raze__quote__1_0_10//:quote",
+        "@raze__syn__1_0_81//:syn",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.inventory-0.2.2.bazel
+++ b/third_party/cargo/remote/BUILD.inventory-0.2.2.bazel
@@ -1,0 +1,62 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "flags" with type "example" omitted
+
+rust_library(
+    name = "inventory",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__ctor__0_1_22//:ctor",
+        "@raze__ghost__0_1_2//:ghost",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=inventory",
+        "manual",
+    ],
+    version = "0.2.2",
+    # buildifier: leave-alone
+    deps = [
+    ],
+)
+
+# Unsupported target "compiletest" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.miniz_oxide-0.5.1.bazel
+++ b/third_party/cargo/remote/BUILD.miniz_oxide-0.5.1.bazel
@@ -1,0 +1,55 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR (Zlib OR Apache-2.0)"
+])
+
+# Generated Targets
+
+rust_library(
+    name = "miniz_oxide",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=miniz_oxide",
+        "manual",
+    ],
+    version = "0.5.1",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__adler__1_0_2//:adler",
+    ],
+)

--- a/third_party/cargo/remote/BUILD.typetag-0.1.8.bazel
+++ b/third_party/cargo/remote/BUILD.typetag-0.1.8.bazel
@@ -1,0 +1,65 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+# Unsupported target "web_event" with type "example" omitted
+
+rust_library(
+    name = "typetag",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    proc_macro_deps = [
+        "@raze__typetag_impl__0_1_8//:typetag_impl",
+    ],
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=typetag",
+        "manual",
+    ],
+    version = "0.1.8",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__erased_serde__0_3_16//:erased_serde",
+        "@raze__inventory__0_2_2//:inventory",
+        "@raze__once_cell__1_8_0//:once_cell",
+        "@raze__serde__1_0_130//:serde",
+    ],
+)
+
+# Unsupported target "test" with type "test" omitted

--- a/third_party/cargo/remote/BUILD.typetag-impl-0.1.8.bazel
+++ b/third_party/cargo/remote/BUILD.typetag-impl-0.1.8.bazel
@@ -1,0 +1,57 @@
+"""
+@generated
+cargo-raze crate build file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+# buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
+load(
+    "@rules_rust//rust:defs.bzl",
+    "rust_binary",
+    "rust_library",
+    "rust_proc_macro",
+    "rust_test",
+)
+
+package(default_visibility = [
+    # Public for visibility by "@raze__crate__version//" targets.
+    #
+    # Prefer access through "//third_party/cargo", which limits external
+    # visibility to explicit Cargo.toml dependencies.
+    "//visibility:public",
+])
+
+licenses([
+    "notice",  # MIT from expression "MIT OR Apache-2.0"
+])
+
+# Generated Targets
+
+rust_proc_macro(
+    name = "typetag_impl",
+    srcs = glob(["**/*.rs"]),
+    crate_features = [
+    ],
+    crate_root = "src/lib.rs",
+    data = [],
+    edition = "2018",
+    rustc_flags = [
+        "--cap-lints=allow",
+    ],
+    tags = [
+        "cargo-raze",
+        "crate-name=typetag-impl",
+        "manual",
+    ],
+    version = "0.1.8",
+    # buildifier: leave-alone
+    deps = [
+        "@raze__proc_macro2__1_0_32//:proc_macro2",
+        "@raze__quote__1_0_10//:quote",
+        "@raze__syn__1_0_81//:syn",
+    ],
+)


### PR DESCRIPTION
1. Eliminate the `transport::Result<>` type, and the private implementations
   of the `bail` and `ensure` macros in favor of those in the `anyhow` crate.
   Using `anyhow::Result` everywhere makes `anyhow::Error` the universal
   error container and includes all of its advantages (Contexts and
   backtraces).
2. Eliminate the `WrapInTransportError` trait in favor of `anyhow::Context`.
   Since we no longer need `TransportError` to be the global sum over all
   possible errors, we attach context messages to assist in describing the
   error that occurred.
3. Instead of a sum-type over all possible transportable errors, implement
   a `SerializedError` that all errors can convert to and from and transport
   it over the wire.
   - All library-specific error types that implement `serde` are faithfully
     recreated at the receiver.
   - Any non-covertable error types (e.g. std::io::Error) have their string
     descriptions captured and are recreated as anyhow::Errors at the
     receiver.
   - All errors can carry a server-side backtrace to assist in debugging.

Signed-off-by: Chris Frantz <cfrantz@google.com>