### PR TITLE
[bazel] quiet bazelisk output to cleanup stdout

### DIFF
--- a/bazelisk.sh
+++ b/bazelisk.sh
@@ -43,8 +43,8 @@ function prepare() {
     local file="${bindir}/bazelisk"
     local url="https://github.com/bazelbuild/bazelisk/releases/download/${release}/bazelisk-${target}"
 
-    echo "Downloading bazelisk ${release} (${url})."
     mkdir -p "$bindir"
+    echo "Downloading bazelisk ${release} (${url})." >> $bindir/bazelisk.log
     curl ${CURL_FLAGS} --location "$url" --output "$file"
     chmod +x "$file"
 }


### PR DESCRIPTION
if we're using stdout from commands like "bazel query" then bazelisk's
report that it downloaded a version of bazelisk is problematic. Because
bazelisk is a wrapper and forwards flags I preferred redirecting to a
log file to requiring and parsing a verbose flag.

Signed-off-by: Drew Macrae <drewmacrae@google.com>