### PR TITLE
[spi_device] Skeleton of PageProgram test in Passthrough

### DIFF
--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_host.sv
@@ -83,6 +83,10 @@ program prog_passthrough_host
         test_wel(subtask_pass);
       end
 
+      "program": begin
+        test_program(subtask_pass);
+      end
+
       default: begin
         $display("Passthrough test requires '+TESTNAME=%%s'");
       end
@@ -329,6 +333,15 @@ program prog_passthrough_host
     end
 
   endtask : test_wel
+
+  static task test_program(output bit pass);
+
+    // Test sequence:
+    // Issue commands w/ random WEL
+    // It is expected for SW to catch program and upload to Mailbox buffer.
+    // Read from SPIFlash and from Mailbox buffer then compare
+
+  endtask : test_program
 
   // Access to Mirrored storage
   function automatic void write_byte(int unsigned addr, spi_data_t data);

--- a/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
+++ b/hw/ip/spi_device/pre_dv/program/prog_passthrough_sw.sv
@@ -104,6 +104,17 @@ program prog_passthrough_sw
       4'b 0001
     );
 
+    // FILTER
+    // Read STATUS filtered.
+    // WREN/ WRDI go through as no SPI_HOST IP in TB yet.
+    // PROGRAM/ BLOCK ERASE go through as same reason as WREN/ WRDI
+    tlul_write(
+      clk, h2d, d2h,
+      32'(spi_device_reg_pkg::SPI_DEVICE_CMD_FILTER_0_OFFSET),
+      32'h 0000_0020, // [5] := 1
+      4'b 1111
+    );
+
     // CMD_INFO
     init_cmdinfo_list();
 

--- a/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
+++ b/hw/ip/spi_device/pre_dv/spid_passthrough_sim_cfg.hjson
@@ -34,6 +34,15 @@
         "+TESTNAME=wel"
       ]
     }
+    {
+      name: spid_passthrough_program
+      // WEL + PageProgram test
+      // Randomly issue Program with/without WEL, then check if the values are
+      // written or not by reading them back.
+      run_opts: [
+        "+TESTNAME=program"
+      ]
+    }
   ]
 
   regressions: [
@@ -41,7 +50,8 @@
       name: smoke
       tests: [
         "spid_passthrough_readbasic",
-        "spid_passthrough_addr4b"
+        "spid_passthrough_addr4b",
+        "spid_passthrough_wel"
       ]
     }
     {

--- a/hw/ip/spi_device/pre_dv/tb/spid_common.sv
+++ b/hw/ip/spi_device/pre_dv/tb/spid_common.sv
@@ -1072,7 +1072,7 @@ package spid_common;
     h2d.a_data    = wdata;
     h2d.a_mask    = wstrb;
     h2d.a_param   = '0;
-    h2d.a_size    = 2;
+    h2d.a_size    = $clog2($countones(wstrb));
     h2d.a_source  = '0;
 
     h2d.d_ready   = 1'b 0;


### PR DESCRIPTION

This commit adds `test_program` to the passthrough pre_dv.

It currently has skeleton only. Does not have Host and SW sequence yet.
But it implements the SPIFlash program behavior and adds random delay to
imitate SPI Flash's Program Latency (not to the Byte Program level).
