### PR TITLE
[dif/sysrst_ctrl] implement remaining config DIFs

### DIFF
--- a/sw/device/lib/dif/dif_sysrst_ctrl.c
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.c
@@ -69,3 +69,156 @@ dif_result_t dif_sysrst_ctrl_key_combo_detect_configure(
 
   return kDifOk;
 }
+
+dif_result_t dif_sysrst_ctrl_input_change_detect_configure(
+    const dif_sysrst_ctrl_t *sysrst_ctrl,
+    dif_sysrst_ctrl_input_change_config_t config) {
+  if (sysrst_ctrl == NULL || config.input_changes & (1U << 7) ||
+      config.input_changes > kDifSysrstCtrlInputAll) {
+    return kDifBadArg;
+  }
+
+  if (!mmio_region_read32(sysrst_ctrl->base_addr,
+                          SYSRST_CTRL_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_KEY_INTR_CTL_REG_OFFSET,
+                      config.input_changes);
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_KEY_INTR_DEBOUNCE_CTL_REG_OFFSET,
+                      config.debounce_time_threshold);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_output_pin_override_configure(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_t output_pin,
+    dif_sysrst_ctrl_pin_config_t config) {
+  if (sysrst_ctrl == NULL ||
+      (config.override_value == true && config.allow_one == false) ||
+      (config.override_value == false && config.allow_zero == false) ||
+      !dif_is_valid_toggle(config.enabled)) {
+    return kDifBadArg;
+  }
+
+  uint32_t pin_out_ctl_bit_index;
+  uint32_t pin_out_value_bit_index;
+  uint32_t pin_out_allow_0_bit_index;
+  uint32_t pin_out_allow_1_bit_index;
+
+  switch (output_pin) {
+    case kDifSysrstCtrlPinKey0Out:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_KEY0_OUT_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_KEY0_OUT_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_KEY0_OUT_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_KEY0_OUT_1_BIT;
+      break;
+    case kDifSysrstCtrlPinKey1Out:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_KEY1_OUT_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_KEY1_OUT_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_KEY1_OUT_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_KEY1_OUT_1_BIT;
+      break;
+    case kDifSysrstCtrlPinKey2Out:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_KEY2_OUT_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_KEY2_OUT_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_KEY2_OUT_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_KEY2_OUT_1_BIT;
+      break;
+    case kDifSysrstCtrlPinPowerButtonOut:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_PWRB_OUT_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_PWRB_OUT_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_PWRB_OUT_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_PWRB_OUT_1_BIT;
+      break;
+    case kDifSysrstCtrlPinBatteryDisableOut:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_BAT_DISABLE_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_BAT_DISABLE_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_BAT_DISABLE_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_BAT_DISABLE_1_BIT;
+      break;
+    case kDifSysrstCtrlPinZ3WakeupOut:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_Z3_WAKEUP_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_Z3_WAKEUP_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_Z3_WAKEUP_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_Z3_WAKEUP_1_BIT;
+      break;
+    case kDifSysrstCtrlPinEcResetInOut:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_EC_RST_L_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_EC_RST_L_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_EC_RST_L_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_EC_RST_L_1_BIT;
+      break;
+    case kDifSysrstCtrlPinFlashWriteProtectInOut:
+      pin_out_ctl_bit_index = SYSRST_CTRL_PIN_OUT_CTL_FLASH_WP_L_BIT;
+      pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_FLASH_WP_L_BIT;
+      pin_out_allow_0_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_FLASH_WP_L_0_BIT;
+      pin_out_allow_1_bit_index = SYSRST_CTRL_PIN_ALLOWED_CTL_FLASH_WP_L_1_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  if (!mmio_region_read32(sysrst_ctrl->base_addr,
+                          SYSRST_CTRL_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
+  // Configure output pin control register.
+  uint32_t pin_out_ctl_reg = mmio_region_read32(
+      sysrst_ctrl->base_addr, SYSRST_CTRL_PIN_OUT_CTL_REG_OFFSET);
+  pin_out_ctl_reg = bitfield_bit32_write(pin_out_ctl_reg, pin_out_ctl_bit_index,
+                                         dif_toggle_to_bool(config.enabled));
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_PIN_OUT_CTL_REG_OFFSET, pin_out_ctl_reg);
+
+  // Configure output pin override value register.
+  uint32_t pin_out_value_reg = mmio_region_read32(
+      sysrst_ctrl->base_addr, SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET);
+  pin_out_value_reg = bitfield_bit32_write(
+      pin_out_value_reg, pin_out_value_bit_index, config.override_value);
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET, pin_out_value_reg);
+
+  // Configure output pin allowed values register.
+  uint32_t pin_out_allowed_values_reg = mmio_region_read32(
+      sysrst_ctrl->base_addr, SYSRST_CTRL_PIN_ALLOWED_CTL_REG_OFFSET);
+  pin_out_allowed_values_reg = bitfield_bit32_write(
+      pin_out_allowed_values_reg, pin_out_allow_0_bit_index, config.allow_zero);
+  pin_out_allowed_values_reg = bitfield_bit32_write(
+      pin_out_allowed_values_reg, pin_out_allow_1_bit_index, config.allow_one);
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_PIN_ALLOWED_CTL_REG_OFFSET,
+                      pin_out_allowed_values_reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_ulp_wakeup_configure(
+    const dif_sysrst_ctrl_t *sysrst_ctrl,
+    dif_sysrst_ctrl_ulp_wakeup_config_t config) {
+  if (sysrst_ctrl == NULL || !dif_is_valid_toggle(config.enabled)) {
+    return kDifBadArg;
+  }
+
+  if (!mmio_region_read32(sysrst_ctrl->base_addr,
+                          SYSRST_CTRL_REGWEN_REG_OFFSET)) {
+    return kDifLocked;
+  }
+
+  mmio_region_write32(sysrst_ctrl->base_addr, SYSRST_CTRL_ULP_CTL_REG_OFFSET,
+                      dif_toggle_to_bool(config.enabled));
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_ULP_AC_DEBOUNCE_CTL_REG_OFFSET,
+                      config.ac_power_debounce_time_threshold);
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_ULP_LID_DEBOUNCE_CTL_REG_OFFSET,
+                      config.lid_open_debounce_time_threshold);
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_ULP_PWRB_DEBOUNCE_CTL_REG_OFFSET,
+                      config.power_button_debounce_time_threshold);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_sysrst_ctrl.h
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.h
@@ -194,6 +194,10 @@ typedef enum dif_sysrst_ctrl_input_change {
    * Flash write protect input signal low-to-high.
    */
   kDifSysrstCtrlInputFlashWriteProtectL2H = 1U << 14,
+  /**
+   * All input signal transitions.
+   */
+  kDifSysrstCtrlInputAll = ((1U << 15) - 1) & ~(1U << 7),
 } dif_sysrst_ctrl_input_change_t;
 
 /**
@@ -315,7 +319,7 @@ typedef enum dif_sysrst_ctrl_pin {
   /**
    * Flash write protect inout.
    */
-  kDifSysrstCtrlPinFlashWriteProtectInOut = 1U << 12,
+  kDifSysrstCtrlPinFlashWriteProtectInOut = 1U << 13,
 } dif_sysrst_ctrl_pin_t;
 
 /**
@@ -324,13 +328,9 @@ typedef enum dif_sysrst_ctrl_pin {
  */
 typedef struct dif_sysrst_ctrl_pin_config_t {
   /**
-   * The output pin whose override feature to configure.
-   */
-  dif_sysrst_ctrl_pin_t output_pin;
-  /**
    * The enablement of the output pin's override feature.
    */
-  dif_toggle_t output_override_enabled;
+  dif_toggle_t enabled;
   /**
    * Whether to allow overriding the output pin with a value of 0.
    */
@@ -364,6 +364,10 @@ typedef struct dif_sysrst_ctrl_pin_config_t {
  */
 typedef struct dif_sysrst_ctrl_ulp_wakeup_config_t {
   /**
+   * The enablement of the ULP wakeup feature.
+   */
+  dif_toggle_t enabled;
+  /**
    * The time to allow the AC Power present signal to stabilize before
    * reevaluating its value to decide whether it was activated.
    *
@@ -376,7 +380,7 @@ typedef struct dif_sysrst_ctrl_ulp_wakeup_config_t {
    *
    * Units: increments of 5us; [0, 2^16) represents [10, 200) milliseconds.
    */
-  uint16_t lib_open_debounce_time_threshold;
+  uint16_t lid_open_debounce_time_threshold;
   /**
    * The time to allow the Power Button signal to stabilize before reevaluating
    * its value to decide whether it was pressed.
@@ -416,28 +420,29 @@ dif_result_t dif_sysrst_ctrl_input_change_detect_configure(
  *
  * Note, only output (or inout) pins may be overriden, i.e., set to a specific
  * value. Attempting to configure the override feature for input pins will
- * return `kDifError`.
+ * return `kDifBadArg`.
  *
  * @param sysrst_ctrl A System Reset Controller handle.
+ * @param output_pin Output pin to configure.
  * @param config Output pin override configuration parameters.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_sysrst_ctrl_output_pin_override_configure(
-    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_config_t config);
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_t output_pin,
+    dif_sysrst_ctrl_pin_config_t config);
 
 /**
  * Configures a System Reset Controller's ultra-low-power (ULP) wakeup feature.
  *
  * @param sysrst_ctrl A System Reset Controller handle.
  * @param config Runtime configuration parameters.
- * @param enabled The enablement state to configure the ULP wakeup feature in.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_sysrst_ctrl_ulp_wakeup_configure(
     const dif_sysrst_ctrl_t *sysrst_ctrl,
-    dif_sysrst_ctrl_ulp_wakeup_config_t config, dif_toggle_t enabled);
+    dif_sysrst_ctrl_ulp_wakeup_config_t config);
 
 /**
  * Sets the enablement state of a System Reset Controller's ultra-low-power

--- a/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
@@ -89,5 +89,156 @@ TEST_F(KeyComboDetectConfigTest, SuccessWithEcReset) {
       &sysrst_ctrl_, kDifSysrstCtrlKeyCombo1, config_));
 }
 
+class InputChangeDetectConfigTest : public SysrstCtrlTest {
+ protected:
+  dif_sysrst_ctrl_input_change_config_t config_ = {
+      .input_changes = kDifSysrstCtrlInputAll,
+      .debounce_time_threshold = 0x1000,
+  };
+};
+
+TEST_F(InputChangeDetectConfigTest, NullArgs) {
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_detect_configure(nullptr, config_));
+}
+
+TEST_F(InputChangeDetectConfigTest, BadArgs) {
+  // Bad input signal changes.
+  config_.input_changes = static_cast<dif_sysrst_ctrl_input_change_t>(1U << 7);
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl_, config_));
+  config_.input_changes = static_cast<dif_sysrst_ctrl_input_change_t>(1U << 15);
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl_, config_));
+}
+
+TEST_F(InputChangeDetectConfigTest, Locked) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(
+      dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl_, config_),
+      kDifLocked);
+}
+
+TEST_F(InputChangeDetectConfigTest, Success) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(SYSRST_CTRL_KEY_INTR_CTL_REG_OFFSET, config_.input_changes);
+  EXPECT_WRITE32(SYSRST_CTRL_KEY_INTR_DEBOUNCE_CTL_REG_OFFSET,
+                 config_.debounce_time_threshold);
+  EXPECT_DIF_OK(
+      dif_sysrst_ctrl_input_change_detect_configure(&sysrst_ctrl_, config_));
+}
+
+class OutputPinOverrideConfigTest : public SysrstCtrlTest {
+ protected:
+  dif_sysrst_ctrl_pin_config_t config_ = {
+      .enabled = kDifToggleEnabled,
+      .allow_zero = true,
+      .allow_one = true,
+      .override_value = true,
+  };
+};
+
+TEST_F(OutputPinOverrideConfigTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_override_configure(
+      nullptr, kDifSysrstCtrlPinBatteryDisableOut, config_));
+}
+
+TEST_F(OutputPinOverrideConfigTest, BadArgs) {
+  // Bad pin.
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_override_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey0In, config_));
+
+  // Bad enabled.
+  config_.enabled = static_cast<dif_toggle_t>(2);
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_override_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey0Out, config_));
+
+  // Bad allow values.
+  config_ = {
+      .enabled = kDifToggleEnabled,
+      .allow_zero = false,
+      .allow_one = true,
+      .override_value = false,
+  };
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_override_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlPinBatteryDisableOut, config_));
+  config_ = {
+      .enabled = kDifToggleEnabled,
+      .allow_zero = true,
+      .allow_one = false,
+      .override_value = true,
+  };
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_override_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlPinBatteryDisableOut, config_));
+}
+
+TEST_F(OutputPinOverrideConfigTest, Locked) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_sysrst_ctrl_output_pin_override_configure(
+                &sysrst_ctrl_, kDifSysrstCtrlPinBatteryDisableOut, config_),
+            kDifLocked);
+}
+
+TEST_F(OutputPinOverrideConfigTest, Success) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_READ32(SYSRST_CTRL_PIN_OUT_CTL_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_OUT_CTL_Z3_WAKEUP_BIT, 1}});
+  EXPECT_WRITE32(SYSRST_CTRL_PIN_OUT_CTL_REG_OFFSET,
+                 {{SYSRST_CTRL_PIN_OUT_CTL_BAT_DISABLE_BIT, 1},
+                  {SYSRST_CTRL_PIN_OUT_CTL_Z3_WAKEUP_BIT, 1}});
+  EXPECT_READ32(SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_OUT_VALUE_Z3_WAKEUP_BIT, 1}});
+  EXPECT_WRITE32(SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET,
+                 {{SYSRST_CTRL_PIN_OUT_VALUE_BAT_DISABLE_BIT, 1},
+                  {SYSRST_CTRL_PIN_OUT_VALUE_Z3_WAKEUP_BIT, 1}});
+  EXPECT_READ32(SYSRST_CTRL_PIN_ALLOWED_CTL_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_ALLOWED_CTL_Z3_WAKEUP_0_BIT, 1}});
+  EXPECT_WRITE32(SYSRST_CTRL_PIN_ALLOWED_CTL_REG_OFFSET,
+                 {{SYSRST_CTRL_PIN_ALLOWED_CTL_Z3_WAKEUP_0_BIT, 1},
+                  {SYSRST_CTRL_PIN_ALLOWED_CTL_BAT_DISABLE_0_BIT, 1},
+                  {SYSRST_CTRL_PIN_ALLOWED_CTL_BAT_DISABLE_1_BIT, 1}});
+  EXPECT_DIF_OK(dif_sysrst_ctrl_output_pin_override_configure(
+      &sysrst_ctrl_, kDifSysrstCtrlPinBatteryDisableOut, config_));
+}
+
+class UlpWakeupConfigTest : public SysrstCtrlTest {
+ protected:
+  dif_sysrst_ctrl_ulp_wakeup_config_t config_ = {
+      .enabled = kDifToggleEnabled,
+      .ac_power_debounce_time_threshold = 0x100,
+      .lid_open_debounce_time_threshold = 0x200,
+      .power_button_debounce_time_threshold = 0x300,
+  };
+};
+
+TEST_F(UlpWakeupConfigTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_ulp_wakeup_configure(nullptr, config_));
+}
+
+TEST_F(UlpWakeupConfigTest, BadArgs) {
+  // Bad enabled.
+  config_.enabled = static_cast<dif_toggle_t>(2);
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_ulp_wakeup_configure(&sysrst_ctrl_, config_));
+}
+
+TEST_F(UlpWakeupConfigTest, Locked) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_EQ(dif_sysrst_ctrl_ulp_wakeup_configure(&sysrst_ctrl_, config_),
+            kDifLocked);
+}
+
+TEST_F(UlpWakeupConfigTest, Success) {
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_WRITE32(SYSRST_CTRL_ULP_CTL_REG_OFFSET, 1);
+  EXPECT_WRITE32(SYSRST_CTRL_ULP_AC_DEBOUNCE_CTL_REG_OFFSET,
+                 config_.ac_power_debounce_time_threshold);
+  EXPECT_WRITE32(SYSRST_CTRL_ULP_LID_DEBOUNCE_CTL_REG_OFFSET,
+                 config_.lid_open_debounce_time_threshold);
+  EXPECT_WRITE32(SYSRST_CTRL_ULP_PWRB_DEBOUNCE_CTL_REG_OFFSET,
+                 config_.power_button_debounce_time_threshold);
+  EXPECT_DIF_OK(dif_sysrst_ctrl_ulp_wakeup_configure(&sysrst_ctrl_, config_));
+}
+
 }  // namespace
 }  // namespace dif_sysrst_ctrl_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -956,6 +956,7 @@ sw_lib_dif_sysrst_ctrl = declare_dependency(
     dependencies: [
       sw_lib_mmio,
       sw_lib_dif_autogen_sysrst_ctrl,
+      sw_lib_dif_base,
     ],
   )
 )
@@ -965,6 +966,7 @@ test('dif_sysrst_ctrl_unittest', executable(
     sources: [
       'dif_sysrst_ctrl_unittest.cc',
       'autogen/dif_sysrst_ctrl_autogen_unittest.cc',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_base.c',
       meson.project_source_root() / 'sw/device/lib/dif/dif_sysrst_ctrl.c',
       meson.project_source_root() / 'sw/device/lib/dif/autogen/dif_sysrst_ctrl_autogen.c',
       hw_ip_sysrst_ctrl_reg_h,


### PR DESCRIPTION
This implements the remaining configuration DIFs for the sysrst_ctrl.

Signed-off-by: Timothy Trippel <ttrippel@google.com>

**_Note: this depends on #12359._**