### PR TITLE
[prim/fifo] Add option to harden prim fifo pointers

### DIFF
--- a/hw/ip/csrng/rtl/csrng_block_encrypt.sv
+++ b/hw/ip/csrng/rtl/csrng_block_encrypt.sv
@@ -152,7 +152,8 @@ module csrng_block_encrypt import csrng_pkg::*; #(
     .rready_i (sfifo_blkenc_pop),
     .rdata_o  (sfifo_blkenc_rdata),
     .full_o   (sfifo_blkenc_full),
-    .depth_o  ()
+    .depth_o  (),
+    .err_o    ()
   );
 
   assign sfifo_blkenc_push = block_encrypt_req_i && !sfifo_blkenc_full;

--- a/hw/ip/csrng/rtl/csrng_cmd_stage.sv
+++ b/hw/ip/csrng/rtl/csrng_cmd_stage.sv
@@ -129,7 +129,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     .rready_i       (sfifo_cmd_pop),
     .rdata_o        (sfifo_cmd_rdata),
     .full_o         (sfifo_cmd_full),
-    .depth_o        (sfifo_cmd_depth)
+    .depth_o        (sfifo_cmd_depth),
+    .err_o          ()
   );
 
   assign sfifo_cmd_wdata = cmd_stage_bus_i;
@@ -362,7 +363,8 @@ module csrng_cmd_stage import csrng_pkg::*; #(
     .rready_i       (sfifo_genbits_pop),
     .rdata_o        (sfifo_genbits_rdata),
     .full_o         (sfifo_genbits_full),
-    .depth_o        () // sfifo_genbits_depth)
+    .depth_o        (), // sfifo_genbits_depth)
+    .err_o          ()
   );
 
   assign sfifo_genbits_wdata = {genbits_fips_i,genbits_bus_i};

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_cmd.sv
@@ -154,7 +154,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
     .rready_i       (sfifo_cmdreq_pop),
     .rdata_o        (sfifo_cmdreq_rdata),
     .full_o         (sfifo_cmdreq_full),
-    .depth_o        ()
+    .depth_o        (),
+    .err_o          ()
   );
 
   assign fips_modified = ((ctr_drbg_cmd_ccmd_i == INS) ||
@@ -250,7 +251,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
     .rready_i       (sfifo_rcstage_pop),
     .rdata_o        (sfifo_rcstage_rdata),
     .full_o         (sfifo_rcstage_full),
-    .depth_o        ()
+    .depth_o        (),
+    .err_o          ()
   );
 
   assign sfifo_rcstage_push = sfifo_cmdreq_pop;
@@ -288,7 +290,8 @@ module csrng_ctr_drbg_cmd import csrng_pkg::*; #(
     .rready_i       (sfifo_keyvrc_pop),
     .rdata_o        (sfifo_keyvrc_rdata),
     .full_o         (sfifo_keyvrc_full),
-    .depth_o        ()
+    .depth_o        (),
+    .err_o          ()
   );
 
   assign sfifo_keyvrc_push = sfifo_rcstage_pop;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_gen.sv
@@ -251,7 +251,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rready_i       (sfifo_genreq_pop),
     .rdata_o        (sfifo_genreq_rdata),
     .full_o         (sfifo_genreq_full),
-    .depth_o        ()
+    .depth_o        (),
+    .err_o          ()
   );
 
   assign genreq_ccmd_modified = (ctr_drbg_gen_ccmd_i == GEN) ? GENB : INV;
@@ -392,7 +393,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rready_i       (sfifo_adstage_pop),
     .rdata_o        (sfifo_adstage_rdata),
     .full_o         (sfifo_adstage_full),
-    .depth_o        ()
+    .depth_o        (),
+    .err_o          ()
   );
 
   assign sfifo_adstage_wdata = {genreq_key,v_sized,genreq_rc,genreq_fips,genreq_glast};
@@ -449,7 +451,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rready_i (sfifo_bencack_pop),
     .rdata_o  (sfifo_bencack_rdata),
     .full_o   (sfifo_bencack_full),
