### PR TITLE
[spi_device] Not push to SRAM when !FwMode

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1213,6 +1213,9 @@ module spi_device
     .clk_spi_out_i (clk_spi_out_buf),
     .rst_txfifo_ni (rst_txfifo_n),
 
+    // Mode
+    .spi_mode_i (spi_mode),
+
     .rxf_overflow_o  (rxf_overflow),
     .txf_underflow_o (txf_underflow),
 

--- a/hw/ip/spi_device/rtl/spi_fwm_rxf_ctrl.sv
+++ b/hw/ip/spi_device/rtl/spi_fwm_rxf_ctrl.sv
@@ -18,6 +18,8 @@ module spi_fwm_rxf_ctrl #(
   input clk_i,
   input rst_ni,
 
+  input spi_device_pkg::spi_mode_e spi_mode_i,
+
   // Configuration
   input      [SramAw-1:0] base_index_i,
   input      [SramAw-1:0] limit_index_i,
@@ -42,6 +44,8 @@ module spi_fwm_rxf_ctrl #(
   input        [SramDw-1:0] sram_rdata,
   input               [1:0] sram_error
 );
+
+  logic active;
 
   // Internal variable
   logic [NumBytes-1:0] byte_enable;
@@ -77,6 +81,7 @@ module spi_fwm_rxf_ctrl #(
     else         st <= st_next;
   end
 
+  assign active = (spi_mode_i == spi_device_pkg::FwMode);
 
   logic [PtrW-1:0] ptr_cmp;
   assign ptr_cmp = rptr ^ wptr;
@@ -184,7 +189,7 @@ module spi_fwm_rxf_ctrl #(
       StIdle: begin
         // Out of reset state. If SRAM Fifo is not full and RX Fifo is not empty,
         // state machine starts process incoming data
-        if (fifo_valid && !sramf_full) begin
+        if (active && fifo_valid && !sramf_full) begin
           st_next = StPop;
           fifo_ready = 1'b1;
           update_wdata = 1'b1;

--- a/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
+++ b/hw/ip/spi_device/rtl/spi_fwm_txf_ctrl.sv
@@ -17,6 +17,8 @@ module spi_fwm_txf_ctrl #(
   input clk_i,
   input rst_ni,
 
+  input spi_device_pkg::spi_mode_e spi_mode_i,
+
   // Configuration
   input [SramAw-1:0] base_index_i,
   input [SramAw-1:0] limit_index_i,
@@ -39,6 +41,8 @@ module spi_fwm_txf_ctrl #(
   input        [SramDw-1:0] sram_rdata,
   input               [1:0] sram_error
 );
+
+  logic active;
 
   logic [SDW-1:0] pos;    // Current write position
   logic [SramAw-1:0] sramf_limit;
@@ -77,6 +81,8 @@ module spi_fwm_txf_ctrl #(
     else         st <= st_next;
   end
 
+  assign active = (spi_mode_i == spi_device_pkg::FwMode);
+
   assign sramf_empty = (rptr == wptr_q);
 
   assign sramf_limit = limit_index_i - base_index_i;
@@ -95,7 +101,7 @@ module spi_fwm_txf_ctrl #(
     unique case (st)
       StIdle: begin
         latch_wptr = 1'b1;
-        if (!sramf_empty && fifo_ready) begin
+        if (active && !sramf_empty && fifo_ready) begin
           st_next = StRead;
           sram_req_d = 1'b1;
         end else begin

--- a/hw/ip/spi_device/rtl/spi_fwmode.sv
+++ b/hw/ip/spi_device/rtl/spi_fwmode.sv
@@ -24,6 +24,8 @@ module spi_fwmode
   input clk_spi_out_i,
   input rst_txfifo_ni,
 
+  input spi_mode_e spi_mode_i,
+
   // Configurations
   // No sync logic. Configuration should be static when SPI operating
 
@@ -82,6 +84,9 @@ module spi_fwmode
   /////////////
   // Signals //
   /////////////
+  logic active;
+  assign active = (spi_mode_i == FwMode);
+
   // RX Async FIFO Signals
   //  Write: SCK positive edge
   logic      rxf_wvalid, rxf_wready;
@@ -115,12 +120,12 @@ module spi_fwmode
   logic        [1:0] fwm_sram_error [2];
 
 
-
-  assign rxf_wvalid = rx_data_valid_i;
+  // Allow Async FIFO update only when the SpiMode is FwMode
+  assign rxf_wvalid = rx_data_valid_i && active;
   assign rxf_wdata  = rx_data_i;
 
   assign tx_wvalid_o = 1'b 1;
-  assign txf_rready  = tx_wready_i;
+  assign txf_rready  = tx_wready_i; // not updated if !FwMode
   assign tx_data_o   = txf_rdata;
 
   // Generic Mode only uses SingleIO. s_i[0] is MOSI, s_o[1] is MISO.
@@ -199,6 +204,8 @@ module spi_fwmode
     .clk_i,
     .rst_ni,
 
+    .spi_mode_i,
+
     .base_index_i  (sram_rxf_bindex_i),
     .limit_index_i (sram_rxf_lindex_i),
     .timer_v      (timer_v_i),
@@ -230,6 +237,8 @@ module spi_fwmode
   ) u_txf_ctrl (
     .clk_i,
     .rst_ni,
+
+    .spi_mode_i,
 
     .base_index_i  (sram_txf_bindex_i),
     .limit_index_i (sram_txf_lindex_i),


### PR DESCRIPTION
This commit fixes the wrong behavior of fwm_rxf_ctrl module. When the
spi mode is not FwMode, fwm_rxf_ctrl, fwm_txf_ctrl should not operate.
The fwm_txf_ctrl only fetches data from DPSRAM when write pointer has
been updated. If it is not FwMode, it is assumed that SW won't touch
write pointer of TXF.

However, the RXF runs based on the read async fifo valid signal. The
FIFO has been updated regardless of the spi mode. This commit adds
prevention logic in front of the async FIFO and also inside the FSMs.

