### PR TITLE
[flash_ctrl] continued regression fixes

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -500,10 +500,10 @@
                To disable, set this field to anything other than kMultiBitBool4False.
               '''
             resval: false,
-            tags: [// Dont touch disable, it has several side effects on the system
-                   "excl:CsrAllTests:CsrExclWrite"],
           },
         ]
+        tags: [// Dont touch disable, it has several side effects on the system
+               "excl:CsrAllTests:CsrExclWrite"],
       },
 
       { name: "EXEC",

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -501,10 +501,10 @@
                To disable, set this field to anything other than kMultiBitBool4False.
               '''
             resval: false,
-            tags: [// Dont touch disable, it has several side effects on the system
-                   "excl:CsrAllTests:CsrExclWrite"],
           },
         ]
+        tags: [// Dont touch disable, it has several side effects on the system
+               "excl:CsrAllTests:CsrExclWrite"],
       },
 
       { name: "EXEC",

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_pkg.sv
@@ -84,8 +84,8 @@ package flash_ctrl_env_pkg;
   parameter uint NUM_PAGE_PART_INFO0       = 10;
 
   parameter otp_ctrl_pkg::flash_otp_key_rsp_t FLASH_OTP_RSP_DEFAULT = '{
-      data_ack: 1'b0,
-      addr_ack: 1'b0,
+      data_ack: 1'b1,
+      addr_ack: 1'b1,
       key: '0,
       rand_key: '0,
       seed_valid: 1'b0

--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_if.sv
@@ -30,7 +30,7 @@ interface flash_ctrl_if ();
   lc_tx_t                           rma_ack;
 
   otp_ctrl_pkg::flash_otp_key_req_t otp_req;
-  otp_ctrl_pkg::flash_otp_key_rsp_t otp_rsp = flash_ctrl_env_pkg::FLASH_OTP_RSP_DEFAULT;
+  otp_ctrl_pkg::flash_otp_key_rsp_t otp_rsp;
 
   // JTAG
   logic                             cio_tck;

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_hw_rma_vseq.sv
@@ -182,9 +182,9 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
       flash_ctrl_mp_region_cfg(i, mp_regions[i]);
     end
 
-    default_region_read_en    = 1'b1;
-    default_region_program_en = 1'b1;
-    default_region_erase_en   = 1'b1;
+    default_region_read_en    = MuBi4True;
+    default_region_program_en = MuBi4True;
+    default_region_erase_en   = MuBi4True;
 
     // Write to Default MP Regions
     flash_ctrl_default_region_cfg(.read_en    (default_region_read_en),
@@ -208,10 +208,10 @@ class flash_ctrl_hw_rma_vseq extends flash_ctrl_base_vseq;
     // Enable All Info Regions for Read, Program and Erase
 
     foreach (info_regions[i]) begin
-      info_regions[i].en         = 1;
-      info_regions[i].read_en    = 1;
-      info_regions[i].program_en = 1;
-      info_regions[i].erase_en   = 1;
+      info_regions[i].en         = MuBi4True;
+      info_regions[i].read_en    = MuBi4True;
+      info_regions[i].program_en = MuBi4True;
+      info_regions[i].erase_en   = MuBi4True;
     end
 
     foreach (info_regions[i]) begin

--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -72,6 +72,14 @@ module tb;
   assign flash_ctrl_if.otp_req.addr_req = otp_req.addr_req;
   assign flash_ctrl_if.otp_req.data_req = otp_req.data_req;
 
+  // TODO: The otp request/response interface for keys needs to be
+  // propertly emulated, otherwise the flash hardware fsm will get stuck
+  assign flash_ctrl_if.otp_rsp = '{
+    default: '0,
+    data_ack: otp_req.data_req,
+    addr_ack: otp_req.addr_req
+  };
+
   assign otp_rsp.addr_ack               = flash_ctrl_if.otp_rsp.addr_ack;
   assign otp_rsp.data_ack               = flash_ctrl_if.otp_rsp.data_ack;
   assign otp_rsp.key                    = flash_ctrl_if.otp_rsp.key;

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_lcmgr.sv
@@ -566,8 +566,8 @@ module flash_ctrl_lcmgr
   end // always_comb
 
   // if disable is seen any state other than StRmaRsp, transition to invalid state
-  `ASSERT(Disable_Invalid_A, prim_mubi_pkg::mubi4_test_true_loose(disable_i) & state_q != StRmaRsp
-          |=> state_q == StInvalid)
+  `ASSERT(DisableChk_A, prim_mubi_pkg::mubi4_test_true_loose(disable_i) & state_q != StRmaRsp
+          |=> state_q == StDisabled)
 
   ///////////////////////////////
   // RMA wiping Mechanism

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -506,10 +506,10 @@
                To disable, set this field to anything other than kMultiBitBool4False.
               '''
             resval: false,
-            tags: [// Dont touch disable, it has several side effects on the system
-                   "excl:CsrAllTests:CsrExclWrite"],
           },
         ]
+        tags: [// Dont touch disable, it has several side effects on the system
+               "excl:CsrAllTests:CsrExclWrite"],
       },
 
       { name: "EXEC",


### PR DESCRIPTION
- more fixes to test for mubi.
- fix to otp_req/rsp emulation, this needs to be actually modeled later.
- move position of exclude tag so that it applies to the whole register
  and not just a field.
- update assertion to transition in to Disabled state instead of Invalid.

Signed-off-by: Timothy Chen <timothytim@google.com>