### PR TITLE
[top, dv] Add waiting for exclk_status after switching extclk

### DIFF
--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -296,3 +296,15 @@ dif_result_t dif_clkmgr_recov_err_code_clear_codes(
                       codes);
   return kDifOk;
 }
+
+dif_result_t dif_clkmgr_wait_for_ext_clk_switch(const dif_clkmgr_t *clkmgr) {
+  if (clkmgr == NULL) {
+    return kDifBadArg;
+  }
+  uint32_t ext_status;
+  do {
+    ext_status =
+        mmio_region_read32(clkmgr->base_addr, CLKMGR_EXTCLK_STATUS_REG_OFFSET);
+  } while (ext_status != kMultiBitBool4True);
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -327,6 +327,14 @@ OT_WARN_UNUSED_RESULT
 dif_result_t dif_clkmgr_recov_err_code_clear_codes(
     const dif_clkmgr_t *clkmgr, dif_clkmgr_recov_err_codes_t codes);
 
+/**
+ * Wait for external clock switch to finish.
+ *
+ * @param clkmgr Clock Manager Handle.
+ * @returns The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_wait_for_ext_clk_switch(const dif_clkmgr_t *clkmgr);
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/tests/sim_dv/uart_tx_rx_test.c
+++ b/sw/device/tests/sim_dv/uart_tx_rx_test.c
@@ -522,9 +522,10 @@ void config_external_clock(void) {
   CHECK(curr_state == kDifLcCtrlStateRma,
         "LC State isn't in kDifLcCtrlStateRma!");
 
-  // Enable external clock
+  // Enable external clock and wait for clk switch to finish
   LOG_INFO("Configure clkmgr to enable external clock");
   CHECK_DIF_OK(dif_clkmgr_external_clock_set_enabled(&clkmgr, kUseLowSpeedSel));
+  CHECK_DIF_OK(dif_clkmgr_wait_for_ext_clk_switch(&clkmgr));
 }
 
 const test_config_t kTestConfig;


### PR DESCRIPTION
Added dif `dif_clkmgr_wait_for_ext_clk_switch` for design udpate #12156
Waited for extclk to be stable to avoid the issue #12152

Signed-off-by: Weicai Yang <weicai@google.com>