### PR TITLE
[sw/lc_ctrl] Add a function to wait for LC status ready

### DIFF
--- a/sw/device/lib/testing/BUILD
+++ b/sw/device/lib/testing/BUILD
@@ -154,6 +154,7 @@ cc_library(
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
         "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/runtime:ibex",
         "//sw/device/lib/runtime:log",
         "//sw/device/lib/testing/test_framework:check",
     ],

--- a/sw/device/lib/testing/lc_ctrl_testutils.c
+++ b/sw/device/lib/testing/lc_ctrl_testutils.c
@@ -7,6 +7,7 @@
 #include <stdbool.h>
 
 #include "sw/device/lib/dif/dif_lc_ctrl.h"
+#include "sw/device/lib/runtime/ibex.h"
 #include "sw/device/lib/runtime/log.h"
 #include "sw/device/lib/testing/test_framework/check.h"
 
@@ -29,4 +30,25 @@ bool lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl) {
     default:
       return false;
   }
+}
+
+/*
+ * LC_CTRL operation status timeout in micro seconds.
+ *
+ * It is not possible to predict the specific cycle count that a LC_CTRL
+ * finishes its operation, thus arbitrary value of 100us is used.
+ */
+const uint8_t kLcOpTimeoutUs = 100;
+
+/**
+ * Checks status is ready.
+ */
+static bool lc_ready(const dif_lc_ctrl_t *lc_ctrl) {
+  dif_lc_ctrl_status_t status;
+  CHECK_DIF_OK(dif_lc_ctrl_get_status(lc_ctrl, &status));
+  return bitfield_bit32_read(status, kDifLcCtrlStatusCodeReady);
+}
+
+void lc_ctrl_testutils_wait_for_idle(const dif_lc_ctrl_t *lc_ctrl) {
+  IBEX_SPIN_FOR(lc_ready(lc_ctrl), kLcOpTimeoutUs);
 }

--- a/sw/device/lib/testing/lc_ctrl_testutils.h
+++ b/sw/device/lib/testing/lc_ctrl_testutils.h
@@ -18,4 +18,9 @@
  */
 bool lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl);
 
+/**
+ * Waits for the LC operation to finish (busy wait).
+ */
+void lc_ctrl_testutils_wait_for_idle(const dif_lc_ctrl_t *lc_ctrl);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_LC_CTRL_TESTUTILS_H_


### PR DESCRIPTION
This PR adds a function to wait for LC status busy bit to set to 0. This
can be used when user request a lc state transition, then this function
can check if the transition is finished.

Please let me know if this function has already been implemented somewhere :)

Signed-off-by: Cindy Chen <chencindy@opentitan.org>