### PR TITLE
[kmac,dv] Fix types in a digestpp_dpi helper function

### DIFF
--- a/hw/ip/kmac/dv/dpi/digestpp_dpi.cc
+++ b/hw/ip/kmac/dv/dpi/digestpp_dpi.cc
@@ -26,14 +26,8 @@ extern "C" {
  */
 static void load_arr_from_simulator(const svOpenArrayHandle arr,
                                     uint8_t *array_out, uint64_t array_len) {
-  svBitVecVal val;
-
-  if (array_len == 0) {
-    return;
-  }
-
-  uint8_t *arr_ptr = (uint8_t *)svGetArrayPtr(arr);
-  for (int i = 0; i < array_len; i++) {
+  for (uint64_t i = 0; i < array_len; i++) {
+    svBitVecVal val;
     svGetBitArrElem1VecVal(&val, arr, i);
     array_out[i] = (uint8_t)val;
   }


### PR DESCRIPTION
The comparison between an `int` and a `uint64_t` was causing
a (reasonable!) compiler warning. Fix that, and also remove an unused
variable (`arr_ptr` was written but not read).

Once that's done, there's no point in the short-circuit when `array_len`
is zero, so we can remove that too.
