### PR TITLE
[clkmgr] Correct the disable condition

### DIFF
--- a/hw/ip/prim/rtl/prim_clock_meas.sv
+++ b/hw/ip/prim/rtl/prim_clock_meas.sv
@@ -62,7 +62,9 @@ module prim_clock_meas #(
     if (!rst_ref_ni) begin
       ref_cnt <= '0;
       ref_valid <= '0;
-    end else if (!ref_en && |ref_cnt) begin
+    end else if (!ref_en && (ref_valid || |ref_cnt)) begin
+      // when disable is seen, if either valid is set or count
+      // is non-zero, clear.
       ref_cnt <= '0;
       ref_valid <= '0;
     end else if (ref_en && (int'(ref_cnt) == RefCnt - 1)) begin


### PR DESCRIPTION
- previously, if RefCnt is set to 1, the disable condition
  would basically never be met, and thus once activated, the
  measurement could never be properly disabled.

- I should note that @eunchan pointed out a similar issue before as well, so this is the proper fix. 

Signed-off-by: Timothy Chen <timothytim@google.com>