### PR TITLE
[bazel] Remove nexysvideo from Bazel

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -39,7 +39,6 @@ _targets_compatible_with = {
 PER_DEVICE_DEPS = {
     "sim_verilator": ["//sw/device/lib/arch:sim_verilator"],
     "sim_dv": ["//sw/device/lib/arch:sim_dv"],
-    "fpga_nexysvideo": ["//sw/device/lib/arch:fpga_nexysvideo"],
     "fpga_cw310": ["//sw/device/lib/arch:fpga_cw310"],
 }
 

--- a/rules/rv.bzl
+++ b/rules/rv.bzl
@@ -14,7 +14,6 @@ OPENTITAN_PLATFORM = "@bazel_embedded//platforms:opentitan_rv32imc"
 PER_DEVICE_DEPS = {
     "sim_verilator": ["//sw/device/lib/arch:sim_verilator"],
     "sim_dv": ["//sw/device/lib/arch:sim_dv"],
-    "fpga_nexysvideo": ["//sw/device/lib/arch:fpga_nexysvideo"],
     "fpga_cw310": ["//sw/device/lib/arch:fpga_cw310"],
 }
 

--- a/sw/device/lib/arch/BUILD
+++ b/sw/device/lib/arch/BUILD
@@ -10,12 +10,6 @@ cc_library(
 )
 
 cc_library(
-    name = "fpga_nexysvideo",
-    srcs = ["device_fpga_nexysvideo.c"],
-    deps = [":device"],
-)
-
-cc_library(
     name = "fpga_cw310",
     srcs = ["device_fpga_cw310.c"],
     deps = [":device"],


### PR DESCRIPTION
Some things still use the Meson version of this build, so we'll remove
that in another change.

Signed-off-by: Miguel Young de la Sota <mcyoung@google.com>