### PR TITLE
[dvsim] revert #12319 to fix CI

### DIFF
--- a/hw/dv/tools/dvsim/sim.mk
+++ b/hw/dv/tools/dvsim/sim.mk
@@ -88,28 +88,8 @@ ifneq (${sw_images},)
 			cp ${proj_root}/$$image* $$target_dir/.; \
 		else \
 			echo "Building SW image \"$$image\"."; \
-			if [[ $$index == "0" ]]; then \
-				target="$$image""_${sw_build_device}"; \
-				image_basename="$$(basename $${target}).scr.39.vmem"; \
-				if [[ -z $${BAZEL_PYTHON_WHEELS_REPO} ]]; then \
-					echo "Building \"//$$(dirname $$image)\" with bazel on network-connected machine."; \
-					./bazelisk.sh build //$$(dirname $$image); \
-					bazel_image_path=$$(find -L $$(./bazelisk.sh info output_path)/ -type f -name "$${image_basename}"); \
-				else \
-					echo "Building \"//$$(dirname $$image)\" with bazel on air-gapped machine."; \
-					bazel build \
-						--distdir=$$BAZEL_DISTDIR \
-						--repository_cache=$$BAZEL_CACHE \
-						//$$(dirname $$image); \
-					bazel_image_path=$$(find -L $$(bazel info output_path)/ -type f -name "$${image_basename}"); \
-				fi; \
-				target_dir="${sw_build_dir}/build-bin/$$(dirname $${target})"; \
-				mkdir -p $$target_dir; \
-				cp $$bazel_image_path $$target_dir/; \
-			else \
-				target="$$image""_export_${sw_build_device}"; \
-				${LOCK_SW_BUILD_DIR} "ninja -C ${sw_build_dir}/build-out $$target"; \
-			fi; \
+			target="$$image""_export_${sw_build_device}"; \
+			${LOCK_SW_BUILD_DIR} "ninja -C ${sw_build_dir}/build-out $$target"; \
 		fi; \
 	done;
 endif

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -158,6 +158,7 @@ opentitan_functest(
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing:pwrmgr_testutils",
         "//sw/device/lib/testing:rstmgr_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
     ],
 )
 

--- a/sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test.c
+++ b/sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test.c
@@ -6,10 +6,10 @@
 #include "sw/device/lib/dif/dif_pwrmgr.h"
 #include "sw/device/lib/dif/dif_rstmgr.h"
 #include "sw/device/lib/runtime/log.h"
-#include "sw/device/lib/testing/check.h"
 #include "sw/device/lib/testing/pwrmgr_testutils.h"
 #include "sw/device/lib/testing/rstmgr_testutils.h"
-#include "sw/device/lib/testing/test_framework/ottf.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
 


### PR DESCRIPTION
This reverts #12319 and changes dvsim.py back to use meson to build the
ROM images.

Signed-off-by: Timothy Trippel <ttrippel@google.com>