### PR TITLE
[spi_device] Let readsram sends Sram Req

### DIFF
--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -499,6 +499,13 @@ module spi_readcmd
     else if (sram_req && mailbox_en_i && cfg_intercept_en_mbx_i
             && addr_in_mailbox) begin
       mailbox_assumed_o <= 1'b 1;
+    end else if (mailbox_en_i && cfg_intercept_en_mbx_i
+                && addr_in_mailbox && (bitcnt == 3'h 0)) begin
+      // Keep checking if the next byte falls into the mailbox region
+      mailbox_assumed_o <= 1'b 1;
+    end else if (!addr_in_mailbox && (bitcnt == 3'h 0)) begin
+      // At every byte, Check the address goes out of mailbox region.
+      mailbox_assumed_o <= 1'b 0;
     end
   end
   //- END:   SRAM Datapath ----------------------------------------------------
@@ -711,8 +718,6 @@ module spi_readcmd
   ) u_readsram (
     .clk_i,
     .rst_ni,
-
-    .spi_mode_i,
 
     .sram_read_req_i   (sram_req),
     .addr_latched_i    (addr_latched),


### PR DESCRIPTION

To make mailbox crossing logic simpler, let SRAM request from readsram
go out to DPSRAM even the operation is not permitted (readbuffer while
in PassThrough)

In order to block the SRAM request, the logic needs:

1. readcmd to hold fifo pop while not in mailbox as FIFO is empty
2. strb in readsram should be reset prior to move to StActive. When the
   address crosses the mailbox (readbuf -> mailbox), the strb is always
   0. strb in the current version latches `current_address_i` when first
   SRAM request sends out to DPSRAM and is incremented at every byte
   being pushed to FIFO.
3. `addr_in_mailbox` should be latched then be used to block the FIFO
   pop. at the last byte of the readbuf, the addr_in_mailbox is already
   high as it sees `addr_d` to check the mailbox region.

So, to make logic simpler, I decided to let request out and sends the
Readbuf data while not in mailbox (in Passthrough mode). The logic will
be blocked by `mailbox_assumed_o` signal at the spi_device top.

To do this, `mailbox_assumed_o` is also revised to set at every byte
while in the mailbox, and to clear if not in the mailbox region.