### PR TITLE
fix(spi_device): Fix the data mismatch error in Addr4B test

### DIFF
--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -172,7 +172,7 @@ program prog_passthrough_host
     repeat(10) @(negedge clk);
   endtask : wait_trans
 
-  static task test_addr_4b(bit pass);
+  static task test_addr_4b(output bit pass);
     automatic spi_queue_t rdata;
     automatic logic [31:0] address;
     automatic int unsigned size;
@@ -285,6 +285,8 @@ program prog_passthrough_host
       if (!mirrored_storage.exists(addr+i)) write_byte(addr+i, data[i]);
       else if (read_byte(addr+i) != data[i]) begin
         pass = 1'b 0;
+        $display("Data mismatch: Addr{%8Xh} EXP(%2Xh) / RCV(%2Xh)",
+          addr+i, read_byte(addr+i), data[i]);
       end
     end
     return pass;

--- a/hw/ip/spi_device/pre_dv/tb/spid_common.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_common.sv
@@ -99,8 +99,8 @@ package spid_common;
     },
     // 25: EX4B
     '{
-      valid:            1'b 0,
-      opcode:           8'h E6,
+      valid:            1'b 1,
+      opcode:           8'h E9,
       addr_mode:        AddrDisabled,
       addr_swap_en:     1'b 0,
       mbyte_en:         1'b 0,
@@ -115,8 +115,8 @@ package spid_common;
 
     // 24: EN4B
     '{
-      valid:            1'b 0,
-      opcode:           8'h E6,
+      valid:            1'b 1,
+      opcode:           8'h B7,
       addr_mode:        AddrDisabled,
       addr_swap_en:     1'b 0,
       mbyte_en:         1'b 0,


### PR DESCRIPTION
This commit fixes the data mismatch error in Passthrough Addr4B test.
The test environment mis-configured EN4B / EX4B opcode so that the
internal passthrough logic could not follow the addr4B enable/disable
sequence. It results in the wrong output enable in case of 4B read
commands.
