### PR TITLE
[spi_device] Passthrough pre_dv skeleton

### DIFF
--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+program prog_passthrough_host
+  import spid_common::*;
+(
+  input clk,
+  input rst_n,
+
+  spi_if sif
+);
+
+  initial begin
+    forever begin
+      @(posedge clk);
+    end
+  end
+
+  // TODO: Do Factory to load proper sequence for the test
+
+endprogram : prog_passthrough_host

--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -6,13 +6,25 @@
 program prog_passthrough_host
   import spid_common::*;
 (
-  input clk,
-  input rst_n,
+  input logic clk,
+  input logic rst_n,
 
   spi_if sif
 );
 
+  // Timeout
   initial begin
+    #1ms
+    $display("TEST TIMED OUT!!");
+    $finish();
+  end
+
+  initial begin
+    // Default value
+    sif.csb = 1'b 1;
+
+    @(posedge rst_n);
+
     forever begin
       @(posedge clk);
     end

--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
@@ -6,15 +6,136 @@
 program prog_passthrough_sw
   import spid_common::*;
 (
-  input clk,
-  input rst_n
+  input logic clk,
+  input logic rst_n,
+
+  output tlul_pkg::tl_h2d_t h2d,
+  input  tlul_pkg::tl_d2h_t d2h
 );
 
   initial begin
+    h2d = tlul_pkg::TL_H2D_DEFAULT;
+
+    // Wait reset relase
+    @(posedge rst_n);
+    #10ns
+    @(posedge clk);
+    $display("Intializing SPI_DEVICE: PassThrough mode");
+    init_spidevice_passthrough();
+
     forever begin
       @(posedge clk);
     end
   end
 
+  task automatic init_spidevice_passthrough(
+  );
+    automatic logic [31:0] csr_wdata;
+    automatic logic [31:0] csr_rdata;
+    // Initialize SPI_DEVICE as in Passthrough mode
+    // - Switch SRAM clock
+    // - Program SpiMode
+    // - Configure CMD_INFO entries
+    // - Configure intercept (can be changed later)
+    // - address swap, payload swap for a specific CMD_INFO entry
+    // - Initialize DPSRAM
+
+    tlul_write(
+      clk,
+      h2d,
+      d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_CFG_OFFSET),
+      32'h 0100_0000, // mailbox_en := 1
+      4'b 1111
+    );
+
+    tlul_write(
+      clk,
+      h2d,
+      d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_MAILBOX_ADDR_OFFSET),
+      32'h 00CD_E000,
+      4'b 1111
+    );
+
+    csr_wdata = '0;
+    csr_wdata[5:4] = spi_device_pkg::PassThrough;
+    tlul_write(
+      clk,
+      h2d,
+      d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_CONTROL_OFFSET),
+      csr_wdata,
+      4'b 1111
+    );
+    csr_wdata[31] = 1'b 1;
+    tlul_write(
+      clk,
+      h2d,
+      d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_CONTROL_OFFSET),
+      csr_wdata,
+      4'b 1111
+    );
+
+    // Turn off intercept for init
+    tlul_write(
+      clk,
+      h2d,
+      d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_INTERCEPT_EN_OFFSET),
+      '0,
+      4'b 1111
+    );
+
+    // CMD_INFO
+    init_cmdinfo_list();
+
+  endtask : init_spidevice_passthrough
+
+  task automatic init_cmdinfo_list();
+    automatic logic [31:0] cmdinfo_wdata;
+    // Init CMD_INFO entries
+    // 0:23 normal CMD_INFO
+    // 24:27 valid, opcode only (EN4B/ EX4B/ WREN/ WRDI)
+    cmdinfo_wdata  = '0; // default
+
+    for (int unsigned i = 0 ; i < spi_device_reg_pkg::NumCmdInfo; i++) begin
+      cmdinfo_wdata[7:0]   = CmdInfo[i].opcode         ;
+      cmdinfo_wdata[9:8]   = CmdInfo[i].addr_mode      ;
+      cmdinfo_wdata[10]    = CmdInfo[i].addr_swap_en   ;
+      cmdinfo_wdata[11]    = CmdInfo[i].mbyte_en       ;
+      cmdinfo_wdata[14:12] = CmdInfo[i].dummy_size     ;
+      cmdinfo_wdata[15]    = CmdInfo[i].dummy_en       ;
+      cmdinfo_wdata[19:16] = CmdInfo[i].payload_en     ;
+      cmdinfo_wdata[20]    = CmdInfo[i].payload_dir    ;
+      cmdinfo_wdata[21]    = CmdInfo[i].payload_swap_en;
+      cmdinfo_wdata[24]    = CmdInfo[i].upload         ;
+      cmdinfo_wdata[25]    = CmdInfo[i].busy           ;
+      cmdinfo_wdata[31]    = CmdInfo[i].valid          ;
+      tlul_write(
+        clk,
+        h2d,
+        d2h,
+        32'(spi_device_reg_pkg::SPI_DEVICE_CMD_INFO_0_OFFSET + i),
+        cmdinfo_wdata,
+        4'b 1111
+      );
+    end
+
+    for (int unsigned i = 0 ;
+      i < (spi_device_pkg::NumTotalCmdInfo-spi_device_reg_pkg::NumCmdInfo);
+      i++) begin
+      tlul_write(
+        clk,
+        h2d,
+        d2h,
+        32'(spi_device_reg_pkg::SPI_DEVICE_CMD_INFO_EN4B_OFFSET+i),
+        32'h 8000_0000 | CmdInfo[24+i].opcode,
+        4'b 1111
+      );
+    end
+
+  endtask : init_cmdinfo_list
 
 endprogram : prog_passthrough_sw

