### PR TITLE
[spi_device] Add Buffer update signal

### DIFF
--- a/hw/ip/spi_device/rtl/spid_readbuffer.sv
+++ b/hw/ip/spi_device/rtl/spid_readbuffer.sv
@@ -57,9 +57,18 @@ module spid_readbuffer
   // start: data Output phase indicator. Either pulse or level are fine.
   input start_i,
 
+  // The Buffer logic updates its status only at the last beat of the byte.
+  // The time is when the address is updated.
+  // It is expected that the address is updated at the end of beat of a byte.
+  input address_update_i,
+
   output logic event_watermark_o,
   output logic event_flip_o
 );
+
+  // FIXME: Update logic
+  logic unused_address_update;
+  assign unused_address_update = address_update_i;
 
   ////////////////
   // Definition //


### PR DESCRIPTION
This commit adds buffer update logic in Read command processing block.
The signal is asserted when the last beat of a byte hit or the full
address (incl. byte) is being latched.

It changes the `start` time. In previous design start asserts while it is in `MainOutput` state. Now it asserts as a pulse when it enters `MainOutput`. The assertion time is a cycle earlier than the previous design.