### PR TITLE
[otbn,rtl] Fix timing of locking signal from controller

### DIFF
--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -285,12 +285,14 @@ module otbn_controller
 
   logic [4:0] insn_bignum_rd_addr_a_q, insn_bignum_rd_addr_b_q, insn_bignum_wr_addr_q;
 
-  logic secure_wipe_running_q;
+  logic secure_wipe_running_q, secure_wipe_running_d;
+  assign secure_wipe_running_d = (start_secure_wipe_o |
+                                  (secure_wipe_running_q & ~secure_wipe_done_i));
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       secure_wipe_running_q <= 1'b0;
     end else begin
-      secure_wipe_running_q <= start_secure_wipe_o | (secure_wipe_running_q & ~secure_wipe_done_i);
+      secure_wipe_running_q <= secure_wipe_running_d;
     end
   end
 
@@ -319,7 +321,7 @@ module otbn_controller
   assign executing = (state_q == OtbnStateRun) ||
                      (state_q == OtbnStateStall);
 
-  assign locking_o = (state_d == OtbnStateLocked) & ~(start_secure_wipe_o | secure_wipe_running_q);
+  assign locking_o = (state_d == OtbnStateLocked) & ~secure_wipe_running_d;
   assign start_secure_wipe_o = executing & (done_complete | err) & ~secure_wipe_running_q;
 
   assign jump_or_branch = (insn_valid_i &


### PR DESCRIPTION
Commit 2aa877f *still* didn't quite get the timing of the locking
signal right. It squashed the single-cycle glitch at the start of the
secure wipe, but left another one at the end. This simple patch sorts
things out at both ends.

Note that there's an open PR at the moment (#12599) which switches the signalling between otbn_controller and otbn_start_stop_control to a proper req/ack interface. My guess is that might take a bit of time to review before it lands properly, so I propose to get this bugfix in now and rebase that PR on this.