### PR TITLE
[otbn,util] Extend OTBN information-flow analysis to handle cyclic control flow.

### DIFF
--- a/hw/ip/otbn/util/analyze_information_flow.py
+++ b/hw/ip/otbn/util/analyze_information_flow.py
@@ -50,6 +50,13 @@ def main() -> int:
     if args.verbose:
         print('Control-flow graph:')
         print(graph.pretty(program, indent=2))
+        cycle_pcs = graph.get_cycle_starts()
+        if cycle_pcs:
+            print('Control flow has cycles starting at the following PCs:')
+            for pc in cycle_pcs:
+                symbols = program.get_symbols_for_pc(pc)
+                label_str = ' <{}>'.format(', '.join(symbols)) if symbols else ''
+                print('{:#x}{}'.format(pc, label_str))
 
     # Compute information-flow graph(s).
     if args.subroutine is None:

--- a/hw/ip/otbn/util/analyze_information_flow.py
+++ b/hw/ip/otbn/util/analyze_information_flow.py
@@ -55,7 +55,8 @@ def main() -> int:
             print('Control flow has cycles starting at the following PCs:')
             for pc in cycle_pcs:
                 symbols = program.get_symbols_for_pc(pc)
-                label_str = ' <{}>'.format(', '.join(symbols)) if symbols else ''
+                label_str = ' <{}>'.format(
+                    ', '.join(symbols)) if symbols else ''
                 print('{:#x}{}'.format(pc, label_str))
 
     # Compute information-flow graph(s).

--- a/hw/ip/otbn/util/shared/constants.py
+++ b/hw/ip/otbn/util/shared/constants.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional
 
 from .insn_yaml import Insn
 from .operand import RegOperandType
@@ -47,11 +47,12 @@ class ConstantContext:
     def __contains__(self, gpr: str) -> bool:
         return gpr in self.values
 
-    def __deepcopy__(self, memo) -> 'ConstantContext':
+    def __deepcopy__(self, memo: Optional[Dict[int,
+                                               Any]]) -> 'ConstantContext':
         return ConstantContext(deepcopy(self.values, memo))
 
-    def includes(self, other: 'ConstantContext') -> 'ConstantContext':
-        '''Returns true iff self contains all key/value pairs in other.'''
+    def includes(self, other: 'ConstantContext') -> bool:
+        '''Returns true iff other is a restriction of self.'''
         for k, v in other.values.items():
             if self.get(k) != v:
                 return False
@@ -78,7 +79,6 @@ class ConstantContext:
         for reg in to_remove:
             if reg != 'x0':
                 self.values.pop(reg, None)
-
 
     def update_insn(self, insn: Insn, op_vals: Dict[str, int]) -> None:
         '''Updates to new known constant values GPRs after the instruction.

--- a/hw/ip/otbn/util/shared/information_flow.py
+++ b/hw/ip/otbn/util/shared/information_flow.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from copy import deepcopy
-from typing import Dict, Iterable, List, Optional, Sequence, Set
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Set
 
 from serialize.parse_helpers import check_keys, check_list, check_str
 
@@ -202,11 +202,12 @@ class InformationFlowGraph:
 
         return InformationFlowGraph(flow)
 
-    def __deepcopy__(self, memo):
+    def __deepcopy__(self,
+                     memo: Optional[Dict[int, Any]]) -> 'InformationFlowGraph':
         flow = deepcopy(self.flow, memo)
         return InformationFlowGraph(flow, self.exists)
 
-    def loop(self, max_iterations=1000) -> 'InformationFlowGraph':
+    def loop(self, max_iterations: int = 1000) -> 'InformationFlowGraph':
         '''Returns graph representing all possible repetitions of seq() of this
         graph with itself.
 
@@ -224,7 +225,7 @@ class InformationFlowGraph:
         stabilized), which is only guaranteed to happen if the node set is
         finite. By default, an error will be produced after a certain maximum
         number of iterations, but the caller can override this by setting
