### PR TITLE
[spi_device] Split addr4b into separate TEST

### DIFF
--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -172,7 +172,7 @@ program prog_passthrough_host
     repeat(10) @(negedge clk);
   endtask : wait_trans
 
-  static task test_addr_4b(bit pass);
+  static task test_addr_4b(output bit pass);
     automatic spi_queue_t rdata;
     automatic logic [31:0] address;
     automatic int unsigned size;
@@ -285,6 +285,8 @@ program prog_passthrough_host
       if (!mirrored_storage.exists(addr+i)) write_byte(addr+i, data[i]);
       else if (read_byte(addr+i) != data[i]) begin
         pass = 1'b 0;
+        $display("Data mismatch: Addr{%8Xh} EXP(%2Xh) / RCV(%2Xh)",
+          addr+i, read_byte(addr+i), data[i]);
       end
     end
     return pass;

--- a/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
@@ -15,19 +15,33 @@
 
   tests: [
     {
-      name: spid_passthrough_smoke
-      //build_mode: spid_status_locality_1
+      name: spid_passthrough_readbasic
+      run_opts: [
+        "+TESTNAME=readbasic"
+      ]
+    }
+    {
+      name: spid_passthrough_addr4b
+      run_opts: [
+        "+TESTNAME=addr_4b"
+      ]
     }
   ]
 
   regressions: [
     {
       name: smoke
-      tests: ["spid_passthrough_smoke"]
+      tests: [
+        "spid_passthrough_readbasic",
+        "spid_passthrough_addr4b"
+      ]
     }
     {
       name: nightly
-      tests: ["spid_passthrough_smoke"]
+      tests: [
+        "spid_passthrough_readbasic",
+        "spid_passthrough_addr4b"
+      ]
     }
   ]
 }

--- a/hw/ip/spi_device/pre_dv/tb/spid_common.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_common.sv
@@ -740,32 +740,35 @@ package spid_common;
 
   endtask : spiflash_readstatus
 
-  task automatic spiflash_wel(
+  task automatic spiflash_oponly(
     virtual spi_if.tb sif,
     input spi_byte_t opcode
   );
+    // OPCODE only commands
     automatic spi_fifo_t send_data [$];
     automatic spi_data_t rcv_data [$];
 
     send_data.push_back('{data: opcode, dir: DirIn,  mode: IoSingle});
     spi_transaction(sif, send_data, rcv_data);
 
-    $display("WREN sent!");
-
-  endtask : spiflash_wel
+  endtask : spiflash_oponly
 
   task automatic spiflash_wren(
     virtual spi_if.tb sif,
     input spi_byte_t opcode
   );
-    spiflash_wel(sif, opcode);
+    spiflash_oponly(sif, opcode);
+    $display("WREN sent!");
+
   endtask : spiflash_wren
 
   task automatic spiflash_wrdi(
     virtual spi_if.tb sif,
     input spi_byte_t opcode
   );
-    spiflash_wel(sif, opcode);
+    spiflash_oponly(sif, opcode);
+    $display("WRDI sent!");
+
   endtask : spiflash_wrdi
 
   task automatic spiflash_readjedec(
@@ -991,12 +994,7 @@ package spid_common;
     virtual spi_if.tb  sif,
     input spi_data_t   opcode
   );
-    automatic spi_fifo_t send_data [$];
-    automatic spi_data_t rcv_data  [$];
-
-    send_data.push_back('{data: opcode, dir: DirIn,  mode: IoSingle});
-
-    spi_transaction(sif, send_data, rcv_data);
+    spiflash_oponly(sif, opcode);
 
   endtask : spiflash_addr_4b
 

--- a/hw/ip/spi_device/pre_dv/tb/spid_common.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_common.sv
@@ -99,8 +99,8 @@ package spid_common;
     },
     // 25: EX4B
     '{
-      valid:            1'b 0,
-      opcode:           8'h E6,
+      valid:            1'b 1,
+      opcode:           8'h E9,
       addr_mode:        AddrDisabled,
       addr_swap_en:     1'b 0,
       mbyte_en:         1'b 0,
@@ -115,8 +115,8 @@ package spid_common;
 
     // 24: EN4B
     '{
-      valid:            1'b 0,
-      opcode:           8'h E6,
+      valid:            1'b 1,
+      opcode:           8'h B7,
       addr_mode:        AddrDisabled,
       addr_swap_en:     1'b 0,
       mbyte_en:         1'b 0,


### PR DESCRIPTION
This commit revises passthrough pre_dv into multiple tests.

Now passthrough pre_dv can be called with `+TESTNAME=` to call specific
test. Currently it has *readbasic* and *addr_4b* tests.

This PR includes #12582 . Please review the last commit only.