### PR TITLE
[opentitanlib] Add serialization for num_de types

### DIFF
--- a/sw/host/opentitanlib/src/otp/otp_mmap.rs
+++ b/sw/host/opentitanlib/src/otp/otp_mmap.rs
@@ -18,9 +18,9 @@ use std::path::Path;
 
 #[derive(Deserialize, Debug)]
 struct OtpMapConfig {
-    #[serde(with = "num_de")]
+    #[serde(deserialize_with = "num_de::deserialize")]
     width: usize,
-    #[serde(with = "num_de")]
+    #[serde(deserialize_with = "num_de::deserialize")]
     depth: usize,
 }
 
@@ -39,11 +39,11 @@ struct OtpMapDigest {
 
 #[derive(Deserialize, Debug)]
 struct OtpMapScrambling {
-    #[serde(with = "num_de")]
+    #[serde(deserialize_with = "num_de::deserialize")]
     key_size: usize,
-    #[serde(with = "num_de")]
+    #[serde(deserialize_with = "num_de::deserialize")]
     iv_size: usize,
-    #[serde(with = "num_de")]
+    #[serde(deserialize_with = "num_de::deserialize")]
     cnst_size: usize,
     keys: Vec<OtpMapKey>,
     digests: Vec<OtpMapDigest>,
@@ -52,7 +52,7 @@ struct OtpMapScrambling {
 #[derive(Deserialize, Debug)]
 struct OtpMapItem {
     name: String,
-    #[serde(with = "num_de")]
+    #[serde(deserialize_with = "num_de::deserialize")]
     size: usize,
     #[serde(default)]
     #[allow(dead_code)]
@@ -66,7 +66,7 @@ pub struct OtpMapPartition {
     name: String,
     #[allow(dead_code)]
     secret: bool,
-    #[serde(default, with = "num_de")]
+    #[serde(default, deserialize_with = "num_de::deserialize")]
     size: usize,
     sw_digest: bool,
     hw_digest: bool,

--- a/sw/host/opentitanlib/src/util/num_de.rs
+++ b/sw/host/opentitanlib/src/util/num_de.rs
@@ -27,14 +27,6 @@ use std::ops::Deref;
 
 use crate::util::parse_int::{ParseInt, ParseIntError};
 
-pub fn _serialize<S, T>(_r: T, _ser: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: Serialize + Copy,
-{
-    unimplemented!();
-}
-
 /// Deserialize numeric types from HJSON config files.
 pub fn deserialize<'de, D, T>(deserializer: D) -> Result<T, D::Error>
 where
@@ -105,7 +97,7 @@ enum DeferredInit {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-pub struct DeferredValue(#[serde(with = "self")] DeferredInit);
+pub struct DeferredValue(#[serde(deserialize_with = "deserialize")] DeferredInit);
 
 impl DeferredValue {
     pub fn resolve(&self, size: usize, rng: &mut dyn RngCore) -> Vec<u8> {
@@ -158,19 +150,25 @@ impl Deref for DeferredValue {
 
 /// Wrapper type to force deserialization assuming octal encoding.
 #[derive(Clone, Deserialize, Debug)]
-pub struct OctEncoded<T: ParseInt>(#[serde(with = "self")] pub T);
+pub struct OctEncoded<T>(#[serde(deserialize_with = "deserialize")] pub T)
+where
+    T: ParseInt + fmt::Octal;
 
 /// Wrapper type to force deserialization assuming decimal encoding.
 #[derive(Clone, Deserialize, Debug)]
-pub struct DecEncoded<T: ParseInt>(#[serde(with = "self")] pub T);
+pub struct DecEncoded<T>(#[serde(deserialize_with = "deserialize")] pub T)
+where
+    T: ParseInt + fmt::Display;
 
 /// Wrapper type to force deserialization assuming hexadecimal encoding.
 #[derive(Clone, Deserialize, Debug)]
-pub struct HexEncoded<T: ParseInt>(#[serde(with = "self")] pub T);
+pub struct HexEncoded<T>(#[serde(deserialize_with = "deserialize")] pub T)
+where
+    T: ParseInt + fmt::UpperHex;
 
 macro_rules! impl_parse_int_enc {
-    ($ty:ident, $radix:expr) => {
-        impl<T: ParseInt> std::ops::Deref for $ty<T> {
+    ($ty:ident, $radix:expr, $fmt:path) => {
+        impl<T: ParseInt + $fmt> std::ops::Deref for $ty<T> {
             type Target = T;
 
             fn deref(&self) -> &Self::Target {
@@ -178,7 +176,7 @@ macro_rules! impl_parse_int_enc {
             }
         }
 
-        impl<T: ParseInt> ParseInt for $ty<T> {
+        impl<T: ParseInt + $fmt> ParseInt for $ty<T> {
             type FromStrRadixErr = T::FromStrRadixErr;
 
             fn from_str_radix(src: &str, radix: u32) -> Result<Self, T::FromStrRadixErr> {
@@ -189,12 +187,27 @@ macro_rules! impl_parse_int_enc {
                 Self::from_str_radix(src, $radix).map_err(|e| e.into())
             }
         }
+
+        impl<T: ParseInt + $fmt> fmt::Display for $ty<T> {
+            fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+                <_ as $fmt>::fmt(&self.0, f)
+            }
+        }
+
+        impl<T: ParseInt + $fmt> Serialize for $ty<T> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(&self.to_string())
+            }
+        }
     };
 }
 
-impl_parse_int_enc!(OctEncoded, 8);
-impl_parse_int_enc!(DecEncoded, 10);
-impl_parse_int_enc!(HexEncoded, 16);
+impl_parse_int_enc!(OctEncoded, 8, fmt::Octal);
+impl_parse_int_enc!(DecEncoded, 10, fmt::Display);
+impl_parse_int_enc!(HexEncoded, 16, fmt::UpperHex);
 
 #[cfg(test)]
 mod test {
@@ -205,11 +218,11 @@ mod test {
     fn de_u8() -> Result<()> {
         #[derive(Debug, Deserialize)]
         struct TestData {
-            #[serde(with = "super")]
+            #[serde(deserialize_with = "deserialize")]
             oct: OctEncoded<u8>,
-            #[serde(with = "super")]
+            #[serde(deserialize_with = "deserialize")]
             dec: DecEncoded<u8>,
-            #[serde(with = "super")]
+            #[serde(deserialize_with = "deserialize")]
             hex: HexEncoded<u8>,
         }
 

--- a/sw/host/opentitantool/src/command/image.rs
+++ b/sw/host/opentitantool/src/command/image.rs
@@ -5,6 +5,7 @@
 use anyhow::{ensure, Result};
 use erased_serde::Serialize;
 use std::any::Any;
+use std::convert::TryInto;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
@@ -78,7 +79,9 @@ impl CommandDispatch for ManifestShowCommand {
         _context: &dyn Any,
         _transport: &TransportWrapper,
     ) -> Result<Option<Box<dyn Serialize>>> {
-        Ok(None)
+        let image = image::Image::read_from_file(&self.image)?;
+        let manifest_def: ManifestDef = image.borrow_manifest()?.try_into()?;
+        Ok(Some(Box::new(manifest_def)))
     }
 }
 


### PR DESCRIPTION
Because of the way we represent certain numeric types - hex integers in particular - in HJSON config files we need to do some extra work to get serde deserialization working correctly. Serializing these types is much simpler, and basically just involves delegating to the correct `std::fmt` trait.

This also enables the implementation of the `opentitantool image manifest show` command.