### PR TITLE
[docs] Document expression of negative immediates in assembly

### DIFF
--- a/doc/rm/asm_coding_style.md
+++ b/doc/rm/asm_coding_style.md
@@ -71,6 +71,15 @@ Example:
   or   a0, a0, 0x4
 ```
 
+To emit assembly that's compatible with [GNU "as", integer literals should be donated with a '-' prefix operator](https://sourceware.org/binutils/docs/as/Integers.html) like `-1`, or `-0x01`.
+GNU "as" may flag two's complement representations of negative integers as out of range:
+```console
+error: operand must be a symbol with %lo/%pcrel_lo/%tprel_lo modifier or
+an integer in the range [-2048, 2047]
+    xori x0, x0, 0xFFFFF803
+                 ^
+```
+
 ### Loading Addresses
 
 ***Always use `la` to load the address of a symbol; always use `li` to load an address stored in a `#define`.***


### PR DESCRIPTION
GNU "as" requires negative hex immediates not be expressed in two's
complement and provides an error that's inconsistant with the RiscV
documentation which states integers are Two's complement. I added a
record of how this might appear because the error doesn't address the
formatting of the integer.

Signed-off-by: Drew Macrae <drewmacrae@google.com>