### PR TITLE
[bazel] Update the cpu to the official riscv32 constraint

### DIFF
--- a/rules/rv.bzl
+++ b/rules/rv.bzl
@@ -4,7 +4,7 @@
 
 """Helpers for transitioning to the RISC-V target."""
 
-OPENTITAN_CPU = "@bazel_embedded//constraints/cpu:riscv32"
+OPENTITAN_CPU = "@platforms//cpu:riscv32"
 OPENTITAN_PLATFORM = "@bazel_embedded//platforms:opentitan_rv32imc"
 
 # This constant holds a dictionary of per-device dependencies which are used to

--- a/third_party/bazel_embedded/repos.bzl
+++ b/third_party/bazel_embedded/repos.bzl
@@ -15,7 +15,17 @@ def bazel_embedded_repos(local = None):
     else:
         http_archive(
             name = "bazel_embedded",
-            sha256 = "2af581b33bf7e8ce702b31fc38ae59ee846ae01d6237ad507c83991eb529826b",
-            strip_prefix = "bazel-embedded-e3e26097f3fe8775670c7031bf03a49e75873a02",
-            url = "https://github.com/lowRISC/bazel-embedded/archive/e3e26097f3fe8775670c7031bf03a49e75873a02.tar.gz",
+            sha256 = "278562634fb0261bc85c9da3ed003eba86430a56bd4668cc742779c3fa085fec",
+            strip_prefix = "bazel-embedded-322dd944eb6b2f1c7736d854ff3026840f3ef8f3",
+            url = "https://github.com/lowRISC/bazel-embedded/archive/322dd944eb6b2f1c7736d854ff3026840f3ef8f3.tar.gz",
         )
+
+    # The platforms repo contains standard cpu/os/disto contraints.
+    http_archive(
+        name = "platforms",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/0.0.5/platforms-0.0.5.tar.gz",
+        ],
+        sha256 = "379113459b0feaf6bfbb584a91874c065078aa673222846ac765f86661c27407",
+    )

--- a/third_party/freertos/BUILD.freertos.bazel
+++ b/third_party/freertos/BUILD.freertos.bazel
@@ -8,7 +8,7 @@ cc_library(
     name = "portmacro",
     hdrs = ["portable/GCC/RISC-V/portmacro.h"],
     includes = ["portable/GCC/RISC-V"],
-    target_compatible_with = ["@bazel_embedded//constraints/cpu:riscv32"],
+    target_compatible_with = ["@platforms//cpu:riscv32"],
 )
 
 cc_library(


### PR DESCRIPTION
- Use bazelbuild/platforms 0.0.5 which contains the official `riscv32` constraint.
- Update the project to use the official constraint.
- Update to a bazel-embedded that uses the official constraint.

Signed-off-by: Chris Frantz <cfrantz@google.com>