### PR TITLE
[bazel,rust] fix stale anyhow crate version & rv test bug

### DIFF
--- a/third_party/riscv-compliance/compliance_main.c
+++ b/third_party/riscv-compliance/compliance_main.c
@@ -24,7 +24,7 @@ bool test_main(void) {
   run_rvc_test();
 
   ptrdiff_t words = end_signature - begin_signature;
-  CHECK_BUFFER_EQbegin_signature, kExpectedSignature, (size_t)words);
+  CHECK_BUFFER_EQ(begin_signature, kExpectedSignature, (size_t)words);
 
   return true;
 }

--- a/third_party/rust/crates/Cargo.toml
+++ b/third_party/rust/crates/Cargo.toml
@@ -13,7 +13,7 @@ path = "empty_file_to_appease_cargo.rs"
 # Keep sorted.
 # Please avoid version numbers that only have one component.
 [dependencies]
-anyhow = { version = "1.0.40", features=["backtrace"] }
+anyhow = { version = "1.0.57", features=["backtrace"] }
 bitflags = "1.0"
 byteorder = "1.4.3"
 deser-hjson = "1.0.2"

--- a/third_party/rust/crates/cargo/BUILD.bazel
+++ b/third_party/rust/crates/cargo/BUILD.bazel
@@ -1,0 +1,328 @@
+"""
+@generated
+cargo-raze generated Bazel file.
+
+DO NOT EDIT! Replaced on runs of cargo-raze
+"""
+
+package(default_visibility = ["//visibility:public"])
+
+licenses([
+    "notice",  # See individual crates for specific licenses
+])
+
+# Aliased targets
+alias(
+    name = "anyhow",
+    actual = "@raze__anyhow__1_0_57//:anyhow",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "bitflags",
+    actual = "@raze__bitflags__1_3_2//:bitflags",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "byteorder",
+    actual = "@raze__byteorder__1_4_3//:byteorder",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "deser_hjson",
+    actual = "@raze__deser_hjson__1_0_2//:deser_hjson",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "directories",
+    actual = "@raze__directories__4_0_1//:directories",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "env_logger",
+    actual = "@raze__env_logger__0_8_4//:env_logger",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "erased_serde",
+    actual = "@raze__erased_serde__0_3_20//:erased_serde",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "hex",
+    actual = "@raze__hex__0_4_3//:hex",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "humantime",
+    actual = "@raze__humantime__2_1_0//:humantime",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "indicatif",
+    actual = "@raze__indicatif__0_16_2//:indicatif",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "lazy_static",
+    actual = "@raze__lazy_static__1_4_0//:lazy_static",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "log",
+    actual = "@raze__log__0_4_16//:log",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "memoffset",
+    actual = "@raze__memoffset__0_6_5//:memoffset",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "mio",
+    actual = "@raze__mio__0_7_14//:mio",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "mio_signals",
+    actual = "@raze__mio_signals__0_1_5//:mio_signals",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "nix",
+    actual = "@raze__nix__0_17_0//:nix",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "num_bigint_dig",
+    actual = "@raze__num_bigint_dig__0_7_0//:num_bigint_dig",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "num_enum",
+    actual = "@raze__num_enum__0_5_7//:num_enum",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "num_traits",
+    actual = "@raze__num_traits__0_2_14//:num_traits",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "object",
+    actual = "@raze__object__0_25_3//:object",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "rand",
+    actual = "@raze__rand__0_8_5//:rand",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "raw_tty",
+    actual = "@raze__raw_tty__0_1_0//:raw_tty",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "regex",
+    actual = "@raze__regex__1_5_5//:regex",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "rusb",
+    actual = "@raze__rusb__0_8_1//:rusb",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "safe_ftdi",
+    actual = "@raze__safe_ftdi__0_3_0//:safe_ftdi",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde",
+    actual = "@raze__serde__1_0_136//:serde",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serde_json",
+    actual = "@raze__serde_json__1_0_79//:serde_json",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "serialport",
+    actual = "@raze__serialport__4_1_0//:serialport",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "sha2",
+    actual = "@raze__sha2__0_10_2//:sha2",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "shellwords",
+    actual = "@raze__shellwords__1_1_0//:shellwords",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "structopt",
+    actual = "@raze__structopt__0_3_26//:structopt",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "thiserror",
+    actual = "@raze__thiserror__1_0_30//:thiserror",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+alias(
+    name = "zerocopy",
+    actual = "@raze__zerocopy__0_5_0//:zerocopy",
+    tags = [
+        "cargo-raze",
+        "manual",
+    ],
+)
+
+# Export file for Stardoc support
+exports_files(
+    glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "srcs",
+    srcs = glob([
+        "**/*.bazel",
+        "**/*.bzl",
+    ]),
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
A stale version for the anyhow crate was causing the `util/prep-bazel-airgapped-build.sh` script to error out. This fixes the issue by bumping the version.

Additionally, an RV compliance test had a typo that was causing a build failure.