### PR TITLE
[sca] Disable peripheral clocks during SCA capture

### DIFF
--- a/sw/device/sca/aes_serial.c
+++ b/sw/device/sca/aes_serial.c
@@ -194,7 +194,7 @@ static void init_aes(void) {
  * UART.
  */
 void _ottf_main(void) {
-  sca_init(kScaTriggerSourceAes, kScaPeripheralAes);
+  sca_init(kScaTriggerSourceAes, kScaPeripheralIoDiv4 | kScaPeripheralAes);
 
   LOG_INFO("Running AES serial");
 

--- a/sw/device/sca/lib/sca.h
+++ b/sw/device/sca/lib/sca.h
@@ -84,9 +84,21 @@ typedef enum sca_peripheral {
    */
   kScaPeripheralOtbn = 1 << 6,
   /**
+   * Peripherals using the IO_DIV4_PERI clock (UART, GPIO, I2C, SPI Dev, ...)
+   */
+  kScaPeripheralIoDiv4 = 1 << 7,
+  /**
+   * Peripherals using the IO_DIV2_PERI clock (SPI Host 1)
+   */
+  kScaPeripheralIoDiv2 = 1 << 8,
+  /**
    * USB.
    */
-  kScaPeripheralUsb = 1 << 7,
+  kScaPeripheralUsb = 1 << 9,
+  /**
+   * Peripherals using the IO_PERI clock (SPI Host 0)
+   */
+  kScaPeripheralIo = 1 << 10,
 } sca_peripheral_t;
 
 /**

--- a/sw/device/sca/sha3_serial.c
+++ b/sw/device/sca/sha3_serial.c
@@ -478,7 +478,7 @@ static void sha3_serial_single_absorb(const uint8_t *msg, size_t msg_len) {
  * UART.
  */
 void _ottf_main(void) {
-  sca_init(kScaTriggerSourceKmac, kScaPeripheralKmac);
+  sca_init(kScaTriggerSourceKmac, kScaPeripheralIoDiv4 | kScaPeripheralKmac);
 
   LOG_INFO("Running sha3_serial");
 


### PR DESCRIPTION
To further reduce unwanted noise during SCA captures, it's better to disable the peripheral clocks in addition to the clocks of the bigger modules like (HMAC, OTBN, KMAC, AES).

Special care is required for the IO_DIV4_PERI clock as the UART and GPIO modules required for communication with the scope are using this clock. Therefore, this clock can only be disabled during the actual capture and has to be re-enabled afterwards to resume communication.