### PR TITLE
[usbdev] Minor lint fix

### DIFF
--- a/hw/ip/usbdev/rtl/usbdev.sv
+++ b/hw/ip/usbdev/rtl/usbdev.sv
@@ -777,7 +777,7 @@ module usbdev
   prim_ram_2p_async_adv #(
     .Depth (SramDepth),
     .Width (SramDw),    // 32 x 512 --> 2kB
-    .DataBitsPerMask(SramDw),
+    .DataBitsPerMask(8),
 
     .EnableECC           (0), // No Protection
     .EnableParity        (0),


### PR DESCRIPTION
For some reason AscentLint complains that the wdata signals are unconnected if the `DataBitsPerMask` parameter is set to `SramDw`. Since we do not use the mask anyways, there is no harm in setting this to 8 instead - and that makes the errors go away.

Signed-off-by: Michael Schaffner <msf@google.com>