### PR TITLE
[dv/aes] Do not bind to interface when unavailable

### DIFF
--- a/hw/ip/aes/dv/sva/aes_bind.sv
+++ b/hw/ip/aes/dv/sva/aes_bind.sv
@@ -51,6 +51,7 @@ module aes_bind;
                             u_aes_control_fsm.block_ctr_expr)
   );
 
+if (`EN_MASKING) begin : gen_prng_bind
   bind aes_prng_masking aes_masking_reseed_if u_aes_masking_reseed_if (
     .clk_i        (clk_i),
     .rst_ni       (rst_ni),
@@ -63,4 +64,5 @@ module aes_bind;
     .lfsr_q_3     (gen_lfsrs[3].u_lfsr_chunk.lfsr_q),
     .lfsr_q_4     (gen_lfsrs[4].u_lfsr_chunk.lfsr_q)
   );
+end
 endmodule


### PR DESCRIPTION
- make sure the prng interface bind only happens when the
  module is actually there.
- partially addresses #12575

Signed-off-by: Timothy Chen <timothytim@google.com>