### PR TITLE
[otbn,dv] Don't connect up "idle_o" output in TB

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
+++ b/hw/ip/otbn/dv/uvm/env/otbn_env_pkg.sv
@@ -52,7 +52,6 @@ package otbn_env_pkg;
   parameter int KEY_RSP_DATA_SIZE = $bits(otp_ctrl_pkg::otbn_otp_key_rsp_t);
 
   // typedefs
-  typedef virtual pins_if #(1)     idle_vif;
   typedef virtual otbn_escalate_if escalate_vif;
   typedef logic [TL_AIW-1:0]       tl_source_t;
   typedef key_sideload_agent#(keymgr_pkg::otbn_key_req_t) otbn_sideload_agent;

--- a/hw/ip/otbn/dv/uvm/tb.sv
+++ b/hw/ip/otbn/dv/uvm/tb.sv
@@ -21,7 +21,7 @@ module tb;
   `include "dv_macros.svh"
 
   wire clk, rst_n;
-  wire idle, intr_done;
+  wire intr_done;
   wire [NUM_MAX_INTERRUPTS-1:0] interrupts;
 
   // Configure internal secure wipe
@@ -30,7 +30,6 @@ module tb;
   // interfaces
   clk_rst_if                    clk_rst_if  (.clk(clk), .rst_n(rst_n));
   tl_if                         tl_if       (.clk(clk), .rst_n(rst_n));
-  pins_if #(1)                  idle_if     (idle);
   otbn_escalate_if              escalate_if (.clk_i (clk), .rst_ni (rst_n));
   pins_if #(NUM_MAX_INTERRUPTS) intr_if     (interrupts);
   assign interrupts[0] = {intr_done};
@@ -126,7 +125,8 @@ module tb;
     .tl_i(tl_if.h2d),
     .tl_o(tl_if.d2h),
 
-    .idle_o(idle),
+    // Correct behaviour of the idle output is ensured by the bound-in otbn_idle_checker instance.
+    .idle_o(),
 
     .intr_done_o(intr_done),
 
@@ -313,7 +313,6 @@ module tb;
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "otp_clk_rst_vif", otp_clk_rst_if);
     uvm_config_db#(virtual clk_rst_if)::set(null, "*.env", "clk_rst_vif", clk_rst_if);
     uvm_config_db#(virtual tl_if)::set(null, "*.env.m_tl_agent*", "vif", tl_if);
-    uvm_config_db#(idle_vif)::set(null, "*.env", "idle_vif", idle_if);
     uvm_config_db#(escalate_vif)::set(null, "*.env", "escalate_vif", escalate_if);
     uvm_config_db#(intr_vif)::set(null, "*.env", "intr_vif", intr_if);
     uvm_config_db#(virtual otbn_model_if)::set(null, "*.env.model_agent", "vif", model_if);


### PR DESCRIPTION
The checking for this signal is handled by the `otbn_idle_checker`
instance which is bound in to the `otbn` module. The connections that
we'd wired up here didn't actually do anything, and in fact were
wrong! This signal turned into a `mubi4_t` back in March (6a18e34) and
the only result was an Xcelium warning about mismatching port widths.
