### PR TITLE
[dv] Lengthen test timeout

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2556,7 +2556,8 @@
                as either recoverable or fatal.
              '''
       milestone: V2
-      tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup"]
+      tests: ["chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup",
+              "chip_sw_sensor_ctrl_alert"]
     }
     {
       name: chip_sw_sensor_ctrl_ast_status

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -634,7 +634,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/sensor_ctrl_alert_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=30000000"]
+      run_opts: ["+sw_test_timeout_ns=40000000"]
     }
     {
       name: chip_sw_pwrmgr_sleep_sensor_ctrl_alert_wakeup


### PR DESCRIPTION
The sensor_ctrl_alert test goes through 10+ resets so unfortunately
it just takes a VERY long time.

Lengthen the timeout in this reset.

In the future, we should consider shrinking this test by only
testing a select few events in each test (using some random info
input from SV side). Then we can simply run this test with more
seeds to get more randomess.

Signed-off-by: Timothy Chen <timothytim@google.com>