### PR TITLE
[sw/silicon_creator] Don't request a new scrambling key for ret ram

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/retention_sram.c
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.c
@@ -18,6 +18,21 @@ enum {
   kBase = TOP_EARLGREY_SRAM_CTRL_RET_AON_REGS_BASE_ADDR,
 };
 
+/**
+ * Check that control register writes are enabled.
+ *
+ * @return Result of the operation.
+ */
+static rom_error_t is_locked(void) {
+  if (!bitfield_bit32_read(
+          abs_mmio_read32(kBase + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET),
+          SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT)) {
+    return kErrorRetSramLocked;
+  }
+
+  return kErrorOk;
+}
+
 volatile retention_sram_t *retention_sram_get(void) {
   static_assert(sizeof(retention_sram_t) == TOP_EARLGREY_RAM_RET_AON_SIZE_BYTES,
                 "Unexpected retention SRAM size.");
@@ -28,13 +43,17 @@ void retention_sram_clear(void) {
   *retention_sram_get() = (retention_sram_t){0};
 }
 
+rom_error_t retention_sram_init(void) {
+  RETURN_IF_ERROR(is_locked());
+
+  uint32_t reg = bitfield_bit32_write(0, SRAM_CTRL_CTRL_INIT_BIT, true);
+  abs_mmio_write32(kBase + SRAM_CTRL_CTRL_REG_OFFSET, reg);
+
+  return kErrorOk;
+}
+
 rom_error_t retention_sram_scramble(void) {
-  // Check that control register writes are enabled.
-  if (!bitfield_bit32_read(
-          abs_mmio_read32(kBase + SRAM_CTRL_CTRL_REGWEN_REG_OFFSET),
-          SRAM_CTRL_CTRL_REGWEN_CTRL_REGWEN_BIT)) {
-    return kErrorRetSramLocked;
-  }
+  RETURN_IF_ERROR(is_locked());
 
   // Request the renewal of the scrambling key and initialization to random
   // values.

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -79,6 +79,16 @@ volatile retention_sram_t *retention_sram_get(void);
 void retention_sram_clear(void);
 
 /**
+ * Initialize the retention SRAM with pseudo-random data from the LFSR.
+ *
+ * This function does not request a new scrambling key. See
+ * `retention_sram_scramble()`.
+ *
+ * @return Result of the operation.
+ */
+rom_error_t retention_sram_init(void);
+
+/**
  * Start scrambling the retention SRAM.
  *
  * Requests a new scrambling key for the retention SRAM. This operation

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -122,7 +122,7 @@ static rom_error_t mask_rom_init(void) {
   // retention SRAM and the reset reason register cleared.
   uint32_t reset_reasons = rstmgr_reason_get();
   if (bitfield_bit32_read(reset_reasons, kRstmgrReasonPowerOn)) {
-    retention_sram_clear();
+    retention_sram_init();
   }
 
   // If running on an FPGA, print the FPGA version-id.


### PR DESCRIPTION
This PR adds retention_sram_init() and uses it in `mask_rom.c` instead of retention_sram_scramble() to reduce boot time (as requested by @tjaychen).

@tjaychen is this close to what you had in mind?

Signed-off-by: Alphan Ulusoy <alphan@google.com>