### PR TITLE
[otbn, dv] Fixes regression failures in otbn_zero_state_err_urnd

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_model.cc
+++ b/hw/ip/otbn/dv/model/otbn_model.cc
@@ -499,6 +499,11 @@ int OtbnModel::set_software_errs_fatal(unsigned char new_val) {
   return 0;
 }
 
+int OtbnModel::set_no_sec_wipe_chk() {
+  OtbnTraceChecker::get().set_no_sec_wipe_chk();
+  return 0;
+}
+
 int OtbnModel::step_crc(const svBitVecVal *item /* bit [47:0] */,
                         svBitVecVal *state /* bit [31:0] */) {
   ISSWrapper *iss = ensure_wrapper();
@@ -910,4 +915,9 @@ int otbn_model_set_software_errs_fatal(OtbnModel *model,
                                        unsigned char new_val) {
   assert(model);
   return model->set_software_errs_fatal(new_val);
+}
+
+int otbn_set_no_sec_wipe_chk(OtbnModel *model) {
+  assert(model);
+  return model->set_no_sec_wipe_chk();
 }

--- a/hw/ip/otbn/dv/model/otbn_model.h
+++ b/hw/ip/otbn/dv/model/otbn_model.h
@@ -93,6 +93,10 @@ class OtbnModel {
   // Set software_errs_fatal bit in ISS model.
   int set_software_errs_fatal(unsigned char new_val);
 
+  // Tell the model to not execute checks to see if secure wiping has written
+  // random data to all registers before wiping them with zeroes.
+  int set_no_sec_wipe_chk();
+
   // Step CRC by consuming 48 bits of data.
   //
   // This doesn't actually update any internal state: we're just using the

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.h
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.h
@@ -119,6 +119,10 @@ int otbn_model_send_err_escalation(OtbnModel *model,
 // is set, any software error will be ellevated to fatal error from recoverable
 // error.
 int otbn_model_set_software_errs_fatal(OtbnModel *model, unsigned char new_val);
+
+// Tell the model to not execute checks to see if secure wiping has written
+// random data to all registers before wiping them with zeroes.
+int otbn_set_no_sec_wipe_chk(OtbnModel *model);
 }
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_MODEL_DPI_H_

--- a/hw/ip/otbn/dv/model/otbn_model_dpi.svh
+++ b/hw/ip/otbn/dv/model/otbn_model_dpi.svh
@@ -61,4 +61,7 @@ import "DPI-C" function void otbn_take_loop_warps(chandle model, chandle memutil
 import "DPI-C" function int otbn_model_send_err_escalation(chandle model, bit [31:0] err_val);
 
 import "DPI-C" context function int otbn_model_set_software_errs_fatal(chandle model, bit new_val);
+
+import "DPI-C" context function int otbn_set_no_sec_wipe_chk(chandle model);
+
 `endif // SYNTHESIS

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.h
@@ -75,6 +75,11 @@ class OtbnTraceChecker : public OtbnTraceListener {
   // through MatchPair if there is any.
   const OtbnIssTraceEntry::IssData *PopIssData();
 
+  // Tell the model not to execute checks to see if secure wiping has written
+  // random data to all registers before wiping them with zeroes on the next
+  // secure wipe entry.
+  void set_no_sec_wipe_chk();
+
  private:
   // If rtl_pending_ and iss_pending_ are not both true, return true
   // immediately with no other change. Otherwise, compare the two pending trace
@@ -97,6 +102,7 @@ class OtbnTraceChecker : public OtbnTraceListener {
   // MatchPair.
   bool last_data_vld_;
   OtbnIssTraceEntry::IssData last_data_;
+  bool no_sec_wipe_data_chk_;
 };
 
 #endif  // OPENTITAN_HW_IP_OTBN_DV_MODEL_OTBN_TRACE_CHECKER_H_

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.cc
@@ -59,8 +59,8 @@ bool OtbnTraceEntry::from_rtl_trace(const std::string &trace) {
   return true;
 }
 
-bool OtbnTraceEntry::compare_rtl_iss_entries(
-    const OtbnTraceEntry &other) const {
+bool OtbnTraceEntry::compare_rtl_iss_entries(const OtbnTraceEntry &other,
+                                             bool no_sec_wipe_data_chk) const {
   if (hdr_ != other.hdr_)
     return false;
 
@@ -70,7 +70,7 @@ bool OtbnTraceEntry::compare_rtl_iss_entries(
       return false;
     // compare rtlptr.second and isskey.second
     if (!check_entries_compatible(trace_type_, rtlptr.first, rtlptr.second,
-                                  isskey->second))
+                                  isskey->second, no_sec_wipe_data_chk))
       return false;
   }
 
@@ -82,15 +82,18 @@ bool OtbnTraceEntry::compare_rtl_iss_entries(
 bool OtbnTraceEntry::check_entries_compatible(
     trace_type_t type, const std::string &key,
     const std::vector<OtbnTraceBodyLine> &rtl_lines,
-    const std::vector<OtbnTraceBodyLine> &iss_lines) {
+    const std::vector<OtbnTraceBodyLine> &iss_lines,
+    bool no_sec_wipe_data_chk) {
   assert(rtl_lines.size() && iss_lines.size());
   assert(type == WipeComplete || type == Exec);
 
   if (type == WipeComplete && key != "FLAGS0" && key != "FLAGS1") {
     if (rtl_lines.size() != 2)
       return false;
-    if (rtl_lines.front() == rtl_lines.back())
-      return false;
+    if (!no_sec_wipe_data_chk && type == WipeComplete) {
+      if (rtl_lines.front() == rtl_lines.back())
+        return false;
+    }
   }
 
   return rtl_lines.back() == iss_lines.back();

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -54,7 +54,8 @@ class OtbnTraceEntry {
   // message to stderr and return false.
   bool from_rtl_trace(const std::string &trace);
 
-  bool compare_rtl_iss_entries(const OtbnTraceEntry &other) const;
+  bool compare_rtl_iss_entries(const OtbnTraceEntry &other,
+                               bool no_sec_wipe_data_chk) const;
   void print(const std::string &indent, std::ostream &os) const;
 
   void take_writes(const OtbnTraceEntry &other, bool other_first);
@@ -74,7 +75,8 @@ class OtbnTraceEntry {
   static bool check_entries_compatible(
       trace_type_t type, const std::string &key,
       const std::vector<OtbnTraceBodyLine> &rtl_lines,
-      const std::vector<OtbnTraceBodyLine> &iss_lines);
+      const std::vector<OtbnTraceBodyLine> &iss_lines,
+      bool no_sec_wipe_data_chk);
 
  protected:
   static trace_type_t hdr_to_trace_type(const std::string &hdr);

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -14,19 +14,15 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
         super.body();
       end
       begin
-        cfg.clk_rst_vif.wait_clks($urandom_range(10, 100));
-        fork
-          begin
-            uvm_hdl_force("tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d", 'b0);
-          end
-          begin
-            bit [31:0] err_val = 32'd1 << 20;
-            cfg.model_agent_cfg.vif.send_err_escalation(err_val);
-            `uvm_info(`gfn,"injecting zero state error into ISS", UVM_HIGH)
-          end
-        join
-        repeat (3) wait_alert_trigger("fatal", .wait_complete(1));
+        bit [31:0] err_val = 32'd1 << 20;
+        cfg.clk_rst_vif.wait_clks($urandom_range(10, 1000));
+        uvm_hdl_force("tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d", 'b0);
+        cfg.clk_rst_vif.wait_clks(1);
+        cfg.model_agent_cfg.vif.otbn_set_no_sec_wipe_chk();
+        cfg.model_agent_cfg.vif.send_err_escalation(err_val);
+        `uvm_info(`gfn,"injecting zero state error into ISS", UVM_HIGH)
         uvm_hdl_release("tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d");
+        reset_if_locked();
       end
     join
 

--- a/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
+++ b/hw/ip/otbn/dv/uvm/otbn_model_agent/otbn_model_if.sv
@@ -98,6 +98,13 @@ interface otbn_model_if
                     "Failed to set software_errs_fatal", "otbn_model_if")
   endfunction
 
+   function automatic void otbn_set_no_sec_wipe_chk();
+    `uvm_info("otbn_model_if", "writing to no_sec_wipe_data_chk", UVM_HIGH);
+    `DV_CHECK_FATAL(u_model.otbn_set_no_sec_wipe_chk(handle) == 0,
+                    "Failed to set no_sec_wipe_data_chk", "otbn_model_if")
+  endfunction
+
+
   // The err signal is asserted by the model if it fails to find the DUT or if it finds a mismatch
   // in results. It should never go high.
   `ASSERT(NoModelErrs, !err)


### PR DESCRIPTION
This commit fixes multiples issues in otbn_zero_state_err_urnd testcase.

It synchronises error injection time between model and the RTL.
It also disables secure wipe checks when the error is injected while the
otbn is busy executing instructions. Functions have been added to tell
the model to not execute checks to see if secure wiping has written
random data  to all registers before wiping them with zeroes.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>