### PR TITLE
[aes, dif] Check that AES is indeed idle before writing IV registers

### DIFF
--- a/sw/device/lib/dif/dif_aes.c
+++ b/sw/device/lib/dif/dif_aes.c
@@ -240,6 +240,10 @@ dif_result_t dif_aes_start(const dif_aes_t *aes,
   }
 
   if (transaction->mode != kDifAesModeEcb) {
+    // Make sure AES is idle before providing the IV. Depending on the
+    // configuration, updating the key might cause the AES to become non-idle
+    // and reseed the internal PRNGs.
+    AES_WAIT_FOR_STATUS(aes, AES_STATUS_IDLE_BIT, true);
     aes_set_multireg(aes, &iv->iv[0], AES_IV_MULTIREG_COUNT,
                      AES_IV_0_REG_OFFSET);
   }

--- a/sw/device/lib/dif/dif_aes_unittest.cc
+++ b/sw/device/lib/dif/dif_aes_unittest.cc
@@ -44,6 +44,7 @@ class AesTest : public testing::Test, public mock_mmio::MmioTest {
   }
 
   void ExpectIv(const dif_aes_iv_t &iv, const uint32_t kIvSize = 4) {
+    EXPECT_READ32(AES_STATUS_REG_OFFSET, {{AES_STATUS_IDLE_BIT, true}});
     ExpectWriteMultreg(AES_IV_0_REG_OFFSET, iv.iv, kIvSize);
   }
 


### PR DESCRIPTION
Whenever, the AES unit is non-idle, updates to IV registers are ignored. Depending on the configuration, updating the key might cause the AES engine to become non-idle and reseed its internal PRNGs. If some writes to the IV registers are ignored the AES unit will never start its operation in automatic mode. 