### PR TITLE
[opentitantool] Eliminate the `mundane` crate

### DIFF
--- a/sw/host/opentitanlib/Cargo.toml
+++ b/sw/host/opentitanlib/Cargo.toml
@@ -25,11 +25,6 @@ rusb = "0.8.1"
 serialport = "4.0.1"
 zerocopy = "0.5.0"
 hex = "0.4.3"
-# We depend on mundane, but `cargo raze` can't auto generate bazel rules for it.
-# In order to not break the current meson-based build system, we'll leave
-# mundane as a dependency.  To regenerate the bazel dependency rules via
-# `cargo raze`, you'll have to temporarily comment out `mundane`.
-mundane = "0.5.0"
 memoffset = "0.6.0"
 num-bigint-dig = "0.7.0"
 num-traits = "0.2.14"

--- a/sw/host/opentitanlib/src/bootstrap/legacy.rs
+++ b/sw/host/opentitanlib/src/bootstrap/legacy.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use mundane::hash::{Digest, Hasher, Sha256};
+use sha2::{Digest, Sha256};
 use std::time::Duration;
 use thiserror::Error;
 use zerocopy::AsBytes;
@@ -51,21 +51,20 @@ impl Frame {
     /// Computes the hash in the header.
     fn header_hash(&self) -> [u8; Frame::HASH_LEN] {
         let frame = self.as_bytes();
-        let sha = Sha256::hash(&frame[Frame::HASH_LEN..]);
-        sha.bytes()
+        let sha = Sha256::digest(&frame[Frame::HASH_LEN..]);
+        sha.into()
     }
 
     /// Computes the hash over the entire frame.
     fn frame_hash(&self) -> [u8; Frame::HASH_LEN] {
-        let sha = Sha256::hash(self.as_bytes());
-        let mut digest = sha.bytes();
+        let mut digest = Sha256::digest(self.as_bytes());
         // Touch up zeroes into ones, as that is what the old chips are doing.
         for b in &mut digest {
             if *b == 0 {
                 *b = 1;
             }
         }
-        digest
+        digest.into()
     }
 
     /// Creates a sequence of frames based on a `payload` binary.

--- a/sw/host/opentitanlib/src/bootstrap/primitive.rs
+++ b/sw/host/opentitanlib/src/bootstrap/primitive.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use mundane::hash::{Digest, Hasher, Sha256};
+use sha2::{Digest, Sha256};
 use std::time::Duration;
 use zerocopy::AsBytes;
 
@@ -44,22 +44,20 @@ impl Frame {
     /// Computes the hash in the header.
     fn header_hash(&self) -> [u8; Frame::HASH_LEN] {
         let frame = self.as_bytes();
-        let sha = Sha256::hash(&frame[Frame::HASH_LEN..]);
-        let mut digest = sha.bytes();
+        let mut digest = Sha256::digest(&frame[Frame::HASH_LEN..]);
         // Note: the OpenTitan HMAC produces the digest in little-endian order,
         // so we reverse the order of the bytes in the digest.
         digest.reverse();
-        digest
+        digest.into()
     }
 
     /// Computes the hash over the entire frame.
     fn frame_hash(&self) -> [u8; Frame::HASH_LEN] {
-        let sha = Sha256::hash(self.as_bytes());
-        let mut digest = sha.bytes();
+        let mut digest = Sha256::digest(self.as_bytes());
         // Note: the OpenTitan HMAC produces the digest in little-endian order,
         // so we reverse the order of the bytes in the digest.
         digest.reverse();
-        digest
+        digest.into()
     }
 
     /// Creates a sequence of frames based on a `payload` binary.

--- a/sw/host/opentitanlib/src/bootstrap/rescue.rs
+++ b/sw/host/opentitanlib/src/bootstrap/rescue.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, ensure, Result};
-use mundane::hash::{Digest, Hasher, Sha256};
+use sha2::{Digest, Sha256};
 use std::time::{Duration, Instant};
 use thiserror::Error;
 use zerocopy::AsBytes;
@@ -51,21 +51,20 @@ impl Frame {
     /// Computes the hash in the header.
     fn header_hash(&self) -> [u8; Frame::HASH_LEN] {
         let frame = self.as_bytes();
-        let sha = Sha256::hash(&frame[Frame::HASH_LEN..]);
-        sha.bytes()
+        let sha = Sha256::digest(&frame[Frame::HASH_LEN..]);
+        sha.into()
     }
 
     /// Computes the hash over the entire frame.
     fn frame_hash(&self) -> [u8; Frame::HASH_LEN] {
-        let sha = Sha256::hash(self.as_bytes());
-        let mut digest = sha.bytes();
+        let mut digest = Sha256::digest(self.as_bytes());
         // Touch up zeroes into ones, as that is what the old chips are doing.
         for b in &mut digest {
             if *b == 0 {
                 *b = 1;
             }
         }
-        digest
+        digest.into()
     }
 
     /// Creates a sequence of frames based on a `payload` binary.

--- a/sw/host/opentitanlib/src/otp/otp_mmap.rs
+++ b/sw/host/opentitanlib/src/otp/otp_mmap.rs
@@ -13,6 +13,9 @@ use std::convert::TryInto;
 use std::fs;
 use std::path::Path;
 
+// FIXME: The OTP module is not being used yet.  When we write the OTP
+// configuration utility, remove the `dead_code`s and clean up the warnings.
+
 #[derive(Deserialize, Debug)]
 struct OtpMapConfig {
     #[serde(with = "num_de")]
@@ -52,13 +55,16 @@ struct OtpMapItem {
     #[serde(with = "num_de")]
     size: usize,
     #[serde(default)]
+    #[allow(dead_code)]
     isdigest: bool,
+    #[allow(dead_code)]
     inv_default: Option<DeferredValue>,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct OtpMapPartition {
     name: String,
+    #[allow(dead_code)]
     secret: bool,
     #[serde(default, with = "num_de")]
     size: usize,
@@ -70,6 +76,7 @@ pub struct OtpMapPartition {
 
 #[derive(Deserialize, Debug)]
 pub struct OtpMap {
+    #[allow(dead_code)]
     seed: String,
     otp: OtpMapConfig,
     scrambling: OtpMapScrambling,

--- a/sw/host/opentitanlib/src/transport/mod.rs
+++ b/sw/host/opentitanlib/src/transport/mod.rs
@@ -154,14 +154,14 @@ pub mod tests {
 
     #[test]
     fn test_capabilities_met() -> anyhow::Result<()> {
-        let mut cap = Capabilities::new(Capability::UART | Capability::SPI);
+        let cap = Capabilities::new(Capability::UART | Capability::SPI);
         assert!(cap.request(Capability::UART).ok().is_ok());
         Ok(())
     }
 
     #[test]
     fn test_capabilities_not_met() -> anyhow::Result<()> {
-        let mut cap = Capabilities::new(Capability::UART | Capability::SPI);
+        let cap = Capabilities::new(Capability::UART | Capability::SPI);
         assert!(cap.request(Capability::GPIO).ok().is_err());
         Ok(())
     }

--- a/sw/host/opentitanlib/src/util/bigint.rs
+++ b/sw/host/opentitanlib/src/util/bigint.rs
@@ -85,6 +85,8 @@ impl<const BIT_LEN: usize, const EXACT_LEN: bool> FixedSizeBigInt<BIT_LEN, EXACT
     }
 
     /// Returns the underlying `BigUint`.
+    // FIXME: remove this `dead_code` if this function is ever used.
+    #[allow(dead_code)]
     pub(crate) fn as_biguint(&self) -> &BigUint {
         &self.0
     }


### PR DESCRIPTION
1. Use the `sha2` crate to compute the needed SHA-256 digests.
2. Disable some unhelpful warnings.

Signed-off-by: Chris Frantz <cfrantz@google.com>