### PR TITLE
[dv/flash_ctrl] Additional regression fixes

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cfg.sv
@@ -136,7 +136,7 @@ class flash_ctrl_env_cfg extends cip_base_env_cfg #(
     if (flash_op.op == flash_ctrl_pkg::FlashOpErase) begin
       case (flash_op.erase_type)
         flash_ctrl_pkg::FlashErasePage: begin
-          addr_attrs.set_attrs(addr_attrs.page_start_addr);
+          addr_attrs.set_attrs(addr_attrs.bank_start_addr + addr_attrs.page_start_addr);
           flash_op.num_words = FlashNumBusWordsPerPage;
         end
         flash_ctrl_pkg::FlashEraseBank: begin

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_phy_arb_vseq.sv
@@ -245,6 +245,8 @@ class flash_ctrl_phy_arb_vseq extends flash_ctrl_base_vseq;
     // enable sw rw access
     cfg.flash_ctrl_vif.lc_creator_seed_sw_rw_en = lc_ctrl_pkg::On;
     cfg.flash_ctrl_vif.lc_owner_seed_sw_rw_en   = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_rd_en     = lc_ctrl_pkg::On;
+    cfg.flash_ctrl_vif.lc_iso_part_sw_wr_en     = lc_ctrl_pkg::On;
 
     //disable polling of fifo status for frontdoor write and read
     poll_fifo_status = 0;


### PR DESCRIPTION
- hardwire lc control signals in phy_arb test to ensure all
  partitions (info and data) can be accessed.
- fix flash_ctrl backdoor read which was not accounting for
  bank address.

Signed-off-by: Timothy Chen <timothytim@google.com>