### PR TITLE
[top, dv] Add jitter_enable control in ottf

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -1900,7 +1900,7 @@
             X-ref'ed with kmac test.
             '''
       milestone: V2
-      tests: ["chip_sw_keymgr_key_derivation"]
+      tests: ["chip_sw_keymgr_key_derivation", "chip_sw_keymgr_key_derivation_jitter_en"]
     }
     {
       name: chip_sw_keymgr_sideload_kmac

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -539,6 +539,13 @@
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }
     {
+      name: chip_sw_keymgr_key_derivation_jitter_en
+      uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
+      sw_images: ["sw/device/tests/keymgr_key_derivation_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+sw_test_timeout_ns=20000000", "+en_jitter=1"]
+    }
+    {
       name: chip_sw_kmac_mode_cshake
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/kmac_mode_cshake_test:1"]

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -83,7 +83,18 @@ class chip_sw_base_vseq extends chip_base_vseq;
     end
     cfg.sw_test_status_vif.sw_test_status = SwTestStatusBooted;
 
+    config_jitter();
+
     `uvm_info(`gfn, "CPU_init done", UVM_MEDIUM)
+  endtask
+
+  task config_jitter();
+    bit en_jitter;
+    void'($value$plusargs("en_jitter=%0d", en_jitter));
+    if (en_jitter) begin
+      bit [7:0] en_jitter_arr[] = {1};
+      sw_symbol_backdoor_overwrite("kJitterEnabled", en_jitter_arr);
+    end
   endtask
 
   virtual function void main_sram_bkdr_write32(

--- a/sw/device/lib/arch/device.h
+++ b/sw/device/lib/arch/device.h
@@ -5,6 +5,7 @@
 #ifndef OPENTITAN_SW_DEVICE_LIB_ARCH_DEVICE_H_
 #define OPENTITAN_SW_DEVICE_LIB_ARCH_DEVICE_H_
 
+#include <stdbool.h>
 #include <stdint.h>
 
 /**
@@ -145,5 +146,10 @@ extern const uintptr_t kDeviceTestStatusAddress;
  * @see #LOG
  */
 extern const uintptr_t kDeviceLogBypassUartAddress;
+
+/**
+ * A knob to set jitter_enable in clkmgr.
+ */
+extern const bool kJitterEnabled;
 
 #endif  // OPENTITAN_SW_DEVICE_LIB_ARCH_DEVICE_H_

--- a/sw/device/lib/arch/device_fpga_cw310.c
+++ b/sw/device/lib/arch/device_fpga_cw310.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdbool.h>
+
 #include "sw/device/lib/arch/device.h"
 
 /**
@@ -30,3 +32,5 @@ const uint32_t kUartTxFifoCpuCycles =
 const uintptr_t kDeviceTestStatusAddress = 0;
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;
+
+const bool kJitterEnabled = false;

--- a/sw/device/lib/arch/device_fpga_nexysvideo.c
+++ b/sw/device/lib/arch/device_fpga_nexysvideo.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdbool.h>
+
 #include "sw/device/lib/arch/device.h"
 
 /**
@@ -30,3 +32,5 @@ const uint32_t kUartTxFifoCpuCycles =
 const uintptr_t kDeviceTestStatusAddress = 0;
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;
+
+const bool kJitterEnabled = false;

--- a/sw/device/lib/arch/device_sim_dv.c
+++ b/sw/device/lib/arch/device_sim_dv.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdbool.h>
+
 #include "sw/device/lib/arch/device.h"
 
 /**
@@ -34,3 +36,5 @@ const uintptr_t kDeviceTestStatusAddress = 0x411f0080;
 
 // Defined in `hw/top_earlgrey/dv/env/chip_env_pkg.sv`
 const uintptr_t kDeviceLogBypassUartAddress = 0x411f0084;
+
+const bool kJitterEnabled = false;

--- a/sw/device/lib/arch/device_sim_verilator.c
+++ b/sw/device/lib/arch/device_sim_verilator.c
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdbool.h>
+
 #include "sw/device/lib/arch/device.h"
 
 /**
@@ -34,3 +36,5 @@ const uint32_t kUartTxFifoCpuCycles =
 const uintptr_t kDeviceTestStatusAddress = 0x411f0080;
 
 const uintptr_t kDeviceLogBypassUartAddress = 0;
+
+const bool kJitterEnabled = false;

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -25,6 +25,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",

--- a/sw/device/lib/testing/test_framework/meson.build
+++ b/sw/device/lib/testing/test_framework/meson.build
@@ -129,6 +129,7 @@ ottf_lib = declare_dependency(
       sw_lib_irq,
       sw_lib_mem,
       sw_lib_dif_uart,
+      sw_lib_dif_clkmgr,
       sw_lib_dif_rv_timer,
       sw_lib_runtime_hart,
       sw_lib_runtime_log,


### PR DESCRIPTION
On DV side, use `+en_jitter=1` to enable jitter for the test
sw_base_vseq will backdoor overwrite `kJitterEnabled` to inform SW to
turn on jitter.

Add test `chip_sw_keymgr_key_derivation_jitter_en` which enables jitter. In this
test, kmac, aes and otbn will be involved.

Signed-off-by: Weicai Yang <weicai@google.com>