-    .depth_o  ()
+    .depth_o  (),
+    .err_o    ()
   );
 
   assign bencack_ccmd_modified = (block_encrypt_ccmd_i == GENB) ? GENU : INV;
@@ -503,7 +506,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rready_i       (sfifo_rcstage_pop),
     .rdata_o        (sfifo_rcstage_rdata),
     .full_o         (sfifo_rcstage_full),
-    .depth_o        ()
+    .depth_o        (),
+    .err_o          ()
   );
 
   assign sfifo_rcstage_push = sfifo_adstage_pop;
@@ -545,7 +549,8 @@ module csrng_ctr_drbg_gen import csrng_pkg::*; #(
     .rready_i       (sfifo_genbits_pop),
     .rdata_o        (sfifo_genbits_rdata),
     .full_o         (sfifo_genbits_full),
-    .depth_o        ()
+    .depth_o        (),
+    .err_o          ()
   );
 
   assign sfifo_genbits_push = sfifo_rcstage_pop;

--- a/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
+++ b/hw/ip/csrng/rtl/csrng_ctr_drbg_upd.sv
@@ -257,7 +257,8 @@ module csrng_ctr_drbg_upd #(
     .rready_i (sfifo_updreq_pop),
     .rdata_o  (sfifo_updreq_rdata),
     .full_o   (sfifo_updreq_full),
-    .depth_o  ()
+    .depth_o  (),
+    .err_o    ()
   );
 
   assign sfifo_updreq_push = !sfifo_updreq_full && ctr_drbg_upd_req_i;
@@ -383,7 +384,8 @@ module csrng_ctr_drbg_upd #(
     .rready_i (sfifo_bencreq_pop),
     .rdata_o  (sfifo_bencreq_rdata),
     .full_o   (sfifo_bencreq_full),
-    .depth_o  ()
+    .depth_o  (),
+    .err_o    ()
   );
 
   assign sfifo_bencreq_pop = block_encrypt_req_o && block_encrypt_rdy_i;
@@ -425,7 +427,8 @@ module csrng_ctr_drbg_upd #(
     .rready_i (sfifo_bencack_pop),
     .rdata_o  (sfifo_bencack_rdata),
     .full_o   (sfifo_bencack_full),
-    .depth_o  ()
+    .depth_o  (),
+    .err_o    ()
   );
 
   assign sfifo_bencack_push = !sfifo_bencack_full && block_encrypt_ack_i;
@@ -459,7 +462,8 @@ module csrng_ctr_drbg_upd #(
     .rready_i (sfifo_pdata_pop),
     .rdata_o  (sfifo_pdata_rdata),
     .full_o   (sfifo_pdata_full),
-    .depth_o  ()
+    .depth_o  (),
+    .err_o    ()
   );
 
   assign sfifo_pdata_wdata = sfifo_updreq_pdata;
@@ -573,7 +577,8 @@ module csrng_ctr_drbg_upd #(
     .rready_i (sfifo_final_pop),
     .rdata_o  (sfifo_final_rdata),
     .full_o   (sfifo_final_full),
-    .depth_o  ()
+    .depth_o  (),
+    .err_o    ()
   );
 
   assign sfifo_final_wdata = {updated_key_and_v,concat_inst_id_q,concat_ccmd_q};

--- a/hw/ip/edn/rtl/edn_core.sv
+++ b/hw/ip/edn/rtl/edn_core.sv
@@ -486,7 +486,8 @@ module edn_core import edn_pkg::*;
     .rready_i (sfifo_rescmd_pop),
     .rdata_o  (sfifo_rescmd_rdata),
     .full_o   (sfifo_rescmd_full),
-    .depth_o  (sfifo_rescmd_depth)
+    .depth_o  (sfifo_rescmd_depth),
+    .err_o    ()
   );
 
   // feedback cmd back into rescmd fifo
@@ -529,7 +530,8 @@ module edn_core import edn_pkg::*;
     .rready_i (sfifo_gencmd_pop),
     .rdata_o  (sfifo_gencmd_rdata),
     .full_o   (sfifo_gencmd_full),
