### PR TITLE
[regtool] Per interface hier_path support

### DIFF
--- a/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
+++ b/hw/ip_templates/alert_handler/data/alert_handler.hjson.tpl
@@ -14,10 +14,9 @@ chars = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
     {clock: "clk_edn_i", reset: "rst_edn_ni"}
   ]
   bus_interfaces: [
-    { protocol: "tlul", direction: "device" }
+    { protocol: "tlul", direction: "device", hier_path: "u_reg_wrap.u_reg" }
   ],
   regwidth: "32",
-  hier_path: "u_reg_wrap.u_reg"
 ##############################################################################
   param_list: [
     // Random netlist constants

--- a/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
+++ b/hw/top_earlgrey/ip_autogen/alert_handler/data/alert_handler.hjson
@@ -11,10 +11,9 @@
     {clock: "clk_edn_i", reset: "rst_edn_ni"}
   ]
   bus_interfaces: [
-    { protocol: "tlul", direction: "device" }
+    { protocol: "tlul", direction: "device", hier_path: "u_reg_wrap.u_reg" }
   ],
   regwidth: "32",
-  hier_path: "u_reg_wrap.u_reg"
   param_list: [
     // Random netlist constants
     { name:      "RndCnstLfsrSeed",

--- a/util/reggen/gen_dv.py
+++ b/util/reggen/gen_dv.py
@@ -155,9 +155,11 @@ def gen_dv(block: IpBlock, dv_base_names: List[str], outdir: str) -> int:
     lblock = block.name.lower()
     dv_base_names_map = get_dv_base_names_objects(dv_base_names)
     block_dv_base_names = get_block_base_name(dv_base_names_map, lblock)
+    device_hier_paths = block.bus_interfaces.device_hier_paths
 
     for if_name, rb in block.reg_blocks.items():
-        hier_path = 'u_reg' if block.hier_path is None else block.hier_path
+
+        hier_path = device_hier_paths[if_name]
         if_suffix = '' if if_name is None else '_' + if_name.lower()
         mod_base = lblock + if_suffix
         reg_block_path = hier_path + if_suffix

--- a/util/reggen/gen_fpv.py
+++ b/util/reggen/gen_fpv.py
@@ -22,6 +22,8 @@ def gen_fpv(block: IpBlock, outdir: str) -> int:
     fpv_csr_tpl = Template(
         filename=resource_filename('reggen', 'fpv_csr.sv.tpl'))
 
+    device_hier_paths = block.bus_interfaces.device_hier_paths
+
     # Generate a module with CSR assertions for each device interface. For a
     # device interface with no name, we generate <block>_csr_assert_fpv. For a
     # named interface, we generate <block>_<ifname>_csr_assert_fpv.
@@ -32,7 +34,7 @@ def gen_fpv(block: IpBlock, outdir: str) -> int:
             # No registers to check!
             continue
 
-        hier_path = 'u_reg' if block.hier_path is None else block.hier_path
+        hier_path = device_hier_paths[if_name]
         if_suffix = '' if if_name is None else '_' + if_name.lower()
         reg_block_path = hier_path + if_suffix
 

--- a/util/reggen/ip_block.py
+++ b/util/reggen/ip_block.py
@@ -12,8 +12,7 @@ from .alert import Alert
 from .bus_interfaces import BusInterfaces
 from .clocking import Clocking, ClockingItem
 from .inter_signal import InterSignal
-from .lib import (check_keys, check_name, check_int, check_bool,
-                  check_list, check_optional_str)
+from .lib import (check_keys, check_name, check_int, check_bool, check_list)
 from .params import ReggenParams, LocalParam
 from .reg_block import RegBlock
 from .signal import Signal
@@ -37,10 +36,6 @@ OPTIONAL_FIELDS = {
     'available_input_list': ['lnw', "list of available peripheral inputs"],
     'available_output_list': ['lnw', "list of available peripheral outputs"],
     'expose_reg_if': ['pb', 'if set, expose reg interface in reg2hw signal'],
-    'hier_path': [
-        None,
-        'additional hierarchy path before the reg block instance'
-    ],
     'interrupt_list': ['lnw', "list of peripheral interrupts"],
     'inter_signal_list': ['l', "list of inter-module signals"],
     'no_auto_alert_regs': [
@@ -85,7 +80,6 @@ class IpBlock:
                  scan: bool,
                  inter_signals: List[InterSignal],
                  bus_interfaces: BusInterfaces,
-                 hier_path: Optional[str],
                  clocking: Clocking,
                  xputs: Tuple[Sequence[Signal],
                               Sequence[Signal],
@@ -117,7 +111,6 @@ class IpBlock:
         self.scan = scan
         self.inter_signals = inter_signals
         self.bus_interfaces = bus_interfaces
-        self.hier_path = hier_path
         self.clocking = clocking
         self.xputs = xputs
         self.wakeups = wakeups
@@ -233,9 +226,6 @@ class IpBlock:
                                    'bus_interfaces field of ' + where))
         inter_signals += bus_interfaces.inter_signals()
 
-        hier_path = check_optional_str(rd.get('hier_path', None),
-                                       'hier_path field of ' + what)
-
         clocking = Clocking.from_raw(rd['clocking'],
                                      'clocking field of ' + what)
 
@@ -280,8 +270,7 @@ class IpBlock:
 
         return IpBlock(name, regwidth, params, reg_blocks,
                        interrupts, no_auto_intr, alerts, no_auto_alert,
-                       scan, inter_signals, bus_interfaces,
-                       hier_path, clocking, xputs,
+                       scan, inter_signals, bus_interfaces, clocking, xputs,
                        wakeups, rst_reqs, expose_reg_if, scan_reset, scan_en,
                        countermeasures)
 
@@ -321,9 +310,6 @@ class IpBlock:
         ret['scan'] = self.scan
         ret['inter_signal_list'] = self.inter_signals
         ret['bus_interfaces'] = self.bus_interfaces.as_dicts()
-
-        if self.hier_path is not None:
-            ret['hier_path'] = self.hier_path
 
         ret['clocking'] = self.clocking.items
 

--- a/util/topgen/top_uvm_reg.sv.tpl
+++ b/util/topgen/top_uvm_reg.sv.tpl
@@ -37,8 +37,7 @@
       if_suffix = '' if if_name is None else '_' + if_name
       esc_if_name = block_name.lower() + if_suffix
       if_desc = '' if if_name is None else '; interface {}'.format(if_name)
-      reg_block_path = 'u_reg' + if_suffix if block.hier_path is None else if_suffix
-      reg_block_path = 'u_reg' + if_suffix if block.hier_path is None else if_suffix + block.hier_path
+      reg_block_path = block.bus_interfaces.device_hier_paths[if_name] + if_suffix
 %>\
 // Block: ${block_name.lower()}${if_desc}
 <%


### PR DESCRIPTION
This adds support for specifying the `hier_path` variable for each reg block / device interface separately, which is useful when an IP has multiple device register blocks that reside in different places in the design.

The change is in preparation for #10982, which will introduce register aliasing functionality.
In the context of register aliasing, at least one register block resides inside a tech-dependent primitive as opposed to the the IP top-level.

Signed-off-by: Michael Schaffner <msf@opentitan.org>