### PR TITLE
[flash_ctrl] Add covergroup and check for fifo eviction test

### DIFF
--- a/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
+++ b/hw/ip/flash_ctrl/dv/env/flash_ctrl_env_cov.sv
@@ -8,7 +8,9 @@
  * Covergroups may also be wrapped inside helper classes if needed.
  */
 
-class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
+class flash_ctrl_env_cov extends cip_base_env_cov #(
+  .CFG_T(flash_ctrl_env_cfg)
+);
   `uvm_component_utils(flash_ctrl_env_cov)
 
   // the base class provides the following handles for use:
@@ -17,17 +19,22 @@ class flash_ctrl_env_cov extends cip_base_env_cov #(.CFG_T(flash_ctrl_env_cfg));
   // covergroups
 
   covergroup control_cg with function sample (flash_op_t flash_cfg_opts);
-    part_cp : coverpoint flash_cfg_opts.partition;
-    erase_cp : coverpoint flash_cfg_opts.erase_type;
-    op_cp : coverpoint flash_cfg_opts.op;
+    part_cp: coverpoint flash_cfg_opts.partition;
+    erase_cp: coverpoint flash_cfg_opts.erase_type;
+    op_cp: coverpoint flash_cfg_opts.op;
+    op_evict_cp: coverpoint flash_cfg_opts.op {
+      bins op[] = {FlashOpRead, FlashOpProgram, FlashOpErase};
+      bins read_prog_read = (FlashOpRead => FlashOpProgram => FlashOpRead);
+      bins read_erase_read = (FlashOpRead => FlashOpErase => FlashOpRead);
+    }
     op_part_cross : cross part_cp, op_cp;
-  endgroup // control_cg
+  endgroup  // control_cg
 
   covergroup erase_susp_cg with function sample (bit erase_req = 0);
-    erase_susp_cp : coverpoint erase_req {
+    erase_susp_cp: coverpoint erase_req {
       bins erase_susp_true = {1};
     }
-  endgroup // erase_susp_cg
+  endgroup  // erase_susp_cg
 
   function new(string name, uvm_component parent);
     super.new(name, parent);

--- a/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
+++ b/hw/ip/flash_ctrl/dv/env/seq_lib/flash_ctrl_rd_buff_evict_vseq.sv
@@ -135,9 +135,9 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
   data_4s_t all_ones = {TL_DW{1'b1}};
 
   task body();
-
+    int func_cov_op;
     //enable polling of fifo status for frontdoor write and read
-    poll_fifo_status = 1;
+    poll_fifo_status           = 1;
 
     // Default region settings
     default_region_read_en     = MuBi4True;
@@ -147,7 +147,7 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
     default_region_scramble_en = MuBi4False;
 
     // Scoreboard knob
-    cfg.block_host_rd = 1;
+    cfg.block_host_rd          = 1;
 
     // Configure the flash with scramble disable.
     foreach (mp_regions[k]) begin
@@ -384,6 +384,16 @@ class flash_ctrl_rd_buff_evict_vseq extends flash_ctrl_base_vseq;
 
     // make sure that controller read data is all ones
     check_all_ones_ctrl();
+
+    // checking coverpoints for state transitions
+    if (cfg.en_cov) begin
+      func_cov_op = cov.control_cg.op_evict_cp.get_inst_coverage();
+      if (func_cov_op == 100) begin
+        `uvm_info(`gfn, $sformatf("Coverage READ/PROGRAM(ERASE)/READ reached!"), UVM_LOW)
+      end else begin
+        `uvm_error(`gfn, $sformatf("Coverage READ/PROGRAM(ERASE)/READ not reached!"))
+      end
+    end
 
   endtask : body
 


### PR DESCRIPTION
Add covergrup for fifo evict test. Add checks in fifo evict test that
coverage is reached within test.

Signed-off-by: Nikola Miladinovic <nikola.miladinovic@ensilica.com>