### PR TITLE
[util] Wrap random seeds just like we do for permutations

### DIFF
--- a/util/design/gen-lfsr-seed.py
+++ b/util/design/gen-lfsr-seed.py
@@ -71,7 +71,9 @@ def main():
 parameter int {}LfsrWidth = {};
 typedef logic [{}LfsrWidth-1:0] {}lfsr_seed_t;
 typedef logic [{}LfsrWidth-1:0][$clog2({}LfsrWidth)-1:0] {}lfsr_perm_t;
-parameter {}lfsr_seed_t RndCnst{}LfsrSeedDefault = {};
+parameter {}lfsr_seed_t RndCnst{}LfsrSeedDefault = {{
+  {}
+}};
 parameter {}lfsr_perm_t RndCnst{}LfsrPermDefault = {{
   {}
 }};

--- a/util/design/lib/common.py
+++ b/util/design/lib/common.py
@@ -64,8 +64,7 @@ def get_random_data_hex_literal(width):
     """ Fetch 'width' random bits and return them as hex literal"""
     width = int(width)
     literal_str = hex(random.getrandbits(width))
-    literal_str = str(width) + "'h" + literal_str[2:]
-    return literal_str
+    return blockify(literal_str, width, 64)
 
 
 def blockify(s, size, limit):


### PR DESCRIPTION
This is more suitable for generating wide default seeds to be included in IP package files as it will generate e.g.: 
```sv
// $ ./util/design/gen-lfsr-seed.py --width 800 --seed 1201202158 --prefix ""
parameter int LfsrWidth = 800;
typedef logic [LfsrWidth-1:0] lfsr_seed_t;
typedef logic [LfsrWidth-1:0][$clog2(LfsrWidth)-1:0] lfsr_perm_t;
parameter lfsr_seed_t RndCnstLfsrSeedDefault = {
  32'h745d5926,
  256'h7ee51b8b8667c5f90e33558c62b75afae1c73076280172d0ef7e582e95a67772,
  256'ha360dad2ceb5ac79c0c5134131f80c4930765e116aaab2971f05c739aa25b4bf,
  256'h48ce8fff5a78282a4846564770410fefcf22c91fdae9f6fff51d5781ee8e8b70
};
```
instead of
```sv
// $ ./util/design/gen-lfsr-seed.py --width 800 --seed 1201202158 --prefix ""
parameter int LfsrWidth = 800;
typedef logic [LfsrWidth-1:0] lfsr_seed_t;
typedef logic [LfsrWidth-1:0][$clog2(LfsrWidth)-1:0] lfsr_perm_t;
parameter lfsr_seed_t RndCnstLfsrSeedDefault = {
  800'h745d59267ee51b8b8667c5f90e33558c62b75afae1c73076280172d0ef7e582e95a67772a360dad2ceb5ac79c0c5134131f80c4930765e116aaab2971f05c739aa25b4bf48ce8fff5a78282a4846564770410fefcf22c91fdae9f6fff51d5781ee8e8b70
};

```