### PR TITLE
[opentitantool] Add version command

### DIFF
--- a/sw/host/opentitantool/BUILD
+++ b/sw/host/opentitantool/BUILD
@@ -19,11 +19,13 @@ rust_binary(
         "src/command/load_bitstream.rs",
         "src/command/mod.rs",
         "src/command/spi.rs",
+        "src/command/version.rs",
         "src/main.rs",
     ],
     proc_macro_deps = [
         "//sw/host/opentitanlib/opentitantool_derive",
     ],
+    stamp = 1,
     deps = [
         "//sw/host/opentitanlib",
         "//third_party/rust/crates:anyhow",

--- a/sw/host/opentitantool/src/command/mod.rs
+++ b/sw/host/opentitantool/src/command/mod.rs
@@ -11,6 +11,7 @@ pub mod i2c;
 pub mod image;
 pub mod load_bitstream;
 pub mod spi;
+pub mod version;
 
 use anyhow::Result;
 use erased_serde::Serialize;

--- a/sw/host/opentitantool/src/command/version.rs
+++ b/sw/host/opentitantool/src/command/version.rs
@@ -1,0 +1,56 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use erased_serde::Serialize;
+use regex::Regex;
+use std::any::Any;
+use std::collections::BTreeMap;
+use structopt::StructOpt;
+
+use opentitanlib::app::command::CommandDispatch;
+use opentitanlib::app::TransportWrapper;
+
+/// At compile time, the contents of `bazel-out/volatile-status.txt` is included, as if it was a
+/// string literal in this file.  Bazel will not recompile this rust_binary solely because
+/// `volatile-status.txt` has been updated, but any time this rust_binary is recompiled, it will
+/// include the newest version of `volatile-status.txt`.
+///
+/// At runtime, this string is parsed into key/value pairs, which are returned.  (It would have
+/// been desirable to perform the parsing at compile time as well.)
+fn get_volatile_status() -> BTreeMap<&'static str, &'static str> {
+    let volatile_status = include_str!("../../../../../bazel-out/volatile-status.txt");
+    let re = Regex::new(r"([A-Z_]+) ([^\n]+)\n").unwrap();
+    let mut properties: BTreeMap<&'static str, &'static str> = BTreeMap::new();
+    for cap in re.captures_iter(volatile_status) {
+        properties.insert(cap.get(1).unwrap().as_str(), cap.get(2).unwrap().as_str());
+    }
+    properties
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Version {}
+#[derive(Debug, serde::Serialize)]
+pub struct VersionResponse {
+    version: String,
+    revision: String,
+    clean: bool,
+    timestamp: i64,
+}
+
+impl CommandDispatch for Version {
+    fn run(
+        &self,
+        _context: &dyn Any,
+        _transport: &TransportWrapper,
+    ) -> Result<Option<Box<dyn Serialize>>> {
+        let properties = get_volatile_status();
+        Ok(Some(Box::new(VersionResponse {
+            version: properties.get("BUILD_GIT_VERSION").unwrap().to_string(),
+            revision: properties.get("BUILD_SCM_REVISION").unwrap().to_string(),
+            clean: *properties.get("BUILD_SCM_STATUS").unwrap() == "clean",
+            timestamp: properties.get("BUILD_TIMESTAMP").unwrap().parse::<i64>()?,
+        })))
+    }
+}

--- a/sw/host/opentitantool/src/main.rs
+++ b/sw/host/opentitantool/src/main.rs
@@ -33,6 +33,7 @@ enum RootCommandHierarchy {
     LoadBitstream(command::load_bitstream::LoadBitstream),
     NoOp(command::NoOp),
     Spi(command::spi::SpiCommand),
+    Version(command::version::Version),
 
     // Flattened because `Greetings` is a subcommand hierarchy.
     #[cfg(feature = "demo_commands")]


### PR DESCRIPTION
`opentitantool version` will print git version number and SHA hash.

It seems that I have encountered
https://github.com/bazelbuild/rules_rust/issues/485

I do not want to merge code that only works for the k8-fastbuild bazel target.

Change-Id: I719d30411bf05d6764f7f414344e533d66b61f35