### PR TITLE
[flash_ctrl] D2S hardening for host/controller arbitration

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -308,6 +308,24 @@
         as well as word count, page count and wipe index in RMA entry phase.
       '''
     }
+    { name: "PHY_ARBITER.CTRL.REDUN",
+      desc: '''
+        The phy arbiter for controller and host is redundant.
+        The arbiter has two instance underneath that are constantly compared to each other.
+      '''
+    }
+    { name: "PHY_HOST_GRANT.CTRL.CONSISTENCY",
+      desc: '''
+        The host grant is consistency checked.
+        If the host is ever granted with info partition access, it is an error.
+        If the host is ever granted at the same time as a program/erase operation, it is an error.
+      '''
+    }
+    { name: "PHY_ACK.CTRL.CONSISTENCY",
+      desc: '''
+        If the host or controller ever receive an unexpeced transaction acknowledge, it is an error.
+      '''
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port
@@ -1890,6 +1908,18 @@
             name: "spurious_ack",
             desc: '''
               The flash emitted an unexpected acknowledgement.
+            '''
+          },
+          { bits: "11",
+            name: "arb_err",
+            desc: '''
+              The phy arbiter encountered inconsistent results.
+            '''
+          },
+          { bits: "12",
+            name: "host_gnt_err",
+            desc: '''
+              A host transaction was granted with illegal properties.
             '''
           },
         ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -319,6 +319,24 @@
         as well as word count, page count and wipe index in RMA entry phase.
       '''
     }
+    { name: "PHY_ARBITER.CTRL.REDUN",
+      desc: '''
+        The phy arbiter for controller and host is redundant.
+        The arbiter has two instance underneath that are constantly compared to each other.
+      '''
+    }
+    { name: "PHY_HOST_GRANT.CTRL.CONSISTENCY",
+      desc: '''
+        The host grant is consistency checked.
+        If the host is ever granted with info partition access, it is an error.
+        If the host is ever granted at the same time as a program/erase operation, it is an error.
+      '''
+    }
+    { name: "PHY_ACK.CTRL.CONSISTENCY",
+      desc: '''
+        If the host or controller ever receive an unexpeced transaction acknowledge, it is an error.
+      '''
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port
@@ -1365,6 +1383,18 @@
             name: "spurious_ack",
             desc: '''
               The flash emitted an unexpected acknowledgement.
+            '''
+          },
+          { bits: "11",
+            name: "arb_err",
+            desc: '''
+              The phy arbiter encountered inconsistent results.
+            '''
+          },
+          { bits: "12",
+            name: "host_gnt_err",
+            desc: '''
+              A host transaction was granted with illegal properties.
             '''
           },
         ]

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -1021,6 +1021,8 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_relbl_err.d    = 1'b1;
   assign hw2reg.fault_status.phy_storage_err.d  = 1'b1;
   assign hw2reg.fault_status.spurious_ack.d     = 1'b1;
+  assign hw2reg.fault_status.arb_err.d          = 1'b1;
+  assign hw2reg.fault_status.host_gnt_err.d     = 1'b1;
   assign hw2reg.fault_status.mp_err.de          = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de          = hw_err.rd_err;
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
@@ -1031,6 +1033,8 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;
   assign hw2reg.fault_status.spurious_ack.de    = flash_phy_rsp.spurious_ack;
+  assign hw2reg.fault_status.arb_err.de         = flash_phy_rsp.arb_err;
+  assign hw2reg.fault_status.host_gnt_err.de    = flash_phy_rsp.host_gnt_err;
 
   // standard faults
   assign hw2reg.std_fault_status.reg_intg_err.d    = 1'b1;

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -431,6 +431,8 @@ package flash_ctrl_pkg;
     logic                    storage_intg_err;
     logic                    fsm_err;
     logic                    spurious_ack;
+    logic                    arb_err;
+    logic                    host_gnt_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -450,7 +452,9 @@ package flash_ctrl_pkg;
     storage_relbl_err:  '0,
     storage_intg_err:   '0,
     fsm_err:            '0,