-        `max_iterations` to None. 
+        `max_iterations` to None.
 
         Returns a new graph; the input graph is unmodified.
         '''
@@ -243,10 +244,9 @@ class InformationFlowGraph:
             ctr += 1
 
         raise RuntimeError(
-                'Maximum number of iterations ({}) exceeded when looping '
-                'information-flow graph. Is the set of possible nodes larger '
-                'than the maximum iterations?'
-                .format(max_iterations))
+            'Maximum number of iterations ({}) exceeded when looping '
+            'information-flow graph. Is the set of possible nodes larger '
+            'than the maximum iterations?'.format(max_iterations))
 
     def pretty(self, indent: int = 0) -> str:
         '''Return a human-readable representation of the graph.'''
@@ -268,12 +268,14 @@ class InformationFlowGraph:
                                                sink))
         return '\n'.join(lines)
 
-    def __eq__(self, other: 'InformationFlowGraph') -> bool:
+    def __eq__(self, other: object) -> bool:
         '''Compare two information flow graphs for equality.
 
         Two graphs are considered equal iff the underlying flow dictionaries
         are equal.
         '''
+        if not isinstance(other, InformationFlowGraph):
+            return False
         return self.flow == other.flow
 
 

--- a/hw/ip/otbn/util/shared/information_flow_analysis.py
+++ b/hw/ip/otbn/util/shared/information_flow_analysis.py
@@ -3,6 +3,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+from copy import deepcopy
 from typing import Dict, List, Optional, Set, Tuple
 
 from .cache import Cache, CacheEntry
@@ -25,14 +26,18 @@ from .insn_yaml import Insn
 #   constants:      known constants that are in common between all "return"
 #                   iflow paths (i.e. the constants that a caller can always
 #                   rely on)
+#   cycles:         TODO: document
 #   control deps:   a dictionary whose keys are the information-flow nodes
 #                   whose values at the start PC influence the control flow of
 #                   the program; the value is a set of PCs of control-flow
 #                   instructions through which the node influences the control
 #                   flow
-IFlowResult = Tuple[Set[str], InformationFlowGraph, InformationFlowGraph,
-                    ConstantContext, Dict[str, Set[int]]]
-
+IFlowResult = Tuple[Set[str],
+                    InformationFlowGraph,
+                    InformationFlowGraph,
+                    Optional[ConstantContext],
+                    Dict[int,InformationFlowGraph],
+                    Dict[str, Set[int]]]
 
 class IFlowCacheEntry(CacheEntry[ConstantContext, IFlowResult]):
     '''Represents an entry in the cache for _get_iflow.
@@ -45,10 +50,7 @@ class IFlowCacheEntry(CacheEntry[ConstantContext, IFlowResult]):
     should not change.
     '''
     def is_match(self, constants: ConstantContext) -> bool:
-        for k, v in self.key.values.items():
-            if constants.get(k) != v:
-                return False
-        return True
+        return constants.includes(self.key)
 
 
 class IFlowCache(Cache[int, ConstantContext, IFlowResult]):
@@ -158,8 +160,7 @@ def _build_iflow_straightline(
 
         used_constants, insn_iflow = _build_iflow_insn(insn, op_vals, pc,
                                                        constants)
-        for const in used_constants:
-            constant_deps.update(iflow.sources(const))
+        constant_deps.update(iflow.sources_for_any(used_constants))
 
         # Compose iflow with the information flow from this instruction
         iflow = iflow.seq(insn_iflow)
@@ -191,13 +192,13 @@ def _get_iflow_cache_update(pc: int, constants: ConstantContext,
                             result: IFlowResult, cache: IFlowCache) -> None:
     '''Updates the cache for _get_iflow.'''
     used_constants = result[0]
-    used_constant_values = {}
+    used_constant_values = ConstantContext.empty()
     for name in used_constants:
-        assert name in constants
-        used_constant_values[name] = constants.values[name]
+        value = constants.get(name)
+        assert value is not None
+        used_constant_values.set(name, value)
 
-    cache.add(pc, IFlowCacheEntry(ConstantContext(used_constant_values),
-                                  result))
+    cache.add(pc, IFlowCacheEntry(used_constant_values, result))
 
     return
 
@@ -225,30 +226,53 @@ def _update_control_deps(current_deps: Dict[str, Set[int]],
 
 
 def _get_iflow_update_state(
-        rec_result: IFlowResult, iflow: InformationFlowGraph,
-        program_end_iflow: InformationFlowGraph, used_constants: Set[str],
+        rec_result: IFlowResult,
+        iflow: InformationFlowGraph,
+        program_end_iflow: InformationFlowGraph,
+        used_constants: Set[str],
+        constants: ConstantContext,
+        cycles: Dict[int,InformationFlowGraph],
         control_deps: Dict[str, Set[int]]) -> InformationFlowGraph:
     '''Update the internal state of _get_iflow after a recursive call.
 
