### PR TITLE
[bazel] Move _mask_rom_interrupt_vector_c to .vectors to eliminate padding

### DIFF
--- a/sw/device/silicon_creator/mask_rom/mask_rom_start.S
+++ b/sw/device/silicon_creator/mask_rom/mask_rom_start.S
@@ -71,11 +71,7 @@ _mask_rom_interrupt_vector_asm:
 
   /**
    * Post C runtime initialization RISC-V vectored exception/interrupt handlers.
-   *
-   * This vector is placed into the .crt section so that .vectors doesn't need to
-   * be padded to a 256 byte boundary.
    */
-  .section .crt, "ax"
   .balign 256
   .global _mask_rom_interrupt_vector_c
   .type _mask_rom_interrupt_vector_c, @function


### PR DESCRIPTION
I had some time to look more into the size difference between the binaries built using meson vs bazel, specifically why `mask_rom_exception_handler()` is placed at the start of the `.crt` section when using bazel. This introduces extra padding since `_mask_rom_interrupt_vector_c` is aligned to 256 bytes.

I think, the reason why we don't have this issue in meson is because `mask_rom_start.S` appears before `mask_rom.c`. Reordering them in the `srcs` of `opentian_rom_binary()` in `sw/device/silicon_creator/mask_rom/BUILD` fixes the issue but would be very fragile (also not allowed by the buildifier).

I was thinking about updating the linker file and `mask_rom.h` to put the functions defined in c after asm definitions but realized that we can actually place `_mask_rom_interrupt_vector_c` into `.vectors` instead of `.crt` without any overhead since the c interrupt vector is aligned to 256 bytes as well, i.e. the comment removed in this PR doesn't seem to be accurate.

`mask_rom_fpga_cw310.elf.s`: [before](https://gist.github.com/8aa8fc7a2256487e9182a77325e434a6), [after](https://gist.github.com/287bfff3f847afb9726669ed2067606f)

This PR also reduces the size of `mask_rom_fpga_cw310.bin` from 31832 bytes to 31640 bytes (-192 bytes)

Related to #12069 (@timothytrippel).

Signed-off-by: Alphan Ulusoy <alphan@google.com>