### PR TITLE
[spi_device] Add Read Status, Read JEDEC to flash behavioral model

### DIFF
--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -12,6 +12,8 @@ program prog_passthrough_host
   spi_if sif
 );
 
+  // Tracked Flash variables
+  spi_data_t [2:0] status;
   // Timeout
   initial begin
     #1ms
@@ -20,6 +22,7 @@ program prog_passthrough_host
   end
 
   initial begin
+    automatic spi_data_t temp_status;
     // Default value
     sif.csb = 1'b 1;
 
@@ -33,10 +36,11 @@ program prog_passthrough_host
     spiflash_readstatus(
       sif.tb,
       spi_device_pkg::CmdReadStatus1,
-      status
+      temp_status
     );
 
-    $display("Received Status: %2Xh", status);
+    $display("Received Status: %2Xh", temp_status);
+    status[0] = temp_status;
 
     forever begin
       @(posedge clk);

--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -14,6 +14,10 @@ program prog_passthrough_host
 
   // Tracked Flash variables
   spi_data_t [2:0] status;
+
+  spi_data_t   jedec_id;
+  logic [15:0] device_id;
+
   // Timeout
   initial begin
     #1ms
@@ -23,6 +27,7 @@ program prog_passthrough_host
 
   initial begin
     automatic spi_data_t temp_status;
+    automatic logic [23:0] temp_jedec_id;
     // Default value
     sif.csb = 1'b 1;
 
@@ -41,6 +46,24 @@ program prog_passthrough_host
 
     $display("Received Status: %2Xh", temp_status);
     status[0] = temp_status;
+
+    repeat(10) @(negedge clk);
+
+    // Test: Jedec ID
+    // CcNum 7, Cc 'h 7F
+    spiflash_readjedec(
+      sif.tb,
+      spi_device_pkg::CmdJedecId,
+      8'h 7,
+      8'h 7F,
+      temp_jedec_id
+    );
+
+    jedec_id  = temp_jedec_id[23:16];
+    device_id = temp_jedec_id[15:0];
+    $display("Received Jedec ID: %2Xh, Device ID: %4Xh", jedec_id, device_id);
+
+    repeat(10) @(negedge clk);
 
     forever begin
       @(posedge clk);

--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -28,6 +28,7 @@ program prog_passthrough_host
   initial begin
     automatic spi_data_t temp_status;
     automatic logic [23:0] temp_jedec_id;
+    automatic int unsigned num_cc;
     // Default value
     sif.csb = 1'b 1;
 
@@ -54,20 +55,21 @@ program prog_passthrough_host
     spiflash_readjedec(
       sif.tb,
       spi_device_pkg::CmdJedecId,
-      8'h 7,
       8'h 7F,
+      num_cc,
       temp_jedec_id
     );
 
     jedec_id  = temp_jedec_id[23:16];
     device_id = temp_jedec_id[15:0];
-    $display("Received Jedec ID: %2Xh, Device ID: %4Xh", jedec_id, device_id);
+    $display("Received Jedec ID: %2Xh (CC: %2d), Device ID: %4Xh",
+      jedec_id, num_cc, device_id);
 
     repeat(10) @(negedge clk);
 
-    forever begin
-      @(posedge clk);
-    end
+
+    // Finish
+    $finish();
   end
 
   // TODO: Do Factory to load proper sequence for the test

--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
@@ -90,6 +90,21 @@ program prog_passthrough_sw
       4'b 1111
     );
 
+    // JEDEC ID: Slightly differ from spiflash behavioral model
+    tlul_write(
+      clk, h2d, d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_JEDEC_CC_OFFSET),
+      '0, // FIXME: Correct CC num and CC
+      4'b 1111
+    );
+    tlul_write(
+      clk, h2d, d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_JEDEC_ID_OFFSET),
+      '0, // FIXME: Google JEDEC ID here
+      4'b 1111
+    );
+
+
     // CMD_INFO
     init_cmdinfo_list();
 
@@ -121,7 +136,7 @@ program prog_passthrough_sw
         clk,
         h2d,
         d2h,
-        32'(spi_device_reg_pkg::SPI_DEVICE_CMD_INFO_0_OFFSET + i),
+        32'(spi_device_reg_pkg::SPI_DEVICE_CMD_INFO_0_OFFSET + (i<<2)),
         cmdinfo_wdata,
         4'b 1111
       );
