### PR TITLE
[otbn,dv] Remove unused "locking_i" signal to the idle checker

### DIFF
--- a/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
+++ b/hw/ip/otbn/dv/uvm/sva/otbn_idle_checker.sv
@@ -22,9 +22,7 @@ module otbn_idle_checker
 
   input logic [7:0] status_q_i,
   input logic [38:0] imem_rdata_bus,
-  input logic [ExtWLEN-1:0] dmem_rdata_bus,
-
-  input logic locking_i
+  input logic [ExtWLEN-1:0] dmem_rdata_bus
 );
 
   // Several of the internal signals that we snoop from the otbn module run "a cycle early". This


### PR DESCRIPTION
This was added in be8fca1 but isn't used (and also isn't connected up
in `otbn_bind.sv`, which gives the warning that made me notice it!)
