### PR TITLE
[dv,full_chip,extclk] Fix clkmgr_external_clk_src_for_sw

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -819,7 +819,8 @@
             Use the clkmgr count measurement feature to verify clock division.
             '''
       milestone: V2
-      tests: ["chip_sw_clkmgr_external_clk_src_for_sw"]
+      tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow"]
       tags: ["conn"]
     }
     {
@@ -843,7 +844,8 @@
             X-ref with chip_sw_uart_tx_rx_alt_clk_freq, which needs to deal with this as well.
             '''
       milestone: V2
-      tests: ["chip_sw_clkmgr_external_clk_src_for_sw"]
+      tests: ["chip_sw_clkmgr_external_clk_src_for_sw_fast",
+              "chip_sw_clkmgr_external_clk_src_for_sw_slow"]
     }
     {
       name: chip_sw_clkmgr_jitter

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -616,10 +616,18 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
-      name: chip_sw_clkmgr_external_clk_src_for_sw
+      name: chip_sw_clkmgr_external_clk_src_for_sw_fast
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_sw_test:1"]
+      sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_sw_fast_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+ext_clk_type=ExtClkHighSpeed", "+calibrate_usb_clk=1"]
+    }
+    {
+      name: chip_sw_clkmgr_external_clk_src_for_sw_slow
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_sw_slow_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+ext_clk_type=ExtClkLowSpeed", "+calibrate_usb_clk=1"]
     }
     {
       name: chip_sw_clkmgr_jitter

--- a/sw/device/lib/dif/dif_clkmgr.c
+++ b/sw/device/lib/dif/dif_clkmgr.c
@@ -42,6 +42,20 @@ static bool clkmgr_measure_ctrl_regwen(const dif_clkmgr_t *clkmgr) {
                              CLKMGR_MEASURE_CTRL_REGWEN_EN_BIT);
 }
 
