### PR TITLE
[sw/silicon_creator] Minor fixes/updates to shutdown_print

### DIFF
--- a/sw/device/silicon_creator/lib/shutdown.c
+++ b/sw/device/silicon_creator/lib/shutdown.c
@@ -308,10 +308,10 @@ enum {
   /**
    * Total message length.
    *
-   * This includes 4 character prefix before the hex string '\n' at the end of
+   * This includes 4 character prefix before the hex string '\r\n' at the end of
    * the message.
    */
-  kErrorMsgLen = kHexStrLen + 5,
+  kErrorMsgLen = kHexStrLen + 6,
   /**
    * Base address of UART.
    */
@@ -326,7 +326,7 @@ enum {
  * Prints a fixed-length (`kErrorMsgLen`) error message.
  *
  * The error message is a concatenation of a 4 character `prefix` (encoded as a
- * 32-bit value), the hexadecimal representation of `val`, and '\n'.
+ * 32-bit value), the hexadecimal representation of `val`, and '\r\n'.
  *
  * @param prefix Prefix encoded as a 32-bit value.
  * @param val Integer to print.
@@ -348,6 +348,7 @@ static void shutdown_print(shutdown_log_prefix_t prefix, uint32_t val) {
         val, (bitfield_field32_t){.mask = 0xf, .index = (7 - i) * 4});
     abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, kHexTable[nibble]);
   }
+  abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, '\r');
   abs_mmio_write32(kUartBase + UART_WDATA_REG_OFFSET, '\n');
 }
 

--- a/sw/device/silicon_creator/lib/shutdown.h
+++ b/sw/device/silicon_creator/lib/shutdown.h
@@ -72,9 +72,9 @@ typedef enum shutdown_error_redact {
 
 /**
  * Helper macro for encoding a 4 character prefix as a 32-bit value. The
- * resulting prefix is the concatenation of the given characters and '_'.
+ * resulting prefix is the concatenation of the given characters and ':'.
  */
-#define LOG_PREFIX_(a_, b_, c_) ('_' << 24 | (c_) << 16 | (b_) << 8 | (a_))
+#define LOG_PREFIX_(a_, b_, c_) (':' << 24 | (c_) << 16 | (b_) << 8 | (a_))
 
 /**
  * Prefixes for error messages printed over UART.

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -311,7 +311,7 @@ cc_test(
 # MASK ROM E2E TESTS
 
 # Bootup tests
-BOOT_FAILURE_MSG = "BFV_[0-9a-z]{{8}}\nLCV_[0-9a-z]{{8}}\n"
+BOOT_FAILURE_MSG = "BFV:[0-9a-z]{{8}}\r\nLCV:[0-9a-z]{{8}}\r\n"
 
 opentitan_functest(
     name = "e2e_bootup_success",


### PR DESCRIPTION
This PR:
* Updates shutdown_print to print CR+LF instead of LF
* Changes the separator in log messages to colon