### PR TITLE
[otbn,iss] Fix URND ISS vs RTL timing

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/wsr.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/wsr.py
@@ -228,6 +228,8 @@ class URNDWSR(WSR):
     def set_seed(self, value: List[int]) -> None:
         self.running = True
         self.state[0] = value
+        # Step immediately to update the internal state with the new seed
+        self.step()
 
     def step(self) -> None:
         if self.running:


### PR DESCRIPTION
Due to a recent functional change RTL URND was one step ahead of ISS.
This fixes it so they remain in sync.

Fixes #12563

Signed-off-by: Greg Chadwick <gac@lowrisc.org>