### PR TITLE
[dif, rv_core_ibex] Add dif and unittest

### DIFF
--- a/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
+++ b/hw/ip/rv_core_ibex/data/rv_core_ibex.hjson
@@ -171,33 +171,25 @@
     # Random netlist constants
     { name:    "RndCnstLfsrSeed",
       type:    "ibex_pkg::lfsr_seed_t",
-      desc:    '''
-        Default seed of the PRNG used for random instructions.
-      '''
+      desc:    "Default seed of the PRNG used for random instructions."
       randcount: "32",
       randtype:  "data"
     },
     { name:    "RndCnstLfsrPerm",
       type:    "ibex_pkg::lfsr_perm_t",
-      desc:    '''
-        Permutation applied to the LFSR of the PRNG used for random instructions.
-      '''
+      desc:    "Permutation applied to the LFSR of the PRNG used for random instructions."
       randcount: "32",
       randtype:  "perm"
     },
     { name:    "RndCnstIbexKeyDefault",
       type:    "logic [ibex_pkg::SCRAMBLE_KEY_W-1:0]",
-      desc:    '''
-        Default icache scrambling key
-      '''
+      desc:    "Default icache scrambling key"
       randcount: "128",
       randtype:  "data"
     },
     { name:    "RndCnstIbexNonceDefault",
       type:    "logic [ibex_pkg::SCRAMBLE_NONCE_W-1:0]",
-      desc:    '''
-        Default icache scrambling nonce
-      '''
+      desc:    "Default icache scrambling nonce"
       randcount: "64",
       randtype:  "data"
     },
@@ -205,9 +197,7 @@
     { name:    "PMPEnable"
       type:    "bit"
       default: "1'b0"
-      desc:    '''
-        Enable PMP
-        '''
+      desc:    "Enable PMP"
       local:   "false"
       expose:  "true"
     },
@@ -215,6 +205,7 @@
     { name:    "PMPGranularity"
       type:    "int unsigned"
       default: "0"
+      desc:    "PMP Granularity"
       local:   "false"
       expose:  "true"
     },
@@ -222,6 +213,7 @@
     { name:    "PMPNumRegions"
       type:    "int unsigned"
       default: "4"
+      desc:    "PMP number of regions"
       local:   "false"
       expose:  "true"
     },
@@ -229,6 +221,7 @@
     { name:    "MHPMCounterNum"
       type:    "int unsigned"
       default: "10"
+      desc:    "Number of the MHPM counter "
       local:   "false"
       expose:  "true"
     },
@@ -236,6 +229,7 @@
     { name:    "MHPMCounterWidth"
       type:    "int unsigned"
       default: "32"
+      desc:    "Width of the MHPM Counter "
       local:   "false"
       expose:  "true"
     },
@@ -243,6 +237,7 @@
     { name:    "RV32E"
       type:    "bit"
       default: "0"
+      desc:    "RV32E"
       local:   "false"
       expose:  "true"
     },
@@ -250,6 +245,7 @@
     { name:    "RV32M"
       type:    "ibex_pkg::rv32m_e"
       default: "ibex_pkg::RV32MSingleCycle"
+      desc:    "RV32M"
       local:   "false"
       expose:  "true"
     },
@@ -257,6 +253,7 @@
     { name:    "RV32B"
       type:    "ibex_pkg::rv32b_e"
       default: "ibex_pkg::RV32BNone"
+      desc:    "RV32B"
       local:   "false"
       expose:  "true"
     },
@@ -264,6 +261,7 @@
     { name:    "RegFile"
       type:    "ibex_pkg::regfile_e"
       default: "ibex_pkg::RegFileFF"
+      desc:    "Reg file"
       local:   "false"
       expose:  "true"
     },
@@ -271,6 +269,7 @@
     { name:    "BranchTargetALU"
       type:    "bit"
       default: "1'b1"
+      desc:    "Branch target ALU"
       local:   "false"
       expose:  "true"
     },
@@ -278,6 +277,7 @@
     { name:    "WritebackStage"
       type:    "bit"
       default: "1'b1"
+      desc:    "Write back stage"
       local:   "false"
       expose:  "true"
     },
@@ -285,6 +285,7 @@
     { name:    "ICache"
       type:    "bit"
       default: "0"
+      desc:    "Instruction cache"
       local:   "false"
       expose:  "true"
     },
@@ -292,6 +293,7 @@
     { name:    "ICacheECC"
       type:    "bit"
       default: "0"
+      desc:    "Instruction cache ECC"
       local:   "false"
       expose:  "true"
     },
@@ -299,6 +301,7 @@
     { name:    "ICacheScramble"
       type:    "bit"
       default: "0"
+      desc:    "Scramble instruction cach"
       local:   "false"
       expose:  "true"
     },
@@ -306,6 +309,7 @@
     { name:    "BranchPredictor"
       type:    "bit"
       default: "0"
+      desc:    "Branch predictor"
       local:   "false"
       expose:  "true"
     },
@@ -313,6 +317,7 @@
     { name:    "DbgTriggerEn"
       type:    "bit"
       default: "1"
+      desc:    "Enable degug trigger"
       local:   "false"
       expose:  "true"
     },
@@ -320,6 +325,7 @@
     { name:    "DbgHwBreakNum"
       type:    "int"
       default: "1"
+      desc:    "Number of debug hardware break"
       local:   "false"
       expose:  "true"
     },
@@ -327,6 +333,7 @@
     { name:    "SecureIbex"
       type:    "bit"
       default: "0"
+      desc:    "Width of the MHPM Counter "
       local:   "false"
       expose:  "true"
     },
