### PR TITLE
[lc_ctrl/dv] Added test lc_ctrl_sec_token_digest

### DIFF
--- a/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/lc_ctrl/data/lc_ctrl_sec_cm_testplan.hjson
@@ -226,7 +226,7 @@
         these checks will lead to a TOKEN_ERROR.
       '''
       milestone: V2S
-      tests: []
+      tests: ["lc_ctrl_sec_token_digest"]
     }
     {
       name: sec_cm_token_mux_ctrl_redun
@@ -270,6 +270,13 @@
       name: sec_token_mux_idx_error_cg
       desc: '''
         Indicates FSM states that a token mux index error is detected
+      '''
+    }
+
+    {
+      name: sec_token_digest_error_cg
+      desc: '''
+        Indicates FSM states that a token digest error is detected
       '''
     }
   ]

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env.core
@@ -36,6 +36,7 @@ filesets:
       - seq_lib/lc_ctrl_regwen_during_op_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_sec_mubi_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_sec_token_mux_vseq.sv: {is_include_file: true}
+      - seq_lib/lc_ctrl_sec_token_digest_vseq.sv: {is_include_file: true}
       - seq_lib/lc_ctrl_stress_all_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_cov.sv
@@ -68,6 +68,13 @@ class lc_ctrl_env_cov extends cip_base_env_cov #(
     transition_count_err_cp: coverpoint cfg.err_inj.transition_count_err;
     post_trans_err_cp: coverpoint cfg.err_inj.post_trans_err;
     security_escalation_err_cp: coverpoint cfg.err_inj.security_escalation_err;
+    clk_byp_rsp_mubi_err_cp: coverpoint cfg.err_inj.clk_byp_rsp_mubi_err;
+    flash_rma_rsp_mubi_err_cp: coverpoint cfg.err_inj.flash_rma_rsp_mubi_err;
+    otp_secrets_valid_mubi_err_cp: coverpoint cfg.err_inj.otp_secrets_valid_mubi_err;
+    otp_test_tokens_valid_mubi_err_cp: coverpoint cfg.err_inj.otp_test_tokens_valid_mubi_err;
+    otp_rma_token_valid_mubi_err_cp: coverpoint cfg.err_inj.otp_rma_token_valid_mubi_err;
+    token_mux_ctrl_redun_err_cp: coverpoint cfg.err_inj.token_mux_ctrl_redun_err;
+    token_mux_digest_err_cp: coverpoint cfg.err_inj.token_mux_digest_err;
     jtag_csr_cp: coverpoint cfg.jtag_csr;
 
     // verilog_format: off - formatter doesnt like the macros here

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_env_pkg.sv
@@ -112,6 +112,8 @@ package lc_ctrl_env_pkg;
     bit otp_rma_token_valid_mubi_err;
     // Force bad values on token mux select lines
     bit token_mux_ctrl_redun_err;
+    // Force bit errors in the token mux inputs
+    bit token_mux_digest_err;
   } lc_ctrl_err_inj_t;
 
   // Test phase - used to synchronise the scoreboard

--- a/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
+++ b/hw/ip/lc_ctrl/dv/env/lc_ctrl_if.sv
@@ -96,6 +96,10 @@ interface lc_ctrl_if (
   // Token mux control
   bit [TokenIdxWidth-1:0] token_idx0;
   bit [TokenIdxWidth-1:0] token_idx1;
+  // Token Mux data
+  lc_token_t hashed_token_i;
+  lc_token_t hashed_token_mux;
+  bit token_hash_ack_i;
 
 
   // Debug signals
@@ -263,6 +267,26 @@ interface lc_ctrl_if (
       1: release `LC_CTRL_FSM_PATH.token_idx1;
       default: begin
         `uvm_fatal($sformatf("%m"), $sformatf("release_token_idx: index %0d out of range", idx))
+      end
+    endcase
+  endfunction
+
+  function static void force_hashed_token(input int idx, input lc_token_t val);
+    case (idx)
+      0: force `LC_CTRL_FSM_PATH.hashed_token_i = val;
+      1: force `LC_CTRL_FSM_PATH.hashed_token_mux = val;
+      default: begin
+        `uvm_fatal($sformatf("%m"), $sformatf("force_hashed_token: index %0d out of range", idx))
+      end
+    endcase
+  endfunction
+
+  function static void release_hashed_token(input int idx);
+    case (idx)
+      0: release `LC_CTRL_FSM_PATH.hashed_token_i;
+      1: release `LC_CTRL_FSM_PATH.hashed_token_mux;
+      default: begin
+        `uvm_fatal($sformatf("%m"), $sformatf("release_hashed_token: index %0d out of range", idx))
       end
     endcase
   endfunction

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_sec_token_digest_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_sec_token_digest_vseq.sv
@@ -1,0 +1,37 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Token mux error injection test
+
+class lc_ctrl_sec_token_digest_vseq extends lc_ctrl_errors_vseq;
+
+  `uvm_object_utils(lc_ctrl_sec_token_digest_vseq)
+  `uvm_object_new
+
+  constraint num_trans_c {num_trans inside {[50 : 100]};}
+
+  // Enable err_inj.token_mismatch_err and disable the others
+  constraint lc_errors_c {
+    err_inj.transition_err == 0;
+    err_inj.transition_count_err == 0;
+    err_inj.clk_byp_error_rsp == 0;
+    err_inj.flash_rma_error_rsp == 0;
+    err_inj.token_response_err == 0;
+    err_inj.token_invalid_err == 0;
+    err_inj.otp_partition_err == 0;
+  }
+
+  constraint lc_token_digest_c {
+    $onehot(
+        {
+          // Either wrong token for transition
+          err_inj.token_mismatch_err,
+          // Or bit errors in token during state transition
+          err_inj.token_mux_digest_err
+        }
+    );
+  }
+
+
+
+endclass

--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_vseq_list.sv
@@ -16,6 +16,7 @@
 `include "lc_ctrl_regwen_during_op_vseq.sv"
 `include "lc_ctrl_sec_mubi_vseq.sv"
 `include "lc_ctrl_sec_token_mux_vseq.sv"
+`include "lc_ctrl_sec_token_digest_vseq.sv"
 `include "lc_ctrl_stress_all_vseq.sv"
 
 

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -237,6 +237,11 @@
       run_opts: ["+create_jtag_riscv_map=1"]
     }
 
+    {
+      name: "lc_ctrl_sec_token_digest"
+      uvm_test_seq: lc_ctrl_sec_token_digest_vseq
+      run_opts: ["+create_jtag_riscv_map=1"]
+    }
 
     {
       name: "lc_ctrl_stress_all"

--- a/hw/ip/lc_ctrl/dv/tb.sv
+++ b/hw/ip/lc_ctrl/dv/tb.sv
@@ -182,6 +182,12 @@ module tb;
   // Token mux control
   assign lc_ctrl_if.token_idx0 = dut.u_lc_ctrl_fsm.token_idx0;
   assign lc_ctrl_if.token_idx1 = dut.u_lc_ctrl_fsm.token_idx1;
+  // Hashed tokens
+  assign lc_ctrl_if.hashed_token_i = dut.u_lc_ctrl_fsm.hashed_token_i;
+  assign lc_ctrl_if.hashed_token_mux = dut.u_lc_ctrl_fsm.hashed_token_mux;
+  assign lc_ctrl_if.token_hash_ack_i = dut.u_lc_ctrl_fsm.token_hash_ack_i;
+
+
 
   initial begin
     static


### PR DESCRIPTION
- Added tests:
  - lc_ctrl_sec_token_digest
- Added test sequences:
  - lc_ctrl_sec_token_digest_vseq
- Added error injection
  - token_mux_digest_err - flip a bit in one of the input busses of the token
  mux.
- Added coverage:
  - Cover group sec_token_digest_error_cg records which FSM states see a
  token invalid error
  - Added V2S error injection flags to err_inj_cg

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>