### PR TITLE
[otbn, dv] Fixes regression failures in otbn_sec_cm

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_common_vseq.sv
@@ -4,7 +4,7 @@
 
 class otbn_common_vseq extends otbn_base_vseq;
   `uvm_object_utils(otbn_common_vseq)
-
+  bit sb_setting;
   constraint num_trans_c {
     num_trans inside {[1:2]};
   }
@@ -117,11 +117,11 @@ class otbn_common_vseq extends otbn_base_vseq;
     if (enable) begin
       $asserton(0, "tb.dut.u_otbn_core.u_otbn_controller.ControllerStateValid");
       $asserton(0, "tb.MatchingStatus_A");
-      $asserton(0, "tb.dut.u_otbn_core.u_otbn_start_stop_control.StartStopStateValid");
+      $asserton(0, "tb.dut.u_otbn_core.u_otbn_start_stop_control.StartStopStateValid_A");
     end else begin
       $assertoff(0, "tb.dut.u_otbn_core.u_otbn_controller.ControllerStateValid");
       $assertoff(0, "tb.MatchingStatus_A");
-      $assertoff(0, "tb.dut.u_otbn_core.u_otbn_start_stop_control.StartStopStateValid");
+      $assertoff(0, "tb.dut.u_otbn_core.u_otbn_start_stop_control.StartStopStateValid_A");
     end
   endfunction: sec_cm_fi_ctrl_svas
 
@@ -137,5 +137,15 @@ class otbn_common_vseq extends otbn_base_vseq;
       end
     join
   endtask : sec_cm_inject_fault
+
+  virtual task pre_run_sec_cm_fi_vseq();
+    sb_setting = cfg.en_scb;
+    cfg.en_scb = 1;
+  endtask : pre_run_sec_cm_fi_vseq
+
+  virtual task post_run_sec_cm_fi_vseq();
+    cfg.en_scb = sb_setting;
+  endtask : post_run_sec_cm_fi_vseq
+
 
 endclass

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1067,10 +1067,10 @@ module otbn
   `ASSERT_INIT(WsrESizeMatchesParameter_A, $bits(wsr_e) == WsrNumWidth)
 
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnStartStopFsmCheck_A,
-    u_otbn_core.u_otbn_start_stop_control.u_state_regs, alert_tx_o[1])
+    u_otbn_core.u_otbn_start_stop_control.u_state_regs, alert_tx_o[AlertFatal])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnControllerFsmCheck_A,
-    u_otbn_core.u_otbn_controller.u_state_regs, alert_tx_o[1])
+    u_otbn_core.u_otbn_controller.u_state_regs, alert_tx_o[AlertFatal])
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnScrambleCtrlFsmCheck_A,
-    u_otbn_scramble_ctrl.u_state_regs, alert_tx_o[1])
+    u_otbn_scramble_ctrl.u_state_regs, alert_tx_o[AlertFatal])
 
 endmodule


### PR DESCRIPTION
This commit fixes two issues in the otbn_sec_cm testcase.
1. The assertions OtbnStartStopFsmCheck_A, OtbnControllerFsmCheck_A,
and OtbnScrambleCtrlFsmCheck_A were wrongly monitoring the recoverable
alert. Now they're made to monitor fatal alert.
2. The scoreboarding is enabled for otbn_sec_cm test to avoid failures
in wait_for_alert function.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>