### PR TITLE
[sw,tests] Test flash_ctrl operations with jitter enabled

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2476,13 +2476,12 @@
       name: chip_sw_flash_ctrl_clock_freqs
       desc: '''Verify flash program and erase operations over the ctrl over a range of clock freqs.
 
-            - The range of clock freqs to test is TBD.
-            - Reuse chip_flash_ctrl_ops to also enable jitter on the clock as well as run with
-              randomized clock frequencies.
+            - Enable jitter on the clock while performing erase, write and read operations
+              to the flash.
             - This sets the test for closed source where the flash access timing matters.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_ctrl_clock_freqs"]
     }
     {
       name: chip_conn_flash_lc_nvm_debug_en

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -389,6 +389,12 @@
       run_opts: ["+sw_test_timeout_ns=200000000"]
     }
     {
+      name: chip_sw_flash_ctrl_clock_freqs
+      uvm_test_seq: chip_sw_base_vseq
+      sw_images: ["sw/device/tests/flash_ctrl_clock_freqs_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_lc_ctrl_otp_hw_cfg
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/lc_ctrl_otp_hw_cfg_test:1"]

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -398,6 +398,21 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "flash_ctrl_clock_freqs_test",
+    srcs = ["flash_ctrl_clock_freqs_test.c"],
+    deps = [
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:rand_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "flash_ctrl_test",
     srcs = ["flash_ctrl_test.c"],
     deps = [

--- a/sw/device/tests/flash_ctrl_clock_freqs_test.c
+++ b/sw/device/tests/flash_ctrl_clock_freqs_test.c
@@ -1,0 +1,146 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_clkmgr.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/rand_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+const test_config_t kTestConfig;
+
+enum {
+  kFlashInfoPageIdCreatorSecret = 1,
+  kFlashInfoPageIdOwnerSecret = 2,
+  kFlashInfoPageIdIsoPart = 3,
+  kFlashInfoBank = 0,
+  kFlashDataBank0 = 0,
+  kFlashDataBank1 = 1,
+  kRegionBaseBank0Page0Index = 0,
+  kRegionBaseBank1Page0Index = 256,
+  kRegionBaseBank1Page255Index = 511,
+  kFlashBank0DataRegion = 0,
+  kFlashBank1DataRegion = 1,
+  kPartitionId = 0,
+  kRegionSize = 1,
+  kDataSize = 16,
+  kPageSize = 2048,
+  kNumLoops = 10,
+};
+
+static dif_flash_ctrl_state_t flash_state;
+static uint32_t test_data[kDataSize];
+
+/**
+ * Check data read from host interface against known data.
+ */
+static void read_and_check_host_if(uint32_t addr, const uint32_t *check_data) {
+  mmio_region_t flash_addr =
+      mmio_region_from_addr(TOP_EARLGREY_EFLASH_BASE_ADDR + addr);
+  uint32_t host_data[kDataSize];
+  for (int i = 0; i < kDataSize; ++i) {
+    host_data[i] = mmio_region_read32(flash_addr, i * sizeof(uint32_t));
+  }
+  CHECK_BUFFER(host_data, check_data, kDataSize);
+}
+
+/**
+ * Tests the erase, write and
+ * read of the specified information partition.
+ * Confirms that the written data is read back correctly.
+ */
+static void do_info_partition_test(uint32_t partition_number) {
+  uint32_t address = flash_ctrl_testutils_info_region_setup(
+      &flash_state, partition_number, kFlashInfoBank, kPartitionId);
+
+  for (int i = 0; i < kDataSize; ++i) {
+    test_data[i] = rand_testutils_gen32();
+  }
+
+  CHECK(!flash_ctrl_testutils_erase_page(&flash_state, address, kPartitionId,
+                                         kDifFlashCtrlPartitionTypeInfo));
+  CHECK(!flash_ctrl_testutils_write(&flash_state, address, kPartitionId,
+                                    test_data, kDifFlashCtrlPartitionTypeInfo,
+                                    kDataSize));
+
+  uint32_t readback_data[kDataSize];
+  CHECK(!flash_ctrl_testutils_read(
+      &flash_state, address, kPartitionId, readback_data,
+      kDifFlashCtrlPartitionTypeInfo, kDataSize, 0));
+
+  CHECK_BUFFER(readback_data, test_data, kDataSize);
+}
+
+/**
+ * Tests the erase, write and read of the lowest and highest page of
+ * bank 1 data partition or the reads for the lowest page of bank 0.
+ * For bank 1 confirms that the written data is read back correctly.
+ */
+static void do_data_partition_test(uint32_t bank_number) {
+  if (bank_number == 0) {
+    // Bank 0 contains the program data so can only be read and checked
+    // against the host interface read.
+    uint32_t address = flash_ctrl_testutils_data_region_setup(
+        &flash_state, kRegionBaseBank0Page0Index, kFlashBank0DataRegion,
+        kRegionSize);
+
+    uint32_t readback_data[kDataSize];
+    CHECK(!flash_ctrl_testutils_read(
+        &flash_state, address, kPartitionId, readback_data,
+        kDifFlashCtrlPartitionTypeData, kDataSize, 0));
+
+    read_and_check_host_if(kRegionBaseBank0Page0Index, readback_data);
+  } else if (bank_number == 1) {
+    for (int i = 0; i < 2; ++i) {
+      uint32_t page_index =
+          (i == 0) ? kRegionBaseBank1Page0Index : kRegionBaseBank1Page255Index;
+      for (int j = 0; j < kDataSize; ++j) {
+        test_data[i] = rand_testutils_gen32();
+      }
+      uint32_t address = flash_ctrl_testutils_data_region_setup(
+          &flash_state, page_index, kFlashBank1DataRegion, kRegionSize);
+      CHECK(!flash_ctrl_testutils_erase_page(
+          &flash_state, address, kPartitionId, kDifFlashCtrlPartitionTypeData));
+      CHECK(!flash_ctrl_testutils_write(
+          &flash_state, address, kPartitionId, test_data,
+          kDifFlashCtrlPartitionTypeData, kDataSize));
+
+      uint32_t readback_data[kDataSize];
+      CHECK(!flash_ctrl_testutils_read(
+          &flash_state, address, kPartitionId, readback_data,
+          kDifFlashCtrlPartitionTypeData, kDataSize, 1));
+      read_and_check_host_if(kPageSize * page_index, test_data);
+      CHECK_BUFFER(readback_data, test_data, kDataSize);
+    }
+  } else {
+    LOG_ERROR("Unexpected bank number, only 0 and 1 are valid.");
+  }
+}
+
+bool test_main(void) {
+  dif_clkmgr_t clkmgr;
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+
+  CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
+
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_state,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  for (int i = 0; i < kNumLoops; ++i) {
+    do_info_partition_test(kFlashInfoPageIdCreatorSecret);
+    do_info_partition_test(kFlashInfoPageIdOwnerSecret);
+    do_info_partition_test(kFlashInfoPageIdIsoPart);
+    do_data_partition_test(kFlashDataBank0);
+    do_data_partition_test(kFlashDataBank1);
+  }
+
+  return true;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -724,6 +724,26 @@ sw_tests += {
   }
 }
 
+flash_ctrl_clock_freqs_test_lib = declare_dependency(
+  link_with: static_library(
+    'flash_ctrl_clock_freqs_test_lib',
+    sources: ['flash_ctrl_clock_freqs_test.c'],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_clkmgr,
+      sw_lib_dif_flash_ctrl,
+      sw_lib_testing_flash_ctrl_testutils,
+      sw_lib_testing_rand_testutils,
+      sw_lib_runtime_log,
+    ],
+  ),
+)
+sw_tests += {
+  'flash_ctrl_clock_freqs_test': {
+    'library': flash_ctrl_clock_freqs_test_lib,
+  }
+}
+
 # KMAC Tests
 kmac_mode_kmac_test_lib = declare_dependency(
   link_with: static_library(


### PR DESCRIPTION
For test: chip_sw_flash_ctrl_clock_freqs.

Enables the jitter register in clock manager and performs and checks a number of erase, write and read cycles
via the flash controller to information and data partitions.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>