@@ -334,6 +341,7 @@
     { name:    "DmHaltAddr"
       type:    "int unsigned"
       default: "437323776" //"32'h1A110800"
+      desc:    "Halt address"
       local:   "false"
       expose:  "true"
     },
@@ -341,6 +349,7 @@
     { name:    "DmExceptionAddr"
       type:    "int unsigned"
       default: "437323784" //"32'h1A110808"
+      desc:    "Exception address"
       local:   "false"
       expose:  "true"
     },
@@ -348,6 +357,7 @@
     { name:    "PipeLine"
       type:    "bit"
       default: "1'b0"
+      desc:    "Pipe line"
       local:   "false"
       expose:  "true"
     },
@@ -367,9 +377,7 @@
     },
     { name:    "NumScratchWords",
       type:    "int",
-      desc:    '''
-        Number of scratch words maintained.
-      '''
+      desc:    "Number of scratch words maintained."
       default: "8"
     },
   ],

--- a/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
+++ b/hw/top_earlgrey/data/autogen/top_earlgrey.gen.hjson
@@ -7108,6 +7108,7 @@
         }
         {
           name: PMPGranularity
+          desc: PMP Granularity
           type: int unsigned
           default: "0"
           expose: "true"
@@ -7115,6 +7116,7 @@
         }
         {
           name: PMPNumRegions
+          desc: PMP number of regions
           type: int unsigned
           default: "16"
           expose: "true"
@@ -7122,6 +7124,7 @@
         }
         {
           name: MHPMCounterNum
+          desc: "Number of the MHPM counter "
           type: int unsigned
           default: "10"
           expose: "true"
@@ -7129,6 +7132,7 @@
         }
         {
           name: MHPMCounterWidth
+          desc: "Width of the MHPM Counter "
           type: int unsigned
           default: "32"
           expose: "true"
@@ -7136,6 +7140,7 @@
         }
         {
           name: RV32E
+          desc: RV32E
           type: bit
           default: "0"
           expose: "true"
@@ -7143,6 +7148,7 @@
         }
         {
           name: RV32M
+          desc: RV32M
           type: ibex_pkg::rv32m_e
           default: ibex_pkg::RV32MSingleCycle
           expose: "true"
@@ -7150,6 +7156,7 @@
         }
         {
           name: RV32B
+          desc: RV32B
           type: ibex_pkg::rv32b_e
           default: ibex_pkg::RV32BOTEarlGrey
           expose: "true"
@@ -7157,6 +7164,7 @@
         }
         {
           name: RegFile
+          desc: Reg file
           type: ibex_pkg::regfile_e
           default: ibex_pkg::RegFileFF
           expose: "true"
@@ -7164,6 +7172,7 @@
         }
         {
           name: BranchTargetALU
+          desc: Branch target ALU
           type: bit
           default: "1"
           expose: "true"
@@ -7171,6 +7180,7 @@
         }
         {
           name: WritebackStage
+          desc: Write back stage
           type: bit
           default: "1"
           expose: "true"
@@ -7178,6 +7188,7 @@
         }
         {
           name: ICache
+          desc: Instruction cache
           type: bit
           default: "1"
           expose: "true"
@@ -7185,6 +7196,7 @@
         }
         {
           name: ICacheECC
+          desc: Instruction cache ECC
           type: bit
           default: "1"
           expose: "true"
@@ -7192,6 +7204,7 @@
         }
         {
           name: ICacheScramble
+          desc: Scramble instruction cach
           type: bit
           default: "1"
           expose: "true"
@@ -7199,6 +7212,7 @@
         }
         {
           name: BranchPredictor
+          desc: Branch predictor
           type: bit
           default: "0"
           expose: "true"
@@ -7206,6 +7220,7 @@
         }
         {
           name: DbgTriggerEn
+          desc: Enable degug trigger
           type: bit
           default: "1"
           expose: "true"
@@ -7213,6 +7228,7 @@
         }
         {
           name: DbgHwBreakNum
+          desc: Number of debug hardware break
           type: int
           default: "4"
           expose: "true"
@@ -7220,6 +7236,7 @@
         }
         {
           name: SecureIbex
+          desc: "Width of the MHPM Counter "
           type: bit
           default: "1"
           expose: "true"
@@ -7227,6 +7244,7 @@
         }
         {
           name: DmHaltAddr
+          desc: Halt address
           type: int unsigned
           default: tl_main_pkg::ADDR_SPACE_RV_DM__ROM + dm::HaltAddress[31:0]
           expose: "true"
@@ -7234,6 +7252,7 @@
         }
         {
           name: DmExceptionAddr
+          desc: Exception address
           type: int unsigned
           default: tl_main_pkg::ADDR_SPACE_RV_DM__ROM + dm::ExceptionAddress[31:0]
           expose: "true"
@@ -7241,6 +7260,7 @@
         }
         {
           name: PipeLine
+          desc: Pipe line
           type: bit
           default: "0"
           expose: "true"

--- a/sw/device/lib/base/bitfield.c
+++ b/sw/device/lib/base/bitfield.c
@@ -32,3 +32,4 @@ extern int32_t bitfield_count_trailing_zeroes32(uint32_t bitfield);
 extern int32_t bitfield_popcount32(uint32_t bitfield);
 extern int32_t bitfield_parity32(uint32_t bitfield);
 extern uint32_t bitfield_byteswap32(uint32_t bitfield);
+extern bool bitfield_is_power_of_two32(uint32_t bitfield);

--- a/sw/device/lib/base/bitfield.h
+++ b/sw/device/lib/base/bitfield.h
@@ -293,6 +293,18 @@ inline uint32_t bitfield_byteswap32(uint32_t bitfield) {
   return __builtin_bswap32(bitfield);
 }
 
+/**
+ * Check whether the bitfield value is power of two aligned.
+ *
+ * Zero will also return false.
+ *
+ * @param bitfield Value to be verified.
+ * @return True if bitfield is power of two, otherwise false.
+ */
+inline bool bitfield_is_power_of_two32(uint32_t bitfield) {
+  return bitfield != 0 && (bitfield & (bitfield - 1)) == 0;
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -822,6 +822,34 @@ cc_test(
 )
 
 cc_library(
+    name = "rv_core_ibex",
+    srcs = [
+        "autogen/dif_rv_core_ibex_autogen.c",
+        "autogen/dif_rv_core_ibex_autogen.h",
+    ],
+    hdrs = [
+    ],
+    deps = [
+        ":base",
+        "//hw/ip/rv_core_ibex/data:rv_core_ibex_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib/base:mmio",
+    ],
+)
+
+cc_test(
+    name = "rv_core_ibex_unittest",
+    srcs = [
+        "autogen/dif_rv_core_ibex_autogen_unittest.cc",
+    ],
+    deps = [
+        ":rv_core_ibex",
+        ":test_base",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_library(
     name = "rv_plic",
     srcs = [
         "autogen/dif_rv_plic_autogen.c",

--- a/sw/device/lib/dif/BUILD
+++ b/sw/device/lib/dif/BUILD
@@ -826,8 +826,10 @@ cc_library(
     srcs = [
         "autogen/dif_rv_core_ibex_autogen.c",
         "autogen/dif_rv_core_ibex_autogen.h",
+        "dif_rv_core_ibex.c",
     ],
     hdrs = [
+        "dif_rv_core_ibex.h",
     ],
     deps = [
         ":base",
@@ -841,6 +843,7 @@ cc_test(
     name = "rv_core_ibex_unittest",
     srcs = [
         "autogen/dif_rv_core_ibex_autogen_unittest.cc",
+        "dif_rv_core_ibex_unittest.cc",
     ],
     deps = [
         ":rv_core_ibex",

--- a/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.c
+++ b/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.c
@@ -1,0 +1,54 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
+// util/make_new_dif.py --mode=regen --only=autogen
+
+#include "sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.h"
+#include <stdint.h>
+
+#include "rv_core_ibex_regs.h"  // Generated.
+
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_init(mmio_region_t base_addr,
+                                   dif_rv_core_ibex_t *rv_core_ibex) {
+  if (rv_core_ibex == NULL) {
+    return kDifBadArg;
+  }
+
+  rv_core_ibex->base_addr = base_addr;
+
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_alert_force(
+    const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_alert_t alert) {
+  if (rv_core_ibex == NULL) {
+    return kDifBadArg;
+  }
+
+  bitfield_bit32_index_t alert_idx;
+  switch (alert) {
+    case kDifRvCoreIbexAlertFatalSwErr:
+      alert_idx = RV_CORE_IBEX_ALERT_TEST_FATAL_SW_ERR_BIT;
+      break;
+    case kDifRvCoreIbexAlertRecovSwErr:
+      alert_idx = RV_CORE_IBEX_ALERT_TEST_RECOV_SW_ERR_BIT;
+      break;
+    case kDifRvCoreIbexAlertFatalHwErr:
+      alert_idx = RV_CORE_IBEX_ALERT_TEST_FATAL_HW_ERR_BIT;
+      break;
+    case kDifRvCoreIbexAlertRecovHwErr:
+      alert_idx = RV_CORE_IBEX_ALERT_TEST_RECOV_HW_ERR_BIT;
+      break;
+    default:
+      return kDifBadArg;
+  }
+
+  uint32_t alert_test_reg = bitfield_bit32_write(0, alert_idx, true);
+  mmio_region_write32(rv_core_ibex->base_addr,
+                      RV_CORE_IBEX_ALERT_TEST_REG_OFFSET, alert_test_reg);
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.h
+++ b/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.h
@@ -1,0 +1,93 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_RV_CORE_IBEX_AUTOGEN_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_RV_CORE_IBEX_AUTOGEN_H_
+
+// THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
+// util/make_new_dif.py --mode=regen --only=autogen
+
+/**
+ * @file
+ * @brief <a href="/hw/ip/rv_core_ibex/doc/">RV_CORE_IBEX</a> Device Interface
+ * Functions
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * A handle to rv_core_ibex.
+ *
+ * This type should be treated as opaque by users.
+ */
+typedef struct dif_rv_core_ibex {
+  /**
+   * The base address for the rv_core_ibex hardware registers.
+   */
+  mmio_region_t base_addr;
+} dif_rv_core_ibex_t;
+
+/**
+ * Creates a new handle for a(n) rv_core_ibex peripheral.
+ *
+ * This function does not actuate the hardware.
+ *
+ * @param base_addr The MMIO base address of the rv_core_ibex peripheral.
+ * @param[out] rv_core_ibex Out param for the initialized handle.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_init(mmio_region_t base_addr,
+                                   dif_rv_core_ibex_t *rv_core_ibex);
+
+/**
+ * A rv_core_ibex alert type.
+ */
+typedef enum dif_rv_core_ibex_alert {
+  /**
+   * Software triggered alert for fatal faults
+   */
+  kDifRvCoreIbexAlertFatalSwErr = 0,
+  /**
+   * Software triggered Alert for recoverable faults
+   */
+  kDifRvCoreIbexAlertRecovSwErr = 1,
+  /**
+   * Triggered when - Ibex raises `alert_major_internal_o` - Ibex raises
+   * `alert_major_bus_o` - A double fault is seen (Ibex raises
+   * `double_fault_seen_o`) - A bus integrity error is seen
+   */
+  kDifRvCoreIbexAlertFatalHwErr = 2,
+  /**
+   * Triggered when Ibex raises `alert_minor_o`
+   */
+  kDifRvCoreIbexAlertRecovHwErr = 3,
+} dif_rv_core_ibex_alert_t;
+
+/**
+ * Forces a particular alert, causing it to be escalated as if the hardware
+ * had raised it.
+ *
+ * @param rv_core_ibex A rv_core_ibex handle.
+ * @param alert The alert to force.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_alert_force(
+    const dif_rv_core_ibex_t *rv_core_ibex, dif_rv_core_ibex_alert_t alert);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_AUTOGEN_DIF_RV_CORE_IBEX_AUTOGEN_H_

--- a/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen_unittest.cc
+++ b/sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen_unittest.cc
@@ -1,0 +1,66 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// THIS FILE HAS BEEN GENERATED, DO NOT EDIT MANUALLY. COMMAND:
+// util/make_new_dif.py --mode=regen --only=autogen
+
+#include "sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
+
+#include "rv_core_ibex_regs.h"  // Generated.
+
+namespace dif_rv_core_ibex_autogen_unittest {
+namespace {
+using ::mock_mmio::MmioTest;
+using ::mock_mmio::MockDevice;
+using ::testing::Eq;
+using ::testing::Test;
+
+class RvCoreIbexTest : public Test, public MmioTest {
+ protected:
+  dif_rv_core_ibex_t rv_core_ibex_ = {.base_addr = dev().region()};
+};
+
+class InitTest : public RvCoreIbexTest {};
+
+TEST_F(InitTest, NullArgs) {
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_init(dev().region(), nullptr));
+}
+
+TEST_F(InitTest, Success) {
+  EXPECT_DIF_OK(dif_rv_core_ibex_init(dev().region(), &rv_core_ibex_));
+}
+
+class AlertForceTest : public RvCoreIbexTest {};
+
+TEST_F(AlertForceTest, NullArgs) {
+  EXPECT_DIF_BADARG(
+      dif_rv_core_ibex_alert_force(nullptr, kDifRvCoreIbexAlertFatalSwErr));
+}
+
+TEST_F(AlertForceTest, BadAlert) {
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_alert_force(
+      nullptr, static_cast<dif_rv_core_ibex_alert_t>(32)));
+}
+
+TEST_F(AlertForceTest, Success) {
+  // Force first alert.
+  EXPECT_WRITE32(RV_CORE_IBEX_ALERT_TEST_REG_OFFSET,
+                 {{RV_CORE_IBEX_ALERT_TEST_FATAL_SW_ERR_BIT, true}});
+  EXPECT_DIF_OK(dif_rv_core_ibex_alert_force(&rv_core_ibex_,
+                                             kDifRvCoreIbexAlertFatalSwErr));
+
+  // Force last alert.
+  EXPECT_WRITE32(RV_CORE_IBEX_ALERT_TEST_REG_OFFSET,
+                 {{RV_CORE_IBEX_ALERT_TEST_RECOV_HW_ERR_BIT, true}});
+  EXPECT_DIF_OK(dif_rv_core_ibex_alert_force(&rv_core_ibex_,
+                                             kDifRvCoreIbexAlertRecovHwErr));
+}
+
+}  // namespace
+}  // namespace dif_rv_core_ibex_autogen_unittest

--- a/sw/device/lib/dif/dif_rv_core_ibex.c
+++ b/sw/device/lib/dif/dif_rv_core_ibex.c
@@ -1,0 +1,163 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/mmio.h"
+
+// #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "rv_core_ibex_regs.h"
+
+typedef struct ibex_addr_translation_regs {
+  uint32_t ibus_maching;
+  uint32_t ibus_remap;
+  uint32_t ibus_en;
+  uint32_t ibus_lock;
+  uint32_t dbus_maching;
+  uint32_t dbus_remap;
+  uint32_t dbus_en;
+  uint32_t dbus_lock;
+} ibex_addr_translation_regs_t;
+
+static const ibex_addr_translation_regs_t
+    kRegsMap[kDifRvCoreIbexAddrTranslationSlotCount] = {
+        [kDifRvCoreIbexAddrTranslationSlot_0] =
+            {
+                .ibus_maching = RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET,
+                .ibus_remap = RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
+                .ibus_en = RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET,
+                .ibus_lock = RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET,
+                .dbus_maching = RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET,
+                .dbus_remap = RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET,
+                .dbus_en = RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET,
+                .dbus_lock = RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET,
+            },
+        [kDifRvCoreIbexAddrTranslationSlot_1] =
+            {
+                .ibus_maching = RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET,
+                .ibus_remap = RV_CORE_IBEX_IBUS_REMAP_ADDR_1_REG_OFFSET,
+                .ibus_en = RV_CORE_IBEX_IBUS_ADDR_EN_1_REG_OFFSET,
+                .ibus_lock = RV_CORE_IBEX_IBUS_REGWEN_1_REG_OFFSET,
+                .dbus_maching = RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET,
+                .dbus_remap = RV_CORE_IBEX_DBUS_REMAP_ADDR_1_REG_OFFSET,
+                .dbus_en = RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET,
+                .dbus_lock = RV_CORE_IBEX_DBUS_REGWEN_1_REG_OFFSET,
+            },
+};
+
+/**
+ * Convert the region address and size into a natural power of two address.
+ *
+ * @param addr Region start address.
+ * @param size region size.
+ * @return Napot address
+ */
+static uint32_t to_napot(uint32_t addr, size_t size) {
+  return addr | (size - 1) >> 1;
+}
+
+/**
+ * Split a natural power of two address into a start address and size.
+ *
+ * @param napot Address formated in NAPOT.
+ * @param size  Pointer to receive the region size.
+ * @return The region start address.
+ */
+static uint32_t from_napot(uint32_t napot, size_t *size) {
+  for (size_t i = 1; i < sizeof(uint32_t) * 8; ++i) {
+    uint32_t ref = (1u << i) - 1;
+    if ((napot & ref) == ref >> 1) {
+      *size = 1u << i;
+      break;
+    }
+  }
+  return napot & ~((*size - 1) >> 1);
+}
+
+dif_result_t dif_rv_core_ibex_configure_addr_translation(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_addr_translation_slot_t slot,
+    dif_rv_core_ibex_addr_translation_region_t region) {
+  if (rv_core_ibex == NULL || slot >= kDifRvCoreIbexAddrTranslationSlotCount) {
+    return kDifBadArg;
+  }
+
+  if (!bitfield_is_power_of_two32(region.dbus.size) ||
+      !bitfield_is_power_of_two32(region.ibus.size)) {
+    return kDifBadArg;
+  }
+
+  const ibex_addr_translation_regs_t regs = kRegsMap[slot];
+
+  if (mmio_region_read32(rv_core_ibex->base_addr, regs.dbus_lock) == 0 ||
+      mmio_region_read32(rv_core_ibex->base_addr, regs.ibus_lock) == 0) {
+    return kDifLocked;
+  }
+
+  uint32_t mask = to_napot(region.ibus.matching_addr, region.ibus.size);
+  mmio_region_write32(rv_core_ibex->base_addr, regs.ibus_maching, mask);
+  mmio_region_write32(rv_core_ibex->base_addr, regs.ibus_remap,
+                      region.ibus.remap_addr);
+  mmio_region_write32(rv_core_ibex->base_addr, regs.ibus_en, 1);
+
+  mask = to_napot(region.dbus.matching_addr, region.dbus.size);
+  mmio_region_write32(rv_core_ibex->base_addr, regs.dbus_maching, mask);
+  mmio_region_write32(rv_core_ibex->base_addr, regs.dbus_remap,
+                      region.dbus.remap_addr);
+  mmio_region_write32(rv_core_ibex->base_addr, regs.dbus_en, 1);
+
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_read_addr_translation(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_addr_translation_slot_t slot,
+    dif_rv_core_ibex_addr_translation_region_t *region) {
+  if (rv_core_ibex == NULL || region == NULL ||
+      slot >= kDifRvCoreIbexAddrTranslationSlotCount) {
+    return kDifBadArg;
+  }
+
+  const ibex_addr_translation_regs_t regs = kRegsMap[slot];
+
+  uint32_t reg = mmio_region_read32(rv_core_ibex->base_addr, regs.ibus_maching);
+  region->ibus.matching_addr = from_napot(reg, &region->ibus.size);
+
+  region->ibus.remap_addr =
+      mmio_region_read32(rv_core_ibex->base_addr, regs.ibus_remap);
+
+  reg = mmio_region_read32(rv_core_ibex->base_addr, regs.dbus_maching);
+  region->dbus.matching_addr = from_napot(reg, &region->dbus.size);
+
+  region->dbus.remap_addr =
+      mmio_region_read32(rv_core_ibex->base_addr, regs.dbus_remap);
+
+  return kDifOk;
+}
+
+dif_result_t dif_rv_core_ibex_lock_addr_translation(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_addr_translation_slot_t slot) {
+  if (rv_core_ibex == NULL || slot >= kDifRvCoreIbexAddrTranslationSlotCount) {
+    return kDifBadArg;
+  }
+
+  const ibex_addr_translation_regs_t regs = kRegsMap[slot];
+
+  // Only locks in case it is not locked already.
+  if (mmio_region_read32(rv_core_ibex->base_addr, regs.dbus_lock) == 1) {
+    mmio_region_write32(rv_core_ibex->base_addr, regs.dbus_lock, 0);
+  }
+
+  if (mmio_region_read32(rv_core_ibex->base_addr, regs.ibus_lock) == 1) {
+    mmio_region_write32(rv_core_ibex->base_addr, regs.ibus_lock, 0);
+  }
+
+  return kDifOk;
+}

--- a/sw/device/lib/dif/dif_rv_core_ibex.h
+++ b/sw/device/lib/dif/dif_rv_core_ibex.h
@@ -1,0 +1,122 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_DIF_DIF_RV_CORE_IBEX_H_
+#define OPENTITAN_SW_DEVICE_LIB_DIF_DIF_RV_CORE_IBEX_H_
+
+#include <stdint.h>
+
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/dif/dif_base.h"
+
+#include "sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Address translation slot.
+ */
+typedef enum dif_rv_core_ibex_addr_translation_slot {
+  kDifRvCoreIbexAddrTranslationSlot_0,
+  kDifRvCoreIbexAddrTranslationSlot_1,
+  kDifRvCoreIbexAddrTranslationSlotCount,
+} dif_rv_core_ibex_addr_translation_slot_t;
+
+/**
+ * Address tranlation matching region.
+ *
+ * The value programmed is done at power-of-2 alignment. For example, if the
+ * intended matching region is 0x8000_0000 to 0x8000_FFFF, the value
+ * programmed is 0x8000_7FFF.
+ *
+ * The value programmed can be determined from the translation granule. Assume
+ * the user wishes to translate a specific 64KB block to a different address:
+ * 64KB has a hex value of 0x10000. Subtract 1 from this value and then right
+ * shift by one to obtain 0x7FFF. This value is then logically OR'd with the
+ * upper address bits that would select which 64KB to translate.
+ */
+typedef struct dif_rv_core_ibex_addr_translation_pair {
+  /**
+   * Matching address (Virtual address).
+   * When an incoming transaction matches the matching
+   * region, it is redirected to the new address. If a transaction does not
+   * match, then it is directly passed through.
+   */
+  uintptr_t matching_addr;
+
+  /**
+   * Remap address (Physical address).
+   * The region where the matched transtaction will be
+   * redirected to.
+   */
+  uintptr_t remap_addr;
+
+  /**
+   * Address region size.
+   */
+  size_t size;
+} dif_rv_core_ibex_addr_translation_pair_t;
+
+/**
+ * Addresses translation region.
+ */
+typedef struct dif_rv_core_ibex_addr_translation_region {
+  /**
+   * Region representing the instruction bus.
+   */
+  dif_rv_core_ibex_addr_translation_pair_t ibus;
+
+  /**
+   * Region representing the data bus.
+   */
+  dif_rv_core_ibex_addr_translation_pair_t dbus;
+} dif_rv_core_ibex_addr_translation_region_t;
+
+/**
+ * Configure the instruction and data bus in the address translation `slot`.
+ *
+ * @param rv_core_ibex Handle.
+ * @param slot   Slot to be used.
+ * @param region Dbus and Ibus addresses.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_configure_addr_translation(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_addr_translation_slot_t slot,
+    dif_rv_core_ibex_addr_translation_region_t region);
+
+/**
+ *
+ * @param rv_core_ibex Handle.
+ * @param slot Slot to be read.
+ * @param[out] region Pointer to receive the Dbus and Ibus addresses.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_read_addr_translation(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_addr_translation_slot_t slot,
+    dif_rv_core_ibex_addr_translation_region_t *region);
+
+/**
+ * Lock the `slot` registers. Once locked it can no longer be unlocked until the
+ * next system reset.
+ *
+ * @param rv_core_ibex Handle.
+ * @param slot Slot to be locked.
+ * @return The result of the operation.
+ */
+OT_WARN_UNUSED_RESULT
+dif_result_t dif_rv_core_ibex_lock_addr_translation(
+    const dif_rv_core_ibex_t *rv_core_ibex,
+    dif_rv_core_ibex_addr_translation_slot_t slot);
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_DIF_DIF_RV_CORE_IBEX_H_

--- a/sw/device/lib/dif/dif_rv_core_ibex.md
+++ b/sw/device/lib/dif/dif_rv_core_ibex.md
@@ -1,0 +1,52 @@
+---
+title: "Rv core ibex DIF Checklist"
+---
+
+This checklist is for [Development Stage]({{< relref "/doc/project/development_stages.md" >}}) transitions for the [Rv core ibex DIF]({{< relref "hw/ip/rv_core_ibex/doc" >}}).
+All checklist items refer to the content in the [Checklist]({{< relref "/doc/project/checklist.md" >}}).
+
+<h2>DIF Checklist</h2>
+
+<h3>S1</h3>
+
+Type           | Item                 | Resolution  | Note/Collaterals
+---------------|----------------------|-------------|------------------
+Implementation | [DIF_EXISTS][]       | In Progress |
+Implementation | [DIF_USED_IN_TREE][] | In Progress |
+Tests          | [DIF_TEST_SMOKE][]   | In Progress |
+
+[DIF_EXISTS]:       {{< relref "/doc/project/checklist.md#dif_exists" >}}
+[DIF_USED_IN_TREE]: {{< relref "/doc/project/checklist.md#dif_used_in_tree" >}}
+[DIF_TEST_SMOKE]:   {{< relref "/doc/project/checklist.md#dif_test_smoke" >}}
+
+<h3>S2</h3>
+
+Type           | Item                        | Resolution  | Note/Collaterals
+---------------|-----------------------------|-------------|------------------
+Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Not Started | [HW Dashboard]({{< relref "hw" >}})
+Implementation | [DIF_FEATURES][]            | In Progress |
+Coordination   | [DIF_DV_TESTS][]            | Not Started |
+
+[DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
+[DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
+[DIF_DV_TESTS]:            {{< relref "/doc/project/checklist.md#dif_dv_tests" >}}
+
+<h3>S3</h3>
+
+Type           | Item                             | Resolution  | Note/Collaterals
+---------------|----------------------------------|-------------|------------------
+Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
+Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
+Documentation  | [DIF_DOC_HW][]                   | Not Started |
+Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | In Progress |
+Review         | [DIF_TODO_COMPLETE][]            | Not Started |
+Review         | Reviewer(s)                      | Not Started |
+Review         | Signoff date                     | Not Started |
+
+[DIF_HW_DESIGN_COMPLETE]:       {{< relref "/doc/project/checklist.md#dif_hw_design_complete" >}}
+[DIF_HW_VERIFICATION_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_verification_complete" >}}
+[DIF_DOC_HW]:                   {{< relref "/doc/project/checklist.md#dif_doc_hw" >}}
+[DIF_CODE_STYLE]:               {{< relref "/doc/project/checklist.md#dif_code_style" >}}
+[DIF_TEST_UNIT]:                {{< relref "/doc/project/checklist.md#dif_test_unit" >}}
+[DIF_TODO_COMPLETE]:            {{< relref "/doc/project/checklist.md#dif_todo_complete" >}}

--- a/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
+++ b/sw/device/lib/dif/dif_rv_core_ibex_unittest.cc
@@ -1,0 +1,265 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/dif/dif_rv_core_ibex.h"
+
+#include "gtest/gtest.h"
+#include "sw/device/lib/base/mmio.h"
+#include "sw/device/lib/base/testing/mock_mmio.h"
+#include "sw/device/lib/dif/dif_test_base.h"
+
+extern "C" {
+#include "rv_core_ibex_regs.h"  // Generated.
+}  // extern "C"
+
+// We define global namespace == and << to make `dif_i2c_timing_params_t` work
+// nicely with EXPECT_EQ.
+bool operator==(const dif_rv_core_ibex_addr_translation_region_t a,
+                const dif_rv_core_ibex_addr_translation_region_t b) {
+  return memcmp(&a, &b, sizeof(dif_rv_core_ibex_addr_translation_region_t)) ==
+         0;
+}
+
+std::ostream &operator<<(
+    std::ostream &os,
+    const dif_rv_core_ibex_addr_translation_region_t &region) {
+  return os << "{\n"
+            << "ibus = {\n"
+            << "  .matching_addr = " << region.ibus.matching_addr << ",\n"
+            << "  .remap_addr = " << region.ibus.remap_addr << ",\n"
+            << "  .size = " << region.ibus.size << ",\n"
+            << "},\n"
+            << "dbus = {\n"
+            << "  .matching_addr = " << region.dbus.matching_addr << ",\n"
+            << "  .remap_addr = " << region.dbus.remap_addr << ",\n"
+            << "  .size = " << region.dbus.size << ",\n"
+            << "},\n"
+            << "}";
+}
+
+namespace dif_rv_core_ibex_test {
+using mock_mmio::MmioTest;
+using mock_mmio::MockDevice;
+using testing::Test;
+
+// Base class for the rest fixtures in this file.
+class RvCoreIbexTest : public testing::Test, public mock_mmio::MmioTest {};
+
+// Base class for the rest of the tests in this file, provides a
+// `dif_aes_t` instance.
+class RvCoreIbexTestInitialized : public RvCoreIbexTest {
+ protected:
+  dif_rv_core_ibex_t ibex_;
+
+  RvCoreIbexTestInitialized() {
+    EXPECT_DIF_OK(dif_rv_core_ibex_init(dev().region(), &ibex_));
+  }
+};
+
+class AddressTranslationTest : public RvCoreIbexTestInitialized {
+ protected:
+  static constexpr dif_rv_core_ibex_addr_translation_region_t kRegion = {
+      .ibus =
+          {
+              .matching_addr = 0x9000000,
+              .remap_addr = 0x2000000,
+              .size = 0x8000,
+          },
+      .dbus =
+          {
+              .matching_addr = 0x9000000,
+              .remap_addr = 0x2000000,
+              .size = 0x8000,
+          },
+  };
+
+  uint32_t Napot(uint32_t addr, size_t size) { return addr | (size - 1) >> 1; }
+};
+constexpr dif_rv_core_ibex_addr_translation_region_t
+    AddressTranslationTest::kRegion;
+
+TEST_F(AddressTranslationTest, Slot0Success) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET, 1);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET, 1);
+
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET, 0x9003fff);
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
+                 kRegion.ibus.remap_addr);
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET, 1);
+
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET, 0x9003fff);
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET,
+                 kRegion.dbus.remap_addr);
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET, 1);
+
+  EXPECT_DIF_OK(dif_rv_core_ibex_configure_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_0, kRegion));
+}
+
+TEST_F(AddressTranslationTest, Slot1Success) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_1_REG_OFFSET, 1);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_1_REG_OFFSET, 1);
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_ADDR_MATCHING_1_REG_OFFSET, 0x9003fff);
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_REMAP_ADDR_1_REG_OFFSET,
+                 kRegion.ibus.remap_addr);
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_ADDR_EN_1_REG_OFFSET, 1);
+
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_ADDR_MATCHING_1_REG_OFFSET, 0x9003fff);
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_REMAP_ADDR_1_REG_OFFSET,
+                 kRegion.dbus.remap_addr);
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_ADDR_EN_1_REG_OFFSET, 1);
+
+  EXPECT_DIF_OK(dif_rv_core_ibex_configure_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_1, kRegion));
+}
+
+TEST_F(AddressTranslationTest, PowerOfTwoAlignmentSuccess) {
+  dif_rv_core_ibex_addr_translation_region_t region = kRegion;
+
+  region.ibus.matching_addr = 0x8000000;
+  region.dbus.matching_addr = 0x8000000;
+
+  for (size_t i = 0; i < (sizeof(uint32_t) * 8) - 1; ++i) {
+    region.ibus.size = 1u << i;
+    region.dbus.size = 1u << i;
+
+    EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET, 1);
+    EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET, 1);
+
+    EXPECT_WRITE32(RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET,
+                   Napot(region.ibus.matching_addr, region.ibus.size));
+    EXPECT_WRITE32(RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
+                   region.ibus.remap_addr);
+    EXPECT_WRITE32(RV_CORE_IBEX_IBUS_ADDR_EN_0_REG_OFFSET, 1);
+
+    EXPECT_WRITE32(RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET,
+                   Napot(region.dbus.matching_addr, region.dbus.size));
+    EXPECT_WRITE32(RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET,
+                   region.dbus.remap_addr);
+    EXPECT_WRITE32(RV_CORE_IBEX_DBUS_ADDR_EN_0_REG_OFFSET, 1);
+
+    EXPECT_DIF_OK(dif_rv_core_ibex_configure_addr_translation(
+        &ibex_, kDifRvCoreIbexAddrTranslationSlot_0, region));
+  }
+}
+
+TEST_F(AddressTranslationTest, ReadSlot0Success) {
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_ADDR_MATCHING_0_REG_OFFSET, 0x9003fff);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REMAP_ADDR_0_REG_OFFSET,
+                kRegion.ibus.remap_addr);
+
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_ADDR_MATCHING_0_REG_OFFSET, 0x9003fff);
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REMAP_ADDR_0_REG_OFFSET,
+                kRegion.dbus.remap_addr);
+
+  dif_rv_core_ibex_addr_translation_region_t region;
+  EXPECT_DIF_OK(dif_rv_core_ibex_read_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_0, &region));
+
+  EXPECT_EQ(region, kRegion);
+}
+
+TEST_F(AddressTranslationTest, LockSlot0Success) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET, 1);
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET, 0);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET, 1);
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET, 0);
+
+  EXPECT_DIF_OK(dif_rv_core_ibex_lock_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_0));
+}
+
+TEST_F(AddressTranslationTest, LockSlot0LockedSuccess) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET, 0);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET, 0);
+
+  EXPECT_DIF_OK(dif_rv_core_ibex_lock_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_0));
+}
+
+TEST_F(AddressTranslationTest, LockSlot1Success) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_1_REG_OFFSET, 1);
+  EXPECT_WRITE32(RV_CORE_IBEX_DBUS_REGWEN_1_REG_OFFSET, 0);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_1_REG_OFFSET, 1);
+  EXPECT_WRITE32(RV_CORE_IBEX_IBUS_REGWEN_1_REG_OFFSET, 0);
+
+  EXPECT_DIF_OK(dif_rv_core_ibex_lock_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_1));
+}
+
+TEST_F(AddressTranslationTest, LockSlot1LockedSuccess) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_1_REG_OFFSET, 0);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_1_REG_OFFSET, 0);
+
+  EXPECT_DIF_OK(dif_rv_core_ibex_lock_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_1));
+}
+
+TEST_F(AddressTranslationTest, BadArg) {
+  dif_rv_core_ibex_addr_translation_region_t region;
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_configure_addr_translation(
+      nullptr, kDifRvCoreIbexAddrTranslationSlot_1, region));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_configure_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlotCount, region));
+
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_read_addr_translation(
+      nullptr, kDifRvCoreIbexAddrTranslationSlot_1, &region));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_read_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlotCount, &region));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_read_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_1, nullptr));
+
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_lock_addr_translation(
+      nullptr, kDifRvCoreIbexAddrTranslationSlot_1));
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_lock_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlotCount));
+}
+
+TEST_F(AddressTranslationTest, Slot0DbusLocked) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_rv_core_ibex_configure_addr_translation(
+                &ibex_, kDifRvCoreIbexAddrTranslationSlot_0, kRegion),
+            kDifLocked);
+}
+
+TEST_F(AddressTranslationTest, Slot0IbusLocked) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_0_REG_OFFSET, 1);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_0_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_rv_core_ibex_configure_addr_translation(
+                &ibex_, kDifRvCoreIbexAddrTranslationSlot_0, kRegion),
+            kDifLocked);
+}
+
+TEST_F(AddressTranslationTest, Slot1DbusLocked) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_1_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_rv_core_ibex_configure_addr_translation(
+                &ibex_, kDifRvCoreIbexAddrTranslationSlot_1, kRegion),
+            kDifLocked);
+}
+
+TEST_F(AddressTranslationTest, Slot1IbusLocked) {
+  EXPECT_READ32(RV_CORE_IBEX_DBUS_REGWEN_1_REG_OFFSET, 1);
+  EXPECT_READ32(RV_CORE_IBEX_IBUS_REGWEN_1_REG_OFFSET, 0);
+
+  EXPECT_EQ(dif_rv_core_ibex_configure_addr_translation(
+                &ibex_, kDifRvCoreIbexAddrTranslationSlot_1, kRegion),
+            kDifLocked);
+}
+
+TEST_F(AddressTranslationTest, NotPowerOfTwo) {
+  dif_rv_core_ibex_addr_translation_region_t region = kRegion;
+  region.dbus.size += 0x20;
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_configure_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_1, region));
+
+  region.dbus.size -= 0x20;
+  region.ibus.size += 0x20;
+  EXPECT_DIF_BADARG(dif_rv_core_ibex_configure_addr_translation(
+      &ibex_, kDifRvCoreIbexAddrTranslationSlot_0, region));
+}
+
+}  // namespace dif_rv_core_ibex_test


### PR DESCRIPTION
This PR:

- Create the dif for the `rv_core_ibex` IP.
- Add address translation implementation.
- Add unittest for the address translation.
- Fix the `hw/ip/rv_core_ibex/data/rv_core_ibex.hjson` in order to generate the `sw/device/lib/dif/autogen/dif_rv_core_ibex_autogen*`