### PR TITLE
[spi_device] Block Read buffer manager whle in Passthrough

### DIFF
--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -181,9 +181,6 @@ module spi_readcmd
   logic unused_p2s_sent ;
   assign unused_p2s_sent = p2s_sent_i;
 
-  spi_mode_e unused_spi_mode ; // will be used for passthrough for output enable
-  assign unused_spi_mode = spi_mode_i;
-
   sram_err_t unused_sram_rerr;
   assign unused_sram_rerr = sram_m2l_i.rerror;
 
@@ -740,6 +737,8 @@ module spi_readcmd
     .rst_ni,
 
     .sys_rst_ni,
+
+    .spi_mode_i,
 
     .current_address_i (addr_d),
     .threshold_i       (readbuf_threshold_i),

--- a/hw/ip/spi_device/rtl/spid_readbuffer.sv
+++ b/hw/ip/spi_device/rtl/spid_readbuffer.sv
@@ -50,6 +50,8 @@ module spid_readbuffer #(
 
   input sys_rst_ni, // to keep the addr, bufidx, flip signals
 
+  input spi_device_pkg::spi_mode_e spi_mode_i,
+
   input [31:0]       current_address_i,
   input [BufferAw:0] threshold_i, // A buffer size among two buffers (in bytes)
 
@@ -101,7 +103,8 @@ module spid_readbuffer #(
   // Datapath //
   //////////////
 
-  assign active = (st_q == StActive);
+  assign active = (st_q == StActive)
+                && (spi_mode_i == spi_device_pkg::FlashMode);
 
   // Flip event handling
   always_ff @(posedge clk_i or negedge sys_rst_ni) begin
@@ -153,7 +156,11 @@ module spid_readbuffer #(
   ///////////////////
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) st_q <= StIdle;
-    else         st_q <= st_d;
+    else if (spi_mode_i != spi_device_pkg::FlashMode) begin
+      st_q <= StIdle;
+    end else begin
+      st_q <= st_d;
+    end
   end
 
   always_comb begin


### PR DESCRIPTION
This commit prevents the readbuffer module from running while SPI_DEVICE
IP is in Passthrough mode (or Generic mode). The Passthrough mode allows
access to the SFDP and Mailbox spaces not the read buffer space.

Now, the module does not report threshold, flip events to SW in
Passthrough mode.