### PR TITLE
[dv] Fix uncovered TLUL assert coverage

### DIFF
--- a/hw/ip/tlul/generic_dv/tests/xbar_error_test.sv
+++ b/hw/ip/tlul/generic_dv/tests/xbar_error_test.sv
@@ -15,6 +15,7 @@ class xbar_error_test extends xbar_base_test;
   virtual task run_phase(uvm_phase phase);
     // disable assertions for TL errors
     uvm_config_db#(bit)::set(null, "*", "tlul_assert_en", 0);
+    uvm_config_db#(bit)::set(null, "*", "tlul_d_error_assert_en", 0);
     super.run_phase(phase);
   endtask : run_phase
 endclass : xbar_error_test


### PR DESCRIPTION
Create another knob to disable d_error related SVA, to fix uncovered
assert coverage.
Only use that knob to disable SVA as xbar doesn't handle tl procotol
errors.

Signed-off-by: Weicai Yang <weicai@google.com>