### PR TITLE
[spi_device] Attenuate watermark event when Not Active

### DIFF
--- a/hw/ip/spi_device/rtl/spid_readbuffer.sv
+++ b/hw/ip/spi_device/rtl/spid_readbuffer.sv
@@ -146,7 +146,7 @@ module spid_readbuffer #(
     end
   end
 
-  assign event_watermark_o = !watermark_crossed && watermark_cross ;
+  assign event_watermark_o = active && !watermark_crossed && watermark_cross ;
 
   ///////////////////
   // State Machine //


### PR DESCRIPTION
This commit fixes the logic error that generates the watermark event
even the address does not target the Read buffer.

It was due to the event_watermark raises the signal regardless of the
`active` condition.

Related issue: #12382