--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
@@ -1,0 +1,20 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+
+program prog_passthrough_sw
+  import spid_common::*;
+(
+  input clk,
+  input rst_n
+);
+
+  initial begin
+    forever begin
+      @(posedge clk);
+    end
+  end
+
+
+endprogram : prog_passthrough_sw

--- a/hw/ip/spi_device/pre_dv/program/prog_spiflash.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_spiflash.sv
@@ -1,0 +1,9 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Behavioral model of SPI Flash
+
+program prog_spiflash;
+
+endprogram : prog_spiflash

--- a/hw/ip/spi_device/pre_dv/spid_passthrough.core
+++ b/hw/ip/spi_device/pre_dv/spid_passthrough.core
@@ -1,0 +1,35 @@
+CAPI=2:
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+name: "lowrisc:dv:spid_passthrough_sim:0.1"
+description: "SPI Device Passthrough mode sim"
+filesets:
+  files_rtl:
+    depend:
+      - lowrisc:ip:spi_device
+    file_type: systemVerilogSource
+
+  files_dv:
+    depend:
+      - lowrisc:dv:dv_utils
+      - lowrisc:dv:dv_test_status
+      - lowrisc:dv:common_ifs
+    files:
+      - tb/spid_common.sv
+      - program/prog_passthrough_host.sv
+      - program/prog_passthrough_sw.sv
+      - program/prog_spiflash.sv
+      - tb/spid_passthrough_tb.sv
+    file_type: systemVerilogSource
+
+targets:
+  sim: &sim_target
+    toplevel: tb
+    filesets:
+      - files_rtl
+      - files_dv
+    default_tool: vcs
+
+  lint:
+    <<: *sim_target

--- a/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
@@ -1,0 +1,33 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  name: spid_passthrough
+  dut:  spid_passthrough
+  tb:   tb
+  tool: vcs
+  fusesoc_core: lowrisc:dv:spid_passthrough_sim:0.1
+  import_cfgs: ["{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson"]
+  reseed: 1
+
+  build_modes: [
+  ]
+
+  tests: [
+    {
+      name: spid_passthrough_smoke
+      //build_mode: spid_status_locality_1
+    }
+  ]
+
+  regressions: [
+    {
+      name: smoke
+      tests: ["spid_passthrough_smoke"]
+    }
+    {
+      name: nightly
+      tests: ["spid_passthrough_smoke"]
+    }
+  ]
+}