-    spurious_ack:       '0
+    spurious_ack:       '0,
+    arb_err:            '0,
+    host_gnt_err:       '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_sec_cm_testplan.hjson
@@ -161,5 +161,23 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_phy_arbiter_ctrl_redun
+      desc: "Verify the countermeasure(s) PHY_ARBITER.CTRL.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_phy_host_grant_ctrl_consistency
+      desc: "Verify the countermeasure(s) PHY_HOST_GRANT.CTRL.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_phy_ack_ctrl_consistency
+      desc: "Verify the countermeasure(s) PHY_ACK.CTRL.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1022,6 +1022,8 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_relbl_err.d    = 1'b1;
   assign hw2reg.fault_status.phy_storage_err.d  = 1'b1;
   assign hw2reg.fault_status.spurious_ack.d     = 1'b1;
+  assign hw2reg.fault_status.arb_err.d          = 1'b1;
+  assign hw2reg.fault_status.host_gnt_err.d     = 1'b1;
   assign hw2reg.fault_status.mp_err.de          = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de          = hw_err.rd_err;
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
@@ -1032,6 +1034,8 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;
   assign hw2reg.fault_status.spurious_ack.de    = flash_phy_rsp.spurious_ack;
+  assign hw2reg.fault_status.arb_err.de         = flash_phy_rsp.arb_err;
+  assign hw2reg.fault_status.host_gnt_err.de    = flash_phy_rsp.host_gnt_err;
 
   // standard faults
   assign hw2reg.std_fault_status.reg_intg_err.d    = 1'b1;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -979,6 +979,8 @@ module flash_ctrl_core_reg_top (
   logic fault_status_phy_relbl_err_qs;
   logic fault_status_phy_storage_err_qs;
   logic fault_status_spurious_ack_qs;
+  logic fault_status_arb_err_qs;
+  logic fault_status_host_gnt_err_qs;
   logic [19:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
@@ -10418,6 +10420,56 @@ module flash_ctrl_core_reg_top (
     .qs     (fault_status_spurious_ack_qs)
   );
 
+  //   F[arb_err]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_arb_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.arb_err.de),
+    .d      (hw2reg.fault_status.arb_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.arb_err.q),
+
+    // to register interface (read)
+    .qs     (fault_status_arb_err_qs)
+  );
+
+  //   F[host_gnt_err]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_host_gnt_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.host_gnt_err.de),
+    .d      (hw2reg.fault_status.host_gnt_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.host_gnt_err.q),
+
+    // to register interface (read)
+    .qs     (fault_status_host_gnt_err_qs)
+  );
+
 
   // R[err_addr]: V(False)
   prim_subreg #(
@@ -12606,6 +12658,8 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[8] = fault_status_phy_relbl_err_qs;
         reg_rdata_next[9] = fault_status_phy_storage_err_qs;
         reg_rdata_next[10] = fault_status_spurious_ack_qs;
+        reg_rdata_next[11] = fault_status_arb_err_qs;
+        reg_rdata_next[12] = fault_status_host_gnt_err_qs;
       end
 
       addr_hit[96]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -431,6 +431,8 @@ package flash_ctrl_pkg;
     logic                    storage_intg_err;
     logic                    fsm_err;
     logic                    spurious_ack;
+    logic                    arb_err;
+    logic                    host_gnt_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -450,7 +452,9 @@ package flash_ctrl_pkg;
     storage_relbl_err:  '0,
     storage_intg_err:   '0,
     fsm_err:            '0,
