### PR TITLE
[dv] Cleanups in TL error vseq's tl_instr_type_err task

### DIFF
--- a/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
+++ b/hw/dv/sv/cip_lib/seq_lib/cip_base_vseq__tl_errors.svh
@@ -158,26 +158,33 @@ virtual task tl_write_ro_mem_err(string ral_name);
 endtask
 
 virtual task tl_instr_type_err(string ral_name);
-  bit [BUS_DW-1:0] data;
   repeat ($urandom_range(10, 100)) begin
+    bit [BUS_AW-1:0] addr;
+    bit              write;
+    bit [BUS_DW-1:0] data;
+    mubi4_t          instr_type;
+
+    `DV_CHECK_STD_RANDOMIZE_FATAL(addr);
+    `DV_CHECK_STD_RANDOMIZE_FATAL(data);
+
     randcase
-      // invalid instr_type
       1: begin
-        bit[3:0] instr_type;
-        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(instr_type,
-                                           !(instr_type inside {MuBi4True, MuBi4False});)
-        data = $urandom();
-        tl_access(.addr($urandom()), .write($urandom_range(0, 1)), .data(data),
-                  .instr_type(instr_type), .exp_err_rsp(1),
-                  .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
+        // invalid instr_type
+        bit[3:0] instr_type_bits;
+        `DV_CHECK_STD_RANDOMIZE_FATAL(write);
+        `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(instr_type_bits,
+                                           !(instr_type_bits inside {MuBi4True, MuBi4False});)
+        instr_type = mubi4_t'(instr_type_bits);
       end
-      // write with instr_type = MuBi4True
       1: begin
-        tl_access(.addr($urandom()), .write(1), .data(data),
-                  .instr_type(MuBi4True), .exp_err_rsp(1),
-                  .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
+        // write with instr_type = MuBi4True
+        write = 1'b1;
+        instr_type = MuBi4True;
       end
     endcase
+
+    tl_access(.addr(addr), .write(write), .data(data), .instr_type(instr_type), .exp_err_rsp(1),
+              .tl_sequencer_h(p_sequencer.tl_sequencer_hs[ral_name]));
   end
 endtask
 


### PR DESCRIPTION
This was prompted by an Xcelium warning caused by the fact `instr_type`
was of type `bit[3:0]` and was passed to a port expecting a `mubi4_t`.

Because it seemed a bit tidier, I've refactored things a bit so that
the `randcase` just picks values that will be passed to a `tl_access` task
that runs afterwards. We're also now randomising `data` properly in the
second case, which I think we'd missed before.
