### PR TITLE
[otbn] Harden stack write pointers

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -178,6 +178,12 @@
         file by monitoring the one-hot0 property of the individual write-enable strobes.
       '''
     }
+    { name: "STACK_WR_PTR.CTR.REDUN"
+      desc: '''
+        The write pointer of the stack (used for calls and loops) is redundant.  If the two
+        instances of the counter mismatch, an error is emitted.
+      '''
+    }
     { name: "RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT"
       desc: '''
         This countermeasure checks for spurious write-enable signals on the register

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -184,6 +184,9 @@
         instances of the counter mismatch, an error is emitted.
       '''
     }
+    { name: "STACK_WR_PTR.CTR.GLITCH_DETECT"
+      desc: "Glitches are detected on the stack counter increment / decrement control signal."
+    }
     { name: "RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT"
       desc: '''
         This countermeasure checks for spurious write-enable signals on the register

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -114,6 +114,12 @@
       tests: []
     }
     {
+      name: sec_cm_stack_wr_ptr_ctr_glitch_detect
+      desc: "Verify the countermeasure(s) STACK_WR_PTR.CTR.GLITCH_DETECT."
+      milestone: V2S
+      tests: []
+    }
+    {
       name: sec_cm_rf_bignum_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT."
       milestone: V2S

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -108,6 +108,12 @@
       tests: []
     }
     {
+      name: sec_cm_stack_wr_ptr_ctr_redun
+      desc: "Verify the countermeasure(s) STACK_WR_PTR.CTR.REDUN."
+      milestone: V2S
+      tests: []
+    }
+    {
       name: sec_cm_rf_bignum_data_reg_sw_glitch_detect
       desc: "Verify the countermeasure(s) RF_BIGNUM.DATA_REG_SW.GLITCH_DETECT."
       milestone: V2S

--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -312,7 +312,7 @@ module otbn_core_model
   bind otbn_rf_base otbn_stack_snooper_if #(.StackIntgWidth(39), .StackWidth(32), .StackDepth(8))
     u_call_stack_snooper (
       .stack_storage(u_call_stack.stack_storage),
-      .stack_wr_ptr_q(u_call_stack.stack_wr_ptr_q)
+      .stack_wr_ptr_q(u_call_stack.stack_wr_ptr)
     );
 
   assign err_o = |{failed_step, failed_check, check_mismatch_q,

--- a/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
+++ b/hw/ip/otbn/dv/verilator/otbn_top_sim.sv
@@ -450,7 +450,10 @@ module otbn_top_sim (
   export "DPI-C" function otbn_base_call_stack_get_size;
 
   function automatic int unsigned otbn_base_call_stack_get_size();
-    return u_otbn_core.u_otbn_rf_base.u_call_stack.stack_wr_ptr_q;
+    // Explicit zero extension required because Verilator (tested with v4.216) otherwise raises
+    // a `WIDTH` warning (which is promoted to an error).
+    return {{(32-$bits(u_otbn_core.u_otbn_rf_base.u_call_stack.stack_wr_ptr)){1'b0}},
+            u_otbn_core.u_otbn_rf_base.u_call_stack.stack_wr_ptr};
   endfunction
 
   export "DPI-C" function otbn_base_call_stack_get_element;

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1100,4 +1100,10 @@ module otbn
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnScrambleCtrlFsmCheck_A,
     u_otbn_scramble_ctrl.u_state_regs, alert_tx_o[AlertFatal])
 
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtbnCallStackWrPtrAlertCheck_A,
+    u_otbn_core.u_otbn_rf_base.u_call_stack.u_stack_wr_ptr, alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtbnLoopInfoStackWrPtrAlertCheck_A,
+    u_otbn_core.u_otbn_controller.u_otbn_loop_controller.loop_info_stack.u_stack_wr_ptr,
+    alert_tx_o[AlertFatal])
+
 endmodule

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -60,6 +60,7 @@ module otbn_controller
   output logic                     rf_base_rd_commit_o,
 
   input logic rf_base_call_stack_sw_err_i,
+  input logic rf_base_call_stack_hw_err_i,
 
   // Bignum register file (WDRs)
   output logic [4:0]         rf_bignum_wr_addr_o,
@@ -261,6 +262,7 @@ module otbn_controller
 
   logic [WLEN-1:0] mac_bignum_rf_wr_data;
 
+  logic loop_hw_err;
   logic csr_illegal_addr, wsr_illegal_addr, ispr_illegal_addr;
   logic imem_addr_err, loop_sw_err, ispr_err;
   logic dmem_addr_err_check, dmem_addr_err;
@@ -462,7 +464,7 @@ module otbn_controller
   assign illegal_insn_static = insn_illegal_i | ispr_err;
 
   assign fatal_software_err       = software_err & software_errs_fatal_i;
-  assign bad_internal_state_err   = state_error;
+  assign bad_internal_state_err   = state_error | loop_hw_err | rf_base_call_stack_hw_err_i;
   assign reg_intg_violation_err   = rf_bignum_rf_err;
   assign key_invalid_err          = ispr_rd_bignum_insn & insn_valid_i & key_invalid;
   assign illegal_insn_err         = illegal_insn_static | rf_indirect_err;
@@ -585,6 +587,7 @@ module otbn_controller
     .loop_jump_addr_o(loop_jump_addr),
 
     .sw_err_o (loop_sw_err),
+    .hw_err_o (loop_hw_err),
 
     .jump_or_branch_i(jump_or_branch),
     .otbn_stall_i    (stall),

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -262,7 +262,7 @@ module otbn_controller
   logic [WLEN-1:0] mac_bignum_rf_wr_data;
 
   logic csr_illegal_addr, wsr_illegal_addr, ispr_illegal_addr;
-  logic imem_addr_err, loop_err, ispr_err;
+  logic imem_addr_err, loop_sw_err, ispr_err;
   logic dmem_addr_err_check, dmem_addr_err;
   logic dmem_addr_unaligned_base, dmem_addr_unaligned_bignum, dmem_addr_overflow;
   logic illegal_insn_static;
@@ -474,7 +474,7 @@ module otbn_controller
   // begin fetched it cannot occur if the current instruction has seen an error and failed to
   // execute.
   assign non_insn_addr_software_err = |{key_invalid_err,
-                                        loop_err,
+                                        loop_sw_err,
                                         illegal_insn_err,
                                         call_stack_err,
                                         bad_data_addr_err};
@@ -488,7 +488,7 @@ module otbn_controller
     rnd_fips_chk_fail:  rnd_fips_err_i,
     rnd_rep_chk_fail:   rnd_rep_err_i,
     key_invalid:        key_invalid_err,
-    loop:               loop_err,
+    loop:               loop_sw_err,
     illegal_insn:       illegal_insn_err,
     call_stack:         call_stack_err,
     bad_data_addr:      bad_data_addr_err,
@@ -583,7 +583,8 @@ module otbn_controller
 
     .loop_jump_o     (loop_jump),
     .loop_jump_addr_o(loop_jump_addr),
-    .loop_err_o      (loop_err),
+
+    .sw_err_o (loop_sw_err),
 
     .jump_or_branch_i(jump_or_branch),
     .otbn_stall_i    (stall),

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -135,7 +135,7 @@ module otbn_core
   logic                     rf_base_rd_en_b;
   logic [BaseIntgWidth-1:0] rf_base_rd_data_b_intg;
   logic                     rf_base_rd_commit;
-  logic                     rf_base_call_stack_err;
+  logic                     rf_base_call_stack_sw_err;
   logic                     rf_base_rf_err;
 
   alu_base_operation_t  alu_base_operation;
@@ -400,20 +400,20 @@ module otbn_core
     .insn_dec_shared_i(insn_dec_shared),
 
     // To/from base register file
-    .rf_base_wr_addr_o         (rf_base_wr_addr_ctrl),
-    .rf_base_wr_en_o           (rf_base_wr_en_ctrl),
-    .rf_base_wr_commit_o       (rf_base_wr_commit_ctrl),
-    .rf_base_wr_data_no_intg_o (rf_base_wr_data_no_intg_ctrl),
-    .rf_base_wr_data_intg_o    (rf_base_wr_data_intg),
-    .rf_base_wr_data_intg_sel_o(rf_base_wr_data_intg_sel_ctrl),
-    .rf_base_rd_addr_a_o       (rf_base_rd_addr_a),
-    .rf_base_rd_en_a_o         (rf_base_rd_en_a),
-    .rf_base_rd_data_a_intg_i  (rf_base_rd_data_a_intg),
-    .rf_base_rd_addr_b_o       (rf_base_rd_addr_b),
-    .rf_base_rd_en_b_o         (rf_base_rd_en_b),
-    .rf_base_rd_data_b_intg_i  (rf_base_rd_data_b_intg),
-    .rf_base_rd_commit_o       (rf_base_rd_commit),
-    .rf_base_call_stack_err_i  (rf_base_call_stack_err),
+    .rf_base_wr_addr_o          (rf_base_wr_addr_ctrl),
+    .rf_base_wr_en_o            (rf_base_wr_en_ctrl),
+    .rf_base_wr_commit_o        (rf_base_wr_commit_ctrl),
+    .rf_base_wr_data_no_intg_o  (rf_base_wr_data_no_intg_ctrl),
+    .rf_base_wr_data_intg_o     (rf_base_wr_data_intg),
+    .rf_base_wr_data_intg_sel_o (rf_base_wr_data_intg_sel_ctrl),
+    .rf_base_rd_addr_a_o        (rf_base_rd_addr_a),
+    .rf_base_rd_en_a_o          (rf_base_rd_en_a),
+    .rf_base_rd_data_a_intg_i   (rf_base_rd_data_a_intg),
+    .rf_base_rd_addr_b_o        (rf_base_rd_addr_b),
+    .rf_base_rd_en_b_o          (rf_base_rd_en_b),
+    .rf_base_rd_data_b_intg_i   (rf_base_rd_data_b_intg),
+    .rf_base_rd_commit_o        (rf_base_rd_commit),
+    .rf_base_call_stack_sw_err_i(rf_base_call_stack_sw_err),
 
     // To/from bignunm register file
     .rf_bignum_wr_addr_o         (rf_bignum_wr_addr_ctrl),
@@ -620,8 +620,8 @@ module otbn_core
     .rd_data_b_intg_o(rf_base_rd_data_b_intg),
     .rd_commit_i     (rf_base_rd_commit),
 
-    .call_stack_err_o(rf_base_call_stack_err),
-    .rf_err_o        (rf_base_rf_err)
+    .call_stack_sw_err_o(rf_base_call_stack_sw_err),
+    .rf_err_o           (rf_base_rf_err)
   );
 
   assign rf_base_wr_addr         = sec_wipe_base ? sec_wipe_addr : rf_base_wr_addr_ctrl;

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -136,6 +136,7 @@ module otbn_core
   logic [BaseIntgWidth-1:0] rf_base_rd_data_b_intg;
   logic                     rf_base_rd_commit;
   logic                     rf_base_call_stack_sw_err;
+  logic                     rf_base_call_stack_hw_err;
   logic                     rf_base_rf_err;
 
   alu_base_operation_t  alu_base_operation;
@@ -414,6 +415,7 @@ module otbn_core
     .rf_base_rd_data_b_intg_i   (rf_base_rd_data_b_intg),
     .rf_base_rd_commit_o        (rf_base_rd_commit),
     .rf_base_call_stack_sw_err_i(rf_base_call_stack_sw_err),
+    .rf_base_call_stack_hw_err_i(rf_base_call_stack_hw_err),
 
     // To/from bignunm register file
     .rf_bignum_wr_addr_o         (rf_bignum_wr_addr_ctrl),
@@ -621,6 +623,7 @@ module otbn_core
     .rd_commit_i     (rf_base_rd_commit),
 
     .call_stack_sw_err_o(rf_base_call_stack_sw_err),
+    .call_stack_hw_err_o(rf_base_call_stack_hw_err),
     .rf_err_o           (rf_base_rf_err)
   );
 

--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -25,6 +25,7 @@ module otbn_loop_controller
   output [ImemAddrWidth-1:0] loop_jump_addr_o,
 
   output sw_err_o,
+  output hw_err_o,
 
   output                     prefetch_loop_active_o,
   output [31:0]              prefetch_loop_iterations_o,
@@ -198,6 +199,8 @@ module otbn_loop_controller
     .rst_ni,
 
     .full_o(loop_stack_full),
+
+    .cnt_err_o(hw_err_o),
 
     .clear_i(state_reset_i),
 

--- a/hw/ip/otbn/rtl/otbn_loop_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_loop_controller.sv
@@ -23,7 +23,8 @@ module otbn_loop_controller
 
   output                     loop_jump_o,
   output [ImemAddrWidth-1:0] loop_jump_addr_o,
-  output                     loop_err_o,
+
+  output sw_err_o,
 
   output                     prefetch_loop_active_o,
   output [31:0]              prefetch_loop_iterations_o,
@@ -127,10 +128,10 @@ module otbn_loop_controller
   assign loop_stack_overflow_err = loop_stack_push_req & loop_stack_full;
   assign loop_at_end_err         = at_current_loop_end_insn & loop_start_req_i;
 
-  assign loop_err_o = loop_iteration_err      |
-                      loop_branch_err         |
-                      loop_stack_overflow_err |
-                      loop_at_end_err;
+  assign sw_err_o = loop_iteration_err      |
+                    loop_branch_err         |
+                    loop_stack_overflow_err |
+                    loop_at_end_err;
 
   always_comb begin
     loop_active_d  = loop_active_q;
@@ -165,7 +166,7 @@ module otbn_loop_controller
   end
 
   // The OTBN controller must not commit a loop request if it sees a loop error.
-  `ASSERT(NoStartCommitIfLoopErr, loop_start_req_i && loop_start_commit_i |-> !loop_err_o)
+  `ASSERT(NoStartCommitIfLoopErr, loop_start_req_i && loop_start_commit_i |-> !sw_err_o)
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -56,7 +56,7 @@ module otbn_rf_base
 
   input  logic                     rd_commit_i,
 
-  output logic                     call_stack_err_o,
+  output logic                     call_stack_sw_err_o,
   output logic                     rf_err_o
 );
   localparam int unsigned CallStackRegIndex = 1;
