### PR TITLE
Revert "[dv/build_seed] Fix build seed errors"

### DIFF
--- a/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
+++ b/hw/ip/otp_ctrl/dv/otp_ctrl_sim_cfg.hjson
@@ -44,7 +44,7 @@
     // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
     {
       name: build_seed
-      pre_build_cmds: ["cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {build_seed}"]
+      pre_build_cmds: ["cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}"]
       is_sim_mode: 1
     }
   ]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -119,13 +119,14 @@
     }
     // Sim mode that enables build randomization. See the `build_seed` mode
     // defined in `hw/dv/tools/dvsim/common_modes.hjson` for more details.
+    // TODO: enable the following pre_build_cmds once the otp init error is fixed
+    // "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {seed}"
     {
       name: build_seed
       pre_build_cmds: [
         '''cd {proj_root} && ./util/topgen.py -t {ral_spec} \
-               -o hw/top_earlgrey --rnd_cnst_seed {build_seed}
-        ''',
-        "cd {proj_root} && ./util/design/gen-otp-mmap.py --seed {build_seed}"
+               -o hw/top_earlgrey --rnd_cnst_seed {seed}
+        '''
       ]
       is_sim_mode: 1
     }
@@ -140,7 +141,7 @@
   // Setup for generating OTP images.
   gen_otp_images_cfg_dir: "{proj_root}/hw/ip/otp_ctrl/data"
   gen_otp_images_cmd: "{proj_root}/util/design/gen-otp-img.py"
-  gen_otp_images_cmd_opts: ["--quiet", "--img-seed {seed}", "--otp-seed {build_seed}"]
+  gen_otp_images_cmd_opts: ["--quiet", "--seed {seed}"]
 
   // Add run modes.
   run_modes: [

--- a/util/dvsim/Deploy.py
+++ b/util/dvsim/Deploy.py
@@ -299,7 +299,6 @@ class CompileSim(Deploy):
     def __init__(self, build_mode, sim_cfg):
         self.build_mode_obj = build_mode
         self.seed = sim_cfg.build_seed
-        self.build_seed = sim_cfg.build_seed
         super().__init__(sim_cfg)
 
     def _define_attrs(self):
@@ -406,7 +405,6 @@ class RunTest(Deploy):
         self.test_obj = test
         self.index = index
         self.seed = RunTest.get_seed()
-        self.build_seed = sim_cfg.build_seed
         super().__init__(sim_cfg)
 
         if build_job is not None:

--- a/util/dvsim/SimCfg.py
+++ b/util/dvsim/SimCfg.py
@@ -60,7 +60,7 @@ class SimCfg(FlowCfg):
     # TODO: Find a way to set these in sim cfg instead
     ignored_wildcards = [
         "build_mode", "index", "test", "seed", "uvm_test", "uvm_test_seq",
-        "cov_db_dirs", "sw_images", "sw_build_device", "build_seed"
+        "cov_db_dirs", "sw_images", "sw_build_device"
     ]
 
     def __init__(self, flow_cfg_file, hjson_data, args, mk_config):
@@ -108,11 +108,6 @@ class SimCfg(FlowCfg):
             self.en_build_modes.append("xprop")
         if self.build_seed:
             self.en_build_modes.append("build_seed")
-        else:
-            # TODO: when build_seed mode is not enabled, the script should not
-            # pass `--otp-seed` args. Temp support this by providing default
-            # build seed value.
-            self.build_seed = 10556718629619452145
 
         # Options built from cfg_file files
         self.project = ""


### PR DESCRIPTION
Reverts lowRISC/opentitan#12112
As discussed in that PR, we are planning to explore a different way to handle build_seed to ensure run phase is not depend on the input from build phase.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>