### PR TITLE
[spi_host] Address small regression failures

### DIFF
--- a/hw/ip/spi_host/data/spi_host.hjson
+++ b/hw/ip/spi_host/data/spi_host.hjson
@@ -485,6 +485,8 @@
           desc: '''Indicates that TLUL attempted to write to TXDATA with no bytes enabled. Such
                    'zero byte' writes are not supported.''',
           resval: "0x0"
+          tags: [// Updated by the hw. Exclude from init and write-checks.
+                 "excl:CsrAllTests:CsrExclCheck"]
         },
         { bits: "4",
           name: "CSIDINVAL",
@@ -508,6 +510,8 @@
           name: "OVERFLOW",
           desc: '''Indicates that firmware has overflowed the TX FIFO'''
           resval: "0x0"
+          tags: [// Updated by the hw. Exclude from init and write-checks.
+                 "excl:CsrAllTests:CsrExclCheck"]
         },
         { bits: "0",
           name: "CMDBUSY",


### PR DESCRIPTION
- fixes #9932

- move tx window usage from tlul_adapter_reg to tlul_adapter_sram
  - the former does not support byte writes completely

- add a couple of exclusions to error status that can be triggered
  by errornous writes to the tx_fifo. Since window regions can be
  excluded, exclude the status instead.

Signed-off-by: Timothy Chen <timothytim@google.com>