### PR TITLE
[spi_device] Latch flip event only when active

### DIFF
--- a/hw/ip/spi_device/rtl/spid_readbuffer.sv
+++ b/hw/ip/spi_device/rtl/spid_readbuffer.sv
@@ -124,7 +124,7 @@ module spid_readbuffer #(
   logic flip_q;
   always_ff @(posedge clk_i or negedge sys_rst_ni) begin
     if (!sys_rst_ni) flip_q <= 1'b 0;
-    else             flip_q <= flip;
+    else if (active) flip_q <= flip;
   end
 
   assign event_flip_o = active && flip && !flip_q;


### PR DESCRIPTION
Problem:

    `flip` occurs regardless of the buffer's active state. Buffer is
    active only when the read command sends output to the host system.
    `flip` sees the address being latched while address is shifted in to
    the register. It causes premature flip event, which in turn results
    in the incorrect watermark event.

Revised the `flip` logic to latch only when the read buffer manager is
active.
