### PR TITLE
[sw/silicon_creator] Return error on payload overflow in spi_device_cmd_get()

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.cc
@@ -9,8 +9,8 @@ extern "C" {
 
 void spi_device_init(void) { MockSpiDevice::Instance().Init(); }
 
-void spi_device_cmd_get(spi_device_cmd_t *cmd) {
-  MockSpiDevice::Instance().CmdGet(cmd);
+rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
+  return MockSpiDevice::Instance().CmdGet(cmd);
 }
 
 void spi_device_flash_status_clear(void) {

--- a/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_spi_device.h
@@ -17,7 +17,7 @@ namespace internal {
 class MockSpiDevice : public global_mock::GlobalMock<MockSpiDevice> {
  public:
   MOCK_METHOD(void, Init, ());
-  MOCK_METHOD(void, CmdGet, (spi_device_cmd_t *));
+  MOCK_METHOD(rom_error_t, CmdGet, (spi_device_cmd_t *));
   MOCK_METHOD(void, FlashStatusClear, ());
   MOCK_METHOD(uint32_t, FlashStatusGet, ());
 };
@@ -31,8 +31,8 @@ extern "C" {
 
 void spi_device_init(void) { MockSpiDevice::Instance().Init(); }
 
-void spi_device_cmd_get(spi_device_cmd_t *cmd) {
-  MockSpiDevice::Instance().CmdGet(cmd);
+rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
+  return MockSpiDevice::Instance().CmdGet(cmd);
 }
 
 void spi_device_flash_status_clear(void) {

--- a/sw/device/silicon_creator/lib/drivers/spi_device.c
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.c
@@ -612,7 +612,7 @@ void spi_device_init(void) {
   abs_mmio_write32(kBase + SPI_DEVICE_CONTROL_REG_OFFSET, reg);
 }
 
-void spi_device_cmd_get(spi_device_cmd_t *cmd) {
+rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd) {
   uint32_t reg = 0;
   bool cmd_pending = false;
   // TODO(#11871): When should sw read cmd, addr, and payload?
@@ -630,7 +630,12 @@ void spi_device_cmd_get(spi_device_cmd_t *cmd) {
         abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_ADDRFIFO_REG_OFFSET);
   }
 
-  // TODO: Handle the case of non-zero PAYLOAD_START_IDX.
+  reg = abs_mmio_read32(kBase + SPI_DEVICE_INTR_STATE_REG_OFFSET);
+  if (bitfield_bit32_read(reg,
+                          SPI_DEVICE_INTR_COMMON_UPLOAD_PAYLOAD_OVERFLOW_BIT)) {
+    return kErrorSpiDevicePayloadOverflow;
+  }
+
   cmd->payload_byte_count =
       abs_mmio_read32(kBase + SPI_DEVICE_UPLOAD_STATUS2_REG_OFFSET);
   uint32_t src =
@@ -639,6 +644,8 @@ void spi_device_cmd_get(spi_device_cmd_t *cmd) {
   for (size_t i = 0; i < cmd->payload_byte_count; i += sizeof(uint32_t)) {
     write_32(abs_mmio_read32(src + i), dest + i);
   }
+
+  return kErrorOk;
 }
 
 void spi_device_flash_status_clear(void) {

--- a/sw/device/silicon_creator/lib/drivers/spi_device.h
+++ b/sw/device/silicon_creator/lib/drivers/spi_device.h
@@ -336,7 +336,7 @@ typedef struct spi_device_cmd {
  *
  * @param[out] cmd SPI flash command.
  */
-void spi_device_cmd_get(spi_device_cmd_t *cmd);
+rom_error_t spi_device_cmd_get(spi_device_cmd_t *cmd);
 
 /**
  * Clears the SPI flash status register.

--- a/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/spi_device_unittest.cc
@@ -194,6 +194,25 @@ struct CmdGetTestCase {
 class CmdGetTest : public SpiDeviceTest,
                    public testing::WithParamInterface<CmdGetTestCase> {};
 
+TEST_F(CmdGetTest, PayloadOverflow) {
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_UPLOAD_STATUS_REG_OFFSET, 0);
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_UPLOAD_STATUS_REG_OFFSET,
+                    {
+                        {SPI_DEVICE_UPLOAD_STATUS_CMDFIFO_NOTEMPTY_BIT, 1},
+                        {SPI_DEVICE_UPLOAD_STATUS_ADDRFIFO_NOTEMPTY_BIT, 1},
+                    });
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_UPLOAD_CMDFIFO_REG_OFFSET,
+                    kSpiDeviceOpcodePageProgram);
+
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_UPLOAD_ADDRFIFO_REG_OFFSET, 0);
+
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_INTR_STATE_REG_OFFSET,
+                    {{SPI_DEVICE_INTR_COMMON_UPLOAD_PAYLOAD_OVERFLOW_BIT, 1}});
+
+  spi_device_cmd_t cmd;
+  EXPECT_EQ(spi_device_cmd_get(&cmd), kErrorSpiDevicePayloadOverflow);
+}
+
 TEST_P(CmdGetTest, CmdGet) {
   bool has_address = GetParam().address != kSpiDeviceNoAddress;
 
@@ -212,6 +231,8 @@ TEST_P(CmdGetTest, CmdGet) {
                       GetParam().address);
   }
 
+  EXPECT_ABS_READ32(base_ + SPI_DEVICE_INTR_STATE_REG_OFFSET, 0);
+
   std::vector<uint32_t> payload_area(kSpiDevicePayloadAreaNumWords,
                                      std::numeric_limits<uint32_t>::max());
   std::memcpy(payload_area.data(), GetParam().payload.data(),
@@ -225,8 +246,7 @@ TEST_P(CmdGetTest, CmdGet) {
   }
 
   spi_device_cmd_t cmd;
-  spi_device_cmd_get(&cmd);
-
+  EXPECT_EQ(spi_device_cmd_get(&cmd), kErrorOk);
   EXPECT_EQ(cmd.opcode, GetParam().opcode);
   EXPECT_EQ(cmd.address, GetParam().address);
   EXPECT_EQ(cmd.payload_byte_count, GetParam().payload.size());

--- a/sw/device/silicon_creator/lib/error.h
+++ b/sw/device/silicon_creator/lib/error.h
@@ -44,6 +44,7 @@ enum module_ {
   kModuleLog =          MODULE_CODE('L', 'G'),
   kModuleBootData =     MODULE_CODE('B', 'D'),
   kModuleShutdown =     MODULE_CODE('S', 'D'),
+  kModuleSpiDevice =    MODULE_CODE('S', 'P'),
   // clang-format on
 };
 
@@ -128,6 +129,7 @@ enum module_ {
   X(kErrorBootDataNotFound,           ERROR_(1, kModuleBootData, kInternal)), \
   X(kErrorBootDataWriteCheck,         ERROR_(2, kModuleBootData, kInternal)), \
   X(kErrorBootDataInvalid,            ERROR_(3, kModuleBootData, kInternal)), \
+  X(kErrorSpiDevicePayloadOverflow,   ERROR_(1, kModuleSpiDevice, kInternal)), \
   X(kErrorUnknown, 0xFFFFFFFF)
 // clang-format on
 

--- a/sw/device/silicon_creator/mask_rom/bootstrap.c
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.c
@@ -226,7 +226,7 @@ static rom_error_t bootstrap_handle_erase(bootstrap_state_t *state) {
   HARDENED_CHECK_EQ(*state, kBootstrapStateErase);
 
   spi_device_cmd_t cmd;
-  spi_device_cmd_get(&cmd);
+  RETURN_IF_ERROR(spi_device_cmd_get(&cmd));
   // Erase requires WREN, ignore if WEL is not set.
   if (!bitfield_bit32_read(spi_device_flash_status_get(), kSpiDeviceWelBit)) {
     return kErrorOk;
@@ -290,7 +290,7 @@ static rom_error_t bootstrap_handle_program(bootstrap_state_t *state) {
   HARDENED_CHECK_EQ(*state, kBootstrapStateProgram);
 
   spi_device_cmd_t cmd;
-  spi_device_cmd_get(&cmd);
+  RETURN_IF_ERROR(spi_device_cmd_get(&cmd));
   // Erase and program require WREN, ignore if WEL is not set.
   if (cmd.opcode != kSpiDeviceOpcodeReset &&
       !bitfield_bit32_read(spi_device_flash_status_get(), kSpiDeviceWelBit)) {


### PR DESCRIPTION
I was planning to treat payload buffer overflows as errors to make debugging trivial (assuming that we will be able to read the error code that led to shutdown) but I marked this as a draft because would like to hear your thoughts after @a-will's comment [here](https://github.com/lowRISC/opentitan/pull/12088#discussion_r856673222).

Related: #11935

cc @cfrantz @a-will 