### PR TITLE
[third_party/rust] fix Cargo workspace path

### DIFF
--- a/third_party/rust/crates/Cargo.toml
+++ b/third_party/rust/crates/Cargo.toml
@@ -55,7 +55,7 @@ zerocopy = "0.5.0"
 safe-ftdi = { git = "https://github.com/cr1901/safe-ftdi" }
 
 [workspace.metadata.raze]
-workspace_path = "//third_party/cargo"
+workspace_path = "//third_party/rust/crates"
 experimental_api = true
 package_aliases_dir = "."
 genmode = "Remote"
@@ -67,6 +67,6 @@ targets = [
 [package.metadata.raze.crates.libudev-sys.'0.1.4']
 gen_buildrs = true
 patches = [
-    "@//third_party/cargo/patches:libudev-sys-0.1.4.patch"
+    "@//third_party/rust/crates/patches:libudev-sys-0.1.4.patch"
 ]
 patch_args = ["-p1"]

--- a/third_party/rust/crates/remote/BUILD.CoreFoundation-sys-0.1.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.CoreFoundation-sys-0.1.4.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.IOKit-sys-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.IOKit-sys-0.1.5.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.addr2line-0.17.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.addr2line-0.17.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.adler-1.0.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.adler-1.0.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.aho-corasick-0.7.18.bazel
+++ b/third_party/rust/crates/remote/BUILD.aho-corasick-0.7.18.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.ansi_term-0.12.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.ansi_term-0.12.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.anyhow-1.0.57.bazel
+++ b/third_party/rust/crates/remote/BUILD.anyhow-1.0.57.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.atty-0.2.14.bazel
+++ b/third_party/rust/crates/remote/BUILD.atty-0.2.14.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.autocfg-0.1.8.bazel
+++ b/third_party/rust/crates/remote/BUILD.autocfg-0.1.8.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.autocfg-1.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.autocfg-1.1.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.backtrace-0.3.65.bazel
+++ b/third_party/rust/crates/remote/BUILD.backtrace-0.3.65.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.bitflags-1.3.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.bitflags-1.3.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.block-buffer-0.10.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.block-buffer-0.10.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.byteorder-1.4.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.byteorder-1.4.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.cc-1.0.73.bazel
+++ b/third_party/rust/crates/remote/BUILD.cc-1.0.73.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.cfg-if-0.1.10.bazel
+++ b/third_party/rust/crates/remote/BUILD.cfg-if-0.1.10.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.cfg-if-1.0.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.clap-2.34.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.clap-2.34.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.console-0.15.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.console-0.15.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.cpufeatures-0.2.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.cpufeatures-0.2.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.crc32fast-1.3.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.crc32fast-1.3.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.crypto-common-0.1.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.crypto-common-0.1.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.ctor-0.1.22.bazel
+++ b/third_party/rust/crates/remote/BUILD.ctor-0.1.22.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.derive_more-0.14.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.derive_more-0.14.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.deser-hjson-1.0.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.deser-hjson-1.0.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.digest-0.10.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.digest-0.10.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.directories-4.0.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.directories-4.0.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.dirs-sys-0.3.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.dirs-sys-0.3.7.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.encode_unicode-0.3.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.encode_unicode-0.3.6.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.env_logger-0.8.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.env_logger-0.8.4.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.erased-serde-0.3.20.bazel
+++ b/third_party/rust/crates/remote/BUILD.erased-serde-0.3.20.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.flate2-1.0.23.bazel
+++ b/third_party/rust/crates/remote/BUILD.flate2-1.0.23.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.generic-array-0.14.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.generic-array-0.14.5.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.getrandom-0.2.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.getrandom-0.2.6.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.ghost-0.1.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.ghost-0.1.4.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.gimli-0.26.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.gimli-0.26.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.heck-0.3.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.heck-0.3.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.hermit-abi-0.1.19.bazel
+++ b/third_party/rust/crates/remote/BUILD.hermit-abi-0.1.19.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.hex-0.4.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.hex-0.4.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.humantime-2.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.humantime-2.1.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.indicatif-0.16.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.indicatif-0.16.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.inventory-0.2.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.inventory-0.2.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.itoa-1.0.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.itoa-1.0.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.lazy_static-1.4.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.lazy_static-1.4.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.libc-0.2.124.bazel
+++ b/third_party/rust/crates/remote/BUILD.libc-0.2.124.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.libftdi1-sys-1.1.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.libftdi1-sys-1.1.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.libm-0.2.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.libm-0.2.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.libudev-0.3.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.libudev-0.3.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.libudev-sys-0.1.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.libudev-sys-0.1.4.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.libusb1-sys-0.5.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.libusb1-sys-0.5.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.log-0.4.16.bazel
+++ b/third_party/rust/crates/remote/BUILD.log-0.4.16.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.mach-0.1.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.mach-0.1.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.mach-0.3.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.mach-0.3.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.memchr-2.4.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.memchr-2.4.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.memoffset-0.6.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.memoffset-0.6.5.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.miniz_oxide-0.5.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.miniz_oxide-0.5.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.mio-0.7.14.bazel
+++ b/third_party/rust/crates/remote/BUILD.mio-0.7.14.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.mio-signals-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.mio-signals-0.1.5.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.miow-0.3.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.miow-0.3.7.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.nix-0.17.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.nix-0.17.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.nix-0.23.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.nix-0.23.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.ntapi-0.3.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.ntapi-0.3.7.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.num-bigint-dig-0.7.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.num-bigint-dig-0.7.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.num-integer-0.1.44.bazel
+++ b/third_party/rust/crates/remote/BUILD.num-integer-0.1.44.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.num-iter-0.1.43.bazel
+++ b/third_party/rust/crates/remote/BUILD.num-iter-0.1.43.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.num-traits-0.2.14.bazel
+++ b/third_party/rust/crates/remote/BUILD.num-traits-0.2.14.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.num_enum-0.5.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.num_enum-0.5.7.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.num_enum_derive-0.5.7.bazel
+++ b/third_party/rust/crates/remote/BUILD.num_enum_derive-0.5.7.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.number_prefix-0.4.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.number_prefix-0.4.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.object-0.25.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.object-0.25.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.object-0.28.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.object-0.28.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.once_cell-1.10.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.once_cell-1.10.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.pkg-config-0.3.25.bazel
+++ b/third_party/rust/crates/remote/BUILD.pkg-config-0.3.25.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.ppv-lite86-0.2.16.bazel
+++ b/third_party/rust/crates/remote/BUILD.ppv-lite86-0.2.16.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.proc-macro-crate-1.1.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-crate-1.1.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-error-1.0.4.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro-error-attr-1.0.4.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.proc-macro2-0.4.30.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro2-0.4.30.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.37.bazel
+++ b/third_party/rust/crates/remote/BUILD.proc-macro2-1.0.37.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.quote-0.6.13.bazel
+++ b/third_party/rust/crates/remote/BUILD.quote-0.6.13.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.quote-1.0.18.bazel
+++ b/third_party/rust/crates/remote/BUILD.quote-1.0.18.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.rand-0.8.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.rand-0.8.5.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.rand_chacha-0.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.rand_chacha-0.3.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.rand_core-0.6.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.rand_core-0.6.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.raw_tty-0.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.raw_tty-0.1.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.redox_syscall-0.2.13.bazel
+++ b/third_party/rust/crates/remote/BUILD.redox_syscall-0.2.13.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.redox_users-0.4.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.redox_users-0.4.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.regex-1.5.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.regex-1.5.5.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.regex-syntax-0.6.25.bazel
+++ b/third_party/rust/crates/remote/BUILD.regex-syntax-0.6.25.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.rusb-0.8.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.rusb-0.8.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.rustc-demangle-0.1.21.bazel
+++ b/third_party/rust/crates/remote/BUILD.rustc-demangle-0.1.21.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.rustc_version-0.2.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.rustc_version-0.2.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.ryu-1.0.9.bazel
+++ b/third_party/rust/crates/remote/BUILD.ryu-1.0.9.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.safe-ftdi-0.3.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.safe-ftdi-0.3.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.semver-0.9.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.semver-0.9.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.semver-parser-0.7.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.semver-parser-0.7.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.serde-1.0.136.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde-1.0.136.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.serde_derive-1.0.136.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_derive-1.0.136.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.serde_json-1.0.79.bazel
+++ b/third_party/rust/crates/remote/BUILD.serde_json-1.0.79.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.serialport-4.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.serialport-4.1.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.sha2-0.10.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.sha2-0.10.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.shellwords-1.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.shellwords-1.1.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.smallvec-1.8.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.smallvec-1.8.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.spin-0.5.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.spin-0.5.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.strsim-0.8.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.strsim-0.8.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.structopt-0.3.26.bazel
+++ b/third_party/rust/crates/remote/BUILD.structopt-0.3.26.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.structopt-derive-0.4.18.bazel
+++ b/third_party/rust/crates/remote/BUILD.structopt-derive-0.4.18.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.syn-0.15.44.bazel
+++ b/third_party/rust/crates/remote/BUILD.syn-0.15.44.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.syn-1.0.91.bazel
+++ b/third_party/rust/crates/remote/BUILD.syn-1.0.91.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.synstructure-0.12.6.bazel
+++ b/third_party/rust/crates/remote/BUILD.synstructure-0.12.6.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.termcolor-1.1.3.bazel
+++ b/third_party/rust/crates/remote/BUILD.termcolor-1.1.3.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.terminal_size-0.1.17.bazel
+++ b/third_party/rust/crates/remote/BUILD.terminal_size-0.1.17.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.textwrap-0.11.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.textwrap-0.11.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.thiserror-1.0.30.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-1.0.30.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.30.bazel
+++ b/third_party/rust/crates/remote/BUILD.thiserror-impl-1.0.30.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.toml-0.5.9.bazel
+++ b/third_party/rust/crates/remote/BUILD.toml-0.5.9.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.typenum-1.15.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.typenum-1.15.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.typetag-0.1.8.bazel
+++ b/third_party/rust/crates/remote/BUILD.typetag-0.1.8.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.typetag-impl-0.1.8.bazel
+++ b/third_party/rust/crates/remote/BUILD.typetag-impl-0.1.8.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.unicode-segmentation-1.9.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-segmentation-1.9.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.unicode-width-0.1.9.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-width-0.1.9.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.unicode-xid-0.1.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-xid-0.1.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.unicode-xid-0.2.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.unicode-xid-0.2.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.vcpkg-0.2.15.bazel
+++ b/third_party/rust/crates/remote/BUILD.vcpkg-0.2.15.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.vec_map-0.8.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.vec_map-0.8.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.version_check-0.9.4.bazel
+++ b/third_party/rust/crates/remote/BUILD.version_check-0.9.4.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.void-1.0.2.bazel
+++ b/third_party/rust/crates/remote/BUILD.void-1.0.2.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
+++ b/third_party/rust/crates/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.winapi-0.3.9.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-0.3.9.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.winapi-util-0.1.5.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-util-0.1.5.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.zerocopy-0.5.0.bazel
+++ b/third_party/rust/crates/remote/BUILD.zerocopy-0.5.0.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])

--- a/third_party/rust/crates/remote/BUILD.zerocopy-derive-0.3.1.bazel
+++ b/third_party/rust/crates/remote/BUILD.zerocopy-derive-0.3.1.bazel
@@ -20,7 +20,7 @@ load(
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
     #
-    # Prefer access through "//third_party/cargo", which limits external
+    # Prefer access through "//third_party/rust/crates", which limits external
     # visibility to explicit Cargo.toml dependencies.
     "//visibility:public",
 ])


### PR DESCRIPTION
In #12038, the sw/host/Cargo.toml was moved but the appropriate path was
not updated. This fixes such. Now, if you need to add a rust crate, you
can:
1. navigate to `third_party/rust/crates/`
2. update the Cargo.toml file, and
3. run `cargo raze` (from the `third_party/rust/crates/` directory.

Signed-off-by: Timothy Trippel <ttrippel@google.com>