-    The `used_constants` and `control_deps` state elements are updated in
-    place, but the new `program_end_iflow` is returned. The `iflow` input is
-    not modified.
+    `iflow` is not modified.
+    `program_end_iflow` is updated in-place.
+    `used_constants` is updated in-place.
+    `constants` is updated in-place.
+    `cycles` is updated in-place.
+    `control_deps` is updated in-place.
+
+    The new information-flow graph for paths ending in a return to the caller
+    (return_iflow) is composed with `iflow` and returned. The caller will
+    likely need to adjust `iflow` using this value, but how varies by use case.
     '''
-    rec_used_constants, _, rec_program_end_iflow, _, rec_control_deps = rec_result
+    rec_used_constants, rec_return_iflow, rec_end_iflow, rec_constants, rec_cycles, rec_control_deps = rec_result
 
     # Update the used constants and control-flow dependencies
-    for const in rec_used_constants:
-        used_constants.update(iflow.sources(const))
+    used_constants.update(iflow.sources_for_any(rec_used_constants))
     _update_control_deps(control_deps, iflow, rec_control_deps)
 
+    # Update the cycles
+    for pc, cycle_iflow in rec_cycles.items():
+        cycles.setdefault(pc, InformationFlowGraph.nonexistent()).update(iflow.seq(cycle_iflow))
+
+    # Update the constants to keep only those that are either unmodified in the
+    # return-path information flow or returned by the recursive call.
+    constants.removemany(rec_return_iflow.all_sinks())
+    if rec_constants is not None:
+        constants.values.update(rec_constants.values)
+
     # Update information flow results for paths where the program ends
-    program_end_iflow.update(iflow.seq(rec_program_end_iflow))
+    program_end_iflow.update(iflow.seq(rec_end_iflow))
 
-    return program_end_iflow
+    return iflow.seq(rec_return_iflow)
 
 
-def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
-               start_constants: ConstantContext, loop_end_pc: Optional[int],
+def _get_iflow(program: OTBNProgram,
+               graph: ControlGraph,
+               start_pc: int,
+               start_constants: ConstantContext,
+               loop_end_pc: Optional[int],
                cache: IFlowCache) -> IFlowResult:
     '''Gets the information-flow graphs for paths starting at start_pc.
 
@@ -266,7 +290,7 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     if cached is not None:
         return cached
 
-    constants = start_constants.copy()
+    constants = deepcopy(start_constants)
 
     # The combined information flow for all paths leading to the end of the
     # subroutine (i.e. a RET, not counting RETS that happen after jumps within
@@ -282,6 +306,15 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     # flow (and the PCs of the control-flow instructions they influence)
     control_deps: Dict[str, Set[int]] = {}
 
+    # Cycle starts that are accessible from this PC.
+    cycles: Dict[int,InformationFlowGraph] = {}
+
+    # If this PC is the start of a cycle, then initialize the information flow
+    # for the cycle with an empty graph (since doing nothing is a valid
+    # traversal of the cycle). 
+    if start_pc in graph.get_cycle_starts():
+        cycles[start_pc] = InformationFlowGraph.empty()
+
     section = graph.get_section(start_pc)
     edges = graph.get_edges(start_pc)
 
@@ -290,7 +323,6 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     # end of the loop like a RET instruction.
     if loop_end_pc is not None and loop_end_pc in section:
         assert loop_end_pc == section.end
-        loop_end_pc = None
         edges = [Ret()]
 
     # Get the information flow, used constants, and known constants at the end
