### PR TITLE
[otbn,rtl] Shuffle timing of some internal signals

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -271,7 +271,7 @@
     { name: "STATUS",
       desc: "Status Register",
       swaccess: "ro",
-      hwaccess: "hrw",
+      hwaccess: "hwo",
       fields: [
         { bits: "7:0",
           name: "status",

--- a/hw/ip/otbn/dv/model/otbn_trace_checker.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_checker.cc
@@ -99,7 +99,7 @@ void OtbnTraceChecker::AcceptTraceString(const std::string &trace,
         seen_err_ = true;
         return;
       }
-      rtl_entry_.take_writes(trace_entry);
+      rtl_entry_.take_writes(trace_entry, false);
     } else {
       // This is the first partial entry. Set the rtl_started_ flag and save
       // trace_entry.
@@ -127,7 +127,7 @@ void OtbnTraceChecker::AcceptTraceString(const std::string &trace,
       return;
     }
 
-    trace_entry.take_writes(rtl_entry_);
+    trace_entry.take_writes(rtl_entry_, true);
   }
 
   rtl_pending_ = true;
@@ -174,7 +174,7 @@ bool OtbnTraceChecker::OnIssTrace(const std::vector<std::string> &lines) {
     // We have some changes associated with a stall. Merge in the changes that
     // we've just seen. We do it "backwards" so that if trace_entry is an
     // final entry then so is the result.
-    trace_entry.take_writes(iss_entry_);
+    trace_entry.take_writes(iss_entry_, true);
   }
 
   iss_started_ = true;

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.cc
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.cc
@@ -105,10 +105,21 @@ void OtbnTraceEntry::print(const std::string &indent, std::ostream &os) const {
   }
 }
 
-void OtbnTraceEntry::take_writes(const OtbnTraceEntry &other) {
+void OtbnTraceEntry::take_writes(const OtbnTraceEntry &other,
+                                 bool other_first) {
   for (const auto &pr : other.writes_) {
-    for (const auto &line : pr.second) {
-      writes_[pr.first].push_back(line);
+    std::vector<OtbnTraceBodyLine> &so_far = writes_[pr.first];
+    if (other_first) {
+      // If other_first is true, we should prepend the writes from other. We do
+      // so by creating a temporary vector (with a copy of the writes from
+      // other) and then appending any writes we had before.
+      std::vector<OtbnTraceBodyLine> tmp(pr.second);
+      tmp.insert(tmp.end(), so_far.begin(), so_far.end());
+      writes_[pr.first] = tmp;
+    } else {
+      // If other_first is false, we should append the writes from other. We
+      // can do that with just a call to insert.
+      so_far.insert(so_far.end(), pr.second.begin(), pr.second.end());
     }
   }
 }

--- a/hw/ip/otbn/dv/model/otbn_trace_entry.h
+++ b/hw/ip/otbn/dv/model/otbn_trace_entry.h
@@ -57,7 +57,7 @@ class OtbnTraceEntry {
   bool compare_rtl_iss_entries(const OtbnTraceEntry &other) const;
   void print(const std::string &indent, std::ostream &os) const;
 
-  void take_writes(const OtbnTraceEntry &other);
+  void take_writes(const OtbnTraceEntry &other, bool other_first);
 
   trace_type_t trace_type() const { return trace_type_; }
 

--- a/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_bind.sv
@@ -31,7 +31,7 @@ module otbn_bind;
     .otbn_dmem_scramble_key_req_busy_i(otbn_dmem_scramble_key_req_busy),
     .otbn_imem_scramble_key_req_busy_i(otbn_imem_scramble_key_req_busy),
 
-    .status_q_i(reg2hw.status.q),
+    .status_q_i(status_q),
 
     .imem_rdata_bus(imem_rdata_bus),
     .dmem_rdata_bus(dmem_rdata_bus)

--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -25,6 +25,20 @@ module otbn_idle_checker
   input logic [ExtWLEN-1:0] dmem_rdata_bus
 );
 
+  // Several of the internal signals that we snoop from the otbn module run "a cycle early". This
+  // lets the design flop some outputs, but we need to do some converting here to get everything to
+  // line up.
+  logic rotating_keys, done;
+  always_ff @(posedge clk_i or negedge rst_ni) begin
+    if (!rst_ni) begin
+      rotating_keys <= 1'b0;
+      done          <= 1'b0;
+    end else begin
+      rotating_keys <= otbn_dmem_scramble_key_req_busy_i | otbn_imem_scramble_key_req_busy_i;
+      done          <= done_i;
+    end
+  end
+
   // Detect writes to CMD. They only take effect if we are in state IDLE
   logic cmd_operation, start_req, do_start;
 
@@ -38,7 +52,7 @@ module otbn_idle_checker
 
   // Our model of whether OTBN is running or not. We start on do_start and stop on done.
   logic running_qq, running_q, running_d;
-  always @(posedge clk_i or negedge rst_ni) begin
+  always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       running_q  <= 1'b0;
       running_qq <= 1'b0;
@@ -47,21 +61,20 @@ module otbn_idle_checker
       running_qq <= running_q;
     end
   end
-  assign running_d = (do_start & ~running_q) | (running_q & ~done_i);
+  assign running_d = (do_start & ~running_q) | (running_q & ~done);
 
-  // We should never see done_i when we're not already running. The converse assertion, that we
-  // never see cmd_start when we are running, need not be true: the host can do that if it likes and
-  // OTBN will ignore it. But we should never see do_start when we think we're running.
-  `ASSERT(RunningIfDone_A, done_i |-> running_q)
+  // We should never see done when we're not already running. The converse assertion, that we never
+  // see cmd_start when we are running, need not be true: the host can do that if it likes and OTBN
+  // will ignore it. But we should never see do_start when we think we're running.
+  `ASSERT(RunningIfDone_A, done |-> running_q)
   `ASSERT(IdleIfStart_A, do_start |-> !running_q)
 
   // Key rotation (used in the logic below) can delay the idle signal. This signal is flopped an
   // extra time to stay "busy" for an extra cycle, so we mirror that here.
-  logic rotating_keys, rotating_keys_q, keys_busy;
-  assign rotating_keys = otbn_dmem_scramble_key_req_busy_i | otbn_imem_scramble_key_req_busy_i;
+  logic rotating_keys_q, keys_busy;
   always @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
-      rotating_keys_q <= 0;
+      rotating_keys_q <= 1'b0;
     end else begin
       rotating_keys_q <= rotating_keys;
     end
@@ -116,6 +129,6 @@ module otbn_idle_checker
   `ASSERT(NotRunningWhenLocked_A,
           !((status_q_i == otbn_pkg::StatusLocked) && running_q))
 
-   `ASSERT(NoMemRdataWhenBusy_A, running_q |-> imem_rdata_bus == 'b0 && dmem_rdata_bus == 'b0)
+  `ASSERT(NoMemRdataWhenBusy_A, running_q |-> imem_rdata_bus == 'b0 && dmem_rdata_bus == 'b0)
 
 endmodule

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -77,7 +77,7 @@ module otbn_top_sim (
 
     .start_i                     ( otbn_start                 ),
     .done_o                      ( otbn_done                  ),
-    .locked_o                    (                            ),
+    .locking_o                   (                            ),
 
     .err_bits_o                  ( core_err_bits              ),
     .recoverable_err_o           (                            ),

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -21,8 +21,8 @@ module otbn_controller
   input logic clk_i,
   input logic rst_ni,
 
-  input  logic start_i,  // start the processing at address zero
-  output logic locked_o, // OTBN in locked state and must be reset to perform any further actions
+  input  logic start_i,   // start the processing at address zero
+  output logic locking_o, // Controller is in or is entering the locked state
 
   input prim_mubi_pkg::mubi4_t escalate_en_i,
   output controller_err_bits_t err_bits_o,
@@ -308,7 +308,7 @@ module otbn_controller
   assign executing = (state_q == OtbnStateRun) ||
                      (state_q == OtbnStateStall);
 
-  assign locked_o = (state_q == OtbnStateLocked) & ~secure_wipe_running_i;
+  assign locking_o = (state_d == OtbnStateLocked) & ~secure_wipe_running_i;
   assign start_secure_wipe_o = executing & (done_complete | err) & ~secure_wipe_running_i;
 
   assign jump_or_branch = (insn_valid_i &
@@ -499,7 +499,7 @@ module otbn_controller
     if (!rst_ni) begin
       err_bits_q <= '0;
     end else begin
-      if (start_i && !locked_o) begin
+      if (start_i && !locking_o) begin
         err_bits_q <= '0;
       end else begin
         err_bits_q <= err_bits_q | err_bits_d;

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -31,9 +31,9 @@ module otbn_core
   input logic clk_i,
   input logic rst_ni,
 
-  input  logic start_i,  // start the operation
-  output logic done_o,   // operation done
-  output logic locked_o, // otbn locked, reset required to perform further commands
+  input  logic start_i,   // start the operation
+  output logic done_o,    // operation done
+  output logic locking_o, // The core is in or is entering the locked state
 
   output core_err_bits_t err_bits_o,  // valid when done_o is asserted
   output logic           recoverable_err_o,
@@ -378,7 +378,7 @@ module otbn_core
     .rst_ni,
 
     .start_i      (controller_start),
-    .locked_o,
+    .locking_o,
 
     .escalate_en_i(controller_escalate_en),
     .err_bits_o   (controller_err_bits),
@@ -540,7 +540,7 @@ module otbn_core
     if (!rst_ni) begin
       err_bits_q <= '0;
     end else begin
-      if (start_i && !locked_o) begin
+      if (start_i && !locking_o) begin
         err_bits_q <= '0;
       end else begin
         err_bits_q <= err_bits_q | err_bits_d;

--- a/hw/ip/otbn/rtl/otbn_reg_pkg.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_pkg.sv
@@ -51,10 +51,6 @@ package otbn_reg_pkg;
   } otbn_reg2hw_ctrl_reg_t;
 
   typedef struct packed {
-    logic [7:0]  q;
-  } otbn_reg2hw_status_reg_t;
-
-  typedef struct packed {
     struct packed {
       logic        q;
       logic        qe;
@@ -241,13 +237,12 @@ package otbn_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    otbn_reg2hw_intr_state_reg_t intr_state; // [124:124]
-    otbn_reg2hw_intr_enable_reg_t intr_enable; // [123:123]
-    otbn_reg2hw_intr_test_reg_t intr_test; // [122:121]
-    otbn_reg2hw_alert_test_reg_t alert_test; // [120:117]
-    otbn_reg2hw_cmd_reg_t cmd; // [116:108]
-    otbn_reg2hw_ctrl_reg_t ctrl; // [107:106]
-    otbn_reg2hw_status_reg_t status; // [105:98]
+    otbn_reg2hw_intr_state_reg_t intr_state; // [116:116]
+    otbn_reg2hw_intr_enable_reg_t intr_enable; // [115:115]
+    otbn_reg2hw_intr_test_reg_t intr_test; // [114:113]
+    otbn_reg2hw_alert_test_reg_t alert_test; // [112:109]
+    otbn_reg2hw_cmd_reg_t cmd; // [108:100]
+    otbn_reg2hw_ctrl_reg_t ctrl; // [99:98]
     otbn_reg2hw_err_bits_reg_t err_bits; // [97:66]
     otbn_reg2hw_insn_cnt_reg_t insn_cnt; // [65:33]
     otbn_reg2hw_load_checksum_reg_t load_checksum; // [32:0]

--- a/hw/ip/otbn/rtl/otbn_reg_top.sv
+++ b/hw/ip/otbn/rtl/otbn_reg_top.sv
@@ -413,7 +413,7 @@ module otbn_reg_top (
 
     // to internal hardware
     .qe     (),
-    .q      (reg2hw.status.q),
+    .q      (),
 
     // to register interface (read)
     .qs     (status_qs)

--- a/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
+++ b/hw/ip/otbn/rtl/otbn_scramble_ctrl.sv
@@ -217,10 +217,10 @@ module otbn_scramble_ctrl
   end
 
   assign otbn_dmem_scramble_key_req_busy_o =
-    (state_q == ScrambleCtrlDmemReq) | dmem_scramble_req_pending_q;
+    (state_d == ScrambleCtrlDmemReq) | dmem_scramble_req_pending_d;
 
   assign otbn_imem_scramble_key_req_busy_o =
-    (state_q == ScrambleCtrlImemReq) | imem_scramble_req_pending_q;
+    (state_d == ScrambleCtrlImemReq) | imem_scramble_req_pending_d;
 
   prim_sync_reqack_data #(
     .Width($bits(otp_ctrl_pkg::otbn_otp_key_rsp_t)-1),

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -177,7 +177,6 @@ module otbn_start_stop_control
       end
       OtbnStartStopSecureWipeComplete: begin
         urnd_advance_o = 1'b1;
-        secure_wipe_running_o = 1'b1;
         state_d = should_lock_d ? OtbnStartStopStateLocked : OtbnStartStopStateHalt;
       end
       OtbnStartStopStateLocked: begin


### PR DESCRIPTION
The first commit is a boring DV bug-fix triggered by the second, whose commit message is below:

The point of this is to allow us to flop the `idle_o` signal (through a
`prim_mubi4_sender`) and the `intr_done_o` signal (by adding a flop to
the `prim_intr_hw` instance).

It turns out that we can do this without changing the external timing
at all. The following signals move forward a cycle:

    locked                           (now called locking)
    otbn_dmem_scramble_key_req_busy
    otbn_imem_scramble_key_req_busy
    idle
    done

and we rename the `is_not_running` signals to have an explicit `_d` and
`_q`. Note that these don't quite line up with the `is_not_running` and
`is_not_running_r` that we had before: `is_not_running_q` is the same
timing as `is_not_running`.
