### PR TITLE
[sw/silicon_creator] flash_ctrl config mubi cleanups

### DIFF
--- a/sw/device/silicon_creator/lib/boot_data.c
+++ b/sw/device/silicon_creator/lib/boot_data.c
@@ -215,16 +215,18 @@ static rom_error_t boot_data_entry_write(flash_ctrl_info_page_t page,
                                          size_t index,
                                          const boot_data_t *boot_data,
                                          hardened_bool_t erase) {
-  flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
-                                      .read = kHardenedBoolTrue,
-                                      .write = kHardenedBoolTrue,
-                                      .erase = erase,
-                                  });
+  flash_ctrl_info_perms_set(
+      page, (flash_ctrl_perms_t){
+                .read = kMultiBitBool4True,
+                .write = kMultiBitBool4True,
+                .erase = erase == kHardenedBoolTrue ? kMultiBitBool4True
+                                                    : kMultiBitBool4False,
+            });
   rom_error_t error = boot_data_entry_write_impl(page, index, boot_data, erase);
   flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
-                                      .read = kHardenedBoolFalse,
-                                      .write = kHardenedBoolFalse,
-                                      .erase = kHardenedBoolFalse,
+                                      .read = kMultiBitBool4False,
+                                      .write = kMultiBitBool4False,
+                                      .erase = kMultiBitBool4False,
                                   });
   SEC_MMIO_WRITE_INCREMENT(2 * kFlashCtrlSecMmioInfoPermsSet);
   return error;
@@ -255,15 +257,15 @@ static rom_error_t boot_data_entry_invalidate(flash_ctrl_info_page_t page,
       index * sizeof(boot_data_t) + offsetof(boot_data_t, is_valid);
   const uint32_t val[2] = {0, 0};
   flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
-                                      .read = kHardenedBoolFalse,
-                                      .write = kHardenedBoolTrue,
-                                      .erase = kHardenedBoolFalse,
+                                      .read = kMultiBitBool4False,
+                                      .write = kMultiBitBool4True,
+                                      .erase = kMultiBitBool4False,
                                   });
   rom_error_t error = flash_ctrl_info_write(page, offset, 2, val);
   flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
-                                      .read = kHardenedBoolFalse,
-                                      .write = kHardenedBoolFalse,
-                                      .erase = kHardenedBoolFalse,
+                                      .read = kMultiBitBool4False,
+                                      .write = kMultiBitBool4False,
+                                      .erase = kMultiBitBool4False,
                                   });
   SEC_MMIO_WRITE_INCREMENT(2 * kFlashCtrlSecMmioInfoPermsSet);
   return error;
@@ -423,16 +425,16 @@ static rom_error_t boot_data_page_info_update(flash_ctrl_info_page_t page,
                                               active_page_info_t *page_info,
                                               boot_data_t *boot_data) {
   flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
-                                      .read = kHardenedBoolTrue,
-                                      .write = kHardenedBoolFalse,
-                                      .erase = kHardenedBoolFalse,
+                                      .read = kMultiBitBool4True,
+                                      .write = kMultiBitBool4False,
+                                      .erase = kMultiBitBool4False,
                                   });
   rom_error_t error =
       boot_data_page_info_update_impl(page, page_info, boot_data);
   flash_ctrl_info_perms_set(page, (flash_ctrl_perms_t){
-                                      .read = kHardenedBoolFalse,
-                                      .write = kHardenedBoolFalse,
-                                      .erase = kHardenedBoolFalse,
+                                      .read = kMultiBitBool4False,
+                                      .write = kMultiBitBool4False,
+                                      .erase = kMultiBitBool4False,
                                   });
   SEC_MMIO_WRITE_INCREMENT(2 * kFlashCtrlSecMmioInfoPermsSet);
   return error;

