### PR TITLE
[sw,flash_ctrl] Modifiy flash_ctrl testutils to use multibit values

### DIFF
--- a/sw/device/lib/testing/flash_ctrl_testutils.c
+++ b/sw/device/lib/testing/flash_ctrl_testutils.c
@@ -81,12 +81,12 @@ uint32_t flash_ctrl_testutils_data_region_setup(
     dif_flash_ctrl_state_t *flash_state, uint32_t base_page_index,
     uint32_t data_region, uint32_t region_size) {
   dif_flash_ctrl_region_properties_t region_properties = {
-      .ecc_en = true,
-      .high_endurance_en = false,
-      .erase_en = true,
-      .prog_en = true,
-      .rd_en = true,
-      .scramble_en = false};
+      .ecc_en = kMultiBitBool4True,
+      .high_endurance_en = kMultiBitBool4False,
+      .erase_en = kMultiBitBool4True,
+      .prog_en = kMultiBitBool4True,
+      .rd_en = kMultiBitBool4True,
+      .scramble_en = kMultiBitBool4False};
   return flash_ctrl_testutils_data_region_setup_properties(
       flash_state, base_page_index, data_region, region_size,
       region_properties);
@@ -96,12 +96,12 @@ uint32_t flash_ctrl_testutils_data_region_scrambled_setup(
     dif_flash_ctrl_state_t *flash_state, uint32_t base_page_index,
     uint32_t data_region, uint32_t region_size) {
   dif_flash_ctrl_region_properties_t region_properties = {
-      .ecc_en = true,
-      .high_endurance_en = false,
-      .erase_en = true,
-      .prog_en = true,
-      .rd_en = true,
-      .scramble_en = true};
+      .ecc_en = kMultiBitBool4True,
+      .high_endurance_en = kMultiBitBool4False,
+      .erase_en = kMultiBitBool4True,
+      .prog_en = kMultiBitBool4True,
+      .rd_en = kMultiBitBool4True,
+      .scramble_en = kMultiBitBool4True};
   return flash_ctrl_testutils_data_region_setup_properties(
       flash_state, base_page_index, data_region, region_size,
       region_properties);
@@ -127,12 +127,12 @@ uint32_t flash_ctrl_testutils_info_region_setup(
     dif_flash_ctrl_state_t *flash_state, uint32_t page_id, uint32_t bank,
     uint32_t partition_id) {
   dif_flash_ctrl_region_properties_t region_properties = {
-      .ecc_en = true,
-      .high_endurance_en = false,
-      .erase_en = true,
-      .prog_en = true,
-      .rd_en = true,
-      .scramble_en = false};
+      .ecc_en = kMultiBitBool4True,
+      .high_endurance_en = kMultiBitBool4False,
+      .erase_en = kMultiBitBool4True,
+      .prog_en = kMultiBitBool4True,
+      .rd_en = kMultiBitBool4True,
+      .scramble_en = kMultiBitBool4False};
   return flash_ctrl_testutils_info_region_setup_properties(
       flash_state, page_id, bank, partition_id, region_properties);
 }
@@ -141,12 +141,12 @@ uint32_t flash_ctrl_testutils_info_region_scrambled_setup(
     dif_flash_ctrl_state_t *flash_state, uint32_t page_id, uint32_t bank,
     uint32_t partition_id) {
   dif_flash_ctrl_region_properties_t region_properties = {
-      .ecc_en = true,
-      .high_endurance_en = false,
-      .erase_en = true,
-      .prog_en = true,
-      .rd_en = true,
-      .scramble_en = true};
+      .ecc_en = kMultiBitBool4True,
+      .high_endurance_en = kMultiBitBool4False,
+      .erase_en = kMultiBitBool4True,
+      .prog_en = kMultiBitBool4True,
+      .rd_en = kMultiBitBool4True,
+      .scramble_en = kMultiBitBool4True};
   return flash_ctrl_testutils_info_region_setup_properties(
       flash_state, page_id, bank, partition_id, region_properties);
 }


### PR DESCRIPTION
The flash_ctrl RTL has changed to use multibit values for the region properties. The flash_ctrl_testutils functions
for data and info region setup have been changed to be compatible with the RTL changes.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>