### PR TITLE
[flash_ctrl] DEBUG and ENABLE the OTP_MODEL

### DIFF
--- a/hw/ip/flash_ctrl/dv/tb/tb.sv
+++ b/hw/ip/flash_ctrl/dv/tb/tb.sv
@@ -72,19 +72,11 @@ module tb;
   assign flash_ctrl_if.otp_req.addr_req = otp_req.addr_req;
   assign flash_ctrl_if.otp_req.data_req = otp_req.data_req;
 
-  // TODO: The otp request/response interface for keys needs to be
-  // propertly emulated, otherwise the flash hardware fsm will get stuck
-  assign flash_ctrl_if.otp_rsp = '{
-    default: '0,
-    data_ack: otp_req.data_req,
-    addr_ack: otp_req.addr_req
-  };
-
-  assign otp_rsp.addr_ack               = flash_ctrl_if.otp_rsp.addr_ack;
-  assign otp_rsp.data_ack               = flash_ctrl_if.otp_rsp.data_ack;
-  assign otp_rsp.key                    = flash_ctrl_if.otp_rsp.key;
-  assign otp_rsp.rand_key               = flash_ctrl_if.otp_rsp.rand_key;
-  assign otp_rsp.seed_valid             = flash_ctrl_if.otp_rsp.seed_valid;
+  assign otp_rsp.addr_ack   = flash_ctrl_if.otp_rsp.addr_ack;
+  assign otp_rsp.data_ack   = flash_ctrl_if.otp_rsp.data_ack;
+  assign otp_rsp.key        = flash_ctrl_if.otp_rsp.key;
+  assign otp_rsp.rand_key   = flash_ctrl_if.otp_rsp.rand_key;
+  assign otp_rsp.seed_valid = flash_ctrl_if.otp_rsp.seed_valid;
 
   wire flash_test_v;
   assign (pull1, pull0) flash_test_v = 1'b1;


### PR DESCRIPTION
For some reason, the OTP_MODEL in the Testbench had been commented out.  This
left the acknowledge signals floating, and hence the otp interface locked up.
I have reviewed the otp_model, and have re-enabled it.  This is now working
with the test flash_ctrl_hw_sec_otp, and is and is safe to be present in all
other tests.  The otp_model is accessed through a vif between TB and the base
sequence.  The model provides random otp keys on demand.

Signed-off-by: TIM EWINS <tim.ewins@ensilica.com>