### PR TITLE
[sw,tests] Test flash_ctrl init and scramble

### DIFF
--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.core
@@ -15,6 +15,7 @@ filesets:
       - lowrisc:prim:cipher_pkg:0.1
       - lowrisc:prim:secded:0.1
       - lowrisc:ip:otp_ctrl_pkg:1.0
+      - lowrisc:ip:flash_ctrl_pkg
       - lowrisc:dv:digestpp_dpi
       - lowrisc:ip:kmac_pkg
     files:
@@ -25,6 +26,7 @@ filesets:
       - mem_bkdr_util__otp.sv: {is_include_file: true}
       - mem_bkdr_util__rom.sv: {is_include_file: true}
       - mem_bkdr_util__sram.sv: {is_include_file: true}
+      - mem_bkdr_util__flash.sv: {is_include_file: true}
     file_type: systemVerilogSource
 
 targets:

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util.sv
@@ -571,6 +571,9 @@ class mem_bkdr_util extends uvm_object;
   // Wrapper function for encrypted ROM reads.
   `include "mem_bkdr_util__rom.sv"
 
+  // Wrapper function for encrypted FLASH writes.
+  `include "mem_bkdr_util__flash.sv"
+
   `undef HAS_ECC
   `undef HAS_PARITY
 

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__flash.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__flash.sv
@@ -1,0 +1,87 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// Wrapper functions to write different partitions in flash.
+// This file is included in `mem_bkdr_util.sv` as a continuation of `mem_bkdr_util` class.
+
+localparam int unsigned FlashDataWidth = flash_phy_pkg::DataWidth;
+localparam int unsigned FlashStagesPerCycle = FlashDataWidth / flash_phy_pkg::GfMultCycles;
+localparam int unsigned FlashKeySize = flash_phy_pkg::KeySize;
+localparam int unsigned FlashNumRoundsHalf = crypto_dpi_prince_pkg::NumRoundsHalf;
+localparam int unsigned FlashAddrWidth = 16;
+
+localparam bit[FlashDataWidth-1:0] IPoly = FlashDataWidth'(1'b1) << 15 |
+                                           FlashDataWidth'(1'b1) << 9  |
+                                           FlashDataWidth'(1'b1) << 7  |
+                                           FlashDataWidth'(1'b1) << 4  |
+                                           FlashDataWidth'(1'b1) << 3  |
+                                           FlashDataWidth'(1'b1) << 0;
+
+function bit [FlashDataWidth-1:0] flash_gf_mult2(bit [FlashDataWidth-1:0] operand);
+  bit [FlashDataWidth-1:0] mult_out;
+
+  mult_out = operand[FlashDataWidth-1] ? (operand << 1) ^ IPoly : (operand << 1);
+  return mult_out;
+endfunction
+
+function bit [FlashStagesPerCycle-1:0][FlashDataWidth-1:0] flash_gen_matrix(
+    bit [FlashDataWidth-1:0] seed, bit init);
+  bit [FlashStagesPerCycle-1:0][FlashDataWidth-1:0] matrix_out;
+
+  matrix_out[0] = init ? seed : flash_gf_mult2(seed);
+  matrix_out[FlashStagesPerCycle-1:1] = '0;
+  for (int i = 1; i < FlashStagesPerCycle; i++) begin
+    matrix_out[i] = flash_gf_mult2(matrix_out[i-1]);
+  end
+  return matrix_out;
+endfunction
+
+function bit [FlashDataWidth-1:0] flash_galois_multiply(bit [FlashKeySize-1:0] addr_key,
+                                                          bit [FlashAddrWidth-1:0] addr);
+  bit [FlashStagesPerCycle-1:0][FlashDataWidth-1:0] matrix[2];
+  bit [FlashDataWidth-1:0] product[2];
+  bit [FlashDataWidth-1:0] add_vector;
+  bit [FlashDataWidth-1:0] mult_out;
+
+  // generate matrix.
+  matrix[0] =
+      flash_gen_matrix({addr_key[FlashKeySize-FlashAddrWidth-1:FlashKeySize-64], addr}, 1'b1);
+  matrix[1] = flash_gen_matrix(matrix[0][FlashStagesPerCycle-1], 1'b0);
+  // galois multiply.
+  for (int j = 0; j < 2; j++) begin
+    mult_out = '0;
+    for (int i = 0; i < FlashStagesPerCycle; i++) begin
+      add_vector = addr_key[(j*FlashStagesPerCycle)+i] ? matrix[j][i] : '0;
+      mult_out   = mult_out ^ add_vector;
+    end
+    product[j] = mult_out;
+  end
+  product[1] = product[1] ^ product[0];
+  return product[1];
+endfunction
+
+virtual function void flash_write_scrambled(
+    bit [FlashDataWidth-1:0] data, bit [FlashAddrWidth-1:0] byte_addr,
+    bit [FlashKeySize-1:0] flash_addr_key, bit [FlashKeySize-1:0] flash_data_key);
+  bit [FlashAddrWidth-1:0] word_addr;
+  bit [FlashDataWidth-1:0] mask;
+  bit [FlashDataWidth-1:0] masked_data;
+  bit [FlashNumRoundsHalf-1:0][FlashDataWidth-1:0] scrambled_data;
+  bit [71:0] ecc_72;
+  bit [75:0] ecc_76;
+
+  word_addr = byte_addr >> addr_lsb;
+  mask = flash_galois_multiply(flash_addr_key, word_addr);
+  masked_data = data ^ mask;
+
+  crypto_dpi_prince_pkg::sv_dpi_prince_encrypt(.plaintext(masked_data), .key(flash_data_key),
+                                               .old_key_schedule(0), .ciphertext(scrambled_data));
+  masked_data = scrambled_data[FlashNumRoundsHalf-1] ^ mask;
+  // ecc functions used are hardcoded to a fixed sized.
+  err_detection_scheme = EccHamming_72_64;
+  ecc_72 = get_ecc_computed_data(data[63:0]);
+  err_detection_scheme = EccHamming_76_68;
+  ecc_76 = get_ecc_computed_data({ecc_72[67:64], masked_data[63:0]});
+  write(byte_addr, ecc_76);
+endfunction

--- a/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
+++ b/hw/dv/sv/mem_bkdr_util/mem_bkdr_util__otp.sv
@@ -53,6 +53,36 @@ virtual function void otp_write_secret0_partition(
   write64(Secret0DigestOffset, digest);
 endfunction
 
+virtual function void otp_write_secret1_partition(
+    bit [FlashAddrKeySeedSize*8-1:0] flash_addr_key_seed,
+    bit [FlashDataKeySeedSize*8-1:0] flash_data_key_seed,
+    bit [SramDataKeySeedSize*8-1:0] sram_data_key_seed);
+  bit [Secret1DigestSize*8-1:0] digest;
+
+  bit [FlashAddrKeySeedSize*8-1:0] scrambled_flash_addr_key;
+  bit [FlashDataKeySeedSize*8-1:0] scrambled_flash_data_key;
+  bit [SramDataKeySeedSize*8-1:0] scrambled_sram_data_key;
+  bit [bus_params_pkg::BUS_DW-1:0] secret_data[$];
+
+  for (int i = 0; i < FlashAddrKeySeedSize; i += 8) begin
+    scrambled_flash_addr_key[i*8+:64] = scramble_data(flash_addr_key_seed[i*8+:64], Secret1Idx);
+    write64(i + FlashAddrKeySeedOffset, scrambled_flash_addr_key[i*8+:64]);
+  end
+  for (int i = 0; i < FlashDataKeySeedSize; i += 8) begin
+    scrambled_flash_data_key[i*8+:64] = scramble_data(flash_data_key_seed[i*8+:64], Secret1Idx);
+    write64(i + FlashDataKeySeedOffset, scrambled_flash_data_key[i*8+:64]);
+  end
+  for (int i = 0; i < SramDataKeySeedSize; i += 8) begin
+    scrambled_sram_data_key[i*8+:64] = scramble_data(sram_data_key_seed[i*8+:64], Secret1Idx);
+    write64(i + SramDataKeySeedOffset, scrambled_sram_data_key[i*8+:64]);
+  end
+
+  secret_data = {<<32 {scrambled_sram_data_key, scrambled_flash_data_key, scrambled_flash_addr_key}};
+  digest = cal_digest(Secret1Idx, secret_data);
+
+  write64(Secret1DigestOffset, digest);
+endfunction
+
 virtual function void otp_write_secret2_partition(bit [RmaTokenSize*8-1:0] rma_unlock_token,
                                                   bit [CreatorRootKeyShare0Size*8-1:0] creator_root_key0,
                                                   bit [CreatorRootKeyShare1Size*8-1:0] creator_root_key1

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2395,7 +2395,7 @@
             - This test needs to execute as a boot rom image.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_init"]
     }
     {
       name: chip_sw_flash_host_access
@@ -2459,7 +2459,7 @@
             - Need to understand the bootstrapping requirements.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_sw_flash_init"]
     }
     {
       name: chip_sw_flash_idle_low_power

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -406,6 +406,13 @@
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
+      name: chip_sw_flash_init
+      uvm_test_seq: chip_sw_flash_init_vseq
+      sw_images: ["sw/device/tests/sim_dv/flash_init_test:0"]
+      en_run_modes: ["sw_test_mode_common"]
+      run_opts: ["+sw_test_timeout_ns=25000000"]
+    }
+    {
       name: chip_sw_flash_rma_unlocked
       uvm_test_seq: chip_sw_flash_rma_unlocked_vseq
       sw_images: ["sw/device/tests/sim_dv/flash_rma_unlocked_test:0"]

--- a/hw/top_earlgrey/dv/env/chip_env.core
+++ b/hw/top_earlgrey/dv/env/chip_env.core
@@ -56,6 +56,7 @@ filesets:
       - seq_lib/chip_sw_gpio_smoke_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_gpio_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_ctrl_lc_rw_en_vseq.sv: {is_include_file: true}
+      - seq_lib/chip_sw_flash_init_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_flash_rma_unlocked_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_ctrl_transition_vseq.sv: {is_include_file: true}
       - seq_lib/chip_sw_lc_walkthrough_vseq.sv: {is_include_file: true}

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_flash_init_vseq.sv
@@ -1,0 +1,301 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class chip_sw_flash_init_vseq extends chip_sw_base_vseq;
+  `uvm_object_utils(chip_sw_flash_init_vseq)
+
+  `uvm_object_new
+
+  localparam string FLASH_DATA_KEY_PATH =
+    "tb.dut.top_earlgrey.u_flash_ctrl.u_flash_hw_if.data_key_o";
+  localparam string FLASH_ADDR_KEY_PATH =
+    "tb.dut.top_earlgrey.u_flash_ctrl.u_flash_hw_if.addr_key_o";
+  localparam string FLASH_INIT_BUSY_PATH =
+    "tb.dut.top_earlgrey.u_flash_ctrl.u_flash_hw_if.init_busy_o";
+  localparam string KEYMGR_SEEDS_PATH = "tb.dut.top_earlgrey.u_flash_ctrl.u_flash_hw_if.seeds_o";
+  localparam string FLASH_LC_SEED_HW_RD_EN_PATH =
+    "tb.dut.top_earlgrey.u_flash_ctrl.lc_seed_hw_rd_en_i";
+
+  localparam string SRAM_CTRL_RET_HDL_PATH =
+    "tb.dut.top_earlgrey.u_sram_ctrl_ret_aon.u_prim_ram_1p_scr";
+  localparam string SRAM_CTRL_RET_NONCE_PATH = {SRAM_CTRL_RET_HDL_PATH, ".nonce_i"};
+  localparam string SRAM_CTRL_RET_KEY_PATH = {SRAM_CTRL_RET_HDL_PATH, ".key_i"};
+
+  localparam uint KeyWidthAddrBits = otp_ctrl_reg_pkg::FlashAddrKeySeedSize * 8;
+  localparam uint KeyWidthAddrBytes = KeyWidthAddrBits / 8;
+  localparam uint KeyWidthDataBits = otp_ctrl_reg_pkg::FlashDataKeySeedSize * 8;
+  localparam uint KeyWidthDataBytes = KeyWidthDataBits / 8;
+  localparam uint KeyWidthSramBits = otp_ctrl_reg_pkg::SramDataKeySeedSize * 8;
+  localparam uint KeyWidthSramBytes = KeyWidthSramBits / 8;
+
+  localparam uint SEED_WIDTH = flash_ctrl_pkg::SeedWidth;
+  localparam uint FLASH_PAGE_SIZE_BYTES = flash_ctrl_reg_pkg::BytesPerPage;
+  localparam uint FLASH_PAGES_PER_BANK = flash_ctrl_reg_pkg::RegPagesPerBank;
+  localparam uint CREATOR_SECRET_PAGE_ID = flash_ctrl_pkg::CreatorInfoPage;
+  localparam uint OWNER_SECRET_PAGE_ID = flash_ctrl_pkg::OwnerInfoPage;
+  localparam uint ISO_PART_PAGE_ID = flash_ctrl_pkg::IsolatedInfoPage;
+
+  localparam uint NUM_TEST_WORDS = 16;
+  localparam uint NUM_TEST_PHASES = 8;
+  localparam uint UNSCRAMBLED_TEST0 = 0;
+  localparam uint UNSCRAMBLED_TEST1 = 1;
+  localparam uint UNSCRAMBLED_TEST2 = 2;
+  localparam uint SCRAMBLED_TEST0 = 3;
+  localparam uint SCRAMBLED_TEST1 = 4;
+  localparam uint BACKDOOR_TEST0 = 5;
+  localparam uint BACKDOOR_TEST1 = 6;
+
+  bit [sram_scrambler_pkg::SRAM_BLOCK_WIDTH-1:0] sram_ret_nonce;
+  bit [sram_scrambler_pkg::SRAM_KEY_WIDTH-1:0] sram_ret_key;
+
+  rand bit [7:0] secret_flash_addr_key[KeyWidthAddrBytes];
+  rand bit [7:0] secret_flash_data_key[KeyWidthDataBytes];
+  rand bit [7:0] secret_sram_key[KeyWidthSramBytes];
+
+  rand bit [31:0] creator_secret_data[NUM_TEST_WORDS];
+  rand bit [31:0] owner_secret_data[NUM_TEST_WORDS];
+  rand bit [31:0] iso_part_data[NUM_TEST_WORDS];
+  rand bit [31:0] bank0_page0_data[NUM_TEST_WORDS];
+  rand bit [31:0] bank1_page0_data[NUM_TEST_WORDS];
+
+  bit [FlashKeyWidth-1:0] flash_data_key;
+  bit [FlashKeyWidth-1:0] flash_addr_key;
+
+  bit write_scrambled;
+  bit do_keymgr_check;
+
+  event init_done_event;
+
+  virtual task ret_backdoor_data_write();
+    `DV_CHECK(uvm_hdl_read(SRAM_CTRL_RET_NONCE_PATH, sram_ret_nonce));
+    `DV_CHECK(uvm_hdl_read(SRAM_CTRL_RET_KEY_PATH, sram_ret_key));
+    for (int i = 0; i < NUM_TEST_WORDS; i++) begin
+      ret_sram_bkdr_write32((i * 4), creator_secret_data[i], sram_ret_key, sram_ret_nonce);
+      ret_sram_bkdr_write32((NUM_TEST_WORDS * 4) + (i * 4), owner_secret_data[i], sram_ret_key,
+                            sram_ret_nonce);
+      ret_sram_bkdr_write32((NUM_TEST_WORDS * 8) + (i * 4), iso_part_data[i], sram_ret_key,
+                            sram_ret_nonce);
+      ret_sram_bkdr_write32((NUM_TEST_WORDS * 12) + (i * 4), bank0_page0_data[i], sram_ret_key,
+                            sram_ret_nonce);
+      ret_sram_bkdr_write32((NUM_TEST_WORDS * 16) + (i * 4), bank1_page0_data[i], sram_ret_key,
+                            sram_ret_nonce);
+    end
+  endtask
+
+  virtual task randomize_data();
+    `DV_CHECK_STD_RANDOMIZE_FATAL(creator_secret_data)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(owner_secret_data)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(iso_part_data)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(bank0_page0_data)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(bank1_page0_data)
+  endtask
+
+  virtual function bit [KeyWidthAddrBits-1:0] get_flash_otp_key(
+      bit [7:0] key_in[KeyWidthAddrBytes]);
+    bit [kmac_pkg::AppDigestW-1:0] digest_bits;
+    bit [7:0] dpi_digest[kmac_pkg::AppDigestW/8];
+
+    digestpp_dpi_pkg::c_dpi_cshake128(key_in, "", "FLASH_CTRL", KeyWidthAddrBytes,
+                                      kmac_pkg::AppDigestW / 8, dpi_digest);
+    digest_bits = {<<byte{dpi_digest}};
+    return (digest_bits[KeyWidthAddrBits-1:0]);
+  endfunction
+
+  virtual function bit [KeyWidthSramBits-1:0] get_sram_otp_key(
+      bit [7:0] key_in[KeyWidthSramBytes]);
+    bit [kmac_pkg::AppDigestW-1:0] digest_bits;
+    bit [7:0] dpi_digest[kmac_pkg::AppDigestW/8];
+
+    digestpp_dpi_pkg::c_dpi_cshake128(key_in, "", "SRAM_CTRL", KeyWidthSramBytes,
+                                      kmac_pkg::AppDigestW / 8, dpi_digest);
+    digest_bits = {<<byte{dpi_digest}};
+    return (digest_bits[KeyWidthSramBits-1:0]);
+  endfunction
+
+  virtual task randomize_keys();
+    `DV_CHECK_STD_RANDOMIZE_FATAL(secret_flash_addr_key)
+    `DV_CHECK_STD_RANDOMIZE_FATAL(secret_flash_data_key)
+    cfg.mem_bkdr_util_h[Otp].otp_write_secret1_partition(
+        .flash_addr_key_seed(get_flash_otp_key(secret_flash_addr_key)),
+        .flash_data_key_seed(get_flash_otp_key(secret_flash_data_key)),
+        .sram_data_key_seed(get_sram_otp_key(secret_sram_key)));
+  endtask
+
+  virtual task calculate_and_write_scrambled();
+    bit [15:0] base_addr_bytes;
+    for (int i = 0; i < NUM_TEST_WORDS / 2; i++) begin
+      base_addr_bytes = 16'h0;
+      cfg.mem_bkdr_util_h[FlashBank0Data].flash_write_scrambled(
+          {bank0_page0_data[(i*2)+1], bank0_page0_data[i*2]}, base_addr_bytes + (i * 8),
+          flash_addr_key, flash_data_key);
+      base_addr_bytes = FLASH_PAGE_SIZE_BYTES * FLASH_PAGES_PER_BANK;
+      cfg.mem_bkdr_util_h[FlashBank1Data].flash_write_scrambled(
+          {bank1_page0_data[(i*2)+1], bank1_page0_data[i*2]}, base_addr_bytes + (i * 8),
+          flash_addr_key, flash_data_key);
+      base_addr_bytes = FLASH_PAGE_SIZE_BYTES * CREATOR_SECRET_PAGE_ID;
+      cfg.mem_bkdr_util_h[FlashBank0Info].flash_write_scrambled(
+          {creator_secret_data[(i*2)+1], creator_secret_data[i*2]}, base_addr_bytes + (i * 8),
+          flash_addr_key, flash_data_key);
+      base_addr_bytes = FLASH_PAGE_SIZE_BYTES * OWNER_SECRET_PAGE_ID;
+      cfg.mem_bkdr_util_h[FlashBank0Info].flash_write_scrambled(
+          {owner_secret_data[(i*2)+1], owner_secret_data[i*2]}, base_addr_bytes + (i * 8),
+          flash_addr_key, flash_data_key);
+      base_addr_bytes = FLASH_PAGE_SIZE_BYTES * ISO_PART_PAGE_ID;
+      cfg.mem_bkdr_util_h[FlashBank0Info].flash_write_scrambled(
+          {iso_part_data[(i*2)+1], iso_part_data[i*2]}, base_addr_bytes + (i * 8), flash_addr_key,
+          flash_data_key);
+    end
+  endtask
+
+  virtual task check_hdl_paths();
+    int retval;
+    retval = uvm_hdl_check_path(FLASH_DATA_KEY_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", FLASH_DATA_KEY_PATH))
+    retval = uvm_hdl_check_path(FLASH_ADDR_KEY_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", FLASH_ADDR_KEY_PATH))
+    retval = uvm_hdl_check_path(FLASH_INIT_BUSY_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", FLASH_INIT_BUSY_PATH))
+    retval = uvm_hdl_check_path(KEYMGR_SEEDS_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", KEYMGR_SEEDS_PATH))
+    retval = uvm_hdl_check_path(FLASH_LC_SEED_HW_RD_EN_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", FLASH_LC_SEED_HW_RD_EN_PATH))
+    retval = uvm_hdl_check_path(SRAM_CTRL_RET_NONCE_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", SRAM_CTRL_RET_NONCE_PATH))
+    retval = uvm_hdl_check_path(SRAM_CTRL_RET_KEY_PATH);
+    `DV_CHECK_EQ_FATAL(retval, 1, $sformatf(
+                       "Hierarchical path %0s appears to be invalid.", SRAM_CTRL_RET_KEY_PATH))
+  endtask
+
+  virtual task wait_init_done();
+    int retval;
+    bit init_busy;
+    bit init_busy_last_value;
+    forever begin
+      init_busy_last_value = init_busy;
+      retval = uvm_hdl_read(FLASH_INIT_BUSY_PATH, init_busy);
+      `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", FLASH_INIT_BUSY_PATH))
+      if (init_busy == 0 && init_busy_last_value == 1) begin
+        ->init_done_event;
+      end
+      // Use top level clock to advance time between samples.
+      cfg.clk_rst_vif.wait_clks(1);
+    end
+  endtask
+
+  virtual task get_keys();
+    int retval;
+    forever begin
+      @(init_done_event);
+      if (write_scrambled == 1) begin
+        retval = uvm_hdl_read(FLASH_DATA_KEY_PATH, flash_data_key);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", FLASH_DATA_KEY_PATH))
+        retval = uvm_hdl_read(FLASH_ADDR_KEY_PATH, flash_addr_key);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", FLASH_ADDR_KEY_PATH))
+        calculate_and_write_scrambled();
+      end
+    end
+  endtask
+
+  virtual task check_keymgr_seeds();
+    int retval;
+    bit [(SEED_WIDTH*2)-1:0] seeds;
+    bit [SEED_WIDTH-1:0] owner_seed;
+    bit [SEED_WIDTH-1:0] last_owner_seed;
+    bit [SEED_WIDTH-1:0] creator_seed;
+    bit [SEED_WIDTH-1:0] last_creator_seed;
+    bit [(SEED_WIDTH*2)-1:0] expected_owner_seed;
+    bit [(SEED_WIDTH*2)-1:0] expected_creator_seed;
+    lc_ctrl_pkg::lc_tx_t lc_seed_hw_rd_en;
+    forever begin
+      @(init_done_event);
+      if (do_keymgr_check == 1) begin
+        last_creator_seed = creator_seed;
+        last_owner_seed = owner_seed;
+        expected_owner_seed = {<<32{owner_secret_data}};
+        expected_creator_seed = {<<32{creator_secret_data}};
+        retval = uvm_hdl_read(FLASH_LC_SEED_HW_RD_EN_PATH, lc_seed_hw_rd_en);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", FLASH_LC_SEED_HW_RD_EN_PATH
+                     ))
+        retval = uvm_hdl_read(KEYMGR_SEEDS_PATH, seeds);
+        `DV_CHECK_EQ(retval, 1, $sformatf("uvm_hdl_read failed for %0s", KEYMGR_SEEDS_PATH))
+        owner_seed   = seeds[(SEED_WIDTH*flash_ctrl_pkg::OwnerSeedIdx)+:SEED_WIDTH];
+        creator_seed = seeds[(SEED_WIDTH*flash_ctrl_pkg::CreatorSeedIdx)+:SEED_WIDTH];
+        if (lc_seed_hw_rd_en == lc_ctrl_pkg::Off) begin
+          `DV_CHECK_EQ(creator_seed, last_creator_seed);
+          `DV_CHECK_EQ(owner_seed, last_owner_seed);
+        end else begin
+          `DV_CHECK_EQ(creator_seed, expected_creator_seed[SEED_WIDTH-1:0]);
+          `DV_CHECK_EQ(owner_seed, expected_owner_seed[SEED_WIDTH-1:0]);
+        end
+      end
+    end
+  endtask
+
+  virtual task body();
+    bit [7:0] array_data[1];
+    super.body();
+    check_hdl_paths();
+
+    cfg.disable_d_user_data_intg_check_for_passthru_mem = 1;
+    cfg.en_scb_mem_chk = 0;
+    // Write randomly generated data to retention SRAM for use in SW.
+    ret_backdoor_data_write();
+    // Fork the tasks for monitoring the key updates and
+    // checking the keymgr seed update where applicable.
+    fork
+      wait_init_done();
+      get_keys();
+      check_keymgr_seeds();
+    join_none
+    // Looping through all test phases.
+    for (int current_phase = 0; current_phase < NUM_TEST_PHASES; current_phase++) begin
+      // Backdoor overwrite the SW variable for the test phase.
+      array_data[0] = current_phase;
+      sw_symbol_backdoor_overwrite("kTestPhase", array_data, Rom, SwTypeRom);
+      if (current_phase < NUM_TEST_PHASES - 1) begin
+        // Backdoor write to the flash only for the backdoor tests.
+        if (current_phase < BACKDOOR_TEST0) begin
+          write_scrambled = 0;
+        end else begin
+          write_scrambled = 1;
+        end
+        // Check the keymgr receives updated keys during the unscrambled tests.
+        if (current_phase <= UNSCRAMBLED_TEST2) begin
+          do_keymgr_check = 1;
+        end else begin
+          do_keymgr_check = 0;
+        end
+        // Wait for the test to start and enter the WFI state,
+        wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInTest);
+        wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInWfi);
+        // Randomize the data and keys for the next test phase.
+        randomize_data();
+        randomize_keys();
+        ret_backdoor_data_write();
+        // Before the last unscrambled test the LC_STATE is set to Prod,
+        // this will cause the lc_seed_hw_rd_en to be low and a check can be made
+        // that the keymgr seeds are not updated during initialization.
+        // After this test set the LC_STATE back to the default Rma.
+        if (current_phase == UNSCRAMBLED_TEST1) begin
+          cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStProd);
+        end else if (current_phase == UNSCRAMBLED_TEST2) begin
+          cfg.mem_bkdr_util_h[Otp].otp_write_lc_partition_state(LcStRma);
+        end
+        // Reset for the next test phase.
+        apply_reset();
+        cfg.clk_rst_vif.wait_clks(1000);
+      end else begin
+        // final phase cleanup.
+        disable fork;
+      end
+    end
+  endtask
+
+endclass

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -21,6 +21,7 @@
 `include "chip_sw_gpio_smoke_vseq.sv"
 `include "chip_sw_gpio_vseq.sv"
 `include "chip_sw_flash_ctrl_lc_rw_en_vseq.sv"
+`include "chip_sw_flash_init_vseq.sv"
 `include "chip_sw_flash_rma_unlocked_vseq.sv"
 `include "chip_sw_lc_ctrl_transition_vseq.sv"
 `include "chip_sw_lc_walkthrough_vseq.sv"

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -81,6 +81,35 @@ opentitan_functest(
 )
 
 opentitan_functest(
+    name = "flash_init_test",
+    srcs = ["flash_init_test.c"],
+    # This test doesn't use the OTTF.
+    targets = ["verilator"],  # Can only run in verilator right now.
+    # This test is designed to run and complete entirely in the ROM boot stage.
+    # Setting the `test_in_rom` flag makes the `opentitan_functest` rule aware
+    # of this, and instructs it to load the test image into ROM (rather than
+    # loading the default test ROM, or any other ROM that may be specified via
+    # Verilator or CW310 params).
+    test_in_rom = True,
+    deps = [
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/arch:device",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:flash_ctrl",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/runtime:print",
+        "//sw/device/lib/testing:flash_ctrl_testutils",
+        "//sw/device/lib/testing:pinmux_testutils",
+        "//sw/device/lib/testing/test_framework:check",
+        "//sw/device/lib/testing/test_framework:status",
+        "//sw/device/lib/testing/test_rom:linker_script",
+        "//sw/device/lib/testing/test_rom:test_rom_lib",
+    ],
+)
+
+opentitan_functest(
     name = "gpio_test",
     srcs = ["gpio_test.c"],
     targets = ["dv"],

--- a/sw/device/tests/sim_dv/flash_init_test.c
+++ b/sw/device/tests/sim_dv/flash_init_test.c
@@ -1,0 +1,349 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/arch/device.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_flash_ctrl.h"
+#include "sw/device/lib/dif/dif_uart.h"
+#include "sw/device/lib/runtime/hart.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/runtime/print.h"
+#include "sw/device/lib/testing/flash_ctrl_testutils.h"
+#include "sw/device/lib/testing/pinmux_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/status.h"
+
+#include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"  // Generated.
+
+static dif_uart_t uart0;
+static dif_flash_ctrl_state_t flash_state;
+
+enum {
+  kFlashInfoPageIdCreatorSecret = 1,
+  kFlashInfoPageIdOwnerSecret = 2,
+  kFlashInfoPageIdIsoPart = 3,
+  kFlashInfoBank = 0,
+  kFlashDataRegionZero = 0,
+  kFlashDataRegionOne = 1,
+  kRegionBaseBank0Page0Index = 0,
+  kRegionBaseBank1Page0Index = 256,
+  kPartitionId = 0,
+  kRegionSize = 1,
+  kPageSize = 2048,
+  kNumTestWords = 16,
+  kNumTestBytes = kNumTestWords * sizeof(uint32_t),
+};
+
+enum {
+  kTestPhaseCheckUnscrambledInit0 = 0,
+  kTestPhaseCheckUnscrambledInit1 = 1,
+  kTestPhaseCheckUnscrambledInit2 = 2,
+  kTestPhaseCheckScrambledInit0 = 3,
+  kTestPhaseCheckScrambledInit1 = 4,
+  kTestPhaseCheckBackdoor0 = 5,
+  kTestPhaseCheckBackdoor1 = 6,
+};
+
+enum {
+  kNumRegions = 5,
+  kAddressBank0Page0Data = 0,
+  kAddressBank1Page0Data = 1,
+  kAddressCreatorSecret = 2,
+  kAddressOwnerSecret = 3,
+  kAddressIsoPart = 4,
+};
+
+enum {
+  kCreatorSecretDataRetSramAddress = 0,
+  kOwnerSecretDataRetSramAddress =
+      kCreatorSecretDataRetSramAddress + (kNumTestWords * sizeof(uint32_t)),
+  kIsoPartDataRetSramAddress =
+      kOwnerSecretDataRetSramAddress + (kNumTestWords * sizeof(uint32_t)),
+  kBank0Page0DataRetSramAddress =
+      kIsoPartDataRetSramAddress + (kNumTestWords * sizeof(uint32_t)),
+  kBank1Page0DataRetSramAddress =
+      kBank0Page0DataRetSramAddress + (kNumTestWords * sizeof(uint32_t)),
+};
+
+// The test phase is updated by the testbench with a symbol backdoor overwrite.
+static volatile const uint8_t kTestPhase = 0;
+
+// The test data is updated by the testbench by filling the retention SRAM
+// which can then be copied and used locally.
+static uint32_t kCreatorSecretData[kNumTestWords];
+static uint32_t kOwnerSecretData[kNumTestWords];
+static uint32_t kIsoPartData[kNumTestWords];
+static uint32_t kBank0Page0Data[kNumTestWords];
+static uint32_t kBank1Page0Data[kNumTestWords];
+
+static uint32_t region_addresses[kNumRegions];
+
+static void setup_unscrambled_regions(void) {
+  region_addresses[kAddressBank0Page0Data] =
+      flash_ctrl_testutils_data_region_setup(&flash_state,
+                                             kRegionBaseBank0Page0Index,
+                                             kFlashDataRegionZero, kRegionSize);
+  region_addresses[kAddressBank1Page0Data] =
+      flash_ctrl_testutils_data_region_setup(&flash_state,
+                                             kRegionBaseBank1Page0Index,
+                                             kFlashDataRegionOne, kRegionSize);
+  region_addresses[kAddressCreatorSecret] =
+      flash_ctrl_testutils_info_region_setup(&flash_state,
+                                             kFlashInfoPageIdCreatorSecret,
+                                             kFlashInfoBank, kPartitionId);
+  region_addresses[kAddressOwnerSecret] =
+      flash_ctrl_testutils_info_region_setup(&flash_state,
+                                             kFlashInfoPageIdOwnerSecret,
+                                             kFlashInfoBank, kPartitionId);
+  region_addresses[kAddressIsoPart] = flash_ctrl_testutils_info_region_setup(
+      &flash_state, kFlashInfoPageIdIsoPart, kFlashInfoBank, kPartitionId);
+}
+
+static void setup_scrambled_regions(void) {
+  region_addresses[kAddressBank0Page0Data] =
+      flash_ctrl_testutils_data_region_scrambled_setup(
+          &flash_state, kRegionBaseBank0Page0Index, kFlashDataRegionZero,
+          kRegionSize);
+  region_addresses[kAddressBank1Page0Data] =
+      flash_ctrl_testutils_data_region_scrambled_setup(
+          &flash_state, kRegionBaseBank1Page0Index, kFlashDataRegionOne,
+          kRegionSize);
+  region_addresses[kAddressCreatorSecret] =
+      flash_ctrl_testutils_info_region_scrambled_setup(
+          &flash_state, kFlashInfoPageIdCreatorSecret, kFlashInfoBank,
+          kPartitionId);
+  region_addresses[kAddressOwnerSecret] =
+      flash_ctrl_testutils_info_region_scrambled_setup(
+          &flash_state, kFlashInfoPageIdOwnerSecret, kFlashInfoBank,
+          kPartitionId);
+  region_addresses[kAddressIsoPart] =
+      flash_ctrl_testutils_info_region_scrambled_setup(
+          &flash_state, kFlashInfoPageIdIsoPart, kFlashInfoBank, kPartitionId);
+}
+
+static void erase_and_write_regions(void) {
+  CHECK(!flash_ctrl_testutils_erase_and_write_page(
+      &flash_state, region_addresses[kAddressBank0Page0Data], kPartitionId,
+      kBank0Page0Data, kDifFlashCtrlPartitionTypeData, kNumTestWords));
+  CHECK(!flash_ctrl_testutils_erase_and_write_page(
+      &flash_state, region_addresses[kAddressBank1Page0Data], kPartitionId,
+      kBank1Page0Data, kDifFlashCtrlPartitionTypeData, kNumTestWords));
+  CHECK(!flash_ctrl_testutils_erase_and_write_page(
+      &flash_state, region_addresses[kAddressCreatorSecret], kPartitionId,
+      kCreatorSecretData, kDifFlashCtrlPartitionTypeInfo, kNumTestWords));
+  CHECK(!flash_ctrl_testutils_erase_and_write_page(
+      &flash_state, region_addresses[kAddressOwnerSecret], kPartitionId,
+      kOwnerSecretData, kDifFlashCtrlPartitionTypeInfo, kNumTestWords));
+  CHECK(!flash_ctrl_testutils_erase_and_write_page(
+      &flash_state, region_addresses[kAddressIsoPart], kPartitionId,
+      kIsoPartData, kDifFlashCtrlPartitionTypeInfo, kNumTestWords));
+}
+
+static void read_and_check_host_if(uint32_t addr, const uint32_t *check_data) {
+  uint32_t host_data[kNumTestWords];
+  mmio_region_memcpy_from_mmio32(
+      mmio_region_from_addr(TOP_EARLGREY_EFLASH_BASE_ADDR), addr, &host_data,
+      kNumTestBytes);
+  CHECK_ARRAYS_EQ(host_data, check_data, kNumTestWords);
+}
+
+static void check_readback_data_match(void) {
+  uint32_t readback_data[kNumTestWords];
+  CHECK(flash_ctrl_testutils_read(
+            &flash_state, region_addresses[kAddressBank0Page0Data],
+            kPartitionId, readback_data, kDifFlashCtrlPartitionTypeData,
+            kNumTestWords, 0) == 0);
+  CHECK_ARRAYS_EQ(readback_data, kBank0Page0Data, kNumTestWords);
+  CHECK(flash_ctrl_testutils_read(
+            &flash_state, region_addresses[kAddressBank1Page0Data],
+            kPartitionId, readback_data, kDifFlashCtrlPartitionTypeData,
+            kNumTestWords, 0) == 0);
+  CHECK_ARRAYS_EQ(readback_data, kBank1Page0Data, kNumTestWords);
+  CHECK(flash_ctrl_testutils_read(
+            &flash_state, region_addresses[kAddressCreatorSecret], kPartitionId,
+            readback_data, kDifFlashCtrlPartitionTypeInfo, kNumTestWords,
+            0) == 0);
+  CHECK_ARRAYS_EQ(readback_data, kCreatorSecretData, kNumTestWords);
+  CHECK(flash_ctrl_testutils_read(
+            &flash_state, region_addresses[kAddressOwnerSecret], kPartitionId,
+            readback_data, kDifFlashCtrlPartitionTypeInfo, kNumTestWords,
+            0) == 0);
+  CHECK_ARRAYS_EQ(readback_data, kOwnerSecretData, kNumTestWords);
+  CHECK(flash_ctrl_testutils_read(
+            &flash_state, region_addresses[kAddressIsoPart], kPartitionId,
+            readback_data, kDifFlashCtrlPartitionTypeInfo, kNumTestWords,
+            0) == 0);
+  CHECK_ARRAYS_EQ(readback_data, kIsoPartData, kNumTestWords);
+
+  read_and_check_host_if(kRegionBaseBank0Page0Index, kBank0Page0Data);
+  read_and_check_host_if(kPageSize * kRegionBaseBank1Page0Index,
+                         kBank1Page0Data);
+}
+
+static bool transaction_end_check_read_error(void) {
+  dif_flash_ctrl_output_t output;
+  while (true) {
+    dif_result_t dif_result = dif_flash_ctrl_end(&flash_state, &output);
+    CHECK(dif_result != kDifBadArg);
+    CHECK(dif_result != kDifError);
+    if (dif_result == kDifOk) {
+      break;
+    }
+  }
+  bool is_read_error = !output.error_code.codes.memory_properties_error &
+                       output.error_code.codes.read_error &
+                       !output.error_code.codes.prog_window_error &
+                       !output.error_code.codes.prog_type_error &
+                       !output.error_code.codes.flash_phy_error &
+                       !output.error_code.codes.shadow_register_error;
+  CHECK_DIF_OK(
+      dif_flash_ctrl_clear_error_codes(&flash_state, output.error_code.codes));
+  return is_read_error;
+}
+
+static void check_readback_fail(void) {
+  uint32_t readback_data[kNumTestWords];
+
+  dif_flash_ctrl_transaction_t transaction = {
+      .byte_address = region_addresses[kAddressBank0Page0Data],
+      .op = kDifFlashCtrlOpRead,
+      .partition_type = kDifFlashCtrlPartitionTypeData,
+      .partition_id = kPartitionId,
+      .word_count = kNumTestWords};
+  CHECK_DIF_OK(dif_flash_ctrl_start(&flash_state, transaction));
+  CHECK_DIF_OK(
+      dif_flash_ctrl_read_fifo_pop(&flash_state, kNumTestWords, readback_data));
+  CHECK(transaction_end_check_read_error());
+
+  transaction.byte_address = region_addresses[kAddressBank1Page0Data];
+  CHECK_DIF_OK(dif_flash_ctrl_start(&flash_state, transaction));
+  CHECK_DIF_OK(
+      dif_flash_ctrl_read_fifo_pop(&flash_state, kNumTestWords, readback_data));
+  CHECK(transaction_end_check_read_error());
+
+  transaction.partition_type = kDifFlashCtrlPartitionTypeInfo;
+  transaction.byte_address = region_addresses[kAddressCreatorSecret];
+  CHECK_DIF_OK(dif_flash_ctrl_start(&flash_state, transaction));
+  CHECK_DIF_OK(
+      dif_flash_ctrl_read_fifo_pop(&flash_state, kNumTestWords, readback_data));
+  CHECK(transaction_end_check_read_error());
+
+  transaction.byte_address = region_addresses[kAddressOwnerSecret];
+  CHECK_DIF_OK(dif_flash_ctrl_start(&flash_state, transaction));
+  CHECK_DIF_OK(
+      dif_flash_ctrl_read_fifo_pop(&flash_state, kNumTestWords, readback_data));
+  CHECK(transaction_end_check_read_error());
+
+  transaction.byte_address = region_addresses[kAddressIsoPart];
+  CHECK_DIF_OK(dif_flash_ctrl_start(&flash_state, transaction));
+  CHECK_DIF_OK(
+      dif_flash_ctrl_read_fifo_pop(&flash_state, kNumTestWords, readback_data));
+  CHECK(transaction_end_check_read_error());
+}
+
+static void flash_init(void) {
+  CHECK_DIF_OK(dif_flash_ctrl_start_controller_init(&flash_state));
+  dif_flash_ctrl_status_t flash_ctrl_status;
+  while (true) {
+    CHECK_DIF_OK(dif_flash_ctrl_get_status(&flash_state, &flash_ctrl_status));
+    if (flash_ctrl_status.controller_init_wip == false) {
+      break;
+    }
+  }
+}
+
+static void check_unscrambled_init(void) {
+  setup_unscrambled_regions();
+  erase_and_write_regions();
+  flash_init();
+  check_readback_data_match();
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+}
+
+static void check_scrambled_init(void) {
+  setup_scrambled_regions();
+  erase_and_write_regions();
+  check_readback_data_match();
+  flash_init();
+  check_readback_fail();
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+}
+
+static void check_scrambled_backdoor_data(void) {
+  setup_scrambled_regions();
+  flash_init();
+  check_readback_data_match();
+  test_status_set(kTestStatusInWfi);
+  wait_for_interrupt();
+}
+
+bool rom_test_main(void) {
+  // We need to set the test status as "in test" to indicate to the test code
+  // has been reached, even though this test is also in the "boot ROM".
+  test_status_set(kTestStatusInTest);
+  dif_pinmux_t pinmux;
+  CHECK_DIF_OK(dif_pinmux_init(
+      mmio_region_from_addr(TOP_EARLGREY_PINMUX_AON_BASE_ADDR), &pinmux));
+  pinmux_testutils_init(&pinmux);
+
+  // We need to initialize the UART regardless if we LOG any messages, since
+  // Verilator and FPGA platforms use the UART to communicate the test results.
+  if (kDeviceType != kDeviceSimDV) {
+    CHECK_DIF_OK(dif_uart_init(
+        mmio_region_from_addr(TOP_EARLGREY_UART0_BASE_ADDR), &uart0));
+    CHECK_DIF_OK(
+        dif_uart_configure(&uart0, (dif_uart_config_t){
+                                       .baudrate = kUartBaudrate,
+                                       .clk_freq_hz = kClockFreqPeripheralHz,
+                                       .parity_enable = kDifToggleDisabled,
+                                       .parity = kDifUartParityEven,
+                                   }));
+    base_uart_stdout(&uart0);
+  }
+
+  // Test code.
+  mmio_region_t sram_region_ret_base_addr =
+      mmio_region_from_addr(TOP_EARLGREY_SRAM_CTRL_RET_AON_RAM_BASE_ADDR);
+
+  mmio_region_memcpy_from_mmio32(sram_region_ret_base_addr,
+                                 kCreatorSecretDataRetSramAddress,
+                                 &kCreatorSecretData, kNumTestBytes);
+  mmio_region_memcpy_from_mmio32(sram_region_ret_base_addr,
+                                 kOwnerSecretDataRetSramAddress,
+                                 &kOwnerSecretData, kNumTestBytes);
+  mmio_region_memcpy_from_mmio32(sram_region_ret_base_addr,
+                                 kIsoPartDataRetSramAddress, &kIsoPartData,
+                                 kNumTestBytes);
+  mmio_region_memcpy_from_mmio32(sram_region_ret_base_addr,
+                                 kBank0Page0DataRetSramAddress,
+                                 &kBank0Page0Data, kNumTestBytes);
+  mmio_region_memcpy_from_mmio32(sram_region_ret_base_addr,
+                                 kBank1Page0DataRetSramAddress,
+                                 &kBank1Page0Data, kNumTestBytes);
+
+  CHECK_DIF_OK(dif_flash_ctrl_init_state(
+      &flash_state,
+      mmio_region_from_addr(TOP_EARLGREY_FLASH_CTRL_CORE_BASE_ADDR)));
+
+  switch (kTestPhase) {
+    case kTestPhaseCheckUnscrambledInit0:
+    case kTestPhaseCheckUnscrambledInit1:
+    case kTestPhaseCheckUnscrambledInit2:
+      check_unscrambled_init();
+      break;
+    case kTestPhaseCheckScrambledInit0:
+    case kTestPhaseCheckScrambledInit1:
+      check_scrambled_init();
+      break;
+    case kTestPhaseCheckBackdoor0:
+    case kTestPhaseCheckBackdoor1:
+      check_scrambled_backdoor_data();
+      break;
+    default:
+      break;
+  }
+  return true;
+}


### PR DESCRIPTION
For tests:
chip_sw_flash_init
chip_sw_flash_scramble

Tests the initialization and scramble functions of the flash_ctrl. Checks that data written to unscrambled
partitions is still accessible following the initialization. Also checks that data written to scrambled partitons
in no longer accessible following initialization when new keys are fetched from OTP.
Checks that the initialization process writes seeds to the keymgr when lc_seed_hw_rd_en is set and does
not when it is unset. Does backdoor writes of scrambled data to the flash to test the flash_ctrl unscrambling.

Signed-off-by: Dave Williams <dave.williams@ensilica.com>