--- a/hw/ip/spi_device/pre_dv/tb/spid_passthrough_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_passthrough_tb.sv
@@ -1,0 +1,145 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Testbench module for spi_device Passthrough feature
+
+module tb;
+  import spi_device_pkg::*;
+
+  import spid_common::*;
+
+  // clock generation
+  localparam time ClkPeriod = 10000; // 10ns
+  localparam time SckPeriod = 14000; // 14ns
+
+  wire clk, rst_n;
+  clk_rst_if main_clk (
+    .clk,
+    .rst_n
+  );
+  logic sw_clk;
+  assign sw_clk = clk;
+
+  wire sck, sck_rst_n;
+  clk_rst_if sck_clk (
+    .clk   (sck),
+    .rst_n (sck_rst_n)
+  );
+
+  spi_if sif(sck);
+
+  virtual spi_if.tb  tb_sif  = sif.tb;
+  virtual spi_if.dut dut_sif = sif.dut;
+
+  logic [3:0] dut_sd_en, dut_sd;
+  logic [3:0] tb_sd_en,  tb_sd;
+
+  for (genvar i = 0 ; i < 4 ; i++) begin : g_dut_sif
+    assign sif.sd_out[i] = dut_sd_en[i] ? dut_sd[i] : 1'b Z;
+  end
+
+  wire sck_en, gated_sck, gated_sck_inverted;
+
+  assign gated_sck          = (sck_en) ? sck : 1'b 0;
+  assign gated_sck_inverted = ~gated_sck;
+
+  assign sck_en = ~sif.csb;
+
+  // Signals
+  tlul_pkg::tl_h2d_t tl_h2d; // into DUT
+  tlul_pkg::tl_d2h_t tl_d2h; // from DUT
+
+  prim_alert_pkg::alert_rx_t [spi_device_reg_pkg::NumAlerts-1:0] alert_rx;
+  prim_alert_pkg::alert_tx_t [spi_device_reg_pkg::NumAlerts-1:0] alert_tx;
+  assign alert_rx = '{default: prim_alert_pkg::ALERT_RX_DEFAULT};
+
+  passthrough_req_t passthrough_h2d;
+  passthrough_rsp_t passthrough_d2h;
+
+  prim_ram_2p_pkg::ram_2p_cfg_t ram_cfg; // tied
+
+  // TB
+  initial begin
+    sck_clk.set_period_ps(SckPeriod);
+    sck_clk.set_active();
+
+    main_clk.set_period_ps(ClkPeriod);
+    main_clk.set_active();
+
+    #1ms
+    $display("TEST TIMED OUT!!");
+    $finish();
+  end
+
+  prog_passthrough_host host (
+    .clk   (sck),
+    .rst_n (sck_rst_n),
+
+    .sif (sif)
+  );
+  prog_passthrough_sw sw (
+    .clk,
+    .rst_n
+  );
+  prog_spiflash spiflash ();
+
+
+  // Instances
+  spi_device dut (
+    .clk_i  (clk),
+    .rst_ni (rst_n),
+
+    .tl_i (tl_h2d),
+    .tl_o (tl_d2h),
+
+    .alert_rx_i (alert_rx),
+    .alert_tx_o (alert_tx),
+
+    // SPI Interface
+    .cio_sck_i   (gated_sck),
+    .cio_csb_i   (sif.csb),
+    .cio_sd_o    (dut_sd),
+    .cio_sd_en_o (dut_sd_en),
+    .cio_sd_i    (sif.sd_in),
+
+    .cio_tpm_csb_i (1'b 1), // Not testing TPM
+
+    .passthrough_o (passthrough_h2d),
+    .passthrough_i (passthrough_d2h),
+
+    // Interrupts
+    // INTR: Generic mode : Not Testing here
+    .intr_generic_rx_full_o     (), // RX FIFO Full
+    .intr_generic_rx_watermark_o(), // RX FIFO above level
+    .intr_generic_tx_watermark_o(), // TX FIFO below level
+    .intr_generic_rx_error_o    (), // RX Frame error
+    .intr_generic_rx_overflow_o (), // RX Async FIFO Overflow
+    .intr_generic_tx_underflow_o(), // TX Async FIFO Underflow
+
+    // INTR: Flash mode : Not testing here
+    .intr_upload_cmdfifo_not_empty_o(),
+    .intr_upload_payload_not_empty_o(),
+    .intr_upload_payload_overflow_o (),
+    .intr_readbuf_watermark_o       (),
+    .intr_readbuf_flip_o            (),
+
+    // INTR: TPM mode : Not Testing here
+    .intr_tpm_header_not_empty_o(),
+
+    // Memory configuration
+    .ram_cfg_i (ram_cfg),
+
+    // External clock sensor
+    .sck_monitor_o(),
+
+    // DFT related controls
+    .mbist_en_i  (1'b 0),
+    .scan_clk_i  (1'b 0),
+    .scan_rst_ni (1'b 1),
+    .scanmode_i  (prim_mubi_pkg::MuBi4False) // disable scan
+  );
+
+  // TODO: Add SPI Flash behavioral model
+
+endmodule : tb


### PR DESCRIPTION
This PR designs the skeleton of Passthrough pre_dv test environment.

It instantiates full SPI_DEVICE HWIP in contrast to the other pre_dv tests. The reason is to test the intercept and mailbox functionality in passthrough mode too.

To achieve that, TL tasks are also added. Now `sw` communicates with the IP via TL-UL interface rather than direct forcing of signals in other pre_dv tests.

To run the test successfully, SPI Flash behavioral model should be designed.