### PR TITLE
[bazel] add bazel rules for OTBN tools

### DIFF
--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -2,6 +2,40 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
 package(default_visibility = ["//visibility:public"])
 
 exports_files(glob(["**"]))
+
+py_binary(
+    name = "otbn_as",
+    srcs = ["otbn_as.py"],
+    deps = [
+        "//hw/ip/otbn/util/shared:bit_ranges",
+        "//hw/ip/otbn/util/shared:encoding",
+        "//hw/ip/otbn/util/shared:insn_yaml",
+        "//hw/ip/otbn/util/shared:operand",
+        "//hw/ip/otbn/util/shared:toolchain",
+    ],
+)
+
+py_binary(
+    name = "otbn_ld",
+    srcs = ["otbn_ld.py"],
+    deps = [
+        "//hw/ip/otbn/util/shared:mem_layout",
+        "//hw/ip/otbn/util/shared:toolchain",
+        requirement("mako"),
+    ],
+)
+
+py_binary(
+    name = "otbn_objdump",
+    srcs = ["otbn_objdump.py"],
+    deps = [
+        "//hw/ip/otbn/util/shared:insn_yaml",
+        "//hw/ip/otbn/util/shared:toolchain",
+    ],
+)

--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -1,0 +1,109 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "bit_ranges",
+    srcs = ["bit_ranges.py"],
+)
+
+py_library(
+    name = "bool_literal",
+    srcs = ["bool_literal.py"],
+)
+
+py_library(
+    name = "encoding",
+    srcs = ["encoding.py"],
+    deps = [
+        ":bool_literal",
+        ":encoding_scheme",
+        "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
+    name = "encoding_scheme",
+    srcs = ["encoding_scheme.py"],
+    deps = [
+        ":bit_ranges",
+        ":bool_literal",
+        "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
+    name = "information_flow",
+    srcs = ["information_flow.py"],
+    deps = [
+        ":operand",
+        "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
+    name = "insn_yaml",
+    srcs = ["insn_yaml.py"],
+    deps = [
+        ":encoding",
+        ":encoding_scheme",
+        ":information_flow",
+        ":lsu_desc",
+        ":operand",
+        ":syntax",
+        "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
+    name = "lsu_desc",
+    srcs = ["lsu_desc.py"],
+    deps = [
+        "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
+    name = "mem_layout",
+    srcs = ["mem_layout.py"],
+    deps = [
+        ":otbn_reggen",
+        "//util/reggen:reg_block",
+    ],
+)
+
+py_library(
+    name = "operand",
+    srcs = ["operand.py"],
+    deps = [
+        ":encoding",
+        ":encoding_scheme",
+        "//util/serialize:parse_helpers",
+    ],
+)
+
+py_library(
+    name = "otbn_reggen",
+    srcs = ["otbn_reggen.py"],
+    deps = [
+        "//util/reggen:ip_block",
+        "//util/reggen:reg_block",
+    ],
+)
+
+py_library(
+    name = "syntax",
+    srcs = ["syntax.py"],
+    deps = [
+        ":operand",
+    ],
+)
+
+py_library(
+    name = "toolchain",
+    srcs = ["toolchain.py"],
+)

--- a/util/serialize/BUILD
+++ b/util/serialize/BUILD
@@ -1,0 +1,14 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_python//python:defs.bzl", "py_library")
+load("@ot_python_deps//:requirements.bzl", "requirement")
+
+package(default_visibility = ["//visibility:public"])
+
+py_library(
+    name = "parse_helpers",
+    srcs = ["parse_helpers.py"],
+    deps = [requirement("pyyaml")],
+)


### PR DESCRIPTION
Building the mask ROM requires use of OTBN python tools. To ensure bazel makes use of the hermetic toolchain, bazel rules must be added for these tools.

**_Note: this depends on #12233. Only review the last commit._**