### PR TITLE
[bazel] Silence reggen warnings in register header generation

### DIFF
--- a/rules/autogen.bzl
+++ b/rules/autogen.bzl
@@ -16,6 +16,7 @@ def _hjson_header(ctx):
         inputs = ctx.files.srcs + [ctx.executable._regtool],
         arguments = [
             "-D",
+            "-q",
             "-o",
             header.path,
         ] + [src.path for src in ctx.files.srcs],

--- a/util/regtool.py
+++ b/util/regtool.py
@@ -87,6 +87,10 @@ def main():
                         '-v',
                         action='store_true',
                         help='Verbose and run validate twice')
+    parser.add_argument('--quiet',
+                        '-q',
+                        action='store_true',
+                        help='Log only errors, not warnings')
     parser.add_argument('--param',
                         '-p',
                         type=str,
@@ -111,8 +115,10 @@ def main():
         version.show_and_exit(__file__, ["Hjson", "Mako"])
 
     verbose = args.verbose
-    if (verbose):
+    if verbose:
         log.basicConfig(format="%(levelname)s: %(message)s", level=log.DEBUG)
+    elif args.quiet:
+        log.basicConfig(format="%(levelname)s: %(message)s", level=log.ERROR)
     else:
         log.basicConfig(format="%(levelname)s: %(message)s")
 


### PR DESCRIPTION
The warnings are not useful for the software build, and make build logs
noisy and harder to search through in CI

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>