### PR TITLE
[dv] lengthen timeout

### DIFF
--- a/hw/top_earlgrey/dv/chip_smoketests.hjson
+++ b/hw/top_earlgrey/dv/chip_smoketests.hjson
@@ -80,7 +80,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/pwrmgr_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+sw_test_timeout_ns=8000000"]
+      run_opts: ["+sw_test_timeout_ns=10000000"]
     }
     {
       name: chip_sw_rv_timer_smoketest


### PR DESCRIPTION
- this test may take longer if the initial uncalibrated clocks happen
  to land in a slower frequency.

Signed-off-by: Timothy Chen <timothytim@google.com>