### PR TITLE
[opentitantool] Make the verilator startup time configurable 

### DIFF
--- a/sw/host/opentitanlib/BUILD
+++ b/sw/host/opentitanlib/BUILD
@@ -80,6 +80,7 @@ rust_library(
         "src/transport/ultradebug/spi.rs",
         "src/transport/ultradebug/uart.rs",
         "src/transport/verilator/mod.rs",
+        "src/transport/verilator/stdout.rs",
         "src/transport/verilator/subprocess.rs",
         "src/transport/verilator/transport.rs",
         "src/transport/verilator/uart.rs",

--- a/sw/host/opentitanlib/src/backend/verilator.rs
+++ b/sw/host/opentitanlib/src/backend/verilator.rs
@@ -2,10 +2,13 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::Result;
+use humantime::parse_duration;
+use std::time::Duration;
+use structopt::StructOpt;
+
 use crate::transport::verilator::{Options, Verilator};
 use crate::transport::Transport;
-use anyhow::Result;
-use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 pub struct VerilatorOpts {
@@ -21,6 +24,9 @@ pub struct VerilatorOpts {
 
     #[structopt(long, required = false)]
     verilator_args: Vec<String>,
+
+    #[structopt(long, parse(try_from_str=parse_duration), default_value="60s", help = "Verilator startup timeout")]
+    verilator_timeout: Duration,
 }
 
 pub fn create(args: &VerilatorOpts) -> Result<Box<dyn Transport>> {
@@ -30,6 +36,7 @@ pub fn create(args: &VerilatorOpts) -> Result<Box<dyn Transport>> {
         flash_image: args.verilator_flash.clone(),
         otp_image: args.verilator_otp.clone(),
         extra_args: args.verilator_args.clone(),
+        timeout: args.verilator_timeout.clone(),
     };
     Ok(Box::new(Verilator::from_options(options)?))
 }

--- a/sw/host/opentitanlib/src/transport/verilator/mod.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+mod stdout;
 pub mod subprocess;
 pub mod transport;
 pub mod uart;

--- a/sw/host/opentitanlib/src/transport/verilator/stdout.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/stdout.rs
@@ -1,0 +1,45 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::io::Read;
+use std::process::ChildStdout;
+use std::sync::{Arc, Mutex};
+
+// The whole point of this module being named `stdout.rs` is so that the log message
+// looks like `[<timestamp> INFO ...verilator::stdout] <message>`.
+
+// Accumulates output from verilator's `stdout`.
+pub fn accumulate(stdout: ChildStdout, accumulator: Arc<Mutex<String>>) {
+    if let Err(e) = worker(stdout, accumulator) {
+        log::error!("accumulate error: {:?}", e);
+    }
+}
+
+fn worker(mut stdout: ChildStdout, accumulator: Arc<Mutex<String>>) -> Result<()> {
+    let mut s = String::default();
+    loop {
+        read(&mut stdout, &mut s)?;
+        let mut lines = s.split('\n').collect::<Vec<&str>>();
+        let next = if !s.ends_with('\n') {
+            // If we didn't read a complete line at the end, save it for the
+            // next read.
+            lines.pop()
+        } else {
+            None
+        };
+        for line in lines {
+            log::info!("{}", line);
+        }
+        accumulator.lock().unwrap().push_str(&s);
+        s = next.unwrap_or("").to_string();
+    }
+}
+
+fn read(stdout: &mut ChildStdout, s: &mut String) -> Result<()> {
+    let mut buf = [0u8; 256];
+    let n = stdout.read(&mut buf)?;
+    s.push_str(&String::from_utf8_lossy(&buf[..n]));
+    Ok(())
+}

--- a/sw/host/opentitanlib/src/transport/verilator/transport.rs
+++ b/sw/host/opentitanlib/src/transport/verilator/transport.rs
@@ -4,11 +4,10 @@
 
 use anyhow::{ensure, Result};
 use lazy_static::lazy_static;
-use log::info;
 use regex::Regex;
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::time::Duration;
+use std::time::Instant;
 
 use crate::io::uart::Uart;
 use crate::transport::verilator::subprocess::{Options, Subprocess};
@@ -45,17 +44,18 @@ impl Verilator {
                 Regex::new(r#"GPIO: FIFO pipes created at [^ ]+ \(read\) and ([^ ]+) \(write\) for 32-bit wide GPIO."#).unwrap();
         }
 
+        let deadline = Instant::now() + options.timeout;
         let mut subprocess = Subprocess::from_options(options)?;
-        let gpio_rd = subprocess.find(&GPIO_RD, Duration::from_secs(5))?;
-        let gpio_wr = subprocess.find(&GPIO_WR, Duration::from_secs(5))?;
-        let uart = subprocess.find(&UART, Duration::from_secs(5))?;
-        let spi = subprocess.find(&SPI, Duration::from_secs(5))?;
+        let gpio_rd = subprocess.find(&GPIO_RD, deadline)?;
+        let gpio_wr = subprocess.find(&GPIO_WR, deadline)?;
+        let uart = subprocess.find(&UART, deadline)?;
+        let spi = subprocess.find(&SPI, deadline)?;
 
-        info!("Verilator started with the following interaces:");
-        info!("gpio_read = {}", gpio_rd);
-        info!("gpio_write = {}", gpio_wr);
-        info!("uart = {}", uart);
-        info!("spi = {}", spi);
+        log::info!("Verilator started with the following interaces:");
+        log::info!("gpio_read = {}", gpio_rd);
+        log::info!("gpio_write = {}", gpio_wr);
+        log::info!("uart = {}", uart);
+        log::info!("spi = {}", spi);
         Ok(Verilator {
             subprocess: Some(subprocess),
             uart_file: uart,


### PR DESCRIPTION
1. Spawn a thread to consume and log the verilator stdout.
2. Add a `--verilator_timeout` parameter to control how long to wait
   for the verilator subprocess to start.  Set the default value to
   60 seconds.

Signed-off-by: Chris Frantz <cfrantz@google.com>