### PR TITLE
[dv/xcelium] Fix Xcelium nightly regression error

### DIFF
--- a/hw/dv/tools/dvsim/xcelium.hjson
+++ b/hw/dv/tools/dvsim/xcelium.hjson
@@ -83,7 +83,9 @@
 
     // Export unr related paths for make
     {cov_unr_dir:     "{cov_unr_dir}" }
-    {cov_merge_cmd: "{cov_merge_cmd}"}
+    // Add an additional single quotation because `cov_merge_cmd` has an empty space, it will cause
+    // trouble when exporting the entire command in the environment.
+    {cov_merge_cmd: "'{cov_merge_cmd}'"}
   ]
 
   // Supported wave dumping formats (in order of preference).


### PR DESCRIPTION
This PR fixes the xcelium nightly regression error because we export
`cov_merge_cmd` in the enviornment.
In the command line, current what we see is that:
cov_merge_cmd={prefix} imc
The space between {prefix} and imc will cause trouble and
`cov_merge_cmd` ends up not loading the correct cmd.

To fix this issue, we add a single quotation, now the export command
looks like this:
cov_merge_cmd=`{prefix} imc`

Thanks @weicaiyang for debugging this issue.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>