### PR TITLE
[dv] Regression debugging

### DIFF
--- a/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
+++ b/hw/ip/sram_ctrl/rtl/sram_ctrl.sv
@@ -448,7 +448,8 @@ module sram_ctrl
   ////////////////
 
   `ASSERT_KNOWN(RegsTlOutKnown_A,  regs_tl_o)
-  `ASSERT_KNOWN(RamTlOutKnown_A,   ram_tl_o)
+  `ASSERT_KNOWN(RamTlOutKnown_A,   ram_tl_o.d_valid)
+  `ASSERT_KNOWN_IF(RamTlOutPayLoadKnown_A, ram_tl_o, ram_tl_o.d_valid)
   `ASSERT_KNOWN(AlertOutKnown_A,   alert_tx_o)
   `ASSERT_KNOWN(SramOtpKeyKnown_A, sram_otp_key_o)
 

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -538,7 +538,8 @@ module tlul_adapter_sram
   `ASSERT_INIT(DataIntgOptions_A, ~(EnableDataIntgGen & EnableDataIntgPt))
 
   // make sure outputs are defined
-  `ASSERT_KNOWN(TlOutKnown_A,    tl_o   )
+  `ASSERT_KNOWN(TlOutKnown_A,    tl_o.d_valid)
+  `ASSERT_KNOWN_IF(TlOutPayloadKnown_A, tl_o, tl_o.d_valid)
   `ASSERT_KNOWN(ReqOutKnown_A,   req_o  )
   `ASSERT_KNOWN(WeOutKnown_A,    we_o   )
   `ASSERT_KNOWN(AddrOutKnown_A,  addr_o )

--- a/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
+++ b/hw/top_earlgrey/dv/chip_mask_rom_tests.hjson
@@ -13,6 +13,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/uart_smoketest:1:signed"]
       en_run_modes: ["sw_test_mode_mask_rom"]
+      run_opts: ["+sw_test_timeout_ns=20000000"]
     }
 
     // Mask ROM func tests to be run with test ROM.

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_base_vseq.sv
@@ -61,6 +61,7 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
     cfg.mem_bkdr_util_h[FlashBank1Info].set_mem();
     // Backdoor load the OTP image.
     cfg.mem_bkdr_util_h[Otp].load_mem_from_file(cfg.otp_images[cfg.use_otp_image]);
+    initialize_otp_sig_verify();
     initialize_otp_creator_sw_cfg_ast_cfg();
     callback_vseq.pre_dut_init();
     // Randomize the ROM image. Subclasses that have an actual ROM image will load it later.
@@ -104,6 +105,15 @@ class chip_base_vseq #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_ba
       uart_tx_data_q.push_back(item.data);
     end
   endtask
+
+  // Initialize the OTP creator SW cfg region to use otbn for signature verification.
+  virtual function void initialize_otp_sig_verify();
+    // Use otbn mod_exp implementation for signature
+    // verification. See the definition of `hardened_bool_t` in
+    // sw/device/lib/base/hardened.h.
+    cfg.mem_bkdr_util_h[Otp].write32(otp_ctrl_reg_pkg::CreatorSwCfgUseSwRsaVerifyOffset,
+                                     32'h1d4);
+  endfunction // initialize_otp_sig_verify
 
   // Initialize the OTP creator SW cfg region with AST configuration data.
   virtual function void initialize_otp_creator_sw_cfg_ast_cfg();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -67,6 +67,13 @@ class chip_sw_base_vseq extends chip_base_vseq;
     cfg.mem_bkdr_util_h[FlashBank0Data].set_mem();
     cfg.mem_bkdr_util_h[FlashBank1Data].set_mem();
 
+    // Randomize retention memory.  This is done intentionally with wrong integrity
+    // as early portions of mask ROM will initialize it to the correct value.
+    // The randomization here is just to ensure we do not have x's in the memory.
+    for (int ram_idx = 0; ram_idx < cfg.num_ram_ret_tiles; ram_idx++) begin
+       cfg.mem_bkdr_util_h[RamRet0 + ram_idx].randomize_mem();
+    end
+
     `uvm_info(`gfn, "Initializing ROM", UVM_MEDIUM)
     // Backdoor load memories with sw images.
     cfg.mem_bkdr_util_h[Rom].load_mem_from_file({cfg.sw_images[SwTypeRom], ".scr.39.vmem"});

--- a/sw/device/tests/example_test_from_rom.c
+++ b/sw/device/tests/example_test_from_rom.c
@@ -41,11 +41,12 @@ bool rom_test_main(void) {
     base_uart_stdout(&uart0);
   }
 
-  bool result = false;
-
   /**
    * Place test code here.
    */
 
-  return result;
+  /**
+   * Return true if the test succeeds. Return false if it should fail.
+   */
+  return true;
 }


### PR DESCRIPTION
- have example_rom test return true since otherwise it fails
  in DV regression.  The flash example test already does so,
  so this should not be a controversial change.

- switch signature verification to otbn instead of software.
  Using software takes over 100mS which is just too long for
  DV. The otp hjson are not changed for this, instead we use
  a backdoor otp load to make sure other platforms are not
  disturbed.

- randomize retention memory.  This is needed because the mask_rom
  memory clearing process uses a memcpy, which actually copies per
  byte.  The byte write turns into a read modified write inside
  tlul_adapter_sram since the stored integrity could not be calculated
  otherwise.  This eventually leads to a known-output assertion failure.

- update various other modules to not always assume tlul output is known,
  and instead use the KNOWN_IF structure.