@@ -134,7 +149,7 @@ program prog_passthrough_sw
         clk,
         h2d,
         d2h,
-        32'(spi_device_reg_pkg::SPI_DEVICE_CMD_INFO_EN4B_OFFSET+i),
+        32'(spi_device_reg_pkg::SPI_DEVICE_CMD_INFO_EN4B_OFFSET+(i<<2)),
         32'h 8000_0000 | CmdInfo[24+i].opcode,
         4'b 1111
       );

--- a/hw/ip/spi_device/pre_dv/tb/spid_common.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_common.sv
@@ -769,11 +769,11 @@ package spid_common;
   endtask : spiflash_wrdi
 
   task automatic spiflash_readjedec(
-    virtual spi_if.tb  sif,
-    input spi_data_t   opcode,
-    input logic [7:0]  num_cc,
-    input logic [7:0]  cc,      // Continuous Code
-    ref   logic [23:0] jedec_id // [23:16] Manufacurer ID, [15:0] ID
+    virtual spi_if.tb   sif,
+    input  spi_data_t   opcode,
+    input  logic [7:0]  cc,      // Continuous Code
+    output int unsigned num_cc,
+    ref    logic [23:0] jedec_id // [23:16] Manufacurer ID, [15:0] ID
   );
     // as the transaction size of Read JEDEC ID depends on the Continuous Code,
     // This task does not follow the conventional SPI transaction commands.
@@ -799,6 +799,8 @@ package spid_common;
       spi_receivebyte(sif, rcv_byte, IoSingle);
       cc_cnt++;
     end while (rcv_byte == cc);
+
+    num_cc = cc_cnt - 1;
 
     // If not matched with CC, then that is the Manufacture ID
     jedec_id[23:16] = rcv_byte;

--- a/hw/ip/spi_device/pre_dv/tb/spid_jedec_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_jedec_tb.sv
@@ -95,6 +95,7 @@ module spid_jedec_tb;
   end
 
   static task host();
+    automatic int unsigned num_cc;
     logic [23:0] jedec_id;
 
     // Initial config
@@ -103,7 +104,9 @@ module spid_jedec_tb;
     repeat(10) @(sck_clk.cbn);
 
     // Expect 5 continuous codes and jedec ID
-    spiflash_readjedec(tb_sif, CmdJedecId, 8'h 5, ContinuousCode, jedec_id);
+    spiflash_readjedec(tb_sif, CmdJedecId, ContinuousCode, num_cc, jedec_id);
+    assert(num_cc == 5)
+      else $display("Num_CC count (%2d) does not match to 5", num_cc);
 
     $display("SPI Flash Read JEDEC ID Tested!!:");
   endtask : host

--- a/hw/ip/spi_device/pre_dv/tb/spid_passthrough_tb.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_passthrough_tb.sv
@@ -65,9 +65,10 @@ module tb;
   passthrough_rsp_t passthrough_d2h;
 
   // Connect passthrough_h2d/d2h <-> spiflash_if
-  logic  gated_pt_sck; // gated SCK to passthrough device
-  assign spiflash_if.sck = (passthrough_h2d.sck_en) ? gated_pt_sck        : 1'b 0;
-  assign spiflash_if.csb = (passthrough_h2d.csb_en) ? passthrough_h2d.csb : 1'b 1;
+  assign spiflash_if.sck = (passthrough_h2d.passthrough_en & passthrough_h2d.sck_en)
+                         ? passthrough_h2d.sck : 1'b 0;
+  assign spiflash_if.csb = (passthrough_h2d.passthrough_en & passthrough_h2d.csb_en)
+                         ? passthrough_h2d.csb : 1'b 1;
 
   assign passthrough_d2h = '{s: spiflash_if.sd};
 
@@ -179,13 +180,6 @@ module tb;
     .scan_clk_i  (1'b 0),
     .scan_rst_ni (1'b 1),
     .scanmode_i  (prim_mubi_pkg::MuBi4False) // disable scan
-  );
-
-  prim_clock_gating u_pt_sck_cg (
-    .clk_i (passthrough_h2d.sck),
-    .en_i  (passthrough_h2d.sck_gate_en),
-    .test_en_i (1'b 0),
-    .clk_o (gated_pt_sck)
   );
 
 endmodule : tb


### PR DESCRIPTION
This PR includes #12527 .

spiflash now returns for the Read Status 1 and Read JEDEC ID commands.