### PR TITLE
[bazel] add shas for remaing deps for airgapped builds

### DIFF
--- a/third_party/cc/repos.bzl
+++ b/third_party/cc/repos.bzl
@@ -14,6 +14,7 @@ def cc_repos():
 
     http_archive(
         name = "com_google_absl",
+        sha256 = "1da554cf5670fc119ef5afbeb31d10d51e7554df9dced2967663e679b8d852ed",
         strip_prefix = "abseil-cpp-e854df09dfcb35056c1d42420028648ee0ebebaf",
         url = "https://github.com/abseil/abseil-cpp/archive/e854df09dfcb35056c1d42420028648ee0ebebaf.tar.gz",
     )

--- a/third_party/rust/crates/crates.bzl
+++ b/third_party/rust/crates/crates.bzl
@@ -5,7 +5,6 @@ cargo-raze generated Bazel file.
 DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
-load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")  # buildifier: disable=load
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")  # buildifier: disable=load
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")  # buildifier: disable=load
 
@@ -1142,13 +1141,17 @@ def raze_fetch_remote_crates():
         build_file = Label("//third_party/rust/crates/remote:BUILD.ryu-1.0.9.bazel"),
     )
 
+    # TODO(lowRISC/opentitan:#12469): this was manually converted to an
+    # http_archive rule. Need to figure out how to update the Cargo.toml file so
+    # `cargo raze` will generate a (cacheable) http_archive rule to support
+    # air-gapped builds.
     maybe(
-        new_git_repository,
+        http_archive,
         name = "raze__safe_ftdi__0_3_0",
-        remote = "https://github.com/cr1901/safe-ftdi",
-        commit = "2e6ff2b77cee8c0d7c04dcdb0dea678edbd8d56f",
+        url = "https://github.com/cr1901/safe-ftdi/archive/2e6ff2b77cee8c0d7c04dcdb0dea678edbd8d56f.tar.gz",
+        sha256 = "bdc434ac8e1b379d434eec54f0aab7d272101630876bd760730f9dd0599e806c",
+        strip_prefix = "safe-ftdi-2e6ff2b77cee8c0d7c04dcdb0dea678edbd8d56f",
         build_file = Label("//third_party/rust/crates/remote:BUILD.safe-ftdi-0.3.0.bazel"),
-        init_submodules = True,
     )
 
     maybe(

--- a/third_party/rust/repos.bzl
+++ b/third_party/rust/repos.bzl
@@ -5,12 +5,19 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def rust_repos():
+    # We use forked/patched Rust Bazel rules to enable caching repository rules
+    # required for air-gapped Bazel builds. See lowRISC/opentitan:#12515 for
+    # more details.
     http_archive(
         name = "rules_rust",
         sha256 = "5e2f59778ee496064b2d96182bc8aa916a0e34921124a359f740f51e5e5afc38",
         strip_prefix = "rules_rust-be0d6ca492f64cc8d460f54f467925ef2753ed89",
         url = "https://github.com/lowRISC/rules_rust/archive/be0d6ca492f64cc8d460f54f467925ef2753ed89.tar.gz",
     )
+
+    # We use GitHub mirrors of boringssl and mundane because their counterparts
+    # hosted on Google's git platform do not provide stable sha256 hashes that
+    # that enable caching these dependencies for air-gapped Bazel builds.
 
     # Boring is only used to build Mundane.
     http_archive(


### PR DESCRIPTION
This add sha256 hashes for the only remaining dependencies in our bazel workspace without them to ensure: 1) hermetic builds, and 2) support caching external bazel repo dependencies in the repository cache, which in turn supports airgapped bazel builds.

These dependencies include the `com_google_absl` and `safe-fdti` rust crate external repositories.

This fixes #11792.

**_Note: this depends on #12526 and #12533. Only review the last commit._**