### PR TITLE
[dv] Add `-xprop=mmsopt` run-opt for VCS

### DIFF
--- a/hw/dv/tools/dvsim/vcs.hjson
+++ b/hw/dv/tools/dvsim/vcs.hjson
@@ -301,7 +301,9 @@
     {
       name: vcs_xprop
       is_sim_mode: 1
-      build_opts: ["-xprop={dv_root}/tools/vcs/xprop.cfg"]
+      build_opts: ["-xprop={dv_root}/tools/vcs/xprop.cfg",
+                   // Enable xmerge mode specific performance optimization
+                   "-xprop=mmsopt"]
     }
     {
       name: vcs_profile

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -34,20 +34,7 @@
                 "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
                 "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"],
 
-  // TODO, #11245. Remove this when the VCS issue is fixed
-  build_modes: [
-    {
-      name: vcs_ip_build_opts
-      build_opts: ["-xprop=mmsopt"]
-    }
-    {
-      name: xcelium_ip_build_opts
-    }
-  ]
-
-  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts",
-                   "{tool}_ip_build_opts"]
-
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
   // Flash references pwrmgr directly, need to reference the top version
   overrides: [
     {


### PR DESCRIPTION
This option can significantly improve some flash_ctrl test in both block
and chip-level.
It was removed due to a tool issue #11245. now the issue is fixed in vcs-2021-09-sp2-1

Need CI to use `vcs-2021-09-sp2-1` before we merge this PR

Signed-off-by: Weicai Yang <weicai@google.com>