### PR TITLE
[rv_core_ibex] Move sim_sram injection point 

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -358,6 +358,13 @@
       default: "2",
       local: "true"
     },
+    { name:    "NumScratchWords",
+      type:    "int",
+      desc:    '''
+        Number of scratch words maintained.
+      '''
+      default: "8"
+    },
   ],
   countermeasures: [
     { name: "BUS.INTEGRITY",
@@ -668,7 +675,7 @@
           desc: '''
                   See !!IBUS_REMAP_ADDR_0 for a detailed description.
                   ''',
-                  count: "NumRegions",
+          count: "NumRegions",
           compact: false,
           swaccess: "rw",
           hwaccess: "hro",
@@ -833,6 +840,21 @@
           },
         ]
       },
+
+      // dv simulation window
+      { window: {
+          name: "DV_SIM_WINDOW",
+          items: "NumScratchWords",
+          validbits: "32",
+          byte-write: "true",
+          swaccess: "rw",
+          unusual: "true"
+          desc: '''
+            Exposed tlul window for DV only purposes.
+          '''
+        },
+      },
+
     ],
   },
 }

--- a/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
+++ b/hw/ip/rv_core_ibex/lint/rv_core_ibex.waiver
@@ -90,7 +90,7 @@ waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_
       -comment "Declaration of signal and assignment to it are in same `else block"
 waive -rules IFDEF_CODE -location {ibex_core.sv} -regexp {Assignment to 'unused_instr_done_wb' contained within `else block} \
       -comment "Declaration of signal and assignment to it are in same `else block"
-waive -rules IFDEF_CODE -location {rv_core_ibex.sv} -regexp {Assignment to 'cored_tl_h_o' contained within `else block} \
+waive -rules IFDEF_CODE -location {rv_core_ibex.sv} -regexp {Assignment to 'tl_win_d2h' contained within `else block} \
       -comment "DV environment will drive things when `else block isn't used so assignment only occurs in `else block"
 waive -rules CLOCK_USE -location {ibex_id_stage.sv} -regexp {'clk_i' is connected to 'ibex_decoder' port 'clk_i'} \
       -comment "clk_i is unused in ibex_decoder configurations without RV32B and isn't connected to logic"

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex.sv
@@ -157,11 +157,6 @@ module rv_core_ibex
   tl_h2d_t tl_d_ibex2fifo;
   tl_d2h_t tl_d_fifo2ibex;
 
-  // Intermediate TL signals to connect an sram used in simulations.
-  tlul_pkg::tl_h2d_t tl_d_o_int;
-  tlul_pkg::tl_d2h_t tl_d_i_int;
-
-
 `ifdef RVFI
   logic        rvfi_valid;
   logic [63:0] rvfi_order;
@@ -571,27 +566,12 @@ module rv_core_ibex
     .rst_ni,
     .tl_h_i      (tl_d_ibex2fifo),
     .tl_h_o      (tl_d_fifo2ibex),
-    .tl_d_o      (tl_d_o_int),
-    .tl_d_i      (tl_d_i_int),
+    .tl_d_o      (cored_tl_h_o),
+    .tl_d_i      (cored_tl_h_i),
     .spare_req_i (1'b0),
     .spare_req_o (),
     .spare_rsp_i (1'b0),
     .spare_rsp_o ());
-
-  //
-  // Interception point for connecting simulation SRAM by disconnecting the tl_d output. The
-  // disconnection is done only if `SYNTHESIS is NOT defined AND `RV_CORE_IBEX_SIM_SRAM is
-  // defined.
-  //
-`ifdef RV_CORE_IBEX_SIM_SRAM
-`ifdef SYNTHESIS
-  // Induce a compilation error by instantiating a non-existent module.
-  illegal_preprocessor_branch_taken u_illegal_preprocessor_branch_taken();
-`endif
-`else
-  assign cored_tl_h_o = tl_d_o_int;
-  assign tl_d_i_int = cored_tl_h_i;
-`endif
 
 `ifdef RVFI
   ibex_tracer ibex_tracer_i (
@@ -631,6 +611,8 @@ module rv_core_ibex
   //////////////////////////////////
 
   logic intg_err;
+  tlul_pkg::tl_h2d_t tl_win_h2d;
+  tlul_pkg::tl_d2h_t tl_win_d2h;
   rv_core_ibex_cfg_reg_top u_reg_cfg (
     .clk_i,
     .rst_ni,
@@ -639,6 +621,8 @@ module rv_core_ibex
     .reg2hw,
     .hw2reg,
     .intg_err_o (intg_err),
+    .tl_win_o(tl_win_h2d),
+    .tl_win_i(tl_win_d2h),
     .devmode_i  (1'b1) // connect to real devmode signal in the future
   );
 
@@ -794,4 +778,50 @@ module rv_core_ibex
   // fpga build info hook-up
   assign hw2reg.fpga_info.d = fpga_info_i;
 
+  /////////////////////////////////////
+  // The carved out space is for DV emulation purposes only
+  /////////////////////////////////////
+
+  import tlul_pkg::tl_h2d_t;
+  import tlul_pkg::tl_d2h_t;
+  localparam int TlH2DWidth = $bits(tl_h2d_t);
+  localparam int TlD2HWidth = $bits(tl_d2h_t);
+
+  logic [TlH2DWidth-1:0] tl_win_h2d_int;
+  logic [TlD2HWidth-1:0] tl_win_d2h_int;
+  tl_d2h_t tl_win_d2h_err_rsp;
+
+  prim_buf #(
+    .Width(TlH2DWidth)
+  ) u_tlul_req_buf (
+    .in_i(tl_win_h2d),
+    .out_o(tl_win_h2d_int)
+  );
+
+  prim_buf #(
+    .Width(TlD2HWidth)
+  ) u_tlul_rsp_buf (
+    .in_i(tl_win_d2h_err_rsp),
+    .out_o(tl_win_d2h_int)
+  );
+
+  // Interception point for connecting simulation SRAM by disconnecting the tl_d output. The
+  // disconnection is done only if `SYNTHESIS is NOT defined AND `RV_CORE_IBEX_SIM_SRAM is
+  // defined.
+  // This define is used only for verilator as verilator does not support forces.
+`ifdef RV_CORE_IBEX_SIM_SRAM
+`ifdef SYNTHESIS
+  // Induce a compilation error by instantiating a non-existent module.
+  illegal_preprocessor_branch_taken u_illegal_preprocessor_branch_taken();
+`endif
+`else
+  assign tl_win_d2h = tl_d2h_t'(tl_win_d2h_int);
+`endif
+
+  tlul_err_resp u_sim_win_rsp (
+    .clk_i,
+    .rst_ni,
+    .tl_h_i(tl_h2d_t'(tl_win_h2d_int)),
+    .tl_h_o(tl_win_d2h_err_rsp)
+  );
 endmodule

--- a/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
+++ b/hw/ip/rv_core_ibex/rtl/rv_core_ibex_reg_pkg.sv
@@ -9,10 +9,11 @@ package rv_core_ibex_reg_pkg;
   // Param list
   parameter int NumSwAlerts = 2;
   parameter int NumRegions = 2;
+  parameter int NumScratchWords = 8;
   parameter int NumAlerts = 4;
 
   // Address widths within the block
-  parameter int CfgAw = 7;
+  parameter int CfgAw = 8;
 
   //////////////////////////////////////////////
   // Typedefs for registers for cfg interface //
@@ -171,31 +172,31 @@ package rv_core_ibex_reg_pkg;
   } rv_core_ibex_cfg_hw2reg_t;
 
   // Register offsets for cfg interface
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ALERT_TEST_OFFSET = 7'h 0;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_RECOV_ERR_OFFSET = 7'h 4;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_FATAL_ERR_OFFSET = 7'h 8;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_0_OFFSET = 7'h c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_1_OFFSET = 7'h 10;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_0_OFFSET = 7'h 14;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_1_OFFSET = 7'h 18;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_OFFSET = 7'h 1c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_OFFSET = 7'h 20;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_0_OFFSET = 7'h 24;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_1_OFFSET = 7'h 28;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_0_OFFSET = 7'h 2c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_1_OFFSET = 7'h 30;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_0_OFFSET = 7'h 34;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_1_OFFSET = 7'h 38;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_OFFSET = 7'h 3c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_OFFSET = 7'h 40;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_0_OFFSET = 7'h 44;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_1_OFFSET = 7'h 48;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_ENABLE_OFFSET = 7'h 4c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_STATE_OFFSET = 7'h 50;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ERR_STATUS_OFFSET = 7'h 54;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_DATA_OFFSET = 7'h 58;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_STATUS_OFFSET = 7'h 5c;
-  parameter logic [CfgAw-1:0] RV_CORE_IBEX_FPGA_INFO_OFFSET = 7'h 60;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ALERT_TEST_OFFSET = 8'h 0;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_RECOV_ERR_OFFSET = 8'h 4;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_SW_FATAL_ERR_OFFSET = 8'h 8;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_0_OFFSET = 8'h c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REGWEN_1_OFFSET = 8'h 10;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_0_OFFSET = 8'h 14;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_EN_1_OFFSET = 8'h 18;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_OFFSET = 8'h 1c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_OFFSET = 8'h 20;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_0_OFFSET = 8'h 24;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_IBUS_REMAP_ADDR_1_OFFSET = 8'h 28;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_0_OFFSET = 8'h 2c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REGWEN_1_OFFSET = 8'h 30;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_0_OFFSET = 8'h 34;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_EN_1_OFFSET = 8'h 38;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_OFFSET = 8'h 3c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_OFFSET = 8'h 40;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_0_OFFSET = 8'h 44;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DBUS_REMAP_ADDR_1_OFFSET = 8'h 48;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_ENABLE_OFFSET = 8'h 4c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_NMI_STATE_OFFSET = 8'h 50;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_ERR_STATUS_OFFSET = 8'h 54;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_DATA_OFFSET = 8'h 58;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_RND_STATUS_OFFSET = 8'h 5c;
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_FPGA_INFO_OFFSET = 8'h 60;
 
   // Reset values for hwext registers and their fields for cfg interface
   parameter logic [3:0] RV_CORE_IBEX_ALERT_TEST_RESVAL = 4'h 0;
@@ -210,6 +211,10 @@ package rv_core_ibex_reg_pkg;
   parameter logic [0:0] RV_CORE_IBEX_RND_STATUS_RND_DATA_FIPS_RESVAL = 1'h 0;
   parameter logic [31:0] RV_CORE_IBEX_FPGA_INFO_RESVAL = 32'h 0;
   parameter logic [31:0] RV_CORE_IBEX_FPGA_INFO_VAL_RESVAL = 32'h 0;
+
+  // Window parameters for cfg interface
+  parameter logic [CfgAw-1:0] RV_CORE_IBEX_DV_SIM_WINDOW_OFFSET = 8'h 80;
+  parameter int unsigned      RV_CORE_IBEX_DV_SIM_WINDOW_SIZE   = 'h 20;
 
   // Register index for cfg interface
   typedef enum int {

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -33,6 +33,8 @@ package chip_env_pkg;
   import top_earlgrey_rnd_cnst_pkg::*;
   import pwm_monitor_pkg::*;
   import pwm_reg_pkg::NOutputs;
+  import tl_main_pkg::ADDR_SPACE_RV_CORE_IBEX__CFG;
+  import rv_core_ibex_reg_pkg::RV_CORE_IBEX_DV_SIM_WINDOW_OFFSET;
 
   // macro includes
   `include "uvm_macros.svh"
@@ -50,7 +52,9 @@ package chip_env_pkg;
   parameter uint SPI_FRAME_BYTE_SIZE = spi_device_reg_pkg::SPI_DEVICE_BUFFER_SIZE/2;
 
   // SW constants - use unmapped address space with at least 32 bytes.
-  parameter bit [TL_AW-1:0] SW_DV_START_ADDR        = 32'h3000_0000;
+
+  parameter bit [TL_AW-1:0] SW_DV_START_ADDR        = ADDR_SPACE_RV_CORE_IBEX__CFG +
+                                                      RV_CORE_IBEX_DV_SIM_WINDOW_OFFSET;
   parameter bit [TL_AW-1:0] SW_DV_TEST_STATUS_ADDR  = SW_DV_START_ADDR + 0;
   parameter bit [TL_AW-1:0] SW_DV_LOG_ADDR          = SW_DV_START_ADDR + 4;
 

--- a/hw/top_earlgrey/dv/tb/tb.sv
+++ b/hw/top_earlgrey/dv/tb/tb.sv
@@ -235,18 +235,17 @@ module tb;
   sim_sram u_sim_sram (
     .clk_i    (`CPU_HIER.clk_i),
     .rst_ni   (`CPU_HIER.rst_ni),
-    .tl_in_i  (`CPU_HIER.tl_d_o_int),
+    .tl_in_i  (tlul_pkg::tl_h2d_t'(`CPU_HIER.u_tlul_req_buf.out_o)),
     .tl_in_o  (),
     .tl_out_o (),
-    .tl_out_i (`CPU_HIER.cored_tl_h_i)
+    .tl_out_i ()
   );
 
   initial begin
     void'($value$plusargs("en_sim_sram=%0b", en_sim_sram));
     if (!stub_cpu && en_sim_sram) begin
       `SIM_SRAM_IF.start_addr = SW_DV_START_ADDR;
-      force `CPU_HIER.tl_d_i_int = u_sim_sram.tl_in_o;
-      force `CPU_HIER.cored_tl_h_o = u_sim_sram.tl_out_o;
+      force `CPU_HIER.u_tlul_rsp_buf.in_i = u_sim_sram.tl_in_o;
     end else begin
       force u_sim_sram.clk_i = 1'b0;
     end

--- a/hw/top_earlgrey/dv/verilator/chip_sim.core
+++ b/hw/top_earlgrey/dv/verilator/chip_sim.core
@@ -78,7 +78,7 @@ targets:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - RVFI=true
       - VERILATOR_MEM_BASE=0x10000000
-      - VERILATOR_TEST_STATUS_ADDR=0x30000000
+      - VERILATOR_TEST_STATUS_ADDR=0x411f0080
       - flashinit
       - rominit
       - otpinit

--- a/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
+++ b/hw/top_earlgrey/dv/verilator/chip_sim_tb.sv
@@ -163,15 +163,15 @@ module chip_sim_tb (
   sim_sram u_sim_sram (
     .clk_i    (`RV_CORE_IBEX.clk_i),
     .rst_ni   (`RV_CORE_IBEX.rst_ni),
-    .tl_in_i  (`RV_CORE_IBEX.tl_d_o_int),
+    .tl_in_i  (tlul_pkg::tl_h2d_t'(`RV_CORE_IBEX.u_tlul_req_buf.out_o)),
     .tl_in_o  (),
     .tl_out_o (),
-    .tl_out_i (`RV_CORE_IBEX.cored_tl_h_i)
+    .tl_out_i ()
+
   );
 
   // Connect the sim SRAM directly inside rv_core_ibex.
-  assign `RV_CORE_IBEX.tl_d_i_int = u_sim_sram.tl_in_o;
-  assign `RV_CORE_IBEX.cored_tl_h_o = u_sim_sram.tl_out_o;
+  assign `RV_CORE_IBEX.tl_win_d2h = u_sim_sram.tl_in_o;
 
   // Instantiate the SW test status interface & connect signals from sim_sram_if instance
   // instantiated inside sim_sram. Bind would have worked nicely here, but Verilator segfaults

--- a/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
+++ b/hw/top_englishbreakfast/chip_englishbreakfast_verilator.core
@@ -78,7 +78,7 @@ targets:
       - PRIM_DEFAULT_IMPL=prim_pkg::ImplGeneric
       - RVFI=true
       - VERILATOR_MEM_BASE=0x10000000
-      - VERILATOR_TEST_STATUS_ADDR=0x30000000
+      - VERILATOR_TEST_STATUS_ADDR=0x411f0080
       - flashinit
       - rominit
       - DMIDirectTAP

--- a/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
+++ b/hw/top_englishbreakfast/rtl/chip_englishbreakfast_verilator.sv
@@ -324,15 +324,14 @@ module chip_englishbreakfast_verilator (
   sim_sram u_sim_sram (
     .clk_i    (`RV_CORE_IBEX.clk_i),
     .rst_ni   (`RV_CORE_IBEX.rst_ni),
-    .tl_in_i  (`RV_CORE_IBEX.tl_d_o_int),
+    .tl_in_i  (tlul_pkg::tl_h2d_t'(`RV_CORE_IBEX.u_tlul_req_buf.out_o)),
     .tl_in_o  (),
     .tl_out_o (),
-    .tl_out_i (`RV_CORE_IBEX.cored_tl_h_i)
+    .tl_out_i ()
   );
 
   // Connect the sim SRAM directly inside rv_core_ibex.
-  assign `RV_CORE_IBEX.tl_d_i_int   = u_sim_sram.tl_in_o;
-  assign `RV_CORE_IBEX.cored_tl_h_o = u_sim_sram.tl_out_o;
+  assign `RV_CORE_IBEX.tl_win_d2h = u_sim_sram.tl_in_o;
 
   // Instantiate the SW test status interface & connect signals from sim_sram_if instance
   // instantiated inside sim_sram. Bind would have worked nicely here, but Verilator segfaults

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -30,7 +30,7 @@ const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 
 // Defined in `hw/top_earlgrey/dv/env/chip_env_pkg.sv`
-const uintptr_t kDeviceTestStatusAddress = 0x30000000;
+const uintptr_t kDeviceTestStatusAddress = 0x411f0080;
 
 // Defined in `hw/top_earlgrey/dv/env/chip_env_pkg.sv`
-const uintptr_t kDeviceLogBypassUartAddress = 0x30000004;
+const uintptr_t kDeviceLogBypassUartAddress = 0x411f0084;

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -31,6 +31,6 @@ const uint32_t kUartTxFifoCpuCycles =
     CALCULATE_UART_TX_FIFO_CPU_CYCLES(kUartBaudrate, kClockFreqCpuHz);
 
 // Defined in `hw/top_earlgrey/chip_earlgrey_verilator.core`
-const uintptr_t kDeviceTestStatusAddress = 0x30000000;
+const uintptr_t kDeviceTestStatusAddress = 0x411f0080;
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;


### PR DESCRIPTION
This addresses https://github.com/lowRISC/opentitan/issues/11965 in a slightly different way.
Instead of replacing sim_sram with scratch registers, this instead
moves the TLUL injection point to an exposed window inside the
rv_core_ibex register space.

This removes the need to use a "fake" physical address that mask
ROM does not open for access.

To ensure this mechanism can be re-used for gate level simulation,
prim buffers are added on both the request/respons channesl for tlul.

This should ensure the signals are not optimized away and can be directly
tapped in a netlist.