### PR TITLE
[otbn, util] Clean up OTBN information-flow analysis backend.

### DIFF
--- a/hw/ip/otbn/util/analyze_information_flow.py
+++ b/hw/ip/otbn/util/analyze_information_flow.py
@@ -64,14 +64,14 @@ def main() -> int:
     # If no secrets were given or the --verbose flag is set, then print the
     # full information-flow graphs.
     if (args.verbose or args.secrets is None):
-        if ret_iflow is not None:
+        if ret_iflow.exists:
             print(
                 'Information flow for paths ending in a return to the caller:')
             print(ret_iflow.pretty(indent=2))
-            if end_iflow is not None:
+            if end_iflow.exists:
                 print('--------')
 
-        if end_iflow is not None:
+        if end_iflow.exists:
             print('Information flow for paths ending the program:')
             print(end_iflow.pretty(indent=2))
 
@@ -101,14 +101,14 @@ def main() -> int:
 
     # Print final secrets (if initial secrets were provided).
     if args.secrets is not None:
-        if ret_iflow is not None:
+        if ret_iflow.exists:
             final_secrets = {
                 sink
                 for node in args.secrets for sink in ret_iflow.sinks(node)
             }
             print('Final secrets for paths ending in a return to the caller:',
                   ', '.join(sorted(final_secrets)))
