### PR TITLE
[dv/flash_ctrl] Fix xcelium coverage error

### DIFF
--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -6,7 +6,7 @@
   name: flash_ctrl
 
   // Top level dut name (sv module).
-  dut: flash_ctrl_wrapper
+  dut: flash_ctrl
 
   // Top level testbench name (sv module).
   tb: tb


### PR DESCRIPTION
This PR fixes xcelium coverage error by setting the correct name to
flash_ctrl DV tb.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>