@@ -109,7 +109,7 @@ module otbn_rf_base
   // push).
   assign push_stack_err  = push_stack_reqd & stack_full & ~pop_stack_reqd;
 
-  assign call_stack_err_o = pop_stack_a_err | pop_stack_b_err | push_stack_err;
+  assign call_stack_sw_err_o = pop_stack_a_err | pop_stack_b_err | push_stack_err;
 
   // Prevent any write to the stack register from going to the register file,
   // all other committed writes are passed straight through

--- a/hw/ip/otbn/rtl/otbn_rf_base.sv
+++ b/hw/ip/otbn/rtl/otbn_rf_base.sv
@@ -57,6 +57,7 @@ module otbn_rf_base
   input  logic                     rd_commit_i,
 
   output logic                     call_stack_sw_err_o,
+  output logic                     call_stack_hw_err_o,
   output logic                     rf_err_o
 );
   localparam int unsigned CallStackRegIndex = 1;
@@ -136,6 +137,8 @@ module otbn_rf_base
     .rst_ni,
 
     .full_o        (stack_full),
+
+    .cnt_err_o     (call_stack_hw_err_o),
 
     .clear_i       (state_reset),
 


### PR DESCRIPTION
- Use a duplicate counter (with `prim_count`) for the stack write pointer. The read pointer is not a register but combinationally derived from the write pointer, so there is no register hardening there. `otbn_stack` is used for the call stack and the loop info stack.
- Detect glitches on the signal that controls the stack write pointer.

This is part of the work on #11019.

## TODO
- [x] Figure out why `AssertConnected_A` inside `prim_count` fails.