### PR TITLE
[primgen] Sort the parameters

### DIFF
--- a/hw/ip/prim/util/primgen.py
+++ b/hw/ip/prim/util/primgen.py
@@ -259,7 +259,7 @@ def _parse_parameter_port_list(parameter_port_list):
     parameters = set()
     for m in re_params.finditer(parameter_port_list):
         parameters.add(m.group('name'))
-    return parameters
+    return list(sorted(parameters))
 
 
 def _parse_module_header(generic_impl_filepath, module_name):


### PR DESCRIPTION
The previous fix #12371 isn't completed
Need to add sorted in one more place
It works when testing with 3.9.10 and 2.7.18

But I'm still not sure if this can fix the issue that some failures
can't be reproduced. Tried to install python virtual env (pyenv) to downgrade
python version to the one we use in nightly, but pyenv doesn't work with
dvsim
Signed-off-by: Weicai Yang <weicai@google.com>