### PR TITLE
[spi_device] Add initial batch of DIFs for flash / passthrough modes

### DIFF
--- a/sw/device/examples/demos.c
+++ b/sw/device/examples/demos.c
@@ -62,16 +62,13 @@ uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state) {
   return gpio_state;
 }
 
-void demo_spi_to_log_echo(const dif_spi_device_t *spi,
-                          const dif_spi_device_config_t *spi_config) {
+void demo_spi_to_log_echo(dif_spi_device_handle_t *spi) {
   uint32_t spi_buf[8];
   size_t spi_len;
-  CHECK_DIF_OK(
-      dif_spi_device_recv(spi, spi_config, spi_buf, sizeof(spi_buf), &spi_len));
+  CHECK_DIF_OK(dif_spi_device_recv(spi, spi_buf, sizeof(spi_buf), &spi_len));
   if (spi_len > 0) {
     uint32_t echo_word = spi_buf[0] ^ 0x01010101;
-    CHECK_DIF_OK(dif_spi_device_send(spi, spi_config, &echo_word,
-                                     sizeof(uint32_t),
+    CHECK_DIF_OK(dif_spi_device_send(spi, &echo_word, sizeof(uint32_t),
                                      /*bytes_sent=*/NULL));
     LOG_INFO("SPI: %!s", spi_len, spi_buf);
   }

--- a/sw/device/examples/demos.h
+++ b/sw/device/examples/demos.h
@@ -41,8 +41,7 @@ uint32_t demo_gpio_to_log_echo(dif_gpio_t *gpio, uint32_t prev_gpio_state);
  * Attempts to read at most 32 bytes from SPI, and echo them as printable
  * characters to LOG.
  */
-void demo_spi_to_log_echo(const dif_spi_device_t *spi,
-                          const dif_spi_device_config_t *spi_config);
+void demo_spi_to_log_echo(dif_spi_device_handle_t *spi);
 
 /**
  * Attempts to read characters from UART and immediately echo them back,

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -25,7 +25,7 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
- * The mode that the spi device operates in
+ * The mode that the spi device operates in.
  */
 typedef enum dif_spi_device_mode {
   /**
@@ -263,6 +263,361 @@ dif_result_t dif_spi_device_recv(dif_spi_device_handle_t *spi, void *buf,
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_spi_device_send(dif_spi_device_handle_t *spi, const void *buf,
                                  size_t buf_len, size_t *bytes_sent);
+
+typedef struct dif_spi_device_flash_id {
+  /** The device ID for the SPI flash. */
+  uint16_t device_id;
+  /** The JEDEC manufacturer ID. */
+  uint8_t manufacturer_id;
+  /** The continuation code used before the `manufacturer_id` byte. */
+  uint8_t continuation_code;
+  /** The number of continuation codes preceding the `manufacturer_id`. */
+  uint8_t num_continuation_code;
+} dif_spi_device_flash_id_t;
+
+/**
+ * Enable the mailbox region for spi_device flash / passthrough modes.
+ *
+ * Allocate 1 KiB for the mailbox, starting from the provided base `address`.
+ *
+ * @param spi A SPI device.
+ * @param address The base address of the 1 KiB mailbox. The lower 10 bits are
+ * ignored.
+ * @return kDifBadArg if spi is null, else kDifOk.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_enable_mailbox(dif_spi_device_handle_t *spi,
+                                           uint32_t address);
+
+/**
+ * Disable the mailbox region for spi_device flash / passthrough modes.
+ *
+ * @param spi A SPI device.
+ * @return kDifBadArg if spi is null, else kDifOk.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_disable_mailbox(dif_spi_device_handle_t *spi);
+
+/**
+ * Get the active configuration for the mailbox region.
+ *
+ * @param spi A SPI device.
+ * @param[out] is_enabled Whether the mailbox region is enabled.
+ * @param[out] address If the mailbox is enabled, the base address of the
+ * mailbox region.
+ * @return kDifBadArg if any argument is null, else kDifOk.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_get_mailbox_configuration(
+    dif_spi_device_handle_t *spi, dif_toggle_t *is_enabled, uint32_t *address);
+
+/**
+ * Set the address mode of the SPI device in flash/passthrough mode.
+ *
+ * @param spi A SPI device.
+ * @param addr_4b If kDifToggleEnabled, set the address mode to 4 Bytes.
+ * Otherwise, set the address mode to 3 Bytes.
+ * @return kDifBadArg if spi is NULL or addr_4b is not a valid toggle. kDifOk
+ * otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_4b_address_mode(dif_spi_device_handle_t *spi,
+                                                dif_toggle_t addr_4b);
+/**
+ * Get the address mode of the SPI device in flash/passthrough mode.
+ *
+ * @param spi A SPI device.
+ * @param[out] addr_4b Points to toggle that will be set to `kDifToggleEnabled`
+ * if the device is in 4-byte address mode, else `kDifToggleDisabled`.
+ * @return kDifBadArg if spi or addr_4b are NULL. kDifOk otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_get_4b_address_mode(dif_spi_device_handle_t *spi,
+                                                dif_toggle_t *addr_4b);
+
+/**
+ * Get the JEDEC ID presented when in flash / passthrough modes.
+ *
+ * @param spi A SPI device.
+ * @param[out] id Points to location that will be set to the current JEDEC ID.
+ * @return kDifBadArg if spi or id are NULL. kDifOk otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_get_flash_id(dif_spi_device_handle_t *spi,
+                                         dif_spi_device_flash_id_t *id);
+/**
+ * Set the JEDEC ID presented when in flash / passthrough modes.
+ *
+ * @param spi A SPI device.
+ * @param id The JEDEC ID to set.
+ * @return kDifBadArg if spi is NULL. kDifOk otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_flash_id(dif_spi_device_handle_t *spi,
+                                         dif_spi_device_flash_id_t id);
+
+typedef enum dif_spi_device_flash_address_type {
+  /** No address for this command */
+  kDifSpiDeviceFlashAddrDisabled = 0,
+  /** Address size for this command is determined by the current address mode */
+  kDifSpiDeviceFlashAddrCfg,
+  /** Address size for this command is fixed at 3 bytes */
+  kDifSpiDeviceFlashAddr3Byte,
+  /** Address size for this command is fixed at 4 bytes */
+  kDifSpiDeviceFlashAddr4Byte,
+  kDifSpiDeviceFlashAddrCount,
+} dif_spi_device_flash_address_type_t;
+
+typedef enum dif_spi_device_payload_io {
+  kDifSpiDevicePayloadIoNone = 0x0,
+  kDifSpiDevicePayloadIoSingle = 0x1,
+  kDifSpiDevicePayloadIoDual = 0x3,
+  kDifSpiDevicePayloadIoQuad = 0xf,
+  kDifSpiDevicePayloadIoInvalid = 0x10,
+} dif_spi_device_payload_io_t;
+
+typedef struct dif_spi_device_flash_command {
+  /** The opcode for this command. */
+  uint8_t opcode;
+  /* The presence and type of the address phase of this command. */
+  dif_spi_device_flash_address_type_t address_type;
+  /** The number of dummy cycles between the address phase and the payload phase
+   * of a command. Note that if `payload_io_width` is
+   * `kDifSpiDevicePayloadIoNone`, a nonzero value may cause undefined behavior,
+   * possibly including the device assuming dummy cycles are part of this
+   * payload-less command.
+   */
+  uint8_t dummy_cycles;
+  /** The I/O width for the payload phase of this command. */
+  dif_spi_device_payload_io_t payload_io_type;
+  /**
+   * Whether to translate the address using the address swap mask and value
+   * provided to `dif_spi_device_passthrough_set_swap_address()`. Incompatible
+   * with a command with `address_type` that is
+   * `kDifSpiDeviceFlashAddrDisabled`.
+   */
+  bool passthrough_swap_address;
+  /** Whether the SPI host is receiving this command's payload phase. */
+  bool payload_dir_to_host;
+  /** Whether to swap up to the first 32 bits of the payload. */
+  bool payload_swap_enable;
+  /** Whether to upload the command to the payload FIFO. */
+  bool upload;
+  /** Whether to set the busy bit in the status register. */
+  bool set_busy_status;
+} dif_spi_device_flash_command_t;
+
+typedef enum dif_spi_device_flash_buffer_type {
+  /** eFlash region */
+  kDifSpiDeviceFlashBufferTypeEFlash = 0,
+  /** Mailbox region */
+  kDifSpiDeviceFlashBufferTypeMailbox,
+  /** SFDP region */
+  kDifSpiDeviceFlashBufferTypeSfdp,
+  /** Payload for uploaded commands */
+  kDifSpiDeviceFlashBufferTypePayload,
+  /** Count of buffer types */
+  kDifSpiDeviceFlashBufferTypes,
+} dif_spi_device_flash_buffer_type_t;
+
+/**
+ * Set up the indicated command info slot for flash / passthrough modes.
+ *
+ * @param spi A handle to a spi device.
+ * @param slot A command info slot ID.
+ * @param enable Whether to enable or disable the command slot.
+ * @param command_info If `enable` is set, provides the configuration for the
+ *        command.
+ * @return `kDifBadArg` if `spi` is NULL or `slot` is larger than the number of
+ * command slots. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_flash_command_slot(
+    dif_spi_device_handle_t *spi, uint8_t slot, dif_toggle_t enable,
+    dif_spi_device_flash_command_t command_info);
+
+/**
+ * Get the current configuration of the indicated command info slot.
+ *
+ * @param spi A handle to a spi device.
+ * @param slot A command info slot ID.
+ * @param[out] enabled A pointer to where the current slot state can be stored.
+ * @param[out] command_info If `enabled`, points to where the current command
+ * configuration can be stored.
+ * @return `kDifBadArg` if any pointers are NULL or `slot` is larger than the
+ * number of command slots. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_get_flash_command_slot(
+    dif_spi_device_handle_t *spi, uint8_t slot, dif_toggle_t *enabled,
+    dif_spi_device_flash_command_t *command_info);
+
+/**
+ * Set which address bits are swapped and their values for commands that have
+ * the address swap enabled.
+ *
+ * @param spi A handle to a spi device.
+ * @param mask A bitmask indicating which address bits should be replaced.
+ * @param replacement The values to swap in for the masked address bits.
+ * @return `kDifBadArg` if spi is NULL, else `kDifOk`.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_flash_address_swap(dif_spi_device_handle_t *spi,
+                                                   uint32_t mask,
+                                                   uint32_t replacement);
+
+/**
+ * Set which bits are swapped and their values for commands that have
+ * the first-word payload swap function enabled.
+ *
+ * @param spi A handle to a spi device.
+ * @param mask A bitmask indicating which bits should be replaced.
+ * @param replacement The values to swap in for the masked bits.
+ * @return `kDifBadArg` if spi is NULL, else `kDifOk`.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_flash_payload_swap(dif_spi_device_handle_t *spi,
+                                                   uint32_t mask,
+                                                   uint32_t replacement);
+
+/**
+ * Pop the first command from the uploaded command FIFO.
+ *
+ * @param spi A handle to a spi device.
+ * @param[out] command A pointer to where the command can be stored.
+ * @return `kDifBadArg` if any pointers are NULL. `kDifUnavailable` if the FIFO
+ * was empty. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_pop_flash_command_fifo(dif_spi_device_handle_t *spi,
+                                                   uint8_t *command);
+
+/**
+ * Pop the first address from the uploaded address FIFO.
+ *
+ * @param spi A handle to a spi device.
+ * @param[out] address A pointer to where the address can be stored.
+ * @return `kDifBadArg` if any pointers are NULL. `kDifUnavailable` if the FIFO
+ * was empty. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_pop_flash_address_fifo(dif_spi_device_handle_t *spi,
+                                                   uint32_t *address);
+
+/**
+ * Read data from one of the memories associated with flash / passthrough modes.
+ *
+ * @param spi A handle to a spi device.
+ * @param buffer_type An identifier for which memory space to read from.
+ * @param offset The starting offset for read data in the memory.
+ * @param length The length, in bytes, of the data to be copied.
+ * @param[out] buf A pointer to the location where the data should be stored.
+ * @return `kDifBadArg` is any pointers are NULL or the `buffer_type` does not
+ * exist. `kDifOutOfRange` if the requested `offset` and `length` go beyond the
+ * indicated `buffer_type` region. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_read_flash_buffer(
+    dif_spi_device_handle_t *spi,
+    dif_spi_device_flash_buffer_type_t buffer_type, uint32_t offset,
+    size_t length, uint8_t *buf);
+
+/**
+ * Write data to one of the memories associated with flash / passthrough modes.
+ *
+ * @param spi A handle to a spi device.
+ * @param buffer_type An identifier for which memory space to write to.
+ * @param offset The starting offset for the write location of the data.
+ * @param length The length, in bytes, of the data to be copied.
+ * @param buf A pointer to the location where the data can be copied from.
+ * @return `kDifBadArg` is any pointers are NULL or the `buffer_type` does not
+ * exist. `kDifOutOfRange` if the requested `offset` and `length` go beyond the
+ * indicated `buffer_type` region. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_write_flash_buffer(
+    dif_spi_device_handle_t *spi,
+    dif_spi_device_flash_buffer_type_t buffer_type, uint32_t offset,
+    size_t length, const uint8_t *buf);
+
+/**
+ * Get whether the indicated command is filtered for passthrough.
+ *
+ * @param spi A handle to a spi device.
+ * @param command The command to be queried.
+ * @param[out] enabled A pointer to a location where the filter status can be
+ * stored. `kDifEnabled` means the command is filtered.
+ * @return `kDifBadArg` if any pointers are NULL. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_get_passthrough_command_filter(
+    dif_spi_device_handle_t *spi, uint8_t command, dif_toggle_t *enabled);
+
+/**
+ * Set whether the indicated command is filtered for passthrough.
+ *
+ * @param spi A handle to a spi device.
+ * @param command The command to have its filter status updated.
+ * @param enable Whether to enable the command filter for the `command`.
+ * @return `kDifBadArg` if `spi` is NULL or `enable` is invalid. `kDifOk`
+ * otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_passthrough_command_filter(
+    dif_spi_device_handle_t *spi, uint8_t command, dif_toggle_t enable);
+
+/**
+ * Set whether ALL commands are filtered for passthrough.
+ *
+ * Can be used for a faster initial state before using
+ * `dif_spi_device_set_passthrough_command_filter` to set the filter status for
+ * individual commands.
+ *
+ * @param spi A handle to a spi device.
+ * @param enable Whether to enable the command filter for all commands.
+ * @return `kDifBadArg` if `spi` is NULL or `enable` is invalid. `kDifOk`
+ * otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_all_passthrough_command_filters(
+    dif_spi_device_handle_t *spi, dif_toggle_t enable);
+
+/**
+ * Clear the busy bit for flash / passthrough modes.
+ *
+ * @param spi A handle to a spi device.
+ * @return `kDifBadArg` if `spi` is NULL. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_clear_flash_busy_bit(dif_spi_device_handle_t *spi);
+
+/**
+ * Write the status registers for flash / passthrough modes.
+ *
+ * Note that the three registers are concatenated to make one 24-bit value, with
+ * the LSB being the busy bit.
+ *
+ * @param spi A handle to a spi device.
+ * @param value The value to write to the registers.
+ * @return `kDifBadArg` if `spi` is NULL. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_set_flash_status_registers(
+    dif_spi_device_handle_t *spi, uint32_t value);
+
+/**
+ * Get the values of the status registers for flash / passthrough modes.
+ *
+ * Note that the three registers are concatenated to make one 24-bit value, with
+ * the LSB being the busy bit.
+ *
+ * @param spi A handle to a spi device.
+ * @param[out] value A pointer to where to write the values of the registesr.
+ * @return `kDifBadArg` if any pointer arguments are NULL. `kDifOk` otherwise.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_get_flash_status_registers(
+    dif_spi_device_handle_t *spi, uint32_t *value);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_spi_device.h
+++ b/sw/device/lib/dif/dif_spi_device.h
@@ -25,6 +25,29 @@ extern "C" {
 #endif  // __cplusplus
 
 /**
+ * The mode that the spi device operates in
+ */
+typedef enum dif_spi_device_mode {
+  /**
+   * In the generic firmware mode, the hardware dumps incoming data to SRAM and
+   * outgoing data from the SRAM.
+   */
+  kDifSpiDeviceModeGeneric = 0,
+  /**
+   * In flash emulation mode, the hardware behaves like a SPI NOR flash device.
+   */
+  kDifSpiDeviceModeFlashEmulation = 1,
+  /**
+   * In pass-through mode, the hardware forwards commands to another SPI flash
+   * device, with various tables providing rules for filtering and forwarding.
+   * The hardware may be configured to also behave like a SPI NOR flash device,
+   * with some commands and/or address regions targeting internal handling,
+   * instead of being passed through.
+   */
+  kDifSpiDeviceModePassthrough = 2,
+} dif_spi_device_mode_t;
+
+/**
  * A signal edge type: positive or negative.
  */
 typedef enum dif_spi_device_edge {
@@ -52,18 +75,7 @@ typedef enum dif_spi_device_bit_order {
   kDifSpiDeviceBitOrderLsbToMsb,
 } dif_spi_device_bit_order_t;
 
-/**
- * Runtime configuration for SPI.
- *
- * This struct describes runtime information for one-time configuration of the
- * hardware.
- */
-typedef struct dif_spi_device_config {
-  dif_spi_device_edge_t clock_polarity;
-  dif_spi_device_edge_t data_phase;
-  dif_spi_device_bit_order_t tx_order;
-  dif_spi_device_bit_order_t rx_order;
-  uint8_t rx_fifo_timeout;
+typedef struct dif_spi_device_generic_mode_config {
   /**
    * The length, in bytes, that should be reserved for the RX FIFO.
    *
@@ -76,7 +88,51 @@ typedef struct dif_spi_device_config {
    * `kDifSpiDeviceBufferLen / 2` is a good default for this value.
    */
   uint16_t tx_fifo_len;
+  /**
+   * The number of bus clock cycles that the RX FIFO waits before committing a
+   * sub-word data item to the SRAM. Only used in Generic Mode.
+   */
+  uint8_t rx_fifo_commit_wait;
+} dif_spi_device_generic_mode_config_t;
+
+/**
+ * Runtime configuration for SPI.
+ *
+ * This struct describes runtime information for one-time configuration of the
+ * hardware.
+ */
+typedef struct dif_spi_device_config {
+  dif_spi_device_edge_t clock_polarity;
+  dif_spi_device_edge_t data_phase;
+  dif_spi_device_bit_order_t tx_order;
+  dif_spi_device_bit_order_t rx_order;
+  dif_spi_device_mode_t device_mode;
+  union {
+    dif_spi_device_generic_mode_config_t generic;
+  } mode_cfg;
 } dif_spi_device_config_t;
+
+typedef struct dif_spi_device_tpm_config_t {
+  /**
+   * Enable the TPM circuit, which has a separate chip-select input but shares
+   * the clock and data pins. The TPM can be enabled alongside the other modes.
+   */
+  bool tpm_enable;
+} dif_spi_device_tpm_config_t;
+
+/**
+ * Struct containing the relevant run-time information for the DIF.
+ */
+typedef struct dif_spi_device_handle {
+  /**
+   * Device information of the hardware.
+   */
+  dif_spi_device_t dev;
+  /**
+   * Configuration information of the hardware.
+   */
+  dif_spi_device_config_t config;
+} dif_spi_device_handle_t;
 
 /**
  * The length of the SPI device FIFO buffer, in bytes.
@@ -85,6 +141,17 @@ typedef struct dif_spi_device_config {
  * `rx_fifo_len` and `tx_fifo_len` would be set to `kDifSpiDeviceBufferLen / 2`.
  */
 extern const uint16_t kDifSpiDeviceBufferLen;
+
+/**
+ * Initializes a SPI device handle for use.
+ *
+ * @param base_addr The MMIO base address of the spi_device peripheral.
+ * @param[out] Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_init_handle(mmio_region_t base_addr,
+                                        dif_spi_device_handle_t *spi);
 
 /**
  * Configures SPI with runtime information.
@@ -96,18 +163,20 @@ extern const uint16_t kDifSpiDeviceBufferLen;
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_configure(const dif_spi_device_t *spi,
-                                      const dif_spi_device_config_t *config);
+dif_result_t dif_spi_device_configure(dif_spi_device_handle_t *spi,
+                                      dif_spi_device_config_t config);
 
 /**
  * Issues an "abort" to the given SPI device, causing all in-progress IO to
  * halt.
  *
+ * Applies only to generic mode.
+ *
  * @param spi A SPI handle.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_abort(const dif_spi_device_t *spi);
+dif_result_t dif_spi_device_abort(dif_spi_device_handle_t *spi);
 
 /**
  * Sets up the "FIFO level" (that is, number of bytes present in a particular
@@ -123,44 +192,50 @@ dif_result_t dif_spi_device_abort(const dif_spi_device_t *spi);
  * to detect that there is free space to write more data to the TX FIFO.
  * This is the `Main Memory -> Spi Buffer` case.
  *
+ * Applies only to generic mode.
+ *
  * @param spi A SPI handle.
  * @param rx_level The new RX level, as described above.
  * @param tx_level The new TX level, as described above.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_set_irq_levels(const dif_spi_device_t *spi,
+dif_result_t dif_spi_device_set_irq_levels(dif_spi_device_handle_t *spi,
                                            uint16_t rx_level,
                                            uint16_t tx_level);
 
 /**
  * Returns the number of bytes still pending receipt by software in the RX FIFO.
  *
- * @param spi A SPI handle.
- * @param[out] bytes_pending The number of bytes pending
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_rx_pending(const dif_spi_device_t *spi,
-                                       const dif_spi_device_config_t *config,
-                                       size_t *bytes_pending);
-
-/**
- * Returns the number of bytes still pending transmission by hardware in the TX
- * FIFO.
+ * Applies only to generic mode.
  *
  * @param spi A SPI handle.
  * @param[out] bytes_pending The number of bytes pending
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_tx_pending(const dif_spi_device_t *spi,
-                                       const dif_spi_device_config_t *config,
+dif_result_t dif_spi_device_rx_pending(const dif_spi_device_handle_t *spi,
+                                       size_t *bytes_pending);
+
+/**
+ * Returns the number of bytes still pending transmission by hardware in the TX
+ * FIFO.
+ *
+ * Applies only to generic mode.
+ *
+ * @param spi A SPI handle.
+ * @param[out] bytes_pending The number of bytes pending
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_spi_device_tx_pending(const dif_spi_device_handle_t *spi,
                                        size_t *bytes_pending);
 
 /**
  * Reads at most `buf_len` bytes from the RX FIFO; the number of bytes read
  * will be written to `bytes_received`.
+ *
+ * Applies only to generic mode.
  *
  * @param spi A SPI device.
  * @param[out] buf A pointer to valid memory.
@@ -170,14 +245,14 @@ dif_result_t dif_spi_device_tx_pending(const dif_spi_device_t *spi,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
-                                 const dif_spi_device_config_t *config,
-                                 void *buf, size_t buf_len,
-                                 size_t *bytes_received);
+dif_result_t dif_spi_device_recv(dif_spi_device_handle_t *spi, void *buf,
+                                 size_t buf_len, size_t *bytes_received);
 
 /**
  * Writes at most `buf_len` bytes to the TX FIFO; the number of bytes actually
  * written will be written to `bytes_sent`.
+ *
+ * Applies only to generic mode.
  *
  * @param spi A SPI device.
  * @param buf A pointer to bytes to be written.
@@ -186,10 +261,8 @@ dif_result_t dif_spi_device_recv(const dif_spi_device_t *spi,
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
-dif_result_t dif_spi_device_send(const dif_spi_device_t *spi,
-                                 const dif_spi_device_config_t *config,
-                                 const void *buf, size_t buf_len,
-                                 size_t *bytes_sent);
+dif_result_t dif_spi_device_send(dif_spi_device_handle_t *spi, const void *buf,
+                                 size_t buf_len, size_t *bytes_sent);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/dif/dif_spi_device_unittest.cc
+++ b/sw/device/lib/dif/dif_spi_device_unittest.cc
@@ -745,9 +745,504 @@ class FlashTest : public SpiTest {
         .rx_order = kDifSpiDeviceBitOrderMsbToLsb,
         .device_mode = kDifSpiDeviceModePassthrough,
     };
-    spi_.config = config;
+    EXPECT_DIF_OK(dif_spi_device_init_handle(dev().region(), &spi_));
+    EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+                   {
+                       {SPI_DEVICE_CFG_CPOL_BIT, 0},
+                       {SPI_DEVICE_CFG_CPHA_BIT, 0},
+                       {SPI_DEVICE_CFG_TX_ORDER_BIT, 0},
+                       {SPI_DEVICE_CFG_RX_ORDER_BIT, 0},
+                   });
+    EXPECT_READ32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                  {
+                      {SPI_DEVICE_CONTROL_MODE_OFFSET, 0},
+                      {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 1},
+                  });
+    EXPECT_WRITE32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                   {
+                       {SPI_DEVICE_CONTROL_MODE_OFFSET, 0},
+                       {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 0},
+                   });
+    EXPECT_WRITE32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                   {
+                       {SPI_DEVICE_CONTROL_MODE_OFFSET,
+                        SPI_DEVICE_CONTROL_MODE_VALUE_PASSTHROUGH},
+                       {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 0},
+                   });
+    EXPECT_WRITE32(SPI_DEVICE_CONTROL_REG_OFFSET,
+                   {
+                       {SPI_DEVICE_CONTROL_MODE_OFFSET,
+                        SPI_DEVICE_CONTROL_MODE_VALUE_PASSTHROUGH},
+                       {SPI_DEVICE_CONTROL_SRAM_CLK_EN_BIT, 1},
+                   });
+    EXPECT_DIF_OK(dif_spi_device_configure(&spi_, config));
   };
 };
+
+TEST_F(FlashTest, NullArgs) {
+  dif_toggle_t toggle_arg;
+  uint32_t uint32_arg;
+  uint8_t uint8_arg;
+  dif_spi_device_flash_id_t id_arg;
+  dif_spi_device_flash_command_t command_arg;
+  EXPECT_DIF_BADARG(dif_spi_device_init_handle(dev().region(), nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_enable_mailbox(nullptr, /*address=*/0x1000));
+  EXPECT_DIF_BADARG(dif_spi_device_disable_mailbox(nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_get_mailbox_configuration(
+      nullptr, &toggle_arg, &uint32_arg));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_get_mailbox_configuration(&spi_, nullptr, &uint32_arg));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_get_mailbox_configuration(&spi_, &toggle_arg, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_set_4b_address_mode(nullptr, kDifToggleEnabled));
+  EXPECT_DIF_BADARG(dif_spi_device_get_4b_address_mode(nullptr, &toggle_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_get_4b_address_mode(&spi_, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_get_flash_id(nullptr, &id_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_get_flash_id(&spi_, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_set_flash_id(nullptr, id_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_get_flash_command_slot(
+      nullptr, /*slot=*/0, &toggle_arg, &command_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_get_flash_command_slot(
+      &spi_, /*slot=*/0, nullptr, &command_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_get_flash_command_slot(
+      &spi_, /*slot=*/0, &toggle_arg, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_set_flash_command_slot(
+      nullptr, /*slot=*/0, kDifToggleEnabled, command_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_set_flash_address_swap(nullptr, /*mask=*/0,
+                                                          /*replacement=*/0));
+  EXPECT_DIF_BADARG(dif_spi_device_set_flash_payload_swap(nullptr, /*mask=*/0,
+                                                          /*replacement=*/0));
+  EXPECT_DIF_BADARG(dif_spi_device_pop_flash_command_fifo(nullptr, &uint8_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_pop_flash_command_fifo(&spi_, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_pop_flash_address_fifo(nullptr, &uint32_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_pop_flash_address_fifo(&spi_, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_read_flash_buffer(
+      nullptr, kDifSpiDeviceFlashBufferTypeSfdp, /*offset=*/0, /*length=*/1,
+      &uint8_arg));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_read_flash_buffer(&spi_, kDifSpiDeviceFlashBufferTypeSfdp,
+                                       /*offset=*/0, /*length=*/1, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_write_flash_buffer(
+      nullptr, kDifSpiDeviceFlashBufferTypeSfdp, /*offset=*/0, /*length=*/1,
+      &uint8_arg));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_write_flash_buffer(&spi_, kDifSpiDeviceFlashBufferTypeSfdp,
+                                        /*offset=*/0, /*length=*/1, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_get_passthrough_command_filter(
+      nullptr, /*command=*/0, &toggle_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_get_passthrough_command_filter(
+      &spi_, /*command=*/0, nullptr));
+  EXPECT_DIF_BADARG(dif_spi_device_set_passthrough_command_filter(
+      nullptr, /*command=*/0, kDifToggleEnabled));
+  EXPECT_DIF_BADARG(dif_spi_device_set_all_passthrough_command_filters(
+      nullptr, kDifToggleEnabled));
+  EXPECT_DIF_BADARG(dif_spi_device_clear_flash_busy_bit(nullptr));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_set_flash_status_registers(nullptr, /*value=*/0));
+  EXPECT_DIF_BADARG(
+      dif_spi_device_get_flash_status_registers(nullptr, &uint32_arg));
+  EXPECT_DIF_BADARG(dif_spi_device_get_flash_status_registers(&spi_, nullptr));
+}
+
+TEST_F(FlashTest, MailboxConfigTest) {
+  dif_toggle_t toggle;
+  uint32_t address = 0x3f0000;
+  EXPECT_WRITE32(SPI_DEVICE_MAILBOX_ADDR_REG_OFFSET, address);
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET, {
+                                               {SPI_DEVICE_CFG_CPOL_BIT, 1},
+                                               {SPI_DEVICE_CFG_CPHA_BIT, 1},
+                                           });
+  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CFG_CPOL_BIT, 1},
+                     {SPI_DEVICE_CFG_CPHA_BIT, 1},
+                     {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_enable_mailbox(&spi_, address));
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                    {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                    {SPI_DEVICE_CFG_RX_ORDER_BIT, 1},
+                });
+  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 0},
+                     {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                     {SPI_DEVICE_CFG_RX_ORDER_BIT, 1},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_disable_mailbox(&spi_));
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                    {SPI_DEVICE_CFG_TX_ORDER_BIT, 1},
+                });
+  EXPECT_READ32(SPI_DEVICE_MAILBOX_ADDR_REG_OFFSET, 0x100000);
+  EXPECT_DIF_OK(
+      dif_spi_device_get_mailbox_configuration(&spi_, &toggle, &address));
+  EXPECT_EQ(toggle, kDifToggleEnabled);
+  EXPECT_EQ(address, 0x100000);
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 0},
+                });
+  EXPECT_READ32(SPI_DEVICE_MAILBOX_ADDR_REG_OFFSET, 0x100000);
+  EXPECT_DIF_OK(
+      dif_spi_device_get_mailbox_configuration(&spi_, &toggle, &address));
+  EXPECT_EQ(toggle, kDifToggleDisabled);
+}
+
+TEST_F(FlashTest, Addr4bConfig) {
+  dif_toggle_t toggle;
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                });
+  EXPECT_DIF_OK(dif_spi_device_get_4b_address_mode(&spi_, &toggle));
+  EXPECT_EQ(toggle, kDifToggleDisabled);
+
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                    {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 1},
+                });
+  EXPECT_DIF_OK(dif_spi_device_get_4b_address_mode(&spi_, &toggle));
+  EXPECT_EQ(toggle, kDifToggleEnabled);
+
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                    {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 0},
+                });
+  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                     {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 1},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_set_4b_address_mode(&spi_, kDifToggleEnabled));
+  EXPECT_READ32(SPI_DEVICE_CFG_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                    {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 1},
+                });
+  EXPECT_WRITE32(SPI_DEVICE_CFG_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CFG_MAILBOX_EN_BIT, 1},
+                     {SPI_DEVICE_CFG_ADDR_4B_EN_BIT, 0},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_set_4b_address_mode(&spi_, kDifToggleDisabled));
+}
+
+TEST_F(FlashTest, DeviceId) {
+  dif_spi_device_flash_id_t id;
+  EXPECT_READ32(SPI_DEVICE_JEDEC_CC_REG_OFFSET,
+                {
+                    {SPI_DEVICE_JEDEC_CC_NUM_CC_OFFSET, 10},
+                    {SPI_DEVICE_JEDEC_CC_CC_OFFSET, 0x5a},
+                });
+  EXPECT_READ32(SPI_DEVICE_JEDEC_ID_REG_OFFSET,
+                {
+                    {SPI_DEVICE_JEDEC_ID_MF_OFFSET, 0xca},
+                    {SPI_DEVICE_JEDEC_ID_ID_OFFSET, 0x1234},
+                });
+  EXPECT_DIF_OK(dif_spi_device_get_flash_id(&spi_, &id));
+  EXPECT_EQ(id.num_continuation_code, 10);
+  EXPECT_EQ(id.continuation_code, 0x5a);
+  EXPECT_EQ(id.manufacturer_id, 0xca);
+  EXPECT_EQ(id.device_id, 0x1234);
+
+  id = (dif_spi_device_flash_id_t){
+      .device_id = 0x2202,
+      .manufacturer_id = 0xd7,
+      .continuation_code = 0x7f,
+      .num_continuation_code = 7,
+  };
+  EXPECT_WRITE32(SPI_DEVICE_JEDEC_CC_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_JEDEC_CC_NUM_CC_OFFSET, 7},
+                     {SPI_DEVICE_JEDEC_CC_CC_OFFSET, 0x7f},
+                 });
+  EXPECT_WRITE32(SPI_DEVICE_JEDEC_ID_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_JEDEC_ID_MF_OFFSET, 0xd7},
+                     {SPI_DEVICE_JEDEC_ID_ID_OFFSET, 0x2202},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_set_flash_id(&spi_, id));
+}
+
+TEST_F(FlashTest, CommandInfo) {
+  dif_spi_device_flash_command_t command_info;
+  dif_toggle_t toggle;
+  EXPECT_READ32(SPI_DEVICE_CMD_INFO_0_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CMD_INFO_0_OPCODE_0_OFFSET, 0x6b},
+                    {SPI_DEVICE_CMD_INFO_0_ADDR_MODE_0_OFFSET,
+                     SPI_DEVICE_CMD_INFO_0_ADDR_MODE_0_VALUE_ADDRCFG},
+                    {SPI_DEVICE_CMD_INFO_0_DUMMY_EN_0_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_0_DUMMY_SIZE_0_OFFSET, 7},
+                    {SPI_DEVICE_CMD_INFO_0_PAYLOAD_EN_0_OFFSET, 0xf},
+                    {SPI_DEVICE_CMD_INFO_0_PAYLOAD_DIR_0_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_0_ADDR_SWAP_EN_0_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_0_PAYLOAD_SWAP_EN_0_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_0_UPLOAD_0_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_0_BUSY_0_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_0_VALID_0_BIT, 0},
+                });
+  EXPECT_DIF_OK(dif_spi_device_get_flash_command_slot(&spi_, /*slot=*/0,
+                                                      &toggle, &command_info));
+  EXPECT_EQ(toggle, kDifToggleDisabled);
+
+  EXPECT_READ32(SPI_DEVICE_CMD_INFO_1_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CMD_INFO_1_OPCODE_1_OFFSET, 0x6b},
+                    {SPI_DEVICE_CMD_INFO_1_ADDR_MODE_1_OFFSET,
+                     SPI_DEVICE_CMD_INFO_0_ADDR_MODE_0_VALUE_ADDRCFG},
+                    {SPI_DEVICE_CMD_INFO_1_DUMMY_EN_1_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_1_DUMMY_SIZE_1_OFFSET, 7},
+                    {SPI_DEVICE_CMD_INFO_1_PAYLOAD_EN_1_OFFSET, 0xf},
+                    {SPI_DEVICE_CMD_INFO_1_PAYLOAD_DIR_1_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_1_ADDR_SWAP_EN_1_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_1_PAYLOAD_SWAP_EN_1_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_1_UPLOAD_1_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_1_BUSY_1_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_1_VALID_1_BIT, 1},
+                });
+  EXPECT_DIF_OK(dif_spi_device_get_flash_command_slot(&spi_, /*slot=*/1,
+                                                      &toggle, &command_info));
+  EXPECT_EQ(toggle, kDifToggleEnabled);
+  EXPECT_EQ(command_info.opcode, 0x6b);
+  EXPECT_EQ(command_info.address_type, kDifSpiDeviceFlashAddrCfg);
+  EXPECT_EQ(command_info.dummy_cycles, 8);
+  EXPECT_EQ(command_info.payload_io_type, kDifSpiDevicePayloadIoQuad);
+  EXPECT_FALSE(command_info.passthrough_swap_address);
+  EXPECT_TRUE(command_info.payload_dir_to_host);
+  EXPECT_FALSE(command_info.payload_swap_enable);
+  EXPECT_FALSE(command_info.upload);
+  EXPECT_FALSE(command_info.set_busy_status);
+
+  EXPECT_READ32(SPI_DEVICE_CMD_INFO_1_REG_OFFSET,
+                {
+                    {SPI_DEVICE_CMD_INFO_1_OPCODE_1_OFFSET, 0x12},
+                    {SPI_DEVICE_CMD_INFO_1_ADDR_MODE_1_OFFSET,
+                     SPI_DEVICE_CMD_INFO_0_ADDR_MODE_0_VALUE_ADDR4B},
+                    {SPI_DEVICE_CMD_INFO_1_DUMMY_EN_1_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_1_DUMMY_SIZE_1_OFFSET, 7},
+                    {SPI_DEVICE_CMD_INFO_1_PAYLOAD_EN_1_OFFSET, 0x1},
+                    {SPI_DEVICE_CMD_INFO_1_PAYLOAD_DIR_1_BIT, 0},
+                    {SPI_DEVICE_CMD_INFO_1_ADDR_SWAP_EN_1_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_1_PAYLOAD_SWAP_EN_1_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_1_UPLOAD_1_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_1_BUSY_1_BIT, 1},
+                    {SPI_DEVICE_CMD_INFO_1_VALID_1_BIT, 1},
+                });
+  EXPECT_DIF_OK(dif_spi_device_get_flash_command_slot(&spi_, /*slot=*/1,
+                                                      &toggle, &command_info));
+  EXPECT_EQ(toggle, kDifToggleEnabled);
+  EXPECT_EQ(command_info.opcode, 0x12);
+  EXPECT_EQ(command_info.address_type, kDifSpiDeviceFlashAddr4Byte);
+  EXPECT_EQ(command_info.dummy_cycles, 0);
+  EXPECT_EQ(command_info.payload_io_type, kDifSpiDevicePayloadIoSingle);
+  EXPECT_TRUE(command_info.passthrough_swap_address);
+  EXPECT_FALSE(command_info.payload_dir_to_host);
+  EXPECT_TRUE(command_info.payload_swap_enable);
+  EXPECT_TRUE(command_info.upload);
+  EXPECT_TRUE(command_info.set_busy_status);
+
+  command_info = (dif_spi_device_flash_command_t){
+      .opcode = 0x06,
+      .address_type = kDifSpiDeviceFlashAddrDisabled,
+      .dummy_cycles = 0,
+      .payload_io_type = kDifSpiDevicePayloadIoSingle,
+      .passthrough_swap_address = false,
+      .payload_dir_to_host = false,
+      .payload_swap_enable = true,
+      .upload = true,
+      .set_busy_status = true,
+  };
+  EXPECT_WRITE32(SPI_DEVICE_CMD_INFO_1_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CMD_INFO_1_OPCODE_1_OFFSET, 0x06},
+                     {SPI_DEVICE_CMD_INFO_1_ADDR_MODE_1_OFFSET,
+                      SPI_DEVICE_CMD_INFO_0_ADDR_MODE_0_VALUE_ADDRDISABLED},
+                     {SPI_DEVICE_CMD_INFO_1_DUMMY_EN_1_BIT, 0},
+                     {SPI_DEVICE_CMD_INFO_1_DUMMY_SIZE_1_OFFSET, 0},
+                     {SPI_DEVICE_CMD_INFO_1_PAYLOAD_EN_1_OFFSET, 0x1},
+                     {SPI_DEVICE_CMD_INFO_1_PAYLOAD_DIR_1_BIT, 0},
+                     {SPI_DEVICE_CMD_INFO_1_ADDR_SWAP_EN_1_BIT, 0},
+                     {SPI_DEVICE_CMD_INFO_1_PAYLOAD_SWAP_EN_1_BIT, 1},
+                     {SPI_DEVICE_CMD_INFO_1_UPLOAD_1_BIT, 1},
+                     {SPI_DEVICE_CMD_INFO_1_BUSY_1_BIT, 1},
+                     {SPI_DEVICE_CMD_INFO_1_VALID_1_BIT, 1},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_set_flash_command_slot(
+      &spi_, /*slot=*/1, kDifToggleEnabled, command_info));
+  command_info = (dif_spi_device_flash_command_t){
+      .opcode = 0x5a,
+      .address_type = kDifSpiDeviceFlashAddr3Byte,
+      .dummy_cycles = 8,
+      .payload_io_type = kDifSpiDevicePayloadIoSingle,
+      .passthrough_swap_address = false,
+      .payload_dir_to_host = true,
+      .payload_swap_enable = false,
+      .upload = false,
+      .set_busy_status = false,
+  };
+  EXPECT_WRITE32(SPI_DEVICE_CMD_INFO_1_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_CMD_INFO_1_OPCODE_1_OFFSET, 0x5a},
+                     {SPI_DEVICE_CMD_INFO_1_ADDR_MODE_1_OFFSET,
+                      SPI_DEVICE_CMD_INFO_0_ADDR_MODE_0_VALUE_ADDR3B},
+                     {SPI_DEVICE_CMD_INFO_1_DUMMY_EN_1_BIT, 1},
+                     {SPI_DEVICE_CMD_INFO_1_DUMMY_SIZE_1_OFFSET, 7},
+                     {SPI_DEVICE_CMD_INFO_1_PAYLOAD_EN_1_OFFSET, 0x2},
+                     {SPI_DEVICE_CMD_INFO_1_PAYLOAD_DIR_1_BIT, 1},
+                     {SPI_DEVICE_CMD_INFO_1_ADDR_SWAP_EN_1_BIT, 0},
+                     {SPI_DEVICE_CMD_INFO_1_PAYLOAD_SWAP_EN_1_BIT, 0},
+                     {SPI_DEVICE_CMD_INFO_1_UPLOAD_1_BIT, 0},
+                     {SPI_DEVICE_CMD_INFO_1_BUSY_1_BIT, 0},
+                     {SPI_DEVICE_CMD_INFO_1_VALID_1_BIT, 1},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_set_flash_command_slot(
+      &spi_, /*slot=*/1, kDifToggleEnabled, command_info));
+}
+
+TEST_F(FlashTest, Swaps) {
+  EXPECT_WRITE32(SPI_DEVICE_ADDR_SWAP_MASK_REG_OFFSET, 0x10203456u);
+  EXPECT_WRITE32(SPI_DEVICE_ADDR_SWAP_DATA_REG_OFFSET, 0xffff0000u);
+  EXPECT_DIF_OK(
+      dif_spi_device_set_flash_address_swap(&spi_, 0x10203456u, 0xffff0000u));
+
+  EXPECT_WRITE32(SPI_DEVICE_PAYLOAD_SWAP_MASK_REG_OFFSET, 0x24587001u);
+  EXPECT_WRITE32(SPI_DEVICE_PAYLOAD_SWAP_DATA_REG_OFFSET, 0xa5a5f00fu);
+  EXPECT_DIF_OK(
+      dif_spi_device_set_flash_payload_swap(&spi_, 0x24587001u, 0xa5a5f00fu));
+}
+
+TEST_F(FlashTest, FifoPop) {
+  uint8_t command;
+  uint32_t address;
+  EXPECT_READ32(SPI_DEVICE_UPLOAD_STATUS_REG_OFFSET,
+                {
+                    {SPI_DEVICE_UPLOAD_STATUS_CMDFIFO_NOTEMPTY_BIT, 0},
+                    {SPI_DEVICE_UPLOAD_STATUS_ADDRFIFO_NOTEMPTY_BIT, 1},
+                });
+  EXPECT_EQ(dif_spi_device_pop_flash_command_fifo(&spi_, &command),
+            kDifUnavailable);
+
+  EXPECT_READ32(SPI_DEVICE_UPLOAD_STATUS_REG_OFFSET,
+                {
+                    {SPI_DEVICE_UPLOAD_STATUS_CMDFIFO_NOTEMPTY_BIT, 1},
+                    {SPI_DEVICE_UPLOAD_STATUS_ADDRFIFO_NOTEMPTY_BIT, 1},
+                });
+  EXPECT_READ32(SPI_DEVICE_UPLOAD_CMDFIFO_REG_OFFSET, 0x06);
+  EXPECT_DIF_OK(dif_spi_device_pop_flash_command_fifo(&spi_, &command));
+  EXPECT_EQ(command, 0x06);
+
+  EXPECT_READ32(SPI_DEVICE_UPLOAD_STATUS_REG_OFFSET,
+                {
+                    {SPI_DEVICE_UPLOAD_STATUS_CMDFIFO_NOTEMPTY_BIT, 1},
+                    {SPI_DEVICE_UPLOAD_STATUS_ADDRFIFO_NOTEMPTY_BIT, 0},
+                });
+  EXPECT_EQ(dif_spi_device_pop_flash_address_fifo(&spi_, &address),
+            kDifUnavailable);
+
+  EXPECT_READ32(SPI_DEVICE_UPLOAD_STATUS_REG_OFFSET,
+                {
+                    {SPI_DEVICE_UPLOAD_STATUS_CMDFIFO_NOTEMPTY_BIT, 1},
+                    {SPI_DEVICE_UPLOAD_STATUS_ADDRFIFO_NOTEMPTY_BIT, 1},
+                });
+  EXPECT_READ32(SPI_DEVICE_UPLOAD_ADDRFIFO_REG_OFFSET, 0x76543210);
+  EXPECT_DIF_OK(dif_spi_device_pop_flash_address_fifo(&spi_, &address));
+  EXPECT_EQ(address, 0x76543210);
+}
+
+TEST_F(FlashTest, MemoryOps) {
+  constexpr uint32_t kSfdpOffset = 3072;
+  constexpr uint32_t kMailboxOffset = 2048;
+
+  uint32_t buf[64];
+  for (uint32_t i = 0; i < (sizeof(buf) / sizeof(buf[0])); i++) {
+    buf[i] = i;
+    EXPECT_WRITE32(
+        SPI_DEVICE_BUFFER_REG_OFFSET + kSfdpOffset + i * sizeof(uint32_t), i);
+  }
+  EXPECT_DIF_OK(dif_spi_device_write_flash_buffer(
+      &spi_, kDifSpiDeviceFlashBufferTypeSfdp, /*offset=*/0,
+      /*length=*/sizeof(buf), reinterpret_cast<uint8_t *>(buf)));
+  for (uint32_t i = 4; i < (sizeof(buf) / sizeof(buf[0])); i++) {
+    EXPECT_READ32(
+        SPI_DEVICE_BUFFER_REG_OFFSET + kMailboxOffset + i * sizeof(uint32_t),
+        0x1000u - i);
+  }
+  EXPECT_DIF_OK(dif_spi_device_read_flash_buffer(
+      &spi_, kDifSpiDeviceFlashBufferTypeMailbox, /*offset=*/16,
+      /*length=*/sizeof(buf) - 16, reinterpret_cast<uint8_t *>(buf)));
+  for (uint32_t i = 4; i < (sizeof(buf) / sizeof(buf[0])); i++) {
+    EXPECT_EQ(buf[i - 4], 0x1000u - i);
+  }
+}
+
+TEST_F(FlashTest, CommandFilters) {
+  dif_toggle_t toggle;
+  EXPECT_READ32(SPI_DEVICE_CMD_FILTER_0_REG_OFFSET, 0xa5642301u);
+  EXPECT_DIF_OK(dif_spi_device_get_passthrough_command_filter(
+      &spi_, /*opcode=*/18, &toggle));
+  EXPECT_EQ(toggle, kDifToggleEnabled);
+
+  EXPECT_READ32(SPI_DEVICE_CMD_FILTER_3_REG_OFFSET, 0xa5642301u);
+  EXPECT_DIF_OK(dif_spi_device_get_passthrough_command_filter(
+      &spi_, /*opcode=*/(3 * 32 + 19), &toggle));
+  EXPECT_EQ(toggle, kDifToggleDisabled);
+
+  EXPECT_READ32(SPI_DEVICE_CMD_FILTER_0_REG_OFFSET, 0xa5a5a5a5u);
+  EXPECT_WRITE32(SPI_DEVICE_CMD_FILTER_0_REG_OFFSET, 0xa585a5a5u);
+  EXPECT_DIF_OK(dif_spi_device_set_passthrough_command_filter(
+      &spi_, /*opcode=*/21, kDifToggleDisabled));
+
+  EXPECT_READ32(SPI_DEVICE_CMD_FILTER_7_REG_OFFSET, 0x5555aaaau);
+  EXPECT_WRITE32(SPI_DEVICE_CMD_FILTER_7_REG_OFFSET, 0x5555aaabu);
+  EXPECT_DIF_OK(dif_spi_device_set_passthrough_command_filter(
+      &spi_, /*opcode=*/224, kDifToggleEnabled));
+
+  for (int i = 0; i < 8; i++) {
+    EXPECT_WRITE32(SPI_DEVICE_CMD_FILTER_0_REG_OFFSET + i * sizeof(uint32_t),
+                   0);
+  }
+  EXPECT_DIF_OK(dif_spi_device_set_all_passthrough_command_filters(
+      &spi_, kDifToggleDisabled));
+
+  for (int i = 0; i < 8; i++) {
+    EXPECT_WRITE32(SPI_DEVICE_CMD_FILTER_0_REG_OFFSET + i * sizeof(uint32_t),
+                   UINT32_MAX);
+  }
+  EXPECT_DIF_OK(dif_spi_device_set_all_passthrough_command_filters(
+      &spi_, kDifToggleEnabled));
+}
+
+TEST_F(FlashTest, StatusRegisters) {
+  uint32_t status;
+  EXPECT_READ32(SPI_DEVICE_FLASH_STATUS_REG_OFFSET,
+                {
+                    {SPI_DEVICE_FLASH_STATUS_BUSY_BIT, 1},
+                    {SPI_DEVICE_FLASH_STATUS_STATUS_OFFSET, 0x143200},
+                });
+  EXPECT_WRITE32(SPI_DEVICE_FLASH_STATUS_REG_OFFSET,
+                 {
+                     {SPI_DEVICE_FLASH_STATUS_BUSY_BIT, 0},
+                     {SPI_DEVICE_FLASH_STATUS_STATUS_OFFSET, 0x143200},
+                 });
+  EXPECT_DIF_OK(dif_spi_device_clear_flash_busy_bit(&spi_));
+
+  EXPECT_WRITE32(SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0x198234);
+  EXPECT_DIF_OK(
+      dif_spi_device_set_flash_status_registers(&spi_, /*status=*/0x198234));
+
+  EXPECT_READ32(SPI_DEVICE_FLASH_STATUS_REG_OFFSET, 0x765432);
+  EXPECT_DIF_OK(dif_spi_device_get_flash_status_registers(&spi_, &status));
+  EXPECT_EQ(status, 0x765432);
+}
 
 }  // namespace
 }  // namespace dif_spi_device_unittest

--- a/sw/device/lib/dif/meson.build
+++ b/sw/device/lib/dif/meson.build
@@ -281,6 +281,7 @@ test('dif_spi_device_unittest', executable(
     sources: [
       'dif_spi_device_unittest.cc',
       'autogen/dif_spi_device_autogen_unittest.cc',
+      meson.project_source_root() / 'sw/device/lib/dif/dif_base.c',
       meson.project_source_root() / 'sw/device/lib/dif/dif_spi_device.c',
       meson.project_source_root() / 'sw/device/lib/dif/autogen/dif_spi_device_autogen.c',
       hw_ip_spi_device_reg_h,


### PR DESCRIPTION
DIFs for handling the general command info table, passthrough filters,
address and data swapping, basic FIFO and memory interaction, flash
status registers, address modes, and identification are all contained in
this commit.