### PR TITLE
[dv,top,clkmgr] top ast_clk_outputs test

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2488,7 +2488,7 @@
 
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_ast_clk_outputs"]
     }
     {
       name: chip_sw_ast_clk_rst_inputs

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -674,6 +674,12 @@
       en_run_modes: ["stub_cpu_mode"]
       run_opts: ["+en_scb=0", "+csr_rw", "+create_jtag_riscv_map=1"]
     }
+    {
+      name: chip_sw_ast_clk_outputs
+      uvm_test_seq: chip_sw_ast_clk_outputs_vseq
+      sw_images: ["sw/device/tests/ast_clk_outs_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+    }
   ]
 
   // List of regressions.

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -55,6 +55,7 @@ filesets:
       - seq_lib/chip_sw_sram_ctrl_execution_main_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_sram_ctrl_scrambled_access_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_keymgr_key_derivation_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_ast_clk_outputs_vseq.sv: {is_include_file: true}
       - seq_lib/chip_callback_vseq.sv: {is_include_file: true}
       - autogen/chip_env_pkg__params.sv: {is_include_file: true}
       - ast_supply_if.sv

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_outputs_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_ast_clk_outputs_vseq.sv
@@ -1,0 +1,22 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_ast_clk_outputs_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_ast_clk_outputs_vseq)
+
+  `uvm_object_new
+
+  task body();
+     // These assertions are invalid with multiple power up / down with
+     // frequency measurement, because rise and fall times are
+     // severly distorted by clock on / off event.
+     $assertoff(0, "tb.dut.top_earlgrey.u_clkmgr_aon.clkmgr_pwrmgr_sva_if.UsbStatusFall_A");
+     $assertoff(0, "tb.dut.top_earlgrey.u_clkmgr_aon.clkmgr_pwrmgr_sva_if.UsbStatusRise_A");
+     $assertoff(0, "tb.dut.top_earlgrey.u_pwrmgr_aon.clkmgr_pwrmgr_sva_if.UsbStatusFall_A");
+     $assertoff(0, "tb.dut.top_earlgrey.u_pwrmgr_aon.clkmgr_pwrmgr_sva_if.UsbStatusRise_A");
+     super.body();
+
+  endtask // body
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -24,3 +24,4 @@
 `include "chip_sw_sram_ctrl_scrambled_access_vseq.sv"
 `include "chip_sw_pwm_pulses_vseq.sv"
 `include "chip_sw_keymgr_key_derivation_vseq.sv"
