### PR TITLE
[sw/host] remove ignore for Cargo.lock ROM_EXT signer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,10 +66,6 @@ hw/top_englishbreakfast/ip/xbar_peri/xbar_peri.core
 # Rust Cargo build system files.
 Cargo.lock
 sw/host/**/target
-# We check this in to ensure the signing tool is built in a reproducible way
-# under meson, however, once the signing tool is integrated into opentitantool,
-# which is built with Bazel, this can be removed. See lowrisc/opentitan#10465.
-!sw/host/rom_ext_image_tools/signer/Cargo.lock
 
 # Bazel-related cache and output directories
 bazel-*


### PR DESCRIPTION
This removes the `.gitignore` entry for the ROM_EXT image signer
Cargo.lock file as this is no longer needed for two reasons:

1. Bazel manages the Rust deps / builds for sw/host tools now,
2. The functionality in this tool will soon be moved to
   opentitantool.

Signed-off-by: Timothy Trippel <ttrippel@google.com>