### PR TITLE
[sw] Fix function prototypes

### DIFF
--- a/hw/dv/dpi/usbdpi/monitor_usb.c
+++ b/hw/dv/dpi/usbdpi/monitor_usb.c
@@ -56,7 +56,7 @@ struct mon_ctx {
   unsigned char bytes[MON_BYTES_SIZE + 2];
 };
 
-void *monitor_usb_init() {
+void *monitor_usb_init(void) {
   struct mon_ctx *mon = (struct mon_ctx *)calloc(1, sizeof(struct mon_ctx));
   assert(mon);
 

--- a/sw/device/lib/crypto/drivers/otbn.c
+++ b/sw/device/lib/crypto/drivers/otbn.c
@@ -59,7 +59,7 @@ void otbn_execute(void) {
                    kOtbnCmdExecute);
 }
 
-bool otbn_is_busy() {
+bool otbn_is_busy(void) {
   uint32_t status =
       abs_mmio_read32(TOP_EARLGREY_OTBN_BASE_ADDR + OTBN_STATUS_REG_OFFSET);
   return status != kOtbnStatusIdle && status != kOtbnStatusLocked;

--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -158,7 +158,7 @@ static void aes_serial_encrypt(const uint8_t *plaintext, size_t plaintext_len) {
  * Wait until AES output is valid and then get ciphertext and send it over
  * serial communication
  */
-static void aes_send_ciphertext() {
+static void aes_send_ciphertext(void) {
   bool ready = false;
   do {
     SS_CHECK_DIF_OK(dif_aes_get_status(&aes, kDifAesStatusOutputValid, &ready));

--- a/sw/device/sca/lib/sca.c
+++ b/sw/device/sca/lib/sca.c
@@ -258,11 +258,11 @@ const dif_uart_t *sca_get_uart(void) {
 #endif
 }
 
-void sca_set_trigger_high() {
+void sca_set_trigger_high(void) {
   OT_DISCARD(dif_gpio_write(&gpio, kTriggerGateBitIndex, true));
 }
 
-void sca_set_trigger_low() {
+void sca_set_trigger_low(void) {
   OT_DISCARD(dif_gpio_write(&gpio, kTriggerGateBitIndex, false));
 }
 

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -130,7 +130,7 @@ rom_error_t otbn_execute(void) {
   return otbn_cmd_run(kOtbnCmdExecute, kErrorOtbnExecutionFailed);
 }
 
-bool otbn_is_busy() {
+bool otbn_is_busy(void) {
   uint32_t status = abs_mmio_read32(kBase + OTBN_STATUS_REG_OFFSET);
   return status != kOtbnStatusIdle && status != kOtbnStatusLocked;
 }

--- a/sw/device/tests/ast_clk_outs_test.c
+++ b/sw/device/tests/ast_clk_outs_test.c
@@ -84,7 +84,7 @@ static void check_measurement_counts(const dif_clkmgr_t *clkmgr) {
   CHECK_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(clkmgr, ~0u));
 }
 
-bool test_main() {
+bool test_main(void) {
   dif_sensor_ctrl_t sensor_ctrl;
   dif_aon_timer_t aon_timer;
 

--- a/sw/device/tests/clkmgr_jitter_test.c
+++ b/sw/device/tests/clkmgr_jitter_test.c
@@ -12,7 +12,7 @@
 
 const test_config_t kTestConfig;
 
-bool test_main() {
+bool test_main(void) {
   dif_clkmgr_t clkmgr;
   CHECK_DIF_OK(dif_clkmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));

--- a/sw/device/tests/clkmgr_off_aes_trans_test.c
+++ b/sw/device/tests/clkmgr_off_aes_trans_test.c
@@ -8,6 +8,6 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-bool test_main() {
+bool test_main(void) {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainAes);
 }

--- a/sw/device/tests/clkmgr_off_hmac_trans_test.c
+++ b/sw/device/tests/clkmgr_off_hmac_trans_test.c
@@ -8,6 +8,6 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-bool test_main() {
+bool test_main(void) {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainHmac);
 }

--- a/sw/device/tests/clkmgr_off_otbn_trans_test.c
+++ b/sw/device/tests/clkmgr_off_otbn_trans_test.c
@@ -8,6 +8,6 @@
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 
-bool test_main() {
+bool test_main(void) {
   return execute_off_trans_test(kTopEarlgreyHintableClocksMainOtbn);
 }

--- a/sw/device/tests/clkmgr_off_peri_test.c
+++ b/sw/device/tests/clkmgr_off_peri_test.c
@@ -62,7 +62,7 @@ static void test_gateable_clocks_off(const dif_clkmgr_t *clkmgr,
   uart0_csr_access();
 }
 
-bool test_main() {
+bool test_main(void) {
   dif_clkmgr_t clkmgr;
   dif_pwrmgr_t pwrmgr;
   dif_rstmgr_t rstmgr;

--- a/sw/device/tests/clkmgr_smoketest.c
+++ b/sw/device/tests/clkmgr_smoketest.c
@@ -79,7 +79,7 @@ void test_hintable_clocks(const dif_clkmgr_t *clkmgr) {
   }
 }
 
-bool test_main() {
+bool test_main(void) {
   dif_clkmgr_t clkmgr;
   CHECK_DIF_OK(dif_clkmgr_init(
       mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));

--- a/sw/device/tests/csrng_smoketest.c
+++ b/sw/device/tests/csrng_smoketest.c
@@ -137,7 +137,7 @@ void test_ctr_drbg_ctr0(const dif_csrng_t *csrng) {
   fips_generate_kat(csrng);
 }
 
-bool test_main() {
+bool test_main(void) {
   dif_csrng_t csrng;
   CHECK_DIF_OK(dif_csrng_init(
       mmio_region_from_addr(TOP_EARLGREY_CSRNG_BASE_ADDR), &csrng));

--- a/sw/device/tests/entropy_src_fw_ovr_test.c
+++ b/sw/device/tests/entropy_src_fw_ovr_test.c
@@ -106,7 +106,7 @@ void test_firmware_override(dif_entropy_src_t *entropy) {
   entropy_data_flush(entropy);
 }
 
-bool test_main() {
+bool test_main(void) {
   dif_entropy_src_t entropy_src;
   CHECK_DIF_OK(dif_entropy_src_init(
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));

--- a/sw/device/tests/entropy_src_smoketest.c
+++ b/sw/device/tests/entropy_src_smoketest.c
@@ -26,7 +26,7 @@ const uint32_t kExpectedEntropyData[] = {
     0x38a9e15d, 0xc615d072, 0x15f21dc9, 0x38f06e56, 0x790a2a87, 0x8bff3d11,
     0xd56913da, 0x75dc72c3, 0xee2d38a2, 0xabfddaec, 0x3837e88b, 0x29cf1c12};
 
-bool test_main() {
+bool test_main(void) {
   dif_entropy_src_t entropy_src;
   CHECK_DIF_OK(dif_entropy_src_init(
       mmio_region_from_addr(TOP_EARLGREY_ENTROPY_SRC_BASE_ADDR), &entropy_src));

--- a/sw/device/tests/hmac_enc_irq_test.c
+++ b/sw/device/tests/hmac_enc_irq_test.c
@@ -89,7 +89,7 @@ static void enable_irqs(void) {
   irq_external_ctrl(true);
 }
 
-bool test_main() {
+bool test_main(void) {
   mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
   CHECK_DIF_OK(dif_hmac_init(base_addr, &hmac));
 

--- a/sw/device/tests/hmac_enc_test.c
+++ b/sw/device/tests/hmac_enc_test.c
@@ -79,7 +79,7 @@ static const dif_hmac_digest_t kExpectedHmacDigest = {
         },
 };
 
-bool test_main() {
+bool test_main(void) {
   dif_hmac_t hmac;
   mmio_region_t base_addr = mmio_region_from_addr(TOP_EARLGREY_HMAC_BASE_ADDR);
   CHECK_DIF_OK(dif_hmac_init(base_addr, &hmac));

--- a/sw/device/tests/hmac_smoketest.c
+++ b/sw/device/tests/hmac_smoketest.c
@@ -94,7 +94,7 @@ static void run_test(const dif_hmac_t *hmac, const char *data, size_t len,
   hmac_testutils_finish_and_check_polled(hmac, expected_digest);
 }
 
-bool test_main() {
+bool test_main(void) {
   LOG_INFO("Running HMAC DIF test...");
 
   dif_hmac_t hmac;

--- a/sw/device/tests/kmac_mode_cshake_test.c
+++ b/sw/device/tests/kmac_mode_cshake_test.c
@@ -87,7 +87,7 @@ const cshake_test_t cshake_tests[] = {
     },
 };
 
-bool test_main() {
+bool test_main(void) {
   LOG_INFO("Running KMAC DIF cSHAKE test...");
 
   // Intialize KMAC hardware.

--- a/sw/device/tests/kmac_mode_kmac_test.c
+++ b/sw/device/tests/kmac_mode_kmac_test.c
@@ -188,7 +188,7 @@ const kmac_test_t kmac_tests[] = {
     },
 };
 
-bool test_main() {
+bool test_main(void) {
   LOG_INFO("Running KMAC DIF test...");
 
   // Intialize KMAC hardware.

--- a/sw/device/tests/kmac_smoketest.c
+++ b/sw/device/tests/kmac_smoketest.c
@@ -263,7 +263,7 @@ void run_shake_test(dif_kmac_t *kmac) {
   }
 }
 
-bool test_main() {
+bool test_main(void) {
   LOG_INFO("Running KMAC DIF test...");
 
   // Intialize KMAC hardware.

--- a/sw/device/tests/otbn_ecdsa_op_irq_test.c
+++ b/sw/device/tests/otbn_ecdsa_op_irq_test.c
@@ -419,7 +419,7 @@ static void test_ecdsa_p256_roundtrip(void) {
   CHECK(otbn_zero_data_memory(&otbn_ctx) == kOtbnOk);
 }
 
-bool test_main() {
+bool test_main(void) {
   entropy_testutils_boot_mode_init();
 
   test_ecdsa_p256_roundtrip();

--- a/sw/device/tests/otbn_irq_test.c
+++ b/sw/device/tests/otbn_irq_test.c
@@ -157,7 +157,7 @@ void ottf_external_isr(void) {
   otbn_finished = true;
 }
 
-bool test_main() {
+bool test_main(void) {
   entropy_testutils_boot_mode_init();
   plic_init_with_irqs();
 

--- a/sw/device/tests/otbn_mem_scramble_test.c
+++ b/sw/device/tests/otbn_mem_scramble_test.c
@@ -89,7 +89,7 @@ static void otbn_check_app(otbn_t *ctx, const otbn_app_t app,
                  dif_otbn_dmem_read);
 }
 
-bool test_main() {
+bool test_main(void) {
   otbn_t otbn_ctx;
   mmio_region_t addr = mmio_region_from_addr(TOP_EARLGREY_OTBN_BASE_ADDR);
   CHECK(otbn_init(&otbn_ctx, addr) == kOtbnOk);

--- a/sw/device/tests/otbn_randomness_test.c
+++ b/sw/device/tests/otbn_randomness_test.c
@@ -152,7 +152,7 @@ void initialize_clkmgr(void) {
   CLKMGR_TESTUTILS_CHECK_CLOCK_HINT(clkmgr, kOtbnClock, kDifToggleEnabled);
 }
 
-bool test_main() {
+bool test_main(void) {
   entropy_testutils_boot_mode_init();
 
   initialize_clkmgr();

--- a/sw/device/tests/otbn_rsa_test.c
+++ b/sw/device/tests/otbn_rsa_test.c
@@ -691,7 +691,7 @@ static void test_rsa4096_roundtrip(void) {
                 kEncryptedExpected, out_encrypted, out_decrypted);
 }
 
-bool test_main() {
+bool test_main(void) {
   entropy_testutils_boot_mode_init();
 
   test_rsa512_roundtrip();

--- a/sw/device/tests/otbn_smoketest.c
+++ b/sw/device/tests/otbn_smoketest.c
@@ -159,7 +159,7 @@ static void test_sec_wipe(otbn_t *otbn_ctx) {
   CHECK(otbn_busy_wait_for_done(otbn_ctx) == kOtbnOk);
 }
 
-bool test_main() {
+bool test_main(void) {
   entropy_testutils_boot_mode_init();
 
   otbn_t otbn_ctx;

--- a/sw/device/tests/sim_dv/lc_walkthrough_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_test.c
@@ -58,7 +58,7 @@ static volatile const uint8_t kOtpRmaToken[LC_TOKEN_SIZE] = {
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 };
 
-static void lock_otp_secret0_partition() {
+static void lock_otp_secret0_partition(void) {
   uint64_t otp_unlock_token_0 = 0;
   uint64_t otp_unlock_token_1 = 0;
   for (int i = 0; i < LC_TOKEN_SIZE; i++) {

--- a/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
+++ b/sw/device/tests/sim_dv/lc_walkthrough_testunlocks_test.c
@@ -38,7 +38,7 @@ static volatile const uint8_t kOtpUnlockToken[LC_TOKEN_SIZE] = {
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
 };
 
-static void lock_otp_secret0_partition() {
+static void lock_otp_secret0_partition(void) {
   uint64_t otp_unlock_token_0 = 0;
   uint64_t otp_unlock_token_1 = 0;
   for (int i = 0; i < LC_TOKEN_SIZE; i++) {

--- a/sw/device/tests/sram_ctrl_smoketest.c
+++ b/sw/device/tests/sram_ctrl_smoketest.c
@@ -48,7 +48,7 @@ static void write_read_check(mmio_region_t base_addr_region,
   }
 }
 
-bool test_main() {
+bool test_main(void) {
   // Initialize SRAM_CTRL hardware.
   dif_sram_ctrl_t sram_ctrl_main;
   dif_sram_ctrl_t sram_ctrl_ret;


### PR DESCRIPTION
Several functions without parameters were declared as `foo()` instead of `foo(void)`. The former is considered a function without a prototype, not a function without parameters. Newer versions of Clang implement a stricter check of this condition, and the new warnings break the build. Fix this by adding the missing `void` in several places.