### PR TITLE
[spi_device] SPIFlash Read SFDP

### DIFF
--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -29,6 +29,7 @@ program prog_passthrough_host
     automatic spi_data_t temp_status;
     automatic logic [23:0] temp_jedec_id;
     automatic int unsigned num_cc;
+    automatic spi_queue_t  rdata = {};
     // Default value
     sif.csb = 1'b 1;
 
@@ -67,6 +68,17 @@ program prog_passthrough_host
 
     repeat(10) @(negedge clk);
 
+    // Read SFDP from SPIFlash (not inside SPI_DEVICE IP)
+    spiflash_readsfdp(
+      sif.tb,
+      spi_device_pkg::CmdReadSfdp, // 5Ah
+      24'h 00_0000, // addr
+      32,           // size
+      rdata
+    );
+
+    // clean-up for SFDP
+    rdata.delete();
 
     // Finish
     $finish();


### PR DESCRIPTION
This PR contains #12528 Please review last commit.

test(spi_device): Get Address/ Dummy/ Read SFDP
This commit adds tasks:

- get_byte: Receive a byte from SPI. replacing cmdparse to get_byte
- dummy: Sitting given number of dummy cycle
- get_address: Get address based on the internal variable or config.
- return_sfdp: Processing Read SFDP command. Added 256B internal
  storage. For now, the storage is initialized with random values.