### PR TITLE
[otbn] Harden instruction fetch address (program counter)

### DIFF
--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -190,6 +190,12 @@
         the stored value against glitches.
       '''
     }
+    { name: "INSN_PREFETCH_ADDR.DATA_REG.REDUN"
+      desc: '''
+        This countermeasure replicates the instruction prefetch address register to protect the
+        stored value against glitches.
+      '''
+    }
   ]
 
   regwidth: "32"

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -196,6 +196,9 @@
         stored value against glitches.
       '''
     }
+    { name: "INSN_PREFETCH.ADDR.GLITCH_DETECT"
+      desc: "This countermeasure detect glitches on the instruction prefetch address."
+    }
   ]
 
   regwidth: "32"

--- a/hw/ip/otbn/data/otbn.hjson
+++ b/hw/ip/otbn/data/otbn.hjson
@@ -184,6 +184,12 @@
         file by monitoring the one-hot0 property of the individual write-enable strobes.
       '''
     }
+    { name: "INSN_FETCH_RESP_ADDR.DATA_REG.REDUN"
+      desc: '''
+        This countermeasure replicates the instruction fetch response address register to protect
+        the stored value against glitches.
+      '''
+    }
   ]
 
   regwidth: "32"

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -125,5 +125,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_insn_prefetch_addr_glitch_detect
+      desc: "Verify the countermeasure(s) INSN_PREFETCH.ADDR.GLITCH_DETECT"
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -113,5 +113,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_insn_fetch_resp_addr_data_reg_redun
+      desc: "Verify the countermeasure(s) INSN_FETCH_RESP_ADDR.DATA_REG.REDUN."
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
+++ b/hw/ip/otbn/data/otbn_sec_cm_testplan.hjson
@@ -119,5 +119,11 @@
       milestone: V2S
       tests: []
     }
+    {
+      name: sec_cm_insn_prefetch_addr_data_reg_redun
+      desc: "Verify the countermeasure(s) INSN_PREFETCH_ADDR.DATA_REG.REDUN."
+      milestone: V2S
+      tests: []
+    }
   ]
 }

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_trace_if.sv
@@ -58,7 +58,7 @@ interface otbn_trace_if
   input logic [31:0]              insn_fetch_resp_data,
   input logic [ImemAddrWidth-1:0] insn_fetch_resp_addr,
   input logic                     insn_fetch_resp_valid,
-  input logic                     insn_fetch_err,
+  input logic                     insn_fetch_intg_err,
 
   input logic                         dmem_req_o,
   input logic                         dmem_write_o,

--- a/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
+++ b/hw/ip/otbn/dv/tracer/rtl/otbn_tracer.sv
@@ -194,7 +194,7 @@ module otbn_tracer
 
   function automatic void trace_header();
     if (otbn_trace.insn_valid) begin
-      if (otbn_trace.insn_fetch_err) begin
+      if (otbn_trace.insn_fetch_intg_err) begin
         // This means that we've seen an IMEM integrity error. Squash the reported instruction bits
         // and ignore any stall: this will be the last cycle of the instruction either way.
         output_trace(InsnExecutePrefix,

--- a/hw/ip/otbn/otbn.core
+++ b/hw/ip/otbn/otbn.core
@@ -26,6 +26,7 @@ filesets:
       - rtl/otbn_controller.sv
       - rtl/otbn_decoder.sv
       - rtl/otbn_predecode.sv
+      - rtl/otbn_instruction_prefetch_controller.sv
       - rtl/otbn_instruction_fetch.sv
       - rtl/otbn_rf_base.sv
       - rtl/otbn_rf_bignum.sv

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1100,4 +1100,6 @@ module otbn
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(OtbnScrambleCtrlFsmCheck_A,
     u_otbn_scramble_ctrl.u_state_regs, alert_tx_o[AlertFatal])
 
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtbnInsnFetchRespAddrErrAlertCheck_A,
+    u_otbn_core.u_otbn_instruction_fetch.u_insn_fetch_resp_addr_cnt, alert_tx_o[AlertFatal])
 endmodule

--- a/hw/ip/otbn/rtl/otbn.sv
+++ b/hw/ip/otbn/rtl/otbn.sv
@@ -1102,4 +1102,7 @@ module otbn
 
   `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtbnInsnFetchRespAddrErrAlertCheck_A,
     u_otbn_core.u_otbn_instruction_fetch.u_insn_fetch_resp_addr_cnt, alert_tx_o[AlertFatal])
+  `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(OtbnInsnPrefetchAddrErrAlertCheck_A,
+    u_otbn_core.u_otbn_instruction_fetch.u_insn_prefetch_addr_cnt, alert_tx_o[AlertFatal])
+
 endmodule

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -98,6 +98,7 @@ module otbn_core
   logic [31:0]              insn_fetch_resp_data;
   logic                     insn_fetch_resp_clear;
   logic                     insn_fetch_err;
+  logic                     insn_fetch_state_err;
 
   rf_predec_bignum_t   rf_predec_bignum;
   alu_predec_bignum_t  alu_predec_bignum;
@@ -313,6 +314,7 @@ module otbn_core
     .insn_fetch_resp_data_o (insn_fetch_resp_data),
     .insn_fetch_resp_clear_i(insn_fetch_resp_clear),
     .insn_fetch_err_o       (insn_fetch_err),
+    .state_err_o            (insn_fetch_state_err),
 
     .rf_predec_bignum_o  (rf_predec_bignum),
     .alu_predec_bignum_o (alu_predec_bignum),
@@ -520,6 +522,7 @@ module otbn_core
     fatal_software:      controller_err_bits.fatal_software,
     bad_internal_state:  |{controller_err_bits.bad_internal_state,
                            start_stop_state_error,
+                           insn_fetch_state_err,
                            urnd_all_zero,
                            predec_error},
     reg_intg_violation:  |{controller_err_bits.reg_intg_violation,

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -97,7 +97,7 @@ module otbn_core
   logic [ImemAddrWidth-1:0] insn_fetch_resp_addr;
   logic [31:0]              insn_fetch_resp_data;
   logic                     insn_fetch_resp_clear;
-  logic                     insn_fetch_err;
+  logic                     insn_fetch_intg_err;
   logic                     insn_fetch_state_err;
 
   rf_predec_bignum_t   rf_predec_bignum;
@@ -313,7 +313,7 @@ module otbn_core
     .insn_fetch_resp_valid_o(insn_fetch_resp_valid),
     .insn_fetch_resp_data_o (insn_fetch_resp_data),
     .insn_fetch_resp_clear_i(insn_fetch_resp_clear),
-    .insn_fetch_err_o       (insn_fetch_err),
+    .insn_fetch_err_o       (insn_fetch_intg_err),
     .state_err_o            (insn_fetch_state_err),
 
     .rf_predec_bignum_o  (rf_predec_bignum),
@@ -528,7 +528,7 @@ module otbn_core
     reg_intg_violation:  |{controller_err_bits.reg_intg_violation,
                            rf_base_rf_err},
     dmem_intg_violation: lsu_rdata_err,
-    imem_intg_violation: insn_fetch_err,
+    imem_intg_violation: insn_fetch_intg_err,
     rnd_fips_chk_fail:   controller_err_bits.rnd_fips_chk_fail,
     rnd_rep_chk_fail:    controller_err_bits.rnd_rep_chk_fail,
     key_invalid:         controller_err_bits.key_invalid,
@@ -558,13 +558,13 @@ module otbn_core
   assign controller_escalate_en =
       mubi4_or_hi(escalate_en_i,
                   mubi4_bool_to_mubi(|{start_stop_state_error, urnd_all_zero, predec_error,
-                                       rf_base_rf_err, lsu_rdata_err, insn_fetch_err}));
+                                       rf_base_rf_err, lsu_rdata_err, insn_fetch_intg_err}));
 
   // Similarly for the start/stop controller
   assign start_stop_escalate_en =
       mubi4_or_hi(escalate_en_i,
                   mubi4_bool_to_mubi(|{urnd_all_zero, rf_base_rf_err, predec_error,
-                                       lsu_rdata_err, insn_fetch_err, controller_fatal_err}));
+                                       lsu_rdata_err, insn_fetch_intg_err, controller_fatal_err}));
 
   assign insn_cnt_o = insn_cnt;
 

--- a/hw/ip/otbn/rtl/otbn_instruction_prefetch_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_instruction_prefetch_controller.sv
@@ -1,0 +1,81 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * OTBN Instruction Prefetch Controller
+ *
+ * Determine if and from which address an instruction should be prefetched.
+ */
+module otbn_instruction_prefetch_controller #(
+  parameter int AddrWidth = 0,
+  parameter bit BufOutput = 1'b0
+) (
+  input  logic                  prefetch_en_i,
+  input  logic [AddrWidth-1:0]  insn_prefetch_addr_i,
+  input  logic                  insn_prefetch_fail_i,
+  input  logic [AddrWidth-1:0]  insn_fetch_req_addr_i,
+  input  logic                  insn_fetch_req_valid_i,
+  input  logic [6:0]            imem_rdata_lsb_i,
+  input  logic                  prefetch_loop_active_i,
+  input  logic                  insn_prefetch_addr_is_loop_end_addr_i,
+  input  logic [AddrWidth-1:0]  prefetch_loop_jump_addr_i,
+  input  logic                  prefetch_loop_iterations_gt_one_i,
+
+  output logic                  insn_prefetch_o,
+  output logic [AddrWidth-1:0]  imem_addr_o
+
+);
+  function automatic logic opcode_is_branch(logic [6:0] opcode);
+    import otbn_pkg::*;
+    return opcode inside {InsnOpcodeBaseBranch, InsnOpcodeBaseJal, InsnOpcodeBaseJalr};
+  endfunction
+
+  logic                 insn_prefetch;
+  logic [AddrWidth-1:0] imem_addr;
+  always_comb begin
+    // Only prefetch if controller tells us to
+    insn_prefetch = prefetch_en_i;
+    // By default prefetch the next instruction
+    imem_addr = insn_prefetch_addr_i + 'd4;
+
+    if (!insn_fetch_req_valid_i) begin
+      // Keep prefetching the same instruction when a new one isn't being requested. In this
+      // scenario OTBN is stalled and will eventually want the prefetched instruction.
+      imem_addr = insn_prefetch_addr_i;
+    end else if (insn_prefetch_fail_i) begin
+      // When prefetching has failed prefetch the requested address
+      imem_addr = insn_fetch_req_addr_i;
+    end else if (opcode_is_branch(imem_rdata_lsb_i)) begin
+      // For a branch we do not know if it will be taken or untaken. So never prefetch to keep
+      // timing consistent regardless of taken/not-taken.
+      // This also applies to jumps, this avoids the need to calculate the jump address here.
+      insn_prefetch = 1'b0;
+    end else if (insn_prefetch_addr_is_loop_end_addr_i &&
+                 prefetch_loop_active_i &&
+                 prefetch_loop_iterations_gt_one_i) begin
+      // When in a loop prefetch the loop beginning when execution reaches the end.
+      imem_addr = prefetch_loop_jump_addr_i;
+    end
+  end
+
+  if (BufOutput) begin : g_oup_buf
+    // Buffer outputs to make sure glitches don't back-propagate to inputs.
+    prim_buf #(
+      .Width(1)
+    ) u_insn_prefetch_buf (
+      .in_i   (insn_prefetch),
+      .out_o  (insn_prefetch_o)
+    );
+    prim_buf #(
+      .Width(AddrWidth)
+    ) u_imem_addr_buf (
+      .in_i   (imem_addr),
+      .out_o  (imem_addr_o)
+    );
+  end else begin : g_no_oup_buf
+    assign insn_prefetch_o = insn_prefetch;
+    assign imem_addr_o = imem_addr;
+  end
+
+endmodule


### PR DESCRIPTION
OTBN D2S (#11019) includes the hardening the program counter (counter duplication and countermeasures like they have been implemented for Ibex' PC).

OTBN's program counter is the `insn_fetch_resp_addr` signal in OTBN core, which directly comes from the `insn_fetch_resp_addr_q` register in the `otbn_instruction_fetch` module. That register is set to the value of the `insn_prefetch_addr` register (when `insn_fetch_en` is high). The next-cycle value of the `insn_prefetch_addr` register is computed combinationally.

Thus, there are no simple counters that could directly be duplicated with a `prim_count`. Ibex's PC countermeasure checks if the PC increments by one instruction, and the check is disabled in cases where it does not simply increment (e.g., branches, exceptions). This principle can be applied for OTBN, where there are hardware loops and branches but no exceptions and other complications.

This PR hardens all three components that result in the instruction fetch address: the instruction fetch response address register, the instruction prefetch address register, and the next-cycle value of the instruction prefetch address register. It is implemented as follows:

- Harden the instruction prefetch response address register against glitch attacks. This is done by instantiating a `prim_count`, of which the counter functionality is *not* used, but the redundant register, cross-checking of register value, error raising, and the DV integration of `prim_count` are used.  The synthesizer should optimize the tied-off counter logic away.
- Harden the instruction prefetch address register against glitch attacks in the same manner as the instruction prefetch response address.
- This hardens the instruction prefetch address (i.e., the input of the instruction prefetch address register) against glitches.  This is done by storing the inputs and outputs of the instruction prefetch controller in one cycle and comparing its output against that of a controller duplicate in the next cycle.