### PR TITLE
[dv,full_chip,extclk] Add clkmgr_external_clk_src_for_lc test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -68,7 +68,7 @@
             Extend from chip_sw_uart_rand_baudrate with following added settings.
             - Configure LC to RMA state, so that it allows clkmgr to use external clock.
             - Configure clkmgr to select external clock.
-            - Randomize `LOW_SPEED_SEL`, so that uart core clock frequency can be either
+            - Randomize `HI_SPEED_SEL`, so that uart core clock frequency can be either
               ext_clk_freq / 4 or ext_clk_freq / 2.
             '''
       milestone: V1
@@ -820,7 +820,8 @@
             '''
       milestone: V2
       tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast",
-              "chip_sw_clkmgr_external_clk_src_for_sw_slow"]
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow",
+              "chip_sw_clkmgr_external_clk_src_for_lc"]
       tags: ["conn"]
     }
     {
@@ -832,15 +833,16 @@
             best to verify this via SVA, unless we implement clock cycle counters.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_clkmgr_external_clk_src_for_lc"]
     }
     {
       name: chip_sw_clkmgr_external_clk_src_for_sw
       desc: '''Verify SW causes the clkmgr requests ext clk src during certain LC states.
 
             In RMA and TEST_UNLOCKED lc states the external clock is enabled in response to
-            `extclk_ctrl.sel` CSR writes. In addition `extclk_ctrl.step_down` CSR causes the divided
-            clocks to step down. Verify this via SVA bound to clkmgr, and clock cycle counters.
+            `extclk_ctrl.sel` CSR writes. In addition `extclk_ctrl.hi_speed_sel` CSR causes the
+            divided clocks to step down. Verify this via SVA bound to clkmgr, and clock cycle
+            counters.
             X-ref with chip_sw_uart_tx_rx_alt_clk_freq, which needs to deal with this as well.
             '''
       milestone: V2
@@ -1258,7 +1260,7 @@
             - Ensure that there is no background or otp_init error.
             - Verify that the LC ctrl has transitioned to the programmed state after a reboot.
 
-            X-ref'ed chip_otp_ctrl_program.
+            X-ref'ed chip_sw_otp_ctrl_program.
             '''
       milestone: V2
       tests: ["chip_sw_lc_ctrl_transition"]

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -622,6 +622,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_clkmgr_external_clk_src_for_lc
+      uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
+      sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_lc_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+ext_clk_type=ExtClkLowSpeed", "+calibrate_usb_clk=1"]
+    }
+    {
       name: chip_sw_clkmgr_external_clk_src_for_sw_fast
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_sw_fast_test:1"]

--- a/sw/device/lib/runtime/ibex.h
+++ b/sw/device/lib/runtime/ibex.h
@@ -13,6 +13,9 @@
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/base/stdasm.h"
 
+// IBEX_SPIN_FOR needs a dependency on check.h, but the build fails if a
+// dependency on sw_lib_testing_check is added.
+
 /**
  * @file
  * @brief This header provides Ibex-specific functions, such as cycle-accurate

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load("//rules:opentitan_test.bzl", "opentitan_functest")
 
 opentitan_functest(
@@ -94,10 +95,11 @@ opentitan_functest(
     ],
 )
 
-opentitan_functest(
-    name = "lc_ctrl_transition_test",
-    srcs = ["lc_ctrl_transition_test.c"],
-    targets = ["dv"],
+cc_library(
+    name = "lc_ctrl_transition_impl",
+    srcs = ["lc_ctrl_transition_impl.c"],
+    hdrs = ["lc_ctrl_transition_impl.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:bitfield",
@@ -105,7 +107,22 @@ opentitan_functest(
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf",
     ],
+)
+
+opentitan_functest(
+    name = "lc_ctrl_transition_test",
+    srcs = ["lc_ctrl_transition_test.c"],
+    targets = ["dv"],
+    deps = ["lc_ctrl_transition_impl"],
+)
+
+opentitan_functest(
+    name = "clkmgr_external_clk_src_for_lc_test",
+    srcs = ["clkmgr_external_clk_src_for_lc_test.c"],
+    targets = ["dv"],
+    deps = ["lc_ctrl_transition_impl"],
 )
 
 opentitan_functest(

--- a/sw/device/tests/sim_dv/clkmgr_external_clk_src_for_lc_test.c
+++ b/sw/device/tests/sim_dv/clkmgr_external_clk_src_for_lc_test.c
@@ -8,5 +8,5 @@
 #include "sw/device/tests/sim_dv/lc_ctrl_transition_impl.h"
 
 bool test_main(void) {
-  return execute_lc_ctrl_transition_test(/*use_ext_clk=*/false);
+  return execute_lc_ctrl_transition_test(/*use_ext_clk=*/true);
 }

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.c
@@ -1,0 +1,119 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+#define LC_TOKEN_SIZE 16
+
+static dif_lc_ctrl_t lc;
+
+const test_config_t kTestConfig;
+
+/**
+ * Track number of iterations of this C test.
+ *
+ * From the software / compiler's perspective, this is a constant (hence the
+ * `const` qualifier). However, the external DV testbench finds this symbol's
+ * address and modifies it via backdoor, to track how many transactions have
+ * been sent. Hence, we add the `volatile` keyword to prevent the compiler from
+ * optimizing it out.
+ * The `const` is needed to put it in the .rodata section, otherwise it gets
+ * placed in .data section in the main SRAM. We cannot backdoor write anything
+ * in SRAM at the start of the test because the CRT init code wipes it to 0s.
+ */
+static volatile const uint8_t kTestIterationCount = 0x0;
+
+// LC exit token value for LC state transition.
+static volatile const uint8_t kLcExitToken[LC_TOKEN_SIZE] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+};
+
+static void check_lc_state_transition_count(uint8_t exp_lc_count) {
+  LOG_INFO("Read LC count and check with expect_val=%0d", exp_lc_count);
+  uint8_t lc_count;
+  CHECK(dif_lc_ctrl_get_attempts(&lc, &lc_count) == kDifOk,
+        "Read lc_count register failed!");
+  CHECK(lc_count == exp_lc_count,
+        "LC_count error, expected %0d but actual count is %0d", exp_lc_count,
+        lc_count);
+}
+
+/**
+ * Tests the state transition request handshake between LC_CTRL and OTP_CTRL.
+ *
+ * 1). OTP pre-load image with lc_count = `8`.
+ * 2). Backdoor write OTP's LC parition to `TestLocked1` state, and backdoor
+ * write OTP's `test_exit` token and `test_unlock` token to match the rand
+ * patterns.
+ * 3). `TestLocked1` state disabled CPU, so external testbench will drive JTAG
+ * interface to transit to `TestUnlocked2` state and increment the LC_CNT.
+ * 4). When LC_CTRL is ready, check LC_CNT and LC_STATE register.
+ * 5). Program LC state transition request to advance to `Prod` state.
+ * 6). Issue hard reset.
+ * 7). Wait for LC_CTRL is ready, then check if LC_STATE advanced to `Dev`
+ * state, and lc_count advanced to `9`.
+ * 8). Issue hard reset and override OTP's LC partition, and reset LC state to
+ * `TestUnlocked2` state.
+ */
+
+bool execute_lc_ctrl_transition_test(bool use_ext_clk) {
+  LOG_INFO("Start LC_CTRL transition test.");
+
+  mmio_region_t lc_reg = mmio_region_from_addr(TOP_EARLGREY_LC_CTRL_BASE_ADDR);
+  CHECK_DIF_OK(dif_lc_ctrl_init(lc_reg, &lc));
+
+  LOG_INFO("Read and check LC state.");
+  dif_lc_ctrl_state_t curr_state;
+  CHECK_DIF_OK(dif_lc_ctrl_get_state(&lc, &curr_state));
+
+  // The OTP preload image hardcodes the initial LC state transition count to 8.
+  // With each iteration of test, there are two LC_CTRL state transitions.
+  // And the first LC_CTRL state transition is done via external JTAG interface.
+  // `kTestIterationCount` starts with 1 in SystemVerilog.
+  const uint8_t kLcStateTransitionCount = 8 + 1 + (kTestIterationCount - 1) * 2;
+
+  if (curr_state == kDifLcCtrlStateTestUnlocked2) {
+    // LC TestUnlocked2 is the intial test state for this sequence.
+    // The sequence will check if lc_count matches the preload value.
+    check_lc_state_transition_count(kLcStateTransitionCount);
+
+    // Request lc_state transfer to Dev state.
+    dif_lc_ctrl_token_t token;
+    dif_lc_ctrl_settings_t settings;
+    settings.clock_select =
+        use_ext_clk ? kDifLcCtrlExternalClockEn : kDifLcCtrlInternalClockEn;
+    for (int i = 0; i < LC_TOKEN_SIZE; i++) {
+      token.data[i] = kLcExitToken[i];
+    }
+    CHECK(dif_lc_ctrl_mutex_try_acquire(&lc) == kDifOk);
+    CHECK(dif_lc_ctrl_transition(&lc, kDifLcCtrlStateDev, &token, &settings) ==
+              kDifOk,
+          "LC_transition failed!");
+
+    LOG_INFO("Waiting for LC transtition done and reboot.");
+    wait_for_interrupt();
+
+  } else {
+    // LC Dev is the requested state from previous lc_state transition request.
+    // Once the sequence checks current state and count via CSRs, the test can
+    // exit successfully.
+    CHECK(curr_state == kDifLcCtrlStateDev, "State transition failed!");
+    check_lc_state_transition_count(kLcStateTransitionCount + 1);
+    return true;
+  }
+
+  return false;
+}

--- a/sw/device/tests/sim_dv/lc_ctrl_transition_impl.h
+++ b/sw/device/tests/sim_dv/lc_ctrl_transition_impl.h
@@ -1,0 +1,11 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_SIM_DV_LC_CTRL_TRANSITION_IMPL_H_
+#define OPENTITAN_SW_DEVICE_TESTS_SIM_DV_LC_CTRL_TRANSITION_IMPL_H_
+
+#include <stdbool.h>
+
+bool execute_lc_ctrl_transition_test(bool use_ext_clk);
+#endif  // OPENTITAN_SW_DEVICE_TESTS_SIM_DV_LC_CTRL_TRANSITION_IMPL_H_

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -108,6 +108,37 @@ sw_tests += {
   }
 }
 
+lc_ctrl_transition_test_impl_lib = declare_dependency(
+  link_with: static_library(
+    'lc_ctrl_transition_test_impl_lib',
+    sources: [
+      'lc_ctrl_transition_impl.c',
+    ],
+    dependencies: [
+      sw_lib_dif_lc_ctrl,
+      sw_lib_mmio,
+      sw_lib_runtime_hart,
+      sw_lib_runtime_log,
+      top_earlgrey,
+    ],
+  ),
+)
+
+clkmgr_external_clk_src_for_lc_test_lib = declare_dependency(
+  link_with: static_library(
+    'clkmgr_external_clk_src_for_lc_test_lib',
+    sources: ['clkmgr_external_clk_src_for_lc_test.c'],
+    dependencies: [
+      lc_ctrl_transition_test_impl_lib,
+    ],
+  ),
+)
+sw_tests += {
+  'clkmgr_external_clk_src_for_lc_test': {
+    'library': clkmgr_external_clk_src_for_lc_test_lib,
+  }
+}
+
 lc_ctrl_transition_test_lib = declare_dependency(
   link_with: static_library(
     'lc_ctrl_transition_test_lib',
@@ -115,10 +146,7 @@ lc_ctrl_transition_test_lib = declare_dependency(
       'lc_ctrl_transition_test.c',
     ],
     dependencies: [
-      sw_lib_dif_lc_ctrl,
-      sw_lib_runtime_log,
-      sw_lib_mmio,
-      sw_lib_runtime_hart,
+      lc_ctrl_transition_test_impl_lib,
     ],
   ),
 )


### PR DESCRIPTION
Use lc_ctrl_transition test configuring it with external clock.

Signed-off-by: Guillermo Maturana <maturana@google.com>