### PR TITLE
[dif/sysrst_ctrl] add build files and some implmenentation

### DIFF
--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -1007,6 +1007,7 @@ cc_library(
     srcs = [
         "autogen/dif_sysrst_ctrl_autogen.c",
         "autogen/dif_sysrst_ctrl_autogen.h",
+        "dif_sysrst_ctrl.c",
     ],
     hdrs = [
         "dif_sysrst_ctrl.h",
@@ -1026,6 +1027,7 @@ cc_test(
     name = "sysrst_ctrl_unittest",
     srcs = [
         "autogen/dif_sysrst_ctrl_autogen_unittest.cc",
+        "dif_sysrst_ctrl_unittest.cc",
     ],
     deps = [
         ":sysrst_ctrl",

--- a/sw/device/lib/dif/dif_sysrst_ctrl.c
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.c
@@ -1,0 +1,71 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+
+#include <assert.h>
+
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sysrst_ctrl_regs.h"  // Generated.
+
+dif_result_t dif_sysrst_ctrl_key_combo_detect_configure(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_key_combo_t key_combo,
+    dif_sysrst_ctrl_key_combo_config_t config) {
+  if (sysrst_ctrl == NULL || config.keys > kDifSysrstCtrlKeyAll ||
+      config.actions > kDifSysrstCtrlKeyComboActionAll) {
+    return kDifBadArg;
+  }
+
+  ptrdiff_t combo_select_ctl_reg_offset;
+  ptrdiff_t combo_detect_ctl_reg_offset;
+  ptrdiff_t combo_action_ctl_reg_offset;
+
+  switch (key_combo) {
+    case kDifSysrstCtrlKeyCombo0:
+      combo_select_ctl_reg_offset = SYSRST_CTRL_COM_SEL_CTL_0_REG_OFFSET;
+      combo_detect_ctl_reg_offset = SYSRST_CTRL_COM_DET_CTL_0_REG_OFFSET;
+      combo_action_ctl_reg_offset = SYSRST_CTRL_COM_OUT_CTL_0_REG_OFFSET;
+      break;
+    case kDifSysrstCtrlKeyCombo1:
+      combo_select_ctl_reg_offset = SYSRST_CTRL_COM_SEL_CTL_1_REG_OFFSET;
+      combo_detect_ctl_reg_offset = SYSRST_CTRL_COM_DET_CTL_1_REG_OFFSET;
+      combo_action_ctl_reg_offset = SYSRST_CTRL_COM_OUT_CTL_1_REG_OFFSET;
+      break;
+    case kDifSysrstCtrlKeyCombo2:
+      combo_select_ctl_reg_offset = SYSRST_CTRL_COM_SEL_CTL_2_REG_OFFSET;
+      combo_detect_ctl_reg_offset = SYSRST_CTRL_COM_DET_CTL_2_REG_OFFSET;
+      combo_action_ctl_reg_offset = SYSRST_CTRL_COM_OUT_CTL_2_REG_OFFSET;
+      break;
+    case kDifSysrstCtrlKeyCombo3:
+      combo_select_ctl_reg_offset = SYSRST_CTRL_COM_SEL_CTL_3_REG_OFFSET;
+      combo_detect_ctl_reg_offset = SYSRST_CTRL_COM_DET_CTL_3_REG_OFFSET;
+      combo_action_ctl_reg_offset = SYSRST_CTRL_COM_OUT_CTL_3_REG_OFFSET;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  if (!mmio_region_read32(sysrst_ctrl->base_addr,
+                          SYSRST_CTRL_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
+  mmio_region_write32(sysrst_ctrl->base_addr, combo_select_ctl_reg_offset,
+                      config.keys);
+  mmio_region_write32(sysrst_ctrl->base_addr, combo_detect_ctl_reg_offset,
+                      config.detection_time_threshold);
+  mmio_region_write32(sysrst_ctrl->base_addr, combo_action_ctl_reg_offset,
+                      config.actions);
+
+  if (config.actions & kDifSysrstCtrlKeyComboActionEcReset) {
+    mmio_region_write32(sysrst_ctrl->base_addr,
+                        SYSRST_CTRL_EC_RST_CTL_REG_OFFSET,
+                        config.embedded_controller_reset_duration);
+  }
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_sysrst_ctrl.h
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.h
@@ -70,6 +70,10 @@ typedef enum dif_sysrst_ctrl_key {
    * AC power preset key.
    */
   kDifSysrstCtrlKeyAcPowerPresent = 1U << 4,
+  /**
+   * All keys ORed together.
+   */
+  kDifSysrstCtrlKeyAll = (1U << 5) - 1,
 } dif_sysrst_ctrl_key_t;
 
 /**
@@ -92,6 +96,10 @@ typedef enum dif_sysrst_ctrl_key_combo_action {
    * Issue a reset request to the reset manager block.
    */
   kDifSysrstCtrlKeyComboActionSelfReset = 1U << 3,
+  /**
+   * All actions.
+   */
+  kDifSysrstCtrlKeyComboActionAll = (1U << 4) - 1,
 } dif_sysrst_ctrl_key_combo_action_t;
 
 /**
@@ -99,10 +107,6 @@ typedef enum dif_sysrst_ctrl_key_combo_action {
  * detection feature.
  */
 typedef struct dif_sysrst_ctrl_key_combo_config {
-  /**
-   * A key combination to configure.
-   */
-  dif_sysrst_ctrl_key_combo_t key_combo;
   /**
    * The keys that comprise the key combination to detect (i.e., one or more
    * `dif_sysrst_ctrl_key_t`s ORed together).
@@ -127,7 +131,7 @@ typedef struct dif_sysrst_ctrl_key_combo_config {
    *
    * Units: increments of 5us; [0, 2^16) represents [10, 200) milliseconds.
    */
-  uint32_t embedded_controller_reset_duration;
+  uint16_t embedded_controller_reset_duration;
 } dif_sysrst_ctrl_key_combo_config_t;
 
 /**
@@ -386,12 +390,13 @@ typedef struct dif_sysrst_ctrl_ulp_wakeup_config_t {
  * Configures a System Reset Controller's key combination detection feature.
  *
  * @param sysrst_ctrl A System Reset Controller handle.
+ * @param key_combo Key combination to configure.
  * @param config Runtime configuration parameters.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_sysrst_ctrl_key_combo_detect_configure(
-    const dif_sysrst_ctrl_t *sysrst_ctrl,
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_key_combo_t key_combo,
     dif_sysrst_ctrl_key_combo_config_t config);
 
 /**

--- a/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_sysrst_ctrl.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/bitfield.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+#include "sw/device/lib/dif/dif_test_base.h"
+
+#include "sysrst_ctrl_regs.h"  // Generated.
+
+namespace dif_sysrst_ctrl_unittest {
+namespace {
+using ::mock_mmio::LeInt;
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+
+class SysrstCtrlTest : public testing::Test, public MmioTest {
+ protected:
+  dif_sysrst_ctrl_t sysrst_ctrl_ = {.base_addr = dev().region()};
+};
+
+class KeyComboDetectConfigTest : public SysrstCtrlTest {
+ protected:
+  dif_sysrst_ctrl_key_combo_config_t config_ = {
+      .keys = kDifSysrstCtrlKey0 | kDifSysrstCtrlKeyPowerButton,
+      .detection_time_threshold = 0x5000,
+      .actions = kDifSysrstCtrlKeyComboActionEcReset,
+      .embedded_controller_reset_duration = 0x100,
+  };
+};
+
+TEST_F(KeyComboDetectConfigTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_key_combo_detect_configure(
+      nullptr, kDifSysrstCtrlKeyCombo1, config_));
+}
+
+TEST_F(KeyComboDetectConfigTest, BadArgs) {
+  // Bad key combination.
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlKeyComboAll, config_));
+
+  // Bad keys.
+  config_.keys = 1U << 5;
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlKeyCombo1, config_));
+
+  // Bad actions.
+  config_.keys = kDifSysrstCtrlKey0 | kDifSysrstCtrlKeyPowerButton,
+  config_.actions = static_cast<dif_sysrst_ctrl_key_combo_action_t>(1U << 5);
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlKeyCombo1, config_));
+}
+
+TEST_F(KeyComboDetectConfigTest, Locked) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_sysrst_ctrl_key_combo_detect_configure(
+                &sysrst_ctrl_, kDifSysrstCtrlKeyCombo1, config_),
+            kDifLocked);
+}
+
+TEST_F(KeyComboDetectConfigTest, SuccessWithoutEcReset) {
+  config_.actions = kDifSysrstCtrlKeyComboActionInterrupt |
+                    kDifSysrstCtrlKeyComboActionBatteryDisable;
+
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(SYSRST_CTRL_COM_SEL_CTL_1_REG_OFFSET, config_.keys);
+  EXPECT_WRITE32(SYSRST_CTRL_COM_DET_CTL_1_REG_OFFSET,
+                 config_.detection_time_threshold);
+  EXPECT_WRITE32(SYSRST_CTRL_COM_OUT_CTL_1_REG_OFFSET, config_.actions);
+
+  EXPECT_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlKeyCombo1, config_));
+}
+
+TEST_F(KeyComboDetectConfigTest, SuccessWithEcReset) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(SYSRST_CTRL_COM_SEL_CTL_1_REG_OFFSET, config_.keys);
+  EXPECT_WRITE32(SYSRST_CTRL_COM_DET_CTL_1_REG_OFFSET,
+                 config_.detection_time_threshold);
+  EXPECT_WRITE32(SYSRST_CTRL_COM_OUT_CTL_1_REG_OFFSET, config_.actions);
+  EXPECT_WRITE32(SYSRST_CTRL_EC_RST_CTL_REG_OFFSET,
+                 config_.embedded_controller_reset_duration);
+
+  EXPECT_DIF_OK(dif_sysrst_ctrl_key_combo_detect_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlKeyCombo1, config_));
+}
+
+}  // namespace
+}  // namespace dif_sysrst_ctrl_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -951,6 +951,7 @@ sw_lib_dif_sysrst_ctrl = declare_dependency(
     'sw_lib_dif_sysrst_ctrl',
     sources: [
       hw_ip_sysrst_ctrl_reg_h,
+      'dif_sysrst_ctrl.c',
     ],
     dependencies: [
       sw_lib_mmio,
@@ -962,7 +963,9 @@ sw_lib_dif_sysrst_ctrl = declare_dependency(
 test('dif_sysrst_ctrl_unittest', executable(
     'dif_sysrst_ctrl_unittest',
     sources: [
+      'dif_sysrst_ctrl_unittest.cc',
       'autogen/dif_sysrst_ctrl_autogen_unittest.cc',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_sysrst_ctrl.c',
       meson.project_source_root() / 'sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c',
       hw_ip_sysrst_ctrl_reg_h,
     ],


### PR DESCRIPTION
This adds the the meson and bazel build files for the sysrst_ctrl DIF.
Additionally the key combination configuration DIF is implemented.

Signed-off-by: Timothy Trippel <ttrippel@google.com>