+`include "chip_sw_ast_clk_outputs_vseq.sv"

--- a/sw/device/tests/BUILD
+++ b/sw/device/tests/BUILD
@@ -908,3 +908,18 @@ opentitan_functest(
         "//sw/device/lib/testing:pinmux_testutils",
     ],
 )
+
+opentitan_functest(
+    name = "ast_clk_outs_test",
+    srcs = ["ast_clk_outs_test.c"],
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:sensor_ctrl",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:aon_timer_testutils",
+        "//sw/device/lib/testing:clkmgr_testutils",
+        "//sw/device/lib/testing:pwrmgr_testutils",
+    ],
+)

--- a/sw/device/tests/ast_clk_outs_test.c
+++ b/sw/device/tests/ast_clk_outs_test.c
@@ -1,0 +1,165 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/dif/dif_sensor_ctrl.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/aon_timer_testutils.h"
+#include "sw/device/lib/testing/check.h"
+#include "sw/device/lib/testing/clkmgr_testutils.h"
+#include "sw/device/lib/testing/pwrmgr_testutils.h"
+#include "sw/device/lib/testing/test_framework/ottf.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+
+/**
+ * AST CLK OUTPUTS TEST
+ *
+ * This test measure 3 clock outputs from ast (sys, io and usb)
+ * by clkmgr frequency measurements.
+ * Frequency meaasurement assumes aon_clk frequency 200KHz.
+ * Given that, measurement is done for 500 us which is equivalent
+ * to 100 measurements.
+ * If measurement detects error (fast, slow), it will be stored
+ * as recoverable error in clkmgr.
+ *
+ * After 100 measurements, test kicks in low-power mode, where
+ * 3 clocks are off and measurement should not report spurious errors.
+ * Wake up timer is set 500us which gives about 500us deep sleep.
+ *
+ * Then dut wakes up and repeat another 100 measurements before
+ * test finish.
+ */
+enum {
+  kWaitForCSRPolling = 1,  // 1us
+  // aon period : 5us
+  // meaure for 100 of period
+  kMeasurementDelayMicros = 500,
+  // at lowpower mode, main/io/usb clocks are off after 40us
+  kClockCoolDownTime = 40,
+};
+static dif_clkmgr_t clkmgr;
+static dif_pwrmgr_t pwrmgr;
+
+typedef struct expected_count_info {
+  int count;
+  int variability;
+} expected_count_info_t;
+
+// Due to u_sync_ref and valid in each measurement block,
+// measurement cnt has 3 cycle offset.
+// So variability becomes 1(calculated from spec) + 3 = 4.
+
+static const expected_count_info_t kCountInfos[] = {
+    {.count = 479, .variability = 4}, {.count = 239, .variability = 4},
+    {.count = 119, .variability = 4}, {.count = 499, .variability = 4},
+    {.count = 239, .variability = 4},
+};
+
+static void enable_clk_measure(void) {
+  // Enable cycle count measurements to confirm the frequencies are correct.
+  for (size_t i = 0; i < ARRAYSIZE(kCountInfos); ++i) {
+    expected_count_info_t count_info = kCountInfos[i];
+    clkmgr_testutils_enable_clock_count_measurement(
+        &clkmgr, (dif_clkmgr_measure_clock_t)i,
+        count_info.count - count_info.variability,
+        count_info.count + count_info.variability);
+  }
+}
+
+static void check_measurement_counts(const dif_clkmgr_t *clkmgr) {
+  dif_clkmgr_recov_err_codes_t err_codes;
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_get_codes(clkmgr, &err_codes));
+  if (err_codes != 0) {
+    LOG_ERROR("Unexpected recoverable error codes 0x%x", err_codes);
+  } else {
+    LOG_INFO("Clock measurements are okay");
+  }
+
+  // clear recoverable errors
+  CHECK_DIF_OK(dif_clkmgr_recov_err_code_clear_codes(clkmgr, ~0u));
+}
+
+bool test_main() {
+  dif_sensor_ctrl_t sensor_ctrl;
+  dif_aon_timer_t aon_timer;
+
+  CHECK_DIF_OK(dif_clkmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
+  CHECK_DIF_OK(dif_sensor_ctrl_init(
+      mmio_region_from_addr(TOP_EARLGREY_SENSOR_CTRL_BASE_ADDR), &sensor_ctrl));
+  CHECK_DIF_OK(dif_pwrmgr_init(
+      mmio_region_from_addr(TOP_EARLGREY_PWRMGR_AON_BASE_ADDR), &pwrmgr));
+  CHECK_DIF_OK(dif_aon_timer_init(
+      mmio_region_from_addr(TOP_EARLGREY_AON_TIMER_AON_BASE_ADDR), &aon_timer));
+
+  // enable usb clock after low power wake up
+  if (pwrmgr_testutils_is_wakeup_reason(&pwrmgr,
+                                        kDifPwrmgrWakeupRequestSourceFive)) {
+    dif_pwrmgr_domain_config_t config =
+        (kDifPwrmgrDomainOptionUsbClockInActivePower +
+         kDifPwrmgrDomainOptionMainPowerInLowPower);
+
+    CHECK_DIF_OK(
+        dif_pwrmgr_set_domain_config(&pwrmgr, config, kDifToggleEnabled));
+  }
+
+  LOG_INFO("TEST: wait for ast init");
+  dif_toggle_t init_st = kDifToggleDisabled;
+
+  while (init_st == kDifToggleDisabled) {
+    CHECK_DIF_OK(
+        dif_sensor_ctrl_get_ast_init_done_status(&sensor_ctrl, &init_st));
+
+    busy_spin_micros(kWaitForCSRPolling);
+  }
+
+  LOG_INFO("TEST: done ast init");
+
+  if (pwrmgr_testutils_is_wakeup_reason(&pwrmgr, 0)) {
+    // program 3 clock meausres
+    enable_clk_measure();
+    busy_spin_micros(kMeasurementDelayMicros);
+    // check results
+    check_measurement_counts(&clkmgr);
+
+    // set wakeup timer to 500us to have enough down time
+    // during the down time, all clock measurements are still enabled but
+    // not suppose to report any errors
+    uint32_t wakeup_threshold = kDeviceType == kDeviceSimVerilator ? 1000 : 100;
+    aon_timer_testutils_wakeup_config(&aon_timer, wakeup_threshold);
+    // go to low power
+    LOG_INFO("TEST: start low power mode");
+    pwrmgr_testutils_enable_low_power(&pwrmgr,
+                                      kDifPwrmgrWakeupRequestSourceFive, 0);
+
+    // Enter low power mode.
+    LOG_INFO("TEST: Issue WFI to enter sleep");
+    wait_for_interrupt();
+
+  } else if (pwrmgr_testutils_is_wakeup_reason(
+                 &pwrmgr, kDifPwrmgrWakeupRequestSourceFive)) {
+    LOG_INFO("TEST: disable clock measures");
+    clkmgr_testutils_disable_clock_count_measurements(&clkmgr);
+    LOG_INFO("TEST: dummy measure");
+    check_measurement_counts(&clkmgr);
+    busy_spin_micros(kMeasurementDelayMicros);
+    LOG_INFO("TEST: re-enable");
+    enable_clk_measure();
+    busy_spin_micros(kMeasurementDelayMicros);
+    LOG_INFO("TEST: check");
+    check_measurement_counts(&clkmgr);
+
+    LOG_INFO("TEST: done");
+    return true;
+  } else {  // error
+    dif_pwrmgr_wakeup_reason_t wakeup_reason;
+    CHECK_DIF_OK(dif_pwrmgr_wakeup_reason_get(&pwrmgr, &wakeup_reason));
+    LOG_ERROR("Unexpected wakeup detected: type = %d, request_source = %d",
+              wakeup_reason.types, wakeup_reason.request_sources);
+    return false;
+  }
+
+  return false;
+}

--- a/sw/device/tests/meson.build
+++ b/sw/device/tests/meson.build
@@ -1232,7 +1232,27 @@ sw_tests += {
   }
 }
 
-
+# AST test
+ast_clk_outs_test_lib = declare_dependency(
+  link_with: static_library(
+    'ast_clk_outs_test_lib',
+    sources: ['ast_clk_outs_test.c'],
+    dependencies: [
+      sw_lib_mmio,
+      sw_lib_dif_sensor_ctrl,
+      sw_lib_runtime_log,
+      top_earlgrey,
+      sw_lib_testing_clkmgr_testutils,
+      sw_lib_testing_pwrmgr_testutils,
+      sw_lib_testing_aon_timer_testutils,
+    ],
+  ),
+)
+sw_tests += {
+  'ast_clk_outs_test': {
+    'library': ast_clk_outs_test_lib,
+  }
+}
 ###############################################################################
 # Auto-generated tests
 ###############################################################################


### PR DESCRIPTION
@tjaychen , this is chip_sw_ast_clk_outputs test draft.
I want to check a few things before open to formal review.

This test use clkmgr frequency measure capability to check 3 ast generated clock(io, sys and usb)
1.
I followed spec (https://github.com/lowRISC/opentitan/blob/master/hw/ip/clkmgr/doc/_index.md#clock-frequency--time-out-measurements) to program  CLKMGR.*_MEAS_CTRL_SHADOWED registers.
However, I had to add 3 extra cycle margins to each hi and lo values. So (hi, lo) = expected value +/- 4
Is this ok?

2.
After 100 measurements, test goes lowpower mode for 500us then come back.
WITHOUT disabling measurement.
During the down time, I can see no measurement executed from the wave.
But when I read CLKMGR.RECOV_ERR after wakeup, some garbage values remains.
Should I ignore these garbage values in CLKMGR.RECOV_ERR?

3.
After wake up, I see usb clock does not come back by itself, while the others do.
So I can manually enable usb clock from PWRMGR.CONTROL. But at that point,
ast init is already done without usb clock enable.
Can ast init and usb clock be independent?

Signed-off-by: Jaedon Kim <jdonjdon@google.com>