### PR TITLE
[dv/lc_ctrl] Add stress_all_with_rand_reset test

### DIFF
--- a/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
+++ b/hw/ip/lc_ctrl/dv/env/seq_lib/lc_ctrl_base_vseq.sv
@@ -28,6 +28,7 @@ class lc_ctrl_base_vseq extends cip_base_vseq #(
   endtask
 
   virtual task apply_resets_concurrently(int reset_duration_ps = 0);
+    cfg.otp_vendor_test_status = 0;
     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.trst_n = 0;
     super.apply_resets_concurrently(reset_duration_ps);
     cfg.m_jtag_riscv_agent_cfg.m_jtag_agent_cfg.vif.trst_n = 1;

--- a/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
+++ b/hw/ip/lc_ctrl/dv/lc_ctrl_sim_cfg.hjson
@@ -31,9 +31,8 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson"]
-                // TODO: temp commented out stress_test
-                // "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"
+                "{proj_root}/hw/dv/tools/dvsim/tests/sec_cm_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"]
 
   // Add additional tops for simulation.
   sim_tops: ["lc_ctrl_bind", "lc_ctrl_cov_bind", "sec_cm_prim_sparse_fsm_flop_bind"]
@@ -249,6 +248,10 @@
       run_opts: ["+create_jtag_riscv_map=1"]
     }
 
+    {
+      name: "lc_ctrl_stress_all_with_rand_reset"
+      run_opts: ["+create_jtag_riscv_map=1"]
+    }
   ]
 
   // List of regressions.


### PR DESCRIPTION
This PR adds stress_all_with_rand_reset test to lc_ctrl.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>