### PR TITLE
[dif/sysrst_ctrl] finish DIF lib

### DIFF
--- a/sw/device/lib/dif/dif_sysrst_ctrl.c
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.c
@@ -12,6 +12,13 @@
 
 #include "sysrst_ctrl_regs.h"  // Generated.
 
+static_assert(SYSRST_CTRL_PARAM_NUM_COMBO == 4,
+              "Number of key combinations has changed. Update the "
+              "dif_sysrst_ctrl_key_combo_t enum.");
+static_assert(SYSRST_CTRL_KEY_INTR_STATUS_FLASH_WP_L_L2H_BIT == 13,
+              "Flash write-protect key interrupt bit has changed. Update the "
+              "dif_sysrst_ctrl_input_change_irq_get_causes() DIF.");
+
 dif_result_t dif_sysrst_ctrl_key_combo_detect_configure(
     const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_key_combo_t key_combo,
     dif_sysrst_ctrl_key_combo_config_t config) {
@@ -697,6 +704,54 @@ dif_result_t dif_sysrst_ctrl_auto_override_get_enabled(
   *is_enabled =
       dif_bool_to_toggle(bitfield_bit32_read(auto_block_ctl_reg, en_bit_index));
 
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_key_combo_irq_get_causes(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, uint32_t *causes) {
+  if (sysrst_ctrl == NULL || causes == NULL) {
+    return kDifBadArg;
+  }
+
+  *causes = mmio_region_read32(sysrst_ctrl->base_addr,
+                               SYSRST_CTRL_COMBO_INTR_STATUS_REG_OFFSET);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_key_combo_irq_clear_causes(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, uint32_t causes) {
+  if (sysrst_ctrl == NULL || causes >= (1U << SYSRST_CTRL_PARAM_NUM_COMBO)) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_COMBO_INTR_STATUS_REG_OFFSET, causes);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_input_change_irq_get_causes(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, uint32_t *causes) {
+  if (sysrst_ctrl == NULL || causes == NULL) {
+    return kDifBadArg;
+  }
+
+  *causes = mmio_region_read32(sysrst_ctrl->base_addr,
+                               SYSRST_CTRL_KEY_INTR_STATUS_REG_OFFSET);
+
+  return kDifOk;
+}
+
+dif_result_t dif_sysrst_ctrl_input_change_irq_clear_causes(
+    const dif_sysrst_ctrl_t *sysrst_ctrl, uint32_t causes) {
+  if (sysrst_ctrl == NULL ||
+      causes >= (1U << (SYSRST_CTRL_KEY_INTR_STATUS_FLASH_WP_L_L2H_BIT + 1))) {
+    return kDifBadArg;
+  }
+
+  mmio_region_write32(sysrst_ctrl->base_addr,
+                      SYSRST_CTRL_KEY_INTR_STATUS_REG_OFFSET, causes);
   return kDifOk;
 }
 

--- a/sw/device/lib/dif/dif_sysrst_ctrl.h
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.h
@@ -437,6 +437,22 @@ dif_result_t dif_sysrst_ctrl_output_pin_override_configure(
     dif_sysrst_ctrl_pin_config_t config);
 
 /**
+ * Configures a System Reset Controller's key signal auto-override feature.
+ *
+ * Upon detection of a Power Button high-to-low transition, the signals from
+ * generic keys 0 through 2 may be overriden with specified values.
+ *
+ * @param sysrst_ctrl A System Reset Controller handle.
+ * @param config Runtime configuration parameters.
+ * @param enabled Whether to enable the feature or not.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_sysrst_ctrl_auto_override_configure(
+    const dif_sysrst_ctrl_t *sysrst_ctrl,
+    dif_sysrst_ctrl_auto_override_config_t config, dif_toggle_t enabled);
+
+/**
  * Configures a System Reset Controller's ultra-low-power (ULP) wakeup feature.
  *
  * @param sysrst_ctrl A System Reset Controller handle.
@@ -582,9 +598,6 @@ dif_result_t dif_sysrst_ctrl_output_pin_override_get_enabled(
  * value. Attempting to set the override value of an input pin will return
  * `kDifBadArg`.
  *
- * Additionally, this will return `kDifError` if an output pin's override
- * fuction is disabled, or the override value is not allowed.
- *
  * @param sysrst_ctrl A System Reset Controller handle.
  * @param pin The output pin to override.
  * @param value The override value to set on the pin.
@@ -634,44 +647,40 @@ dif_result_t dif_sysrst_ctrl_input_pin_read(
     bool *value);
 
 /**
- * Configures a System Reset Controller's key signal auto-override feature.
- *
- * Upon detection of a Power Button high-to-low transition, the signals from
- * generic keys 0 through 2 may be overriden with specified values.
- *
- * @param sysrst_ctrl A System Reset Controller handle.
- * @param config Runtime configuration parameters.
- * @param enabled Whether to enable the feature or not.
- * @return The result of the operation.
- */
-OT_WARN_UNUSED_RESULT
-dif_result_t dif_sysrst_ctrl_auto_override_configure(
-    const dif_sysrst_ctrl_t *sysrst_ctrl,
-    dif_sysrst_ctrl_auto_override_config_t config, dif_toggle_t enabled);
-
-/**
  * Sets the enablement of a System Reset Controller's key signal auto-override
  * feature.
  *
+ * Note, this feature is only available for keys 0, 1, and 2. Attempting to
+ * enable the auto-override feature on non-supported keys will return
+ * `kDifBadArg`.
+ *
  * @param sysrst_ctrl A System Reset Controller handle.
+ * @param key The key to enable the override feature for.
  * @param enabled Whether to enable the feature or not.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_sysrst_ctrl_auto_override_set_enabled(
-    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_toggle_t enabled);
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_key_t key,
+    dif_toggle_t enabled);
 
 /**
  * Gets the enablement of a System Reset Controller's key signal auto-override
  * feature.
  *
+ * Note, this feature is only available for keys 0, 1, and 2. Attempting to
+ * check whether the auto-override feature is enabled non-supported keys will
+ * return `kDifBadArg`.
+ *
  * @param sysrst_ctrl A System Reset Controller handle.
+ * @param key The key the override feature is enabled for.
  * @param[out] is_enabled Whether the feature is enabled or not.
  * @return The result of the operation.
  */
 OT_WARN_UNUSED_RESULT
 dif_result_t dif_sysrst_ctrl_auto_override_get_enabled(
-    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_toggle_t *is_enabled);
+    const dif_sysrst_ctrl_t *sysrst_ctrl, dif_sysrst_ctrl_key_t key,
+    dif_toggle_t *is_enabled);
 
 /**
  * Gets the cause(s) of a key combination detection IRQ.

--- a/sw/device/lib/dif/dif_sysrst_ctrl.md
+++ b/sw/device/lib/dif/dif_sysrst_ctrl.md
@@ -11,8 +11,8 @@ All checklist items refer to the content in the [Checklist]({{< relref "/doc/pro
 
 Type           | Item                 | Resolution  | Note/Collaterals
 ---------------|----------------------|-------------|------------------
-Implementation | [DIF_EXISTS][]       | In Progress |
-Implementation | [DIF_USED_IN_TREE][] | In Progress |
+Implementation | [DIF_EXISTS][]       | Done        |
+Implementation | [DIF_USED_IN_TREE][] | Done        |
 Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 
 [DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
@@ -24,8 +24,8 @@ Tests          | [DIF_TEST_SMOKE][]   | Not Started |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
@@ -39,7 +39,7 @@ Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
 Documentation  | [DIF_DOC_HW][]                   | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
-Tests          | [DIF_TEST_UNIT][]                | In Progress |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |

--- a/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_sysrst_ctrl_unittest.cc
@@ -691,6 +691,78 @@ TEST_F(AutoOverrideGetEnabledTest, Success) {
   EXPECT_EQ(is_enabled, kDifToggleEnabled);
 }
 
+class KeyComboIrqGetCausesTest : public SysrstCtrlTest {};
+
+TEST_F(KeyComboIrqGetCausesTest, NullArgs) {
+  uint32_t causes;
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_key_combo_irq_get_causes(nullptr, &causes));
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_key_combo_irq_get_causes(&sysrst_ctrl_, nullptr));
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_key_combo_irq_get_causes(nullptr, nullptr));
+}
+
+TEST_F(KeyComboIrqGetCausesTest, Success) {
+  uint32_t causes;
+  EXPECT_READ32(SYSRST_CTRL_COMBO_INTR_STATUS_REG_OFFSET, 0xf);
+  EXPECT_DIF_OK(
+      dif_sysrst_ctrl_key_combo_irq_get_causes(&sysrst_ctrl_, &causes));
+  EXPECT_EQ(causes, 0xf);
+}
+
+class KeyComboIrqClearCausesTest : public SysrstCtrlTest {};
+
+TEST_F(KeyComboIrqClearCausesTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_sysrst_ctrl_key_combo_irq_clear_causes(nullptr, 0xf));
+}
+
+TEST_F(KeyComboIrqClearCausesTest, BadCauses) {
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_key_combo_irq_clear_causes(&sysrst_ctrl_, 0x1f));
+}
+
+TEST_F(KeyComboIrqClearCausesTest, Success) {
+  EXPECT_WRITE32(SYSRST_CTRL_COMBO_INTR_STATUS_REG_OFFSET, 0xf);
+  EXPECT_DIF_OK(dif_sysrst_ctrl_key_combo_irq_clear_causes(&sysrst_ctrl_, 0xf));
+}
+
+class InputChangeIrqGetCausesTest : public SysrstCtrlTest {};
+
+TEST_F(InputChangeIrqGetCausesTest, NullArgs) {
+  uint32_t causes;
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_irq_get_causes(nullptr, &causes));
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_irq_get_causes(&sysrst_ctrl_, nullptr));
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_irq_get_causes(nullptr, nullptr));
+}
+
+TEST_F(InputChangeIrqGetCausesTest, Success) {
+  uint32_t causes;
+  EXPECT_READ32(SYSRST_CTRL_KEY_INTR_STATUS_REG_OFFSET, 0x3f);
+  EXPECT_DIF_OK(
+      dif_sysrst_ctrl_input_change_irq_get_causes(&sysrst_ctrl_, &causes));
+  EXPECT_EQ(causes, 0x3f);
+}
+
+class InputChangeIrqClearCausesTest : public SysrstCtrlTest {};
+
+TEST_F(InputChangeIrqClearCausesTest, NullArgs) {
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_irq_clear_causes(nullptr, 0xf));
+}
+
+TEST_F(InputChangeIrqClearCausesTest, BadCauses) {
+  EXPECT_DIF_BADARG(
+      dif_sysrst_ctrl_input_change_irq_clear_causes(&sysrst_ctrl_, 0x4000));
+}
+
+TEST_F(InputChangeIrqClearCausesTest, Success) {
+  EXPECT_WRITE32(SYSRST_CTRL_KEY_INTR_STATUS_REG_OFFSET, 0xff);
+  EXPECT_DIF_OK(
+      dif_sysrst_ctrl_input_change_irq_clear_causes(&sysrst_ctrl_, 0xff));
+}
+
 class UlpWakeupGetStatusTest : public SysrstCtrlTest {};
 
 TEST_F(UlpWakeupGetStatusTest, NullArgs) {


### PR DESCRIPTION
This completes the sysrst_ctrl DIF library by implementing all remaining functions and corresponding unit tests.