### PR TITLE
[dv] Update xcelium cover.ccf to only enable coverage for dut

### DIFF
--- a/hw/dv/tools/xcelium/cover.ccf
+++ b/hw/dv/tools/xcelium/cover.ccf
@@ -5,6 +5,9 @@
 // Include our common coverage CCF.
 include_ccf ${dv_root}/tools/xcelium/common.ccf
 
+deselect_coverage -betfs -module tb...
+select_coverage -befs -module ${DUT_TOP}...
+
 // Black-box pre-verified IPs from coverage collection.
 deselect_coverage -betfs -module pins_if
 deselect_coverage -betfs -module clk_rst_if


### PR DESCRIPTION
No need to collect code coverage at DV files
Signed-off-by: Weicai Yang <weicai@google.com>