### PR TITLE
[dv/clkmgr] Fix frequency tests

### DIFF
--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_common_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_common_vseq.sv
@@ -46,6 +46,6 @@ class clkmgr_common_vseq extends clkmgr_base_vseq;
     // update default idle to false for
     // csr test.
     cfg.clkmgr_vif.idle_i = {NUM_TRANS{MuBi4False}};
-  endtask // initialize_on_start
+  endtask : initialize_on_start
 
 endclass

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_extclk_vseq.sv
@@ -74,9 +74,8 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
     if (mubi_mode == ClkmgrMubiHand && value == MuBi4True) begin
       repeat ($urandom_range(1, 10)) begin
         cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
-        cfg.clkmgr_vif.update_all_clk_byp_ack(get_rand_mubi4_val(.t_weight(0),
-                                                                 .f_weight(1),
-                                                                 .other_weight(1)));
+        cfg.clkmgr_vif.update_all_clk_byp_ack(get_rand_mubi4_val(
+                                              .t_weight(0), .f_weight(1), .other_weight(1)));
       end
     end
     cfg.clk_rst_vif.wait_clks(cycles);
@@ -84,12 +83,11 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
   endtask
 
   local task delayed_update_div_step_down_req(mubi4_t value, int cycles);
-    if (mubi_mode ==  ClkmgrMubiDiv && value == MuBi4True) begin
+    if (mubi_mode == ClkmgrMubiDiv && value == MuBi4True) begin
       repeat ($urandom_range(1, 10)) begin
         cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
-        cfg.clkmgr_vif.update_div_step_down_req(get_rand_mubi4_val(.t_weight(0),
-                                                                   .f_weight(1),
-                                                                   .other_weight(1)));
+        cfg.clkmgr_vif.update_div_step_down_req(get_rand_mubi4_val(
+                                                .t_weight(0), .f_weight(1), .other_weight(1)));
       end
     end
     cfg.clk_rst_vif.wait_clks(cycles);
@@ -100,9 +98,8 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
     if (mubi_mode == ClkmgrMubiHand && value == MuBi4True) begin
       repeat ($urandom_range(1, 10)) begin
         cfg.clk_rst_vif.wait_clks($urandom_range(1, 10));
-        cfg.clkmgr_vif.update_io_clk_byp_ack(get_rand_mubi4_val(.t_weight(0),
-                                                                .f_weight(1),
-                                                                .other_weight(1)));
+        cfg.clkmgr_vif.update_io_clk_byp_ack(get_rand_mubi4_val(
+                                             .t_weight(0), .f_weight(1), .other_weight(1)));
       end
     end
     cfg.clk_rst_vif.wait_clks(cycles);
@@ -122,8 +119,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
           `uvm_info(`gfn, "Got all_clk_byp_req off", UVM_MEDIUM)
           // Set inputs to mubi4 non-True.
           fork
-            delayed_update_all_clk_byp_ack(all_clk_byp_ack_non_true,
-                                           cycles_before_all_clk_byp_ack);
+            delayed_update_all_clk_byp_ack(all_clk_byp_ack_non_true, cycles_before_all_clk_byp_ack);
             delayed_update_div_step_down_req(div_step_down_req_non_true,
                                              cycles_before_div_step_down_req);
           join
@@ -144,8 +140,7 @@ class clkmgr_extclk_vseq extends clkmgr_base_vseq;
           `uvm_info(`gfn, "Got io_clk_byp_req non True", UVM_MEDIUM)
           // Set inputs to mubi4 non-True.
           fork
-            delayed_update_io_clk_byp_ack(io_clk_byp_ack_non_true,
-                                          cycles_before_io_clk_byp_ack);
+            delayed_update_io_clk_byp_ack(io_clk_byp_ack_non_true, cycles_before_io_clk_byp_ack);
             delayed_update_div_step_down_req(div_step_down_req_non_true,
                                              cycles_before_div_step_down_req);
           join

--- a/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
+++ b/hw/ip/clkmgr/dv/env/seq_lib/clkmgr_trans_vseq.sv
@@ -34,7 +34,7 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
 
       csr_rd(.ptr(ral.clk_hints_status), .value(value));
 
-      `uvm_info(`gfn, $sformatf("Initial clk_hints_status: %b",value),UVM_MEDIUM)
+      `uvm_info(`gfn, $sformatf("Initial clk_hints_status: %b", value), UVM_MEDIUM)
       cfg.clkmgr_vif.init(.idle(idle), .scanmode(scanmode));
 
       // add random value if mubi idle test
@@ -74,13 +74,12 @@ class clkmgr_trans_vseq extends clkmgr_base_vseq;
   task drive_idle(ref mubi_hintables_t tbl);
     int period;
     mubi_hintables_t rand_idle;
-    foreach (rand_idle[i]) rand_idle[i] = get_rand_mubi4_val(.t_weight(0),
-                                                             .f_weight(0),
-                                                             .other_weight(1));
+    foreach (rand_idle[i])
+      rand_idle[i] = get_rand_mubi4_val(.t_weight(0), .f_weight(0), .other_weight(1));
 
     @cfg.clkmgr_vif.trans_cb;
     cfg.clkmgr_vif.idle_i = rand_idle;
 
     tbl = rand_idle;
-  endtask // drive_idle
+  endtask : drive_idle
 endclass : clkmgr_trans_vseq


### PR DESCRIPTION
The clkmgr_frequency test needs to wait more time between measurements, and
cannot check using the cip alert checks because we cannot consistently get
a single alert per round. Use the alert count instead.

The clkmgr_frequency_timeout test needs to disable some assertions when it
turns off some of the non-aon clocks.

Fix some formatting issues.

Signed-off-by: Guillermo Maturana <maturana@google.com>