### PR TITLE
[otbn, rtl] Blank bus read data paths

### DIFF
--- a/hw/ip/otbn/rtl/otbn_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_pkg.sv
@@ -42,6 +42,10 @@ package otbn_pkg;
 
   parameter int unsigned LoopStackDepth = 8;
 
+  // Zero word in the implemented ECC scheme. If changing the ECC scheme, this has to be changed,
+  // and vice-versa.
+  localparam logic [BaseIntgWidth-1:0] EccZeroWord     = prim_secded_pkg::SecdedInv3932ZeroWord;
+  localparam logic [ExtWLEN-1:0]       EccWideZeroWord = {BaseWordsPerWLEN{EccZeroWord}};
 
   // Toplevel constants ============================================================================
 


### PR DESCRIPTION
Blanking was already occurring but the enable signal was combinatorial
and didn't utilise prim_blanker so was liable to be optimised away
during synthesis.

This also blanks imem/dmem read data to 0 when OTBN is locked, which is
documented in the specification but wasn't implemented.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>