### PR TITLE
[bazel,otbn] Add otbn_test rule for OTBN simulator tests.

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/BUILD
+++ b/hw/ip/otbn/dv/otbnsim/BUILD
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+# Make standalone simulator visible to OTBN tests within Bazel (see
+# rules/otbn.bzl). Note that this means other files in this directory and
+# subdirectories are not included in all_files targets for higher-level
+# directories.
+exports_files(["standalone.py"])

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:otbn.bzl", "otbn_binary", "otbn_library")
+load("//rules:otbn.bzl", "otbn_binary", "otbn_library", "otbn_sim_test")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -13,7 +13,7 @@ otbn_library(
     ],
 )
 
-otbn_binary(
+otbn_sim_test(
     name = "field25519_test",
     srcs = [
         "field25519_test.s",


### PR DESCRIPTION
Resolves #11606 
Related to discussion here: https://github.com/lowRISC/opentitan/pull/11597#discussion_r832398664

While OTBN code can be embedded into Ibex code and run as an `opentitan_functest`, it's often faster and more convenient to run quick sanity-checks on the OTBN simulator, directly on the host machine. This creates a Bazel test rule to run the simulator tests.

Now, instead of finding the generated `.elf` file for an OTBN test, manually invoking the simulator locally, and checking the register dump with my eyes, I can just run `bazel test` and get the result.

The rule has not been applied to any existing simulator tests because it expects the convention that `w0 = 0` if the test passed. I followed that convention in https://github.com/lowRISC/opentitan/pull/11778 and tested out the rule on the test from that PR.