### PR TITLE
[ast] Fix Lint, Latches syntax, & Registers numbers (32->39)

### DIFF
--- a/hw/top_earlgrey/ip/ast/ast.core
+++ b/hw/top_earlgrey/ip/ast/ast.core
@@ -21,6 +21,7 @@ filesets:
       - lowrisc:prim:mubi
       - lowrisc:ip:lc_ctrl_pkg
       - lowrisc:ip:edn_pkg
+      - lowrisc:ip_interfaces:alert_handler_reg
       - lowrisc:ip:rstmgr_pkg
       - lowrisc:systems:clkmgr_pkg
     files:
@@ -120,6 +121,5 @@ targets:
       - files_rtl
     tools:
       vcs:
-        vcs_options: [-timescale=1ns/1ps -l vcs.log]
+        vcs_options: [-sverilog -ntb_opts uvm-1.2 -CFLAGS --std=c99 -CFLAGS -fno-extended-identifiers -CFLAGS --std=c++11 -timescale=1ns/1ps -l vcs.log]
     toplevel: ast
-

--- a/hw/top_earlgrey/ip/ast/data/ast.hjson
+++ b/hw/top_earlgrey/ip/ast/data/ast.hjson
@@ -464,6 +464,104 @@
         },
       ],
     }, //----------------------------------------------------------------------
+    { name: "REGA31",
+      desc: "AST 31 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x1F",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA32",
+      desc: "AST 32 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x20",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA33",
+      desc: "AST 33 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x21",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA34",
+      desc: "AST 34 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x22",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA35",
+      desc: "AST 35 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x23",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA36",
+      desc: "AST 36 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x24",
+        },
+      ],
+    }, //----------------------------------------------------------------------
+    { name: "REGA37",
+      desc: "AST 37 Register for OTP/ROM Write Testing",
+      swaccess: "rw",
+      hwaccess: "hro",
+      tags: [ // don't write random data to any of the AST registers
+	      "excl:CsrAllTests:CsrExclWrite" ],
+      fields: [
+        { bits: "31:0",
+          name: "reg32",
+          desc: "32-bit Register",
+          resval: "0x25",
+        },
+      ],
+    }, //----------------------------------------------------------------------
     { name: "REGAL",
       desc: "AST Last Register for OTP/ROM Write Testing",
       swaccess: "wo",
@@ -476,7 +574,7 @@
         { bits: "31:0",
           name: "reg32",
           desc: "32-bit Register",
-          resval: "0x1F",
+          resval: "0x26",
         },
       ],
     }, //----------------------------------------------------------------------

--- a/hw/top_earlgrey/ip/ast/doc/ast_regs.html
+++ b/hw/top_earlgrey/ip/ast/doc/ast_regs.html
@@ -2,7 +2,7 @@
  table.regpic {
   width: 95%;
   border-collapse: collapse;
-  margin-left:auto; 
+  margin-left:auto;
   margin-right:auto;
   table-layout:fixed;
  }
@@ -10,7 +10,7 @@
   border: 1px solid black;
   width: 80%;
   border-collapse: collapse;
-  margin-left:auto; 
+  margin-left:auto;
   margin-right:auto;
   table-layout:auto;
  }
@@ -495,11 +495,11 @@
 </tr></table></td></tr>
 <tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1e</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
 <br>
-<table class="regdef" id="Reg_regal">
+<table class="regdef" id="Reg_rega31">
  <tr>
   <th class="regdef" colspan=5>
-   <div>ast.REGAL @ 0x7c</div>
-   <div><p>AST Last Register for OTP/ROM Write Testing</p></div>
+   <div>ast.REGA31 @ 0x7c</div>
+   <div><p>AST 31 Register for OTP/ROM Write Testing</p></div>
    <div>Reset default = 0x1f, mask 0xffffffff</div>
   </th>
  </tr>
@@ -507,7 +507,105 @@
 </tr>
 <tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
 </tr></table></td></tr>
-<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">wo</td><td class="regrv">0x1f</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x1f</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega32">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA32 @ 0x80</div>
+   <div><p>AST 32 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x20, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x20</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega33">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA33 @ 0x84</div>
+   <div><p>AST 33 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x21, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x21</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega34">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA34 @ 0x88</div>
+   <div><p>AST 34 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x22, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x22</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega35">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA35 @ 0x8c</div>
+   <div><p>AST 35 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x23, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x23</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega36">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA36 @ 0x90</div>
+   <div><p>AST 36 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x24, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x24</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_rega37">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGA37 @ 0x94</div>
+   <div><p>AST 37 Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x25, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">rw</td><td class="regrv">0x25</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
+<br>
+<table class="regdef" id="Reg_regal">
+ <tr>
+  <th class="regdef" colspan=5>
+   <div>ast.REGAL @ 0x98</div>
+   <div><p>AST Last Register for OTP/ROM Write Testing</p></div>
+   <div>Reset default = 0x26, mask 0xffffffff</div>
+  </th>
+ </tr>
+<tr><td colspan=5><table class="regpic"><tr><td class="bitnum">31</td><td class="bitnum">30</td><td class="bitnum">29</td><td class="bitnum">28</td><td class="bitnum">27</td><td class="bitnum">26</td><td class="bitnum">25</td><td class="bitnum">24</td><td class="bitnum">23</td><td class="bitnum">22</td><td class="bitnum">21</td><td class="bitnum">20</td><td class="bitnum">19</td><td class="bitnum">18</td><td class="bitnum">17</td><td class="bitnum">16</td></tr><tr><td class="fname" colspan=16>reg32...</td>
+</tr>
+<tr><td class="bitnum">15</td><td class="bitnum">14</td><td class="bitnum">13</td><td class="bitnum">12</td><td class="bitnum">11</td><td class="bitnum">10</td><td class="bitnum">9</td><td class="bitnum">8</td><td class="bitnum">7</td><td class="bitnum">6</td><td class="bitnum">5</td><td class="bitnum">4</td><td class="bitnum">3</td><td class="bitnum">2</td><td class="bitnum">1</td><td class="bitnum">0</td></tr><tr><td class="fname" colspan=16>...reg32</td>
+</tr></table></td></tr>
+<tr><th width=5%>Bits</th><th width=5%>Type</th><th width=5%>Reset</th><th>Name</th><th>Description</th></tr><tr><td class="regbits">31:0</td><td class="regperm">wo</td><td class="regrv">0x26</td><td class="regfn">reg32</td><td class="regde"><p>32-bit Register</p></td></table>
 <br>
 <table class="regdef" id="Reg_regb_0">
  <tr>

--- a/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/aon_osc.sv
@@ -29,8 +29,9 @@ initial init_start = 1'b0;
 
 initial begin
   if ( !$value$plusargs("osc200k_freq_multiplier=%f", ckmul) ) ckmul = 1.0;
-
-  #1; init_start = 1'b1;
+  #1;
+  init_start = 1'b1;
+  #1;
   $display("\n%m: AON Base Clock Power-up Frequency: %0d Hz", $rtoi(10**9/(CLK_PERIOD*ckmul)));
   $display("%m: AON %0.1fxBase Clock Power-up Frequency: %0d Hz", ckmul, $rtoi(10**9/CLK_PERIOD));
 end
