### PR TITLE
[adc_ctrl/dv] Mapped adc_ctrl_tl_intg_err to sec_cm_bus_integrity

### DIFF
--- a/hw/ip/adc_ctrl/data/adc_ctrl_sec_cm_testplan.hjson
+++ b/hw/ip/adc_ctrl/data/adc_ctrl_sec_cm_testplan.hjson
@@ -27,7 +27,7 @@
       name: sec_cm_bus_integrity
       desc: "Verify the countermeasure(s) BUS.INTEGRITY."
       milestone: V2S
-      tests: []
+      tests: ["adc_ctrl_tl_intg_err"]
     }
   ]
 }


### PR DESCRIPTION
- Mapped adc_ctrl_tl_intg_err to security testpoint sec_cm_bus_integrity

Signed-off-by: Nigel Scales <nigel.scales@gmail.com>