--- a/sw/device/silicon_creator/lib/boot_data_functest.c
+++ b/sw/device/silicon_creator/lib/boot_data_functest.c
@@ -46,11 +46,13 @@ boot_data_t kTestBootData = (boot_data_t){
  * @param enable New read, write, and erase permissions.
  */
 static void boot_data_pages_mp_set(hardened_bool_t perm) {
+  multi_bit_bool_t mubi_perm =
+      perm == kHardenedBoolTrue ? kMultiBitBool4True : kMultiBitBool4False;
   for (size_t i = 0; i < ARRAYSIZE(kPages); ++i) {
     flash_ctrl_info_perms_set(kPages[i], (flash_ctrl_perms_t){
-                                             .read = perm,
-                                             .write = perm,
-                                             .erase = perm,
+                                             .read = mubi_perm,
+                                             .write = mubi_perm,
+                                             .erase = mubi_perm,
                                          });
   }
 }

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -469,17 +469,11 @@ void flash_ctrl_data_default_perms_set(flash_ctrl_perms_t perms) {
   // Read first to preserve ECC, scrambling, and high endurance bits.
   uint32_t reg = sec_mmio_read32(kBase + FLASH_CTRL_DEFAULT_REGION_REG_OFFSET);
   reg = bitfield_field32_write(reg, FLASH_CTRL_DEFAULT_REGION_RD_EN_FIELD,
-                               perms.read == kHardenedBoolTrue
-                                   ? kMultiBitBool4True
-                                   : kMultiBitBool4False);
+                               perms.read);
   reg = bitfield_field32_write(reg, FLASH_CTRL_DEFAULT_REGION_PROG_EN_FIELD,
-                               perms.write == kHardenedBoolTrue
-                                   ? kMultiBitBool4True
-                                   : kMultiBitBool4False);
+                               perms.write);
   reg = bitfield_field32_write(reg, FLASH_CTRL_DEFAULT_REGION_ERASE_EN_FIELD,
-                               perms.erase == kHardenedBoolTrue
-                                   ? kMultiBitBool4True
-                                   : kMultiBitBool4False);
+                               perms.erase);
   sec_mmio_write32(kBase + FLASH_CTRL_DEFAULT_REGION_REG_OFFSET, reg);
 }
 
@@ -493,17 +487,11 @@ void flash_ctrl_info_perms_set(flash_ctrl_info_page_t info_page,
   reg = bitfield_field32_write(
       reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_EN_0_FIELD, kMultiBitBool4True);
   reg = bitfield_field32_write(
-      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_RD_EN_0_FIELD,
-      perms.read == kHardenedBoolTrue ? kMultiBitBool4True
-                                      : kMultiBitBool4False);
+      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_RD_EN_0_FIELD, perms.read);
   reg = bitfield_field32_write(
-      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_PROG_EN_0_FIELD,
-      perms.write == kHardenedBoolTrue ? kMultiBitBool4True
-                                       : kMultiBitBool4False);
+      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_PROG_EN_0_FIELD, perms.write);
   reg = bitfield_field32_write(
-      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_ERASE_EN_0_FIELD,
-      perms.erase == kHardenedBoolTrue ? kMultiBitBool4True
-                                       : kMultiBitBool4False);
+      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_ERASE_EN_0_FIELD, perms.erase);
   sec_mmio_write32(cfg_addr, reg);
 }
 
@@ -513,15 +501,11 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg) {
   // Read first to preserve permission bits.
   uint32_t reg = sec_mmio_read32(kBase + FLASH_CTRL_DEFAULT_REGION_REG_OFFSET);
   reg = bitfield_field32_write(reg, FLASH_CTRL_DEFAULT_REGION_SCRAMBLE_EN_FIELD,
-                               cfg.scrambling == kMultiBitBool8True
-                                   ? kMultiBitBool4True
-                                   : kMultiBitBool4False);
-  reg = bitfield_field32_write(
-      reg, FLASH_CTRL_DEFAULT_REGION_ECC_EN_FIELD,
-      cfg.ecc == kMultiBitBool8True ? kMultiBitBool4True : kMultiBitBool4False);
-  reg = bitfield_field32_write(
-      reg, FLASH_CTRL_DEFAULT_REGION_HE_EN_FIELD,
-      cfg.he == kMultiBitBool8True ? kMultiBitBool4True : kMultiBitBool4False);
+                               cfg.scrambling);
+  reg = bitfield_field32_write(reg, FLASH_CTRL_DEFAULT_REGION_ECC_EN_FIELD,
+                               cfg.ecc);
+  reg = bitfield_field32_write(reg, FLASH_CTRL_DEFAULT_REGION_HE_EN_FIELD,
+                               cfg.he);
   sec_mmio_write32(kBase + FLASH_CTRL_DEFAULT_REGION_REG_OFFSET, reg);
 }
 
