### PR TITLE
fix(spi_device): Placed CG on Passthrough SCK

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device_pkg.sv
+++ b/hw/ip/spi_device/rtl/spi_device_pkg.sv
@@ -16,7 +16,6 @@ package spi_device_pkg;
     // Passthrough includes SCK also. The sck_en is pad out enable not CG
     // enable. The CG is placed in SPI_DEVICE IP.
     logic       sck;
-    logic       sck_gate_en; // TBD: place for CG?
     logic       sck_en;
 
     // CSb should be pull-up pad. In passthrough mode, CSb is directly connected
@@ -38,7 +37,6 @@ package spi_device_pkg;
   parameter passthrough_req_t PASSTHROUGH_REQ_DEFAULT = '{
     passthrough_en: 1'b 0,
     sck:            1'b 0,
-    sck_gate_en:    1'b 0,
     sck_en:         1'b 0,
     csb:            1'b 1,
     csb_en:         1'b 0,

--- a/hw/ip/spi_device/rtl/spi_passthrough.sv
+++ b/hw/ip/spi_device/rtl/spi_passthrough.sv
@@ -639,9 +639,19 @@ module spi_passthrough
     else         host_s_en_o <= host_s_en_inclk;
   end
 
-  assign passthrough_o.sck_gate_en = sck_gate_en;
-  assign passthrough_o.sck         = host_sck_i;
-  assign passthrough_o.sck_en      = 1'b 1;
+  logic pt_gated_sck;
+  prim_clock_gating #(
+    .NoFpgaGate    (1'b 0),
+    .FpgaBufGlobal (1'b 1) // Going outside of chip
+  ) u_pt_sck_cg (
+    .clk_i     (host_sck_i  ),
+    .en_i      (sck_gate_en ),
+    .test_en_i (1'b 0       ), // No FF connected to this gated SCK
+    .clk_o     (pt_gated_sck)
+  );
+
+  assign passthrough_o.sck    = pt_gated_sck;
+  assign passthrough_o.sck_en = 1'b 1;
 
   // CSb propagation:  csb_deassert signal should be an output of FF or latch to
   // make CSb glitch-free.

--- a/hw/ip/spi_host/dv/env/spi_passthrough_if.sv
+++ b/hw/ip/spi_host/dv/env/spi_passthrough_if.sv
@@ -9,7 +9,6 @@ interface spi_passthrough_if
 
   bit       passthrough_en;
   bit       sck;
-  bit       sck_gate_en;
   bit       sck_en;
   bit       csb;
   bit       csb_en;

--- a/hw/ip/spi_host/dv/tb.sv
+++ b/hw/ip/spi_host/dv/tb.sv
@@ -83,14 +83,12 @@ module tb;
       passthrough_i.sck_en <= 1'b0;
       passthrough_i.csb_en <= 1'b0;
       passthrough_i.s_en   <= 1'b0;
-      passthrough_i.sck_gate_en <= 1'b0;
       passthrough_i.csb    <= 1'b1;
     end else begin
       passthrough_i.passthrough_en <= spi_passthrough_if.passthrough_en;
       passthrough_i.sck_en         <= spi_passthrough_if.sck_en;
       passthrough_i.csb_en         <= spi_passthrough_if.csb_en;
       passthrough_i.s_en           <= spi_passthrough_if.s_en;
-      passthrough_i.sck_gate_en    <= spi_passthrough_if.sck_gate_en;
       passthrough_i.csb            <= spi_passthrough_if.csb;
   end
   end
@@ -98,7 +96,7 @@ module tb;
   assign passthrough_i.s      = spi_passthrough_if.is;
   assign spi_passthrough_if.os = passthrough_o.s;
   assign spi_passthrough_if.cio_sd_o = cio_sd_o;
-  
+
   assign cio_sd_i =  spi_passthrough_if.passthrough_en ? spi_passthrough_if.cio_sd_i : si_pulldown;
 
   // configure spi_if i/o

--- a/hw/ip/spi_host/rtl/spi_host.sv
+++ b/hw/ip/spi_host/rtl/spi_host.sv
@@ -153,9 +153,6 @@ module spi_host
 
   end                   : gen_passthrough_ignore
 
-  logic unused_pt_sck_gate_en;
-  assign unused_pt_sck_gate_en = passthrough_i.sck_gate_en;
-
   assign passthrough_o.s = cio_sd_i;
   assign sd_i            = cio_sd_i;
 


### PR DESCRIPTION
This commit places a clock gating cell on the passthrough SCK path. The
gated SCK clock does not drive any logic inside the chip but goes out to
the PAD and downstream SPI Flash device.

Issue #12502 