### PR TITLE
[hw/dv] further updated dv coverage flow to not score uvm packages

### DIFF
--- a/hw/dv/tools/xcelium/common.ccf
+++ b/hw/dv/tools/xcelium/common.ccf
@@ -20,10 +20,6 @@ set_expr_coverable_statements -all
 // disable the scoring of Verilog modules defined with the 'celldefine compiler directive.
 set_libcell_scoring
 
-// Enables scoring of block and expression coverage for functions and tasks defined directly inside
-// SystemVerilog packages.
-set_subprogram_scoring -svpackage
-
 // Enables scoring of SystemVerilog continuous assignments, which is by disabled by default.
 set_assign_scoring
 
@@ -32,9 +28,7 @@ set_branch_scoring
 
 // Scores statements within a block.
 set_statement_scoring
-//
-// Enables expression coverage for expression containing structs (packed and unpacked).
-set_expr_scoring -struct
+
 
 // Enables Toggle scoring and reporting of SystemVerilog enumerations and multidimensional static
 // arrays , vectors, packed union, modport and generate blocks.
@@ -42,10 +36,6 @@ set_toggle_scoring -sv_enum enable_mda -sv_struct_with_enum -sv_modport -sv_mda 
 
 // Enables scoring of reset states and transitions for identified FSMs.
 set_fsm_reset_scoring
-
-// Enables scoring of immediate assertions inside a class in a package and assertions inside AMS
-// modules.
-select_functional  -ams_control  -imm_asrt_class_package
 
 // Enable toggle coverage only on ports.
 set_toggle_portsonly

--- a/hw/dv/tools/xcelium/cover.ccf
+++ b/hw/dv/tools/xcelium/cover.ccf
@@ -6,6 +6,7 @@
 include_ccf ${dv_root}/tools/xcelium/common.ccf
 
 // enable coverage on dut and below
+
 select_coverage -befts -module ${DUT_TOP}...
 
 // Black-box pre-verified IPs from coverage collection.


### PR DESCRIPTION
I found another problem in the common ccf

Generally I don't think we want to generate coverage for the environment.

