### PR TITLE
[primgen] Sort the parameters to ensure stable order 

### DIFF
--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -135,8 +135,8 @@ def _parse_module_header_verible(generic_impl_filepath, module_name):
     parameters_list = header.find({"tag": "kFormalParameterList"})
     parameters = set()
     if parameters_list:
-        for parameter in parameters_list.iter_find_all(
-                {"tag": "kParamDeclaration"}):
+        for parameter in sorted(
+                parameters_list.iter_find_all({"tag": "kParamDeclaration"})):
             if parameter.find({"tag": "parameter"}):
                 parameter_id = parameter.find(
                     {"tag": ["SymbolIdentifier", "EscapedIdentifier"]})


### PR DESCRIPTION
First commit only fixes style errors.

The 2nd commit sorts the parameter to ensure the order.
Otherwise, we will see the generated code is different if python version is changed.
![Screen Shot 2022-04-27 at 4 15 06 PM](https://user-images.githubusercontent.com/49293026/165692813-a6e10988-e7cc-4a40-835d-0da971333b8c.png)

Not sure if this affects simulation reproducibility. But it's good to always generate the same RTL code.