+dif_result_t dif_clkmgr_external_clock_is_settled(const dif_clkmgr_t *clkmgr,
+                                                  bool *status) {
+  if (clkmgr == NULL || status == NULL) {
+    return kDifBadArg;
+  }
+  uint32_t extclk_status_val =
+      mmio_region_read32(clkmgr->base_addr, CLKMGR_EXTCLK_STATUS_REG_OFFSET);
+  *status = bitfield_field32_read(extclk_status_val,
+                                  CLKMGR_EXTCLK_STATUS_ACK_FIELD) ==
+            kMultiBitBool4True;
+
+  return kDifOk;
+}
+
 dif_result_t dif_clkmgr_jitter_get_enabled(const dif_clkmgr_t *clkmgr,
                                            dif_toggle_t *state) {
   if (clkmgr == NULL || state == NULL) {

--- a/sw/device/lib/dif/dif_clkmgr.h
+++ b/sw/device/lib/dif/dif_clkmgr.h
@@ -258,6 +258,17 @@ dif_result_t dif_clkmgr_external_clock_set_enabled(const dif_clkmgr_t *clkmgr,
                                                    bool is_low_speed);
 
 /**
+ * Determine if the transition to using external clock is complete.
+ *
+ * @param clkmgr Clock Manager Handle.
+ * @param[out] status Set to true if the transition is complete.
+ * @returns The result of the operation once it completes.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_clkmgr_external_clock_is_settled(const dif_clkmgr_t *clkmgr,
+                                                  bool *status);
+
+/**
  * Disable measurement control updates.
  *
  * This can only be disabled, and stays disabled until the next POR.

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -59,8 +59,8 @@ sw_lib_dif_clkmgr = declare_dependency(
       'dif_clkmgr.c',
     ],
     dependencies: [
-      sw_lib_mmio,
       sw_lib_dif_autogen_clkmgr,
+      sw_lib_mmio,
     ],
   )
 )

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -2,6 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 
 opentitan_functest(
@@ -137,15 +138,11 @@ opentitan_functest(
     ],
 )
 
-opentitan_functest(
-    name = "clkmgr_external_clk_src_for_sw_test",
-    srcs = ["clkmgr_external_clk_src_for_sw_test.c"],
-    verilator = verilator_params(
-        tags = [
-            "cpu:4",
-            "failing_verilator",
-        ],
-    ),
+cc_library(
+    name = "clkmgr_external_clk_src_for_sw_impl",
+    srcs = ["clkmgr_external_clk_src_for_sw_impl.c"],
+    hdrs = ["clkmgr_external_clk_src_for_sw_impl.h"],
+    target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:memory",
@@ -155,7 +152,32 @@ opentitan_functest(
         "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:clkmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf",
     ],
+)
+
+opentitan_functest(
+    name = "clkmgr_external_clk_src_for_sw_fast_test",
+    srcs = ["clkmgr_external_clk_src_for_sw_fast_test.c"],
+    verilator = verilator_params(
+        tags = [
+            "cpu:4",
+            "failing_verilator",
+        ],
+    ),
+    deps = ["clkmgr_external_clk_src_for_sw_impl"],
+)
+
+opentitan_functest(
+    name = "clkmgr_external_clk_src_for_sw_slow_test",
+    srcs = ["clkmgr_external_clk_src_for_sw_slow_test.c"],
+    verilator = verilator_params(
+        tags = [
+            "cpu:4",
+            "failing_verilator",
+        ],
+    ),
+    deps = ["clkmgr_external_clk_src_for_sw_impl"],
 )
 
 opentitan_functest(

--- a/sw/device/tests/clkmgr_external_clk_src_for_sw_fast_test.c
+++ b/sw/device/tests/clkmgr_external_clk_src_for_sw_fast_test.c
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This test enables the external clock running at nominal speed. It checks
+// the expected frequencies via the clock count measurement feature.
+
+#include <stdbool.h>
+
+#include "sw/device/tests/clkmgr_external_clk_src_for_sw_impl.h"
+
+bool test_main(void) {
+  return execute_clkmgr_external_clk_src_for_sw_test(/*fast_ext_clk=*/true);
+}

--- a/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.c
+++ b/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.c
@@ -2,14 +2,9 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 //
-// This test enables the external clock via software and ramps down the
-// clock dividers. It checks the expected frequencies via the clock count
+// This runs a test with external clock enabled via software for either fast
+// or slow speed. It checks the expected frequencies via the clock count
 // measurement feature.
-//
-// The variability for USB is larger because that clock is uncalibrated at
-// power-on.
-// TODO(lowrisc/opentitan:#11264): tighten up the USB measurement once
-// this issue is addressed.
 
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/dif/dif_base.h"
@@ -31,9 +26,11 @@ typedef struct expected_count_info {
 } expected_count_info_t;
 
 expected_count_info_t count_infos[kDifClkmgrMeasureClockUsb + 1] = {
-    {479, 1}, {239, 1}, {119, 1}, {499, 1}, {239, 6}};
+    {479, 1}, {239, 1}, {119, 1}, {499, 1}, {239, 1}};
 
