### PR TITLE
[dif/otp_ctrl] add DIF to check if a partition digest is computed

### DIFF
--- a/sw/device/lib/dif/dif_otp_ctrl.h
+++ b/sw/device/lib/dif/dif_otp_ctrl.h
@@ -521,6 +521,24 @@ dif_result_t dif_otp_ctrl_dai_digest(const dif_otp_ctrl_t *otp,
                                      uint64_t digest);
 
 /**
+ * Checks if the digest value for the given partition has been computed. Once a
+ * digest has been computed for a partition, the partition is write-locked
+ * (additionally, read-locked if the partition is secret).
+ *
+ * The lifecycle partition does not have a digest, and checking if this region
+ * has a computed digest will return an error.
+ *
+ * @param otp An OTP handle.
+ * @param partition The partition to check the digest of.
+ * @param[out] is_computed Indicates if the digest has been computed.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_otp_ctrl_is_digest_computed(const dif_otp_ctrl_t *otp,
+                                             dif_otp_ctrl_partition_t partition,
+                                             bool *is_computed);
+
+/**
  * Gets the buffered digest value for the given partition.
  *
  * Note that this value is only updated when the device is reset; if the digest

--- a/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
+++ b/sw/device/lib/dif/dif_otp_ctrl_unittest.cc
@@ -496,6 +496,40 @@ TEST_F(DaiDigestTest, NullArgs) {
                                             /*digest=*/0xabcdef0000abcdef));
 }
 
+class IsDigestComputed : public OtpTest {};
+
+TEST_F(IsDigestComputed, NullArgs) {
+  bool is_computed;
+  EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
+      nullptr, kDifOtpCtrlPartitionSecret2, &is_computed));
+  EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
+      &otp_, kDifOtpCtrlPartitionSecret2, nullptr));
+  EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
+      nullptr, kDifOtpCtrlPartitionSecret2, nullptr));
+}
+
+TEST_F(IsDigestComputed, BadPartition) {
+  bool is_computed;
+  EXPECT_DIF_BADARG(dif_otp_ctrl_is_digest_computed(
+      &otp_, kDifOtpCtrlPartitionLifeCycle, &is_computed));
+}
+
+TEST_F(IsDigestComputed, Success) {
+  bool is_computed;
+
+  EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0x98abcdef);
+  EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0xabcdef01);
+  EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
+      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+  EXPECT_TRUE(is_computed);
+
+  EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_1_REG_OFFSET, 0);
+  EXPECT_READ32(OTP_CTRL_SECRET2_DIGEST_0_REG_OFFSET, 0);
+  EXPECT_DIF_OK(dif_otp_ctrl_is_digest_computed(
+      &otp_, kDifOtpCtrlPartitionSecret2, &is_computed));
+  EXPECT_FALSE(is_computed);
+}
+
 struct DigestParams {
   dif_otp_ctrl_partition_t partition;
   ptrdiff_t reg0, reg1;


### PR DESCRIPTION
This adds a DIF to check if the partition's digest has been computed,
and therefore, determine if a partition has been write-locked.

This fixes #12588.

Signed-off-by: Timothy Trippel <ttrippel@google.com>