@@ -64,7 +65,7 @@ logic en_osc;
 logic en_clk, clk;
 
 always_latch begin
-  if ( !clk_osc ) en_clk <= en_osc;
+  if ( !clk_osc ) en_clk = en_osc;
 end
 
 assign clk = clk_osc && en_clk;

--- a/hw/top_earlgrey/ip/ast/rtl/ast.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast.sv
@@ -123,7 +123,7 @@ module ast #(
   input [8-1:0] fla_obs_i,                    // FLASH Observe Bus
   input [8-1:0] otp_obs_i,                    // OTP Observe Bus
   input [8-1:0] otm_obs_i,                    // OT Modules Observe Bus
-  input usb_obs_i,                            // USB DIFF RX Observe
+  input usb_obs_i,                            // USB DIFF RX Observe  //JL TODO
   output ast_pkg::ast_obs_ctrl_t obs_ctrl_o,  // Observe Control
 
   // pad mux/pad related
@@ -162,7 +162,6 @@ module ast #(
 import ast_pkg::* ;
 import ast_reg_pkg::* ;
 import ast_bhv_pkg::* ;
-
 
 logic scan_mode, shift_en, scan_reset_n;
 logic vcc_pok, vcc_pok_h, vcc_pok_str;
@@ -218,12 +217,13 @@ assign vcc_pok_h = vcc_pok;     // "Level Shifter"
 ////////////////////////////////////////
 // VCAON POK (Always ON)
 ///////////////////////////////////////
-logic rst_poks_n, rst_poks_por_n;
-
-assign rst_poks_n = scan_mode ? scan_reset_n : vcc_pok_str && vcaon_pok;
-assign rst_poks_por_n = scan_mode ? scan_reset_n : vcc_pok_str && vcaon_pok && por_ni;
-
+logic rst_poks_n, rst_poks_por_n, por_sync_n;
 logic vcaon_pok_por_src, vcaon_pok_por_lat, poks_por_ack, rglssm_vcmon, rglssm_brout;
+
+// assign rst_poks_n = scan_mode ? scan_reset_n : vcc_pok_str && vcaon_pok;
+// assign rst_poks_por_n = scan_mode ? scan_reset_n : vcc_pok_str && vcaon_pok && por_ni;
+assign rst_poks_n = vcc_pok_str && vcaon_pok;
+assign rst_poks_por_n = vcc_pok_str && vcaon_pok && por_ni;
 
 assign poks_por_ack = vcaon_pok_por_src || rglssm_vcmon;
 
@@ -231,47 +231,48 @@ assign poks_por_ack = vcaon_pok_por_src || rglssm_vcmon;
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_poks_por_dasrt (
+) u_no_scan_poks_por_dasrt (
   .clk_i ( clk_aon ),
   .rst_ni ( rst_poks_por_n ),
   .d_i ( poks_por_ack ),
   .q_o ( vcaon_pok_por_src )
 );
 
-// Replace Latch for the OS code
-assign vcaon_pok_por_lat = rglssm_brout || vcaon_pok_por_src;
-
-assign vcaon_pok_por = scan_mode ? scan_reset_n : vcaon_pok_por_lat;
-assign ast_pwst_o.aon_pok = vcaon_pok_por;
-
 logic clk_aon_n;
+
 prim_clock_inv #(