-        if end_iflow is not None:
+        if end_iflow.exists:
             final_secrets = {
                 sink
                 for node in args.secrets for sink in end_iflow.sinks(node)

--- a/hw/ip/otbn/util/analyze_information_flow.py
+++ b/hw/ip/otbn/util/analyze_information_flow.py
@@ -5,10 +5,10 @@
 
 import argparse
 import sys
-from typing import Dict, List, Optional, Set, Tuple
 
 from shared.control_flow import program_control_graph, subroutine_control_graph
 from shared.decode import decode_elf
+from shared.information_flow import InformationFlowGraph
 from shared.information_flow_analysis import (get_program_iflow,
                                               get_subroutine_iflow,
                                               stringify_control_deps)
@@ -52,10 +52,10 @@ def main() -> int:
         print(graph.pretty(program, indent=2))
 
     # Compute information-flow graph(s).
-    ret_iflow, end_iflow = None, None
     if args.subroutine is None:
         what = 'program'
         end_iflow, control_deps = get_program_iflow(program, graph)
+        ret_iflow = InformationFlowGraph.nonexistent()
     else:
         what = 'subroutine'
         ret_iflow, end_iflow, control_deps = get_subroutine_iflow(

--- a/hw/ip/otbn/util/shared/cache.py
+++ b/hw/ip/otbn/util/shared/cache.py
@@ -1,0 +1,61 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Generic, Optional, TypeVar
+
+K = TypeVar('K')
+V = TypeVar('V')
+I = TypeVar('I')
+
+class CacheEntry(Generic[K,V]):
+    '''Represents a single entry in a cache.
+
+    The entry must hold two pieces of information:
+    - value, the cached result to be returned on a matching lookup
+    - key, data needed to determine if the entry matches a lookup (e.g. input
+      parameters to the function whose result has been cached)
+
+    Note that this is not a simple key/value store, because a key might match a
+    lookup even if it's not an exact match. Determining what exactly needs to
+    match is implementation-specific and implemented by subclasses.
+    '''
+    def __init__(self, key: K, value: V):
+        self.key = key
+        self.value = value
+
+    def is_match(self, key: K) -> bool:
+        '''Returns whether this entry is a match for the key.
+
+        In the simplest case, this could be just self.key == key; however, the
+        implementer might choose to ignore certain information when evaluating
+        the match, depending on the use-case.
+        '''
+        raise NotImplementedError()
+
+class Cache(Generic[I,K,V]):
+    '''Represents a cache to speed up recursive functions.
+
+    The cache is structured with two layers:
+    - The first layer is a dictionary that maps some hashable index type to the
+      second layer, a list for each dictionary entry.
+    - The second layer is a list of CacheEntry instances to be checked.
+
+    The purpose of the two-layer structure is to speed up lookups; the index
+    type should be used to quickly narrow things down to a limited number of
+    potentially matching entries (for instance, it could be an input parameter
+    to the function that absolutely must match for the cache entries to match).
+    '''
+    def __init__(self) -> None:
+        self.entries : Dict[I,List[CacheEntry[K,V]]] = {}
+
+    def add(self, index: I, entry: CacheEntry[K,V]) -> None:
+        # Only add if there's no matching entry already 
+        if self.lookup(index, entry.key) is None:
+            self.entries.setdefault(index, []).append(entry)
+
+    def lookup(self, index: I, key: K) -> Optional[V]:
+        for entry in self.entries.get(index, []):
+            if entry.is_match(key):
+                return entry.value
+        return None

--- a/hw/ip/otbn/util/shared/cache.py
+++ b/hw/ip/otbn/util/shared/cache.py
@@ -2,13 +2,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, Generic, Optional, List, TypeVar
+from typing import Dict, Generic, List, Optional, TypeVar
 
-K = TypeVar('K')
-V = TypeVar('V')
-I = TypeVar('I')
+K = TypeVar('K')  # Key type.
+V = TypeVar('V')  # Value type.
+X = TypeVar('X')  # Index type.
 
-class CacheEntry(Generic[K,V]):
+
+class CacheEntry(Generic[K, V]):
     '''Represents a single entry in a cache.
 
     The entry must hold two pieces of information:
@@ -33,7 +34,8 @@ class CacheEntry(Generic[K,V]):
         '''
         raise NotImplementedError()
 
-class Cache(Generic[I,K,V]):
+
+class Cache(Generic[X, K, V]):
     '''Represents a cache to speed up recursive functions.
 
     The cache is structured with two layers:
@@ -47,14 +49,14 @@ class Cache(Generic[I,K,V]):
     to the function that absolutely must match for the cache entries to match).
     '''
     def __init__(self) -> None:
-        self.entries : Dict[I,List[CacheEntry[K,V]]] = {}
+        self.entries: Dict[X, List[CacheEntry[K, V]]] = {}
 
-    def add(self, index: I, entry: CacheEntry[K,V]) -> None:
-        # Only add if there's no matching entry already 
+    def add(self, index: X, entry: CacheEntry[K, V]) -> None:
+        # Only add if there's no matching entry already
         if self.lookup(index, entry.key) is None:
             self.entries.setdefault(index, []).append(entry)
 
-    def lookup(self, index: I, key: K) -> Optional[V]:
+    def lookup(self, index: X, key: K) -> Optional[V]:
         for entry in self.entries.get(index, []):
             if entry.is_match(key):
                 return entry.value

--- a/hw/ip/otbn/util/shared/cache.py
+++ b/hw/ip/otbn/util/shared/cache.py
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Generic, Optional, TypeVar
+from typing import Dict, Generic, Optional, List, TypeVar
 
 K = TypeVar('K')
 V = TypeVar('V')

--- a/hw/ip/otbn/util/shared/constants.py
+++ b/hw/ip/otbn/util/shared/constants.py
@@ -8,11 +8,13 @@ from typing import Dict, Optional
 from .insn_yaml import Insn
 from .operand import RegOperandType
 
+
 def get_op_val_str(insn: Insn, op_vals: Dict[str, int], opname: str) -> str:
     '''Get the value of the given (register) operand as a string.'''
     op = insn.name_to_operand[opname]
     assert isinstance(op.op_type, RegOperandType)
     return op.op_type.op_val_to_str(op_vals[opname], None)
+
 
 class ConstantContext:
     '''Represents known-constant GPRs.
@@ -20,7 +22,7 @@ class ConstantContext:
     This datatype is used to track and evaluate GPR pointers for indirect
     references.
     '''
-    def __init__(self, values: Dict[str,int]):
+    def __init__(self, values: Dict[str, int]):
         # The x0 register needs to always be 0
         assert values.get('x0', None) == 0
         self.values = values.copy()
@@ -53,7 +55,7 @@ class ConstantContext:
         Does not modify self or other.
         '''
         out = {}
-        for k,v in self.values.items():
+        for k, v in self.values.items():
             if other.get(k) == v:
                 out[k] = v
         return ConstantContext(out)
@@ -73,7 +75,7 @@ class ConstantContext:
             if grs1_name in self.values:
                 grd_name = get_op_val_str(insn, op_vals, 'grd')
                 # Operand is a constant; add/update grd
-                new_values[grd_name]= self.values[grs1_name] + op_vals['imm']
+                new_values[grd_name] = self.values[grs1_name] + op_vals['imm']
         elif insn.mnemonic == 'lui':
             grd_name = get_op_val_str(insn, op_vals, 'grd')
             new_values[grd_name] = op_vals['imm'] << 12
@@ -81,7 +83,7 @@ class ConstantContext:
             # If the instruction has any op_vals ending in _inc,
             # assume we're incrementing the corresponding register
             for op in insn.operands:
-                if op.name.endswith('_inc'):
+                if op.name.endswith('_inc') and op_vals[op.name] != 0:
                     # If reg to be incremented is a constant, increment it
                     inc_op = op.name[:-(len('_inc'))]
                     inc_name = get_op_val_str(insn, op_vals, inc_op)

--- a/hw/ip/otbn/util/shared/constants.py
+++ b/hw/ip/otbn/util/shared/constants.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Dict, Optional
+
+from .insn_yaml import Insn
+from .operand import RegOperandType
+
+def get_op_val_str(insn: Insn, op_vals: Dict[str, int], opname: str) -> str:
+    '''Get the value of the given (register) operand as a string.'''
+    op = insn.name_to_operand[opname]
+    assert isinstance(op.op_type, RegOperandType)
+    return op.op_type.op_val_to_str(op_vals[opname], None)
+
+class ConstantContext:
+    '''Represents known-constant GPRs.
+
+    This datatype is used to track and evaluate GPR pointers for indirect
+    references.
+    '''
+    def __init__(self, values: Dict[str,int]):
+        # The x0 register needs to always be 0
+        assert values.get('x0', None) == 0
+        self.values = values.copy()
+
+    @staticmethod
+    def empty() -> 'ConstantContext':
+        '''Represents a context with no known constants.'''
+        return ConstantContext({'x0': 0})
+
+    def set(self, gpr: str, value: int) -> None:
+        '''Set the value of a GPR in the context.'''
+        if gpr == 'x0':
+            # Ignore writes to x0; it's read-only.
+            return
+        self.values[gpr] = value
+
+    def get(self, gpr: str) -> Optional[int]:
+        '''Get the value of a GPR in the context.'''
+        return self.values.get(gpr, None)
+
+    def __contains__(self, gpr: str) -> bool:
+        return gpr in self.values
+
+    def copy(self) -> 'ConstantContext':
+        return ConstantContext(self.values)
+
+    def intersect(self, other: 'ConstantContext') -> 'ConstantContext':
+        '''Returns a new context with only values on which self/other agree.
+
+        Does not modify self or other.
+        '''
+        out = {}
+        for k,v in self.values.items():
+            if other.get(k) == v:
+                out[k] = v
+        return ConstantContext(out)
+
+    def update_insn(self, insn: Insn, op_vals: Dict[str, int]) -> None:
+        '''Updates to new known constant values GPRs after the instruction.
+
+        Currently, this procedure supports only a limited set of instructions.
+        Since constant values only need to be known in order to decode indirect
+        references to WDRs and loop counts, this set is chosen based on operations
+        likely to happen to those registers: `addi`, `lui`, and bignum instructions
+        containing `_inc` op_vals.
+        '''
+        new_values = {}
+        if insn.mnemonic == 'addi':
+            grs1_name = get_op_val_str(insn, op_vals, 'grs1')
+            if grs1_name in self.values:
+                grd_name = get_op_val_str(insn, op_vals, 'grd')
+                # Operand is a constant; add/update grd
+                new_values[grd_name]= self.values[grs1_name] + op_vals['imm']
+        elif insn.mnemonic == 'lui':
+            grd_name = get_op_val_str(insn, op_vals, 'grd')
+            new_values[grd_name] = op_vals['imm'] << 12
+        else:
+            # If the instruction has any op_vals ending in _inc,
+            # assume we're incrementing the corresponding register
+            for op in insn.operands:
+                if op.name.endswith('_inc'):
+                    # If reg to be incremented is a constant, increment it
+                    inc_op = op.name[:-(len('_inc'))]
+                    inc_name = get_op_val_str(insn, op_vals, inc_op)
+                    if inc_name in self.values:
+                        new_values[inc_name] = self.values[inc_name] + 1
+
+        # If the instruction's information-flow graph indicates that we updated any
+        # constant register other than the ones handled above, the value of that
+        # register can no longer be determined; remove it from the constants
+        # dictionary.
+        iflow = insn.iflow.evaluate(op_vals, self.values)
+        for sink in iflow.all_sinks():
+            # Remove from self.values if key exists
+            self.values.pop(sink, None)
+
+        self.values.update(new_values)

--- a/hw/ip/otbn/util/shared/information_flow_analysis.py
+++ b/hw/ip/otbn/util/shared/information_flow_analysis.py
@@ -3,15 +3,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Callable, Dict, List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
-from .cache import CacheEntry, Cache
+from .cache import Cache, CacheEntry
 from .constants import ConstantContext, get_op_val_str
-from .control_flow import *
+from .control_flow import ControlLoc, ControlGraph, Ecall, ImemEnd, LoopStart, LoopEnd, Ret
 from .decode import OTBNProgram
-from .information_flow import InformationFlowGraph, InsnInformationFlow
+from .information_flow import InformationFlowGraph
 from .insn_yaml import Insn
-from .section import CodeSection
 
 # Calls to _get_iflow return results in the form of a tuple with entries:
 #   used constants: a set containing the names of input constants the
@@ -31,8 +30,9 @@ from .section import CodeSection
 #                   the program; the value is a set of PCs of control-flow
 #                   instructions through which the node influences the control
 #                   flow
-IFlowResult = Tuple[Set[str], InformationFlowGraph, InformationFlowGraph, ConstantContext,
-                    Dict[str, Set[int]]]
+IFlowResult = Tuple[Set[str], InformationFlowGraph, InformationFlowGraph,
+                    ConstantContext, Dict[str, Set[int]]]
+
 
 class IFlowCacheEntry(CacheEntry[ConstantContext, IFlowResult]):
     '''Represents an entry in the cache for _get_iflow.
@@ -42,32 +42,36 @@ class IFlowCacheEntry(CacheEntry[ConstantContext, IFlowResult]):
     result. Only constants that were actually used in the process of computing
     the result are stored in the key; if another call to _get_iflow has the
     same values for those constants but different values for others, the result
-    should not change. 
+    should not change.
     '''
     def is_match(self, constants: ConstantContext) -> bool:
-        for k,v in self.key.values.items():
+        for k, v in self.key.values.items():
             if constants.get(k) != v:
                 return False
         return True
 
-class IFlowCache(Cache[int,ConstantContext, IFlowResult]):
+
+class IFlowCache(Cache[int, ConstantContext, IFlowResult]):
     '''Represents the cache for _get_iflow.
 
     The index of the cache is the start PC for the call to _get_iflow. If this
     index and the values of the constants used in the call match a new call,
-    the cached result is returned. 
+    the cached result is returned.
     '''
     pass
+
 
 # The information flow of a subroutine is represented as a tuple whose entries
 # are a subset of the IFlowResult tuple entries; in particular, it has the form
 # (return iflow, end iflow, control deps).
-SubroutineIFlow = Tuple[InformationFlowGraph,InformationFlowGraph, Dict[str, Set[int]]]
+SubroutineIFlow = Tuple[InformationFlowGraph, InformationFlowGraph,
+                        Dict[str, Set[int]]]
 
 # The information flow of a full program is the same as for a subroutine,
 # except with no "return" information flow. Since the call stack is empty
 # at the start, we're not expecting any return paths!
 ProgramIFlow = Tuple[InformationFlowGraph, Dict[str, Set[int]]]
+
 
 def _build_iflow_insn(
         insn: Insn, op_vals: Dict[str, int], pc: int,
@@ -136,8 +140,7 @@ def _build_iflow_straightline(
     '''Constructs the information-flow graph for a straightline code section.
 
     Returns two values:
-    - The set of constants (at the start instruction) that the graph and new
-      state of `constants` depend on
+    - The set of constants (at the start instruction) that the graph depends on
     - The information-flow graph
 
     The instruction at end_pc is included in the calculation. Errors upon
@@ -163,13 +166,6 @@ def _build_iflow_straightline(
 
         # Update constants to their values after the instruction
         constants.update_insn(insn, op_vals)
-
-    # Update used constants to include constants that were used to compute the
-    # new constants
-    # TODO: results in unnecessary re-computations for updated constants that
-    # we don't end up using; see if we can improve performance here?
-    const_sources = iflow.sources_for_any(iter(constants.values.keys()))
-    constant_deps.update(const_sources)
 
     return constant_deps, iflow
 
@@ -200,7 +196,8 @@ def _get_iflow_cache_update(pc: int, constants: ConstantContext,
         assert name in constants
         used_constant_values[name] = constants.values[name]
 
-    cache.add(pc, IFlowCacheEntry(ConstantContext(used_constant_values), result))
+    cache.add(pc, IFlowCacheEntry(ConstantContext(used_constant_values),
+                                  result))
 
     return
 
@@ -229,8 +226,7 @@ def _update_control_deps(current_deps: Dict[str, Set[int]],
 
 def _get_iflow_update_state(
         rec_result: IFlowResult, iflow: InformationFlowGraph,
-        program_end_iflow: InformationFlowGraph,
-        used_constants: Set[str],
+        program_end_iflow: InformationFlowGraph, used_constants: Set[str],
         control_deps: Dict[str, Set[int]]) -> InformationFlowGraph:
     '''Update the internal state of _get_iflow after a recursive call.
 
@@ -388,8 +384,7 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
         _, jump_return_iflow, _, constants, _ = jump_result
 
         # Compose current iflow with the flow for the jump's return paths
-        if jump_return_iflow is not None:
-            iflow = iflow.seq(jump_return_iflow)
+        iflow = iflow.seq(jump_return_iflow)
 
         # Set the next edges to the instruction after the jump returns
         edges = [ControlLoc(section.end + 4)]
@@ -417,11 +412,12 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
             # Since this is the only edge, common_constants must be unset
             common_constants = constants
             return_iflow.update(iflow)
-        elif isinstance(loc, LoopStart):
-            # We shouldn't hit a LoopStart here; those cases (a loop
+        elif isinstance(loc, LoopStart) or isinstance(loc, LoopEnd):
+            # We shouldn't hit a loop instances here; those cases (a loop
             # instruction or the end of a loop) are all handled earlier
-            raise RuntimeError('Unexpected LoopStart at PC {:#x}'.format(
-                section.end))
+            raise RuntimeError(
+                'Unexpected loop edge (type {}) at PC {:#x}'.format(
+                    type(loc), section.end))
         elif not loc.is_special():
             # Just a normal PC; recurse
             result = _get_iflow(program, graph, loc.pc, constants, loop_end_pc,
@@ -452,6 +448,18 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     # common_constants to some non-None value
     assert common_constants is not None
 
+    # Update used_constants to include any constant dependencies of
+    # common_constants, since common_constants will be cached
+    used_constants.update(
+        return_iflow.sources_for_any(common_constants.values.keys()))
+
+    # Strip special register x0 from both sources and sinks of graphs returned.
+    return_iflow.remove_source('x0')
+    return_iflow.remove_sink('x0')
+    program_end_iflow.remove_source('x0')
+    program_end_iflow.remove_sink('x0')
+    control_deps.pop('x0', None)
+
     # Update the cache and return
     out = (used_constants, return_iflow, program_end_iflow, common_constants,
            control_deps)
@@ -472,7 +480,7 @@ def check_acyclic(graph: ControlGraph) -> None:
         ]
         for pc, links in cycles.items():
             msg.append('{:#x} <-> {}'.format(
-                pc, ','.join(['{:#x}'.format(l) for l in links])))
+                pc, ','.join(['{:#x}'.format(link) for link in links])))
         msg.append('Analyzing cyclic control flow outside of LOOP/LOOPI '
                    'instructions is not currently supported.')
         raise ValueError('\n'.join(msg))
@@ -514,7 +522,8 @@ def get_program_iflow(program: OTBNProgram,
     '''
     check_acyclic(graph)
     _, ret_iflow, end_iflow, _, control_deps = _get_iflow(
-        program, graph, program.min_pc(), ConstantContext.empty(), None, IFlowCache())
+        program, graph, program.min_pc(), ConstantContext.empty(), None,
+        IFlowCache())
     if ret_iflow.exists:
         # No paths from imem_start should end in RET
         raise ValueError('Unexpected information flow for paths ending in RET '
@@ -523,7 +532,8 @@ def get_program_iflow(program: OTBNProgram,
     return end_iflow, control_deps
 
 
-def stringify_control_deps(program: OTBNProgram, control_deps: Dict[str,Set[int]]) -> List[str]:
+def stringify_control_deps(program: OTBNProgram,
+                           control_deps: Dict[str, Set[int]]) -> List[str]:
     '''Compute string representations of nodes that influence control flow.
 
     Returns a list of strings, each representing one node that influences
@@ -542,7 +552,6 @@ def stringify_control_deps(program: OTBNProgram, control_deps: Dict[str,Set[int]
             continue
         for pc in pcs:
             insn = program.get_insn(pc)
-            pc_strings.append('{} at PC {:#x}'.format(
-                insn.mnemonic, pc))
+            pc_strings.append('{} at PC {:#x}'.format(insn.mnemonic, pc))
         out.append('{} (via {})'.format(node, ', '.join(pc_strings)))
     return out

--- a/hw/ip/otbn/util/shared/information_flow_analysis.py
+++ b/hw/ip/otbn/util/shared/information_flow_analysis.py
@@ -3,14 +3,14 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Callable, Dict, List, Optional, Set, Tuple
 
-from .control_flow import *
 from .cache import CacheEntry, Cache
+from .constants import ConstantContext, get_op_val_str
+from .control_flow import *
 from .decode import OTBNProgram
 from .information_flow import InformationFlowGraph, InsnInformationFlow
 from .insn_yaml import Insn
-from .operand import RegOperandType
 from .section import CodeSection
 
 # Calls to _get_iflow return results in the form of a tuple with entries:
@@ -23,18 +23,18 @@ from .section import CodeSection
 #   end iflow:      an information-flow graph for any paths that lead to the
 #                   end of the entire program (i.e. ECALL instruction or end of
 #                   IMEM)
-#   new constants:  values of constants that are shared between all paths
-#                   ending in RET (i.e. the constants a caller can rely on
-#                   regardless of input)
+#   constants:      known constants that are in common between all "return"
+#                   iflow paths (i.e. the constants that a caller can always
+#                   rely on)
 #   control deps:   a dictionary whose keys are the information-flow nodes
 #                   whose values at the start PC influence the control flow of
 #                   the program; the value is a set of PCs of control-flow
 #                   instructions through which the node influences the control
 #                   flow
-IFlowResult = Tuple[Set[str], InformationFlowGraph, InformationFlowGraph, Dict[str, int],
+IFlowResult = Tuple[Set[str], InformationFlowGraph, InformationFlowGraph, ConstantContext,
                     Dict[str, Set[int]]]
 
-class IFlowCacheEntry(CacheEntry[Dict[str,int], IFlowResult]):
+class IFlowCacheEntry(CacheEntry[ConstantContext, IFlowResult]):
     '''Represents an entry in the cache for _get_iflow.
 
     The key for the cache entry is the values of certain constants in the input
@@ -44,13 +44,13 @@ class IFlowCacheEntry(CacheEntry[Dict[str,int], IFlowResult]):
     same values for those constants but different values for others, the result
     should not change. 
     '''
-    def is_match(self, constants: Dict[str,int]) -> bool:
-        for k,v in self.key.items():
-            if constants.get(k, None) != v:
+    def is_match(self, constants: ConstantContext) -> bool:
+        for k,v in self.key.values.items():
+            if constants.get(k) != v:
                 return False
         return True
 
-class IFlowCache(Cache[int,Dict[str,int], IFlowResult]):
+class IFlowCache(Cache[int,ConstantContext, IFlowResult]):
     '''Represents the cache for _get_iflow.
 
     The index of the cache is the start PC for the call to _get_iflow. If this
@@ -69,64 +69,9 @@ SubroutineIFlow = Tuple[InformationFlowGraph,InformationFlowGraph, Dict[str, Set
 # at the start, we're not expecting any return paths!
 ProgramIFlow = Tuple[InformationFlowGraph, Dict[str, Set[int]]]
 
-
-def _get_op_val_str(insn: Insn, op_vals: Dict[str, int], opname: str) -> str:
-    '''Get the value of the given operand as a string.'''
-    op = insn.name_to_operand[opname]
-    return op.op_type.op_val_to_str(op_vals[opname], None)
-
-
-def _update_constants_insn(insn: Insn, op_vals: Dict[str, int],
-                           constants: Dict[str, int]) -> None:
-    '''Determines the values of constant registers after the instruction.
-
-    Currently, this procedure supports only a limited set of instructions.
-    Since constant values only need to be known in order to decode indirect
-    references to WDRs and loop counts, this set is chosen based on operations
-    likely to happen to those registers: `addi`, `lui`, and bignum instructions
-    containing `_inc` op_vals.
-
-    Modifies the input `constants` dictionary.
-    '''
-    new_constants = {'x0': 0}
-    if insn.mnemonic == 'addi':
-        grs1_name = _get_op_val_str(insn, op_vals, 'grs1')
-        if grs1_name in constants:
-            grd_name = _get_op_val_str(insn, op_vals, 'grd')
-            # Operand is a constant; add/update grd
-            new_constants[grd_name] = constants[grs1_name] + op_vals['imm']
-    elif insn.mnemonic == 'lui':
-        grd_name = _get_op_val_str(insn, op_vals, 'grd')
-        new_constants[grd_name] = op_vals['imm'] << 12
-    else:
-        # If the instruction has any op_vals ending in _inc that are nonzero,
-        # assume we're incrementing the corresponding register
-        for op in insn.operands:
-            if op.name.endswith('_inc'):
-                if op_vals[op.name] != 0:
-                    # If reg to be incremented is a constant, increment it!
-                    inc_op = op.name[:-(len('_inc'))]
-                    inc_name = _get_op_val_str(insn, op_vals, inc_op)
-                    if inc_name in constants:
-                        new_constants[inc_name] = constants[inc_name] + 1
-
-    # If the instruction's information-flow graph indicates that we updated any
-    # constant register other than the ones handled above, the value of that
-    # register can no longer be determined; remove it from the constants
-    # dictionary.
-    iflow_graph = insn.iflow.evaluate(op_vals, constants)
-    for sink, sources in iflow_graph.flow.items():
-        if sink in constants and sink not in new_constants:
-            del constants[sink]
-
-    constants.update(new_constants)
-
-    return
-
-
 def _build_iflow_insn(
         insn: Insn, op_vals: Dict[str, int], pc: int,
-        constants: Dict[str, int]) -> Tuple[Set[str], InformationFlowGraph]:
+        constants: ConstantContext) -> Tuple[Set[str], InformationFlowGraph]:
     '''Constructs the information-flow graph for a single instruction.
 
     Raises a ValueError if the information-flow graph cannot be constructed
@@ -149,9 +94,9 @@ def _build_iflow_insn(
                 'need to add constant-tracking support for more '
                 'instructions.'.format(const, pc,
                                        insn.disassemble(pc, op_vals),
-                                       list(constants.keys())))
+                                       list(constants.values.keys())))
 
-    return constant_deps, insn.iflow.evaluate(op_vals, constants)
+    return constant_deps, insn.iflow.evaluate(op_vals, constants.values)
 
 
 def _get_insn_control_deps(insn: Insn, op_vals: Dict[str, int]) -> Set[str]:
@@ -164,18 +109,18 @@ def _get_insn_control_deps(insn: Insn, op_vals: Dict[str, int]) -> Set[str]:
         return set()
     elif insn.mnemonic in ['beq', 'bne']:
         # both compared values influence control flow
-        grs1_name = _get_op_val_str(insn, op_vals, 'grs1')
-        grs2_name = _get_op_val_str(insn, op_vals, 'grs2')
+        grs1_name = get_op_val_str(insn, op_vals, 'grs1')
+        grs2_name = get_op_val_str(insn, op_vals, 'grs2')
         return {grs1_name, grs2_name}
     elif insn.mnemonic == 'jalr':
         if op_vals['grs1'] == 1:
             return set()
         # jump destination register influences control flow
-        grs1_name = _get_op_val_str(insn, op_vals, 'grs1')
+        grs1_name = get_op_val_str(insn, op_vals, 'grs1')
         return {grs1_name}
     elif insn.mnemonic == 'loop':
         # loop #iterations influences control flow
-        grs_name = _get_op_val_str(insn, op_vals, 'grs')
+        grs_name = get_op_val_str(insn, op_vals, 'grs')
         return {grs_name}
     elif insn.mnemonic in ['ecall', 'jal', 'loopi']:
         # these all rely only on immediates
@@ -187,7 +132,7 @@ def _get_insn_control_deps(insn: Insn, op_vals: Dict[str, int]) -> Set[str]:
 
 def _build_iflow_straightline(
         program: OTBNProgram, start_pc: int, end_pc: int,
-        constants: Dict[str, int]) -> Tuple[Set[str], InformationFlowGraph]:
+        constants: ConstantContext) -> Tuple[Set[str], InformationFlowGraph]:
     '''Constructs the information-flow graph for a straightline code section.
 
     Returns two values:
@@ -217,19 +162,20 @@ def _build_iflow_straightline(
         iflow = iflow.seq(insn_iflow)
 
         # Update constants to their values after the instruction
-        _update_constants_insn(insn, op_vals, constants)
+        constants.update_insn(insn, op_vals)
 
     # Update used constants to include constants that were used to compute the
     # new constants
-    for const in constants:
-        const_sources = iflow.flow[const] if const in iflow.flow else {const}
-        constant_deps.update(const_sources)
+    # TODO: results in unnecessary re-computations for updated constants that
+    # we don't end up using; see if we can improve performance here?
+    const_sources = iflow.sources_for_any(iter(constants.values.keys()))
+    constant_deps.update(const_sources)
 
     return constant_deps, iflow
 
 
 def _get_constant_loop_iterations(insn: Insn, op_vals: Dict[str, int],
-                                  constants: Dict[str, int]) -> Optional[int]:
+                                  constants: ConstantContext) -> Optional[int]:
     '''Given a loop instruction, returns the number of iterations if constant.
 
     If the number of iterations is not constant, returns None.
@@ -238,23 +184,23 @@ def _get_constant_loop_iterations(insn: Insn, op_vals: Dict[str, int],
     if insn.mnemonic == 'loopi':
         return op_vals['iterations']
     elif insn.mnemonic == 'loop':
-        reg_name = _get_op_val_str(insn, op_vals, 'grs')
-        return constants.get(reg_name, None)
+        reg_name = get_op_val_str(insn, op_vals, 'grs')
+        return constants.get(reg_name)
 
     # Should not get here!
     assert False
 
 
-def _get_iflow_cache_update(pc: int, constants: Dict[str, int],
+def _get_iflow_cache_update(pc: int, constants: ConstantContext,
                             result: IFlowResult, cache: IFlowCache) -> None:
     '''Updates the cache for _get_iflow.'''
     used_constants = result[0]
     used_constant_values = {}
     for name in used_constants:
         assert name in constants
-        used_constant_values[name] = constants[name]
+        used_constant_values[name] = constants.values[name]
 
-    cache.add(pc, IFlowCacheEntry(used_constant_values, result))
+    cache.add(pc, IFlowCacheEntry(ConstantContext(used_constant_values), result))
 
     return
 
@@ -306,7 +252,7 @@ def _get_iflow_update_state(
 
 
 def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
-               start_constants: Dict[str, int], loop_end_pc: Optional[int],
+               start_constants: ConstantContext, loop_end_pc: Optional[int],
                cache: IFlowCache) -> IFlowResult:
     '''Gets the information-flow graphs for paths starting at start_pc.
 
@@ -337,7 +283,7 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     program_end_iflow = InformationFlowGraph.nonexistent()
 
     # The control-flow nodes whose values at the start PC influence control
-    # flow
+    # flow (and the PCs of the control-flow instructions they influence)
     control_deps: Dict[str, Set[int]] = {}
 
     section = graph.get_section(start_pc)
@@ -358,7 +304,8 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
                                                       section.end - 4,
                                                       constants)
 
-    # Get the instruction/operands at the very end of the block for special handling
+    # Get the instruction/operands at the very end of the block (i.e. the
+    # control-flow instruction) for special handling
     last_insn = program.get_insn(section.end)
     last_op_vals = program.get_operands(section.end)
 
@@ -390,18 +337,15 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
                 'known constant at PC {:#x} (known constants: {}). If '
                 'the register is in fact a constant, you may need to '
                 'add constant-tracking support for more instructions.'.format(
-                    section.end, constants.keys()))
+                    section.end, constants.values.keys()))
 
-        if len(edges) != 1 or not isinstance(edges[0], LoopStart):
-            raise RuntimeError(
-                'Control graph section ends in {} at PC {:#x} but the '
-                'next control-flow locations are: {} instead of 1 '
-                'LoopStart instance as expected'.format(
-                    last_insn.mnemonic, section.end, edges))
+        # A loop instruction should result in exactly one edge of type
+        # LoopStart; check that assumption before we rely on it
+        assert len(edges) == 1 and isinstance(edges[0], LoopStart)
         body_loc = edges[0]
 
         # Update the constants to include the loop instruction
-        _update_constants_insn(last_insn, last_op_vals, constants)
+        constants.update_insn(last_insn, last_op_vals)
 
         # Recursive calls for each iteration
         for _ in range(iterations):
@@ -426,13 +370,10 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     elif last_insn.mnemonic == 'jal' and last_op_vals['grd'] == 1:
         # Special handling for jumps; recursive call for jump destination, then
         # continue at pc+4
-        if len(edges) != 1 or edges[0].is_special():
-            raise RuntimeError(
-                'Control graph section ends in {} at PC {:#x} but the '
-                'next control-flow locations are: {} instead of 1 '
-                'non-special ControlLoc instance as expected'.format(
-                    last_insn.mnemonic, section.end, edges))
 
+        # Jumps should produce exactly one non-special edge; check that
+        # assumption before we rely on it
+        assert len(edges) == 1 and not edges[0].is_special()
         jump_loc = edges[0]
         jump_result = _get_iflow(program, graph, jump_loc.pc, constants, None,
                                  cache)
@@ -454,37 +395,28 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
         edges = [ControlLoc(section.end + 4)]
     else:
         # Update the constants to include the last instruction
-        _update_constants_insn(last_insn, last_op_vals, constants)
+        constants.update_insn(last_insn, last_op_vals)
 
     # We're only returning constants that are the same in all RET branches
     common_constants = None
 
     for loc in edges:
         if isinstance(loc, Ecall) or isinstance(loc, ImemEnd):
-            if len(edges) != 1:
-                raise RuntimeError(
-                    'Control graph section at PC {:#x} has edges {}; if '
-                    'edges contain an Ecall or ImemEnd, it is expected to '
-                    'be the only edge.'.format(section.end, edges))
-
+            # Ecall or ImemEnd nodes are expected to be the only edge
+            assert len(edges) == 1
             # Clear common constants; there are no return branches here
-            common_constants = {'x0': 0}
+            common_constants = ConstantContext.empty()
             program_end_iflow.update(iflow)
         elif isinstance(loc, Ret):
             if loop_end_pc is not None:
                 raise RuntimeError(
                     'RET before end of loop at PC {:#x} (loop end PC: '
                     '{:#x})'.format(section.end, loop_end_pc))
-            if len(edges) != 1:
-                raise RuntimeError(
-                    'Control graph section at PC {:#x} has edges {}; if '
-                    'edges contain a Ret, it is expected to be the only '
-                    'edge.'.format(section.end, edges))
-
+            # Ret nodes are expected to be the only edge
+            assert len(edges) == 1
             # Since this is the only edge, common_constants must be unset
             common_constants = constants
             return_iflow.update(iflow)
-
         elif isinstance(loc, LoopStart):
             # We shouldn't hit a LoopStart here; those cases (a loop
             # instruction or the end of a loop) are all handled earlier
@@ -502,14 +434,11 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
             # Get information flow for return paths and new constants
             _, rec_return_iflow, _, rec_constants, _ = result
 
-            # Update common constants
+            # Take values on which existing and recursive constants agree
             if common_constants is None:
                 common_constants = rec_constants
             else:
-                for const, value in rec_constants.items():
-                    if common_constants.get(const, None) != value:
-                        # Remove from common_constants if key exists
-                        common_constants.pop(const, None)
+                common_constants.intersect(rec_constants)
 
             #  Update return_iflow with the current iflow composed with return
             #  paths
@@ -519,8 +448,9 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
                 'Unexpected next control location type at PC {:#x}: {}'.format(
                     section.end, type(loc)))
 
-    if common_constants is None:
-        common_constants = constants
+    # There should be at least one edge, and all edges should set
+    # common_constants to some non-None value
+    assert common_constants is not None
 
     # Update the cache and return
     out = (used_constants, return_iflow, program_end_iflow, common_constants,
@@ -565,7 +495,7 @@ def get_subroutine_iflow(program: OTBNProgram, graph: ControlGraph,
     check_acyclic(graph)
     start_pc = program.get_pc_at_symbol(subroutine_name)
     _, ret_iflow, end_iflow, _, control_deps = _get_iflow(
-        program, graph, start_pc, {'x0': 0}, None, IFlowCache())
+        program, graph, start_pc, ConstantContext.empty(), None, IFlowCache())
     if not (ret_iflow.exists or end_iflow.exists):
         raise ValueError('Could not find any complete control-flow paths when '
                          'analyzing subroutine.')
@@ -584,7 +514,7 @@ def get_program_iflow(program: OTBNProgram,
     '''
     check_acyclic(graph)
     _, ret_iflow, end_iflow, _, control_deps = _get_iflow(
-        program, graph, program.min_pc(), {'x0': 0}, None, IFlowCache())
+        program, graph, program.min_pc(), ConstantContext.empty(), None, IFlowCache())
     if ret_iflow.exists:
         # No paths from imem_start should end in RET
         raise ValueError('Unexpected information flow for paths ending in RET '

--- a/hw/ip/otbn/util/shared/section.py
+++ b/hw/ip/otbn/util/shared/section.py
@@ -3,7 +3,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List
+from typing import Iterator, List
 
 from shared.decode import OTBNProgram
 from shared.insn_yaml import Insn
@@ -19,12 +19,14 @@ class CodeSection:
         self.end = end
 
     def get_insn_sequence(self, program: OTBNProgram) -> List[Insn]:
-        return [
-            program.get_insn(pc) for pc in range(self.start, self.end + 4, 4)
-        ]
+        return [ program.get_insn(pc) for pc in self.__iter__() ]
 
     def pretty(self) -> str:
         return '0x{:x}-0x{:x}'.format(self.start, self.end)
+
+    def __iter__(self) -> Iterator[int]:
+        '''Iterates through PCs in the section.'''
+        return iter(range(self.start, self.end + 4, 4))
 
     def __contains__(self, pc: int) -> bool:
         return self.start <= pc and pc <= self.end

--- a/hw/ip/otbn/util/shared/section.py
+++ b/hw/ip/otbn/util/shared/section.py
@@ -19,7 +19,7 @@ class CodeSection:
         self.end = end
 
     def get_insn_sequence(self, program: OTBNProgram) -> List[Insn]:
-        return [ program.get_insn(pc) for pc in self.__iter__() ]
+        return [program.get_insn(pc) for pc in self.__iter__()]
 
     def pretty(self) -> str:
         return '0x{:x}-0x{:x}'.format(self.start, self.end)


### PR DESCRIPTION
In https://github.com/lowRISC/opentitan/pull/10128 I introduced some information-flow and constant-time analysis scripts for OTBN. There's some fairly involved machinery behind those that tracks information flow through OTBN binaries, and there were a few items of cleanup that I had been meaning to get around to. Broadly, this PR:
- Simplifies and better documents reasoning about [nonexistent information-flow](https://github.com/lowRISC/opentitan/pull/9716/files#r770613647), for instance the "end-of-program" information flow for a subroutine that has no end-program branches
- Adds a generic `Cache` class to cleanly handle logic around caching information-flow results
- Adds a `ConstantContext` class (see [this discussion](https://github.com/lowRISC/opentitan/pull/9716#discussion_r770621610)) to keep track of the registers holding known constants and their values (this is needed to resolve indirect references)

This is part 1/2; on top of this slightly cleaner interface, I was then able to remove one of the major limitations of the analysis scripts so that handling of dynamic loops and non-loop cycles is much improved. But more on that interesting stuff in part 2/2!

I actually made these changes and added support for cycles way back in January, but have only now had time to put them together into a proper PR. But it seemed like a good idea to do it, because I've been using the updated versions locally and it might be useful for others such as @felixmiller to have easy access to them as well!