### PR TITLE
[bazel] add bazel rules for `regtool.py`

### DIFF
--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -13,13 +13,13 @@ def _hjson_header(ctx):
     header = ctx.actions.declare_file("{}.h".format(ctx.label.name))
     ctx.actions.run(
         outputs = [header],
-        inputs = ctx.files.srcs + ctx.files._tool,
+        inputs = ctx.files.srcs + [ctx.executable._regtool],
         arguments = [
             "-D",
             "-o",
             header.path,
         ] + [src.path for src in ctx.files.srcs],
-        executable = ctx.files._tool[0],
+        executable = ctx.executable._regtool,
     )
     return [
         CcInfo(compilation_context = cc_common.create_compilation_context(
@@ -33,7 +33,11 @@ autogen_hjson_header = rule(
     implementation = _hjson_header,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
-        "_tool": attr.label(default = "//util:regtool.py", allow_files = True),
+        "_regtool": attr.label(
+            default = "//util:regtool",
+            executable = True,
+            cfg = "exec",
+        ),
     },
 )
 

--- a/util/BUILD
+++ b/util/BUILD
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_python//python:defs.bzl", "py_binary")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["**"]))
@@ -11,4 +13,23 @@ genrule(
     outs = ["ot_version.txt"],
     cmd = """awk '/BUILD_GIT_VERSION/ { print $$2 }' bazel-out/volatile-status.txt > $@""",
     stamp = 1,  # this provides volatile-status.txt
+)
+
+py_binary(
+    name = "regtool",
+    srcs = ["regtool.py"],
+    deps = [
+        "//util/reggen:countermeasure",
+        "//util/reggen:gen_cheader",
+        "//util/reggen:gen_dv",
+        "//util/reggen:gen_fpv",
+        "//util/reggen:gen_html",
+        "//util/reggen:gen_json",
+        "//util/reggen:gen_rtl",
+        "//util/reggen:gen_rust",
+        "//util/reggen:gen_sec_cm_testplan",
+        "//util/reggen:gen_selfdoc",
+        "//util/reggen:ip_block",
+        "//util/reggen:version",
+    ],
 )

--- a/util/design/mubi/BUILD
+++ b/util/design/mubi/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "prim_mubi",
+    srcs = ["prim_mubi.py"],
+    deps = [requirement("mako")],
+)

--- a/util/reggen/BUILD
+++ b/util/reggen/BUILD
@@ -1,0 +1,299 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "lib",
+    srcs = ["lib.py"],
+)
+
+py_library(
+    name = "access",
+    srcs = ["access.py"],
+    deps = [":lib"],
+)
+
+py_library(
+    name = "alert",
+    srcs = ["alert.py"],
+    deps = [
+        ":bits",
+        ":lib",
+        ":signal",
+    ],
+)
+
+py_library(
+    name = "bits",
+    srcs = ["bits.py"],
+    deps = [
+        ":lib",
+        ":params",
+    ],
+)
+
+py_library(
+    name = "bus_interfaces",
+    srcs = ["bus_interfaces.py"],
+    deps = [
+        ":inter_signal",
+        ":lib",
+    ],
+)
+
+py_library(
+    name = "clocking",
+    srcs = ["clocking.py"],
+    deps = [":lib"],
+)
+
+py_library(
+    name = "countermeasure",
+    srcs = ["countermeasure.py"],
+    deps = [":lib"],
+)
+
+py_library(
+    name = "enum_entry",
+    srcs = ["enum_entry.py"],
+    deps = [":lib"],
+)
+
+py_library(
+    name = "field",
+    srcs = ["field.py"],
+    deps = [
+        ":access",
+        ":bits",
+        ":enum_entry",
+        ":lib",
+        ":params",
+        "//util/design/mubi:prim_mubi",
+    ],
+)
+
+py_library(
+    name = "html_helpers",
+    srcs = ["html_helpers.py"],
+)
+
+py_library(
+    name = "inter_signal",
+    srcs = ["inter_signal.py"],
+    deps = [":lib"],
+)
+
+py_library(
+    name = "ip_block",
+    srcs = ["ip_block.py"],
+    deps = [
+        ":alert",
+        ":bus_interfaces",
+        ":clocking",
+        ":countermeasure",
+        ":inter_signal",
+        ":lib",
+        ":params",
+        ":reg_block",
+        ":signal",
+        requirement("hjson"),
+    ],
+)
+
+py_library(
+    name = "params",
+    srcs = ["params.py"],
+    deps = [":lib"],
+)
+
+py_library(
+    name = "reg_base",
+    srcs = ["reg_base.py"],
+    deps = [":field"],
+)
+
+py_library(
+    name = "reg_block",
+    srcs = ["reg_block.py"],
+    deps = [
+        ":access",
+        ":alert",
+        ":bus_interfaces",
+        ":clocking",
+        ":field",
+        ":lib",
+        ":multi_register",
+        ":params",
+        ":register",
+        ":signal",
+        ":window",
+    ],
+)
+
+py_library(
+    name = "register",
+    srcs = ["register.py"],
+    deps = [
+        ":access",
+        ":clocking",
+        ":field",
+        ":lib",
+        ":params",
+        ":reg_base",
+    ],
+)
+
+py_library(
+    name = "multi_register",
+    srcs = ["multi_register.py"],
+    deps = [
+        ":clocking",
+        ":field",
+        ":lib",
+        ":params",
+        ":reg_base",
+        ":register",
+    ],
+)
+
+py_library(
+    name = "signal",
+    srcs = ["signal.py"],
+    deps = [
+        ":bits",
+        ":lib",
+    ],
+)
+
+py_library(
+    name = "window",
+    srcs = ["window.py"],
+    deps = [
+        ":access",
+        ":lib",
+        ":params",
+    ],
+)
+
+py_library(
+    name = "gen_cheader",
+    srcs = ["gen_cheader.py"],
+    deps = [
+        ":field",
+        ":ip_block",
+        ":multi_register",
+        ":params",
+        ":register",
+        ":signal",
+        ":window",
+    ],
+)
+
+py_library(
+    name = "gen_dv",
+    srcs = ["gen_dv.py"],
+    deps = [
+        ":ip_block",
+        ":multi_register",
+        ":register",
+        ":window",
+        requirement("mako"),
+        requirement("pyyaml"),
+    ],
+)
+
+py_library(
+    name = "gen_fpv",
+    srcs = ["gen_fpv.py"],
+    deps = [
+        ":ip_block",
+        requirement("mako"),
+        requirement("pyyaml"),
+    ],
+)
+
+py_library(
+    name = "gen_html",
+    srcs = ["gen_html.py"],
+    deps = [
+        ":html_helpers",
+        ":ip_block",
+        ":multi_register",
+        ":reg_block",
+        ":register",
+        ":window",
+    ],
+)
+
+py_library(
+    name = "gen_json",
+    srcs = ["gen_json.py"],
+    deps = [requirement("hjson")],
+)
+
+py_library(
+    name = "gen_rtl",
+    srcs = ["gen_json.py"],
+    deps = [
+        ":ip_block",
+        ":lib",
+        ":multi_register",
+        ":reg_base",
+        ":register",
+        requirement("mako"),
+    ],
+)
+
+py_library(
+    name = "gen_rust",
+    srcs = ["gen_rust.py"],
+    deps = [
+        ":field",
+        ":ip_block",
+        ":multi_register",
+        ":params",
+        ":register",
+        ":signal",
+        ":window",
+    ],
+)
+
+py_library(
+    name = "gen_sec_cm_testplan",
+    srcs = ["gen_sec_cm_testplan.py"],
+    deps = [
+        ":ip_block",
+        requirement("hjson"),
+        requirement("mako"),
+    ],
+)
+
+py_library(
+    name = "gen_selfdoc",
+    srcs = ["gen_selfdoc.py"],
+    deps = [
+        ":access",
+        ":enum_entry",
+        ":field",
+        ":ip_block",
+        ":multi_register",
+        ":register",
+        ":validate",
+        ":window",
+    ],
+)
+
+py_library(
+    name = "validate",
+    srcs = ["validate.py"],
+)
+
+py_library(
+    name = "version",
+    srcs = ["version.py"],
+)


### PR DESCRIPTION
The `regtool.py` generates the register header files from HJSON data files. This adds bazel rules for this tool (and all of its libraries) to support running it in a hermetic fashion. 

Additionally, this commit updates the `autogen_hjson_header` rule to use a `py_binary` executable in a proper fashion.