### PR TITLE
[otp_ctrl] Set Dev image with legal HW_CFG value

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_img_dev.hjson
@@ -64,6 +64,10 @@
                     name:  "EN_ENTROPY_SRC_FW_READ",
                     value: true,
                 },
+                {
+                    name: "EN_ENTROPY_SRC_FW_OVER",
+                    value: false,
+                }
             ],
         }
         {


### PR DESCRIPTION
it will trigger assertion errors if HW_CFG isn't set to a legal value
Similar to #12428

Signed-off-by: Weicai Yang <weicai@google.com>