### PR TITLE
[clkmgr] External ack readback for external clock switch

### DIFF
--- a/hw/ip/clkmgr/data/clkmgr.hjson.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.hjson.tpl
@@ -279,6 +279,30 @@
       tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
+    { name: "EXTCLK_STATUS",
+      desc: '''
+        Status of requested external clock switch
+      ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        {
+          bits: "3:0",
+          name: "ACK",
+          mubi: true,
+          desc: '''
+            When !!EXTCLK_CTRL.SEL is set to kMultiBitBool4True, this field reflects
+            whether the clock has been switched the external source.
+
+            kMultiBitBool4True indicates the switch is complete.
+            kMultiBitBool4False indicates the switch is either not possible or still ongoing.
+          '''
+          resval: "false"
+        },
+      ]
+    },
+
     { name: "JITTER_REGWEN",
       desc: "Jitter write enable",
       swaccess: "rw0c",

--- a/hw/ip/clkmgr/data/clkmgr.sv.tpl
+++ b/hw/ip/clkmgr/data/clkmgr.sv.tpl
@@ -238,6 +238,7 @@ from topgen.lib import Name
     .lc_clk_byp_req_i,
     .lc_clk_byp_ack_o,
     .byp_req_i(extclk_ctrl_sel),
+    .byp_ack_o(hw2reg.extclk_status.d),
     .hi_speed_sel_i(extclk_ctrl_hi_speed_sel),
     .all_clk_byp_req_o,
     .all_clk_byp_ack_i,

--- a/hw/ip/clkmgr/rtl/clkmgr_byp.sv
+++ b/hw/ip/clkmgr/rtl/clkmgr_byp.sv
@@ -19,6 +19,7 @@ module clkmgr_byp
   output lc_tx_t          lc_clk_byp_ack_o,
   // interaction with software
   input  mubi4_t          byp_req_i,
+  output mubi4_t          byp_ack_o,
   input  mubi4_t          hi_speed_sel_i,
   // interaction with ast
   output mubi4_t          all_clk_byp_req_o,
@@ -107,7 +108,7 @@ module clkmgr_byp
 
   // software switch request handling
   mubi4_t dft_en;
-  assign dft_en = (en == lc_ctrl_pkg::On) ? MuBi4True : MuBi4False;
+  assign dft_en = lc_ctrl_pkg::lc_to_mubi4(en);
 
   mubi4_t all_clk_byp_req_d;
   assign all_clk_byp_req_d = mubi4_and_hi(byp_req_i, dft_en);
@@ -122,9 +123,6 @@ module clkmgr_byp
     .mubi_i(all_clk_byp_req_d),
     .mubi_o(all_clk_byp_req_o)
   );
-
-  // divider step down handling
-  mubi4_t unused_all_clk_byp_ack;
 
   prim_mubi4_sync #(
     .AsyncOn(1),
@@ -147,7 +145,7 @@ module clkmgr_byp
     .clk_i,
     .rst_ni,
     .mubi_i(all_clk_byp_ack_i),
-    .mubi_o({unused_all_clk_byp_ack})
+    .mubi_o(byp_ack_o)
   );
 
   // the software high speed select is valid only when software requests clock

--- a/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
+++ b/hw/top_earlgrey/ip/clkmgr/data/autogen/clkmgr.hjson
@@ -277,6 +277,30 @@
       tags: ["excl:CsrAllTests:CsrExclWrite"]
     },
 
+    { name: "EXTCLK_STATUS",
+      desc: '''
+        Status of requested external clock switch
+      ''',
+      swaccess: "ro",
+      hwaccess: "hwo",
+      hwext: "true",
+      fields: [
+        {
+          bits: "3:0",
+          name: "ACK",
+          mubi: true,
+          desc: '''
+            When !!EXTCLK_CTRL.SEL is set to kMultiBitBool4True, this field reflects
+            whether the clock has been switched the external source.
+
+            kMultiBitBool4True indicates the switch is complete.
+            kMultiBitBool4False indicates the switch is either not possible or still ongoing.
+          '''
+          resval: "false"
+        },
+      ]
+    },
+
     { name: "JITTER_REGWEN",
       desc: "Jitter write enable",
       swaccess: "rw0c",

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr.sv
@@ -271,6 +271,7 @@
     .lc_clk_byp_req_i,
     .lc_clk_byp_ack_o,
     .byp_req_i(extclk_ctrl_sel),
+    .byp_ack_o(hw2reg.extclk_status.d),
     .hi_speed_sel_i(extclk_ctrl_hi_speed_sel),
     .all_clk_byp_req_o,
     .all_clk_byp_ack_i,

--- a/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/clkmgr/rtl/autogen/clkmgr_reg_pkg.sv
@@ -13,7 +13,7 @@ package clkmgr_reg_pkg;
   parameter int NumAlerts = 2;
 
   // Address widths within the block
-  parameter int BlockAw = 6;
+  parameter int BlockAw = 7;
 
   ////////////////////////////
   // Typedefs for registers //
@@ -146,6 +146,10 @@ package clkmgr_reg_pkg;
   } clkmgr_reg2hw_fatal_err_code_reg_t;
 
   typedef struct packed {
+    logic [3:0]  d;
+  } clkmgr_hw2reg_extclk_status_reg_t;
+
+  typedef struct packed {
     struct packed {
       logic        d;
       logic        de;
@@ -243,39 +247,44 @@ package clkmgr_reg_pkg;
 
   // HW -> register type
   typedef struct packed {
+    clkmgr_hw2reg_extclk_status_reg_t extclk_status; // [39:36]
     clkmgr_hw2reg_clk_hints_status_reg_t clk_hints_status; // [35:28]
     clkmgr_hw2reg_recov_err_code_reg_t recov_err_code; // [27:6]
     clkmgr_hw2reg_fatal_err_code_reg_t fatal_err_code; // [5:0]
   } clkmgr_hw2reg_t;
 
   // Register offsets
-  parameter logic [BlockAw-1:0] CLKMGR_ALERT_TEST_OFFSET = 6'h 0;
-  parameter logic [BlockAw-1:0] CLKMGR_EXTCLK_CTRL_REGWEN_OFFSET = 6'h 4;
-  parameter logic [BlockAw-1:0] CLKMGR_EXTCLK_CTRL_OFFSET = 6'h 8;
-  parameter logic [BlockAw-1:0] CLKMGR_JITTER_REGWEN_OFFSET = 6'h c;
-  parameter logic [BlockAw-1:0] CLKMGR_JITTER_ENABLE_OFFSET = 6'h 10;
-  parameter logic [BlockAw-1:0] CLKMGR_CLK_ENABLES_OFFSET = 6'h 14;
-  parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_OFFSET = 6'h 18;
-  parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_STATUS_OFFSET = 6'h 1c;
-  parameter logic [BlockAw-1:0] CLKMGR_MEASURE_CTRL_REGWEN_OFFSET = 6'h 20;
-  parameter logic [BlockAw-1:0] CLKMGR_IO_MEAS_CTRL_SHADOWED_OFFSET = 6'h 24;
-  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED_OFFSET = 6'h 28;
-  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED_OFFSET = 6'h 2c;
-  parameter logic [BlockAw-1:0] CLKMGR_MAIN_MEAS_CTRL_SHADOWED_OFFSET = 6'h 30;
-  parameter logic [BlockAw-1:0] CLKMGR_USB_MEAS_CTRL_SHADOWED_OFFSET = 6'h 34;
-  parameter logic [BlockAw-1:0] CLKMGR_RECOV_ERR_CODE_OFFSET = 6'h 38;
-  parameter logic [BlockAw-1:0] CLKMGR_FATAL_ERR_CODE_OFFSET = 6'h 3c;
+  parameter logic [BlockAw-1:0] CLKMGR_ALERT_TEST_OFFSET = 7'h 0;
+  parameter logic [BlockAw-1:0] CLKMGR_EXTCLK_CTRL_REGWEN_OFFSET = 7'h 4;
+  parameter logic [BlockAw-1:0] CLKMGR_EXTCLK_CTRL_OFFSET = 7'h 8;
+  parameter logic [BlockAw-1:0] CLKMGR_EXTCLK_STATUS_OFFSET = 7'h c;
+  parameter logic [BlockAw-1:0] CLKMGR_JITTER_REGWEN_OFFSET = 7'h 10;
+  parameter logic [BlockAw-1:0] CLKMGR_JITTER_ENABLE_OFFSET = 7'h 14;
+  parameter logic [BlockAw-1:0] CLKMGR_CLK_ENABLES_OFFSET = 7'h 18;
+  parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_OFFSET = 7'h 1c;
+  parameter logic [BlockAw-1:0] CLKMGR_CLK_HINTS_STATUS_OFFSET = 7'h 20;
+  parameter logic [BlockAw-1:0] CLKMGR_MEASURE_CTRL_REGWEN_OFFSET = 7'h 24;
+  parameter logic [BlockAw-1:0] CLKMGR_IO_MEAS_CTRL_SHADOWED_OFFSET = 7'h 28;
+  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED_OFFSET = 7'h 2c;
+  parameter logic [BlockAw-1:0] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED_OFFSET = 7'h 30;
+  parameter logic [BlockAw-1:0] CLKMGR_MAIN_MEAS_CTRL_SHADOWED_OFFSET = 7'h 34;
+  parameter logic [BlockAw-1:0] CLKMGR_USB_MEAS_CTRL_SHADOWED_OFFSET = 7'h 38;
+  parameter logic [BlockAw-1:0] CLKMGR_RECOV_ERR_CODE_OFFSET = 7'h 3c;
+  parameter logic [BlockAw-1:0] CLKMGR_FATAL_ERR_CODE_OFFSET = 7'h 40;
 
   // Reset values for hwext registers and their fields
   parameter logic [1:0] CLKMGR_ALERT_TEST_RESVAL = 2'h 0;
   parameter logic [0:0] CLKMGR_ALERT_TEST_RECOV_FAULT_RESVAL = 1'h 0;
   parameter logic [0:0] CLKMGR_ALERT_TEST_FATAL_FAULT_RESVAL = 1'h 0;
+  parameter logic [3:0] CLKMGR_EXTCLK_STATUS_RESVAL = 4'h 5;
+  parameter logic [3:0] CLKMGR_EXTCLK_STATUS_ACK_RESVAL = 4'h 5;
 
   // Register index
   typedef enum int {
     CLKMGR_ALERT_TEST,
     CLKMGR_EXTCLK_CTRL_REGWEN,
     CLKMGR_EXTCLK_CTRL,
+    CLKMGR_EXTCLK_STATUS,
     CLKMGR_JITTER_REGWEN,
     CLKMGR_JITTER_ENABLE,
     CLKMGR_CLK_ENABLES,
@@ -292,23 +301,24 @@ package clkmgr_reg_pkg;
   } clkmgr_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] CLKMGR_PERMIT [16] = '{
+  parameter logic [3:0] CLKMGR_PERMIT [17] = '{
     4'b 0001, // index[ 0] CLKMGR_ALERT_TEST
     4'b 0001, // index[ 1] CLKMGR_EXTCLK_CTRL_REGWEN
     4'b 0001, // index[ 2] CLKMGR_EXTCLK_CTRL
-    4'b 0001, // index[ 3] CLKMGR_JITTER_REGWEN
-    4'b 0001, // index[ 4] CLKMGR_JITTER_ENABLE
-    4'b 0001, // index[ 5] CLKMGR_CLK_ENABLES
-    4'b 0001, // index[ 6] CLKMGR_CLK_HINTS
-    4'b 0001, // index[ 7] CLKMGR_CLK_HINTS_STATUS
-    4'b 0001, // index[ 8] CLKMGR_MEASURE_CTRL_REGWEN
-    4'b 0111, // index[ 9] CLKMGR_IO_MEAS_CTRL_SHADOWED
-    4'b 0111, // index[10] CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED
-    4'b 0111, // index[11] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED
-    4'b 0111, // index[12] CLKMGR_MAIN_MEAS_CTRL_SHADOWED
-    4'b 0111, // index[13] CLKMGR_USB_MEAS_CTRL_SHADOWED
-    4'b 0011, // index[14] CLKMGR_RECOV_ERR_CODE
-    4'b 0001  // index[15] CLKMGR_FATAL_ERR_CODE
+    4'b 0001, // index[ 3] CLKMGR_EXTCLK_STATUS
+    4'b 0001, // index[ 4] CLKMGR_JITTER_REGWEN
+    4'b 0001, // index[ 5] CLKMGR_JITTER_ENABLE
+    4'b 0001, // index[ 6] CLKMGR_CLK_ENABLES
+    4'b 0001, // index[ 7] CLKMGR_CLK_HINTS
+    4'b 0001, // index[ 8] CLKMGR_CLK_HINTS_STATUS
+    4'b 0001, // index[ 9] CLKMGR_MEASURE_CTRL_REGWEN
+    4'b 0111, // index[10] CLKMGR_IO_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[11] CLKMGR_IO_DIV2_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[12] CLKMGR_IO_DIV4_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[13] CLKMGR_MAIN_MEAS_CTRL_SHADOWED
+    4'b 0111, // index[14] CLKMGR_USB_MEAS_CTRL_SHADOWED
+    4'b 0011, // index[15] CLKMGR_RECOV_ERR_CODE
+    4'b 0001  // index[16] CLKMGR_FATAL_ERR_CODE
   };
 
 endpackage


### PR DESCRIPTION
- when software requests an external clock switch, it can
  now poll on a status to see when the switch is complete.

- fixes #12152

Signed-off-by: Timothy Chen <timothytim@google.com>