### PR TITLE
[spi_device] Fast Read tests in pre_dv

### DIFF
--- a/hw/ip/spi_device/pre_dv/tb/spid_common.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_common.sv
@@ -368,7 +368,7 @@ package spid_common;
       addr_swap_en:     1'b 1,
       mbyte_en:         1'b 0,
       dummy_en:         1'b 1,
-      dummy_size:        'h 1,
+      dummy_size:        'h 2,
       payload_en:       4'b 1111, // MISO
       payload_dir:      PayloadOut,
       payload_swap_en:  1'b 0,

--- a/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
@@ -245,6 +245,25 @@ module tb;
 
     //=========================================================================
     // Issue Read Cmd: Fast Read Cmd
+    $display("Sending Fast Read Command");
+    spiflash_read(
+      tb_sif,
+      8'h 0B,         // opcode
+      32'h 0000_03FF, // address (at the end of a buffer)
+      1'b 0,          // address mode
+      8,              // dummy beat (8 cycles)
+      3,              // Read 3 bytes, should cross the buffer 0 to 1
+      IoSingle,       // io_mode
+      read_data
+    );
+
+    expected_data = get_read_data(SramAw'('h3FF), 3);
+
+    match = check_data(read_data, expected_data);
+    if (match == 1'b 0) test_passed = 1'b 0;
+    read_data.delete();
+    expected_data.delete();
+
     //=========================================================================
     // Issue Read Cmd: Fast Read Dual Output
     //=========================================================================

--- a/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
@@ -266,6 +266,26 @@ module tb;
 
     //=========================================================================
     // Issue Read Cmd: Fast Read Dual Output
+    $display("Sending Fast Read Dual Command");
+    spiflash_read(
+      tb_sif,
+      8'h 3B,         // opcode
+      32'h 0000_0403, // address (at the end of a buffer)
+      1'b 0,          // address mode
+      4,              // dummy beat (4 cycles)
+      7,              // Read 3 bytes, should cross the buffer 0 to 1
+      IoDual,         // io_mode
+      read_data
+    );
+
+    expected_data = get_read_data(SramAw'('h403), 7);
+
+    match = check_data(read_data, expected_data);
+    if (match == 1'b 0) test_passed = 1'b 0;
+    read_data.delete();
+    expected_data.delete();
+
+
     //=========================================================================
     // Issue Read Cmd: Fast Read Quad Output
     //=========================================================================

--- a/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
@@ -162,7 +162,7 @@ module tb;
 
     fork
       begin
-        #20us
+        #40us
         $display("TEST TIMED OUT!!");
         $finish();
       end
@@ -288,6 +288,26 @@ module tb;
 
     //=========================================================================
     // Issue Read Cmd: Fast Read Quad Output
+    $display("Sending Fast Read Quad Command");
+    spiflash_read(
+      tb_sif,
+      8'h 6B,         // opcode
+      32'h 0000_05F3, // address (at the end of a buffer)
+      1'b 0,          // address mode
+      3,              // dummy beat (3 cycles) : non power-of-2
+      32,             // Read 32 bytes
+      IoQuad,         // io_mode
+      read_data
+    );
+
+    expected_data = get_read_data(SramAw'('h5F3), 32);
+
+    match = check_data(read_data, expected_data);
+    if (match == 1'b 0) test_passed = 1'b 0;
+    read_data.delete();
+    expected_data.delete();
+
+
     //=========================================================================
     // Issue Read Cmd: Fast Read Dual Mis-aligned
     //=========================================================================


### PR DESCRIPTION
This PR contains #12317 #12341 #12355. Please review last three commits.

This PR adds Fast Read, Fast Read Dual, Fast Read Quad to `spid_readcmd` pre_dv tests. In Fast Read Quad test, it tests the non-byte size dummy cycle (3 cycles in this case), which needs #12355 