### PR TITLE
[entropy_src/doc] remove TBD with fw process

### DIFF
--- a/hw/ip/entropy_src/data/entropy_src.hjson
+++ b/hw/ip/entropy_src/data/entropy_src.hjson
@@ -1157,7 +1157,7 @@
       hwext: "false",
       fields: [
         { bits: "0",
-          name: "FW_OV_DR_FIFO_OVERFLOW",
+          name: "FW_OV_RD_FIFO_OVERFLOW",
           desc: '''
                 This bit is set by hardware whenever RNG data is lost due to an overflow condition
                 in the Observe FIFO. The RNG data rate is slow enough that firmware should always


### PR DESCRIPTION
Removing a TBD placeholder and adding the description of how
firmware can override the hardware entropy flow.
Fixes #12295.

Signed-off-by: Mark Branstad <mark.branstad@wdc.com>