### PR TITLE
[sw/test_rom] move clk jitter enable to test ROM

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -93,7 +93,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
     void'($value$plusargs("en_jitter=%0d", en_jitter));
     if (en_jitter) begin
       bit [7:0] en_jitter_arr[] = {1};
-      sw_symbol_backdoor_overwrite("kJitterEnabled", en_jitter_arr);
+      sw_symbol_backdoor_overwrite("kJitterEnabled", en_jitter_arr, Rom, SwTypeRom);
     end
   endtask
 

--- a/sw/device/lib/testing/test_framework/BUILD
+++ b/sw/device/lib/testing/test_framework/BUILD
@@ -94,7 +94,6 @@ cc_library(
         ":status",
         "//sw/device/lib/arch:device",
         "//sw/device/lib/base:macros",
-        "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:uart",
         "//sw/device/lib/runtime:hart",
         "//sw/device/lib/runtime:log",

--- a/sw/device/lib/testing/test_framework/meson.build
+++ b/sw/device/lib/testing/test_framework/meson.build
@@ -129,7 +129,6 @@ ottf_lib = declare_dependency(
       sw_lib_irq,
       sw_lib_mem,
       sw_lib_dif_uart,
-      sw_lib_dif_clkmgr,
       sw_lib_dif_rv_timer,
       sw_lib_runtime_hart,
       sw_lib_runtime_log,

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -10,7 +10,6 @@
 #include "sw/device/lib/arch/device.h"
 #include "sw/device/lib/base/macros.h"
 #include "sw/device/lib/dif/dif_base.h"
-#include "sw/device/lib/dif/dif_clkmgr.h"
 #include "sw/device/lib/dif/dif_uart.h"
 #include "sw/device/lib/runtime/hart.h"
 #include "sw/device/lib/runtime/log.h"
@@ -85,17 +84,6 @@ void _ottf_main(void) {
   // Initialize the UART to enable logging for non-DV simulation platforms.
   if (kDeviceType != kDeviceSimDV) {
     init_uart();
-  }
-
-  // The kJitterEnabled symbol defaults to false across all hardware platforms.
-  // However, in DV simulation, it may be overridden via a backdoor write with
-  // the plusarg: `+en_jitter=1`.
-  if (kJitterEnabled) {
-    dif_clkmgr_t clkmgr;
-    CHECK_DIF_OK(dif_clkmgr_init(
-        mmio_region_from_addr(TOP_EARLGREY_CLKMGR_AON_BASE_ADDR), &clkmgr));
-    CHECK_DIF_OK(dif_clkmgr_jitter_set_enabled(&clkmgr, kDifToggleEnabled));
-    LOG_INFO("Jitter is enabled");
   }
 
   // Run the test.

--- a/sw/device/lib/testing/test_rom/BUILD
+++ b/sw/device/lib/testing/test_rom/BUILD
@@ -52,6 +52,7 @@ cc_library(
         "//sw/device/lib:ibex_peri",
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/crt",
+        "//sw/device/lib/dif:clkmgr",
         "//sw/device/lib/dif:flash_ctrl",
         "//sw/device/lib/dif:gpio",
         "//sw/device/lib/dif:hmac",

--- a/sw/device/lib/testing/test_rom/meson.build
+++ b/sw/device/lib/testing/test_rom/meson.build
@@ -56,6 +56,7 @@ foreach device_name, device_lib : sw_lib_arch_core_devices
       sw_lib_runtime_hart,
       sw_lib_runtime_print,
       sw_lib_ibex,
+      sw_lib_dif_clkmgr,
       sw_lib_dif_flash_ctrl,
       sw_lib_dif_gpio,
       sw_lib_dif_spi_device,


### PR DESCRIPTION
This moves the jitter enable feature from the OTTF to the test ROM.

Signed-off-by: Timothy Trippel <ttrippel@google.com>