### PR TITLE
[flash_ctrl/dv] Add controls for prog type select

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_seq_cfg.sv
@@ -72,6 +72,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
   bit op_readonly_on_info1_partition;  // Make info1 partition read-only.
 
   uint op_erase_type_bank_pc;
+  uint op_prog_type_repair_pc;
   uint op_max_words;
   bit op_allow_invalid;
 
@@ -178,6 +179,7 @@ class flash_ctrl_seq_cfg extends uvm_object;
     op_readonly_on_info1_partition = 1;
 
     op_erase_type_bank_pc = 20;
+    op_prog_type_repair_pc = 10;
     op_max_words = 512;
     op_allow_invalid = 1'b0;
 

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rand_ops_base_vseq.sv
@@ -44,6 +44,11 @@ class flash_ctrl_rand_ops_base_vseq extends flash_ctrl_base_vseq;
       flash_ctrl_pkg::FlashEraseBank :/ cfg.seq_cfg.op_erase_type_bank_pc
     };
 
+    flash_op.prog_sel dist {
+      FlashProgSelNormal :/ (100 - cfg.seq_cfg.op_prog_type_repair_pc),
+      FlashProgSelRepair :/ cfg.seq_cfg.op_prog_type_repair_pc
+    };
+
     flash_op.partition dist {
       FlashPartData  :/ cfg.seq_cfg.op_on_data_partition_pc,
       FlashPartInfo  :/ cfg.seq_cfg.op_on_info_partition_pc,


### PR DESCRIPTION
Hi,
This PR adding controls for the program type select in the sequence config same as the erase-type select and make the normal type to be much more frequent in default. In addition this PR make the rand_ops_base_vseq to select the program type based on those added controls.
Thanks!

Signed-off-by: Eitan Shapira <eitanshapira89@gmail.com>