### PR TITLE
[dv/chip] Fix chip_level alert scb error

### DIFF
--- a/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_agent.sv
@@ -65,6 +65,7 @@ class alert_esc_agent extends dv_base_agent#(
     // set variables to alert_esc interface
     cfg.vif.is_async = cfg.is_async;
     cfg.vif.is_alert = cfg.is_alert;
+    cfg.vif.is_active = cfg.is_active;
     cfg.vif.if_mode  = cfg.if_mode;
     // set async alert clock frequency
     if (cfg.is_alert && cfg.is_async) begin

--- a/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
+++ b/hw/dv/sv/alert_esc_agent/alert_esc_if.sv
@@ -27,7 +27,7 @@ interface alert_esc_if(input clk, input rst_n);
   prim_esc_pkg::esc_rx_t     esc_rx_int;   // internal esc_rx
 
   wire                    async_clk;
-  bit                     is_async, is_alert;
+  bit                     is_async, is_alert, is_active;
   dv_utils_pkg::if_mode_e if_mode;
   clk_rst_if              clk_rst_async_if(.clk(async_clk), .rst_n(rst_n));
 
@@ -79,10 +79,10 @@ interface alert_esc_if(input clk, input rst_n);
     input esc_rx;
   endclocking
 
-  assign alert_tx = (if_mode == dv_utils_pkg::Host && is_alert)    ? alert_tx_int : 'z;
-  assign alert_rx = (if_mode == dv_utils_pkg::Device && is_alert)  ? alert_rx_int : 'z;
-  assign esc_tx   = (if_mode == dv_utils_pkg::Host && !is_alert)   ? esc_tx_int   : 'z;
-  assign esc_rx   = (if_mode == dv_utils_pkg::Device && !is_alert) ? esc_rx_int   : 'z;
+  assign alert_tx = (if_mode == dv_utils_pkg::Host && is_alert && is_active)   ? alert_tx_int : 'z;
+  assign alert_rx = (if_mode == dv_utils_pkg::Device && is_alert && is_active) ? alert_rx_int : 'z;
+  assign esc_tx = (if_mode == dv_utils_pkg::Host && !is_alert && is_active)   ? esc_tx_int   : 'z;
+  assign esc_rx = (if_mode == dv_utils_pkg::Device && !is_alert && is_active) ? esc_rx_int   : 'z;
 
   task automatic wait_ack_complete();
     while (alert_tx_final.alert_p === 1'b1) @(monitor_cb);

--- a/hw/top_earlgrey/dv/env/chip_scoreboard.sv
+++ b/hw/top_earlgrey/dv/env/chip_scoreboard.sv
@@ -34,6 +34,8 @@ class chip_scoreboard #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_b
     // Disable alert signal integrity check to avoid false alert on low_power_group_en or
     // alert_init. Alert signal integrity can be checked by assertions.
     check_alert_sig_int_err = 0;
+    // Disable individual alert checking in scb. Alerts should be checked in SW or DV sequence.
+    do_alert_check = 0;
     super.run_phase(phase);
     fork
       process_jtag_fifo();


### PR DESCRIPTION
This PR:
1). Fix alert_esc_agent in chip_level still driving alert_rx when the
  drivers are inactive.
2). Disable individual alert checking in chip-level scb.

Thanks @weicaiyang and @tjaychen for helping identifying and debugging this issue!

Signed-off-by: Cindy Chen <chencindy@opentitan.org>