### PR TITLE
[fpv] Change `stopats` entry to a list

### DIFF
--- a/hw/formal/README.md
+++ b/hw/formal/README.md
@@ -296,7 +296,7 @@ To set up the FPV security check environment, please follow the steps below:
 This entry tells the tcl file to black-box security prim modules in the FPV environment, and define required macros.
 This "task" entry also tells the tcl file to disable regular assertions and only analyze macro defined security assertions with prefix `FpvSecCm`.
 3. Under the item add an entry "stopats" if design has sparse FSMs.
-This is an optional step. If design contains more than one stopat path, user can input them with bracket `stopat: "{path1}, {path2}"`.
+This is an optional step. Because some designs contain more than one stopat path, the entry "stopats" is declared as a list of strings.
 
 Here is an example on csrng module:
 ```
@@ -308,7 +308,7 @@ Here is an example on csrng module:
   rel_path: "hw/ip/csrng/{sub_flow}/{tool}"
   cov: false
   task: "FpvSecCm"
-  stopats: "*u_state_regs.state_o"
+  stopats: ["*u_state_regs.state_o"]
 }
 ```
 

--- a/hw/formal/tools/dvsim/common_fpv_cfg.hjson
+++ b/hw/formal/tools/dvsim/common_fpv_cfg.hjson
@@ -4,13 +4,13 @@
 {
   sub_flow: fpv
   import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_formal_cfg.hjson"]
-  stopats: ""
+  stopats: []
   task: ""
   defines: ""
 
   // Optional vars that need to exported to the env
   exports: [
-    {STOPATS: '{stopats}'},
+    {STOPATS: "'{stopats}'"},
     {TASK:    '{task}'},
     {FPV_DEFINES:  '{defines}'},
   ]

--- a/hw/formal/tools/jaspergold/fpv.tcl
+++ b/hw/formal/tools/jaspergold/fpv.tcl
@@ -55,8 +55,9 @@ if {$env(DUT_TOP) == "prim_count_tb"} {
   elaborate -top $env(DUT_TOP) -enable_sva_isunknown -disable_auto_bbox
 }
 
-if {$env(STOPATS) ne ""} {
-  stopat -env $env(STOPATS)
+set stopat [regexp -all -inline {[^\s\']+} $env(STOPATS)]
+if {$stopat ne ""} {
+  stopat -env $stopat
 }
 
 #-------------------------------------------------------------------------

--- a/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
+++ b/hw/top_earlgrey/formal/top_earlgrey_fpv_cfgs.hjson
@@ -96,7 +96,7 @@
                build_opts: ["-define OutSelDnCnt 0", "-define CntStyle DupCnt"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: false
-               stopats: "*.up_cnt_q[0]"
+               stopats: ["*.up_cnt_q[0]"]
              }
              {
                name: prim_dup_up_count_stopat_cnt1_fpv
@@ -106,7 +106,7 @@
                build_opts: ["-define OutSelDnCnt 0", "-define CntStyle DupCnt"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: false
-               stopats: "*.up_cnt_q[1]"
+               stopats: ["*.up_cnt_q[1]"]
              }
              {
                name: prim_cross_up_count_stopat_upcnt_fpv
@@ -116,7 +116,7 @@
                build_opts: ["-define OutSelDnCnt 0",  "-define CntStyle CrossCnt"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: false
-               stopats: "*.up_cnt_q[0]"
+               stopats: ["*.up_cnt_q[0]"]
              }
              {
                name: prim_cross_up_count_stopat_downcnt_fpv
@@ -126,7 +126,7 @@
                build_opts: ["-define OutSelDnCnt 0",  "-define CntStyle CrossCnt"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
                cov: false
-               stopats: "*.down_cnt"
+               stopats: ["*.down_cnt"]
              }
              {
                name: prim_cross_down_count_stopat_upcnt_fpv
@@ -135,7 +135,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                build_opts: ["-define OutSelDnCnt 1", "-define CntStyle CrossCnt"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
-               stopats: "*.up_cnt_q[0]"
+               stopats: ["*.up_cnt_q[0]"]
                cov: false
              }
              {
@@ -145,7 +145,7 @@
                import_cfgs: ["{proj_root}/hw/formal/tools/dvsim/common_fpv_cfg.hjson"]
                build_opts: ["-define OutSelDnCnt 1", "-define CntStyle CrossCnt"]
                rel_path: "hw/ip/prim/prim_count/{name}/{sub_flow}/{tool}"
-               stopats: "*.down_cnt"
+               stopats: ["*.down_cnt"]
                cov: false
              }
              {
@@ -419,7 +419,7 @@
                rel_path: "hw/ip/aes/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              // TODO: alert_handler does not fire alerts.
              /*
@@ -439,7 +439,7 @@
                rel_path: "hw/ip/csrng/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: edn_sec_cm
@@ -449,7 +449,7 @@
                rel_path: "hw/ip/edn/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: entropy_src_sec_cm
@@ -459,7 +459,7 @@
                rel_path: "hw/ip/entropy_src/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: flash_ctrl_sec_cm
@@ -475,7 +475,7 @@
                  }
                ]
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: keymgr_sec_cm
@@ -485,7 +485,8 @@
                rel_path: "hw/ip/keymgr/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "{*u_state_regs.state_o} {*u_ctrl.u_data_state_regs.state_o}"
+               stopats: ["{*u_state_regs.state_o}",
+                         "{*u_ctrl.u_data_state_regs.state_o}"]
              }
              {
                name: kmac_sec_cm
@@ -495,7 +496,7 @@
                rel_path: "hw/ip/kmac/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: lc_ctrl_sec_cm
@@ -505,7 +506,10 @@
                rel_path: "hw/ip/lc_ctrl/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_lc_ctrl_fsm.u_fsm_state_regs.state_o",
+                         "*u_lc_ctrl_fsm.u_state_regs.state_o",
+                         "*u_lc_ctrl_fsm.u_cnt_regs.state_o",
+                         "*u_lc_ctrl_kmac_if.u_state_regs.state_o"]
              }
              {
                name: otp_ctrl_sec_cm
@@ -515,7 +519,7 @@
                rel_path: "hw/ip/otp_ctrl/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: otbn_sec_cm
@@ -525,7 +529,7 @@
                rel_path: "hw/ip/otbn/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: pwrmgr_sec_cm
@@ -541,7 +545,7 @@
                  }
                ]
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: rom_ctrl_sec_cm
@@ -551,7 +555,7 @@
                rel_path: "hw/ip/rom_ctrl/{sub_flow}/{tool}"
                cov: false
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: rstmgr_sec_cm
@@ -567,7 +571,7 @@
                  }
                ]
                task: "FpvSecCm"
-               stopats: "*u_state_regs.state_o"
+               stopats: ["*u_state_regs.state_o"]
              }
              {
                name: sram_ctrl_sec_cm


### PR DESCRIPTION
Stopats entry was previously declared as a string input.
But lc_ctrl_sec_cm has 4 stopats, which makes it exceed the line limit.
To make it more presentable, I changed the input type to a list of
strings instead.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>