### PR TITLE
[ci] Modify Bazel timeouts to reduce test failures

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -583,7 +583,7 @@ jobs:
 
 - job: bazel_test
   displayName: Bazel Software Build and Test
-  timeoutInMinutes: 90
+  timeoutInMinutes: 120
   dependsOn: lint
   pool:
     vmImage: ubuntu-18.04

--- a/ci/.bazelrc
+++ b/ci/.bazelrc
@@ -8,7 +8,7 @@ common --color=no --curses=yes
 
 # These options ensure that Bazel prints *everything* it is doing as aggressively
 # as possible, but only updating once every second.
-build --show_timestamps 
+build --show_timestamps
 build --show_progress_rate_limit=1
 
 # If something goes wrong, show the whole command line for it.
@@ -20,4 +20,4 @@ build --keep_going
 
 # Use the remote Bazel cache for CI.
 build --remote_cache=https://storage.googleapis.com/opentitan-bazel-cache
-build --remote_timeout=600
+build --remote_timeout=60


### PR DESCRIPTION
Increase the maximum allowed runtime of the Bazel job to allow more time
to populate the cache in the event of cache misses. This should be
relatively infrequent but can reduce unnecessary Bazel job failures.

Reduce the remote cache timeout to reduce the amount of time Bazel
spends waiting on the cache in the event of a flaky connection to
the GCP bucket.

Signed-off-by: Miles Dai <milesdai@google.com>