### PR TITLE
[dv, flash_ctrl] update state value due to design change

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -190,7 +190,7 @@ package flash_ctrl_env_pkg;
   // Parameter for Probing into the DUT RMA FSM
   parameter string PRB_RMA_FSM = "tb.dut.u_flash_hw_if.state_q";
   // Taken from enum type lcmgr_state_e in flash_ctrl_lcmgr.sv
-  parameter uint RMA_FSM_STATE_ST_RMA_RSP = 11'b10100100001;
+  parameter uint RMA_FSM_STATE_ST_RMA_RSP = 11'b10110001010;
 
   // functions
 


### PR DESCRIPTION
- a better fix is to make the state available via the package
  so that the DV check moves directly with the design.

Signed-off-by: Timothy Chen <timothytim@google.com>