### PR TITLE
[bazel] Control bitstream loading via a bazel --define

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,3 +66,7 @@ riscv_compliance_repos()
 # Bitstreams from https://storage.googleapis.com/opentitan-bitstreams/
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")
+
+# The nonhermetic_repo imports environment variables needed to run vivado.
+load("//rules:nonhermetic.bzl", "nonhermetic_repo")
+nonhermetic_repo(name = "nonhermetic")

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -1,0 +1,52 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+# TODO(cfrantz): Add a config setting that will choose bitstream emitted by
+# a local run of the vivado tools.
+
+# Use a bitstream from the GCP bucket (this is also the default condition).
+# You can control the GCP bitstream selection via the BITSTREAM environment
+# variable.  See //rules/bitstreams.bzl for more information.
+#
+# Example:
+#   bazel test //sw/device/silicon_creator/lib/drivers:fpga_cw310_hmac_functest --define bitstream=gcp
+config_setting(
+    name = "bitstream_gcp",
+    define_values = {
+        "bitstream": "gcp",
+    },
+)
+
+# Skip loading a bitstream in to the FPGA.  This is useful if you already
+# have a bitstream loaded into the FPGA and you don't want the GCP cache
+# manager to do anything unexpected.
+#
+# Example:
+#   bazel test //sw/device/silicon_creator/lib/drivers:fpga_cw310_hmac_functest --define bitstream=skip
+config_setting(
+    name = "bitstream_skip",
+    define_values = {
+        "bitstream": "skip",
+    },
+)
+
+filegroup(
+    name = "test_rom",
+    srcs = select({
+        "bitstream_skip": ["skip.bit"],
+        "bitstream_gcp": ["@bitstreams//:bitstream_test_rom"],
+        "//conditions:default": ["@bitstreams//:bitstream_test_rom"],
+    }),
+)
+
+filegroup(
+    name = "mask_rom",
+    srcs = select({
+        "bitstream_skip": ["skip.bit"],
+        "bitstream_gcp": ["@bitstreams//:bitstream_mask_rom"],
+        "//conditions:default": ["@bitstreams//:bitstream_mask_rom"],
+    }),
+)

--- a/hw/bitstream/BUILD
+++ b/hw/bitstream/BUILD
@@ -4,9 +4,6 @@
 
 package(default_visibility = ["//visibility:public"])
 
-# TODO(cfrantz): Add a config setting that will choose bitstream emitted by
-# a local run of the vivado tools.
-
 # Use a bitstream from the GCP bucket (this is also the default condition).
 # You can control the GCP bitstream selection via the BITSTREAM environment
 # variable.  See //rules/bitstreams.bzl for more information.
@@ -33,10 +30,24 @@ config_setting(
     },
 )
 
+# Use a bitstream built by Vivado.  You'll need to have Xilinx Vivado
+# installed and have properly configured access to a license or license
+# server.
+#
+# Example:
+#   bazel test //sw/device/silicon_creator/lib/drivers:fpga_cw310_hmac_functest --define bitstream=vivado
+config_setting(
+    name = "bitstream_vivado",
+    define_values = {
+        "bitstream": "vivado",
+    },
+)
+
 filegroup(
     name = "test_rom",
     srcs = select({
         "bitstream_skip": ["skip.bit"],
+        "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_test_rom"],
         "bitstream_gcp": ["@bitstreams//:bitstream_test_rom"],
         "//conditions:default": ["@bitstreams//:bitstream_test_rom"],
     }),
