### PR TITLE
[sensor_ctrl] sensor_ctrl top level test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2528,10 +2528,15 @@
       name: chip_sw_sensor_ctrl_ast_alerts
       desc: '''Verify the alerts from AST aggregating into the sensor_ctrl.
 
-             Details TBD.
+               Check that AST events can be triggered from sensor_ctrl and that
+               the resulting AST outputs are observed in both sensor_ctrl and
+               the alert_handler.
+
+               For the alert handler case, make sure to test each alert configured
+               as either recoverable or fatal.
              '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup"]
     }
     {
       name: chip_sw_sensor_ctrl_ast_status
@@ -2549,7 +2554,7 @@
                AST. X-ref'ed chip_sw_pwrmgr_sleep_all_wake_ups.
              '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup"]
     }
 
     //////////////////

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -590,6 +590,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/sensor_ctrl_wakeup_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=8000000"]
+    }
+    {
       name: chip_sw_coremark
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/benchmarks/coremark/coremark_top_earlgrey:1:external"]

--- a/sw/device/lib/dif/dif_sensor_ctrl.h
+++ b/sw/device/lib/dif/dif_sensor_ctrl.h
@@ -12,9 +12,11 @@
  */
 
 #include <stdint.h>
+
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/base/mmio.h"
 #include "sw/device/lib/dif/dif_base.h"
+
 #include "sw/device/lib/dif/autogen/dif_sensor_ctrl_autogen.h"
 
 #ifdef __cplusplus

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -815,6 +815,27 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "sensor_ctrl_wakeup_test",
+    srcs = ["sensor_ctrl_wakeup.c"],
+    deps = [
+        "//hw/top_earlgrey/ip/sensor_ctrl/data:sensor_ctrl_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:sensor_ctrl",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:isr_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rv_plic_testutils",
+    ],
+)
+
+opentitan_functest(
     name = "sleep_pwm_pulses_test",
     srcs = ["sleep_pwm_pulses_test.c"],
     verilator = verilator_params(

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -892,6 +892,33 @@ sw_tests += {
   }
 }
 
+sensor_ctrl_wakeup_test_lib = declare_dependency(
+  link_with: static_library(
+    'sensor_ctrl_wakeup_test_lib',
+    sources: [
+      hw_ip_sensor_ctrl_reg_h,
+      'sensor_ctrl_wakeup.c'],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_pwrmgr,
+      sw_lib_dif_rv_plic,
+      sw_lib_dif_sensor_ctrl,
+      sw_lib_irq,
+      sw_lib_runtime_ibex,
+      sw_lib_runtime_log,
+      sw_lib_testing_isr_testutils,
+      sw_lib_testing_pwrmgr_testutils,
+      sw_lib_testing_rv_plic_testutils,
+      top_earlgrey,
+    ],
+  ),
+)
+sw_tests += {
+  'sensor_ctrl_wakeup_test': {
+    'library': sensor_ctrl_wakeup_test_lib,
+  }
+}
+
 # USB Device Tests
 usbdev_test_lib = declare_dependency(
   link_with: static_library(

--- a/sw/device/tests/sensor_ctrl_wakeup.c
+++ b/sw/device/tests/sensor_ctrl_wakeup.c
@@ -1,0 +1,133 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
+#include "sw/device/lib/dif/dif_rv_plic.h"
+#include "sw/device/lib/dif/dif_sensor_ctrl.h"
+#include "sw/device/lib/irq.h"
+#include "sw/device/lib/runtime/ibex.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/rv_plic_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "sensor_ctrl_regs.h"  // Generated.
+#include "sw/device/lib/testing/autogen/isr_testutils.h"
+
+const test_config_t kTestConfig;
+
+static dif_pwrmgr_t pwrmgr;
+static dif_rv_plic_t plic;
+static plic_isr_ctx_t plic_ctx = {.rv_plic = &plic,
+                                  .hart_id = kTopEarlgreyPlicTargetIbex0};
+
+static pwrmgr_isr_ctx_t pwrmgr_isr_ctx = {
+    .pwrmgr = &pwrmgr,
+    .plic_pwrmgr_start_irq_id = kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+    .expected_irq = kDifPwrmgrIrqWakeup,
+    .is_only_irq = true};
+
+static bool get_wakeup_status(void) {
+  dif_pwrmgr_request_sources_t wake_req = -1;
+  CHECK_DIF_OK(dif_pwrmgr_get_current_request_sources(
+      &pwrmgr, kDifPwrmgrReqTypeWakeup, &wake_req));
+  return (wake_req > 0);
+}
+
+/**
+ * External interrupt handler.
+ */
+void ottf_external_isr(void) {
+  dif_rv_plic_irq_id_t irq_id;
+  top_earlgrey_plic_peripheral_t peripheral;
+
+  isr_testutils_pwrmgr_isr(plic_ctx, pwrmgr_isr_ctx, &peripheral, &irq_id);
+
+  // Check that both the peripheral and the irq id is correct
+  CHECK(peripheral == kTopEarlgreyPlicPeripheralPwrmgrAon,
+        "IRQ peripheral: %d is incorrect", peripheral);
+  CHECK(irq_id == kDifPwrmgrIrqWakeup, "IRQ ID: %d is incorrect", irq_id);
+}
+
+bool test_main(void) {
+  dif_sensor_ctrl_t sensor_ctrl;
+
+  // Enable global and external IRQ at Ibex.
+  irq_global_ctrl(true);
+  irq_external_ctrl(true);
+
+  // Initialize the PLIC.
+  mmio_region_t plic_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_RV_PLIC_BASE_ADDR);
+  CHECK_DIF_OK(dif_rv_plic_init(plic_base_addr, &plic));
+
+  // Initialize pwrmgr
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+
+  // Initialize sensor_ctrl
+  CHECK_DIF_OK(dif_sensor_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SENSOR_CTRL_BASE_ADDR), &sensor_ctrl));
+
+  // Enable all the AON interrupts used in this test.
+  rv_plic_testutils_irq_range_enable(&plic, kTopEarlgreyPlicTargetIbex0,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup,
+                                     kTopEarlgreyPlicIrqIdPwrmgrAonWakeup);
+
+  // Enable pwrmgr interrupt
+  CHECK_DIF_OK(dif_pwrmgr_irq_set_enabled(&pwrmgr, 0, kDifToggleEnabled));
+
+  // Capture the number of events to test
+  uint32_t sensor_ctrl_events = SENSOR_CTRL_PARAM_NUM_ALERT_EVENTS;
+
+  dif_pwrmgr_domain_config_t sleep_config =
+      kDifPwrmgrDomainOptionMainPowerInLowPower;
+
+  for (size_t i = 0; i < sensor_ctrl_events; ++i) {
+    LOG_INFO("Testing sensor_ctrl event %d", i);
+
+    // Setup event trigger
+    CHECK_DIF_OK(dif_sensor_ctrl_set_ast_event_trigger(&sensor_ctrl, i,
+                                                       kDifToggleEnabled));
+
+    // Normal sleep.
+    pwrmgr_testutils_enable_low_power(&pwrmgr, kDifPwrmgrWakeupRequestSourceSix,
+                                      sleep_config);
+
+    // Enter low power mode.
+    LOG_INFO("Issue WFI to enter sleep");
+    wait_for_interrupt();
+
+    // Wakeup from sleep.
+    LOG_INFO("Wake from sleep");
+
+    dif_sensor_ctrl_events_t events;
+    CHECK_DIF_OK(dif_sensor_ctrl_get_recov_events(&sensor_ctrl, &events));
+
+    if (events != (1 << i)) {
+      LOG_ERROR("Recoverable event 0x%x does not match expectation %d", events,
+                i);
+    }
+
+    // clear event trigger
+    CHECK_DIF_OK(dif_sensor_ctrl_set_ast_event_trigger(&sensor_ctrl, i,
+                                                       kDifToggleDisabled));
+
+    // since there is synchronization delay to trigger clearing and actual event
+    // de-assertion, clear and poll until it is finished before moving on
+    while (events) {
+      CHECK_DIF_OK(dif_sensor_ctrl_clear_recov_event(&sensor_ctrl, i));
+      CHECK_DIF_OK(dif_sensor_ctrl_get_recov_events(&sensor_ctrl, &events));
+    }
+
+    // ensure the de-asserted events have cleared from the wakeup pipeline
+    // within 30us
+    IBEX_SPIN_FOR(!get_wakeup_status(), 30);
+  }
+
+  return true;
+}


### PR DESCRIPTION
- this test checks to make sure every trigger event can be received
  by AST and a corresponding incoming event is generated.

- this test also checks that incoming alerts can wake the system from
  normal sleep.  Deep sleep wakeup is not expected to work.


Signed-off-by: Timothy Chen <timothytim@google.com>