### PR TITLE
[pwrmgr] Tighten window of main power supply monitoring

### DIFF
--- a/hw/ip/pwrmgr/doc/_index.md
+++ b/hw/ip/pwrmgr/doc/_index.md
@@ -222,8 +222,11 @@ When this happens, the power manager creates a local escalation request that beh
 
 #### Main Power Unstable Reset Requests
 If the main power ever becomes unstable (the power okay indication is low even though it is powered on), the power manager requests an internal reset.
-
 This reset behaves similarly to the escalation reset and transitions directly into reset handling.
+
+Note that under normal low power conditions, the main power may be be turned off.
+As a result of this, the main power unstable checks are valid only during states that power should be on and stable.
+This includes any state where power manager has requested the power to be turned on.
 
 
 ### Reset Requests Received During Other States

--- a/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
@@ -284,12 +284,12 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
     if (!rst_ni) begin
       mon_main_pok <= '0;
     end else if (!pd_nd && mon_main_pok) begin
-      mon_main_pok <= 1'b0;       
+      mon_main_pok <= 1'b0;
     end else if (set_main_pok) begin
       mon_main_pok <= 1'b1;
     end
   end
-   
+
   // power stability reset request
   // If the main power becomes unstable for whatever reason,
   // request reset

--- a/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
+++ b/hw/ip/pwrmgr/rtl/pwrmgr_slow_fsm.sv
@@ -145,7 +145,6 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
     ack_pwrdn_d    = ack_pwrdn_q;
     fsm_invalid_d  = fsm_invalid_q;
 
-    mon_main_pok   = '0;
     set_main_pok   = '0;
 
     clk_active     = '0;
@@ -158,9 +157,6 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
       end
 
       SlowPwrStateLowPower: begin
-        // if main power was not turned off, monitor power for stability
-        mon_main_pok = main_pd_ni;
-
         // reset request behaves identically to a wakeup, other than the power-up cause being
         // different
         if (wakeup_i || reset_req_i) begin
@@ -209,7 +205,6 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
         // ack_pwrup_i should be 0 here to indicate
         // the ack from the previous round has definitively completed
         clk_active = 1'b1;
-        mon_main_pok = 1'b1;
 
         if (req_pwrdn_i && !ack_pwrup_i) begin
           state_d = SlowPwrStateAckPwrDn;
