### PR TITLE
[dvsim] Remove most uses of nargs=wildcard from dvsim

### DIFF
--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -418,9 +418,8 @@ def parse_args():
 
     buildg.add_argument("--build-opts",
                         "-bo",
-                        nargs="+",
-                        default=[],
-                        metavar="OPT",
+                        default='',
+                        metavar="OPTS",
                         help=('Additional options passed on the command line '
                               'each time a build tool is run.'))
 
@@ -461,9 +460,8 @@ def parse_args():
 
     rung.add_argument("--run-opts",
                       "-ro",
-                      nargs="+",
-                      default=[],
-                      metavar="OPT",
+                      default='',
+                      metavar="OPTS",
                       help=('Additional options passed on the command line '
                             'each time a test is run.'))
 
@@ -669,6 +667,12 @@ def parse_args():
         if not args.select_cfgs:
             raise argparse.ArgumentError('--select-cfgs expects a non-empty '
                                          'list of configurations to run.')
+
+    # Turn --build-opts and --run-opts into lists of arguments. We want to be
+    # able to write something like `--build-opts 'a "b c"'` and get the quoting
+    # right so that this turns into ['a', 'b c'].
+    args.build_opts = shlex.split(args.build_opts)
+    args.run_opts = shlex.split(args.run_opts)
 
     # We want the --list argument to default to "all categories", but allow
     # filtering. If args.list is None, then --list wasn't supplied. If it is

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -425,11 +425,12 @@ def parse_args():
 
     buildg.add_argument("--build-modes",
                         "-bm",
-                        nargs="+",
-                        default=[],
-                        metavar="MODE",
+                        default='',
+                        metavar="MODES",
                         help=('The options for each build_mode in this list '
-                              'are applied to all build and run targets.'))
+                              'are applied to all build and run targets. To '
+                              'specify more than one mode, pass a comma '
+                              'separated list.'))
 
     buildg.add_argument("--build-timeout-mins",
                         type=int,
@@ -467,11 +468,11 @@ def parse_args():
 
     rung.add_argument("--run-modes",
                       "-rm",
-                      nargs="+",
-                      default=[],
-                      metavar="MODE",
+                      default='',
+                      metavar="MODES",
                       help=('The options for each run_mode in this list are '
-                            'applied to each simulation run.'))
+                            'applied to each simulation run. To specify more '
+                            'than one mode, pass a comma separated list.'))
 
     rung.add_argument("--profile",
                       "-p",
@@ -673,6 +674,10 @@ def parse_args():
     # right so that this turns into ['a', 'b c'].
     args.build_opts = shlex.split(args.build_opts)
     args.run_opts = shlex.split(args.run_opts)
+
+    # Split build and run modes as comma-separated lists
+    args.build_modes = split_commas(args.build_modes)
+    args.run_modes = split_commas(args.run_modes)
 
     # We want the --list argument to default to "all categories", but allow
     # filtering. If args.list is None, then --list wasn't supplied. If it is

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -528,12 +528,11 @@ def parse_args():
 
     seedg.add_argument("--seeds",
                        "-s",
-                       nargs="+",
-                       default=[],
+                       default='',
                        metavar="S",
-                       help=('A list of seeds for tests. Note that these '
-                             'specific seeds are applied to items being run '
-                             'in the order they are passed.'))
+                       help=('A comma-separated list of seeds for tests. Note '
+                             'that these specific seeds are applied to items '
+                             'being run in the order they are passed.'))
 
     seedg.add_argument("--fixed-seed",
                        type=int,
@@ -676,6 +675,9 @@ def parse_args():
     # Split build and run modes as comma-separated lists
     args.build_modes = split_commas(args.build_modes)
     args.run_modes = split_commas(args.run_modes)
+
+    # Split --seeds as a comma-separated list
+    args.seeds = split_commas(args.seeds)
 
     # We want the --list argument to default to "all categories", but allow
     # filtering. If args.list is None, then --list wasn't supplied. If it is

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -476,9 +476,7 @@ def parse_args():
 
     rung.add_argument("--profile",
                       "-p",
-                      nargs="?",
                       choices=['time', 'mem'],
-                      const="time",
                       metavar="P",
                       help=('Turn on simulation profiling (where P is time '
                             'or mem).'))

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -722,7 +722,6 @@ def main():
 
     # Build infrastructure from hjson file and create the list of items to
     # be deployed.
-    global cfg
     cfg = make_cfg(args.cfg, args, proj_root)
 
     # List items available for run if --list switch is passed, and exit.

--- a/util/dvsim/dvsim.py
+++ b/util/dvsim/dvsim.py
@@ -327,10 +327,10 @@ def parse_args():
                              'names.'))
 
     whatg.add_argument("--select-cfgs",
-                       nargs="*",
-                       metavar="CFG",
+                       metavar="CFGS",
                        help=('The .hjson file is a primary config. Only run '
-                             'the given configs from it. If this argument is '
+                             'the given configs (specified in a comma '
+                             'separated list) from it. If this argument is '
                              'not used, dvsim will process all configs listed '
                              'in a primary config.'))
 
@@ -660,6 +660,15 @@ def parse_args():
     if not args.items:
         raise argparse.ArgumentError('--items expects a non-empty list '
                                      'of items to run.')
+
+    # Apply a similar transformation to --select-cfgs. Unlike --items, this
+    # argument can be None (if it was not passed) and we want to pass that
+    # straight through.
+    if args.select_cfgs is not None:
+        args.select_cfgs = split_commas(args.select_cfgs)
+        if not args.select_cfgs:
+            raise argparse.ArgumentError('--select-cfgs expects a non-empty '
+                                         'list of configurations to run.')
 
     # We want the --list argument to default to "all categories", but allow
     # filtering. If args.list is None, then --list wasn't supplied. If it is


### PR DESCRIPTION
This is sparked by the discussion at #12377. I've not actually removed *all* of these uses (remaining: `--list`, `--waves`, `--verbose`). These remaining flags all use `nargs='?'`, which is less confusing than `nargs='*'` or `nargs='+'`, and it seems like the current behaviour might be quite useful and I can't see a super-obvious way to change it.

So this is supposed to be the easy, non-contentious part :-)
