### PR TITLE
[otbn,dv] Silence an Xcelium warning from otbn_core_model.sv

### DIFF
--- a/hw/ip/otbn/dv/model/otbn_core_model.sv
+++ b/hw/ip/otbn/dv/model/otbn_core_model.sv
@@ -227,8 +227,7 @@ module otbn_core_model
     end else begin
       if (new_escalation) begin
         // Setting LIFECYCLE_ESCALATION bit
-        bit[31:0] err_val = 32'd1 << 22;
-        failed_lc_escalate <= (otbn_model_send_err_escalation(model_handle, err_val) != 0);
+        failed_lc_escalate <= (otbn_model_send_err_escalation(model_handle, 32'd1 << 22) != 0);
       end
       if (!$stable(keymgr_key_i) || $rose(rst_ni)) begin
         failed_keymgr_value <= (otbn_model_set_keymgr_value(model_handle,


### PR DESCRIPTION
Since this code is inside a process, local variables default to static
lifetime. Xcelium spits out a warning if you don't say that
explicitly (because not noticing static lifetimes is an excellent way
to introduce silly bugs!). However, there's no strong reason not to
just inline the constant so let's do that.
