### PR TITLE
[xbar, dv] Fix assert coverage

### DIFF
--- a/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_main/dv/autogen/xbar_cover.cfg
@@ -8,6 +8,11 @@
 -module pins_if     // DV construct.
 -module clk_rst_if  // DV construct.
 
+-assert legalAOpcodeErr_A
+-assert sizeGTEMaskErr_A
+-assert sizeMatchesMaskErr_A
+-assert addrSizeAlignedErr_A
+
 // due to VCS issue (fixed at VCS/2020.12), can't move this part into begin...end (tgl) or after.
 -node tb.dut tl_*.a_param
 -node tb.dut tl_*.d_param

--- a/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
+++ b/hw/top_earlgrey/ip/xbar_peri/dv/autogen/xbar_cover.cfg
@@ -8,6 +8,11 @@
 -module pins_if     // DV construct.
 -module clk_rst_if  // DV construct.
 
+-assert legalAOpcodeErr_A
+-assert sizeGTEMaskErr_A
+-assert sizeMatchesMaskErr_A
+-assert addrSizeAlignedErr_A
+
 // due to VCS issue (fixed at VCS/2020.12), can't move this part into begin...end (tgl) or after.
 -node tb.dut tl_*.a_param
 -node tb.dut tl_*.d_param

--- a/util/tlgen/xbar_cover.cfg.tpl
+++ b/util/tlgen/xbar_cover.cfg.tpl
@@ -18,6 +18,11 @@
 -module pins_if     // DV construct.
 -module clk_rst_if  // DV construct.
 
+-assert legalAOpcodeErr_A
+-assert sizeGTEMaskErr_A
+-assert sizeMatchesMaskErr_A
+-assert addrSizeAlignedErr_A
+
 // due to VCS issue (fixed at VCS/2020.12), can't move this part into begin...end (tgl) or after.
 -node tb.dut tl_*.a_param
 -node tb.dut tl_*.d_param


### PR DESCRIPTION
Exclude d_error related assertions as xbar doesn't trigger d_error for
protocol violations
Signed-off-by: Weicai Yang <weicai@google.com>