### PR TITLE
[top, dv] Fix ext clk plusarg

### DIFF
--- a/hw/dv/sv/dv_utils/dv_macros.svh
+++ b/hw/dv/sv/dv_utils/dv_macros.svh
@@ -423,7 +423,7 @@
 // PLUSARG_: the name of the plusarg (as raw text). This is typically the same as the enum variable.
 // CHECK_EXISTS_: Throws a fatal error if the plusarg is not set.
 `ifndef DV_GET_ENUM_PLUSARG
-`define DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_ = VAR_, CHECK_EXISTS_ = 0, ID_ = `gfn) \
+`define DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_, CHECK_EXISTS_ = 0, ID_ = `gfn) \
   begin \
     string str; \
     if ($value$plusargs("``PLUSARG_``=%0s", str)) begin \

--- a/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
+++ b/hw/ip/keymgr/dv/env/seq_lib/keymgr_sideload_one_intf_vseq.sv
@@ -22,7 +22,7 @@ class keymgr_sideload_one_intf_vseq extends keymgr_sideload_vseq;
   }
 
   function void pre_randomize();
-    `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, 1)
+    `DV_GET_ENUM_PLUSARG(keymgr_pkg::keymgr_key_dest_e, sideload_dest, sideload_dest, 1)
     super.pre_randomize();
   endfunction
 endclass : keymgr_sideload_one_intf_vseq

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -317,7 +317,8 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRma", "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1"]
+      run_opts: ["+sw_test_timeout_ns=80000000", "+use_otp_image=LcStRma",
+                 "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1"]
       reseed: 5
     }
     {
@@ -325,8 +326,8 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRma", "+ext_clk_type=ExtClkLowSpeed",
-                 "+use_extclk=1", "+extclk_low_speed_sel=1"]
+      run_opts: ["+sw_test_timeout_ns=80000000", "+use_otp_image=LcStRma",
+                 "+ext_clk_type=ExtClkLowSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
       reseed: 5
     }
     // usually, uart core clock should be 24 Mhz, same as the div_4_clock, regardless using ext_clk
@@ -339,8 +340,8 @@
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
       sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRma", "+ext_clk_type=ExtClkHighSpeed",
-                 "+use_extclk=1", "+extclk_low_speed_sel=1"]
+      run_opts: ["+sw_test_timeout_ns=80000000", "+use_otp_image=LcStRma",
+                 "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
       reseed: 5
     }
     {

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -105,8 +105,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
   `uvm_object_new
 
   virtual function void initialize(bit [TL_AW-1:0] csr_base_addr = '1);
-    int extclk_freq_mhz = UseInternalClk;
-    ext_clk_type_e ext_clk_type;
+    ext_clk_type_e ext_clk_type = UseInternalClk;
     has_devmode = 0;
     list_of_alerts = chip_env_pkg::LIST_OF_ALERTS;
 
@@ -142,7 +141,7 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
     `DV_CHECK_LE_FATAL(num_ram_ret_tiles, 16)
 
     // Set external clock frequency.
-    `DV_GET_ENUM_PLUSARG(ext_clk_type_e, ext_clk_type)
+    `DV_GET_ENUM_PLUSARG(ext_clk_type_e, ext_clk_type, ext_clk_type)
     case (ext_clk_type)
       UseInternalClk: ; // clk_freq_mhz can be a random value
       ExtClkLowSpeed:  clk_freq_mhz = 48;

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_rand_baudrate_vseq.sv
@@ -35,6 +35,9 @@ class chip_sw_uart_rand_baudrate_vseq extends chip_sw_uart_tx_rx_vseq;
       uart_clk_freq_khz = cfg.clk_freq_mhz * 1000 / 4;
 
       if (extclk_low_speed_sel) uart_clk_freq_khz = uart_clk_freq_khz * 2;
+    end else begin
+      // internal uart bus clock is 24Mhz
+      uart_clk_freq_khz = 24_000;
     end
     `uvm_info(`gfn,
               $sformatf("External clock freq: %0dmhz, use_extclk: %0d, extclk_low_speed_sel: %0d",

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_uart_tx_rx_vseq.sv
@@ -62,7 +62,7 @@ class chip_sw_uart_tx_rx_vseq extends chip_sw_base_vseq;
     // Check if we received the right data set over the TX port.
     `uvm_info(`gfn, "Checking the received UART TX data for consistency.", UVM_LOW)
     foreach (uart_tx_data_q[i]) begin
-      `DV_CHECK_EQ(uart_tx_data_q[i], exp_uart_tx_data[i])
+      `DV_CHECK_EQ(uart_tx_data_q[i], exp_uart_tx_data[i], $sformatf("index: %0d", i))
     end
 
     // Send UART_RX_FIFO_SIZE+1 random bytes over RX to create an overflow condition.


### PR DESCRIPTION
`DV_GET_ENUM_PLUSARG(ENUM_, VAR_, PLUSARG_ = VAR_)` isn't right, as
`PLUSARG_` can't be assigned with another input argument. Remove `VAR`
Updated the places that use this macro.

Also increased uart timeout timer to fix regression failure

Signed-off-by: Weicai Yang <weicai@google.com>