### PR TITLE
[aes, dv] AES reseeding check update

### DIFF
--- a/hw/ip/aes/dv/sva/aes_bind.sv
+++ b/hw/ip/aes/dv/sva/aes_bind.sv
@@ -54,6 +54,7 @@ module aes_bind;
   bind aes_prng_masking aes_masking_reseed_if u_aes_masking_reseed_if (
     .clk_i        (clk_i),
     .rst_ni       (rst_ni),
+    .entropy_i    (entropy_i),
     .prng_seed_en (prng_seed_en),
     .prng_seed    (prng_seed),
     .lfsr_q_0     (gen_lfsrs[0].u_lfsr_chunk.lfsr_q),

--- a/hw/ip/aes/dv/sva/aes_masking_reseed_if.sv
+++ b/hw/ip/aes/dv/sva/aes_masking_reseed_if.sv
@@ -8,12 +8,14 @@ interface aes_masking_reseed_if
   import aes_pkg::*;
   import aes_reg_pkg::*;
 #(
-  parameter  int unsigned Width     = WidthPRDMasking,     // Must be divisble by ChunkSize and 8
-  parameter  int unsigned ChunkSize = ChunkSizePRDMasking, // Width of the LFSR primitives
-  localparam int unsigned NumChunks = Width/ChunkSize      // derived parameter
+  parameter int unsigned  EntropyWidth = edn_pkg::ENDPOINT_BUS_WIDTH,
+  parameter int unsigned  Width        = WidthPRDMasking, // Must be divisble by ChunkSize and 8
+  parameter int unsigned  ChunkSize    = ChunkSizePRDMasking, // Width of the LFSR primitives
+  localparam int unsigned NumChunks    = Width/ChunkSize      // derived parameter
 ) (
   input logic                                clk_i,
   input logic                                rst_ni,
+  input logic [EntropyWidth-1:0]             entropy_i,
   input logic [NumChunks-1:0]                prng_seed_en,
   input logic [NumChunks-1:0][ChunkSize-1:0] prng_seed,
   input logic [ChunkSize-1:0]                lfsr_q_0,
@@ -23,10 +25,16 @@ interface aes_masking_reseed_if
   input logic [ChunkSize-1:0]                lfsr_q_4
   );
 
-  // make sure masking PRNG LSFR inputs always match the EDN input
-  `ASSERT(MaskingPrngInputMatchesEdnInput0_A, prng_seed_en[0] |-> ##1 prng_seed[0] == lfsr_q_0);
-  `ASSERT(MaskingPrngInputMatchesEdnInput1_A, prng_seed_en[1] |-> ##1 prng_seed[1] == lfsr_q_1);
-  `ASSERT(MaskingPrngInputMatchesEdnInput2_A, prng_seed_en[2] |-> ##1 prng_seed[2] == lfsr_q_2);
-  `ASSERT(MaskingPrngInputMatchesEdnInput3_A, prng_seed_en[3] |-> ##1 prng_seed[3] == lfsr_q_3);
-  `ASSERT(MaskingPrngInputMatchesEdnInput4_A, prng_seed_en[4] |-> ##1 prng_seed[4] == lfsr_q_4);
+  // make sure the entropy received from EDN goes into the masking prng_seed signals
+  `ASSERT(EdnInputMatchesMaskingPrngSeed0_A, prng_seed_en[0] |-> ##1 entropy_i == prng_seed[0]);
+  `ASSERT(EdnInputMatchesMaskingPrngSeed1_A, prng_seed_en[1] |-> ##1 entropy_i == prng_seed[1]);
+  `ASSERT(EdnInputMatchesMaskingPrngSeed2_A, prng_seed_en[2] |-> ##1 entropy_i == prng_seed[2]);
+  `ASSERT(EdnInputMatchesMaskingPrngSeed3_A, prng_seed_en[3] |-> ##1 entropy_i == prng_seed[3]);
+  `ASSERT(EdnInputMatchesMaskingPrngSeed4_A, prng_seed_en[4] |-> ##1 entropy_i == prng_seed[4]);
+  // make sure masking prng_seed signals match the PRNG LSFR inputs
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput0_A, prng_seed_en[0] |-> ##1 prng_seed[0] == lfsr_q_0);
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput1_A, prng_seed_en[1] |-> ##1 prng_seed[1] == lfsr_q_1);
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput2_A, prng_seed_en[2] |-> ##1 prng_seed[2] == lfsr_q_2);
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput3_A, prng_seed_en[3] |-> ##1 prng_seed[3] == lfsr_q_3);
+  `ASSERT(MaskingPrngSeedMatchesLfsrInput4_A, prng_seed_en[4] |-> ##1 prng_seed[4] == lfsr_q_4);
 endinterface // aes_masking_reseed_if

--- a/hw/ip/aes/dv/sva/aes_reseed_if.sv
+++ b/hw/ip/aes/dv/sva/aes_reseed_if.sv
@@ -46,5 +46,5 @@ interface aes_reseed_if
           prng_reseed_rate == PER_8K) && block_ctr_expr) |-> ##[1:$] entropy_masking_req);
   // check the reseed happens after the block counter resets (when control register is updated)
   `ASSERT(MaskingPrngReseedCorrectAfter_A, (SecMasking && ctrl_we_q && !ctrl_phase_i) |->
-          strong(##[1:$] entropy_masking_req));
+          ##[1:$] entropy_masking_req);
 endinterface // aes_reseed_if


### PR DESCRIPTION
  - Check the entropy input from EDN actually goes into the masking prng_seed signal
  - Remove the "strong" argument in one assertion to avoid unexpected firing
  - Fixed #12198

Signed-off-by: Muqing Liu <muqing.liu@wdc.com>