### PR TITLE
[doc] Upgrade hugo to v0.97.3

### DIFF
--- a/tool_requirements.py
+++ b/tool_requirements.py
@@ -26,7 +26,7 @@ __TOOL_REQUIREMENTS__ = {
         'as_needed': True
     },
     'hugo_extended': {
-        'min_version': '0.82.0',
+        'min_version': '0.97.3',
         'as_needed': True
     },
     'verible': {


### PR DESCRIPTION
This is the latest version. This is downloaded by the `./util/build_docs.py` script so this change should be transparent to most users.