### PR TITLE
[dv/xcelium] 1 attempt of cleaning up the coverage files

### DIFF
--- a/hw/dv/tools/xcelium/common.ccf
+++ b/hw/dv/tools/xcelium/common.ccf
@@ -32,7 +32,7 @@ set_branch_scoring
 
 // Scores statements within a block.
 set_statement_scoring
-
+//
 // Enables expression coverage for expression containing structs (packed and unpacked).
 set_expr_scoring -struct
 
@@ -46,9 +46,6 @@ set_fsm_reset_scoring
 // Enables scoring of immediate assertions inside a class in a package and assertions inside AMS
 // modules.
 select_functional  -ams_control  -imm_asrt_class_package
-
-// Improve the scoping and naming of covergroup instances.
-set_covergroup -new_instance_reporting
 
 // Enable toggle coverage only on ports.
 set_toggle_portsonly

--- a/hw/dv/tools/xcelium/cover.ccf
+++ b/hw/dv/tools/xcelium/cover.ccf
@@ -5,8 +5,8 @@
 // Include our common coverage CCF.
 include_ccf ${dv_root}/tools/xcelium/common.ccf
 
-deselect_coverage -betfs -module tb...
-select_coverage -befs -module ${DUT_TOP}...
+// enable coverage on dut and below
+select_coverage -befts -module ${DUT_TOP}...
 
 // Black-box pre-verified IPs from coverage collection.
 deselect_coverage -betfs -module pins_if
@@ -17,6 +17,8 @@ deselect_coverage -betfs -module prim_esc_sender...
 deselect_coverage -betfs -module prim_esc_receiver...
 deselect_coverage -betfs -module prim_prince...
 deselect_coverage -betfs -module prim_lfsr...
+
+
 // Black-box DV CDC module.
 deselect_coverage -betfs -module prim_cdc_rand_delay
 // csr_assert_fpv is an auto-generated csr read assertion module. So only assertion coverage is
@@ -24,8 +26,8 @@ deselect_coverage -betfs -module prim_cdc_rand_delay
 deselect_coverage -betf -module *csr_assert_fpv...
 
 // Only collect toggle coverage on the DUT and the black-boxed IP (above) ports.
-deselect_coverage -toggle -module ${DUT_TOP}...
-select_coverage -toggle -module ${DUT_TOP}
+
+
 select_coverage -toggle -module prim_alert_sender
 select_coverage -toggle -module prim_alert_receiver
 select_coverage -toggle -module prim_esc_sender


### PR DESCRIPTION
1 attempt of cleaning up the ccf files for xcelium coverage.
there was a few doublicates and some rules that would overwrite others

I suspect a bit more cleaning up is needed.

@weicaiyang could you run this on your end make sure it collects what we need and nothing we don't

I will look at it some more next week but I would appreciate some feedback
