### PR TITLE
[dv/chip] Move a checking to common testutils file

### DIFF
--- a/sw/device/lib/testing/lc_ctrl_testutils.c
+++ b/sw/device/lib/testing/lc_ctrl_testutils.c
@@ -30,3 +30,14 @@ bool lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl) {
       return false;
   }
 }
+
+void lc_ctrl_testutils_check_transition_count(const dif_lc_ctrl_t *lc_ctrl,
+                                              uint8_t exp_lc_count) {
+  LOG_INFO("Read LC count and check with expect_val=%0d", exp_lc_count);
+  uint8_t lc_count;
+  CHECK(dif_lc_ctrl_get_attempts(lc_ctrl, &lc_count) == kDifOk,
+        "Read lc_count register failed!");
+  CHECK(lc_count == exp_lc_count,
+        "LC_count error, expected %0d but actual count is %0d", exp_lc_count,
+        lc_count);
+}

--- a/sw/device/lib/testing/lc_ctrl_testutils.h
+++ b/sw/device/lib/testing/lc_ctrl_testutils.h
@@ -18,4 +18,13 @@
  */
 bool lc_ctrl_testutils_debug_func_enabled(const dif_lc_ctrl_t *lc_ctrl);
 
+/**
+ * Check if Lifecycle Controller count number is expected.
+ *
+ * This function will read out lc_transition_cnt register and check the value
+ * against exp_lc_count value.
+ */
+void lc_ctrl_testutils_check_transition_count(const dif_lc_ctrl_t *lc_ctrl,
+                                              uint8_t exp_lc_count);
+
 #endif  // OPENTITAN_SW_DEVICE_LIB_TESTING_LC_CTRL_TESTUTILS_H_

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -114,6 +114,7 @@ cc_library(
         "//sw/device/lib/base:mmio",
         "//sw/device/lib/dif:lc_ctrl",
         "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:lc_ctrl_testutils",
         "//sw/device/lib/testing/test_framework:check",
     ],
 )

--- a/sw/device/tests/sim_dv/meson.build
+++ b/sw/device/tests/sim_dv/meson.build
@@ -119,6 +119,7 @@ lc_ctrl_transition_test_impl_lib = declare_dependency(
       sw_lib_mmio,
       sw_lib_runtime_hart,
       sw_lib_runtime_log,
+      sw_lib_testing_lc_ctrl_testutils,
       top_earlgrey,
     ],
   ),


### PR DESCRIPTION
This PR moves the `check_lc_state_transition_count` task to the common
`lc_ctrl_testuitls` file so that it can be used by other tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>