-    .depth_o  (sfifo_gencmd_depth)
+    .depth_o  (sfifo_gencmd_depth),
+    .err_o    ()
   );
 
   // feedback cmd back into gencmd fifo

--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -840,7 +840,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rdata_o    (sfifo_esrng_rdata),
     .rready_i   (sfifo_esrng_pop),
     .full_o     (sfifo_esrng_full),
-    .depth_o    ()
+    .depth_o    (),
+    .err_o      ()
   );
 
   // fifo controls
@@ -2152,7 +2153,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rdata_o    (sfifo_observe_rdata),
     .rready_i   (sfifo_observe_pop),
     .full_o     (sfifo_observe_full),
-    .depth_o    (sfifo_observe_depth)
+    .depth_o    (sfifo_observe_depth),
+    .err_o      ()
   );
 
   // The Observe fifo is intended to hold kilobits of contiguous data, yet still gracefully
@@ -2398,7 +2400,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
     .rready_i       (sfifo_esfinal_pop),
     .rdata_o        (sfifo_esfinal_rdata),
     .full_o         (sfifo_esfinal_full),
-    .depth_o        (sfifo_esfinal_depth)
+    .depth_o        (sfifo_esfinal_depth),
+    .err_o          ()
   );
 
   assign fips_compliance = !es_bypass_mode && es_enable_q_fo[29] && !rng_bit_en;

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -534,7 +534,8 @@ module flash_ctrl
     .full_o  (),
     .rvalid_o(prog_fifo_rvalid),
     .rready_i(prog_fifo_ren),
-    .rdata_o (prog_fifo_rdata)
+    .rdata_o (prog_fifo_rdata),
+    .err_o   ()
   );
   assign hw2reg.curr_fifo_lvl.prog.d = prog_fifo_depth;
 
@@ -641,7 +642,8 @@ module flash_ctrl
     .depth_o (rd_fifo_depth),
     .rvalid_o(rd_fifo_rvalid),
     .rready_i(rd_fifo_rready),
-    .rdata_o (rd_fifo_rdata)
+    .rdata_o (rd_fifo_rdata),
+    .err_o   ()
   );
   assign hw2reg.curr_fifo_lvl.rd.d = rd_fifo_depth;
 

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -535,7 +535,8 @@ module flash_ctrl
     .full_o  (),
     .rvalid_o(prog_fifo_rvalid),
     .rready_i(prog_fifo_ren),
-    .rdata_o (prog_fifo_rdata)
+    .rdata_o (prog_fifo_rdata),
+    .err_o   ()
   );
   assign hw2reg.curr_fifo_lvl.prog.d = prog_fifo_depth;
 
@@ -642,7 +643,8 @@ module flash_ctrl
     .depth_o (rd_fifo_depth),
     .rvalid_o(rd_fifo_rvalid),
     .rready_i(rd_fifo_rready),
-    .rdata_o (rd_fifo_rdata)
+    .rdata_o (rd_fifo_rdata),
+    .err_o   ()
   );
   assign hw2reg.curr_fifo_lvl.rd.d = rd_fifo_depth;
 

--- a/hw/ip/flash_ctrl/rtl/flash_phy.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy.sv
@@ -149,7 +149,8 @@ module flash_phy
     .full_o (),
     .rvalid_o(seq_fifo_pending),
     .rready_i(host_req_done_o),
-    .rdata_o (rsp_bank_sel)
+    .rdata_o (rsp_bank_sel),
+    .err_o   ()
   );
 
   // Generate host scramble_en indication, broadcasted to all banks
@@ -226,7 +227,8 @@ module flash_phy
       .full_o (),
       .rvalid_o(host_rsp_vld[bank]),
       .rready_i(host_rsp_ack[bank]),
-      .rdata_o ({host_rsp_err[bank], host_rsp_data[bank]})
+      .rdata_o ({host_rsp_err[bank], host_rsp_data[bank]}),
+      .err_o   ()
     );
 
     logic host_req;

