### PR TITLE
[sw/benchmarks] fix coremark benchmark nightly test

### DIFF
--- a/sw/device/benchmarks/meson.build
+++ b/sw/device/benchmarks/meson.build
@@ -2,4 +2,4 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-# subdir('coremark')
+subdir('coremark')

--- a/sw/vendor/eembc_coremark/core_main.c
+++ b/sw/vendor/eembc_coremark/core_main.c
@@ -86,11 +86,11 @@ char *mem_name[3] = {"Static","Heap","Stack"};
 */
 
 #if MAIN_HAS_NOARGC
-MAIN_RETURN_TYPE main(void) {
+MAIN_RETURN_TYPE _ottf_main(void) {
 	int argc=0;
 	char *argv[1];
 #else
-MAIN_RETURN_TYPE main(int argc, char *argv[]) {
+MAIN_RETURN_TYPE _ottf_main(int argc, char *argv[]) {
 #endif
 	ee_u16 i,j=0,num_algorithms=0;
 	ee_s16 known_id=-1,total_errors=0;

--- a/sw/vendor/patches/eembc_coremark/use_ottf_main.patch
+++ b/sw/vendor/patches/eembc_coremark/use_ottf_main.patch
@@ -1,0 +1,18 @@
+diff --git a/core_main.c b/core_main.c
+index 285abec56..61f55853e 100644
+--- a/core_main.c
++++ b/core_main.c
+@@ -86,11 +86,11 @@ char *mem_name[3] = {"Static","Heap","Stack"};
+ */
+ 
+ #if MAIN_HAS_NOARGC
+-MAIN_RETURN_TYPE main(void) {
++MAIN_RETURN_TYPE _ottf_main(void) {
+ 	int argc=0;
+ 	char *argv[1];
+ #else
+-MAIN_RETURN_TYPE main(int argc, char *argv[]) {
++MAIN_RETURN_TYPE _ottf_main(int argc, char *argv[]) {
+ #endif
+ 	ee_u16 i,j=0,num_algorithms=0;
+ 	ee_s16 known_id=-1,total_errors=0;


### PR DESCRIPTION
The coremark benchmark test meson build target was commented out in
PR #12206, since it failed to build when the OTTF entry point was
renamed from `main` to `_ottf_main` (the `ottf_start.asm` assembly is
used with the benchmark code to setup the device). However, this benchmark
is run as a nightly regression in DV simulation. As a result of the missing
build target, this test was failing.

This patches the coremark benchmark code to work with the new entry
point symbol: `_ottf_main`.

Signed-off-by: Timothy Trippel <ttrippel@google.com>