### PR TITLE
[dv/chip_lc_trans] Fix timeout issue

### DIFF
--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_pkg.sv
@@ -39,6 +39,7 @@ package jtag_riscv_agent_pkg;
 
   typedef enum logic [DMI_OPW-1:0] {
     DmiNoErr      = 'h0,
+    DmiReserved   = 'h1,
     DmiFail       = 'h2,
     DmiInProgress = 'h3
   } jtag_op_status_e;

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_driver.sv
@@ -167,7 +167,9 @@ class jtag_riscv_driver extends dv_base_driver #(jtag_riscv_item, jtag_riscv_age
       status = dout[0 +: DMI_OPW];
 
       // The DmiInProgress status is sticky and has to be cleared by dmireset via DTMCS.
-      if (status == DmiInProgress) begin
+      // Accessing the reserved value means there is also something wrong with the JTAG sequence,
+      // potentially IR request, so also need to reset.
+      if (status inside {DmiInProgress, DmiReserved}) begin
         if (!cfg.in_reset) send_riscv_ir_req(JtagDtmCsr);
         if (!cfg.in_reset) send_dtmcs_dr_req(DmiReset);
         if (!cfg.in_reset) send_riscv_ir_req(JtagDmiAccess);

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_ctrl_transition_vseq.sv
@@ -15,7 +15,7 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
   rand bit [7:0] lc_unlock_token[TokenWidthByte];
 
   constraint num_trans_c {
-    num_trans inside {[2:3]};
+    num_trans inside {[1:2]};
   }
 
   // Reassign `select_jtag` variable to drive LC JTAG tap at start,
@@ -128,8 +128,9 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
     end
   endtask
 
-  virtual task wait_lc_status(lc_ctrl_status_e expect_status);
-    while(1) begin
+  virtual task wait_lc_status(lc_ctrl_status_e expect_status, int max_attemp = 5000);
+    int i;
+    for (i = 0; i < max_attemp; i++) begin
       bit [TL_DW-1:0]  status_val;
       lc_ctrl_status_e dummy;
       cfg.clk_rst_vif.wait_clks($urandom_range(0, 10));
@@ -144,6 +145,10 @@ class chip_sw_lc_ctrl_transition_vseq extends chip_sw_base_vseq;
         `uvm_info(`gfn, $sformatf("LC status %0s.", expect_status.name), UVM_LOW)
         break;
       end
+    end
+
+    if (i > max_attemp) begin
+      `uvm_fatal(`gfn, $sformatf("max attempt reached to get lc status %0s!", expect_status.name))
     end
   endtask
 


### PR DESCRIPTION
This PR fixes chip_sw_lc_ctrl_transition_vseq timeout issue from nightly
regression.
1). First reason for timeout is the `num_trans`. If the num_trans = 3,
  it might run over the sw_timeout limit, and make it hard to dump waves
  and debug. So I reduced the `num_trans` to only 1-2 iterations.

2). Second reason is when IR is not correctly set, read DR value is not right either.
In the future when we switch to the same method as RV_DM, it will be replaced by the
jtag_dmi_agent. So here we simply retry setting IR if DR status returns invalid data.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>