### PR TITLE
[otbn,dv] Check success of uvm_hdl_force/release in vseqs

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_illegal_mem_acc_vseq.sv
@@ -41,10 +41,11 @@ class otbn_illegal_mem_acc_vseq extends otbn_single_vseq;
     cfg.en_scb_tl_err_chk = 0;
     fork
       begin
+        string valid_signal_path = "tb.dut.tl_i.a_valid";
         bit temp_var;
         do begin
           cfg.clk_rst_vif.wait_clks(1);
-          uvm_hdl_read("tb.dut.tl_i.a_valid", temp_var);
+          `DV_CHECK_FATAL(uvm_hdl_read(valid_signal_path, temp_var) == 1)
         end while (!temp_var);
         cfg.model_agent_cfg.vif.send_err_escalation(err_val);
       end

--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_zero_state_err_urnd_vseq.sv
@@ -7,21 +7,21 @@ class otbn_zero_state_err_urnd_vseq extends otbn_single_vseq;
   `uvm_object_new
 
   task body();
-
-    // We've loaded the binary. Run the processor to see what happens!
     fork
       begin
         super.body();
       end
       begin
         bit [31:0] err_val = 32'd1 << 20;
+        string prng_path = "tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d";
+
         cfg.clk_rst_vif.wait_clks($urandom_range(10, 1000));
-        uvm_hdl_force("tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d", 'b0);
+        `DV_CHECK_FATAL(uvm_hdl_force(prng_path, 'b0) == 1);
         cfg.clk_rst_vif.wait_clks(1);
         cfg.model_agent_cfg.vif.otbn_set_no_sec_wipe_chk();
         cfg.model_agent_cfg.vif.send_err_escalation(err_val);
         `uvm_info(`gfn,"injecting zero state error into ISS", UVM_HIGH)
-        uvm_hdl_release("tb.dut.u_otbn_core.u_otbn_rnd.u_xoshiro256pp.xoshiro_d");
+        `DV_CHECK_FATAL(uvm_hdl_release(prng_path) == 1);
         reset_if_locked();
       end
     join


### PR DESCRIPTION
This silences a *W,FUNTSK warning from Xcelium. Also, remove a comment
which isn't quite true (copied from `otbn_single_vseq`, I think) and
factor out a long repeated string (required because `DV_CHECK_FATAL`
tries to "stringify" its first argument, which doesn't work with
embedded string literals).
