### PR TITLE
[sw/silicon_creator] Use the actual HW revision in spi_device_init()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -600,6 +600,7 @@ dual_cc_library(
             "@googletest//:gtest",
         ],
         shared = [
+            ":lifecycle",
             "//sw/device/lib/base:abs_mmio",
             "//sw/device/lib/base:memory",
             "//sw/device/silicon_creator/lib:error",

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.c
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.c
@@ -87,4 +87,12 @@ void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {
   }
 }
 
+void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
+  uint32_t reg = sec_mmio_read32(kBase + LC_CTRL_HW_REV_REG_OFFSET);
+  *hw_rev = (lifecycle_hw_rev_t){
+      .chip_gen = bitfield_field32_read(reg, LC_CTRL_HW_REV_CHIP_GEN_FIELD),
+      .chip_rev = bitfield_field32_read(reg, LC_CTRL_HW_REV_CHIP_REV_FIELD),
+  };
+}
+
 #endif

--- a/sw/device/silicon_creator/lib/drivers/lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle.h
@@ -68,6 +68,16 @@ typedef struct lifecycle_device_id {
 } lifecycle_device_id_t;
 
 /**
+ * Hardware revision.
+ *
+ * Consists of a 16-bit chip generation and a 16-bit chip revision.
+ */
+typedef struct lifecycle_hw_rev {
+  uint16_t chip_gen;
+  uint16_t chip_rev;
+} lifecycle_hw_rev_t;
+
+/**
  * Get the life cycle state.
  *
  * This function checks the value read from the hardware and returns a
@@ -93,6 +103,13 @@ uint32_t lifecycle_raw_state_get(void);
  * `HW_CFG` partition in OTP.
  */
 void lifecycle_device_id_get(lifecycle_device_id_t *device_id);
+
+/**
+ * Get the hardware revision.
+ *
+ * @param[out] hw_rev Hardware revision.
+ */
+void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/lifecycle_unittest.cc
@@ -46,6 +46,22 @@ TEST_F(LifecycleTest, DeviceId) {
   EXPECT_THAT(device_id.device_id, ElementsAreArray(kDeviceId));
 }
 
+TEST_F(LifecycleTest, HwRev) {
+  uint16_t exp_chip_gen = 0xa5;
+  uint16_t exp_chip_rev = 0xc3;
+
+  EXPECT_SEC_READ32(base_ + LC_CTRL_HW_REV_REG_OFFSET,
+                    {
+                        {LC_CTRL_HW_REV_CHIP_GEN_OFFSET, exp_chip_gen},
+                        {LC_CTRL_HW_REV_CHIP_REV_OFFSET, exp_chip_rev},
+                    });
+
+  lifecycle_hw_rev_t hw_rev;
+  lifecycle_hw_rev_get(&hw_rev);
+  EXPECT_EQ(hw_rev.chip_gen, exp_chip_gen);
+  EXPECT_EQ(hw_rev.chip_rev, exp_chip_rev);
+}
+
 struct ValidStateTestCase {
   /**
    * Value reported by hardware.

--- a/sw/device/silicon_creator/lib/drivers/meson.build
+++ b/sw/device/silicon_creator/lib/drivers/meson.build
@@ -595,6 +595,7 @@ sw_silicon_creator_lib_driver_spi_device = declare_dependency(
     dependencies: [
       sw_lib_abs_mmio,
       sw_lib_mem,
+      sw_silicon_creator_lib_driver_lifecycle,
     ],
   ),
 )

--- a/sw/device/silicon_creator/lib/drivers/mock_lifecycle.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_lifecycle.cc
@@ -17,5 +17,9 @@ uint32_t lifecycle_raw_state_get(void) {
 void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {
   MockLifecycle::Instance().DeviceId(device_id);
 }
+
+void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
+  MockLifecycle::Instance().HwRev(hw_rev);
+}
 }  // extern "C"
 }  // namespace mask_rom_test

--- a/sw/device/silicon_creator/lib/drivers/mock_lifecycle.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_lifecycle.h
@@ -20,6 +20,7 @@ class MockLifecycle : public global_mock::GlobalMock<MockLifecycle> {
   MOCK_METHOD(lifecycle_state_t, State, ());
   MOCK_METHOD(uint32_t, RawState, ());
   MOCK_METHOD(void, DeviceId, (lifecycle_device_id_t * device_id));
+  MOCK_METHOD(void, HwRev, (lifecycle_hw_rev_t * hw_rev));
 };
 
 }  // namespace internal
@@ -39,6 +40,10 @@ uint32_t lifecycle_raw_state_get(void) {
 
 void lifecycle_device_id_get(lifecycle_device_id_t *device_id) {
   MockLifecycle::Instance().DeviceId(device_id);
+}
+
+void lifecycle_hw_rev_get(lifecycle_hw_rev_t *hw_rev) {
+  MockLifecycle::Instance().HwRev(hw_rev);
 }
 
 }  // extern "C"


### PR DESCRIPTION
This PR updates `spi_device_init()` to use the actual HW revision added in #11617.