### PR TITLE
[dv/top] Bypass fatal alert check at the end of post_start

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -47,6 +47,9 @@ class alert_esc_agent extends dv_base_agent#(
     end
 
     super.build_phase(phase);
+    void'($value$plusargs("bypass_alert_ready_to_end_check=%0b",
+          cfg.bypass_alert_ready_to_end_check));
+
     // get alert_esc_if handle
     if (!uvm_config_db#(virtual alert_esc_if)::get(this, "", "vif", cfg.vif)) begin
       `uvm_fatal(`gfn, "failed to get alert_esc_if handle from uvm_config_db")

--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent_cfg.sv
@@ -16,6 +16,11 @@ class alert_esc_agent_cfg extends dv_base_agent_cfg;
   bit alert_init_done = 0;
   bit en_alert_lpg    = 0;
 
+  // Enabled via plusarg.
+  // Please only use this plusarg in top-level test.
+  // For IP level test, please set `exp_fatal_alert` in post_start() instead.
+  bit bypass_alert_ready_to_end_check = 0;
+
   // dut clk frequency, used to generate alert async_clk frequency
   int clk_freq_mhz;
 

--- a/hw/dv/sv/alert_esc_agent/alert_monitor.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_monitor.sv
@@ -248,10 +248,12 @@ class alert_monitor extends alert_esc_base_monitor;
 
   // end phase when no alert is triggered
   virtual task monitor_ready_to_end();
-    forever begin
-      @(cfg.vif.monitor_cb.alert_tx_final.alert_p);
-      ok_to_end = !cfg.vif.monitor_cb.alert_tx_final.alert_p &&
-                  cfg.vif.monitor_cb.alert_tx_final.alert_n;
+    if (!cfg.bypass_alert_ready_to_end_check) begin
+      forever begin
+        @(cfg.vif.monitor_cb.alert_tx_final.alert_p);
+        ok_to_end = !cfg.vif.monitor_cb.alert_tx_final.alert_p &&
+                    cfg.vif.monitor_cb.alert_tx_final.alert_n;
+      end
     end
   endtask
 

--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq.sv
@@ -495,7 +495,14 @@ class cip_base_vseq #(type RAL_T               = dv_base_reg_block,
     // - 20 cycles includes ack response and ack stable time.
     // - 10 is the max difference between alert clock and dut clock.
     int max_alert_handshake_cycles = 20 * 10;
-    if (cfg.list_of_alerts.size() > 0) begin
+
+    // Please only use `bypass_alert_ready_to_end_check` in top-level test.
+    // Because in top-level issuing an reset takes a large amount of simulation time.
+    // For IP level test, please set `exp_fatal_alert` in post_start() instead.
+    bit bypass_alert_ready_to_end_check;
+    void'($value$plusargs("bypass_alert_ready_to_end_check=%0b",
+          bypass_alert_ready_to_end_check));
+    if (cfg.list_of_alerts.size() > 0 && !bypass_alert_ready_to_end_check) begin
       int check_cycles = $urandom_range(max_alert_handshake_cycles,
                                         max_alert_handshake_cycles * 3);
 


### PR DESCRIPTION
For some top-level sequence, we expect to see fatal alert firing. But
the alert agent's ok_to_end task will block the test from existing
unless the alerts stop firing.
In block level, this is done by issuing a dut_init at the end, however
top-level test, issuing an dut_init might take too much simulation
time. So here I added a plusarg option to bypass alert check.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>