@@ -309,8 +341,7 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
         last_insn, last_op_vals, section.end, constants)
 
     # Update used constants to include last instruction
-    for const in last_insn_used_constants:
-        used_constants.update(iflow.sources(const))
+    used_constants.update(last_insn_iflow.sources_for_any(last_insn_used_constants))
 
     # Update control_deps to include last instruction
     last_insn_control_deps = {
@@ -323,49 +354,35 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     iflow = iflow.seq(last_insn_iflow)
 
     if last_insn.mnemonic in ['loopi', 'loop']:
-        # Special handling for loops; reject non-constant #iterations, and run
-        # loop body #iterations times
-        iterations = _get_constant_loop_iterations(last_insn, last_op_vals,
-                                                   constants)
-        if iterations is None:
-            raise ValueError(
-                'LOOP instruction on a register that is not a '
-                'known constant at PC {:#x} (known constants: {}). If '
-                'the register is in fact a constant, you may need to '
-                'add constant-tracking support for more instructions.'.format(
-                    section.end, constants.values.keys()))
-
         # A loop instruction should result in exactly one edge of type
         # LoopStart; check that assumption before we rely on it
         assert len(edges) == 1 and isinstance(edges[0], LoopStart)
         body_loc = edges[0]
 
+        # Try to get the number of loop iterations.
+        iterations = _get_constant_loop_iterations(last_insn, last_op_vals,
+                                                   constants)
+
         # Update the constants to include the loop instruction
         constants.update_insn(last_insn, last_op_vals)
 
-        # Recursive calls for each iteration
-        for _ in range(iterations):
-            body_result = _get_iflow(program, graph, body_loc.loop_start_pc,
-                                     constants, body_loc.loop_end_pc, cache)
+        if iterations is not None:
+            # If the number of iterations is constant, perform recursive calls
+            # for each iteration
+            for _ in range(iterations):
+                body_result = _get_iflow(program, graph, body_loc.loop_start_pc,
+                                         constants, body_loc.loop_end_pc, cache)
 
-            # Update program_end_iflow, used constants, and control_deps
-            program_end_iflow = _get_iflow_update_state(
-                body_result, iflow, program_end_iflow, used_constants,
-                control_deps)
+                iflow = _get_iflow_update_state(
+                    body_result, iflow, program_end_iflow, used_constants, constants, cycles, control_deps)
 
-            # Update constants and get information flow for paths that loop
-            # back to the start ("return")
-            _, body_return_iflow, _, constants, _ = body_result
+            # Set the next edges to the instruction after the loop ends
+            edges = [ControlLoc(body_loc.loop_end_pc + 4)]
 
-            # Compose current iflow with the flow for paths that hit the end of
-            # the loop
-            iflow = iflow.seq(body_return_iflow)
-
-        # Set the next edges to the instruction after the loop ends
-        edges = [ControlLoc(body_loc.loop_end_pc + 4)]
     elif last_insn.mnemonic == 'jal' and last_op_vals['grd'] == 1:
         # Special handling for jumps; recursive call for jump destination, then
         # continue at pc+4
+        constants.update_insn(last_insn, last_op_vals)
 
         # Jumps should produce exactly one non-special edge; check that
         # assumption before we rely on it
@@ -373,15 +390,15 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
         jump_loc = edges[0]
         jump_result = _get_iflow(program, graph, jump_loc.pc, constants, None,
                                  cache)
-
-        # Update program_end_iflow, used constants, and control_deps
-        program_end_iflow = _get_iflow_update_state(jump_result, iflow,
+        iflow = _get_iflow_update_state(jump_result, iflow,
                                                     program_end_iflow,
                                                     used_constants,
+                                                    constants,
+                                                    cycles,
                                                     control_deps)
 
-        # Update constants and get information flow for return paths
-        _, jump_return_iflow, _, constants, _ = jump_result
+        # Get information flow for return paths
+        _, jump_return_iflow, _, _, _, _ = jump_result
 
         # Compose current iflow with the flow for the jump's return paths
         iflow = iflow.seq(jump_return_iflow)
@@ -399,11 +416,9 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
         if isinstance(loc, Ecall) or isinstance(loc, ImemEnd):
             # Ecall or ImemEnd nodes are expected to be the only edge
             assert len(edges) == 1
-            # Clear common constants; there are no return branches here
-            common_constants = ConstantContext.empty()
             program_end_iflow.update(iflow)
         elif isinstance(loc, Ret):
-            if loop_end_pc is not None:
+            if loop_end_pc is not None and loop_end_pc != section.end:
                 raise RuntimeError(
                     'RET before end of loop at PC {:#x} (loop end PC: '
                     '{:#x})'.format(section.end, loop_end_pc))
@@ -412,46 +427,80 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
             # Since this is the only edge, common_constants must be unset
             common_constants = constants
             return_iflow.update(iflow)
-        elif isinstance(loc, LoopStart) or isinstance(loc, LoopEnd):
-            # We shouldn't hit a loop instances here; those cases (a loop
-            # instruction or the end of a loop) are all handled earlier
-            raise RuntimeError(
-                'Unexpected loop edge (type {}) at PC {:#x}'.format(
-                    type(loc), section.end))
-        elif not loc.is_special():
+        elif isinstance(loc, Cycle):
+            # Add the flow from start PC to this cyclic PC to the existing
+            # flow, if any.
+            cycles.setdefault(loc.pc, InformationFlowGraph.nonexistent()).update(iflow)
+        elif isinstance(loc, LoopStart) or not loc.is_special():
             # Just a normal PC; recurse
             result = _get_iflow(program, graph, loc.pc, constants, loop_end_pc,
                                 cache)
 
-            # Update program_end_iflow, used constants, and control_deps
-            program_end_iflow = _get_iflow_update_state(
-                result, iflow, program_end_iflow, used_constants, control_deps)
-
-            # Get information flow for return paths and new constants
-            _, rec_return_iflow, _, rec_constants, _ = result
+            # Defensively copy constants so they don't cross between branches
+            local_constants = deepcopy(constants)
+            rec_return_iflow = _get_iflow_update_state(
+                result, iflow, program_end_iflow, used_constants, local_constants, cycles, control_deps)
 
             # Take values on which existing and recursive constants agree
             if common_constants is None:
-                common_constants = rec_constants
+                common_constants = local_constants
             else:
-                common_constants.intersect(rec_constants)
+                common_constants.intersect(local_constants)
 
-            #  Update return_iflow with the current iflow composed with return
-            #  paths
-            return_iflow.update(iflow.seq(rec_return_iflow))
+            # Update return_iflow with the current iflow composed with return
+            # paths
+            return_iflow.update(rec_return_iflow)
         else:
             raise RuntimeError(
                 'Unexpected next control location type at PC {:#x}: {}'.format(
                     section.end, type(loc)))
 
-    # There should be at least one edge, and all edges should set
-    # common_constants to some non-None value
-    assert common_constants is not None
-
     # Update used_constants to include any constant dependencies of
     # common_constants, since common_constants will be cached
-    used_constants.update(
-        return_iflow.sources_for_any(common_constants.values.keys()))
+    if common_constants is not None:
+        used_constants.update(return_iflow.sources_for_any(common_constants.values.keys()))
+
+    # If this PC is the start of one of the cycles we're currently processing,
+    # see if it can be finalized.
+    if start_pc in cycles:
+        cycle_iflow = cycles[start_pc]
+
+        # Find which constants are "stable" (unmodified throughout all paths in
+        # the cycle)
+        stable_constants = ConstantContext.empty()
+        for k, v in start_constants.values.items():
+            if k not in cycle_iflow.all_sinks():
+                stable_constants.set(k, v)
+
+        # If any start constants were modified during the cycle; do a recursive
+        # call with only the unmodified constants, and return that. 
+        if not stable_constants.includes(start_constants):
+            return _get_iflow(program, graph, start_pc, stable_constants, loop_end_pc, cache)
+
+        # If all starting constants were stable, just loop() the information
+        # flow graph for this cycle to get the combined flow for all paths that
+        # cycle back to this point (including no cycling, i.e. the empty graph).
+        cycle_iflow = cycle_iflow.loop()
+
+        # The final information flow for all paths is the graph of any valid
+        # traversals of the cycle, sequentially composed with the return or
+        # end-program paths from here.
+        return_iflow  = cycle_iflow.seq(return_iflow)
+        program_end_iflow = cycle_iflow.seq(program_end_iflow)
+        for pc in cycles:
+            if pc == start_pc:
+                continue
+            cycles[pc] = cycle_iflow.seq(cycles[pc])
+
+        # Control-flow dependencies must also be updated to include the
+        # dependencies stemming from any valid traversal of the cycle
+        new_control_deps = {}
+        _update_control_deps(new_control_deps, cycle_iflow, control_deps)
+        control_deps = new_control_deps
+
+
+        # Remove this cycle from the cycles dict, since it is now resolved.
+        del cycles[start_pc]
 
     # Strip special register x0 from both sources and sinks of graphs returned.
     return_iflow.remove_source('x0')
@@ -461,30 +510,10 @@ def _get_iflow(program: OTBNProgram, graph: ControlGraph, start_pc: int,
     control_deps.pop('x0', None)
 
     # Update the cache and return
-    out = (used_constants, return_iflow, program_end_iflow, common_constants,
+    out = (used_constants, return_iflow, program_end_iflow, common_constants, cycles,
            control_deps)
     _get_iflow_cache_update(start_pc, start_constants, out, cache)
     return out
-
-
-def check_acyclic(graph: ControlGraph) -> None:
-    '''Checks for (non LOOP/LOOPI) cycles in control-flow graph.
-
-    If there are such cycles, we need to raise an error and not proceed; the
-    control-flow traversal would infinite-loop.
-    '''
-    cycles = graph.get_cycles(graph.start)
-    if cycles:
-        msg = [
-            'One or more cycles found in control-flow graph at the following PCs:'
-        ]
-        for pc, links in cycles.items():
-            msg.append('{:#x} <-> {}'.format(
-                pc, ','.join(['{:#x}'.format(link) for link in links])))
-        msg.append('Analyzing cyclic control flow outside of LOOP/LOOPI '
-                   'instructions is not currently supported.')
-        raise ValueError('\n'.join(msg))
-    return
 
 
 def get_subroutine_iflow(program: OTBNProgram, graph: ControlGraph,
@@ -500,10 +529,14 @@ def get_subroutine_iflow(program: OTBNProgram, graph: ControlGraph,
     3. The information-flow nodes whose values at the start of the subroutine
        influence its control flow.
     '''
-    check_acyclic(graph)
     start_pc = program.get_pc_at_symbol(subroutine_name)
-    _, ret_iflow, end_iflow, _, control_deps = _get_iflow(
+    _, ret_iflow, end_iflow, _, cycles, control_deps = _get_iflow(
         program, graph, start_pc, ConstantContext.empty(), None, IFlowCache())
+    if cycles:
+        for pc in cycles:
+            print(cycles[pc].pretty())
+            print('---')
+        raise RuntimeError('Unresolved cycles; start PCs: {}'.format(', '.join(['{:#x}'.format(pc) for pc in cycles.keys()])))
     if not (ret_iflow.exists or end_iflow.exists):
         raise ValueError('Could not find any complete control-flow paths when '
                          'analyzing subroutine.')
@@ -520,10 +553,10 @@ def get_program_iflow(program: OTBNProgram,
     2. The information-flow nodes whose values at the start of the subroutine
        influence its control flow.
     '''
-    check_acyclic(graph)
-    _, ret_iflow, end_iflow, _, control_deps = _get_iflow(
-        program, graph, program.min_pc(), ConstantContext.empty(), None,
-        IFlowCache())
+    _, ret_iflow, end_iflow, _, cycles, control_deps = _get_iflow(
+        program, graph, program.min_pc(), ConstantContext.empty(), None, IFlowCache())
+    if cycles:
+        raise RuntimeError('Unresolved cycles; start PCs: {}'.format(', '.join(['{:#x}'.format(k) for k in cycles.keys()])))
     if ret_iflow.exists:
         # No paths from imem_start should end in RET
         raise ValueError('Unexpected information flow for paths ending in RET '


### PR DESCRIPTION
This is the promised follow-up to #12487.

### Context

In https://github.com/lowRISC/opentitan/pull/10128, I introduced some scripts that analyze information-flow in OTBN code and check if code is constant-time with respect to secret values. But they had limitations, especially regarding "cyclical" control-flow. The analysis pretty much just handled loops by unfolding them, so loops with a non-constant number of iterations couldn't be reasoned about. The analysis also followed both branches for `beq` and `bne` instructions, which meant that it needed to error out if it detected branch cycles that could cause an infinite loop (such as the [GCD computation](https://github.com/lowRISC/opentitan/blob/8fef8b556d338e38808105b3a183b94e347ef9c8/sw/otbn/crypto/p256.s#L1345) in `p256_verify`, which is mathematically guaranteed to terminate but is hard for the static analysis to predict).

This PR removes that limitation -- `p256_verify` and non-constant loops work just fine now! The core technical parts of this code are the `loop()` method on information-flow graphs and new the cycle-handling pass in `get_iflow`, which are discussed below in more detail.

### Cyclic information flow

Determining information flow through a cyclical control-flow graph is a little tricky. For example, let's say I have a loop that does something like this:
```
tmp = a
a = b
b = b + tmp
```
After one iteration, the final value of `a` depends on the initial value of `b`, and the final value of `b` depends on the initial values of `a` and `b`. (We'll assume for simplicity that we're not interested in analyzing `tmp` here.)  As an information-flow graph, that one-iteration flow would look like:
```
b -> a
a, b -> b
```
However, if the loop ran for 0 iterations, we'd have a no-op information flow graph where each final value depended only on its own initial value, like this:
```
a -> a
b -> b
```
And if the loop ran for two iterations, we'd have a different graph too:
```
a, b -> a
a, b -> b
```
(Because the initial value of `a` influences the value of `b` after 1 iteration, in subsequent iterations the value of `a` also depends on the initial value of `a`.)

We have to somehow present the union of all these possible scenarios. This actually ends up quite neat algorithmically, and is implemented as the `loop()` method on information-flow graphs in this PR, which takes a 1-iteration information flow graph and turns it into a union of all possible numbers of iterations, including 0. The algorithm works something like this:
1. Initialize a variable `graph` to the "empty" graph, which represents 0 iterations. Every node depends only on itself.
2. Use sequential composition (the `seq()` method) to get the information flow for `graph` plus 1 additional iteration.
3. Use the `update()` method to take the union of information flow from `graph` and `graph`-plus-1-iteration.
4. Check if the `update()` did anything. If not, then the graph has stabilized and future iterations will also not change it; return `graph`. If so, then repeat steps 2-4.

#### Tracking constants

One complex part of handling this type of control flow is the constant-tracking. OTBN code involves a lot of indirectly referencing wide registers (WDRs) using GPRs. For example, the code below sets `x2 = 1` in order to load data into the wide register `w1`.
https://github.com/lowRISC/opentitan/blob/8fef8b556d338e38808105b3a183b94e347ef9c8/sw/otbn/crypto/p256.s#L1743-L1745

If you want to analyze information flow between wide registers, you therefore need to keep track of which GPR values you know to be constants, and update their values as needed. This was included in the original design. However, it gets very tricky with cyclical control flow; for a simple example, if a loop increments a constant register on every iteration, but the number of iterations is not constant, then the register can't be considered constant after the loop.

To resolve this, we look for constants that are "stable", i.e. they are not modified at all during any path through the cycle. However, in order to tell if they're modified, we need information flow, which requires us to resolve indirect references, which could depend on constants, creating a bit of a circular dependency chain. So, first we analyze the cycle with whatever constant-state holds in the first iteration. Then, if any of those starting constants are non-stable in the course of the cycle, we remove them from the list of starting constants and repeat the analysis + constant-removal as many times as necessary until we have an analysis that depends only on stable constants. (This is guaranteed to terminate because there are a finite number of registers, and on every retry we remove at least one from the starting constants.) 

CC @felixmiller 