### PR TITLE
[opentitanlib] Add auto-default values for the ti50 emulator backend

### DIFF
--- a/sw/host/opentitanlib/src/backend/ti50emulator.rs
+++ b/sw/host/opentitanlib/src/backend/ti50emulator.rs
@@ -10,13 +10,13 @@ use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct Ti50EmulatorOpts {
-    #[structopt(long)]
+    #[structopt(long, default_value)]
     executable_directory: String,
 
     #[structopt(long, default_value = "host_emulation")]
     executable: String,
 
-    #[structopt(long)]
+    #[structopt(long, default_value = "ti50")]
     instance_prefix: String,
 }
 


### PR DESCRIPTION
These commands should have default values. This was breaking all the Bazel functional tests which call opentitantool. 

Signed-off-by: Miles Dai <milesdai@google.com>