### PR TITLE
[ci] Enable bazel remote caching

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -584,8 +584,19 @@ jobs:
   dependsOn: lint
   pool:
     vmImage: ubuntu-18.04
+  variables:
+  - name: bazelCacheGcpKeyPath
+    value: ''
   steps:
     - template: ci/install-package-dependencies.yml
+    - task: DownloadSecureFile@1
+      condition: eq(variables['Build.SourceBranchName'], 'master')
+      name: bazelCacheGcpKey
+      inputs:
+        secureFile: "bazel_cache_gcp_key.json"
+    - bash: echo "##vso[task.setvariable variable=bazelCacheGcpKeyPath]$(bazelCacheGcpKey.secureFilePath)"
+      condition: eq(variables['Build.SourceBranchName'], 'master')
+      displayName: Set the remote cache GCP key path
+    - bash: ci/scripts/quick-bazel.sh $(bazelCacheGcpKeyPath)
       # The default timeout is too short to build verilator so let's skip it for the first pass
-    - bash: ci/scripts/quick-bazel.sh
       displayName: "Build and Test Software with Bazel (except //hw:verilator)"


### PR DESCRIPTION
This commit runs bazel with remote caching enabled in CI. Only CI
master have write access to the cache. All other CI runs can read from
the cache.

Signed-off-by: Miles Dai <milesdai@google.com>