-const int extclk_settle_delay_us = 30;
+// Switching to external clocks causes the clocks to be unstable for some time.
+// This is used to delay further action when the switch happens.
+const int extclk_settle_delay_us = 35;
 const int measurement_delay_us = 100;
 
 static void clear_recoverable_errors(const dif_clkmgr_t *clkmgr) {
@@ -51,7 +48,13 @@ static void check_measurement_counts(const dif_clkmgr_t *clkmgr) {
   clear_recoverable_errors(clkmgr);
 }
 
-bool test_main() {
+static bool did_extclk_settle(const dif_clkmgr_t *clkmgr) {
+  bool status;
+  CHECK_DIF_OK(dif_clkmgr_external_clock_is_settled(clkmgr, &status));
+  return status;
+}
+
+bool execute_clkmgr_external_clk_src_for_sw_test(bool fast_ext_clk) {
   dif_clkmgr_t clkmgr;
   dif_clkmgr_recov_err_codes_t err_codes;
 
@@ -76,54 +79,36 @@ bool test_main() {
   check_measurement_counts(&clkmgr);
   clkmgr_testutils_disable_clock_count_measurements(&clkmgr);
 
-  // Configure external clock and low speed: both main and io clocks counts
-  // are the nominal IoDiv2's.
+  // Configure external clock:
+  // - at low speed (48 MHz) both main and io clocks count are the nominal
+  //   IoDiv2's.
+  // - at high speed (96 MHz) the main clock count is the nominal Io's.
   LOG_INFO("Selecting external clock and low speed clocks");
-  CHECK_DIF_OK(dif_clkmgr_external_clock_set_enabled(&clkmgr, true));
+  CHECK_DIF_OK(
+      dif_clkmgr_external_clock_set_enabled(&clkmgr,
+                                            /*is_low_speed=*/!fast_ext_clk));
 
   // Wait a few AON cycles for glitches from the transition to external
   // clock to settle.
-  busy_spin_micros(extclk_settle_delay_us);
+  IBEX_SPIN_FOR(did_extclk_settle(&clkmgr), extclk_settle_delay_us);
 
   // Enable cycle measurements to confirm the frequencies are correct.
   for (int i = 0; i <= kDifClkmgrMeasureClockUsb; ++i) {
     dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
     expected_count_info_t count_info;
-    if (clock == kDifClkmgrMeasureClockIo ||
-        clock == kDifClkmgrMeasureClockMain) {
-      count_info = count_infos[kDifClkmgrMeasureClockIoDiv2];
+    if (fast_ext_clk) {
+      if (clock == kDifClkmgrMeasureClockMain) {
+        count_info = count_infos[kDifClkmgrMeasureClockIo];
+      } else {
+        count_info = count_infos[clock];
+      }
     } else {
-      count_info = count_infos[clock];
-    }
-    clkmgr_testutils_enable_clock_count_measurement(
-        &clkmgr, clock, count_info.count - count_info.variability,
-        count_info.count + count_info.variability);
-  }
-
-  busy_spin_micros(measurement_delay_us);
-  check_measurement_counts(&clkmgr);
-  clkmgr_testutils_disable_clock_count_measurements(&clkmgr);
-
-  // Configure external clock and high speed: io, io_div2, and main expected
-  // at 96 MHz, and io_div4 at 48 MHz.
-  LOG_INFO("Selecting external clock and high speed clocks");
-  CHECK_DIF_OK(dif_clkmgr_external_clock_set_enabled(&clkmgr, false));
-
-  // Wait a few AON cycles for glitches from the transition to external
-  // high speed to settle.
-  busy_spin_micros(10);
-
-  // Enable cycle measurements to confirm the frequencies are correct.
-  for (int i = 0; i <= kDifClkmgrMeasureClockUsb; ++i) {
-    dif_clkmgr_measure_clock_t clock = (dif_clkmgr_measure_clock_t)i;
-    expected_count_info_t count_info;
-    if (clock == kDifClkmgrMeasureClockMain ||
-        clock == kDifClkmgrMeasureClockIoDiv2) {
-      count_info = count_infos[kDifClkmgrMeasureClockIo];
-    } else if (clock == kDifClkmgrMeasureClockIoDiv4) {
-      count_info = count_infos[kDifClkmgrMeasureClockIoDiv2];
-    } else {
-      count_info = count_infos[clock];
+      if (clock == kDifClkmgrMeasureClockIo ||
+          clock == kDifClkmgrMeasureClockMain) {
+        count_info = count_infos[kDifClkmgrMeasureClockIoDiv2];
+      } else {
+        count_info = count_infos[clock];
+      }
     }
     clkmgr_testutils_enable_clock_count_measurement(
         &clkmgr, clock, count_info.count - count_info.variability,

--- a/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.h
+++ b/sw/device/tests/clkmgr_external_clk_src_for_sw_impl.h
@@ -1,0 +1,21 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CLKMGR_EXTERNAL_CLK_SRC_FOR_SW_IMPL_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CLKMGR_EXTERNAL_CLK_SRC_FOR_SW_IMPL_H_
+
+#include <stdbool.h>
+
+/**
+ * This test enables the external clock running at high or low speed.
+ * It checks the expected frequencies via the clock count measurement feature.
+ *
+ * @param fast_ext_clk When true, run the test for an external clock running
+ *                     at 96 MHz.
+ * @returns True if the test succeeds.
+ */
+
+bool execute_clkmgr_external_clk_src_for_sw_test(bool fast_ext_clk);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CLKMGR_EXTERNAL_CLK_SRC_FOR_SW_IMPL_H_

--- a/sw/device/tests/clkmgr_external_clk_src_for_sw_slow_test.c
+++ b/sw/device/tests/clkmgr_external_clk_src_for_sw_slow_test.c
@@ -1,0 +1,14 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This test enables the external clock running at slow speed. It checks
+// the expected frequencies via the clock count measurement feature.
+
+#include <stdbool.h>
+
+#include "sw/device/tests/clkmgr_external_clk_src_for_sw_impl.h"
+
+bool test_main(void) {
+  return execute_clkmgr_external_clk_src_for_sw_test(/*fast_ext_clk=*/false);
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -385,10 +385,10 @@ sw_tests += {
   }
 }
 
-clkmgr_external_clk_src_for_sw_test_lib = declare_dependency(
+clkmgr_external_clk_src_for_sw_impl_lib = declare_dependency(
   link_with: static_library(
-    'clkmgr_external_clk_src_for_sw_test_lib',
-    sources: ['clkmgr_external_clk_src_for_sw_test.c'],
+    'clkmgr_external_clk_src_for_sw_impl_lib',
+    sources: ['clkmgr_external_clk_src_for_sw_impl.c'],
     dependencies: [
       sw_lib_dif_clkmgr,
       sw_lib_mmio,
@@ -400,9 +400,34 @@ clkmgr_external_clk_src_for_sw_test_lib = declare_dependency(
     ],
   ),
 )
+
+clkmgr_external_clk_src_for_sw_fast_test_lib = declare_dependency(
+  link_with: static_library(
+    'clkmgr_external_clk_src_for_sw_fast_test_lib',
+    sources: ['clkmgr_external_clk_src_for_sw_fast_test.c'],
+    dependencies: [
+      clkmgr_external_clk_src_for_sw_impl_lib,
+    ],
+  ),
+)
 sw_tests += {
-  'clkmgr_external_clk_src_for_sw_test': {
-    'library': clkmgr_external_clk_src_for_sw_test_lib,
+  'clkmgr_external_clk_src_for_sw_fast_test': {
+    'library': clkmgr_external_clk_src_for_sw_fast_test_lib,
+  }
+}
+
+clkmgr_external_clk_src_for_sw_slow_test_lib = declare_dependency(
+  link_with: static_library(
+    'clkmgr_external_clk_src_for_sw_slow_test_lib',
+    sources: ['clkmgr_external_clk_src_for_sw_slow_test.c'],
+    dependencies: [
+      clkmgr_external_clk_src_for_sw_impl_lib,
+    ],
+  ),
+)
+sw_tests += {
+  'clkmgr_external_clk_src_for_sw_slow_test': {
+    'library': clkmgr_external_clk_src_for_sw_slow_test_lib,
   }
 }
 


### PR DESCRIPTION
Split the previous test in two, one running with 96 MHz ext clk and
another with 48 MHz. Fix the failures.

Signed-off-by: Guillermo Maturana <maturana@google.com>