### PR TITLE
[bazel] Add infrastructure for linking in external test hooks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -67,6 +67,17 @@ riscv_compliance_repos()
 load("//rules:bitstreams.bzl", "bitstreams_repo")
 bitstreams_repo(name = "bitstreams")
 
+# Setup for linking in external test hooks.
+load("//rules:hooks_setup.bzl", "hooks_setup")
+hooks_setup(
+    name = "hooks_setup",
+    dummy = "sw/device/tests/closed_source",
+)
+
+# Declare the external test_hooks repository.
+load("@hooks_setup//:repos.bzl", "hooks_repo")
+hooks_repo(name = "test_hooks")
+
 # The nonhermetic_repo imports environment variables needed to run vivado.
 load("//rules:nonhermetic.bzl", "nonhermetic_repo")
 nonhermetic_repo(name = "nonhermetic")

--- a/rules/hooks_setup.bzl
+++ b/rules/hooks_setup.bzl
@@ -15,7 +15,7 @@ exports_files(glob(["**"]))
 """
 
 def _hooks_setup_impl(rctx):
-    hooks_dir = rctx.os.environ.get("CLOSED_SOURCE_HOOKS", rctx.attr.dummy)
+    hooks_dir = rctx.os.environ.get("MANUFACTURER_HOOKS_DIR", rctx.attr.dummy)
     rctx.file("repos.bzl", _TEMPLATE.format(hooks_dir = hooks_dir))
     rctx.file("BUILD.bazel", _BUILD)
 
@@ -27,5 +27,5 @@ hooks_setup = repository_rule(
             doc = "Location of the dummy hooks directory.",
         ),
     },
-    environ = ["CLOSED_SOURCE_HOOKS"],
+    environ = ["MANUFACTURER_HOOKS_DIR"],
 )

--- a/rules/hooks_setup.bzl
+++ b/rules/hooks_setup.bzl
@@ -1,0 +1,31 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+_TEMPLATE = """
+def hooks_repo(name):
+    native.local_repository(
+        name = name,
+        path = "{hooks_dir}",
+    )
+"""
+
+_BUILD = """
+exports_files(glob(["**"]))
+"""
+
+def _hooks_setup_impl(rctx):
+    hooks_dir = rctx.os.environ.get("CLOSED_SOURCE_HOOKS", rctx.attr.dummy)
+    rctx.file("repos.bzl", _TEMPLATE.format(hooks_dir = hooks_dir))
+    rctx.file("BUILD.bazel", _BUILD)
+
+hooks_setup = repository_rule(
+    implementation = _hooks_setup_impl,
+    attrs = {
+        "dummy": attr.string(
+            mandatory = True,
+            doc = "Location of the dummy hooks directory.",
+        ),
+    },
+    environ = ["CLOSED_SOURCE_HOOKS"],
+)

--- a/sw/device/lib/testing/test_framework/ottf_main.c
+++ b/sw/device/lib/testing/test_framework/ottf_main.c
@@ -63,18 +63,18 @@ static void report_test_status(bool result) {
   test_status_set(result ? kTestStatusPassed : kTestStatusFailed);
 }
 
-OT_WEAK bool closed_source_pre_test_hook(void) { return true; }
+OT_WEAK bool manufacturer_pre_test_hook(void) { return true; }
 
-OT_WEAK bool closed_source_post_test_hook(void) { return true; }
+OT_WEAK bool manufacturer_post_test_hook(void) { return true; }
 
 // A wrapper function is required to enable `test_main()` and test teardown
 // logic to be invoked as a FreeRTOS task. This wrapper can be used by tests
 // that are run on bare-metal.
 static void test_wrapper(void *task_parameters) {
   // Invoke weak symbol that can be overriden in closed source code.
-  bool result = closed_source_pre_test_hook();
+  bool result = manufacturer_pre_test_hook();
 
-  result = result && test_main() && closed_source_post_test_hook();
+  result = result && test_main() && manufacturer_post_test_hook();
   report_test_status(result);
 }
 

--- a/sw/device/tests/closed_source/BUILD.bazel
+++ b/sw/device/tests/closed_source/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    # The name is the label that will be used to refer to this library.
+    # Tests will use the full label `@test_hooks//:ip_config_hooks`.
+    name = "ip_config_hooks",
+
+    # `srcs` is a list of source files and private header files.
+    srcs = [
+        "sample_hooks.c",
+    ],
+
+    # `hdrs` is a list of public header files for this library.
+    hdrs = [],
+
+    # `deps` is a list of dependencies for this library.  You may use
+    # any library from the main opentitan repo; just prefix the label
+    # with `@lowrisc_opentitan`.
+    #
+    # Any dependencies local to this repo can simply start with `//`.
+    deps = [
+        "@lowrisc_opentitan//sw/device/lib/runtime:log",
+    ],
+
+    # We use alwayslink to force the symbols exported by this library to
+    # override any weak symbols provided by targets in `@lowrisc_opentitan`.
+    alwayslink = True,
+)

--- a/sw/device/tests/closed_source/WORKSPACE.bazel
+++ b/sw/device/tests/closed_source/WORKSPACE.bazel
@@ -1,0 +1,13 @@
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+workspace(name = "test_hooks")
+
+# This is a sample workspace to demonstrate how to write test hooks for
+# the OpenTitan Test Framework (ottf).  This bazel repository is not
+# a stand-alone project: it must be connected into the main OpenTitan
+# repository by way of the `hooks_setup` call in OpenTitan's WORKSPACE file.
+
+# See this repository's BUILD.bazel file to understand how to write rules
+# for the test hooks.

--- a/sw/device/tests/closed_source/sample_hooks.c
+++ b/sw/device/tests/closed_source/sample_hooks.c
@@ -1,0 +1,23 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stddef.h>
+
+#include "sw/device/lib/runtime/log.h"
+
+bool closed_source_pre_test_hook(void) {
+  // LOG_INFO("open_source_pre_test_hook");
+
+  // Perform whatever pre-test setup needs to be done.
+  // Return true if successful, false if unsuccessful.
+  return true;
+}
+
+bool closed_source_post_test_hook(void) {
+  // LOG_INFO("open_source_post_test_hook");
+
+  // Perform whatever post-test teardown needs to be done.
+  // Return true if successful, false if unsuccessful.
+  return true;
+}

--- a/sw/device/tests/closed_source/sample_hooks.c
+++ b/sw/device/tests/closed_source/sample_hooks.c
@@ -6,7 +6,7 @@
 
 #include "sw/device/lib/runtime/log.h"
 
-bool closed_source_pre_test_hook(void) {
+bool manufacturer_pre_test_hook(void) {
   // LOG_INFO("open_source_pre_test_hook");
 
   // Perform whatever pre-test setup needs to be done.
@@ -14,7 +14,7 @@ bool closed_source_pre_test_hook(void) {
   return true;
 }
 
-bool closed_source_post_test_hook(void) {
+bool manufacturer_post_test_hook(void) {
   // LOG_INFO("open_source_post_test_hook");
 
   // Perform whatever post-test teardown needs to be done.


### PR DESCRIPTION
1. Define a `hooks_setup` repo that can point either to a dummy `test_hooks`
   repository or to a manufacturer-provided repository.  The `hooks_setup`
   repo writes out a configuration file (`repos.bzl`) which points to the
   manufacturer supplied repository.
2. Add a dummy `test_hooks` repository with do-nothing hooks.  This repo
   serves as an example to manufacturers and as a source of empty hooks
   so tests which need hooks can always have a `@test_hooks//...` label
   in their `deps` and will be supplied with empty functions when external
   test hooks are not in use.
3. Rename `closed_source` hooks as `manufacturer` hooks.  Specify the
   location of hooks with the `MANUFACTURER_HOOKS_DIR` environment
   variable.

Signed-off-by: Chris Frantz <cfrantz@google.com>