### PR TITLE
[dv/cdc assertion] Temp remove CDC assertion cov collection in VCS

### DIFF
--- a/hw/dv/tools/vcs/cover.cfg
+++ b/hw/dv/tools/vcs/cover.cfg
@@ -33,7 +33,7 @@ end
 
 begin assert
   +moduletree *csr_assert_fpv
-
+  -module prim_cdc_rand_delay // TODO: CDC not enabled yet
   // These three assertions in prim_lc_sync and prim_mubi* check when `lc_ctrl_pkg::lc_tx_t` or
   // `mubi*_t` input are neither `On` or `Off`, it is interrupted to the correct `On` or `Off`
   // after one clock cycle. This behavior is implemented outside of IP level design thus these


### PR DESCRIPTION
This PR temp remove cdc DV module assertion cov in regression. Right now
this temp removal only on VCS because adc_ctrl seems to be the only IP
blocked by this to reach V2.
Once CDC is fully supported in DV simulation, we can remove this. So I
did not implement it in Xcelium.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>