@@ -285,6 +280,16 @@ module pwrmgr_slow_fsm import pwrmgr_pkg::*; (
     end
   end
 
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      mon_main_pok <= '0;
+    end else if (!pd_nd && mon_main_pok) begin
+      mon_main_pok <= 1'b0;       
+    end else if (set_main_pok) begin
+      mon_main_pok <= 1'b1;
+    end
+  end
+   
   // power stability reset request
   // If the main power becomes unstable for whatever reason,
   // request reset

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -968,7 +968,7 @@
             test restarts and the POR bit is not set.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_pwrmgr_sleep_power_glitch_reset"]
     }
     {
       name: chip_sw_pwrmgr_b2b_sleep_reset_req

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -433,6 +433,12 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_pwrmgr_sleep_power_glitch_reset
+      uvm_test_seq: chip_sw_main_power_glitch_vseq
+      sw_images: ["sw/device/tests/pwrmgr_sleep_power_glitch_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
+    {
       name: chip_sw_pwrmgr_sleep_disabled
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/pwrmgr_sleep_disabled_test:1"]

--- a/hw/top_earlgrey/dv/env/ast_supply_if.sv
+++ b/hw/top_earlgrey/dv/env/ast_supply_if.sv
@@ -54,7 +54,6 @@ interface ast_supply_if (
       $assertoff(1, top_earlgrey.u_pwrmgr_aon.u_slow_fsm.IntRstReq_A);
     end
     force u_ast.u_rglts_pdm_3p3v.vcmain_pok_h_o = value;
-    if (value) reenable_vcmain_assertion();
   endtask
 
   // Create glitch in vcmain_pok_h_o some cycles after a trigger transitions high.
@@ -64,6 +63,8 @@ interface ast_supply_if (
     force_vcmain_pok(1'b0);
     repeat (GlitchCycles) @(posedge clk);
     force_vcmain_pok(1'b1);
-  endtask
+  endtask // glitch_vcmain_pok_on_next_trigger
+
+
 
 endinterface

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_main_power_glitch_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_main_power_glitch_vseq.sv
@@ -15,7 +15,12 @@ class chip_sw_main_power_glitch_vseq extends chip_sw_base_vseq;
 
     // Wait until we reach the SW test state.
     wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
-
     cfg.ast_supply_vif.glitch_vcmain_pok_on_next_trigger(cycles_after_trigger);
+
+    // the above glitch should cause the system to reboot, now wait for reset
+    // before re-enabling assertion
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+    cfg.ast_supply_vif.reenable_vcmain_assertion();
+
   endtask
 endclass

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -138,6 +138,20 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "pwrmgr_sleep_power_glitch_test",
+    srcs = ["pwrmgr_sleep_power_glitch_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:pwrmgr",
+        "//sw/device/lib/dif:rstmgr",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+        "//sw/device/lib/testing:rstmgr_testutils",
+    ],
+)
+
+opentitan_functest(
     name = "pwrmgr_usbdev_smoketest",
     srcs = ["pwrmgr_usbdev_smoketest.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -357,4 +357,3 @@ sw_tests += {
     'library': sram_ctrl_main_scrambled_access_test_lib,
   }
 }
-

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -161,6 +161,24 @@ pwrmgr_main_power_glitch_test_lib = declare_dependency(
     'pwrmgr_main_power_glitch_test_lib',
     sources: ['pwrmgr_main_power_glitch_test.c'],
     dependencies: [
+      sw_lib_dif_rstmgr,
+      sw_lib_mmio,
+      sw_lib_runtime_log,
+      sw_lib_testing_rstmgr_testutils,
+    ],
+  ),
+)
+sw_tests += {
+  'pwrmgr_main_power_glitch_test': {
+    'library': pwrmgr_main_power_glitch_test_lib,
+  }
+}
+
+pwrmgr_sleep_power_glitch_test_lib = declare_dependency(
+  link_with: static_library(
+    'pwrmgr_sleep_power_glitch_test_lib',
+    sources: ['pwrmgr_sleep_power_glitch_test.c'],
+    dependencies: [
       sw_lib_dif_pwrmgr,
       sw_lib_dif_rstmgr,
       sw_lib_mmio,
@@ -171,8 +189,8 @@ pwrmgr_main_power_glitch_test_lib = declare_dependency(
   ),
 )
 sw_tests += {
-  'pwrmgr_main_power_glitch_test': {
-    'library': pwrmgr_main_power_glitch_test_lib,
+  'pwrmgr_sleep_power_glitch_test': {
+    'library': pwrmgr_sleep_power_glitch_test_lib,
   }
 }
 

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test.c
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_pwrmgr.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
 #include "sw/device/lib/testing/test_framework/ottf.h"
 
@@ -14,13 +16,18 @@
 const test_config_t kTestConfig;
 
 // When the test first runs the rstmgr's `reset_info` CSR should have the POR
-// bit set, the code clears reset_info and calls wait_for_interrupt(). The WFI
+// bit set, the code clears reset_info and puts the chip in deep sleep. The WFI
 // causes core_sleeping to rise, and that causes the SV side to glitch the main
 // power rail, causing a pwrmgr internally generated reset. The next time the
 // test runs is after the power glitch reset, which is confirmed reading the
 // `reset_info` CSR.
 bool test_main(void) {
+  dif_pwrmgr_t pwrmgr;
   dif_rstmgr_t rstmgr;
+
+  // Initialize pwrmgr since this will put the chip in deep sleep.
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
 
   // Initialize rstmgr since this will check some registers.
   CHECK_DIF_OK(dif_rstmgr_init(
@@ -32,11 +39,17 @@ bool test_main(void) {
   if (rstmgr_testutils_is_reset_info(&rstmgr, kDifRstmgrResetInfoPor)) {
     LOG_INFO("Powered up for the first time, begin test");
 
+    CHECK(pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0));
+
     rstmgr_testutils_pre_reset(&rstmgr);
 
+    // Configure deep sleep.
+    pwrmgr_testutils_enable_low_power(&pwrmgr,
+                                      kDifPwrmgrWakeupRequestSourceFive, 0);
+
     // This causes core_sleeping to rise and triggers the injection of the
-    // power glitch. Notice it does not by itself trigger a low power
-    // transition.
+    // power glitch. Enter low power mode.
+    LOG_INFO("Issue WFI to enter sleep");
     wait_for_interrupt();
 
   } else {


### PR DESCRIPTION
- the previous window of monitor main power stability was
  too loose. This update makes it much it much tigher.
    
- clarify in the documentation the detection condition for
  power stability checks.