@@ -536,14 +520,11 @@ void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page,
       reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_EN_0_FIELD, kMultiBitBool4True);
   reg = bitfield_field32_write(
       reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_SCRAMBLE_EN_0_FIELD,
-      cfg.scrambling == kMultiBitBool8True ? kMultiBitBool4True
-                                           : kMultiBitBool4False);
+      cfg.scrambling);
   reg = bitfield_field32_write(
-      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_ECC_EN_0_FIELD,
-      cfg.ecc == kMultiBitBool8True ? kMultiBitBool4True : kMultiBitBool4False);
+      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_ECC_EN_0_FIELD, cfg.ecc);
   reg = bitfield_field32_write(
-      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_HE_EN_0_FIELD,
-      cfg.he == kMultiBitBool8True ? kMultiBitBool4True : kMultiBitBool4False);
+      reg, FLASH_CTRL_BANK0_INFO0_PAGE_CFG_0_HE_EN_0_FIELD, cfg.he);
   sec_mmio_write32(cfg_addr, reg);
 }
 

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -336,27 +336,31 @@ rom_error_t flash_ctrl_info_erase(flash_ctrl_info_page_t info_page,
 
 /**
  * A struct for specifying access permissions.
+ *
+ * flash_ctrl config registers use 4-bits for boolean values. Use
+ * `kMultiBitBool4True` to enable and `kMultiBitBool4False` to disable
+ * permissions.
  */
 typedef struct flash_ctrl_perms {
   /**
    * Read.
    */
-  hardened_bool_t read;
+  multi_bit_bool_t read;
   /**
    * Write.
    */
-  hardened_bool_t write;
+  multi_bit_bool_t write;
   /**
    * Erase.
    */
-  hardened_bool_t erase;
+  multi_bit_bool_t erase;
 } flash_ctrl_perms_t;
 
 /**
  * Sets default access permissions for the data partition.
  *
  * A permission is enabled only if the corresponding field in `perms` is
- * `kHardenedBoolTrue`.
+ * `kMultiBitBool4True`.
  *
  * The caller is responsible for calling
  * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioDataDefaultPermsSet)` when
@@ -370,7 +374,7 @@ void flash_ctrl_data_default_perms_set(flash_ctrl_perms_t perms);
  * Sets access permissions for an info page.
  *
  * A permission is enabled only if the corresponding field in `perms` is
- * `kHardenedBoolTrue`.
+ * `kMultiBitBool4True`.
  *
  * * The caller is responsible for calling
  * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioInfoPermsSet)` when sec_mmio is
@@ -384,6 +388,10 @@ void flash_ctrl_info_perms_set(flash_ctrl_info_page_t info_page,
 
 /**
  * A struct for flash configuration settings.
+ *
+ * flash_ctrl config registers use 4-bits for boolean values. Use
+ * `kMultiBitBool4True` to enable and `kMultiBitBool4False` to disable
+ * these settings.
  */
 typedef struct flash_ctrl_cfg {
   /**


### PR DESCRIPTION
Fields of some flash_ctrl config registers were updated to use 4-bit MUBI values in #11907. This change updates `flash_ctrl_perms_t` and usages of `flash_ctrl_cfg_t` to remove the conversions added in that PR.

Signed-off-by: Alphan Ulusoy <alphan@google.com>