@@ -46,6 +57,7 @@ filegroup(
     name = "mask_rom",
     srcs = select({
         "bitstream_skip": ["skip.bit"],
+        "bitstream_vivado": ["//hw/bitstream/vivado:fpga_cw310_mask_rom"],
         "bitstream_gcp": ["@bitstreams//:bitstream_mask_rom"],
         "//conditions:default": ["@bitstreams//:bitstream_mask_rom"],
     }),

--- a/hw/bitstream/skip.bit
+++ b/hw/bitstream/skip.bit
@@ -1,0 +1,4 @@
+__skip__
+
+# This is not a real bitstream, but a magic value that causes opentitantool
+# to skip loading a bitstream.

--- a/hw/bitstream/vivado/BUILD
+++ b/hw/bitstream/vivado/BUILD
@@ -1,0 +1,72 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("//rules:fusesoc.bzl", "fusesoc_build")
+load("//rules:splice.bzl", "bitstream_splice")
+
+package(default_visibility = ["//visibility:public"])
+
+# The readmem directives in the fusesoc-ized build tree will be in the subdir
+# ${build_root}/src/lowrisc_prim_util_memload_0/rtl/prim_util_memload.svh,
+# and ${build_root} will be a subdirectory called `build.fpga_cw310` inside of
+# bazel-out/k8-{configname}/bin/hw/bitstream/vivado.
+# Therefore, the relative path between prim_util_memload.svh and the project-root
+# relative $(location ...) resolved labels is up 10 subdirectories.
+_PREFIX = "../../../../../../../../../.."
+
+_FPGA_CW310_TESTROM = "//sw/device/lib/testing/test_rom:test_rom_fpga_cw310_scr_vmem"
+
+_FPGA_CW310_OTP_RMA = "//hw/ip/otp_ctrl/data:rma_image_verilator"
+
+_FPGA_CW310_TESTROM_PATH = "{}/$(location {})".format(_PREFIX, _FPGA_CW310_TESTROM)
+
+_FPGA_CW310_OTP_RMA_PATH = "{}/$(location {})".format(_PREFIX, _FPGA_CW310_OTP_RMA)
+
+# Note: all of the targets are tagged with "manual" to prevent them from being
+# matched by bazel wildcards like "//...".  In order to build the bitstream,
+# you need to ask for it directly or by dependency via another rule, such as
+# a functest.
+fusesoc_build(
+    name = "fpga_cw310",
+    srcs = [
+        "//hw:all_files",
+        _FPGA_CW310_TESTROM,
+        _FPGA_CW310_OTP_RMA,
+    ],
+    cores = ["//:cores"],
+    data = ["//hw/ip/otbn:all_files"],
+    flags = [
+        "--BootRomInitFile=" + _FPGA_CW310_TESTROM_PATH,
+        "--OtpCtrlMemInitFile=" + _FPGA_CW310_OTP_RMA_PATH,
+    ],
+    output_groups = {
+        "bitstream": ["synth-vivado/lowrisc_systems_chip_earlgrey_cw310_0.1.bit"],
+        "mmi": ["synth-vivado/rom.mmi"],
+    },
+    systems = ["lowrisc:systems:chip_earlgrey_cw310"],
+    tags = ["manual"],
+    target = "synth",
+)
+
+filegroup(
+    name = "fpga_cw310_test_rom",
+    srcs = [":fpga_cw310"],
+    output_group = "bitstream",
+    tags = ["manual"],
+)
+
+filegroup(
+    name = "rom_mmi",
+    srcs = [":fpga_cw310"],
+    output_group = "mmi",
+    tags = ["manual"],
+)
+
+bitstream_splice(
+    name = "fpga_cw310_mask_rom",
+    src = ":fpga_cw310_test_rom",
+    data = "//sw/device/silicon_creator/mask_rom:mask_rom_fpga_cw310_scr_vmem",
+    meminfo = ":rom_mmi",
+    tags = ["manual"],
+)

--- a/hw/ip/rom_ctrl/util/BUILD
+++ b/hw/ip/rom_ctrl/util/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
 load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
@@ -27,6 +27,7 @@ py_binary(
     srcs = ["scramble_image.py"],
     deps = [
         ":mem",
+        "//util/design:secded_gen",
         requirement("hjson"),
         requirement("pycryptodome"),
     ],

--- a/hw/ip/rom_ctrl/util/Makefile
+++ b/hw/ip/rom_ctrl/util/Makefile
@@ -19,7 +19,7 @@ pylibs := $(filter-out $(pyscripts),$(wildcard *.py))
 
 lint-stamps := $(foreach s,$(pyscripts),$(lint-build-dir)/$(s).stamp)
 $(lint-build-dir)/%.stamp: % $(pylibs) | $(lint-build-dir)
-	mypy --strict $< $(pylibs)
+	PYTHONPATH=$(repo-top) mypy --strict $< $(pylibs)
 	touch $@
 
 .PHONY: lint

--- a/hw/ip/rom_ctrl/util/mem.py
+++ b/hw/ip/rom_ctrl/util/mem.py
@@ -12,19 +12,7 @@ import tempfile
 from typing import BinaryIO, IO, List, Optional, TextIO, Tuple
 
 from elftools.elf.elffile import ELFFile  # type: ignore
-
-
-_REPO_ROOT = os.path.join(os.path.dirname(__file__), '../../../..')
-_UTIL_DESIGN = os.path.normpath(os.path.join(_REPO_ROOT, 'util/design'))
-old_sys_path = sys.path
-try:
-    sys.path = sys.path + [_UTIL_DESIGN]
-    # This strange formulation explicitly re-exports ecc_encode_some from this
-    # module, allowing users of mem.py to call it directly without needing to
-    # do the sys.path dance.
-    from secded_gen import ecc_encode_some as ecc_encode_some  # type: ignore
-finally:
-    sys.path = old_sys_path
+from util.design.secded_gen import ecc_encode_some # type: ignore
 
 
 class MemChunk:

--- a/hw/ip/rom_ctrl/util/scramble_image.py
+++ b/hw/ip/rom_ctrl/util/scramble_image.py
@@ -12,7 +12,8 @@ from typing import Dict, List
 import hjson  # type: ignore
 from Crypto.Hash import cSHAKE256
 
-from mem import MemChunk, MemFile, ecc_encode_some
+from mem import MemChunk, MemFile
+from util.design.secded_gen import ecc_encode_some # type: ignore
 
 ROM_BASE_WORD = 0x8000 // 4
 ROM_SIZE_WORDS = 8192

--- a/rules/fusesoc.bzl
+++ b/rules/fusesoc.bzl
@@ -2,6 +2,8 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@nonhermetic//:env.bzl", "ENV")
+
 """Rules for running FuseSoC.
 
 FuseSoC is a package manager and set of build tools for HDL code.
@@ -18,10 +20,19 @@ dependencies so the FuseSoC rules can be sandboxed.
 """
 
 def _fusesoc_build_impl(ctx):
-    out_dir = ctx.actions.declare_directory("build.{}".format(ctx.label.name))
+    dirname = "build.{}".format(ctx.label.name)
+    out_dir = ctx.actions.declare_directory(dirname)
+    flags = [ctx.expand_location(f, ctx.attr.srcs) for f in ctx.attr.flags]
+    outputs = [out_dir]
+    groups = {}
+    for group, files in ctx.attr.output_groups.items():
+        deps = [ctx.actions.declare_file("{}/{}".format(dirname, f)) for f in files]
+        outputs.extend(deps)
+        groups[group] = depset(deps)
+
     ctx.actions.run(
         mnemonic = "FuseSoC",
-        outputs = [out_dir],
+        outputs = outputs,
         inputs = ctx.files.srcs + ctx.files.cores,
         arguments = [
             "--cores-root={}".format(c.dirname)
@@ -33,17 +44,21 @@ def _fusesoc_build_impl(ctx):
             "--setup",
             "--build",
             "--build-root={}".format(out_dir.path),
-        ] + ctx.attr.systems,
+        ] + ctx.attr.systems + flags,
         executable = "fusesoc",
-        use_default_shell_env = True,
+        use_default_shell_env = False,
         execution_requirements = {
             "no-sandbox": "",
         },
+        env = ENV,
     )
-    return [DefaultInfo(
-        files = depset([out_dir]),
-        data_runfiles = ctx.runfiles(files = [out_dir] + ctx.files.data),
-    )]
+    return [
+        DefaultInfo(
+            files = depset(outputs),
+            data_runfiles = ctx.runfiles(files = outputs + ctx.files.data),
+        ),
+        OutputGroupInfo(**groups),
+    ]
 
 fusesoc_build = rule(
     implementation = _fusesoc_build_impl,
@@ -53,5 +68,10 @@ fusesoc_build = rule(
         "data": attr.label_list(allow_files = True, doc = "Files needed at runtime"),
         "target": attr.string(mandatory = True, doc = "Target name (e.g. 'sim')"),
         "systems": attr.string_list(mandatory = True, doc = "Systems to build"),
+        "flags": attr.string_list(doc = "Flags controlling the FuseSOC system build"),
+        "output_groups": attr.string_list_dict(
+            allow_empty = True,
+            doc = "Mapping of group name to lists of files in that named group",
+        ),
     },
 )

--- a/rules/nonhermetic.bzl
+++ b/rules/nonhermetic.bzl
@@ -1,0 +1,22 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+NONHERMETIC_ENV_VARS = [
+    "HOME",
+    "PATH",
+    "XILINX_VIVADO",
+    "XILINX_HLS",
+    "XILINXD_LICENSE_FILE",
+]
+
+def _nonhermetic_repo_impl(rctx):
+    env = "\n".join(["    \"{}\": \"{}\",".format(v, rctx.os.environ.get(v, "")) for v in NONHERMETIC_ENV_VARS])
+    rctx.file("env.bzl", "ENV = {{\n{}\n}}\n".format(env))
+    rctx.file("BUILD.bazel", "exports_files(glob([\"**\"]))\n")
+
+nonhermetic_repo = repository_rule(
+    implementation = _nonhermetic_repo_impl,
+    attrs = {},
+    environ = NONHERMETIC_ENV_VARS,
+)

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -164,7 +164,7 @@ def cw310_params(
         tags = _BASE_PARAMS["tags"] + ["cpu:4"],
         timeout = _BASE_PARAMS["timeout"],
         # CW310-specific Parameters
-        bitstream = "@bitstreams//:bitstream_test_rom",
+        bitstream = "//hw/bitstream:test_rom",
         rom_kind = None,
         # None
         **kwargs):

--- a/rules/splice.bzl
+++ b/rules/splice.bzl
@@ -1,0 +1,79 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@nonhermetic//:env.bzl", "ENV")
+
+"""Rules for memory splicing with Vivado.
+"""
+
+def _bitstream_splice_impl(ctx):
+    update = ctx.actions.declare_file("{}.update.mem".format(ctx.label.name))
+    output = ctx.actions.declare_file("{}.bit".format(ctx.label.name))
+
+    ctx.actions.run(
+        mnemonic = "GenVivadoImage",
+        outputs = [update],
+        inputs = [ctx.executable._tool, ctx.file.data],
+        arguments = [
+            ctx.file.data.path,
+            update.path,
+        ] + ["--swap-nibbles"] if ctx.attr.swap_nybbles else [],
+        executable = ctx.executable._tool,
+        use_default_shell_env = True,
+        execution_requirements = {
+            "no-sandbox": "",
+        },
+    )
+
+    ctx.actions.run(
+        mnemonic = "SpliceBitstream",
+        outputs = [output],
+        inputs = [ctx.file.src, ctx.file.meminfo, update],
+        arguments = [
+            "-force",
+            "--meminfo",
+            ctx.file.meminfo.path,
+            "--data",
+            update.path,
+            "--bit",
+            ctx.file.src.path,
+            "--proc",
+            "dummy",
+            "--out",
+            output.path,
+        ] + ["--debug"] if ctx.attr.debug else [],
+        executable = "updatemem",
+        use_default_shell_env = False,
+        execution_requirements = {
+            "no-sandbox": "",
+        },
+        env = ENV,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([output]),
+            data_runfiles = ctx.runfiles(files = [output]),
+        ),
+        OutputGroupInfo(
+            bitstream = depset([output]),
+            update = depset([update]),
+        ),
+    ]
+
+bitstream_splice = rule(
+    implementation = _bitstream_splice_impl,
+    attrs = {
+        "meminfo": attr.label(allow_single_file = True, doc = "Memory layout info file (an .mmi file)"),
+        "src": attr.label(allow_single_file = True, doc = "The bitstream to splice"),
+        "data": attr.label(allow_single_file = True, doc = "The memory image to splice into the bitstream"),
+        "swap_nybbles": attr.bool(default = True, doc = "Swap nybbles while preparing the memory image"),
+        "debug": attr.bool(default = True, doc = "Emit debug info while updating"),
+        "_tool": attr.label(
+            default = "//hw/ip/rom_ctrl/util:gen_vivado_mem_image",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)

--- a/sw/device/lib/testing/test_rom/meson.build
+++ b/sw/device/lib/testing/test_rom/meson.build
@@ -100,6 +100,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   test_rom_scrambled = custom_target(
     target_name.format('scrambled'),
     command: scramble_image_command,
+    env: {'PYTHONPATH': meson.project_source_root()},
     depend_files: scramble_image_depend_files,
     input: test_rom_elf,
     output: scramble_image_outputs,

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -284,7 +284,7 @@ opentitan_functest(
     name = "e2e_bootup_success",
     srcs = ["mask_rom_test.c"],
     cw310 = cw310_params(
-        bitstream = "@bitstreams//:bitstream_mask_rom",
+        bitstream = "//hw/bitstream:mask_rom",
     ),
     signed = True,
     targets = [
@@ -313,7 +313,7 @@ opentitan_functest(
             "--exit-success='{}'".format(BOOT_FAILURE_MSG),
             "--exit-failure='PASS!'",
         ],
-        bitstream = "@bitstreams//:bitstream_mask_rom",
+        bitstream = "//hw/bitstream:mask_rom",
     ),
     signed = False,
     targets = ["cw310"],

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -145,6 +145,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   mask_rom_epmp_test_scrambled = custom_target(
     target_name.format('scrambled'),
     command: scramble_image_command,
+    env: {'PYTHONPATH': meson.project_source_root()},
     depend_files: scramble_image_depend_files,
     input: mask_rom_epmp_test_elf,
     output: scramble_image_outputs,
@@ -280,6 +281,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
   mask_rom_scrambled = custom_target(
     target_name.format('scrambled'),
     command: scramble_image_command,
+    env: {'PYTHONPATH': meson.project_source_root()},
     depend_files: scramble_image_depend_files,
     input: mask_rom_elf,
     output: scramble_image_outputs,

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -1382,6 +1382,7 @@ foreach sw_test_name, sw_test_info : sw_tests
       sw_test_scr_vmem32 = custom_target(
         target_name.format('scr_vmem32'),
         command: scramble_image_command,
+        env: {'PYTHONPATH': meson.project_source_root()},
         depend_files: scramble_image_depend_files,
         input: sw_test_elf,
         output: scramble_image_outputs,

--- a/sw/host/opentitanlib/src/transport/cw310/mod.rs
+++ b/sw/host/opentitanlib/src/transport/cw310/mod.rs
@@ -148,6 +148,10 @@ impl Transport for CW310 {
 
     fn dispatch(&self, action: &dyn Any) -> Result<Option<Box<dyn Serialize>>> {
         if let Some(fpga_program) = action.downcast_ref::<FpgaProgram>() {
+            if fpga_program.bitstream.starts_with(b"__skip__") {
+                log::info!("Skip loading the __skip__ bitstream.");
+                return Ok(None);
+            }
             if let Some(rom_kind) = &fpga_program.rom_kind {
                 let mut rd = RomDetect::new(
                     *rom_kind,

--- a/util/build_consts.sh
+++ b/util/build_consts.sh
@@ -44,3 +44,4 @@ readonly OBJ_DIR="$BUILD_ROOT/build-out"
 export OBJ_DIR
 readonly BIN_DIR="$BUILD_ROOT/build-bin"
 export BIN_DIR
+export PYTHONPATH="${REPO_TOP}"

--- a/util/design/BUILD
+++ b/util/design/BUILD
@@ -10,6 +10,7 @@ package(default_visibility = ["//visibility:public"])
 py_library(
     name = "secded_gen",
     srcs = ["secded_gen.py"],
+    data = ["//util/design/data:secded_cfg.hjson"],
     deps = [requirement("hjson")],
 )
 

--- a/util/design/data/BUILD
+++ b/util/design/data/BUILD
@@ -1,0 +1,7 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+exports_files(glob(["**"]))


### PR DESCRIPTION
Use a bazel `--define` to tell which bitstream to load.

- `--define bitstream=gcp` (also the default condition) loads a bitstream published in the GCP bucket.
- `--define bittream=skip` unconditionally skips loading a bitstream (e.g. you're debugging and don't want a new bitstream loaded).
- `--define bitstream=vivado` loads a bitstream built by asking vivado to synthesize the bitstream.

Vivado synthesis is accomplished by invoking `fusesoc` with the proper options and optionally splicing in the Mask ROM.

1. Import environment variables important to Vivado into the workspace.
2. Adjust `fusesoc_build` rule to permit building the FPGA bitstreams.
3. Fix `rom_ctrl` utilities to execute under bazel.
4. Add a bazel rule to facilitate ROM splicing (via Vivado).

Signed-off-by: Chris Frantz <cfrantz@google.com>