### PR TITLE
[Kmac ] Bring Kmac to S2

### DIFF
--- a/hw/ip/kmac/data/kmac.prj.hjson
+++ b/hw/ip/kmac/data/kmac.prj.hjson
@@ -14,7 +14,7 @@
         life_stage:         "L1",
         design_stage:       "D2S",
         verification_stage: "V2",
-        dif_stage:          "S1",
+        dif_stage:          "S2",
         commit_id:          "54b949255a8c463ea365126d90c39cd26c462638",
       }
     ]

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -813,3 +813,21 @@ dif_result_t dif_kmac_get_error(const dif_kmac_t *kmac,
   *error = mmio_region_read32(kmac->base_addr, KMAC_ERR_CODE_REG_OFFSET);
   return kDifOk;
 }
+
+dif_result_t dif_kmac_reset(const dif_kmac_t *kmac,
+                            dif_kmac_operation_state_t *operation_state) {
+  if (kmac == NULL || operation_state == NULL) {
+    return kDifBadArg;
+  }
+  operation_state->d = 0;
+  operation_state->r = 0;
+  operation_state->offset = 0;
+  operation_state->squeezing = false;
+  uint32_t reg =
+      mmio_region_read32(kmac->base_addr, KMAC_CFG_SHADOWED_REG_OFFSET);
+  reg = bitfield_bit32_write(reg, KMAC_CFG_SHADOWED_ERR_PROCESSED_BIT, 1);
+
+  mmio_region_write32_shadowed(kmac->base_addr, KMAC_CFG_SHADOWED_REG_OFFSET,
+                               reg);
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_kmac.c
+++ b/sw/device/lib/dif/dif_kmac.c
@@ -712,12 +712,7 @@ dif_result_t dif_kmac_squeeze(const dif_kmac_t *kmac,
     }
 
     // Poll the status register until in the 'squeeze' state.
-    while (true) {
-      if (is_state_squeeze(kmac)) {
-        break;
-      }
-      // TODO(#6248): check for error.
-    }
+    DIF_RETURN_IF_ERROR(poll_state(kmac, KMAC_STATUS_SHA3_SQUEEZE_BIT));
 
     uint32_t offset =
         KMAC_STATE_REG_OFFSET + operation_state->offset * sizeof(uint32_t);

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -666,7 +666,11 @@ dif_result_t dif_kmac_end(const dif_kmac_t *kmac,
                           dif_kmac_operation_state_t *operation_state);
 
 /**
- * Get the current error code.
+ * Read the kmac error register to get the error code indicated the interrupt
+ * state.
+ *
+ * This function should be called in case of any of the `start` functions
+ * returns `kDifError`.
  *
  * @param kmac A KMAC handle.
  * @param[out] error The current error code.

--- a/sw/device/lib/dif/dif_kmac.h
+++ b/sw/device/lib/dif/dif_kmac.h
@@ -629,7 +629,7 @@ dif_result_t dif_kmac_absorb(const dif_kmac_t *kmac,
 /**
  * Squeeze bytes into the output buffer provided.
  *
- * Requesting a squeeze operation will prevent any further absorbtion operations
+ * Requesting a squeeze operation will prevent any further absorption operations
  * from taking place.
  *
  * If `kDifKmacIncomplete` is returned then the hardware is currently

--- a/sw/device/lib/dif/dif_kmac.md
+++ b/sw/device/lib/dif/dif_kmac.md
@@ -24,7 +24,7 @@ Tests          | [DIF_TEST_SMOKE][]   | Done        |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
+Implementation | [DIF_FEATURES][]            | Done        |
 Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -964,4 +964,25 @@ TEST_F(KmacSqueezeTest, RequestLessDataThanFixedLenError) {
                              ARRAYSIZE(out_buffer_), nullptr),
             kDifError);
 }
+
+class KmacResetTest : public KmacTest {};
+
+TEST_F(KmacResetTest, Success) {
+  EXPECT_READ32(KMAC_CFG_SHADOWED_REG_OFFSET, 0);
+  EXPECT_WRITE32_SHADOWED(KMAC_CFG_SHADOWED_REG_OFFSET,
+                          {{KMAC_CFG_SHADOWED_ERR_PROCESSED_BIT, true}});
+  EXPECT_DIF_OK(dif_kmac_reset(&kmac_, &op_state_));
+  EXPECT_EQ(op_state_.squeezing, false);
+  EXPECT_EQ(op_state_.append_d, false);
+  EXPECT_EQ(op_state_.offset, 0);
+  EXPECT_EQ(op_state_.r, 0);
+  EXPECT_EQ(op_state_.d, 0);
+}
+
+TEST_F(KmacResetTest, BadArg) {
+  EXPECT_DIF_BADARG(dif_kmac_reset(nullptr, &op_state_));
+
+  EXPECT_DIF_BADARG(dif_kmac_reset(&kmac_, nullptr));
+}
+
 }  // namespace dif_kmac_unittest

--- a/sw/device/lib/dif/dif_kmac_unittest.cc
+++ b/sw/device/lib/dif/dif_kmac_unittest.cc
@@ -717,4 +717,33 @@ TEST_F(KmacStatusTest, BadArg) {
   EXPECT_DIF_BADARG(dif_kmac_get_status(&kmac_, nullptr));
 }
 
+class KmacGetErrorTest : public KmacTest {
+ protected:
+  static constexpr std::array<dif_kmac_error_t, 7> kErrors = {
+      kDifErrorNone,
+      kDifErrorKeyNotValid,
+      kDifErrorSoftwarePushedMessageFifo,
+      kDifErrorSoftwarePushedWrongCommand,
+      kDifErrorEntropyWaitTimerExpired,
+      kDifErrorEntropyModeIncorrect,
+      kDifErrorUnknownError};
+  dif_kmac_error_t error_;
+  KmacGetErrorTest() { op_state_.squeezing = true; }
+};
+constexpr std::array<dif_kmac_error_t, 7> KmacGetErrorTest::kErrors;
+
+TEST_F(KmacGetErrorTest, Success) {
+  for (auto err : kErrors) {
+    EXPECT_READ32(KMAC_ERR_CODE_REG_OFFSET, err);
+    EXPECT_DIF_OK(dif_kmac_get_error(&kmac_, &error_));
+    EXPECT_EQ(error_, err);
+  }
+}
+
+TEST_F(KmacGetErrorTest, BadArg) {
+  EXPECT_DIF_BADARG(dif_kmac_get_error(nullptr, &error_));
+
+  EXPECT_DIF_BADARG(dif_kmac_get_error(&kmac_, nullptr));
+}
+
 }  // namespace dif_kmac_unittest


### PR DESCRIPTION
This PR brings the kmac DIF to S2.
Tests implemented:

- dif_kmac_reset
- dif_kmac_squeeze
- dif_kmac_get_error