### PR TITLE
[spi_device] Define a buffer address width

### DIFF
--- a/hw/ip/spi_device/data/spi_device.hjson
+++ b/hw/ip/spi_device/data/spi_device.hjson
@@ -617,6 +617,7 @@
           name: "threshold"
           desc: '''If 0, disable the watermark. If non-zero, when the host
             access above or equal to the threshold, it reports an interrupt.
+            The value is byte-granularity not SRAM index.
             '''
         } // f: threshold
       ]

--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -372,11 +372,17 @@ package spi_device_pkg;
   } spi_cmd_e;
 
   // Sram parameters
-  parameter int unsigned SramDw    = 32;
-  parameter int unsigned SramStrbW = SramDw/8;
+  parameter int unsigned SramDw      = 32;
+  parameter int unsigned SramStrbW   = SramDw/8;
+  parameter int unsigned SramOffsetW = $clog2(SramStrbW);
 
   // Msg region is used for read cmd in Flash and Passthrough region
   parameter int unsigned SramMsgDepth = 512; // 2kB
+  parameter int unsigned SramMsgBytes = SramMsgDepth * SramStrbW;
+
+  // Address Width of a Buffer in bytes
+  parameter int unsigned SramBufferBytes = SramMsgBytes / 2; // Double Buffer
+  parameter int unsigned SramBufferAw    = $clog2(SramBufferBytes);
 
   parameter int unsigned SramMailboxDepth = 256; // 1kB for mailbox
 

--- a/hw/ip/spi_device/rtl/spi_readcmd.sv
+++ b/hw/ip/spi_device/rtl/spi_readcmd.sv
@@ -105,9 +105,7 @@ module spi_readcmd
   // SFDP Base Addr: the beginning index of the SFDP region in DPSRAM
   // SFDP Depth: The size of the SFDP buffer (64 fixed in the spi_device_pkg)
   parameter sram_addr_t  SfdpBaseAddr    = spi_device_pkg::SramSfdpIdx,
-  parameter int unsigned SfdpDepth       = spi_device_pkg::SramSfdpDepth,
-
-  localparam int unsigned BufferAw = $clog2(ReadBufferDepth)
+  parameter int unsigned SfdpDepth       = spi_device_pkg::SramSfdpDepth
 ) (
   input clk_i,
   input rst_ni,
@@ -145,7 +143,7 @@ module spi_readcmd
   input logic [CmdInfoIdxW-1:0] cmd_info_idx_i,
 
   // Double buffering in bytes
-  input [BufferAw:0] readbuf_threshold_i,
+  input [SramBufferAw-1:0] readbuf_threshold_i,
 
   // The command mode is 4B mode. Every read command receives 4B address
   input addr_4b_en_i,
@@ -738,9 +736,7 @@ module spi_readcmd
   );
 
   // Double Buffer Management logic
-  spid_readbuffer #(
-    .ReadBufferDepth (ReadBufferDepth)
-  ) u_readbuffer (
+  spid_readbuffer u_readbuffer (
     .clk_i,
     .rst_ni,
 


### PR DESCRIPTION
Previous design defined `threshold` as `[BufferAw:0]`. It is
syntatically correct but confuses contextually. It reduces readability.

In this commit, `SramBufferAw` is defined. It is the required bit width
of a Read Buffer size in bytes rather than the entries in DPSRAM.

This commit does not alter the width of the threshold. It stays 10 bits
as a Read Buffer size is 1kB.