### PR TITLE
[bazel] Disassemble blocks of zeroes

### DIFF
--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -138,7 +138,7 @@ def _elf_to_disassembly_impl(ctx):
                 ctx.file._cleanup_script.path,
                 disassembly.path,
             ],
-            command = "$1 --disassemble --headers --line-numbers --source $2 | $3 > $4",
+            command = "$1 --disassemble --headers --line-numbers --disassemble-zeroes --source $2 | $3 > $4",
         )
         return [DefaultInfo(files = depset(outputs), data_runfiles = ctx.runfiles(files = outputs))]
 


### PR DESCRIPTION
This commit adds the "--disassemble-zeroes" option to objdump command to
make it easier to see usages of hardened check macros.

Before:
```
mask_rom_main():
    84c0:       1101                    addi    sp,sp,-32
    84c2:       ce06                    sw      ra,28(sp)
    84c4:       cc22                    sw      s0,24(sp)
    84c6:       ca26                    sw      s1,20(sp)
    84c8:       c84a                    sw      s2,16(sp)
    84ca:       c64e                    sw      s3,12(sp)
    84cc:       6905                    lui     s2,0x1
    84ce:       f5f90413                addi    s0,s2,-161 # f5f <_otbn_remote_app_run_rsa_verify_3072_rr_modexp__dmem_bss_end+0x93f>
    84d2:       c5418493                addi    s1,gp,-940 # 10000aa4 <rom_counters>
    84d6:       c080                    sw      s0,0(s1)
    84d8:       8522                    mv      a0,s0
    84da:       3e8060ef                jal     ra,e8c2 <barrier32>
    84de:       4088                    lw      a0,0(s1)
    84e0:       00850663                beq     a0,s0,84ec <mask_rom_main+0x2c>
        ...
```

After:
```
mask_rom_main():
    82e8:       1101                    addi    sp,sp,-32
    82ea:       ce06                    sw      ra,28(sp)
    82ec:       cc22                    sw      s0,24(sp)
    82ee:       ca26                    sw      s1,20(sp)
    82f0:       c84a                    sw      s2,16(sp)
    82f2:       c64e                    sw      s3,12(sp)
    82f4:       c452                    sw      s4,8(sp)
    82f6:       6505                    lui     a0,0x1
    82f8:       f5f50593                addi    a1,a0,-161 # f5f <_otbn_remote_app_run_rsa_verify_3072_rr_modexp__dmem_bss_end+0x93f>
    82fc:       c5418a13                addi    s4,gp,-940 # 10000aa4 <rom_counters>
    8399:       00ba2023                sw      a1,0(s4)
    8403:       000a2603                lw      a2,0(s4)
    8407:       00b60663                beq     a2,a1,8414 <mask_rom_main+0x2c>
    839c:       0000                    unimp
    839e:       0000                    unimp
    8409:       0000                    unimp
    8411:       0000                    unimp
```

Signed-off-by: Alphan Ulusoy <alphan@google.com>