### PR TITLE
[spi_device] Revise Command Parser to support WREN/WRDI

### DIFF
--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -89,7 +89,7 @@ waive -rules CONST_FF -location {spi_device.sv} -msg {Flip-flop 'fwm_rxerr_q' is
       -comment "This is an unimplemented error signal which is currently tied to 0."
 
 # intentional terminal states
-waive -rules TERMINAL_STATE -location {spi_cmdparse.sv} -regexp {Terminal state 'St(Status|Jedec|Sfdp|ReadCmd|Upload|Addr4B)' is detected}
+waive -rules TERMINAL_STATE -location {spi_cmdparse.sv} -regexp {Terminal state 'St(Status|Jedec|Sfdp|ReadCmd|Upload|Addr4B|WrEn)' is detected}
 waive -rules TERMINAL_STATE -location {spi_readcmd.sv} \
       -regexp {Terminal state 'Main(Output|Error)' is detected} \
       -comment "Intentional dead-end. CSb will reset"

--- a/hw/ip/spi_device/lint/spi_device.waiver
+++ b/hw/ip/spi_device/lint/spi_device.waiver
@@ -70,6 +70,9 @@ waive -rules TWO_STATE_TYPE -location {spi_device.sv} \
 waive -rules TWO_STATE_TYPE -location {spid_upload.sv} \
       -regexp {'sramintf_e' is of two state type} \
       -comment "Enum int unsigned is used as a index. OK to be two state"
+waive -rules TWO_STATE_TYPE -location {spid_status.sv} \
+      -regexp {'status_bit_e' is of two state type} \
+      -comment "Enum status_bit_e is used as an index. OK to be two state"
 
 waive -rules ONE_BIT_MEM_WIDTH -location {spi_device.sv spi_fwmode.sv} -regexp {Memory 'fwm_sram_.*' has word} \
       -comment "Intended implementation to make it consistent with other signals"

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -310,6 +310,10 @@ module spi_device
   logic sck_status_busy_set;       // set by HW (upload)
   logic csb_status_busy_broadcast; // from spid_status
 
+  // WREN / WRDI HW signal
+  logic sck_status_wr_set;
+  logic sck_status_wr_clr;
+
   // Jedec ID
   jedec_cfg_t jedec_cfg;
 
@@ -1355,6 +1359,9 @@ module spi_device
   assign hw2reg.flash_status.busy.d   = readstatus_d[0];
   assign hw2reg.flash_status.status.d = readstatus_d[23:1];
 
+  assign sck_status_wr_set = (cmd_dp_sel == DpWrEn);
+  assign sck_status_wr_clr = (cmd_dp_sel == DpWrDi);
+
   spid_status u_spid_status (
     .clk_i  (clk_spi_in_buf),
     .rst_ni (rst_spi_n),
@@ -1383,6 +1390,9 @@ module spi_device
     .io_mode_o   (sub_iomode[IoModeStatus]),
 
     .inclk_busy_set_i  (sck_status_busy_set), // SCK domain
+
+    .inclk_we_set_i (sck_status_wr_set),
+    .inclk_we_clr_i (sck_status_wr_clr),
 
     .csb_busy_broadcast_o (csb_status_busy_broadcast) // SCK domain
   );

--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -775,16 +775,20 @@ module spi_device
       cmd_info[i] = CmdInfoInput;
     end
 
+    // Hand crafted command information slots
     cmd_info[CmdInfoEn4B].valid  = reg2hw.cmd_info_en4b.valid.q;
     cmd_info[CmdInfoEn4B].opcode = reg2hw.cmd_info_en4b.opcode.q;
 
     cmd_info[CmdInfoEx4B].valid  = reg2hw.cmd_info_ex4b.valid.q;
     cmd_info[CmdInfoEx4B].opcode = reg2hw.cmd_info_ex4b.opcode.q;
 
-  end
+    cmd_info[CmdInfoWrEn].valid  = reg2hw.cmd_info_wren.valid.q;
+    cmd_info[CmdInfoWrEn].opcode = reg2hw.cmd_info_wren.opcode.q;
 
-  logic  unused_wrendi;
-  assign unused_wrendi = ^{reg2hw.cmd_info_wren, reg2hw.cmd_info_wrdi};
+    cmd_info[CmdInfoWrDi].valid  = reg2hw.cmd_info_wrdi.valid.q;
+    cmd_info[CmdInfoWrDi].opcode = reg2hw.cmd_info_wrdi.opcode.q;
+
+  end
 
   //////////////////////////////
   // // Clock & reset control //

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -234,6 +234,8 @@ package spi_device_pkg;
     CmdInfoReserveEnd   = spi_device_reg_pkg::NumCmdInfo - 1,
     CmdInfoEn4B         = CmdInfoReserveEnd + 1,
     CmdInfoEx4B         = CmdInfoEn4B + 1,
+    CmdInfoWrEn         = CmdInfoEx4B + 1,
+    CmdInfoWrDi         = CmdInfoWrEn + 1,
     NumTotalCmdInfo
   } cmd_info_index_e;
 
@@ -311,24 +313,26 @@ package spi_device_pkg;
 
   localparam int MEM_AW = 12; // Memory Address width (Byte based)
 
-  typedef enum logic [7:0] {
-    DpNone       = 'b 00000000,
-    DpReadCmd    = 'b 00000001,
-    DpReadStatus = 'b 00000010,
-    DpReadSFDP   = 'b 00000100,
-    DpReadJEDEC  = 'b 00001000,
+  typedef enum logic [9:0] {
+    DpNone       = 'b 0000000000,
+    DpReadCmd    = 'b 0000000001,
+    DpReadStatus = 'b 0000000010,
+    DpReadSFDP   = 'b 0000000100,
+    DpReadJEDEC  = 'b 0000001000,
 
     // Command + Address only: e.g Block Erase
     // Command + Address + Paylod: Program
     // Command followed by direct payload
     // Write Status could be an example
     // Command only: Write Protect Enable / Chip Erase
-    DpUpload     = 'b 00010000,
+    DpUpload     = 'b 0000010000,
 
-    DpEn4B       = 'b 00100000,
-    DpEx4B       = 'b 01000000,
+    DpEn4B       = 'b 0000100000,
+    DpEx4B       = 'b 0001000000,
+    DpWrEn       = 'b 0010000000,
+    DpWrDi       = 'b 0100000000,
     // Unrecognizable commands: Just handle this as DpPayload
-    DpUnknown    = 'b 10000000
+    DpUnknown    = 'b 1000000000
   } sel_datapath_e;
 
   typedef enum spi_byte_t {


### PR DESCRIPTION
This commit adds WREN/ WRDI to the command information entries then
revises the command parser to support those two commands.

As they are opcode complete commands (8 beats only), cmdparse sets the
sel_dp at the 8th cycle without latch.