### PR TITLE
[DRAFT - DO NOT MERGE][dv/flash_ctrl] Example for vcs cfg file override

### DIFF
--- a/hw/ip/flash_ctrl/dv/cov/flash_ctrl_cover.cfg
+++ b/hw/ip/flash_ctrl/dv/cov/flash_ctrl_cover.cfg
@@ -1,0 +1,8 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+// Specific coverage configuration for the Lifecycle Controller
+
+// Exclude u_cfg and u_cfg_ram
+-tree tb.dut.u_eflash.u_flash.gen_generic.u_impl_generic.u_cfg
+-tree tb.dut.u_eflash.u_flash.gen_generic.u_impl_generic.u_cfg_ram

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -54,6 +54,10 @@
       name: design_level
       value: "top"
     }
+    {
+      name: default_vcs_cov_cfg_file
+      value: "-cm_hier {proj_root}/hw/dv/tools/vcs/cover.cfg+{proj_root}/hw/dv/tools/vcs/common_cov_excl.cfg+{proj_root}/hw/ip/flash_ctrl/dv/cov/flash_ctrl_cover.cfg"
+    }
   ]
 
   // Add additional tops for simulation.


### PR DESCRIPTION
This is an example of how to override the vcs cfg file in flash_ctrl.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>