-    spurious_ack:       '0
+    spurious_ack:       '0,
+    arb_err:            '0,
+    host_gnt_err:       '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -431,6 +431,12 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } spurious_ack;
+    struct packed {
+      logic        q;
+    } arb_err;
+    struct packed {
+      logic        q;
+    } host_gnt_err;
   } flash_ctrl_reg2hw_fault_status_reg_t;
 
   typedef struct packed {
@@ -647,6 +653,14 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } spurious_ack;
+    struct packed {
+      logic        d;
+      logic        de;
+    } arb_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } host_gnt_err;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -690,29 +704,29 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1318:1313]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1312:1307]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1306:1295]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1294:1289]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [1288:1285]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [1284:1253]
-    flash_ctrl_reg2hw_init_reg_t init; // [1252:1252]
-    flash_ctrl_reg2hw_control_reg_t control; // [1251:1232]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [1231:1212]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1211:1210]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1209:1209]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1208:985]
-    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [984:833]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [832:809]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [808:529]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [528:501]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [500:445]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [444:165]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [164:137]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [136:81]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [80:79]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [78:71]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:61]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1320:1315]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1314:1309]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1308:1297]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1296:1291]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [1290:1287]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [1286:1255]
+    flash_ctrl_reg2hw_init_reg_t init; // [1254:1254]
+    flash_ctrl_reg2hw_control_reg_t control; // [1253:1234]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [1233:1214]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1213:1212]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1211:1211]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1210:987]
+    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [986:835]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [834:811]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [810:531]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [530:503]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [502:447]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [446:167]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [166:139]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [138:83]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [82:81]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [80:73]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [72:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
@@ -722,15 +736,15 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [177:166]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [165:165]
-    flash_ctrl_hw2reg_control_reg_t control; // [164:163]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [162:161]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [160:157]
-    flash_ctrl_hw2reg_status_reg_t status; // [156:147]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [146:133]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [132:117]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [116:97]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [181:170]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [169:169]
+    flash_ctrl_hw2reg_control_reg_t control; // [168:167]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [166:165]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [164:161]
+    flash_ctrl_hw2reg_status_reg_t status; // [160:151]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [150:137]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [136:121]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [120:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [75:58]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [57:16]

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -101,6 +101,10 @@ module flash_phy
   logic [NumBanks-1:0] relbl_ecc_err;
   logic [NumBanks-1:0] intg_ecc_err;
 
+  // consistency error per bank
+  logic [NumBanks-1:0] arb_err;
+  logic [NumBanks-1:0] host_gnt_err;
+
   // select which bank each is operating on
   assign host_bank_sel = host_req_i ? host_addr_i[BusAddrW-1 -: BankW] : '0;
   assign ctrl_bank_sel = flash_ctrl_i.addr[BusAddrW-1 -: BankW];
@@ -126,6 +130,8 @@ module flash_phy
   assign flash_ctrl_o.storage_intg_err = |intg_ecc_err;
   assign flash_ctrl_o.fsm_err = |fsm_err;
   assign flash_ctrl_o.spurious_ack = |spurious_acks;
+  assign flash_ctrl_o.arb_err = |arb_err;
+  assign flash_ctrl_o.host_gnt_err = |host_gnt_err;
 
   // This fifo holds the expected return order
   prim_fifo_sync #(
@@ -277,7 +283,9 @@ module flash_phy
       .prog_intg_err_o(prog_intg_err[bank]),
       .relbl_ecc_err_o(relbl_ecc_err[bank]),
       .intg_ecc_err_o(intg_ecc_err[bank]),
-      .spurious_ack_o(spurious_acks[bank])
+      .spurious_ack_o(spurious_acks[bank]),
+      .arb_err_o(arb_err[bank]),
+      .host_gnt_err_o(host_gnt_err[bank])
     );
   end // block: gen_flash_banks
 

--- a/hw/ip/prim/prim_arbiter.core
+++ b/hw/ip/prim/prim_arbiter.core
@@ -10,9 +10,10 @@ filesets:
     depend:
       - lowrisc:prim:assert
     files:
+      - rtl/prim_arbiter_fixed.sv
       - rtl/prim_arbiter_ppc.sv
       - rtl/prim_arbiter_tree.sv
