### PR TITLE
[spi_device]: pre_dv - Test mailbox crossing in Flash mode

### DIFF
--- a/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_readcmd_tb.sv
@@ -425,6 +425,30 @@ module tb;
     //=========================================================================
     // Issue Read Cmd starting at the last byte in front of the Mailbox then
     // cross
+    $display("Sending a read command starting at the end of read buffer and crossing Mailbox");
+    mbx_reqsize = $urandom_range(2,36);
+    spiflash_read(
+      tb_sif,
+      8'h 3B,
+      32'h 0000_17FF, // end of read buffer
+      1'b 0,
+      4,
+      mbx_reqsize, // min value 2 that crosses the mailbox boundary
+      IoDual,
+      read_data
+    );
+
+    expected_data = get_read_data('h 7FF, 1);
+    if (read_data.pop_front() != expected_data.pop_front()) begin
+      test_passed = 1'b 0;
+    end
+    expected_data.delete();
+    expected_data = get_mbx_data(SramMailboxIdx, mbx_reqsize -1);
+
+    match = check_data(read_data, expected_data);
+    if (match == 1'b 0) test_passed = 1'b 0;
+    read_data.delete();
+    expected_data.delete();
 
     // Switch PassThrough mode
     ->flashmode_done;


### PR DESCRIPTION
The first two commits belong to #12441 . Please review the last two commits.

**test(spi_device): Read command ending at the mailbox**

This commit adds a pre_dv test that ending at the last byte of the read
buffer. It is to visually check if mailbox information is changed due to
the command.

**test(spi_device): Add read command crossing Mailbox in Flash mode**

This commit adds a pre_dv test that crosses the Mailbox space in Flash
mode. It begins the read at the last byte of the read buffer space then
crosses.