### PR TITLE
[bazel/rules_rust] use forked/patched `rules_rust` repo

### DIFF
--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -7,9 +7,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def rust_repos():
     http_archive(
         name = "rules_rust",
-        sha256 = "531bdd470728b61ce41cf7604dc4f9a115983e455d46ac1d0c1632f613ab9fc3",
-        strip_prefix = "rules_rust-d8238877c0e552639d3e057aadd6bfcf37592408",
-        url = "https://github.com/bazelbuild/rules_rust/archive/d8238877c0e552639d3e057aadd6bfcf37592408.tar.gz",
+        sha256 = "5e2f59778ee496064b2d96182bc8aa916a0e34921124a359f740f51e5e5afc38",
+        strip_prefix = "rules_rust-be0d6ca492f64cc8d460f54f467925ef2753ed89",
+        url = "https://github.com/lowRISC/rules_rust/archive/be0d6ca492f64cc8d460f54f467925ef2753ed89.tar.gz",
     )
 
     # Boring is only used to build Mundane.

--- a/util/prep-bazel-airgapped-build.sh
+++ b/util/prep-bazel-airgapped-build.sh
@@ -27,7 +27,7 @@ function usage() {
 Utility script to prepare a directory with all bazel dependencies needed to
 build project artifacts with bazel in an airgapped environment.
 
-Usage: $0 [-c all | distdir | cache]
+Usage: $0 [-c ALL | DISTDIR | CACHE]
 
   - c: airgapped directory contents, set to either ALL or DISTDIR or CACHE.
   - f: force rebuild of airgapped directory, overwriting any existing one.
@@ -145,7 +145,9 @@ if [[ ${AIRGAPPED_DIR_CONTENTS} == "ALL" || \
     @local_config_platform//... \
     @local_config_sh//... \
     @python3_toolchains//... \
+    @remotejdk11_linux//... \
     @riscv-compliance//... \
+    @rust_linux_x86_64//... \
     @rust_darwin_aarch64_toolchains//... \
     @rust_darwin_x86_64_toolchains//... \
     @rust_freebsd_x86_64_toolchains//... \


### PR DESCRIPTION
As described in #12515, the upstream `rules_rust` repository attempted
to download several dependencies in a manner that did not first check
the repository cache before going to the network. This made supporting
an airgapped build environment problematic. To fix this issue, the
`rules_rust` repository was forked and patched. Please follow this link
for the commit message that describes the patch in detail:
https://github.com/lowRISC/rules_rust/commit/be0d6ca492f64cc8d460f54f467925ef2753ed89

This commit update the bazel dependencies to use our patched
`rust_rules` instead of the upstream ones. Additionally, this commit
updates the `prep-bazel-airgapped-builds.sh` script to pre-fetch
additional dependencies to pre-populate the bazel repository cache with
additional required dependencies to support airgapped builds.

This fixes #12515.

Signed-off-by: Timothy Trippel <ttrippel@google.com>