### PR TITLE
[otp_ctrl] Update raw image to avoid assertion error

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_raw.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_raw.hjson
@@ -24,6 +24,26 @@
             ],
         }
         {
+            name:  "HW_CFG",
+            // If set to true, this computes the HW digest value
+            // and locks the partition.
+            lock:  "False",
+            items: [
+                {
+                    name:  "EN_CSRNG_SW_APP_READ",
+                    value: false,
+                },
+                {
+                    name:  "EN_ENTROPY_SRC_FW_READ",
+                    value: false,
+                },
+                {
+                    name: "EN_ENTROPY_SRC_FW_OVER",
+                    value: false,
+                }
+            ],
+        }
+        {
             name:  "LIFE_CYCLE",
             // Can be one of the following strings:
             // RAW, TEST_UNLOCKED0-3, TEST_LOCKED0-2, DEV, PROD, PROD_END, RMA, SCRAP


### PR DESCRIPTION
This PR updates raw image to give a default mubi type in HW CFG
partition fields: en_csrgn_sw_app_read, en_entropy_src_fw_read,
en_entropy_src_fw_over.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>