### PR TITLE
[otbn] Harden URND reseed request

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -156,7 +156,6 @@ class OTBNSim:
             FsmState.MEM_SEC_WIPE: (self._step_ext_wipe, False),
             FsmState.IDLE: (self._step_idle, False),
             FsmState.PRE_EXEC: (self._step_pre_exec, False),
-            FsmState.FETCH_WAIT: (self._step_fetch_wait, False),
             FsmState.EXEC: (self._step_exec, True),
             FsmState.WIPING_GOOD: (self._step_wiping, False),
             FsmState.WIPING_BAD: (self._step_wiping, False),
@@ -201,10 +200,10 @@ class OTBNSim:
         '''Step the simulation in the PRE_EXEC state
 
         In this state, we're waiting for a URND seed. Once that appears, we
-        switch to FETCH_WAIT.
+        switch to EXEC.
         '''
         if self.state.wsrs.URND.running:
-            self.state.set_fsm_state(FsmState.FETCH_WAIT)
+            self.state.set_fsm_state(FsmState.EXEC)
 
         changes = self._on_stall(verbose, fetch_next=False)
 
@@ -212,17 +211,6 @@ class OTBNSim:
         if self.state.ext_regs.read('INSN_CNT', True) != 0:
             self.state.ext_regs.write('INSN_CNT', 0, True)
 
-        return (None, changes)
-
-    def _step_fetch_wait(self, verbose: bool) -> StepRes:
-        '''Step the simulation in the FETCH_WAIT state
-
-        This state lasts a single cycle while we fetch our first instruction
-        and then jump to EXEC.
-        '''
-        self.state.wsrs.URND.step()
-        self.state.set_fsm_state(FsmState.EXEC)
-        changes = self._on_stall(verbose, fetch_next=False)
         return (None, changes)
 
     def _step_exec(self, verbose: bool) -> StepRes:

--- a/hw/ip/otbn/dv/otbnsim/test/stats_test.py
+++ b/hw/ip/otbn/dv/otbnsim/test/stats_test.py
@@ -137,7 +137,7 @@ def test_general_and_loop(tmpdir: py.path.local) -> None:
     stats = _simulate_asm_file(asm_file, tmpdir)
 
     # General statistics
-    assert stats.stall_count == 4
+    assert stats.stall_count == 3
     assert stats.get_insn_count() == 28
     assert stats.insn_histo == {'addi': 22, 'loop': 4, 'loopi': 1, 'ecall': 1}
     assert stats.func_calls == []

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -206,7 +206,7 @@ module otbn_core
   logic            rnd_fips_err;
 
   logic            urnd_reseed_req;
-  logic            urnd_reseed_busy;
+  logic            urnd_reseed_ack;
   logic            urnd_advance;
   logic            urnd_advance_start_stop_control;
   logic [WLEN-1:0] urnd_data;
@@ -262,7 +262,7 @@ module otbn_core
     .controller_start_o(controller_start),
 
     .urnd_reseed_req_o (urnd_reseed_req),
-    .urnd_reseed_busy_i(urnd_reseed_busy),
+    .urnd_reseed_ack_i (urnd_reseed_ack),
     .urnd_advance_o    (urnd_advance_start_stop_control),
 
     .start_secure_wipe_i  (start_secure_wipe),
@@ -795,7 +795,7 @@ module otbn_core
     .rnd_fips_err_o    (rnd_fips_err),
 
     .urnd_reseed_req_i (urnd_reseed_req),
-    .urnd_reseed_busy_o(urnd_reseed_busy),
+    .urnd_reseed_ack_o (urnd_reseed_ack),
     .urnd_advance_i    (urnd_advance),
     .urnd_data_o       (urnd_data),
     .urnd_all_zero_o   (urnd_all_zero),

--- a/hw/ip/otbn/rtl/otbn_rnd.sv
+++ b/hw/ip/otbn/rtl/otbn_rnd.sv
@@ -38,8 +38,8 @@ module otbn_rnd import otbn_pkg::*;
 
   // Request URND PRNG reseed from the EDN
   input  logic            urnd_reseed_req_i,
-  // Remains asserted whilst reseed is in progress
-  output logic            urnd_reseed_busy_o,
+  // Acknowledge URND PRNG reseed from the EDN
+  output logic            urnd_reseed_ack_o,
   // When asserted PRNG state advances. It is permissible to advance the state whilst
   // reseeding.
   input  logic            urnd_advance_i,
@@ -165,10 +165,13 @@ module otbn_rnd import otbn_pkg::*;
   logic edn_urnd_req_q, edn_urnd_req_d;
 
   assign edn_urnd_req_complete = edn_urnd_req_o & edn_urnd_ack_i;
+
+  // Keep EDN URND request high even if input URND reseed request goes low before the reseed has
+  // completed.
   assign edn_urnd_req_d = (edn_urnd_req_q | urnd_reseed_req_i) & ~edn_urnd_req_complete;
 
   assign edn_urnd_req_o = edn_urnd_req_q;
-  assign urnd_reseed_busy_o = edn_urnd_req_q;
+  assign urnd_reseed_ack_o = edn_urnd_ack_i;
 
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin

--- a/hw/ip/otbn/rtl/otbn_start_stop_control.sv
+++ b/hw/ip/otbn/rtl/otbn_start_stop_control.sv
@@ -38,7 +38,7 @@ module otbn_start_stop_control
   output logic controller_start_o,
 
   output logic urnd_reseed_req_o,
-  input  logic urnd_reseed_busy_i,
+  input  logic urnd_reseed_ack_i,
   output logic urnd_advance_o,
 
   input   logic start_secure_wipe_i,
@@ -118,9 +118,10 @@ module otbn_start_stop_control
         end
       end
       OtbnStartStopStateUrndRefresh: begin
+        urnd_reseed_req_o = 1'b1;
         if (stop) begin
           state_d = OtbnStartStopStateLocked;
-        end else if (!urnd_reseed_busy_i) begin
+        end else if (urnd_reseed_ack_i) begin
           state_d     = OtbnStartStopStateRunning;
         end
       end
@@ -194,7 +195,7 @@ module otbn_start_stop_control
   end
 
   // Logic separate from main FSM code to avoid false combinational loop warning from verilator
-  assign controller_start_o = (state_q == OtbnStartStopStateUrndRefresh) & !urnd_reseed_busy_i;
+  assign controller_start_o = (state_q == OtbnStartStopStateUrndRefresh) & urnd_reseed_ack_i;
 
   assign done_o = ((state_q == OtbnStartStopSecureWipeComplete) ||
                    (stop && (state_q == OtbnStartStopStateUrndRefresh)));


### PR DESCRIPTION
Prior to this change, the OTBN-internal URND reseed request signal was
high for a single cycle to communicate a request.  This could be
counter-glitched to suppress a reseed request.

To harden against this glitch, the URND reseed request signal now
remains high until the reseed has been acknowledged.

Part of the work on #11019.