### PR TITLE
[top, dv] Update ext clk frequency

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -72,7 +72,8 @@
               ext_clk_freq / 4 or ext_clk_freq / 2.
             '''
       milestone: V1
-      tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed"]
+      tests: ["chip_sw_uart_tx_rx_alt_clk_freq", "chip_sw_uart_tx_rx_alt_clk_freq_low_speed",
+              "chip_sw_uart_tx_rx_alt_clk_fast_ip_clk"]
     }
 
     // GPIO (pre-verified IP) integration tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -297,16 +297,31 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRma", "+use_extclk=1"]
-      reseed: 10
+      run_opts: ["+use_otp_image=LcStRma", "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1"]
+      reseed: 5
     }
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq_low_speed
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRma", "+use_extclk=1", "extclk_low_speed_sel=1"]
-      reseed: 10
+      run_opts: ["+use_otp_image=LcStRma", "+ext_clk_type=ExtClkLowSpeed",
+                 "+use_extclk=1", "+extclk_low_speed_sel=1"]
+      reseed: 5
+    }
+    // usually, uart core clock should be 24 Mhz, same as the div_4_clock, regardless using ext_clk
+    // or not.
+    // This test uses the high speed ext clk 96 Mhz, but only enable div2, so that it runs at
+    // 48Mhz, so that we know ext_clk is actually used. But this test may not work in gate-sim, as
+    // div_4_clock is too fast and it may cause some timing issue
+    {
+      name: chip_sw_uart_tx_rx_alt_clk_fast_ip_clk
+      uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
+      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=LcStRma", "+ext_clk_type=ExtClkHighSpeed",
+                 "+use_extclk=1", "+extclk_low_speed_sel=1"]
+      reseed: 5
     }
     {
       name: chip_sw_spi_device_tx_rx

--- a/hw/top_earlgrey/dv/env/chip_env_pkg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_pkg.sv
@@ -61,6 +61,15 @@ package chip_env_pkg;
 
   // Types of memories in the chip.
   //
+  typedef enum {
+    // external clock is still on, but the source of all IP clocks is the internal clock
+    UseInternalClk,
+    // 48Mhz, same for Life cycle transition mode
+    ExtClkLowSpeed,
+    // 96Mhz
+    ExtClkHighSpeed
+  } ext_clk_type_e;
+
   // RAM instances have support for up to 16 tiles. Actual number of tiles in use in the design is a
   // runtime setting in chip_env_cfg.
   typedef enum {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
@@ -35,14 +35,11 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
       uart_clk_freq_khz = cfg.clk_freq_mhz * 1000 / 4;
 
       if (extclk_low_speed_sel) uart_clk_freq_khz = uart_clk_freq_khz * 2;
-    end else begin
-      // internal uart bus clock is 24Mhz
-      uart_clk_freq_khz = 24_0000;
     end
     `uvm_info(`gfn,
               $sformatf("External clock freq: %0dmhz, use_extclk: %0d, extclk_low_speed_sel: %0d",
               cfg.clk_freq_mhz, use_extclk, extclk_low_speed_sel),
-              UVM_MEDIUM)
+              UVM_LOW)
   endfunction
 
   virtual task dut_init(string reset_kind = "HARD");
@@ -65,18 +62,12 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
       bit [7:0] uart_clk_freq_arr[8] = {<< byte {uart_clk_freq_khz * 1000}};
 
       sw_symbol_backdoor_overwrite("kUseExtClk", use_extclk_arr);
-      `uvm_info(`gfn, $sformatf("Backdoor_overwrite: configure uart use_extclk: %0d", use_extclk),
-                UVM_LOW)
 
       sw_symbol_backdoor_overwrite("kUseLowSpeedSel", low_speed_sel_arr);
-      `uvm_info(`gfn, $sformatf("Backdoor_overwrite: configure low_speed_sel: %0d",
-                extclk_low_speed_sel), UVM_LOW)
 
       // SW relies on kClockFreqPeripheralHz to calcuate NCO and it's hard-coded to 24Mhz in SW.
       // this value is changed when extclk is used
       sw_symbol_backdoor_overwrite("kClockFreqPeripheralHz", uart_clk_freq_arr);
-      `uvm_info(`gfn, $sformatf("Backdoor_overwrite: configure uart use_extclk: %0d",
-                uart_clk_freq_khz), UVM_LOW)
     end
   endtask
 


### PR DESCRIPTION
Update ext clk freq to 48 and 96Mhz based on this [spec](https://github.com/lowRISC/opentitan/blob/master/hw/ip/clkmgr/doc/_index.md#clock-frequency-summary) [#12095](https://github.com/lowRISC/opentitan/pull/12095)

The freq can be controlled via plusarg

Also add a uart test to run with higher freq on the uart core clock

Signed-off-by: Weicai Yang <weicai@google.com>