### PR TITLE
[verible] Update verible version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ variables:
   VERILATOR_VERSION: 4.210
   OPENOCD_VERSION: 0.11.0
   TOOLCHAIN_PATH: /opt/buildcache/riscv
-  VERIBLE_VERSION: v0.0-1213-g9e5c085
+  VERIBLE_VERSION: v0.0-2135-gb534c1fe
   RUST_VERSION: 1.58.0
   # Release tag from https://github.com/lowRISC/lowrisc-toolchains/releases
   TOOLCHAIN_VERSION: 20220210-1

--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -30,7 +30,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'verible': {
-        'min_version': 'v0.0-1213-g9e5c085',
+        'min_version': 'v0.0-2135-gb534c1fe',
         'as_needed': True
     },
     'vcs': {

--- a/util/container/Dockerfile
+++ b/util/container/Dockerfile
@@ -8,7 +8,7 @@
 # Global configuration options.
 ARG VERILATOR_VERSION=4.210
 ARG OPENOCD_VERSION=0.11.0
-ARG VERIBLE_VERSION=v0.0-1213-g9e5c085
+ARG VERIBLE_VERSION=v0.0-2135-gb534c1fe
 # The RISCV toolchain version should match the release tag used in GitHub.
 ARG RISCV_TOOLCHAIN_TAR_VERSION=20220210-1
 ARG RUST_VERSION=1.58.0


### PR DESCRIPTION
This updates Verible, since the version we are using is pretty old (from last May).
This version has many improvements, including new features such as [LSP support for editors](https://github.com/chipsalliance/verible/tree/master/verilog/tools/ls).

Note: this will not be merged until an announcement has been sent out via email to give people time to update their local installs.

Signed-off-by: Michael Schaffner <msf@google.com>