### PR TITLE
[otbn] Wipe RND cache at the beginning of a new OTBN run

### DIFF
--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -776,6 +776,7 @@ module otbn_core
     .clk_i,
     .rst_ni,
 
+    .rnd_wipe_i        (controller_start),
     .rnd_req_i         (rnd_req),
     .rnd_prefetch_req_i(rnd_prefetch_req),
     .rnd_valid_o       (rnd_valid),


### PR DESCRIPTION
At the beginning of an OTBN run, the RND cache may still contain RND data prefetched due to a previous OTBN run. Also, the prefetch may still be outstanding, meaning the RND cache gets filled early during the OTBN run. In both cases, the RND data should be discarded as it stems from a previous OTBN run which may have used a different configuration for EDN, CSRNG or the entropy source.

Therefore, this commit changes the design to wipe the RND cache at the beginning of every new OTBN run and also marks outstanding RND prefetches to throw away the data once it's returned. New prefetches and RND requests arriving after the wipe are queued up.

This PR is factored out from and required by #11914 which will take care of signaling errors on the RND interface. Basically, we don't want RND requests from previous OTBN runs to trigger errors later on.