-      - rtl/prim_arbiter_fixed.sv
+      - rtl/prim_arbiter_tree_dup.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/prim/rtl/prim_arbiter_tree_dup.sv
+++ b/hw/ip/prim/rtl/prim_arbiter_tree_dup.sv
@@ -1,0 +1,124 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// This is a wrapper module that instantiates two prim_aribter_tree modules.
+// The reason for two is similar to modules such as prim_count/prim_lfsr where
+// we use spatial redundancy to ensure the arbitration results are not altered.
+//
+// Note there are limits to this check, as the inputs to the duplicated arbiter
+// is still a single lane. So an upstream attack can defeat this module.  The
+// duplication merely protects against attacks directly on the arbiter.
+
+`include "prim_assert.sv"
+
+module prim_arbiter_tree_dup #(
+  parameter int N   = 8,
+  parameter int DW  = 32,
+
+  // Configurations
+  // EnDataPort: {0, 1}, if 0, input data will be ignored
+  parameter bit EnDataPort = 1,
+
+  // Derived parameters
+  localparam int IdxW = $clog2(N)
+) (
+  input clk_i,
+  input rst_ni,
+
+  input                    req_chk_i, // Used for gating assertions. Drive to 1 during normal
+                                      // operation.
+  input        [ N-1:0]    req_i,
+  input        [DW-1:0]    data_i [N],
+  output logic [ N-1:0]    gnt_o,
+  output logic [IdxW-1:0]  idx_o,
+
+  output logic             valid_o,
+  output logic [DW-1:0]    data_o,
+  input                    ready_i,
+  output logic             err_o
+);
+
+  localparam int ArbInstances = 2;
+
+  //typedef struct packed {
+  //  logic [N-1:0] req;
+  //  logic [N-1:0][DW-1:0] data;
+  //} arb_inputs_t;
+
+  typedef struct packed {
+    logic valid;
+    logic [N-1:0] gnt;
+    logic [IdxW-1:0] idx;
+    logic [DW-1:0] data;
+  } arb_outputs_t;
+
+  // buffer up the inputs separately for each instance
+  //arb_inputs_t arb_in;
+  //arb_inputs_t [ArbInstances-1:0] arb_input_buf;
+  arb_outputs_t [ArbInstances-1:0] arb_output_buf;
+
+  for (genvar i = 0; i < ArbInstances; i++) begin : gen_input_bufs
+    logic [N-1:0] req_buf;
+    prim_buf #(
+      .Width(N)
+    ) u_req_buf (
+      .in_i(req_i),
+      .out_o(req_buf)
+    );
+
+    logic [DW-1:0] data_buf [N];
+    for (genvar j = 0; j < N; j++) begin : gen_data_bufs
+      prim_buf #(
+        .Width(DW)
+      ) u_dat_buf (
+        .in_i(data_i[j]),
+        .out_o(data_buf[j])
+      );
+    end
+
+    prim_arbiter_tree #(
+      .N(N),
+      .DW(DW),
+      .EnDataPort(EnDataPort)
+    ) u_arb (
+      .clk_i,
+      .rst_ni,
+      .req_chk_i,
+      .req_i(req_buf),
+      .data_i(data_buf),
+      .gnt_o(arb_output_buf[i].gnt),
+      .idx_o(arb_output_buf[i].idx),
+      .valid_o(arb_output_buf[i].valid),
+      .data_o(arb_output_buf[i].data),
+      .ready_i
+    );
+  end
+
+  // the last buffered position is sent out
+  assign gnt_o = arb_output_buf[ArbInstances-1].gnt;
+  assign idx_o = arb_output_buf[ArbInstances-1].idx;
+  assign valid_o = arb_output_buf[ArbInstances-1].valid;
+  assign data_o = arb_output_buf[ArbInstances-1].data;
+
+  // Check the last buffer index against all other instances
+  logic [ArbInstances-2:0] output_delta;
+
+  for (genvar i = 0; i < ArbInstances-1; i++) begin : gen_checks
+    assign output_delta[i] = arb_output_buf[ArbInstances-1] != arb_output_buf[i];
+  end
+
+  logic err_d, err_q;
+  // There is an error if anything ever disagrees
+  assign err_d = |output_delta;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      err_q <= '0;
+    end else begin
+      err_q <= err_d | err_q;
+    end
+  end
+
+  assign err_o = err_q;
+
+endmodule // prim_arbiter_tree

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -314,6 +314,24 @@
         as well as word count, page count and wipe index in RMA entry phase.
       '''
     }
+    { name: "PHY_ARBITER.CTRL.REDUN",
+      desc: '''
+        The phy arbiter for controller and host is redundant.
+        The arbiter has two instance underneath that are constantly compared to each other.
+      '''
+    }
+    { name: "PHY_HOST_GRANT.CTRL.CONSISTENCY",
+      desc: '''
+        The host grant is consistency checked.
+        If the host is ever granted with info partition access, it is an error.
+        If the host is ever granted at the same time as a program/erase operation, it is an error.
+      '''
+    }
+    { name: "PHY_ACK.CTRL.CONSISTENCY",
+      desc: '''
+        If the host or controller ever receive an unexpeced transaction acknowledge, it is an error.
+      '''
+    }
   ]
 
   scan: "true",       // Enable `scanmode_i` port
@@ -1896,6 +1914,18 @@
             name: "spurious_ack",
             desc: '''
               The flash emitted an unexpected acknowledgement.
+            '''
+          },
+          { bits: "11",
+            name: "arb_err",
+            desc: '''
+              The phy arbiter encountered inconsistent results.
+            '''
+          },
+          { bits: "12",
+            name: "host_gnt_err",
+            desc: '''
+              A host transaction was granted with illegal properties.
             '''
           },
         ]

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl_sec_cm_testplan.hjson
@@ -161,5 +161,23 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_phy_arbiter_ctrl_redun
+      desc: "Verify the countermeasure(s) PHY_ARBITER.CTRL.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_phy_host_grant_ctrl_consistency
+      desc: "Verify the countermeasure(s) PHY_HOST_GRANT.CTRL.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
+    {
+      name: sec_cm_phy_ack_ctrl_consistency
+      desc: "Verify the countermeasure(s) PHY_ACK.CTRL.CONSISTENCY."
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -1028,6 +1028,8 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_relbl_err.d    = 1'b1;
   assign hw2reg.fault_status.phy_storage_err.d  = 1'b1;
   assign hw2reg.fault_status.spurious_ack.d     = 1'b1;
+  assign hw2reg.fault_status.arb_err.d          = 1'b1;
+  assign hw2reg.fault_status.host_gnt_err.d     = 1'b1;
   assign hw2reg.fault_status.mp_err.de          = hw_err.mp_err;
   assign hw2reg.fault_status.rd_err.de          = hw_err.rd_err;
   assign hw2reg.fault_status.prog_err.de        = hw_err.prog_err;
@@ -1038,6 +1040,8 @@ module flash_ctrl
   assign hw2reg.fault_status.phy_relbl_err.de   = flash_phy_rsp.storage_relbl_err;
   assign hw2reg.fault_status.phy_storage_err.de = flash_phy_rsp.storage_intg_err;
   assign hw2reg.fault_status.spurious_ack.de    = flash_phy_rsp.spurious_ack;
+  assign hw2reg.fault_status.arb_err.de         = flash_phy_rsp.arb_err;
+  assign hw2reg.fault_status.host_gnt_err.de    = flash_phy_rsp.host_gnt_err;
 
   // standard faults
   assign hw2reg.std_fault_status.reg_intg_err.d    = 1'b1;

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -979,6 +979,8 @@ module flash_ctrl_core_reg_top (
   logic fault_status_phy_relbl_err_qs;
   logic fault_status_phy_storage_err_qs;
   logic fault_status_spurious_ack_qs;
+  logic fault_status_arb_err_qs;
+  logic fault_status_host_gnt_err_qs;
   logic [19:0] err_addr_qs;
   logic ecc_single_err_cnt_we;
   logic [7:0] ecc_single_err_cnt_ecc_single_err_cnt_0_qs;
@@ -10418,6 +10420,56 @@ module flash_ctrl_core_reg_top (
     .qs     (fault_status_spurious_ack_qs)
   );
 
+  //   F[arb_err]: 11:11
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_arb_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.arb_err.de),
+    .d      (hw2reg.fault_status.arb_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.arb_err.q),
+
+    // to register interface (read)
+    .qs     (fault_status_arb_err_qs)
+  );
+
+  //   F[host_gnt_err]: 12:12
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_fault_status_host_gnt_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.fault_status.host_gnt_err.de),
+    .d      (hw2reg.fault_status.host_gnt_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.fault_status.host_gnt_err.q),
+
+    // to register interface (read)
+    .qs     (fault_status_host_gnt_err_qs)
+  );
+
 
   // R[err_addr]: V(False)
   prim_subreg #(
@@ -12606,6 +12658,8 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[8] = fault_status_phy_relbl_err_qs;
         reg_rdata_next[9] = fault_status_phy_storage_err_qs;
         reg_rdata_next[10] = fault_status_spurious_ack_qs;
+        reg_rdata_next[11] = fault_status_arb_err_qs;
+        reg_rdata_next[12] = fault_status_host_gnt_err_qs;
       end
 
       addr_hit[96]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -437,6 +437,8 @@ package flash_ctrl_pkg;
     logic                    storage_intg_err;
     logic                    fsm_err;
     logic                    spurious_ack;
+    logic                    arb_err;
+    logic                    host_gnt_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -456,7 +458,9 @@ package flash_ctrl_pkg;
     storage_relbl_err:  '0,
     storage_intg_err:   '0,
     fsm_err:            '0,
-    spurious_ack:       '0
+    spurious_ack:       '0,
+    arb_err:            '0,
+    host_gnt_err:       '0
   };
 
   // RMA entries

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -431,6 +431,12 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } spurious_ack;
+    struct packed {
+      logic        q;
+    } arb_err;
+    struct packed {
+      logic        q;
+    } host_gnt_err;
   } flash_ctrl_reg2hw_fault_status_reg_t;
 
   typedef struct packed {
@@ -647,6 +653,14 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } spurious_ack;
+    struct packed {
+      logic        d;
+      logic        de;
+    } arb_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } host_gnt_err;
   } flash_ctrl_hw2reg_fault_status_reg_t;
 
   typedef struct packed {
@@ -690,29 +704,29 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1318:1313]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1312:1307]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1306:1295]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1294:1289]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [1288:1285]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [1284:1253]
-    flash_ctrl_reg2hw_init_reg_t init; // [1252:1252]
-    flash_ctrl_reg2hw_control_reg_t control; // [1251:1232]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [1231:1212]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1211:1210]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1209:1209]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1208:985]
-    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [984:833]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [832:809]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [808:529]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [528:501]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [500:445]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [444:165]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [164:137]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [136:81]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [80:79]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [78:71]
-    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [70:61]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1320:1315]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1314:1309]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1308:1297]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1296:1291]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [1290:1287]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [1286:1255]
+    flash_ctrl_reg2hw_init_reg_t init; // [1254:1254]
+    flash_ctrl_reg2hw_control_reg_t control; // [1253:1234]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [1233:1214]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1213:1212]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1211:1211]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1210:987]
+    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [986:835]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [834:811]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [810:531]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [530:503]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [502:447]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [446:167]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [166:139]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [138:83]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [82:81]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [80:73]
+    flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [72:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
     flash_ctrl_reg2hw_scratch_reg_t scratch; // [42:11]
@@ -722,15 +736,15 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [177:166]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [165:165]
-    flash_ctrl_hw2reg_control_reg_t control; // [164:163]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [162:161]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [160:157]
-    flash_ctrl_hw2reg_status_reg_t status; // [156:147]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [146:133]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [132:117]
-    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [116:97]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [181:170]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [169:169]
+    flash_ctrl_hw2reg_control_reg_t control; // [168:167]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [166:165]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [164:161]
+    flash_ctrl_hw2reg_status_reg_t status; // [160:151]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [150:137]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [136:121]
+    flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [120:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [75:58]
     flash_ctrl_hw2reg_ecc_single_err_addr_mreg_t [1:0] ecc_single_err_addr; // [57:16]


### PR DESCRIPTION
- refactor `flash_phy_core` to use `prim_arbiter_tree`
- introduce a `prim_arbiter_tree_dup` instance
- use the new duplicated arbiter and add some checks on post-arbitration behavior.