### PR TITLE
[sw/silicon_creator] Configure WREN and WRDI in spi_device_init()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -567,6 +567,14 @@ void spi_device_init(void) {
       .dummy_cycles = 0,
       .handled_in_sw = true,
   });
+  // Configure the WRITE_ENABLE and WRITE_DISABLE commands.
+  reg = bitfield_field32_write(0, SPI_DEVICE_CMD_INFO_WREN_OPCODE_FIELD,
+                               kSpiDeviceOpcodeWriteEnable);
+  reg = bitfield_bit32_write(reg, SPI_DEVICE_CMD_INFO_WREN_VALID_BIT, true);
+  abs_mmio_write32(kBase + SPI_DEVICE_CMD_INFO_WREN_REG_OFFSET, reg);
+  reg = bitfield_field32_write(reg, SPI_DEVICE_CMD_INFO_WRDI_OPCODE_FIELD,
+                               kSpiDeviceOpcodeWriteDisable);
+  abs_mmio_write32(kBase + SPI_DEVICE_CMD_INFO_WRDI_REG_OFFSET, reg);
 
   // Write SFDP table to the reserved region in spi_device buffer.
   uint32_t dest = kSfdpAreaStartAddr;

--- a/sw/device/silicon_creator/lib/drivers/spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.h
@@ -152,6 +152,20 @@ typedef enum spi_device_opcode {
    * the chip should be reset.
    */
   kSpiDeviceOpcodeReset = 0xf0,
+  /**
+   * WRITE_ENABLE command.
+   *
+   * This command is handled by the spi_device. Upon receiving this command,
+   * spi_device sets the WEL (write enable latch) bit of the status register.
+   */
+  kSpiDeviceOpcodeWriteEnable = 0x06,
+  /**
+   * WRITE_DISABLE command.
+   *
+   * This command is handled by the spi_device. Upon receiving this command,
+   * spi_device clears the WEL (write enable latch) bit of the status register.
+   */
+  kSpiDeviceOpcodeWriteDisable = 0x04,
 
 } spi_device_opcode_t;
 

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -119,6 +119,20 @@ TEST_F(InitTest, Init) {
           {SPI_DEVICE_CMD_INFO_14_VALID_14_BIT, 1},
       });
 
+  EXPECT_ABS_WRITE32(
+      base_ + SPI_DEVICE_CMD_INFO_WREN_REG_OFFSET,
+      {
+          {SPI_DEVICE_CMD_INFO_WREN_OPCODE_OFFSET, kSpiDeviceOpcodeWriteEnable},
+          {SPI_DEVICE_CMD_INFO_WREN_VALID_BIT, 1},
+      });
+
+  EXPECT_ABS_WRITE32(base_ + SPI_DEVICE_CMD_INFO_WRDI_REG_OFFSET,
+                     {
+                         {SPI_DEVICE_CMD_INFO_WRDI_OPCODE_OFFSET,
+                          kSpiDeviceOpcodeWriteDisable},
+                         {SPI_DEVICE_CMD_INFO_WRDI_VALID_BIT, 1},
+                     });
+
   std::array<uint32_t, kSpiDeviceSfdpAreaNumBytes / sizeof(uint32_t)>
       sfdp_buffer;
   sfdp_buffer.fill(std::numeric_limits<uint32_t>::max());


### PR DESCRIPTION
spi_device can now handle WREN and WRDI (see #11869 for more details). This PR updates spi_device_init() to configure the relevant registers to handle WREN and WRDI in hardware.

Signed-off-by: Alphan Ulusoy <alphan@google.com>