### PR TITLE
[flash_ctrl/dv] Split out a base hjson without setting tool

### DIFF
--- a/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson
@@ -1,0 +1,149 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+{
+  // Name of the sim cfg - typically same as the name of the DUT.
+  name: flash_ctrl
+
+  // Top level dut name (sv module).
+  dut: flash_ctrl
+
+  // Top level testbench name (sv module).
+  tb: tb
+
+  // Fusesoc core file used for building the file list.
+  fusesoc_core: lowrisc:dv:flash_ctrl_sim:0.1
+
+  // Testplan hjson file.
+  testplan: "{proj_root}/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson"
+
+  // Import additional common sim cfg files.
+  import_cfgs: [// Project wide common sim cfg file
+                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
+                // Config files to get the correct flags for crypto_dpi_prince
+                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson",
+                // Common CIP test lists
+                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
+                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"],
+
+  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
+  // Flash references pwrmgr directly, need to reference the top version
+  overrides: [
+    {
+      name: design_level
+      value: "top"
+    }
+  ]
+
+  // Add additional tops for simulation.
+  sim_tops: ["flash_ctrl_bind","flash_ctrl_cov_bind"]
+
+  // Default iterations for all tests - each test entry can override this.
+  reseed: 50
+
+  // Default UVM test and seq class name.
+  uvm_test: flash_ctrl_base_test
+  uvm_test_seq: flash_ctrl_base_vseq
+
+  // List of test specifications.
+  tests: [
+    {
+      name: flash_ctrl_smoke
+      uvm_test_seq: flash_ctrl_smoke_vseq
+    }
+    {
+      name: flash_ctrl_smoke_hw
+      uvm_test_seq: flash_ctrl_smoke_hw_vseq
+    }
+    {
+      name: flash_ctrl_rand_ops
+      uvm_test_seq: flash_ctrl_rand_ops_vseq
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_sw_op
+      uvm_test_seq: flash_ctrl_sw_op_vseq
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_host_dir_rd
+      uvm_test_seq: flash_ctrl_host_dir_rd_vseq
+      run_opts: ["+zero_delays=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_rd_buff_evict
+      uvm_test_seq: flash_ctrl_rd_buff_evict_vseq
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_phy_arb
+      uvm_test_seq: flash_ctrl_phy_arb_vseq
+      run_opts: ["+zero_delays=1"]
+      reseed: 20
+    }
+    {
+      name: flash_ctrl_hw_sec_otp
+      uvm_test_seq: flash_ctrl_hw_sec_otp_vseq
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_erase_suspend
+      uvm_test_seq: flash_ctrl_erase_suspend_vseq
+      run_opts: ["+zero_delays=1"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_hw_rma
+      uvm_test_seq: flash_ctrl_hw_rma_vseq
+      run_opts: ["+test_timeout_ns=15000000000"]
+      reseed: 3
+    }
+    {
+      name: flash_ctrl_host_ctrl_arb
+      uvm_test_seq: flash_ctrl_host_ctrl_arb_vseq
+      run_opts: ["+zero_delays=1", "+test_timeout_ns=15000000000"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_mp_regions
+      uvm_test_seq: flash_ctrl_mp_regions_vseq
+      run_opts: ["+test_timeout_ns=300000000000"]
+      reseed: 8
+    }
+    {
+      name: flash_ctrl_fetch_code
+      uvm_test_seq: flash_ctrl_fetch_code_vseq
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_full_mem_access
+      uvm_test_seq: flash_ctrl_full_mem_access_vseq
+      run_opts: ["+test_timeout_ns=300000000000"]
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_error_prog_type
+      uvm_test_seq: flash_ctrl_error_prog_type_vseq
+      reseed: 5
+    }
+    {
+      name: flash_ctrl_error_prog_win
+      uvm_test_seq: flash_ctrl_error_prog_win_vseq
+      reseed: 10
+    }
+  ]
+
+  // List of regressions.
+  regressions: [
+    {
+      name: smoke
+      tests: ["flash_ctrl_smoke"]
+    }
+  ]
+}

--- a/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
+++ b/hw/ip/flash_ctrl/dv/flash_ctrl_sim_cfg.hjson
@@ -1,152 +1,18 @@
 // Copyright lowRISC contributors.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
+
+// We want to use a different tool in another flash_ctrl env, but overriding `tool` doesn't work, as
+// it needs to first import all the included hjson to know what to override, but some sim_cfg hjson
+// files depends on the `tool` variable, such as {tool}.hjson.
+// To solve this issue, split out the sim_cfg file into 2 files. the base contains everything except
+// `tool`, the other one includes the base and set the `tool`.
+//
+// In this file, only `tool` can be set. Tests or other configuration should be add in
+// flash_ctrl_base_sim_cfg.hjson.
 {
-  // Name of the sim cfg - typically same as the name of the DUT.
-  name: flash_ctrl
-
-  // Top level dut name (sv module).
-  dut: flash_ctrl
-
-  // Top level testbench name (sv module).
-  tb: tb
-
   // Simulator used to sign off this block
   tool: xcelium
 
-  // Fusesoc core file used for building the file list.
-  fusesoc_core: lowrisc:dv:flash_ctrl_sim:0.1
-
-  // Testplan hjson file.
-  testplan: "{proj_root}/hw/ip/flash_ctrl/data/flash_ctrl_testplan.hjson"
-
-  // Import additional common sim cfg files.
-  import_cfgs: [// Project wide common sim cfg file
-                "{proj_root}/hw/dv/tools/dvsim/common_sim_cfg.hjson",
-                // Config files to get the correct flags for crypto_dpi_prince
-                "{proj_root}/hw/ip/prim/dv/prim_prince/crypto_dpi_prince/crypto_dpi_prince_sim_opts.hjson",
-                // Common CIP test lists
-                "{proj_root}/hw/dv/tools/dvsim/tests/csr_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/mem_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/alert_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/intr_test.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/shadow_reg_errors_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/tl_access_tests.hjson",
-                "{proj_root}/hw/dv/tools/dvsim/tests/stress_tests.hjson"],
-
-  en_build_modes: ["{tool}_crypto_dpi_prince_build_opts"]
-  // Flash references pwrmgr directly, need to reference the top version
-  overrides: [
-    {
-      name: design_level
-      value: "top"
-    }
-  ]
-
-  // Add additional tops for simulation.
-  sim_tops: ["flash_ctrl_bind","flash_ctrl_cov_bind"]
-
-  // Default iterations for all tests - each test entry can override this.
-  reseed: 50
-
-  // Default UVM test and seq class name.
-  uvm_test: flash_ctrl_base_test
-  uvm_test_seq: flash_ctrl_base_vseq
-
-  // List of test specifications.
-  tests: [
-    {
-      name: flash_ctrl_smoke
-      uvm_test_seq: flash_ctrl_smoke_vseq
-    }
-    {
-      name: flash_ctrl_smoke_hw
-      uvm_test_seq: flash_ctrl_smoke_hw_vseq
-    }
-    {
-      name: flash_ctrl_rand_ops
-      uvm_test_seq: flash_ctrl_rand_ops_vseq
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_sw_op
-      uvm_test_seq: flash_ctrl_sw_op_vseq
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_host_dir_rd
-      uvm_test_seq: flash_ctrl_host_dir_rd_vseq
-      run_opts: ["+zero_delays=1"]
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_rd_buff_evict
-      uvm_test_seq: flash_ctrl_rd_buff_evict_vseq
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_phy_arb
-      uvm_test_seq: flash_ctrl_phy_arb_vseq
-      run_opts: ["+zero_delays=1"]
-      reseed: 20
-    }
-    {
-      name: flash_ctrl_hw_sec_otp
-      uvm_test_seq: flash_ctrl_hw_sec_otp_vseq
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_erase_suspend
-      uvm_test_seq: flash_ctrl_erase_suspend_vseq
-      run_opts: ["+zero_delays=1"]
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_hw_rma
-      uvm_test_seq: flash_ctrl_hw_rma_vseq
-      run_opts: ["+test_timeout_ns=15000000000"]
-      reseed: 3
-    }
-    {
-      name: flash_ctrl_host_ctrl_arb
-      uvm_test_seq: flash_ctrl_host_ctrl_arb_vseq
-      run_opts: ["+zero_delays=1", "+test_timeout_ns=15000000000"]
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_mp_regions
-      uvm_test_seq: flash_ctrl_mp_regions_vseq
-      run_opts: ["+test_timeout_ns=300000000000"]
-      reseed: 8
-    }
-    {
-      name: flash_ctrl_fetch_code
-      uvm_test_seq: flash_ctrl_fetch_code_vseq
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_full_mem_access
-      uvm_test_seq: flash_ctrl_full_mem_access_vseq
-      run_opts: ["+test_timeout_ns=300000000000"]
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_error_prog_type
-      uvm_test_seq: flash_ctrl_error_prog_type_vseq
-      reseed: 5
-    }
-    {
-      name: flash_ctrl_error_prog_win
-      uvm_test_seq: flash_ctrl_error_prog_win_vseq
-      reseed: 10
-    }
-  ]
-
-  // List of regressions.
-  regressions: [
-    {
-      name: smoke
-      tests: ["flash_ctrl_smoke"]
-    }
-  ]
+  import_cfgs: ["{proj_root}/hw/ip/flash_ctrl/dv/flash_ctrl_base_sim_cfg.hjson"]
 }


### PR DESCRIPTION
We want to use xcelium in open-source flash, while using another tool in
close source. See #12483

But tool can't be overridden. As we need to import all hjson before we
do the override, but one of the hjson file is {tool}.hjson, it causes a
chicken-egg problem.
split out a base hjson file which doesn't specify tool, to solve this problem.

Signed-off-by: Weicai Yang <weicai@google.com>