### PR TITLE
[top_earlgrey/test] Remove low-speed USB test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -282,15 +282,6 @@
       tests: []
     }
     {
-      name: chip_usb_ls_tx_rx
-      desc: '''Verify the transmission of single-ended data over the USB at low speed.
-
-            - Similar to `chip_usb_fs_df_tx_rx`, except testing USB at Low-Speed (1.5 Mbps).
-            '''
-      milestone: V2
-      tests: []
-    }
-    {
       name: chip_sw_usb_vbus
       desc: '''Verify that the USB device can detect the presence of VBUS from the USB host.
 


### PR DESCRIPTION
usbdev will not support low-speed, so remove the test for it.

Signed-off-by: Alexander Williams <awill@google.com>