### PR TITLE
[flash_ctrl] Switching tool from VCS to XCELIUM

### DIFF
--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -12,7 +12,7 @@
   tb: tb
 
   // Simulator used to sign off this block
-  tool: vcs
+  tool: xcelium
 
   // Fusesoc core file used for building the file list.
   fusesoc_core: lowrisc:dv:flash_ctrl_sim:0.1


### PR DESCRIPTION
Change default tool from vcs to xcelium since xcelium is
sign off tool. Exclusions needs to be added only for one tool. Also we have enough Xcelium licenses to do small local regressions.

Signed-off-by: Nikola Miladinovic <nikola.miladinovic@ensilica.com>