### PR TITLE
[doc] Make Hugo server not watch for changes to fix local previews.

### DIFF
--- a/util/build_docs.py
+++ b/util/build_docs.py
@@ -436,6 +436,10 @@ def invoke_hugo(preview, bind_wan, hugo_opts, hugo_bin_path):
         str(SRCTREE_TOP),
         "--layoutDir",
         layout_dir,
+        # This option is needed because otherwise Hugo hangs trying to follow
+        # Bazel symlinks (even though they're in config.toml's ignoreFiles):
+        # see https://github.com/lowRISC/opentitan/issues/12322 for details.
+        "--watch=false",
     ]
     if preview:
         args += ["server"]


### PR DESCRIPTION
Resolves #12322 

New symlinks introduced by the Bazel migration were causing Hugo to hang on local previews because (it looks like) the procedure that watches files for changes doesn't ignore symlinks listed in the configuration's `ignoreFiles`. This passes `--watch=false` to Hugo server to avoid that issue (at the unfortunate cost of local previews no longer automatically
updating).

I've filed a bug with Hugo to see if we can get a nicer fix, like the watch procedure ignoring the things in `ignoreFiles`: https://github.com/gohugoio/hugo/issues/9838