### PR TITLE
[bazel] Add sha256s for http_archives

### DIFF
--- a/rules/dynamic_archive.bzl
+++ b/rules/dynamic_archive.bzl
@@ -1,0 +1,215 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamic archive macro loads repos from archives with dynamic tarballs but
+stable contents for OpenTitan.
+"""
+
+load(
+    "@bazel_tools//tools/build_defs/repo:utils.bzl",
+    "patch",
+    "read_netrc",
+    "read_user_netrc",
+    "update_attrs",
+    "use_netrc",
+    "workspace_and_buildfile",
+)
+
+def _get_auth(ctx, urls):
+    """Given the list of URLs obtain the correct auth dict."""
+    if ctx.attr.netrc:
+        netrc = read_netrc(ctx, ctx.attr.netrc)
+    else:
+        netrc = read_user_netrc(ctx)
+    return use_netrc(netrc, urls, ctx.attr.auth_patterns)
+
+def _check_dir_sha(ctx):
+    """Utility function checks the sha256 of a directory instead of an archive
+
+    It assumes the parameters `sha256` and `output` to be present in
+    `ctx.attr`; the latter possibly with value None.
+
+    Args:
+      ctx: The repository context of the repository rule calling this utility
+      function.
+
+    Returns a sha256 of the directory contents.
+    """
+    command = "find . -type f -print0 | xargs -0 sha256sum | sort -k 2 | sha256sum"
+    st = ctx.execute(["bash", "-c", command])
+    if st.return_code:
+        fail("Error listing and hashing with command %s:\n%s$s" %
+             (command, st.stdout, st.stderr))
+    else:
+        sha256 = st.stdout[:64]
+    if ctx.attr.sha256 and ctx.attr.sha256 != sha256:
+        findv = ctx.execute(["bash", "-c", "find --version"])
+        shav = ctx.execute(["bash", "-c", "sha256sum --version"])
+        pwd = ctx.execute(["bash", "-c", "pwd"])
+        print("\n{}\n{}\n{}".format(findv.stdout, shav.stdout, pwd.stdout))
+        fail("hashed directory contents, and got sha {}, expected {}\n".format(sha256, ctx.attr.sha256))
+    return sha256
+
+def _dynamic_archive_impl(ctx):
+    """Implementation of the dynamic_archive rule."""
+    if not ctx.attr.urls:
+        fail("urls must be provided")
+    if ctx.attr.build_file and ctx.attr.build_file_content:
+        fail("Only one of build_file and build_file_content can be provided.")
+
+    auth = _get_auth(ctx, ctx.attr.urls)
+
+    download_info = ctx.download_and_extract(
+        url = ctx.attr.urls,
+        output = "",
+        sha256 = "",  #omit ctx.attr.sha256 here but check later
+        type = ctx.attr.type,
+        stripPrefix = ctx.attr.strip_prefix,
+        canonical_id = ctx.attr.canonical_id,
+        auth = auth,
+    )
+
+    # check sha256 here before we edit the directory strucutre
+    sha256 = _check_dir_sha(ctx)
+
+    workspace_and_buildfile(ctx)
+    patch(ctx, auth = auth)
+
+    sha256_override = {"sha256": sha256}
+    return update_attrs(ctx.attr, _dynamic_archive_attrs.keys(), sha256_override)
+
+_dynamic_archive_attrs = {
+    "urls": attr.string_list(
+        doc =
+            """A list of URLs to a file that will be made available to Bazel.
+Each entry must be a file, http or https URL. Redirections are followed.
+Authentication is not supported.
+URLs are tried in order until one succeeds, so you should list local mirrors first.
+If all downloads fail, the rule will fail.""",
+    ),
+    "sha256": attr.string(
+        doc = """The expected SHA-256 of the file downloaded.
+This must match the SHA-256 of the file downloaded. _It is a security risk
+to omit the SHA-256 as remote files can change._ At best omitting this
+field will make your build non-hermetic. It is optional to make development
+easier but either this attribute should be set before shipping.""",
+    ),
+    "netrc": attr.string(
+        doc = "Location of the .netrc file to use for authentication",
+    ),
+    "auth_patterns": attr.string_dict(),
+    "canonical_id": attr.string(
+        doc = """A canonical id of the archive downloaded.
+If specified and non-empty, bazel will not take the archive from cache,
+unless it was added to the cache by a request with the same canonical id.
+""",
+    ),
+    "strip_prefix": attr.string(
+        doc = """A directory prefix to strip from the extracted files.
+Many archives contain a top-level directory that contains all of the useful
+files in archive. Instead of needing to specify this prefix over and over
+in the `build_file`, this field can be used to strip it from all of the
+extracted files.
+For example, suppose you are using `foo-lib-latest.zip`, which contains the
+directory `foo-lib-1.2.3/` under which there is a `WORKSPACE` file and are
+`src/`, `lib/`, and `test/` directories that contain the actual code you
+wish to build. Specify `strip_prefix = "foo-lib-1.2.3"` to use the
+`foo-lib-1.2.3` directory as your top-level directory.
+Note that if there are files outside of this directory, they will be
+discarded and inaccessible (e.g., a top-level license file). This includes
+files/directories that start with the prefix but are not in the directory
+(e.g., `foo-lib-1.2.3.release-notes`). If the specified prefix does not
+match a directory in the archive, Bazel will return an error.""",
+    ),
+    "type": attr.string(
+        doc = """The archive type of the downloaded file.
+By default, the archive type is determined from the file extension of the
+URL. If the file has no extension, you can explicitly specify one of the
+following: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`, `"tar.gz"`, `"tgz"`,
+`"tar.xz"`, `"txz"`, `"tar.zst"`, `"tzst"`, `tar.bz2`, `"ar"`, or `"deb"`.""",
+    ),
+    "patches": attr.label_list(
+        default = [],
+        doc =
+            "A list of files that are to be applied as patches after " +
+            "extracting the archive. By default, it uses the Bazel-native patch implementation " +
+            "which doesn't support fuzz match and binary patch, but Bazel will fall back to use " +
+            "patch command line tool if `patch_tool` attribute is specified or there are " +
+            "arguments other than `-p` in `patch_args` attribute.",
+    ),
+    "remote_patches": attr.string_dict(
+        default = {},
+        doc =
+            "A map of patch file URL to its integrity value, they are applied after extracting " +
+            "the archive and before applying patch files from the `patches` attribute. " +
+            "It uses the Bazel-native patch implementation, you can specify the patch strip " +
+            "number with `remote_patch_strip`",
+    ),
+    "remote_patch_strip": attr.int(
+        default = 0,
+        doc =
+            "The number of leading slashes to be stripped from the file name in the remote patches.",
+    ),
+    "patch_tool": attr.string(
+        default = "",
+        doc = "The patch(1) utility to use. If this is specified, Bazel will use the specifed " +
+              "patch tool instead of the Bazel-native patch implementation.",
+    ),
+    "patch_args": attr.string_list(
+        default = ["-p0"],
+        doc =
+            "The arguments given to the patch tool. Defaults to -p0, " +
+            "however -p1 will usually be needed for patches generated by " +
+            "git. If multiple -p arguments are specified, the last one will take effect." +
+            "If arguments other than -p are specified, Bazel will fall back to use patch " +
+            "command line tool instead of the Bazel-native patch implementation. When falling " +
+            "back to patch command line tool and patch_tool attribute is not specified, " +
+            "`patch` will be used. This only affects patch files in the `patches` attribute.",
+    ),
+    "patch_cmds": attr.string_list(
+        default = [],
+        doc = "Sequence of Bash commands to be applied on Linux/Macos after patches are applied.",
+    ),
+    "build_file": attr.label(
+        allow_single_file = True,
+        doc =
+            "The file to use as the BUILD file for this repository." +
+            "This attribute is an absolute label (use '@//' for the main " +
+            "repo). The file does not need to be named BUILD, but can " +
+            "be (something like BUILD.new-repo-name may work well for " +
+            "distinguishing it from the repository's actual BUILD files. " +
+            "Either build_file or build_file_content can be specified, but " +
+            "not both.",
+    ),
+    "build_file_content": attr.string(
+        doc =
+            "The content for the BUILD file for this repository. " +
+            "Either build_file or build_file_content can be specified, but " +
+            "not both.",
+    ),
+    "workspace_file": attr.label(
+        doc =
+            "The file to use as the `WORKSPACE` file for this repository. " +
+            "Either `workspace_file` or `workspace_file_content` can be " +
+            "specified, or neither, but not both.",
+    ),
+    "workspace_file_content": attr.string(
+        doc =
+            "The content for the WORKSPACE file for this repository. " +
+            "Either `workspace_file` or `workspace_file_content` can be " +
+            "specified, or neither, but not both.",
+    ),
+}
+
+dynamic_archive = repository_rule(
+    implementation = _dynamic_archive_impl,
+    attrs = _dynamic_archive_attrs,
+    doc =
+        """Downloads a Bazel repository as a compressed archive file, decompresses it,
+and makes its targets available for binding.
+It supports the following file extensions: `"zip"`, `"jar"`, `"war"`, `"aar"`, `"tar"`,
+`"tar.gz"`, `"tgz"`, `"tar.xz"`, `"txz"`, `"tar.zst"`, `"tzst"`, `tar.bz2`, `"ar"`,
+or `"deb"`.
+""",
+)

--- a/third_party/cc/repos.bzl
+++ b/third_party/cc/repos.bzl
@@ -14,8 +14,9 @@ def cc_repos():
 
     http_archive(
         name = "com_google_absl",
+        sha256 = "1da554cf5670fc119ef5afbeb31d10d51e7554df9dced2967663e679b8d852ed",
         strip_prefix = "abseil-cpp-e854df09dfcb35056c1d42420028648ee0ebebaf",
-        url = "https://github.com/abseil/abseil-cpp/archive/e854df09dfcb35056c1d42420028648ee0ebebaf.tar.gz",
+        urls = ["https://github.com/abseil/abseil-cpp/archive/e854df09dfcb35056c1d42420028648ee0ebebaf.tar.gz"],
     )
 
     native.local_repository(

--- a/third_party/lint/repos.bzl
+++ b/third_party/lint/repos.bzl
@@ -13,8 +13,9 @@ def lint_repos():
 
     http_archive(
         name = "com_github_bazelbuild_buildtools",
-        strip_prefix = "buildtools-main",
-        url = "https://github.com/bazelbuild/buildtools/archive/main.zip",
+        sha256 = "3a2d2890d6a2948adb3040ee555483eeb483f73b839376c0fac60443e9a3d5b2",
+        strip_prefix = "buildtools-c802c3b06ba674e8a76d04c0677d153ab9f660c9",
+        url = "https://github.com/bazelbuild/buildtools/archive/c802c3b06ba674e8a76d04c0677d153ab9f660c9.zip",
     )
 
     http_archive(

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//rules:dynamic_archive.bzl", "dynamic_archive")
 
 def rust_repos():
     http_archive(
@@ -13,14 +14,16 @@ def rust_repos():
     )
 
     # Boring is only used to build Mundane.
-    http_archive(
+    dynamic_archive(
         name = "boringssl",
-        url = "https://boringssl.googlesource.com/boringssl/+archive/4fb158925f7753d80fb858cb0239dff893ef9f15.tar.gz",
+        sha256 = "9b0e6195cf7270149f7719467c284f4882bdfb7a6c288fb9ca6618ef2e3dc83f",
+        urls = ["https://boringssl.googlesource.com/boringssl/+archive/4fb158925f7753d80fb858cb0239dff893ef9f15.tar.gz"],
     )
 
-    http_archive(
+    dynamic_archive(
         name = "mundane",
-        url = "https://fuchsia.googlesource.com/mundane/+archive/f516499751b45969ac5a95091b1f68cf5ec23f04.tar.gz",
+        sha256 = "583d5cacb3c6c68c65c59d69786c0563bd9bbcebe8c375a81bc51e9b016332c7",
+        urls = ["https://fuchsia.googlesource.com/mundane/+archive/f516499751b45969ac5a95091b1f68cf5ec23f04.tar.gz"],
         patch_args = ["-p1"],
         patches = ["//sw/vendor/patches/mundane:build_with_bazel.patch"],
     )


### PR DESCRIPTION
For archives with stable files, the sha256sum is computed locally and
added.
`sha256 () { wget $1 -O file ; sha256sum file ; }`
`sha256 "https://github.com/abseil/abseil-cpp/archive/e854df09dfcb35056c1d42420028648ee0ebebaf.tar.gz"`
Archives with unstable files use a sha256sum of the set of files which allows bazel to draw from the cache and to perform
checking even when the archive file has a varying timestamp. The sha256 is emitted during build in a debug message in this case.

Signed-off-by: Drew Macrae <drewmacrae@google.com>