-  .HasScanMode(0)
-) u_prim_clock_inv (
-  .clk_i     (clk_aon),
-  .scanmode_i(1'b0),
-  .clk_no    (clk_aon_n)
+  .HasScanMode ( 1 )
+) u_clk_aon_inv (
+  .clk_i ( clk_aon ),
+  .scanmode_i ( scan_mode ),
+  .clk_no ( clk_aon_n )
 );
 
-logic por_sync_n;
+prim_flop #(
+  .Width ( 1 ),
+  .ResetValue ( 1'b0 )
+) u_no_scan_por_sync_n (
+  .clk_i ( clk_aon_n ),
+  .rst_ni ( rst_poks_n ),
+  .d_i ( vcaon_pok_por_src ),
+  .q_o ( por_sync_n )
+);
 
-always_ff @( posedge clk_aon_n, negedge rst_poks_n ) begin
-  if ( !rst_poks_n ) begin
-    por_sync_n <= 1'b0;
-  end else begin
-    por_sync_n <= vcaon_pok_por_src;
-  end
-end
+// Replace Latch for the OS code
+assign vcaon_pok_por_lat = rglssm_brout || vcaon_pok_por_src;
+assign ast_pwst_o.aon_pok = vcaon_pok_por_lat;
+assign vcaon_pok_por = scan_mode ? scan_reset_n : vcaon_pok_por_lat;
 
 
 ///////////////////////////////////////
 // VCMAIN POK (Always ON)
 ///////////////////////////////////////
 
-logic rglssm_vmppr;
+logic rglssm_vmppr, vcmain_pok_por_src;
 
-assign vcmain_pok_por = scan_mode ? scan_reset_n : vcaon_pok_por && vcmain_pok && !rglssm_vmppr;
-assign ast_pwst_o.main_pok = vcmain_pok_por;
+assign vcmain_pok_por_src = vcaon_pok_por_lat && vcmain_pok && !rglssm_vmppr;
+assign ast_pwst_o.main_pok = vcmain_pok_por_src;
+assign vcmain_pok_por = scan_mode ? scan_reset_n : vcmain_pok_por_src;
 
 
 ///////////////////////////////////////
@@ -305,8 +306,9 @@ assign ast_pwst_o.io_pok[1] = vcaon_pok && viob_pok;
 ///////////////////////////////////////
 // Regulators & PDM Logic (VCC)
 ///////////////////////////////////////
-
 logic deep_sleep;
+
+// For UPF level shifter generation
 logic [1:0] otp_power_seq;
 
 prim_buf u_otp_power_seq[1:0] (
@@ -316,15 +318,16 @@ prim_buf u_otp_power_seq[1:0] (
 
 rglts_pdm_3p3v u_rglts_pdm_3p3v (
   .vcc_pok_h_i ( vcc_pok_h ),
-  .vcaon_pok_por_h_i ( vcaon_pok_por ),
-  .vcmain_pok_por_h_i ( vcmain_pok_por ),
+  .vcaon_pok_por_h_i ( vcaon_pok_por_src ),
+  .vcmain_pok_por_h_i ( vcmain_pok_por_src ),
   .vio_pok_h_i ( ast_pwst_o.io_pok[1:0] ),
   .clk_src_aon_h_i ( clk_aon ),
   .main_pd_h_ni ( main_pd_ni ),
   .por_sync_h_ni ( por_sync_n ),
   .otp_power_seq_h_i ( otp_power_seq[1:0] ),
   .scan_mode_h_i ( scan_mode ),
-  .scan_reset_h_ni ( scan_reset_n ),
+  .vcaon_supp_i ( vcaon_supp_i ),
+  .vcmain_supp_i ( vcmain_supp_i ),
   .rglssm_vmppr_h_o ( rglssm_vmppr ),
   .rglssm_vcmon_h_o ( rglssm_vcmon ),
   .rglssm_brout_h_o ( rglssm_brout ),
@@ -372,7 +375,7 @@ assign clk_sys_ext = clk_osc_byp_i.sys;
 `endif
 
 sys_clk u_sys_clk (
-  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_strict(clk_src_sys_jen) ),
+  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_loose(clk_src_sys_jen) ),
   .clk_src_sys_en_i ( clk_sys_en ),
   .clk_sys_pd_ni ( clk_sys_pd_n ),
   .rst_sys_clk_ni ( rst_sys_clk_n ),
@@ -639,7 +642,7 @@ ast_entropy #(
   .clk_src_sys_i ( clk_sys ),
   .rst_src_sys_ni ( rst_src_sys_n ),
   .clk_src_sys_val_i ( clk_src_sys_val_o ),
-  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_strict(clk_src_sys_jen) ),
+  .clk_src_sys_jen_i ( prim_mubi_pkg::mubi4_test_true_loose(clk_src_sys_jen) ),
   .entropy_req_o ( entropy_req_o )
 );  // of u_entropy
 
@@ -678,15 +681,16 @@ ast_pkg::ast_dif_t ot3_alert_src;
 ast_pkg::ast_dif_t ot4_alert_src;
 ast_pkg::ast_dif_t ot5_alert_src;
 
+
 // Active Shield (AS)
 ///////////////////////////////////////
 ast_alert u_alert_as (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( as_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[AsSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[AsSel] ),
-  .alert_req_o ( alert_req_o.alerts[AsSel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::AsSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::AsSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::AsSel] )
 );  // u_alert_as
 
 // Clock Glitch (CG)
@@ -695,9 +699,9 @@ ast_alert u_alert_cg (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( cg_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[CgSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[CgSel] ),
-  .alert_req_o ( alert_req_o.alerts[CgSel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::CgSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::CgSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::CgSel] )
 );  // of u_alert_cg
 
 // Glitch Detector (GD)
@@ -706,11 +710,10 @@ ast_alert u_alert_gd (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( gd_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[GdSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[GdSel] ),
-  .alert_req_o ( alert_req_o.alerts[GdSel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::GdSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::GdSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::GdSel] )
 );  // of u_alert_gd
-
 
 // Temprature Sensor High (TS Hi)
 ///////////////////////////////////////
@@ -718,9 +721,9 @@ ast_alert u_alert_ts_hi (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( ts_alert_hi_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[TsHiSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[TsHiSel] ),
-  .alert_req_o ( alert_req_o.alerts[TsHiSel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::TsHiSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::TsHiSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::TsHiSel] )
 );  // of u_alert_ts_hi
 
 // Temprature Sensor Low (TS Lo)
@@ -729,9 +732,9 @@ ast_alert u_alert_ts_lo (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( ts_alert_lo_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[TsLoSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[TsLoSel] ),
-  .alert_req_o ( alert_req_o.alerts[TsLoSel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::TsLoSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::TsLoSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::TsLoSel] )
 );  // of u_alert_ts_lo
 
 // Flash Alert (FLA)
@@ -740,9 +743,9 @@ ast_alert u_alert_fla (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( fla_alert_src_i ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[FlaSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[FlaSel] ),
-  .alert_req_o ( alert_req_o.alerts[FlaSel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::FlaSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::FlaSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::FlaSel] )
 );  // of u_alert_fla
 
 // OTP Alert (OTP)
@@ -751,9 +754,9 @@ ast_alert u_alert_otp (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( otp_alert_src_i ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[OtpSel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[OtpSel] ),
-  .alert_req_o ( alert_req_o.alerts[OtpSel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::OtpSel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::OtpSel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::OtpSel] )
 );  // of u_alert_otp
 
 // Other-0 Alert (OT0)
@@ -762,9 +765,9 @@ ast_alert u_alert_ot0 (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( ot0_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot0Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot0Sel] ),
-  .alert_req_o ( alert_req_o.alerts[Ot0Sel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot0Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot0Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot0Sel] )
 ); // of u_alert_ot0
 
 // Other-1 Alert (OT1)
@@ -773,9 +776,9 @@ ast_alert u_alert_ot1 (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( ot1_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot1Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot1Sel] ),
-  .alert_req_o ( alert_req_o.alerts[Ot1Sel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot1Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot1Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot1Sel] )
 ); // of u_alert_ot1
 
 // Other-2 Alert (OT2)
@@ -806,9 +809,9 @@ ast_alert u_alert_ot4 (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( ot4_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot4Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot4Sel] ),
-  .alert_req_o ( alert_req_o.alerts[Ot4Sel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot4Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot4Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot4Sel] )
 ); // of u_alert_ot4
 
 // Other-5 Alert (OT5)
@@ -817,11 +820,10 @@ ast_alert u_alert_ot5 (
   .clk_i ( clk_ast_alert_i ),
   .rst_ni ( rst_ast_alert_ni ),
   .alert_src_i ( ot5_alert_src ),
-  .alert_trig_i ( alert_rsp_i.alerts_trig[Ot5Sel] ),
-  .alert_ack_i ( alert_rsp_i.alerts_ack[Ot5Sel] ),
-  .alert_req_o ( alert_req_o.alerts[Ot5Sel] )
+  .alert_trig_i ( alert_rsp_i.alerts_trig[ast_pkg::Ot5Sel] ),
+  .alert_ack_i ( alert_rsp_i.alerts_ack[ast_pkg::Ot5Sel] ),
+  .alert_req_o ( alert_req_o.alerts[ast_pkg::Ot5Sel] )
 ); // of u_alert_ot5
-
 assign as_alert_src    = '{p: 1'b0, n: 1'b1};
 assign cg_alert_src    = '{p: 1'b0, n: 1'b1};
 assign gd_alert_src    = '{p: 1'b0, n: 1'b1};
@@ -869,7 +871,7 @@ assign hw2reg.regal.d = regal;
 // REGAL & AST init done indication
 always_ff @( posedge clk_ast_tlul_i, negedge regal_rst_n ) begin
   if ( !regal_rst_n ) begin
-    regal           <= AST_REGAL_RESVAL;
+    regal           <= ast_reg_pkg::AST_REGAL_RESVAL;
     ast_init_done_o <= 1'b0;
   end else if ( regal_we ) begin
     regal           <= regal_di;
@@ -1007,8 +1009,6 @@ assign unused_sigs = ^{ clk_ast_usb_i,
                         sns_spi_ext_clk_i,
                         sns_clks_i,
                         sns_rsts_i,
-                        vcaon_supp_i,
-                        vcmain_supp_i,
                         intg_err,
                         shift_en,
                         main_env_iso_en_i,
@@ -1052,6 +1052,13 @@ assign unused_sigs = ^{ clk_ast_usb_i,
                         reg2hw.rega28,
                         reg2hw.rega29,
                         reg2hw.rega30,
+                        reg2hw.rega31,
+                        reg2hw.rega32,
+                        reg2hw.rega33,
+                        reg2hw.rega34,
+                        reg2hw.rega35,
+                        reg2hw.rega36,
+                        reg2hw.rega37,
                         reg2hw.regb   // [0:3]
                       };
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_clks_byp.sv
@@ -41,9 +41,8 @@ module ast_clks_byp (
 
 logic scan_mode_i, scan_reset_ni;
 
-assign scan_mode_i = 1'b0;
+assign scan_mode_i   = 1'b0;
 assign scan_reset_ni = 1'b1;
-
 
 ////////////////////////////////////////
 // Local AON clock buffer
@@ -115,7 +114,7 @@ prim_flop_2sync #(
   .Width ( 1 ),
   // Assume external clock is 96Hhz on reset
   .ResetValue ( 1'b1 )
-) u_ext_freq_is_96m_sync (
+) u_no_scan_ext_freq_is_96m_sync (
   .clk_i ( clk_ext ),
   .rst_ni ( rst_aon_exda_n ),
   .d_i ( ext_freq_is_96m ),
@@ -124,7 +123,7 @@ prim_flop_2sync #(
 
 prim_clock_div #(
   .Divisor( 2 )
-) u_clk_ext_d1ord2 (
+) u_no_scan_clk_ext_d1ord2 (
   .clk_i ( clk_ext ),
   .rst_ni ( rst_aon_exda_n ),
   .step_down_req_i( !ext_freq_is_96m_sync ),
@@ -139,7 +138,7 @@ assign clk_ext_aon_val = 1'b1;  // Always ON clock
 
 prim_clock_div #(
   .Divisor( 240 )
-) u_clk_usb_div240_div (
+) u_no_scan_clk_usb_div240_div (
   .clk_i ( clk_src_ext_usb ),
   .rst_ni ( rst_aon_exda_n ),
   .step_down_req_i( 1'b0 ),
@@ -177,7 +176,7 @@ logic clk_src_sys_en;
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_clk_src_sys_en_sync (
+) u_no_scan_clk_src_sys_en_sync (
   .clk_i ( clk_ext ),
   .rst_ni ( rst_aon_exda_n ),
   .d_i ( clk_src_sys_en_i ),
@@ -204,7 +203,7 @@ logic clk_src_io_en;
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_clk_src_io_en_sync (
+) u_no_scan_clk_src_io_en_sync (
   .clk_i ( clk_ext ),
   .rst_ni ( rst_aon_exda_n ),
   .d_i ( clk_src_io_en_i ),
@@ -231,7 +230,7 @@ logic clk_src_usb_en;
 prim_flop_2sync #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_clk_src_usb_en_sync (
+) u_no_scan_clk_src_usb_en_sync (
   .clk_i ( clk_ext ),
   .rst_ni ( rst_aon_exda_n ),
   .d_i ( clk_src_usb_en_i ),
@@ -254,7 +253,7 @@ prim_clock_gating #(
 ////////////////////////////////////////
 // SW Bypass select logic
 ////////////////////////////////////////
-// Sync to local AON clcok
+// Sync to local AON clock
 prim_mubi_pkg::mubi4_t ot_io_clk_byp_req, ot_all_clk_byp_req, ot_ext_freq_is_96m;
 
 prim_mubi4_sync #(
@@ -312,7 +311,7 @@ prim_flop #(
 prim_flop #(
   .Width ( 1 ),
   .ResetValue ( 1'b0 )
-) u_no_scan_sw_sys_clk_byp_dgl (
+) u_sw_sys_clk_byp_dgl (
   .clk_i ( clk_aon ),
   .rst_ni ( rst_aon_n ),
   .d_i ( ot_sys_clk_byp ),
@@ -396,7 +395,7 @@ assign extfreq_is_96m = sw_exfr_is_96m;
 logic sys_clk_byp_sel, io_clk_byp_sel, usb_clk_byp_sel, aon_clk_byp_sel;
 
 always_latch begin
-  if (!scan_mode_i) begin
+  if ( !scan_mode_i ) begin
     sys_clk_byp_sel = sys_clk_byp;
     io_clk_byp_sel  = io_clk_byp;
     usb_clk_byp_sel = usb_clk_byp;
@@ -411,20 +410,63 @@ end
 ////////////////////////////////////////
 logic sys_clk_osc_en, io_clk_osc_en, usb_clk_osc_en, aon_clk_osc_en;
 logic sys_clk_byp_en, io_clk_byp_en, usb_clk_byp_en, aon_clk_byp_en;
-
 logic rst_clk_osc_n, rst_clk_ext_n;
+
 assign rst_clk_osc_n = vcaon_pok;
 assign rst_clk_ext_n = vcaon_pok;
+
+logic rst_clk_osc_sys_n, rst_clk_ext_sys_n, rst_clk_osc_io_n, rst_clk_ext_io_n;
+logic rst_clk_osc_usb_n, rst_clk_ext_usb_n, rst_clk_osc_aon_n, rst_clk_ext_aon_n;
+
+prim_buf u_rst_clk_osc_sys (
+  .in_i ( rst_clk_osc_n ),
+  .out_o ( rst_clk_osc_sys_n )
+);
+
+prim_buf u_rst_clk_ext_sys (
+  .in_i ( rst_clk_ext_n ),
+  .out_o ( rst_clk_ext_sys_n )
+);
+
+prim_buf u_rst_clk_osc_io (
+  .in_i ( rst_clk_osc_n ),
+  .out_o ( rst_clk_osc_io_n )
+);
+
+prim_buf u_rst_clk_ext_io (
+  .in_i ( rst_clk_ext_n ),
+  .out_o ( rst_clk_ext_io_n )
+);
+
+prim_buf u_rst_clk_osc_usb (
+  .in_i ( rst_clk_osc_n ),
+  .out_o ( rst_clk_osc_usb_n )
+);
+
+prim_buf u_rst_clk_ext_usb (
+  .in_i ( rst_clk_ext_n ),
+  .out_o ( rst_clk_ext_usb_n )
+);
+
+prim_buf u_rst_clk_osc_aon (
+  .in_i ( rst_clk_osc_n ),
+  .out_o ( rst_clk_osc_aon_n )
+);
+
+prim_buf u_rst_clk_ext_aon (
+  .in_i ( rst_clk_ext_n ),
+  .out_o ( rst_clk_ext_aon_n )
+);
 
 // SYS Clock Bypass Mux
 ////////////////////////////////////////
 gfr_clk_mux2 u_clk_src_sys_sel (
   .clk_osc_i ( clk_osc_sys_i ),
   .clk_osc_val_i ( clk_osc_sys_val_i ),
-  .rst_clk_osc_ni ( rst_clk_osc_n ),
+  .rst_clk_osc_ni ( rst_clk_osc_sys_n ),
   .clk_ext_i ( clk_ext_sys ),
   .clk_ext_val_i ( clk_ext_sys_val ),
-  .rst_clk_ext_ni ( rst_clk_ext_n ),
+  .rst_clk_ext_ni ( rst_clk_ext_sys_n ),
   .ext_sel_i ( sys_clk_byp_sel ),
   .clk_osc_en_o ( sys_clk_osc_en ),
   .clk_ext_en_o ( sys_clk_byp_en ),
@@ -437,10 +479,10 @@ gfr_clk_mux2 u_clk_src_sys_sel (
 gfr_clk_mux2 u_clk_src_io_sel (
   .clk_osc_i ( clk_osc_io_i ),
   .clk_osc_val_i ( clk_osc_io_val_i ),
-  .rst_clk_osc_ni ( rst_clk_osc_n ),
+  .rst_clk_osc_ni ( rst_clk_osc_io_n ),
   .clk_ext_i ( clk_ext_io ),
   .clk_ext_val_i ( clk_ext_io_val ),
-  .rst_clk_ext_ni ( rst_clk_ext_n ),
+  .rst_clk_ext_ni ( rst_clk_ext_io_n ),
   .ext_sel_i ( io_clk_byp_sel ),
   .clk_osc_en_o ( io_clk_osc_en ),
   .clk_ext_en_o ( io_clk_byp_en ),
@@ -453,10 +495,10 @@ gfr_clk_mux2 u_clk_src_io_sel (
 gfr_clk_mux2 u_clk_src_usb_sel (
   .clk_osc_i ( clk_osc_usb_i ),
   .clk_osc_val_i ( clk_osc_usb_val_i ),
-  .rst_clk_osc_ni ( rst_clk_osc_n ),
+  .rst_clk_osc_ni ( rst_clk_osc_usb_n ),
   .clk_ext_i ( clk_ext_usb ),
   .clk_ext_val_i ( clk_ext_usb_val ),
-  .rst_clk_ext_ni ( rst_clk_ext_n ),
+  .rst_clk_ext_ni ( rst_clk_ext_usb_n ),
   .ext_sel_i ( usb_clk_byp_sel ),
   .clk_osc_en_o ( usb_clk_osc_en ),
   .clk_ext_en_o ( usb_clk_byp_en ),
@@ -469,10 +511,10 @@ gfr_clk_mux2 u_clk_src_usb_sel (
 gfr_clk_mux2 u_clk_src_aon_sel (
   .clk_osc_i ( clk_osc_aon_i ),
   .clk_osc_val_i ( clk_osc_aon_val_i ),
-  .rst_clk_osc_ni ( rst_clk_osc_n ),
+  .rst_clk_osc_ni ( rst_clk_osc_aon_n ),
   .clk_ext_i ( clk_ext_aon ),
   .clk_ext_val_i ( clk_ext_aon_val ),
-  .rst_clk_ext_ni ( rst_clk_ext_n ),
+  .rst_clk_ext_ni ( rst_clk_ext_aon_n ),
   .ext_sel_i ( aon_clk_byp_sel ),
   .clk_osc_en_o ( aon_clk_osc_en ),
   .clk_ext_en_o ( aon_clk_byp_en ),
@@ -569,7 +611,7 @@ always_ff @( posedge clk_aon, negedge rst_aon_n ) begin
   if ( !rst_aon_n ) begin
     io_clk_byp_is_48m_src <= 1'b0;
   end else begin
-    io_clk_byp_is_48m_src <= io_clk_byp_sel && io_clk_byp_en && !ext_freq_is_96m;
+    io_clk_byp_is_48m_src <= io_clk_byp_en && !ext_freq_is_96m;
   end
 end
 

--- a/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_pkg.sv
@@ -41,7 +41,7 @@ parameter int unsigned Pad2AstInWidth   = 9;
 // AstRegsNum is the number of AST registers programmed during initialization. It includes
 // the register that marks the finalization of init, which asserts the ast_init_done_o.
 // The offset of this register is represented with the AstLastRegOffset parameter.
-parameter int unsigned AstRegsNum       = 32;
+parameter int unsigned AstRegsNum       = 39;
 parameter int unsigned AstLastRegOffset = (AstRegsNum-1)*4;
 
 // Memories Read-Write Margin Interface

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_pkg.sv
@@ -142,6 +142,34 @@ package ast_reg_pkg;
 
   typedef struct packed {
     logic [31:0] q;
+  } ast_reg2hw_rega31_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega32_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega33_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega34_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega35_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega36_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
+  } ast_reg2hw_rega37_reg_t;
+
+  typedef struct packed {
+    logic [31:0] q;
     logic        qe;
   } ast_reg2hw_regal_reg_t;
 
@@ -155,37 +183,44 @@ package ast_reg_pkg;
 
   // Register -> HW type
   typedef struct packed {
-    ast_reg2hw_rega0_reg_t rega0; // [1184:1153]
-    ast_reg2hw_rega1_reg_t rega1; // [1152:1121]
-    ast_reg2hw_rega2_reg_t rega2; // [1120:1089]
-    ast_reg2hw_rega3_reg_t rega3; // [1088:1057]
-    ast_reg2hw_rega4_reg_t rega4; // [1056:1025]
-    ast_reg2hw_rega5_reg_t rega5; // [1024:993]
-    ast_reg2hw_rega6_reg_t rega6; // [992:961]
-    ast_reg2hw_rega7_reg_t rega7; // [960:929]
-    ast_reg2hw_rega8_reg_t rega8; // [928:897]
-    ast_reg2hw_rega9_reg_t rega9; // [896:865]
-    ast_reg2hw_rega10_reg_t rega10; // [864:833]
-    ast_reg2hw_rega11_reg_t rega11; // [832:801]
-    ast_reg2hw_rega12_reg_t rega12; // [800:769]
-    ast_reg2hw_rega13_reg_t rega13; // [768:737]
-    ast_reg2hw_rega14_reg_t rega14; // [736:705]
-    ast_reg2hw_rega15_reg_t rega15; // [704:673]
-    ast_reg2hw_rega16_reg_t rega16; // [672:641]
-    ast_reg2hw_rega17_reg_t rega17; // [640:609]
-    ast_reg2hw_rega18_reg_t rega18; // [608:577]
-    ast_reg2hw_rega19_reg_t rega19; // [576:545]
-    ast_reg2hw_rega20_reg_t rega20; // [544:513]
-    ast_reg2hw_rega21_reg_t rega21; // [512:481]
-    ast_reg2hw_rega22_reg_t rega22; // [480:449]
-    ast_reg2hw_rega23_reg_t rega23; // [448:417]
-    ast_reg2hw_rega24_reg_t rega24; // [416:385]
-    ast_reg2hw_rega25_reg_t rega25; // [384:353]
-    ast_reg2hw_rega26_reg_t rega26; // [352:321]
-    ast_reg2hw_rega27_reg_t rega27; // [320:289]
-    ast_reg2hw_rega28_reg_t rega28; // [288:257]
-    ast_reg2hw_rega29_reg_t rega29; // [256:225]
-    ast_reg2hw_rega30_reg_t rega30; // [224:193]
+    ast_reg2hw_rega0_reg_t rega0; // [1408:1377]
+    ast_reg2hw_rega1_reg_t rega1; // [1376:1345]
+    ast_reg2hw_rega2_reg_t rega2; // [1344:1313]
+    ast_reg2hw_rega3_reg_t rega3; // [1312:1281]
+    ast_reg2hw_rega4_reg_t rega4; // [1280:1249]
+    ast_reg2hw_rega5_reg_t rega5; // [1248:1217]
+    ast_reg2hw_rega6_reg_t rega6; // [1216:1185]
+    ast_reg2hw_rega7_reg_t rega7; // [1184:1153]
+    ast_reg2hw_rega8_reg_t rega8; // [1152:1121]
+    ast_reg2hw_rega9_reg_t rega9; // [1120:1089]
+    ast_reg2hw_rega10_reg_t rega10; // [1088:1057]
+    ast_reg2hw_rega11_reg_t rega11; // [1056:1025]
+    ast_reg2hw_rega12_reg_t rega12; // [1024:993]
+    ast_reg2hw_rega13_reg_t rega13; // [992:961]
+    ast_reg2hw_rega14_reg_t rega14; // [960:929]
+    ast_reg2hw_rega15_reg_t rega15; // [928:897]
+    ast_reg2hw_rega16_reg_t rega16; // [896:865]
+    ast_reg2hw_rega17_reg_t rega17; // [864:833]
+    ast_reg2hw_rega18_reg_t rega18; // [832:801]
+    ast_reg2hw_rega19_reg_t rega19; // [800:769]
+    ast_reg2hw_rega20_reg_t rega20; // [768:737]
+    ast_reg2hw_rega21_reg_t rega21; // [736:705]
+    ast_reg2hw_rega22_reg_t rega22; // [704:673]
+    ast_reg2hw_rega23_reg_t rega23; // [672:641]
+    ast_reg2hw_rega24_reg_t rega24; // [640:609]
+    ast_reg2hw_rega25_reg_t rega25; // [608:577]
+    ast_reg2hw_rega26_reg_t rega26; // [576:545]
+    ast_reg2hw_rega27_reg_t rega27; // [544:513]
+    ast_reg2hw_rega28_reg_t rega28; // [512:481]
+    ast_reg2hw_rega29_reg_t rega29; // [480:449]
+    ast_reg2hw_rega30_reg_t rega30; // [448:417]
+    ast_reg2hw_rega31_reg_t rega31; // [416:385]
+    ast_reg2hw_rega32_reg_t rega32; // [384:353]
+    ast_reg2hw_rega33_reg_t rega33; // [352:321]
+    ast_reg2hw_rega34_reg_t rega34; // [320:289]
+    ast_reg2hw_rega35_reg_t rega35; // [288:257]
+    ast_reg2hw_rega36_reg_t rega36; // [256:225]
+    ast_reg2hw_rega37_reg_t rega37; // [224:193]
     ast_reg2hw_regal_reg_t regal; // [192:160]
     ast_reg2hw_regb_mreg_t [4:0] regb; // [159:0]
   } ast_reg2hw_t;
@@ -227,7 +262,14 @@ package ast_reg_pkg;
   parameter logic [BlockAw-1:0] AST_REGA28_OFFSET = 10'h 70;
   parameter logic [BlockAw-1:0] AST_REGA29_OFFSET = 10'h 74;
   parameter logic [BlockAw-1:0] AST_REGA30_OFFSET = 10'h 78;
-  parameter logic [BlockAw-1:0] AST_REGAL_OFFSET = 10'h 7c;
+  parameter logic [BlockAw-1:0] AST_REGA31_OFFSET = 10'h 7c;
+  parameter logic [BlockAw-1:0] AST_REGA32_OFFSET = 10'h 80;
+  parameter logic [BlockAw-1:0] AST_REGA33_OFFSET = 10'h 84;
+  parameter logic [BlockAw-1:0] AST_REGA34_OFFSET = 10'h 88;
+  parameter logic [BlockAw-1:0] AST_REGA35_OFFSET = 10'h 8c;
+  parameter logic [BlockAw-1:0] AST_REGA36_OFFSET = 10'h 90;
+  parameter logic [BlockAw-1:0] AST_REGA37_OFFSET = 10'h 94;
+  parameter logic [BlockAw-1:0] AST_REGAL_OFFSET = 10'h 98;
   parameter logic [BlockAw-1:0] AST_REGB_0_OFFSET = 10'h 200;
   parameter logic [BlockAw-1:0] AST_REGB_1_OFFSET = 10'h 204;
   parameter logic [BlockAw-1:0] AST_REGB_2_OFFSET = 10'h 208;
@@ -235,8 +277,8 @@ package ast_reg_pkg;
   parameter logic [BlockAw-1:0] AST_REGB_4_OFFSET = 10'h 210;
 
   // Reset values for hwext registers and their fields
-  parameter logic [31:0] AST_REGAL_RESVAL = 32'h 1f;
-  parameter logic [31:0] AST_REGAL_REG32_RESVAL = 32'h 1f;
+  parameter logic [31:0] AST_REGAL_RESVAL = 32'h 26;
+  parameter logic [31:0] AST_REGAL_REG32_RESVAL = 32'h 26;
 
   // Register index
   typedef enum int {
@@ -271,6 +313,13 @@ package ast_reg_pkg;
     AST_REGA28,
     AST_REGA29,
     AST_REGA30,
+    AST_REGA31,
+    AST_REGA32,
+    AST_REGA33,
+    AST_REGA34,
+    AST_REGA35,
+    AST_REGA36,
+    AST_REGA37,
     AST_REGAL,
     AST_REGB_0,
     AST_REGB_1,
@@ -280,7 +329,7 @@ package ast_reg_pkg;
   } ast_id_e;
 
   // Register width information to check illegal writes
-  parameter logic [3:0] AST_PERMIT [37] = '{
+  parameter logic [3:0] AST_PERMIT [44] = '{
     4'b 1111, // index[ 0] AST_REGA0
     4'b 1111, // index[ 1] AST_REGA1
     4'b 1111, // index[ 2] AST_REGA2
@@ -312,12 +361,19 @@ package ast_reg_pkg;
     4'b 1111, // index[28] AST_REGA28
     4'b 1111, // index[29] AST_REGA29
     4'b 1111, // index[30] AST_REGA30
-    4'b 1111, // index[31] AST_REGAL
-    4'b 1111, // index[32] AST_REGB_0
-    4'b 1111, // index[33] AST_REGB_1
-    4'b 1111, // index[34] AST_REGB_2
-    4'b 1111, // index[35] AST_REGB_3
-    4'b 1111  // index[36] AST_REGB_4
+    4'b 1111, // index[31] AST_REGA31
+    4'b 1111, // index[32] AST_REGA32
+    4'b 1111, // index[33] AST_REGA33
+    4'b 1111, // index[34] AST_REGA34
+    4'b 1111, // index[35] AST_REGA35
+    4'b 1111, // index[36] AST_REGA36
+    4'b 1111, // index[37] AST_REGA37
+    4'b 1111, // index[38] AST_REGAL
+    4'b 1111, // index[39] AST_REGB_0
+    4'b 1111, // index[40] AST_REGB_1
+    4'b 1111, // index[41] AST_REGB_2
+    4'b 1111, // index[42] AST_REGB_3
+    4'b 1111  // index[43] AST_REGB_4
   };
 
 endpackage

--- a/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/ast_reg_top.sv
@@ -55,9 +55,9 @@ module ast_reg_top (
 
   // also check for spurious write enables
   logic reg_we_err;
-  logic [36:0] reg_we_check;
+  logic [43:0] reg_we_check;
   prim_reg_we_check #(
-    .OneHotWidth(37)
+    .OneHotWidth(44)
   ) u_prim_reg_we_check (
     .clk_i(clk_i),
     .rst_ni(rst_ni),
@@ -208,6 +208,27 @@ module ast_reg_top (
   logic rega30_we;
   logic [31:0] rega30_qs;
   logic [31:0] rega30_wd;
+  logic rega31_we;
+  logic [31:0] rega31_qs;
+  logic [31:0] rega31_wd;
+  logic rega32_we;
+  logic [31:0] rega32_qs;
+  logic [31:0] rega32_wd;
+  logic rega33_we;
+  logic [31:0] rega33_qs;
+  logic [31:0] rega33_wd;
+  logic rega34_we;
+  logic [31:0] rega34_qs;
+  logic [31:0] rega34_wd;
+  logic rega35_we;
+  logic [31:0] rega35_qs;
+  logic [31:0] rega35_wd;
+  logic rega36_we;
+  logic [31:0] rega36_qs;
+  logic [31:0] rega36_wd;
+  logic rega37_we;
+  logic [31:0] rega37_qs;
+  logic [31:0] rega37_wd;
   logic regal_we;
   logic [31:0] regal_wd;
   logic regb_0_we;
@@ -1033,6 +1054,188 @@ module ast_reg_top (
   );
 
 
+  // R[rega31]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h1f)
+  ) u_rega31 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (rega31_we),
+    .wd     (rega31_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.rega31.q),
+
+    // to register interface (read)
+    .qs     (rega31_qs)
+  );
+
+
+  // R[rega32]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h20)
+  ) u_rega32 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (rega32_we),
+    .wd     (rega32_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.rega32.q),
+
+    // to register interface (read)
+    .qs     (rega32_qs)
+  );
+
+
+  // R[rega33]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h21)
+  ) u_rega33 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (rega33_we),
+    .wd     (rega33_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.rega33.q),
+
+    // to register interface (read)
+    .qs     (rega33_qs)
+  );
+
+
+  // R[rega34]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h22)
+  ) u_rega34 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (rega34_we),
+    .wd     (rega34_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.rega34.q),
+
+    // to register interface (read)
+    .qs     (rega34_qs)
+  );
+
+
+  // R[rega35]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h23)
+  ) u_rega35 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (rega35_we),
+    .wd     (rega35_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.rega35.q),
+
+    // to register interface (read)
+    .qs     (rega35_qs)
+  );
+
+
+  // R[rega36]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h24)
+  ) u_rega36 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (rega36_we),
+    .wd     (rega36_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.rega36.q),
+
+    // to register interface (read)
+    .qs     (rega36_qs)
+  );
+
+
+  // R[rega37]: V(False)
+  prim_subreg #(
+    .DW      (32),
+    .SwAccess(prim_subreg_pkg::SwAccessRW),
+    .RESVAL  (32'h25)
+  ) u_rega37 (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (rega37_we),
+    .wd     (rega37_wd),
+
+    // from internal hardware
+    .de     (1'b0),
+    .d      ('0),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.rega37.q),
+
+    // to register interface (read)
+    .qs     (rega37_qs)
+  );
+
+
   // R[regal]: V(True)
   logic regal_qe;
   logic [0:0] regal_flds_we;
@@ -1188,7 +1391,7 @@ module ast_reg_top (
 
 
 
-  logic [36:0] addr_hit;
+  logic [43:0] addr_hit;
   always_comb begin
     addr_hit = '0;
     addr_hit[ 0] = (reg_addr == AST_REGA0_OFFSET);
@@ -1222,12 +1425,19 @@ module ast_reg_top (
     addr_hit[28] = (reg_addr == AST_REGA28_OFFSET);
     addr_hit[29] = (reg_addr == AST_REGA29_OFFSET);
     addr_hit[30] = (reg_addr == AST_REGA30_OFFSET);
-    addr_hit[31] = (reg_addr == AST_REGAL_OFFSET);
-    addr_hit[32] = (reg_addr == AST_REGB_0_OFFSET);
-    addr_hit[33] = (reg_addr == AST_REGB_1_OFFSET);
-    addr_hit[34] = (reg_addr == AST_REGB_2_OFFSET);
-    addr_hit[35] = (reg_addr == AST_REGB_3_OFFSET);
-    addr_hit[36] = (reg_addr == AST_REGB_4_OFFSET);
+    addr_hit[31] = (reg_addr == AST_REGA31_OFFSET);
+    addr_hit[32] = (reg_addr == AST_REGA32_OFFSET);
+    addr_hit[33] = (reg_addr == AST_REGA33_OFFSET);
+    addr_hit[34] = (reg_addr == AST_REGA34_OFFSET);
+    addr_hit[35] = (reg_addr == AST_REGA35_OFFSET);
+    addr_hit[36] = (reg_addr == AST_REGA36_OFFSET);
+    addr_hit[37] = (reg_addr == AST_REGA37_OFFSET);
+    addr_hit[38] = (reg_addr == AST_REGAL_OFFSET);
+    addr_hit[39] = (reg_addr == AST_REGB_0_OFFSET);
+    addr_hit[40] = (reg_addr == AST_REGB_1_OFFSET);
+    addr_hit[41] = (reg_addr == AST_REGB_2_OFFSET);
+    addr_hit[42] = (reg_addr == AST_REGB_3_OFFSET);
+    addr_hit[43] = (reg_addr == AST_REGB_4_OFFSET);
   end
 
   assign addrmiss = (reg_re || reg_we) ? ~|addr_hit : 1'b0 ;
@@ -1271,7 +1481,14 @@ module ast_reg_top (
                (addr_hit[33] & (|(AST_PERMIT[33] & ~reg_be))) |
                (addr_hit[34] & (|(AST_PERMIT[34] & ~reg_be))) |
                (addr_hit[35] & (|(AST_PERMIT[35] & ~reg_be))) |
-               (addr_hit[36] & (|(AST_PERMIT[36] & ~reg_be)))));
+               (addr_hit[36] & (|(AST_PERMIT[36] & ~reg_be))) |
+               (addr_hit[37] & (|(AST_PERMIT[37] & ~reg_be))) |
+               (addr_hit[38] & (|(AST_PERMIT[38] & ~reg_be))) |
+               (addr_hit[39] & (|(AST_PERMIT[39] & ~reg_be))) |
+               (addr_hit[40] & (|(AST_PERMIT[40] & ~reg_be))) |
+               (addr_hit[41] & (|(AST_PERMIT[41] & ~reg_be))) |
+               (addr_hit[42] & (|(AST_PERMIT[42] & ~reg_be))) |
+               (addr_hit[43] & (|(AST_PERMIT[43] & ~reg_be)))));
   end
 
   // Generate write-enables
@@ -1359,22 +1576,43 @@ module ast_reg_top (
   assign rega30_we = addr_hit[30] & reg_we & !reg_error;
 
   assign rega30_wd = reg_wdata[31:0];
-  assign regal_we = addr_hit[31] & reg_we & !reg_error;
+  assign rega31_we = addr_hit[31] & reg_we & !reg_error;
+
+  assign rega31_wd = reg_wdata[31:0];
+  assign rega32_we = addr_hit[32] & reg_we & !reg_error;
+
+  assign rega32_wd = reg_wdata[31:0];
+  assign rega33_we = addr_hit[33] & reg_we & !reg_error;
+
+  assign rega33_wd = reg_wdata[31:0];
+  assign rega34_we = addr_hit[34] & reg_we & !reg_error;
+
+  assign rega34_wd = reg_wdata[31:0];
+  assign rega35_we = addr_hit[35] & reg_we & !reg_error;
+
+  assign rega35_wd = reg_wdata[31:0];
+  assign rega36_we = addr_hit[36] & reg_we & !reg_error;
+
+  assign rega36_wd = reg_wdata[31:0];
+  assign rega37_we = addr_hit[37] & reg_we & !reg_error;
+
+  assign rega37_wd = reg_wdata[31:0];
+  assign regal_we = addr_hit[38] & reg_we & !reg_error;
 
   assign regal_wd = reg_wdata[31:0];
-  assign regb_0_we = addr_hit[32] & reg_we & !reg_error;
+  assign regb_0_we = addr_hit[39] & reg_we & !reg_error;
 
   assign regb_0_wd = reg_wdata[31:0];
-  assign regb_1_we = addr_hit[33] & reg_we & !reg_error;
+  assign regb_1_we = addr_hit[40] & reg_we & !reg_error;
 
   assign regb_1_wd = reg_wdata[31:0];
-  assign regb_2_we = addr_hit[34] & reg_we & !reg_error;
+  assign regb_2_we = addr_hit[41] & reg_we & !reg_error;
 
   assign regb_2_wd = reg_wdata[31:0];
-  assign regb_3_we = addr_hit[35] & reg_we & !reg_error;
+  assign regb_3_we = addr_hit[42] & reg_we & !reg_error;
 
   assign regb_3_wd = reg_wdata[31:0];
-  assign regb_4_we = addr_hit[36] & reg_we & !reg_error;
+  assign regb_4_we = addr_hit[43] & reg_we & !reg_error;
 
   assign regb_4_wd = reg_wdata[31:0];
 
@@ -1412,12 +1650,19 @@ module ast_reg_top (
     reg_we_check[28] = 1'b0;
     reg_we_check[29] = rega29_we;
     reg_we_check[30] = rega30_we;
-    reg_we_check[31] = regal_we;
-    reg_we_check[32] = regb_0_we;
-    reg_we_check[33] = regb_1_we;
-    reg_we_check[34] = regb_2_we;
-    reg_we_check[35] = regb_3_we;
-    reg_we_check[36] = regb_4_we;
+    reg_we_check[31] = rega31_we;
+    reg_we_check[32] = rega32_we;
+    reg_we_check[33] = rega33_we;
+    reg_we_check[34] = rega34_we;
+    reg_we_check[35] = rega35_we;
+    reg_we_check[36] = rega36_we;
+    reg_we_check[37] = rega37_we;
+    reg_we_check[38] = regal_we;
+    reg_we_check[39] = regb_0_we;
+    reg_we_check[40] = regb_1_we;
+    reg_we_check[41] = regb_2_we;
+    reg_we_check[42] = regb_3_we;
+    reg_we_check[43] = regb_4_we;
   end
 
   // Read data return
@@ -1549,26 +1794,54 @@ module ast_reg_top (
       end
 
       addr_hit[31]: begin
-        reg_rdata_next[31:0] = '0;
+        reg_rdata_next[31:0] = rega31_qs;
       end
 
       addr_hit[32]: begin
-        reg_rdata_next[31:0] = regb_0_qs;
+        reg_rdata_next[31:0] = rega32_qs;
       end
 
       addr_hit[33]: begin
-        reg_rdata_next[31:0] = regb_1_qs;
+        reg_rdata_next[31:0] = rega33_qs;
       end
 
       addr_hit[34]: begin
-        reg_rdata_next[31:0] = regb_2_qs;
+        reg_rdata_next[31:0] = rega34_qs;
       end
 
       addr_hit[35]: begin
-        reg_rdata_next[31:0] = regb_3_qs;
+        reg_rdata_next[31:0] = rega35_qs;
       end
 
       addr_hit[36]: begin
+        reg_rdata_next[31:0] = rega36_qs;
+      end
+
+      addr_hit[37]: begin
+        reg_rdata_next[31:0] = rega37_qs;
+      end
+
+      addr_hit[38]: begin
+        reg_rdata_next[31:0] = '0;
+      end
+
+      addr_hit[39]: begin
+        reg_rdata_next[31:0] = regb_0_qs;
+      end
+
+      addr_hit[40]: begin
+        reg_rdata_next[31:0] = regb_1_qs;
+      end
+
+      addr_hit[41]: begin
+        reg_rdata_next[31:0] = regb_2_qs;
+      end
+
+      addr_hit[42]: begin
+        reg_rdata_next[31:0] = regb_3_qs;
+      end
+
+      addr_hit[43]: begin
         reg_rdata_next[31:0] = regb_4_qs;
       end
 

--- a/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/io_osc.sv
@@ -28,7 +28,9 @@ reg init_start;
 initial init_start = 1'b0;
 
 initial begin
-  #1; init_start  = 1'b1;
+  #1;
+  init_start  = 1'b1;
+  #1;
   $display("\n%m: IO Clock Power-up Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
 end
 
@@ -62,7 +64,7 @@ logic en_osc;
 logic en_clk, clk;
 
 always_latch begin
-  if ( !clk_osc ) en_clk <= en_osc;
+  if ( !clk_osc ) en_clk = en_osc;
 end
 
 assign clk = clk_osc && en_clk;

--- a/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/sys_osc.sv
@@ -29,7 +29,9 @@ reg init_start;
 initial init_start = 1'b0;
 
 initial begin
-  #1; init_start  = 1'b1;
+  #1;
+  init_start  = 1'b1;
+  #1;
   $display("\n%m: System Clock Power-up Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
 end
 
@@ -65,7 +67,7 @@ logic en_osc;
 logic en_clk, clk;
 
 always_latch begin
-  if ( !clk_osc ) en_clk <= en_osc;
+  if ( !clk_osc ) en_clk = en_osc;
 end
 
 assign clk = clk_osc && en_clk;

--- a/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
+++ b/hw/top_earlgrey/ip/ast/rtl/usb_osc.sv
@@ -46,7 +46,9 @@ initial begin
     calibrate_usb_clk = 1'b1;
   end
   //
-  #1; init_start = 1'b1;
+  #1;
+  init_start = 1'b1;
+  #1;
   $display("\n%m: USB Clock Power-up Frequency: %0d Hz", $rtoi(10**9/CLK_PERIOD));
   rand32 = ($urandom_range(0, 832) - 416);  // +/-416ps (+/-2% max)
   $display("%m: USB Clock Drift: %0d ps", rand32);
@@ -89,7 +91,7 @@ logic en_osc;
 logic en_clk, clk;
 
 always_latch begin
-  if ( !clk_osc ) en_clk <= en_osc;
+  if ( !clk_osc ) en_clk = en_osc;
 end
 
 assign clk = clk_osc && en_clk;


### PR DESCRIPTION
This Draft PR includes:
* Fix Lint issues, including latches syntax.
* Fix JEN decode from strict to loose
* Update AST register's nuber from 32 to 39.

Signed-off-by: Jacob Levy <jacob.levy@nuvoton.com>