### PR TITLE
[dif/sysrst_ctrl] add output pin override, wakeup status, and locking DIFs

### DIFF
--- a/sw/device/lib/dif/dif_sysrst_ctrl.c
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.c
@@ -454,3 +454,153 @@ dif_result_t dif_sysrst_ctrl_output_pin_override_get_enabled(
 
   return kDifOk;
 }
+
+static bool get_output_pin_value_bit_index(dif_sysrst_ctrl_pin_t pin,
+                                           uint32_t *pin_out_value_bit_index) {
+  switch (pin) {
+    case kDifSysrstCtrlPinKey0Out:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_KEY0_OUT_BIT;
+      break;
+    case kDifSysrstCtrlPinKey1Out:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_KEY1_OUT_BIT;
+      break;
+    case kDifSysrstCtrlPinKey2Out:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_KEY2_OUT_BIT;
+      break;
+    case kDifSysrstCtrlPinPowerButtonOut:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_PWRB_OUT_BIT;
+      break;
+    case kDifSysrstCtrlPinBatteryDisableOut:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_BAT_DISABLE_BIT;
+      break;
+    case kDifSysrstCtrlPinZ3WakeupOut:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_Z3_WAKEUP_BIT;
+      break;
+    case kDifSysrstCtrlPinEcResetInOut:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_EC_RST_L_BIT;
+      break;
+    case kDifSysrstCtrlPinFlashWriteProtectInOut:
+      *pin_out_value_bit_index = SYSRST_CTRL_PIN_OUT_VALUE_FLASH_WP_L_BIT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+dif_result_t dif_sysrst_ctrl_output_pin_set_override(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_t pin,
+    bool value) {
+  if (sysrst_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t pin_out_value_bit_index;
+  if (!get_output_pin_value_bit_index(pin, &pin_out_value_bit_index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t pin_out_value_reg = mmio_region_read32(
+      sysrst_ctrl->base_addr, SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET);
+  pin_out_value_reg =
+      bitfield_bit32_write(pin_out_value_reg, pin_out_value_bit_index, value);
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET, pin_out_value_reg);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_output_pin_get_override(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_t pin,
+    bool *value) {
+  if (sysrst_ctrl == NULL || value == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t pin_out_value_bit_index;
+  if (!get_output_pin_value_bit_index(pin, &pin_out_value_bit_index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t pin_out_value_reg = mmio_region_read32(
+      sysrst_ctrl->base_addr, SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET);
+  *value = bitfield_bit32_read(pin_out_value_reg, pin_out_value_bit_index);
+
+  return kDifOk;
+}
+
+static bool get_input_pin_value_bit_index(dif_sysrst_ctrl_pin_t pin,
+                                          uint32_t *pin_in_value_bit_index) {
+  switch (pin) {
+    case kDifSysrstCtrlPinKey0In:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_KEY0_IN_BIT;
+      break;
+    case kDifSysrstCtrlPinKey1In:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_KEY1_IN_BIT;
+      break;
+    case kDifSysrstCtrlPinKey2In:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_KEY2_IN_BIT;
+      break;
+    case kDifSysrstCtrlPinPowerButtonIn:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_PWRB_IN_BIT;
+      break;
+    case kDifSysrstCtrlPinAcPowerPresentIn:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_AC_PRESENT_BIT;
+      break;
+    case kDifSysrstCtrlPinLidOpenIn:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_LID_OPEN_BIT;
+      break;
+    case kDifSysrstCtrlPinEcResetInOut:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_EC_RST_L_BIT;
+      break;
+    case kDifSysrstCtrlPinFlashWriteProtectInOut:
+      *pin_in_value_bit_index = SYSRST_CTRL_PIN_IN_VALUE_FLASH_WP_L_BIT;
+      break;
+    default:
+      return false;
+  }
+  return true;
+}
+
+dif_result_t dif_sysrst_ctrl_input_pin_read(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_t pin,
+    bool *value) {
+  if (sysrst_ctrl == NULL || value == NULL) {
+    return kDifBadArg;
+  }
+
+  uint32_t pin_in_value_bit_index;
+  if (!get_input_pin_value_bit_index(pin, &pin_in_value_bit_index)) {
+    return kDifBadArg;
+  }
+
+  uint32_t pin_in_value_reg = mmio_region_read32(
+      sysrst_ctrl->base_addr, SYSRST_CTRL_PIN_IN_VALUE_REG_OFFSET);
+  *value = bitfield_bit32_read(pin_in_value_reg, pin_in_value_bit_index);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_ulp_wakeup_get_status(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, bool *wakeup_detected) {
+  if (sysrst_ctrl == NULL || wakeup_detected == NULL) {
+    return kDifBadArg;
+  }
+
+  *wakeup_detected = mmio_region_read32(sysrst_ctrl->base_addr,
+                                        SYSRST_CTRL_WKUP_STATUS_REG_OFFSET);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_ulp_wakeup_clear_status(
+    const dif_sysrst_ctrl_t *sysrst_ctrl) {
+  if (sysrst_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_WKUP_STATUS_REG_OFFSET, 1);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_sysrst_ctrl.c
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.c
@@ -604,3 +604,25 @@ dif_result_t dif_sysrst_ctrl_ulp_wakeup_clear_status(
 
   return kDifOk;
 }
+
+dif_result_t dif_sysrst_ctrl_lock(const dif_sysrst_ctrl_t *sysrst_ctrl) {
+  if (sysrst_ctrl == NULL) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(sysrst_ctrl->base_addr, SYSRST_CTRL_REGWEN_REG_OFFSET, 0);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_is_locked(const dif_sysrst_ctrl_t *sysrst_ctrl,
+                                       bool *is_locked) {
+  if (sysrst_ctrl == NULL || is_locked == NULL) {
+    return kDifBadArg;
+  }
+
+  *is_locked = !mmio_region_read32(sysrst_ctrl->base_addr,
+                                   SYSRST_CTRL_REGWEN_REG_OFFSET);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_sysrst_ctrl.h
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.h
@@ -320,6 +320,10 @@ typedef enum dif_sysrst_ctrl_pin {
    * Flash write protect inout.
    */
   kDifSysrstCtrlPinFlashWriteProtectInOut = 1U << 13,
+  /**
+   * All non open drain pins.
+   */
+  kDifSysrstCtrlPinAllNonOpenDrain = (1U << 12) - 1,
 } dif_sysrst_ctrl_pin_t;
 
 /**

--- a/sw/device/lib/dif/dif_sysrst_ctrl.h
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.h
@@ -621,15 +621,17 @@ dif_result_t dif_sysrst_ctrl_output_pin_get_override(
  * Reads a System Reset Controller's input pin (like a GPIO pin).
  *
  * Note, only input (or inout) pins may be read. Attempting to read the value of
- * an output pin will return `kDifError`.
+ * an output pin will return `kDifBadArg`.
  *
  * @param sysrst_ctrl A System Reset Controller handle.
  * @param pin The pin to read.
+ * @param[out] value The value set on the pin.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_sysrst_ctrl_input_pin_read(
-    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_t pin);
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_pin_t pin,
+    bool *value);
 
 /**
  * Configures a System Reset Controller's key signal auto-override feature.

--- a/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
@@ -476,5 +476,128 @@ TEST_F(PinOverrideGetEnabledTest, Success) {
   EXPECT_EQ(is_enabled, kDifToggleDisabled);
 }
 
+class PinSetOverrideTest : public SysrstCtrlTest {};
+
+TEST_F(PinSetOverrideTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_set_override(
+      nullptr, kDifSysrstCtrlPinKey1Out, true));
+}
+
+TEST_F(PinSetOverrideTest, BadPin) {
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_set_override(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey1In, true));
+}
+
+TEST_F(PinSetOverrideTest, Success) {
+  EXPECT_READ32(SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_OUT_VALUE_FLASH_WP_L_BIT, 1}});
+  EXPECT_WRITE32(SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET,
+                 {{SYSRST_CTRL_PIN_OUT_VALUE_KEY1_OUT_BIT, 1},
+                  {SYSRST_CTRL_PIN_OUT_VALUE_FLASH_WP_L_BIT, 1}});
+  EXPECT_DIF_OK(dif_sysrst_ctrl_output_pin_set_override(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey1Out, true));
+}
+
+class PinGetOverrideTest : public SysrstCtrlTest {};
+
+TEST_F(PinGetOverrideTest, NullArgs) {
+  bool value;
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_get_override(
+      nullptr, kDifSysrstCtrlPinKey1Out, &value));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_get_override(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey1Out, nullptr));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_get_override(
+      nullptr, kDifSysrstCtrlPinKey1Out, nullptr));
+}
+
+TEST_F(PinGetOverrideTest, BadPin) {
+  bool value;
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_output_pin_get_override(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey1In, &value));
+}
+
+TEST_F(PinGetOverrideTest, Success) {
+  bool value;
+  EXPECT_READ32(SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_OUT_VALUE_KEY1_OUT_BIT, 1}});
+  EXPECT_DIF_OK(dif_sysrst_ctrl_output_pin_get_override(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey1Out, &value));
+  EXPECT_TRUE(value);
+
+  EXPECT_READ32(SYSRST_CTRL_PIN_OUT_VALUE_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_OUT_VALUE_KEY1_OUT_BIT, 1}});
+  EXPECT_DIF_OK(dif_sysrst_ctrl_output_pin_get_override(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey2Out, &value));
+  EXPECT_FALSE(value);
+}
+
+class InputPinReadTest : public SysrstCtrlTest {};
+
+TEST_F(InputPinReadTest, NullArgs) {
+  bool value;
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_pin_read(nullptr, kDifSysrstCtrlPinKey2In, &value));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_input_pin_read(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey2In, nullptr));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_input_pin_read(
+      nullptr, kDifSysrstCtrlPinKey2In, nullptr));
+}
+
+TEST_F(InputPinReadTest, BadPin) {
+  bool value;
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_input_pin_read(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey2Out, &value));
+}
+
+TEST_F(InputPinReadTest, Success) {
+  bool value;
+  EXPECT_READ32(SYSRST_CTRL_PIN_IN_VALUE_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_IN_VALUE_KEY1_IN_BIT, 1}});
+  EXPECT_DIF_OK(dif_sysrst_ctrl_input_pin_read(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey1In, &value));
+  EXPECT_TRUE(value);
+
+  EXPECT_READ32(SYSRST_CTRL_PIN_IN_VALUE_REG_OFFSET,
+                {{SYSRST_CTRL_PIN_IN_VALUE_KEY1_IN_BIT, 1}});
+  EXPECT_DIF_OK(dif_sysrst_ctrl_input_pin_read(
+      &sysrst_ctrl_, kDifSysrstCtrlPinKey2In, &value));
+  EXPECT_FALSE(value);
+}
+
+class UlpWakeupGetStatusTest : public SysrstCtrlTest {};
+
+TEST_F(UlpWakeupGetStatusTest, NullArgs) {
+  bool wakeup_detected;
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_ulp_wakeup_get_status(nullptr, &wakeup_detected));
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_ulp_wakeup_get_status(&sysrst_ctrl_, nullptr));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_ulp_wakeup_get_status(nullptr, nullptr));
+}
+
+TEST_F(UlpWakeupGetStatusTest, Success) {
+  bool wakeup_detected;
+  EXPECT_READ32(SYSRST_CTRL_WKUP_STATUS_REG_OFFSET, 1);
+  EXPECT_DIF_OK(
+      dif_sysrst_ctrl_ulp_wakeup_get_status(&sysrst_ctrl_, &wakeup_detected));
+  EXPECT_TRUE(wakeup_detected);
+
+  EXPECT_READ32(SYSRST_CTRL_WKUP_STATUS_REG_OFFSET, 0);
+  EXPECT_DIF_OK(
+      dif_sysrst_ctrl_ulp_wakeup_get_status(&sysrst_ctrl_, &wakeup_detected));
+  EXPECT_FALSE(wakeup_detected);
+}
+
+class UlpWakeupClearStatusTest : public SysrstCtrlTest {};
+
+TEST_F(UlpWakeupClearStatusTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_ulp_wakeup_clear_status(nullptr));
+}
+
+TEST_F(UlpWakeupClearStatusTest, Success) {
+  EXPECT_WRITE32(SYSRST_CTRL_WKUP_STATUS_REG_OFFSET, 1);
+  EXPECT_DIF_OK(dif_sysrst_ctrl_ulp_wakeup_clear_status(&sysrst_ctrl_));
+}
+
 }  // namespace
 }  // namespace dif_sysrst_ctrl_unittest

--- a/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
@@ -599,5 +599,34 @@ TEST_F(UlpWakeupClearStatusTest, Success) {
   EXPECT_DIF_OK(dif_sysrst_ctrl_ulp_wakeup_clear_status(&sysrst_ctrl_));
 }
 
+class LockTest : public SysrstCtrlTest {};
+
+TEST_F(LockTest, NullArgs) { EXPECT_DIF_BADARG(dif_sysrst_ctrl_lock(nullptr)); }
+
+TEST_F(LockTest, Success) {
+  EXPECT_WRITE32(SYSRST_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_sysrst_ctrl_lock(&sysrst_ctrl_));
+}
+
+class IsLockedTest : public SysrstCtrlTest {};
+
+TEST_F(IsLockedTest, NullArgs) {
+  bool is_locked;
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_is_locked(nullptr, &is_locked));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_is_locked(&sysrst_ctrl_, nullptr));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_is_locked(nullptr, nullptr));
+}
+
+TEST_F(IsLockedTest, Success) {
+  bool is_locked;
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_sysrst_ctrl_is_locked(&sysrst_ctrl_, &is_locked));
+  EXPECT_TRUE(is_locked);
+
+  EXPECT_READ32(SYSRST_CTRL_REGWEN_REG_OFFSET, 1);
+  EXPECT_DIF_OK(dif_sysrst_ctrl_is_locked(&sysrst_ctrl_, &is_locked));
+  EXPECT_FALSE(is_locked);
+}
+
 }  // namespace
 }  // namespace dif_sysrst_ctrl_unittest


### PR DESCRIPTION
This adds the output pin override, wakeup status, and locking DIFs, and corresponding unit tests.

Signed-off-by: Timothy Trippel <ttrippel@google.com>