### PR TITLE
[bazel] Add enough verilator tags to reliably filter it out of the build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -559,5 +559,6 @@ jobs:
             --build_tests_only=false \
             --define DISABLE_VERILATOR_BUILD=true \
             --test_tag_filters=-broken,-cw310,-verilator,-dv \
+            --build_tag_filters=-verilator,-test_suite \
             //sw/...
       displayName: "Build and Unit Test Software with Bazel"

--- a/hw/BUILD
+++ b/hw/BUILD
@@ -14,6 +14,7 @@ fusesoc_build(
     ],
     data = ["//hw/ip/otbn:all_files"],
     systems = ["lowrisc:dv:chip_verilator_sim"],
+    tags = ["verilator"],
     target = "sim",
 )
 
@@ -48,6 +49,7 @@ alias(
         ":disable_verilator_build": ":verilator-stub",
         "//conditions:default": ":verilator_real",
     }),
+    tags = ["verilator"],
     visibility = ["//visibility:public"],
 )
 

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -372,4 +372,5 @@ def opentitan_functest(
     native.test_suite(
         name = name,
         tests = all_tests,
+        tags = ["test_suite"],
     )


### PR DESCRIPTION
The test suite contains verilator tests so we really want to filter it out
when we exclude verilator tests from targets to be built. If we also tag the
//hw:verilator targets that have a verilated model, we should be able to
build the hw directory and the whole software directory without relying
on clever tricks. (Let's keep the clever trick for a bit.

Addresses #9653 partially

Tested: 
```
ci/bazelisk.sh test
--build_tests_only=false
--test_tag_filters=-broken,-cw310,-verilator,-dv
//...
--build_tag_filters=-verilator
```
after cleaning and checked that it didn't build `hw:verilator`

Signed-off-by: Drew Macrae <drewmacrae@google.com>