### PR TITLE
Aes fi

### DIFF
--- a/hw/ip/aes/data/aes_testplan.hjson
+++ b/hw/ip/aes/data/aes_testplan.hjson
@@ -130,8 +130,15 @@
             excercise the different reseeding configuations
             for reseeding every 8k blocks the DUT internal block counter will be manually changed to something close to 8k.
             to provoke the reseeding within reasonable simulation time '''
-      milestone: V2
+      milestone: V2S
       tests: ["aes_deinit"]
+    }
+    {
+      name:fault_inject
+      desc: '''
+            Verify that injecting bit errors in one of the statemachines or the round counter triggers an error '''
+      milestone: V2S
+      tests: ["aes_fi"]
     }
   ]
 

--- a/hw/ip/aes/dv/aes_base_sim_cfg.hjson
+++ b/hw/ip/aes/dv/aes_base_sim_cfg.hjson
@@ -32,12 +32,15 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson"]
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson"]
                 // TODO: enable stress tests later.
                 // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
-  sim_tops: [ "aes_bind", "aes_cov_bind"]
+  sim_tops: [ "aes_bind",
+              "aes_cov_bind",
+              "sec_cm_prim_sparse_fsm_flop_bind"]
 
   // TODO remove v2s refine for v2s
   xcelium_cov_refine_files: ["{proj_root}/hw/ip/aes/dv/cov/refines/aes_remove_for_v2s.vRefine"]
@@ -153,6 +156,11 @@
       name: aes_reseed
       uvm_test: aes_reseed_test
       uvm_test_seq: aes_reseed_vseq
+    }
+    {
+      name: aes_fi
+      uvm_test: aes_alert_reset_test
+      uvm_test_seq: aes_fi_vseq
     }
   ]
 

--- a/hw/ip/aes/dv/env/aes_env.core
+++ b/hw/ip/aes/dv/env/aes_env.core
@@ -37,6 +37,7 @@ filesets:
       - seq_lib/aes_deinit_vseq.sv: {is_include_file: true}
       - seq_lib/aes_manual_config_err_vseq.sv: {is_include_file: true}
       - seq_lib/aes_reseed_vseq.sv: {is_include_file: true}
+      - seq_lib/aes_fi_vseq.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 generate:

--- a/hw/ip/aes/dv/env/aes_env_cfg.sv
+++ b/hw/ip/aes/dv/env/aes_env_cfg.sv
@@ -12,6 +12,12 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   virtual pins_if #(1) idle_vif;
   virtual aes_reseed_if aes_reseed_vif;
   virtual aes_masking_reseed_if aes_masking_reseed_vif;
+  virtual force_if#(.Signal("aes_ctrl_cs"),
+                    .SignalWidth(aes_env_pkg::StateWidth)
+                   ) aes_fi_vif[Sp2VWidth];
+  virtual force_if#(.Signal("aes_cipher_ctrl_cs"),
+                    .SignalWidth(aes_env_pkg::StateWidth)
+                   ) aes_cipher_fi_vif[Sp2VWidth];
 
   rand key_sideload_agent_cfg keymgr_sideload_agent_cfg;
   // test environment constraints //
@@ -85,7 +91,7 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
   // min and max wait (clk) before an error injection
   // this is only for injection and random reset
   int                inj_min_delay              = 10;
-  int                inj_max_delay              = 500;
+  int                inj_max_delay              = 1000;
   rand int           inj_delay;
 
   rand flip_rst_lc_esc_e    flip_rst_lc_esc;
@@ -221,6 +227,22 @@ class aes_env_cfg extends cip_base_env_cfg #(.RAL_T(aes_reg_block));
       if (!uvm_config_db#(virtual aes_masking_reseed_if)::get(null, "*.env" ,
           "aes_masking_reseed_vif", aes_masking_reseed_vif)) begin
         `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO AES MASKING RESEED IF"))
+      end
+    end
+    foreach (aes_fi_vif[nn]) begin
+      if (!uvm_config_db#(virtual force_if#(.Signal("aes_ctrl_cs"),
+                                            .SignalWidth(aes_env_pkg::StateWidth))
+                                           )::get(null, "*.env", $sformatf("aes_fi_vif_%0d", nn),
+                                                  aes_fi_vif[nn])) begin
+        `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO FALT INJECT INTERFACE %d",nn))
+      end
+    end
+    foreach (aes_cipher_fi_vif[nn]) begin
+      if (!uvm_config_db#(virtual force_if#(.Signal("aes_cipher_ctrl_cs"),
+                                            .SignalWidth(aes_env_pkg::StateWidth))
+                                           )::get(null, "*.env",
+                           $sformatf("aes_cipher_fi_vif_%0d",  nn), aes_cipher_fi_vif[nn])) begin
+        `uvm_fatal(`gfn, $sformatf("FAILED TO GET HANDLE TO CIPHER FALT INJECT INTERFACE %d",nn))
       end
     end
   endfunction

--- a/hw/ip/aes/dv/env/aes_env_pkg.sv
+++ b/hw/ip/aes/dv/env/aes_env_pkg.sv
@@ -50,6 +50,9 @@ package aes_env_pkg;
     bit          rsd_rate;
   } cfg_error_type_t;
 
+  // used in FI verification seq and if
+  localparam int StateWidth = 6;
+
 
   // package sources
  `include "aes_env_cfg.sv"

--- a/hw/ip/aes/dv/env/seq_lib/aes_fi_vseq.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_fi_vseq.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Test that injects random resets &
+// bit errors into FSMs
+class aes_fi_vseq extends aes_base_vseq;
+  `uvm_object_utils(aes_fi_vseq)
+
+  `uvm_object_new
+  aes_message_item my_message;
+  status_t aes_status;
+  bit  finished_all_msgs = 0;
+  bit  wait_for_alert_clear = 0;
+  bit  alert = 0;
+
+  rand bit [StateWidth-1:0] force_state;
+  rand int if_num;
+
+  task body();
+    `uvm_info(`gfn, $sformatf("\n\n\t ----| STARTING AES MAIN SEQUENCE |----\n %s",
+                              cfg.convert2string()), UVM_LOW)
+
+    // generate list of messages //
+    generate_message_queue();
+
+    // process all messages //
+    fork
+      begin: isolation_fork
+        fork
+          error: begin
+            // avoid forcing IDLE
+            if (!randomize(force_state) with { force_state != 6'b100100;}) begin
+              `uvm_fatal(`gfn, $sformatf("Randomization failed"))
+            end
+            if (!randomize(if_num) with { if_num inside { [0:2] };}) begin
+              `uvm_fatal(`gfn, $sformatf("Randomization failed"))
+            end
+            cfg.clk_rst_vif.wait_clks(cfg.inj_delay);
+            `uvm_info(`gfn, $sformatf("FORCING %h on if[%d]", force_state, if_num), UVM_MEDIUM)
+            cfg.aes_fi_vif[if_num].force_state(force_state);
+            wait_for_alert_clear = 1;
+            cfg.m_alert_agent_cfg["fatal_fault"].vif.wait_ack_complete();
+            wait(!cfg.clk_rst_vif.rst_n);
+            cfg.aes_fi_vif[if_num].release_state();
+            wait_for_alert_clear = 0;
+          end
+          basic: begin
+            send_msg_queue(cfg.unbalanced, cfg.read_prob, cfg.write_prob);
+            finished_all_msgs = 1;
+          end
+        join_none
+        // make sure we don't wait for a reset that never comes
+        // in case the inject happened efter test finished
+        wait (finished_all_msgs);
+        if (wait_for_alert_clear) begin
+          `uvm_fatal(`gfn, $sformatf("Was Able to finish without clearing reset"))
+        end
+        wait_no_outstanding_access();
+        disable fork;
+      end // fork
+    join
+  endtask : body
+endclass

--- a/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
+++ b/hw/ip/aes/dv/env/seq_lib/aes_vseq_list.sv
@@ -11,3 +11,4 @@
 `include "aes_deinit_vseq.sv"
 `include "aes_manual_config_err_vseq.sv"
 `include "aes_reseed_vseq.sv"
+`include "aes_fi_vseq.sv"

--- a/hw/ip/aes/dv/sva/aes_bind.sv
+++ b/hw/ip/aes/dv/sva/aes_bind.sv
@@ -65,4 +65,29 @@ if (`EN_MASKING) begin : gen_prng_bind
     .lfsr_q_4     (gen_lfsrs[4].u_lfsr_chunk.lfsr_q)
   );
 end
+
+  // bind fault inject if
+  bind aes_control_fsm signal_force
+    #(.Signal("aes_ctrl_cs"),
+      .IfName("aes_fi_vif"),
+      .SignalWidth(aes_env_pkg::StateWidth)
+     )
+  u_fi
+    (
+     .clk          (clk_i),
+     .rst_ni       (rst_ni)
+    );
+
+  // bind fault inject if
+  bind aes_cipher_control_fsm signal_force
+    #(.Signal("aes_cipher_ctrl_cs"),
+      .IfName("aes_cipher_fi_vif"),
+      .SignalWidth(aes_env_pkg::StateWidth)
+     )
+  u_cipher_fi
+    (
+     .clk          (clk_i),
+     .rst_ni       (rst_ni)
+    );
+
 endmodule

--- a/hw/ip/aes/dv/sva/aes_sva.core
+++ b/hw/ip/aes/dv/sva/aes_sva.core
@@ -10,11 +10,14 @@ filesets:
       - lowrisc:tlul:headers
       - lowrisc:fpv:csr_assert_gen
       - lowrisc:ip:aes
+      - lowrisc:dv:aes_env
     files:
       - aes_bind.sv
       - aes_idle_check.sv
       - aes_reseed_if.sv
       - aes_masking_reseed_if.sv
+      - signal_force.sv
+      - force_if.sv
     file_type: systemVerilogSource
 
   files_formal:

--- a/hw/ip/aes/dv/sva/force_if.sv
+++ b/hw/ip/aes/dv/sva/force_if.sv
@@ -1,0 +1,32 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Interface used for fault inject verification
+interface force_if
+  import uvm_pkg::*;
+  #(parameter string Signal = "",
+    parameter int SignalWidth = 1 )
+  (
+   input logic clk_i,
+   input logic rst_ni
+   );
+
+  string       par_hier = dv_utils_pkg::get_parent_hier($sformatf("%m"),2);
+  string       path     = $sformatf("%s.%s", par_hier, Signal);
+
+  function static void force_state(bit [SignalWidth-1:0] state);
+    $assertoff(0, "tb.dut");
+    if (!uvm_hdl_check_path(path)) begin
+      `uvm_fatal("Force_if", $sformatf("PATH NOT EXISTING %m"))
+    end
+    if (!uvm_hdl_force(path,state)) begin
+      `uvm_error("Force_if", $sformatf("Was not able to force %s", state))
+    end
+  endfunction
+
+  function static void release_state();
+    uvm_hdl_release(path);
+    $asserton(0,"tb.dut");
+  endfunction
+endinterface

--- a/hw/ip/aes/dv/sva/signal_force.sv
+++ b/hw/ip/aes/dv/sva/signal_force.sv
@@ -1,0 +1,64 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+
+//wrapper module to avoid having to know/write out the path from tb to bind
+
+
+module signal_force
+  import uvm_pkg::*;
+  #(parameter string Signal  = "",
+    parameter string IfName = "vif",
+    parameter int    SignalWidth = 1
+  )
+  ( input clk,
+    input rst_ni
+    );
+
+  // declare interface
+  force_if#(.Signal(Signal), .SignalWidth(SignalWidth))  fi_if (.clk_i  (clk), .rst_ni (rst_ni));
+ // `define gfn $sformatf("%m")
+  initial begin
+    uvm_config_db#(virtual force_if#(.Signal(Signal), .SignalWidth(SignalWidth))
+                   )::set(null, "*", pick_if_name(), fi_if);
+  end
+
+  // Pick a name for this interface, under which it will be registered with the UVM DB. This is
+  // based on IfName but also appends the index under the deepest generate block if necessary. For
+  // example, if IfName is "foo" and we're bound into a module that is instantiated with indices 0,
+  // 1 and 2 and then this should return "foo_0", "foo_1" and "foo_2", respectively.
+  function automatic string pick_if_name();
+    // find the interface index
+    string str = $sformatf("%m");
+    string suffix = "";
+    int    closing_bracket = -1;
+    int    opening_bracket  = -1;
+
+    // Walk from the back, searching for something of the form "[123]".
+    for (int i = str.len() - 1; i >= 0; i--) begin
+      if (str[i] == "]") begin
+        closing_bracket = i;
+        break;
+      end
+    end
+    for (int i = str.len() - 1; i >= 0; i--) begin
+      if (str[i] == "[") begin
+        opening_bracket = i;
+        break;
+      end
+    end
+    if (str[opening_bracket] == "[") begin
+      // we do not expect to see "[]"
+      if (!(closing_bracket > opening_bracket + 1)) begin
+        // we cannot use macro as module is not a part of hierarchy
+        // will fail the get_full_name() lookup
+        `uvm_fatal($sformatf("%m"), $sformatf("Found unexpected empty bracket"))
+      end
+      // Put the stuff in the brackets in suffix
+      suffix = str.substr(opening_bracket + 1, closing_bracket - 1);
+    end
+
+    return $sformatf("%s_%s", IfName, suffix);
+  endfunction
+endmodule

--- a/hw/ip/aes/dv/tb/tb.sv
+++ b/hw/ip/aes/dv/tb/tb.sv
@@ -23,6 +23,7 @@ module tb;
   lc_ctrl_pkg::lc_tx_t                    lc_escalate_en;
   keymgr_pkg::hw_key_req_t                keymgr_key;
 
+
   // interfaces
   clk_rst_if clk_rst_if(.clk(clk), .rst_n(rst_n));
   rst_shadowed_if rst_shadowed_if(.rst_n(rst_n), .rst_shadowed_n(rst_shadowed_n));
@@ -44,6 +45,7 @@ module tb;
                           lc_ctrl_pkg::Off;
 
   assign idle = (idle_s == prim_mubi_pkg::MuBi4True) ? 1 : 0;
+
   // dut
   aes #(
     .SecMasking  ( `EN_MASKING   ),


### PR DESCRIPTION
This PR contains the first of two Fault injection tests.

I have tried to come up with a way to force signals without having to know the very long hierarchical path from tb->signal to be forced.

The bind command with auto resolve the module name in the hierarchy, which solves half the problem.
the other problem is to register the interface(s) with the uvm_config_db.
to do this you need to point to the interface instance.
by binding the wrapper module - I can instantiate the interface inside it and hence the path to the module is at the same hierarchical level as the bind and we don't need to know the path.

in my case the bind results in 3 instances as the  module I am binding to has 3 instances.
so I use a little string "magic" to get the index number for the interface. 
the rest is standard.

I ended up making this bind module and interface complete IP agnostic
so we might want to put it else where.
so others can use it.
@rswarbrick 
@sriyerg 
@weicaiyang 