--- a/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_rd.sv
@@ -297,7 +297,8 @@ module flash_phy_rd
     .full_o (),
     .rvalid_o(rsp_fifo_vld),
     .rready_i(data_valid_o), // pop when a match has been found
-    .rdata_o (rsp_fifo_rdata)
+    .rdata_o (rsp_fifo_rdata),
+    .err_o   ()
   );
 
 
@@ -465,7 +466,8 @@ module flash_phy_rd
     .full_o (),
     .rvalid_o(fifo_data_valid),
     .rready_i(rd_and_mask_fifo_pop),
-    .rdata_o ({alloc_q2, descram_q, forward_q, data_err_q, fifo_data})
+    .rdata_o ({alloc_q2, descram_q, forward_q, data_err_q, fifo_data}),
+    .err_o   ()
   );
 
   // storage for mask calculations
@@ -485,7 +487,8 @@ module flash_phy_rd
     .full_o (),
     .rvalid_o(mask_valid),
     .rready_i(rd_and_mask_fifo_pop),
-    .rdata_o (mask)
+    .rdata_o (mask),
+    .err_o   ()
   );
 
   // generate the mask calculation request

--- a/hw/ip/hmac/rtl/hmac.sv
+++ b/hw/ip/hmac/rtl/hmac.sv
@@ -285,7 +285,8 @@ module hmac
 
     .rvalid_o(fifo_rvalid),
     .rready_i(fifo_rready),
-    .rdata_o (fifo_rdata)
+    .rdata_o (fifo_rdata),
+    .err_o   ()
   );
 
   // TL ADAPTER SRAM

--- a/hw/ip/i2c/rtl/i2c_core.sv
+++ b/hw/ip/i2c/rtl/i2c_core.sv
@@ -317,7 +317,8 @@ module  i2c_core #(
     .rvalid_o(fmt_fifo_rvalid),
     .rready_i(fmt_fifo_rready),
     .rdata_o (fmt_fifo_rdata),
-    .full_o  ()
+    .full_o  (),
+    .err_o   ()
   );
 
   assign rx_fifo_rready = reg2hw.rdata.re;
@@ -337,7 +338,8 @@ module  i2c_core #(
     .rvalid_o(rx_fifo_rvalid),
     .rready_i(rx_fifo_rready),
     .rdata_o (rx_fifo_rdata),
-    .full_o  ()
+    .full_o  (),
+    .err_o   ()
   );
 
   // Target TX and ACQ FIFOs
@@ -362,7 +364,8 @@ module  i2c_core #(
     .rvalid_o(tx_fifo_rvalid),
     .rready_i(tx_fifo_rready),
     .rdata_o (tx_fifo_rdata),
-    .full_o  ()
+    .full_o  (),
+    .err_o   ()
   );
 
   assign acq_fifo_rready = reg2hw.acqdata.abyte.re & reg2hw.acqdata.signal.re;
@@ -382,7 +385,8 @@ module  i2c_core #(
     .rvalid_o(acq_fifo_rvalid),
     .rready_i(acq_fifo_rready),
     .rdata_o (acq_fifo_rdata),
-    .full_o  ()
+    .full_o  (),
+    .err_o   ()
   );
 
   // sync the incoming SCL and SDA signals

--- a/hw/ip/kmac/rtl/kmac_msgfifo.sv
+++ b/hw/ip/kmac/rtl/kmac_msgfifo.sv
@@ -148,7 +148,9 @@ module kmac_msgfifo
 
     .rvalid_o (fifo_rvalid),
     .rready_i (fifo_rready),
-    .rdata_o  (fifo_rdata)
+    .rdata_o  (fifo_rdata),
+    .err_o    ()
+
   );
 
   assign fifo_wvalid = packer_wvalid;

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl.sv
@@ -814,7 +814,8 @@ module otp_ctrl
     .rready_i ( otp_rvalid         ),
     .rdata_o  ( otp_part_idx       ),
     .depth_o  (                    ),
