### PR TITLE
[usbdev] Fix clock domain crossing issues

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -430,7 +430,7 @@ module usbdev
       set_sent_q       <= 1'b0;
       setup_received_q <= 1'b0;
     end else begin
-      set_sent_q       <= set_sent_q;
+      set_sent_q       <= set_sent_d;
       setup_received_q <= setup_received_d;
     end
   end
@@ -549,15 +549,15 @@ module usbdev
       clear_rdybit = {NEndpoints{1'b1}};
       update_pend  = {NEndpoints{1'b1}};
     end else begin
-      if (out_endpoint_val) begin
+      if (out_endpoint_val && setup_received_q) begin
         // Clear pending when a SETUP is received
-        clear_rdybit[out_endpoint] = setup_received_q;
-        update_pend[out_endpoint]  = setup_received_q;
+        clear_rdybit[out_endpoint] = 1'b1;
+        update_pend[out_endpoint]  = 1'b1;
       end
 
-      if (in_endpoint_val) begin
+      if (in_endpoint_val && set_sent_q) begin
         // Clear when a IN transmission was sucessful
-        clear_rdybit[in_endpoint] = set_sent_q;
+        clear_rdybit[in_endpoint] = 1'b1;
       end
     end
   end

--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -514,20 +514,10 @@ module usbdev
     .dst_pulse_o (event_frame)
   );
 
-  logic event_link_reset_q;
-
-  always_ff @(posedge clk_usb_48mhz_i or negedge rst_usb_48mhz_ni) begin
-    if (!rst_usb_48mhz_ni) begin
-      event_link_reset_q <= 0;
-    end else begin
-      event_link_reset_q <= event_link_reset;
-    end
-  end
-
   always_comb begin
     clear_rdybit = '0;
     update_pend  = '0;
-    if (event_link_reset && !event_link_reset_q) begin
+    if (event_link_reset) begin
       clear_rdybit = {NEndpoints{1'b1}};
       update_pend  = {NEndpoints{1'b1}};
     end else begin


### PR DESCRIPTION
This PR fixes a number of issues identified during the back-end design of one of our chips at ETH. Mostly they are related to clock domain crossing (CDC) in usbdev.sv:
 - The `event_link_reset_q` FF was placed in the wrong clock-domain. This is in the system clock part of usbdev.sv. Also: This was never needed, since event_link_reset is already the output of a pulse synchronizer.
 -  The old CDC for usb_setup_received, usb_set_sent was very questionable. Assignments `update_pend[usb_out_endpoint] = setup_received;` may not be safe, depending on what the synthesis tool does with the code. I've added synchronization for these signals and delayed setup_received & set_sent by one cycle to make sure the (2FF) synchronized values are ready and consistent.
 -  I also noticed and fixed a control bug regarding `clear_rdybit`, which I introduced when I first worked on the usbdev peripheral. Oops.