### PR TITLE
[dv/flash_ctrl] Update region address check

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_scoreboard.sv
@@ -543,7 +543,7 @@ class flash_ctrl_scoreboard #(
               base = get_field_val(ral.mp_region[i].base, data);
               size = get_field_val(ral.mp_region[i].size, data);
               if (in_erase_addr
-                  inside {[base*BytesPerPage:base*BytesPerPage+size*BytesPerPage]}) begin
+                  inside {[base*BytesPerPage:base*BytesPerPage+size*BytesPerPage-1]}) begin
                 if (en) begin
                   erase_access       = erase_en;
                   erase_access_found = 1'b1;


### PR DESCRIPTION
- the previous address range check was inclusive. Meaning
  if base is set to 0, and size set to 1, and access to
  access 1 would be "allowed". This is not the intended
  behavior.  If base is set to 0, and size is set to 1,
  only accesses to 0 should be allowed, 1 and above would
  be disallowed.

- the fix aligns the scoreboard / design behavior for the
  occassional flash_ctrl_mp failures.

Signed-off-by: Timothy Chen <timothytim@google.com>