### PR TITLE
[dv/chip] lc_walkthrough test [part 2]

### DIFF
--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -2744,7 +2744,7 @@
              Verify that the features that should indeed be disabled are indeed disabled.
              '''
       milestone: V2
-      tests: ["chip_sw_lc_walkthrough"]
+      tests: ["chip_sw_lc_walkthrough_prodend", "chip_sw_lc_walkthrough_rma"]
     }
     {
       name: chip_sw_device_ownership

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -410,11 +410,19 @@
       reseed: 15
     }
     {
-      name: chip_sw_lc_walkthrough
+      name: chip_sw_lc_walkthrough_prodend
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRaw"]
+      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
+      reseed: 1
+    }
+    {
+      name: chip_sw_lc_walkthrough_rma
+      uvm_test_seq: chip_sw_lc_walkthrough_vseq
+      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma"]
       reseed: 1
     }
     {

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -444,7 +444,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
                                  src_state.name, dest_state.name))
     end
 
-    `uvm_info(`gfn, $sformatf("Start LC transition request from %0s staet to %0s state",
+    `uvm_info(`gfn, $sformatf("Start LC transition request from %0s state to %0s state",
                               src_state.name, dest_state.name), UVM_LOW)
     jtag_riscv_agent_pkg::jtag_write_csr(ral.lc_ctrl.claim_transition_if.get_offset(),
                                          p_sequencer.jtag_sequencer_h,


### PR DESCRIPTION
Add a plusarg for user to input destination state.
Current test supports:
1). RAW -> TESTUNLOCK ->  ProdEnd
2). RAW -> TESTUNLOCK -> RMA
Coming tests will support:
3). RAW -> TESTUNLOCK -> PROD -> RMA
4). RAW -> TESTUNLCOK -> DEV -> RMA
5). Walk through all test lock and unlock tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>