### PR TITLE
[bazel/ci] Lengthen timeout to 90 mins

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -749,6 +749,7 @@ jobs:
 
 - job: bazel_test
   displayName: Bazel Software Build and Test
+  timeoutInMinutes: 90
   dependsOn: lint
   pool:
     vmImage: ubuntu-18.04


### PR DESCRIPTION
The Bazel Build and Test job occasionally goes beyond the 60 minute
timeout, so increase it to accommodate slower runs.

Signed-off-by: Alexander Williams <awill@google.com>