### PR TITLE
[dv] Adding GetMemoryArea() to dpi_memutil

### DIFF
--- a/hw/dv/verilator/cpp/dpi_memutil.cc
+++ b/hw/dv/verilator/cpp/dpi_memutil.cc
@@ -569,3 +569,16 @@ size_t DpiMemUtil::GetRegionForSegment(const std::string &path, int seg_idx,
 
   return mem_area_it->second;
 }
+
+const MemArea &DpiMemUtil::GetMemoryArea(const std::string &name) {
+  // Search for corresponding registered memory based on the name
+  auto it = name_to_mem_.find(name);
+  if (it == name_to_mem_.end()) {
+    std::ostringstream oss;
+    oss << "`" << name
+        << ("' is not the name of a known memory region. "
+            "Run with --meminit=list to get a list.");
+    throw std::runtime_error(oss.str());
+  }
+  return *mem_areas_[it->second];
+}

--- a/hw/dv/verilator/cpp/dpi_memutil.h
+++ b/hw/dv/verilator/cpp/dpi_memutil.h
@@ -86,6 +86,13 @@ class DpiMemUtil {
                           const MemArea *mem_area);
 
   /**
+   * Get a Memory Area by name
+   *
+   * @see RegisterMemoryArea()
+   */
+  const MemArea &GetMemoryArea(const std::string &name);
+
+  /**
    * Guess the type of the file at |path|.
    *
    * If |type| is non-null, it is the name of an image type and will be used.


### PR DESCRIPTION
There doesn't seem to be a way to retreive a MemArea object from
DpiMemUtil such that you can use the MemArea::Write and Read methods.
This fix adds DpiMemUtil::GetMemoryArea to do just that.

Signed-off-by: Shareef Jalloq <shareef.jalloq@idexbiometrics.com>