-    .full_o   (                    )
+    .full_o   (                    ),
+    .err_o    (                    )
   );
 
   // Steer response back to the partition where this request originated.

--- a/hw/ip/prim/prim_fifo.core
+++ b/hw/ip/prim/prim_fifo.core
@@ -11,10 +11,12 @@ filesets:
       - lowrisc:prim:assert
       - lowrisc:prim:util
       - lowrisc:prim:flop_2sync
+      - lowrisc:prim:count_pkg
     files:
       - rtl/prim_fifo_async_sram_adapter.sv
       - rtl/prim_fifo_async.sv
       - rtl/prim_fifo_sync.sv
+      - rtl/prim_fifo_sync_cnt.sv
     file_type: systemVerilogSource
 
   files_verilator_waiver:

--- a/hw/ip/prim/rtl/prim_fifo_sync_cnt.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync_cnt.sv
@@ -1,0 +1,102 @@
+// Copyright lowRISC contributors.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Generic synchronous fifo for use in a variety of devices.
+
+`include "prim_assert.sv"
+
+module prim_fifo_sync_cnt #(
+  parameter int Depth = 4,
+  parameter int Width = 16,
+  parameter bit Secure = 1'b0
+) (
+  input clk_i,
+  input rst_ni,
+  input clr_i,
+  input incr_wptr_i,
+  input incr_rptr_i,
+  output logic [Width-1:0] wptr_o,
+  output logic [Width-1:0] rptr_o,
+  output logic err_o
+);
+
+  logic wptr_wrap;
+  logic [Width-1:0] wptr_wrap_cnt;
+  logic rptr_wrap;
+  logic [Width-1:0] rptr_wrap_cnt;
+
+  assign wptr_wrap = incr_wptr_i & (wptr_o[Width-2:0] == unsigned'((Width-1)'(Depth-1)));
+  assign rptr_wrap = incr_rptr_i & (rptr_o[Width-2:0] == unsigned'((Width-1)'(Depth-1)));
+
+  assign wptr_wrap_cnt = {~wptr_o[Width-1],{(Width-1){1'b0}}};
+  assign rptr_wrap_cnt = {~rptr_o[Width-1],{(Width-1){1'b0}}};
+
+  if (Secure) begin : gen_secure_ptrs
+    logic wptr_err;
+    prim_count #(
+      .Width(Width),
+      .OutSelDnCnt(0),
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_wptr (
+      .clk_i,
+      .rst_ni,
+      .clr_i,
+      .set_i(wptr_wrap),
+      .set_cnt_i(wptr_wrap_cnt),
+      .en_i(incr_wptr_i),
+      .step_i(Width'(1'b1)),
+      .cnt_o(wptr_o),
+      .err_o(wptr_err)
+    );
+
+    logic rptr_err;
+    prim_count #(
+      .Width(Width),
+      .OutSelDnCnt(0),
+      .CntStyle(prim_count_pkg::DupCnt)
+    ) u_rptr (
+      .clk_i,
+      .rst_ni,
+      .clr_i,
+      .set_i(rptr_wrap),
+      .set_cnt_i(rptr_wrap_cnt),
+      .en_i(incr_rptr_i),
+      .step_i(Width'(1'b1)),
+      .cnt_o(rptr_o),
+      .err_o(rptr_err)
+    );
+
+    assign err_o = wptr_err | rptr_err;
+
+  end else begin : gen_normal_ptrs
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        wptr_o <= {(Width){1'b0}};
+      end else if (clr_i) begin
+        wptr_o <= {(Width){1'b0}};
+      end else if (wptr_wrap) begin
+        wptr_o <= wptr_wrap_cnt;
+      end else if (incr_wptr_i) begin
+        wptr_o <= wptr_o + {{(Width-1){1'b0}},1'b1};
+      end
+    end
+
+    always_ff @(posedge clk_i or negedge rst_ni) begin
+      if (!rst_ni) begin
+        rptr_o <= {(Width){1'b0}};
+      end else if (clr_i) begin
+        rptr_o <= {(Width){1'b0}};
+      end else if (rptr_wrap) begin
+         rptr_o <= rptr_wrap_cnt;
+      end else if (incr_rptr_i) begin
+         rptr_o <= rptr_o + {{(Width-1){1'b0}},1'b1};
+      end
+    end
+
+    assign err_o = '0;
+  end
+
+
+
+endmodule // prim_fifo_sync_cnt

--- a/hw/ip/prim/rtl/prim_sram_arbiter.sv
+++ b/hw/ip/prim/rtl/prim_sram_arbiter.sv
@@ -140,7 +140,8 @@ module prim_sram_arbiter #(
     .rready_i (sram_ack),
     .rdata_o  (steer),
     .full_o   (),
-    .depth_o  ()     // Not used
+    .depth_o  (),     // Not used
+    .err_o    ()
   );
 
   assign rsp_rvalid_o = steer & {N{sram_rvalid_i}};

--- a/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
+++ b/hw/ip/prim_generic/rtl/prim_generic_flash_bank.sv
@@ -143,7 +143,8 @@ module prim_generic_flash_bank #(
     .full_o (),
     .rvalid_o(cmd_valid),
     .rready_i(pop_cmd),
-    .rdata_o (cmd_q)
+    .rdata_o (cmd_q),
+    .err_o   ()
   );
 
   logic rd_req, prog_req, pg_erase_req, bk_erase_req;

--- a/hw/ip/spi_device/rtl/spid_readsram.sv
+++ b/hw/ip/spi_device/rtl/spid_readsram.sv
@@ -313,7 +313,8 @@ module spid_readsram
     .rdata_o  (sram_data),
 
     .full_o   (sram_fifo_full),
-    .depth_o  (unused_sram_depth)
+    .depth_o  (unused_sram_depth),
+    .err_o    ()
   );
 
   prim_fifo_sync #(
@@ -336,7 +337,8 @@ module spid_readsram
     .rdata_o  (fifo_rdata_o ),
 
     .full_o   (unused_fifo_full ),
-    .depth_o  (unused_fifo_depth)
+    .depth_o  (unused_fifo_depth),
+    .err_o    ()
   );
 
   // TODO: Handle SRAM integrity errors

--- a/hw/ip/spi_host/rtl/spi_host_command_queue.sv
+++ b/hw/ip/spi_host/rtl/spi_host_command_queue.sv
@@ -50,7 +50,8 @@ module spi_host_command_queue #(
     .rready_i (core_command_ready_i),
     .rdata_o  (core_command_o),
     .full_o   (),
-    .depth_o  (cmd_depth)
+    .depth_o  (cmd_depth),
+    .err_o    ()
   );
 
   assign qd_o = 4'(cmd_depth);

--- a/hw/ip/spi_host/rtl/spi_host_data_fifos.sv
+++ b/hw/ip/spi_host/rtl/spi_host_data_fifos.sv
@@ -87,7 +87,8 @@ module spi_host_data_fifos #(
     .rready_i (core_tx_ready_i),
     .rdata_o  (core_tx_data_be),
     .full_o   (),
-    .depth_o  (tx_depth)
+    .depth_o  (tx_depth),
+    .err_o    ()
   );
 
   logic [RxDepthW-1:0] rx_depth;
@@ -109,7 +110,8 @@ module spi_host_data_fifos #(
     .rready_i (rx_ready_i),
     .rdata_o  (rx_data_unordered),
     .full_o   (),
-    .depth_o  (rx_depth)
+    .depth_o  (rx_depth),
+    .err_o    ()
   );
 
   assign tx_empty_o = (tx_qd_o == 0);

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -472,7 +472,8 @@ module tlul_adapter_sram
     .rready_i(reqfifo_rready),
     .rdata_o (reqfifo_rdata),
     .full_o  (),
-    .depth_o ()
+    .depth_o (),
+    .err_o   ()
   );
 
   // sramreqfifo:
@@ -494,7 +495,8 @@ module tlul_adapter_sram
     .rready_i(sramreqfifo_rready),
     .rdata_o (sramreqfifo_rdata),
     .full_o  (),
-    .depth_o ()
+    .depth_o (),
+    .err_o   ()
   );
 
   // Rationale having #Outstanding depth in response FIFO.
@@ -518,7 +520,8 @@ module tlul_adapter_sram
     .rready_i(rspfifo_rready),
     .rdata_o (rspfifo_rdata),
     .full_o  (),
-    .depth_o ()
+    .depth_o (),
+    .err_o   ()
   );
 
   // below assertion fails when SRAM rvalid is asserted even though ReqFifo is empty

--- a/hw/ip/tlul/rtl/tlul_fifo_sync.sv
+++ b/hw/ip/tlul/rtl/tlul_fifo_sync.sv
@@ -56,7 +56,8 @@ module tlul_fifo_sync #(
                      tl_d_o.a_user   ,
                      spare_req_o}),
     .full_o        (),
-    .depth_o       ());
+    .depth_o       (),
+    .err_o         ());
 
   // Put everything on the response side into the other FIFO
 
@@ -90,6 +91,7 @@ module tlul_fifo_sync #(
                      tl_h_o.d_error ,
                      spare_rsp_o}),
     .full_o        (),
-    .depth_o       ());
+    .depth_o       (),
+    .err_o         ());
 
 endmodule

--- a/hw/ip/tlul/rtl/tlul_sram_byte.sv
+++ b/hw/ip/tlul/rtl/tlul_sram_byte.sv
@@ -168,7 +168,8 @@ module tlul_sram_byte import tlul_pkg::*; #(
       .rready_i(sram_a_ack),
       .rdata_o(held_data),
       .full_o(),
-      .depth_o()
+      .depth_o(),
+      .err_o()
     );
 
     // captured read data
@@ -279,7 +280,8 @@ module tlul_sram_byte import tlul_pkg::*; #(
       .rready_i(d_ack),
       .rdata_o(a_size),
       .full_o(),
-      .depth_o(pending_txn_cnt)
+      .depth_o(pending_txn_cnt),
+      .err_o()
     );
 
     always_comb begin

--- a/hw/ip/uart/rtl/uart_core.sv
+++ b/hw/ip/uart/rtl/uart_core.sv
@@ -184,7 +184,8 @@ module uart_core (
     .full_o (),
     .rvalid_o(tx_fifo_rvalid),
     .rready_i(tx_fifo_rready),
-    .rdata_o (tx_fifo_data)
+    .rdata_o (tx_fifo_data),
+    .err_o   ()
   );
 
   uart_tx uart_tx (
@@ -284,7 +285,8 @@ module uart_core (
     .full_o (),
     .rvalid_o(rx_fifo_rvalid),
     .rready_i(reg2hw.rdata.re),
-    .rdata_o (uart_rdata)
+    .rdata_o (uart_rdata),
+    .err_o   ()
   );
 
   always_ff @(posedge clk_i or negedge rst_ni) begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl.sv
@@ -541,7 +541,8 @@ module flash_ctrl
     .full_o  (),
     .rvalid_o(prog_fifo_rvalid),
     .rready_i(prog_fifo_ren),
-    .rdata_o (prog_fifo_rdata)
+    .rdata_o (prog_fifo_rdata),
+    .err_o   ()
   );
   assign hw2reg.curr_fifo_lvl.prog.d = prog_fifo_depth;
 
@@ -648,7 +649,8 @@ module flash_ctrl
     .depth_o (rd_fifo_depth),
     .rvalid_o(rd_fifo_rvalid),
     .rready_i(rd_fifo_rready),
-    .rdata_o (rd_fifo_rdata)
+    .rdata_o (rd_fifo_rdata),
+    .err_o   ()
   );
   assign hw2reg.curr_fifo_lvl.rd.d = rd_fifo_depth;
 


### PR DESCRIPTION
Addresses #10069 and also hardens #11045.
The prim_count option is opt-in and not enabled by default.