### PR TITLE
[bazel] invoke OTBN tools with hermetic Python toolchain

### DIFF
--- a/hw/ip/otbn/util/BUILD
+++ b/hw/ip/otbn/util/BUILD
@@ -7,8 +7,6 @@ load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
-exports_files(glob(["**"]))
-
 py_binary(
     name = "otbn_as",
     srcs = ["otbn_as.py"],

--- a/hw/ip/otbn/util/otbn_as.py
+++ b/hw/ip/otbn/util/otbn_as.py
@@ -1187,10 +1187,9 @@ def run_binutils_as(other_args: List[str], inputs: List[str]) -> int:
         return 127
 
 
-def main() -> int:
-    files, other_args, flags = parse_positionals(sys.argv)
+def main(argv: List[str]) -> int:
+    files, other_args, flags = parse_positionals(argv)
     files = files or ['--']
-
     just_translate = '--otbn-translate' in flags
 
     # files is now a nonempty list of input files. Rather unusually, '--'
@@ -1246,4 +1245,4 @@ def main() -> int:
 
 
 if __name__ == '__main__':
-    sys.exit(main())
+    sys.exit(main(sys.argv))

--- a/hw/ip/otbn/util/shared/BUILD
+++ b/hw/ip/otbn/util/shared/BUILD
@@ -89,6 +89,7 @@ py_library(
 py_library(
     name = "otbn_reggen",
     srcs = ["otbn_reggen.py"],
+    data = ["//hw/ip/otbn/data:all_files"],
     deps = [
         "//util/reggen:ip_block",
         "//util/reggen:reg_block",

--- a/meson.build
+++ b/meson.build
@@ -209,6 +209,7 @@ prog_as = find_program('as')
 prog_objdump = find_program('objdump')
 prog_objcopy = find_program('objcopy')
 
+path_otbn_tools = meson.project_source_root() / 'hw/ip/otbn/util/'
 prog_otbn_as = meson.project_source_root() / 'hw/ip/otbn/util/otbn_as.py'
 prog_otbn_ld = meson.project_source_root() / 'hw/ip/otbn/util/otbn_ld.py'
 
@@ -285,6 +286,8 @@ r = run_command(
 
   'PYTHON=@0@'.format(prog_python.full_path()),
   'OTBN_AS=@0@'.format(prog_otbn_as),
+  'OTBN_LD=@0@'.format(prog_otbn_ld),
+  'OTBN_TOOLS=@0@'.format(path_otbn_tools),
   'OTBN_LD=@0@'.format(prog_otbn_ld),
   'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.full_path()),
   'RV32_TOOL_AS=@0@'.format(prog_as.full_path()),

--- a/meson.build
+++ b/meson.build
@@ -288,7 +288,6 @@ r = run_command(
   'OTBN_AS=@0@'.format(prog_otbn_as),
   'OTBN_LD=@0@'.format(prog_otbn_ld),
   'OTBN_TOOLS=@0@'.format(path_otbn_tools),
-  'OTBN_LD=@0@'.format(prog_otbn_ld),
   'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.full_path()),
   'RV32_TOOL_AS=@0@'.format(prog_as.full_path()),
   'RV32_TOOL_LD=@0@'.format(prog_ld.full_path()),

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -100,9 +100,8 @@ def _otbn_binary(ctx):
                   [ctx.executable._otbn_as] +
                   ctx.files._otbn_ld +
                   ctx.files._otbn_data +
-                  ctx.files._wrapper),
+                  [ctx.executable._wrapper]),
         env = {
-            "OTBN_AS": ctx.executable._otbn_as.path,
             "OTBN_LD": ctx.file._otbn_ld.path,
             "RV32_TOOL_AS": assembler.path,
             "RV32_TOOL_AR": cc_toolchain.ar_executable,
@@ -115,7 +114,7 @@ def _otbn_binary(ctx):
             "--no-assembler",
             "--out-dir={}".format(elf.dirname),
         ] + [obj.path for obj in (objs + deps)],
-        executable = ctx.file._wrapper,
+        executable = ctx.executable._wrapper,
     )
 
     feature_configuration = cc_common.configure_features(
@@ -189,8 +188,9 @@ otbn_binary = rv_rule(
             allow_files = True,
         ),
         "_wrapper": attr.label(
-            default = "//util:otbn_build.py",
-            allow_single_file = True,
+            default = "//util:otbn_build",
+            executable = True,
+            cfg = "exec",
         ),
     },
     fragments = ["cpp"],

--- a/rules/otbn.bzl
+++ b/rules/otbn.bzl
@@ -97,12 +97,9 @@ def _otbn_binary(ctx):
         inputs = (objs +
                   deps +
                   cc_toolchain.all_files.to_list() +
-                  [ctx.executable._otbn_as] +
-                  ctx.files._otbn_ld +
                   ctx.files._otbn_data +
                   [ctx.executable._wrapper]),
         env = {
-            "OTBN_LD": ctx.file._otbn_ld.path,
             "RV32_TOOL_AS": assembler.path,
             "RV32_TOOL_AR": cc_toolchain.ar_executable,
             "RV32_TOOL_LD": cc_toolchain.ld_executable,
@@ -178,10 +175,6 @@ otbn_binary = rv_rule(
             default = "//hw/ip/otbn/util:otbn_as",
             executable = True,
             cfg = "exec",
-        ),
-        "_otbn_ld": attr.label(
-            default = "//hw/ip/otbn/util:otbn_ld.py",
-            allow_single_file = True,
         ),
         "_otbn_data": attr.label(
             default = "//hw/ip/otbn/data:all_files",

--- a/sw/device/lib/crypto/meson.build
+++ b/sw/device/lib/crypto/meson.build
@@ -26,7 +26,6 @@ prog_otbn_build = meson.project_source_root() / 'util/otbn_build.py'
 otbn_build_command = [
   prog_env,
   'OTBN_TOOLS=@0@'.format(path_otbn_tools),
-  'OTBN_LD=@0@'.format(prog_otbn_ld),
   'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.full_path()),
   'RV32_TOOL_AS=@0@'.format(prog_as.full_path()),
   'RV32_TOOL_LD=@0@'.format(prog_ld.full_path()),

--- a/sw/device/lib/crypto/meson.build
+++ b/sw/device/lib/crypto/meson.build
@@ -25,7 +25,7 @@ prog_otbn_build = meson.project_source_root() / 'util/otbn_build.py'
 
 otbn_build_command = [
   prog_env,
-  'OTBN_AS=@0@'.format(prog_otbn_as),
+  'OTBN_TOOLS=@0@'.format(path_otbn_tools),
   'OTBN_LD=@0@'.format(prog_otbn_ld),
   'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.full_path()),
   'RV32_TOOL_AS=@0@'.format(prog_as.full_path()),

--- a/sw/otbn/meson.build
+++ b/sw/otbn/meson.build
@@ -46,7 +46,6 @@ prog_otbn_build = meson.project_source_root() / 'util/otbn_build.py'
 otbn_build_command = [
   prog_env,
   'OTBN_TOOLS=@0@'.format(path_otbn_tools),
-  'OTBN_LD=@0@'.format(prog_otbn_ld),
   'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.full_path()),
   'RV32_TOOL_AS=@0@'.format(prog_as.full_path()),
   'RV32_TOOL_LD=@0@'.format(prog_ld.full_path()),

--- a/sw/otbn/meson.build
+++ b/sw/otbn/meson.build
@@ -45,7 +45,7 @@ prog_otbn_build = meson.project_source_root() / 'util/otbn_build.py'
 
 otbn_build_command = [
   prog_env,
-  'OTBN_AS=@0@'.format(prog_otbn_as),
+  'OTBN_TOOLS=@0@'.format(path_otbn_tools),
   'OTBN_LD=@0@'.format(prog_otbn_ld),
   'RV32_TOOL_OBJCOPY=@0@'.format(prog_objcopy.full_path()),
   'RV32_TOOL_AS=@0@'.format(prog_as.full_path()),

--- a/util/BUILD
+++ b/util/BUILD
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@rules_python//python:defs.bzl", "py_binary")
+load("@ot_python_deps//:requirements.bzl", "requirement")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -13,6 +14,16 @@ genrule(
     outs = ["ot_version.txt"],
     cmd = """awk '/BUILD_GIT_VERSION/ { print $$2 }' bazel-out/volatile-status.txt > $@""",
     stamp = 1,  # this provides volatile-status.txt
+)
+
+py_binary(
+    name = "otbn_build",
+    srcs = ["otbn_build.py"],
+    imports = ["../hw/ip/otbn/util/"],
+    deps = [
+        requirement("pyelftools"),
+        "//hw/ip/otbn/util:otbn_as",
+    ],
 )
 
 py_binary(

--- a/util/BUILD
+++ b/util/BUILD
@@ -23,6 +23,7 @@ py_binary(
     deps = [
         requirement("pyelftools"),
         "//hw/ip/otbn/util:otbn_as",
+        "//hw/ip/otbn/util:otbn_ld",
     ],
 )
 

--- a/util/otbn_build.py
+++ b/util/otbn_build.py
@@ -16,7 +16,6 @@ environment variables:
   the $PATH).
 
   OTBN_TOOLS         path to the OTBN linker and assemler tools
-  OTBN_LD            path to otbn_ld.py, the OTBN linker
   RV32_TOOL_LD       path to RV32 ld
   RV32_TOOL_AS       path to RV32 as
   RV32_TOOL_AR       path to RV32 ar
@@ -46,16 +45,14 @@ from typing import List, Optional, Tuple
 
 from elftools.elf.elffile import ELFFile, SymbolTableSection  # type: ignore
 
-REPO_TOP = Path(__file__).parent.parent.resolve()
-
 # yapf: disable
 
-# TODO: remove with meson; bazel will set the PYTHONPATH to locate otbn
-# tool modules
+# TODO: remove with meson; bazel will set the PYTHONPATH to locate otbn tools
 otbn_tools_path = os.environ.get('OTBN_TOOLS', None)
 if otbn_tools_path:
     sys.path.append(otbn_tools_path)
 import otbn_as
+import otbn_ld
 
 # yapf: enable
 
@@ -120,14 +117,12 @@ def call_otbn_as(src_file: Path, out_file: Path):
 
 def call_otbn_ld(src_files: List[Path], out_file: Path,
                  linker_script: Optional[Path]):
-    otbn_ld_cmd = os.environ.get('OTBN_LD',
-                                 str(REPO_TOP / 'hw/ip/otbn/util/otbn_ld.py'))
 
     args = ['-gc-sections', '-gc-keep-exported']
     if linker_script:
         args += ['-T', linker_script]
     args += src_files
-    run_tool(otbn_ld_cmd, out_file, args)
+    run_tool(otbn_ld.main, out_file, args)
 
 
 def call_rv32_objcopy(args: List[str]):


### PR DESCRIPTION
In order to support building the mask ROM with bazel, the OTBN linker and assembler tools needed to be invoked by the hermetic Python toolchain. This required refactoring the `otbn_build.py` script to import the `otbn_as` and `otbn_ld` modules directly, rather than invoke these tools via the shell. Additionally, it required marking the tools as bazel executables in the `otbn.bzl` rules file.

**_Note: this depends on #12233 and #12235. Only review the last 3 commits._**