### PR TITLE
[bazel] add rules for misc. python scripts

### DIFF
--- a/hw/ip/otp_ctrl/data/BUILD
+++ b/hw/ip/otp_ctrl/data/BUILD
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-package(default_visibility = ["//visibility:public"])
-
 load("//rules:autogen.bzl", "autogen_hjson_header", "otp_image")
+
+package(default_visibility = ["//visibility:public"])
 
 autogen_hjson_header(
     name = "otp_ctrl_regs",
@@ -15,11 +15,7 @@ autogen_hjson_header(
 
 otp_image(
     name = "rma_image_verilator",
-    src = "otp_ctrl_img_rma.hjson",
-    deps = [
-        "otp_ctrl_mmap.hjson",
-        "//hw/ip/lc_ctrl/data:lc_ctrl_state.hjson",
-    ],
+    src = ":otp_ctrl_img_rma.hjson",
 )
 
 filegroup(

--- a/hw/ip/rom_ctrl/util/BUILD
+++ b/hw/ip/rom_ctrl/util/BUILD
@@ -2,6 +2,32 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
-exports_files(["scramble_image.py"])
+py_library(
+    name = "mem",
+    srcs = ["mem.py"],
+    deps = [
+        "//util/design:secded_gen",
+        requirement("pyelftools"),
+    ],
+)
+
+py_binary(
+    name = "gen_vivado_mem_image",
+    srcs = ["gen_vivado_mem_image.py"],
+    deps = [":mem"],
+)
+
+py_binary(
+    name = "scramble_image",
+    srcs = ["scramble_image.py"],
+    deps = [
+        ":mem",
+        requirement("hjson"),
+        requirement("pycryptodome"),
+    ],
+)

--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -84,9 +84,18 @@ def _otp_image(ctx):
     output = ctx.actions.declare_file(ctx.attr.name + ".vmem")
     ctx.actions.run(
         outputs = [output],
-        inputs = [ctx.file.src] + ctx.files.deps + [ctx.executable._tool],
+        inputs = [
+            ctx.file.src,
+            ctx.file.lc_state_def,
+            ctx.file.mmap_def,
+            ctx.executable._tool,
+        ],
         arguments = [
             "--quiet",
+            "--lc-state-def",
+            ctx.file.lc_state_def.path,
+            "--mmap-def",
+            ctx.file.mmap_def.path,
             "--img-cfg",
             ctx.file.src.path,
             "--out",
@@ -100,7 +109,16 @@ otp_image = rule(
     implementation = _otp_image,
     attrs = {
         "src": attr.label(allow_single_file = True),
-        "deps": attr.label_list(allow_files = True),
+        "lc_state_def": attr.label(
+            allow_single_file = True,
+            default = "//hw/ip/lc_ctrl/data:lc_ctrl_state.hjson",
+            doc = "Life-cycle state definition file in Hjson format.",
+        ),
+        "mmap_def": attr.label(
+            allow_single_file = True,
+            default = "//hw/ip/otp_ctrl/data:otp_ctrl_mmap.hjson",
+            doc = "OTP Controller memory map file in Hjson format.",
+        ),
         "_tool": attr.label(
             default = "//util/design:gen-otp-img",
             executable = True,

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -275,13 +275,13 @@ def _scramble_flash_vmem_impl(ctx):
         outputs = [scrambled_vmem],
         inputs = [
             ctx.file.vmem,
-            ctx.file._tool,
+            ctx.executable._tool,
         ],
         arguments = [
             ctx.file.vmem.path,
             scrambled_vmem.path,
         ],
-        executable = ctx.file._tool.path,
+        executable = ctx.executable._tool,
     )
     return [DefaultInfo(
         files = depset(outputs),
@@ -293,8 +293,9 @@ scramble_flash_vmem = rv_rule(
     attrs = {
         "vmem": attr.label(allow_single_file = True),
         "_tool": attr.label(
-            default = "//util/design:gen-flash-img.py",
-            allow_single_file = True,
+            default = "//util/design:gen-flash-img",
+            executable = True,
+            cfg = "exec",
         ),
     },
 )

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -176,15 +176,15 @@ def _elf_to_scrambled_rom_impl(ctx):
             outputs = [scrambled],
             inputs = [
                 src,
-                ctx.files._tool[0],
-                ctx.files._config[0],
+                ctx.executable._scramble_tool,
+                ctx.file._config,
             ],
             arguments = [
-                ctx.files._config[0].path,
+                ctx.file._config.path,
                 src.path,
                 scrambled.path,
             ],
-            executable = ctx.files._tool[0].path,
+            executable = ctx.executable._scramble_tool,
         )
     return [DefaultInfo(
         files = depset(outputs),
@@ -195,13 +195,14 @@ elf_to_scrambled_rom_vmem = rv_rule(
     implementation = _elf_to_scrambled_rom_impl,
     attrs = {
         "srcs": attr.label_list(allow_files = True),
-        "_tool": attr.label(
-            default = "//hw/ip/rom_ctrl/util:scramble_image.py",
-            allow_files = True,
+        "_scramble_tool": attr.label(
+            default = "//hw/ip/rom_ctrl/util:scramble_image",
+            executable = True,
+            cfg = "exec",
         ),
         "_config": attr.label(
             default = "//hw/top_earlgrey/data:autogen/top_earlgrey.gen.hjson",
-            allow_files = True,
+            allow_single_file = True,
         ),
     },
 )
@@ -386,7 +387,7 @@ gen_sim_dv_logs_db = rule(
         "platform": attr.string(default = OPENTITAN_PLATFORM),
         "_tool": attr.label(
             default = "//util/device_sw_utils:extract_sw_logs_db",
-            cfg = "host",
+            cfg = "exec",
             executable = True,
         ),
         "_allowlist_function_transition": attr.label(

--- a/util/BUILD
+++ b/util/BUILD
@@ -16,6 +16,11 @@ genrule(
 )
 
 py_binary(
+    name = "rom_chip_info",
+    srcs = ["rom_chip_info.py"],
+)
+
+py_binary(
     name = "regtool",
     srcs = ["regtool.py"],
     deps = [

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -2,9 +2,35 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@ot_python_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_binary")
+
 package(default_visibility = ["//visibility:public"])
 
-exports_files([
-    "gen-flash-img.py",
-    "gen-otp-img.py",
-])
+py_library(
+    name = "lib",
+    srcs = ["secded_gen.py"],
+    deps = [requirement("hjson")],
+)
+
+py_library(
+    name = "secded_gen",
+    srcs = ["secded_gen.py"],
+    deps = [requirement("hjson")],
+)
+
+py_binary(
+    name = "gen-flash-img",
+    srcs = ["gen-flash-img.py"],
+    deps = [":secded_gen"],
+)
+
+py_binary(
+    name = "gen-otp-img",
+    srcs = ["gen-otp-img.py"],
+    deps = [
+        "//util/design/lib:common",
+        "//util/design/lib:otp_mem_img",
+        requirement("hjson"),
+    ],
+)

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -8,12 +8,6 @@ load("@rules_python//python:defs.bzl", "py_binary")
 package(default_visibility = ["//visibility:public"])
 
 py_library(
-    name = "lib",
-    srcs = ["secded_gen.py"],
-    deps = [requirement("hjson")],
-)
-
-py_library(
     name = "secded_gen",
     srcs = ["secded_gen.py"],
     deps = [requirement("hjson")],
@@ -28,6 +22,7 @@ py_binary(
 py_binary(
     name = "gen-otp-img",
     srcs = ["gen-otp-img.py"],
+    imports = ["."],
     deps = [
         "//util/design/lib:common",
         "//util/design/lib:otp_mem_img",

--- a/util/design/lib/BUILD
+++ b/util/design/lib/BUILD
@@ -1,0 +1,49 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "common",
+    srcs = ["common.py"],
+)
+
+py_library(
+    name = "lc_st_enc",
+    srcs = ["LcStEnc.py"],
+    deps = [
+        ":common",
+        requirement("pycryptodome"),
+    ],
+)
+
+py_library(
+    name = "otp_mem_map",
+    srcs = ["OtpMemMap.py"],
+    deps = [
+        ":common",
+        "//util/design/mubi:prim_mubi",
+        requirement("tabulate"),
+    ],
+)
+
+py_library(
+    name = "otp_mem_img",
+    srcs = ["OtpMemImg.py"],
+    deps = [
+        ":common",
+        ":lc_st_enc",
+        ":otp_mem_map",
+        ":present",
+        "//util/design/mubi:prim_mubi",
+        requirement("pycryptodome"),
+    ],
+)
+
+py_library(
+    name = "present",
+    srcs = ["Present.py"],
+)

--- a/util/rom_chip_info.py
+++ b/util/rom_chip_info.py
@@ -7,12 +7,9 @@ r"""Generates chip_info.h for ROM build
 
 import argparse
 import logging as log
-import os
 import sys
 from datetime import datetime
-from io import StringIO
 from pathlib import Path
-
 
 header_template = r"""
 // Copyright lowRISC contributors.
@@ -31,21 +28,20 @@ static const char chip_info[128] __attribute__((section(".chip_info"))) =
 #endif  // _F_CHIPINFO_H__
 
 """
+
+
 def main():
     parser = argparse.ArgumentParser(prog="rom_chip_info")
     parser.add_argument('--outdir',
                         '-o',
                         required=True,
-                        help='Output Directory'
-                        )
+                        help='Output Directory')
     parser.add_argument('--ot_version',
                         required=False,
-                        help='OpenTitan Version'
-                        )
+                        help='OpenTitan Version')
     parser.add_argument('--ot_version_file',
                         required=False,
-                        help='Path to a file with the OpenTitan Version'
-                        )
+                        help='Path to a file with the OpenTitan Version')
 
     log.basicConfig(format="%(levelname)s: %(message)s")
     args = parser.parse_args()
@@ -60,8 +56,7 @@ def main():
         version = open(args.ot_version_file, "rt").read().strip()
     else:
         log.error(
-            "Missing ot_version, provide --ot_version or --ot_version_file."
-        )
+            "Missing ot_version, provide --ot_version or --ot_version_file.")
         raise SystemExit(sys.exc_info()[1])
 
     outdir = Path(args.outdir)
@@ -72,8 +67,8 @@ def main():
     now = datetime.now()
     wall_time = now.strftime("%Y-%m-%d, %H:%M:%S")
 
-    log.info("Version: %s" % (version,))
-    log.info("Build Date: %s" % (wall_time,))
+    log.info("Version: %s" % (version, ))
+    log.info("Build Date: %s" % (wall_time, ))
 
     output = header_template
     output = output.replace('{%version%}', version, 1)


### PR DESCRIPTION
Misc. python scripts are used by rules in `rules/opentitan.bzl` and `rules/autogen.bzl` to scramble ROM images, prep flash images with correct ECC bits, and generate OTP image. This adds bazel rules so they may be picked up and executed by the hermetic Python toolchain.