### PR TITLE
[otbn, dv] Fixes insn_cnt mismatch issue when error occurs in idle state

### DIFF
--- a/hw/ip/otbn/dv/otbnsim/sim/sim.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/sim.py
@@ -147,7 +147,6 @@ class OTBNSim:
 
         '''
         fsm_state = self.state.get_fsm_state()
-
         # Pairs: (stepper, handles_injected_err). If handles_injected_err is
         # False then the generic code here will deal with any pending errors in
         # self.state.injected_err_bits. If True, then we expect the stepper
@@ -174,6 +173,9 @@ class OTBNSim:
             # We've reached the end of the run because of some error. Register
             # it on the next cycle.
             self.state.stop()
+        if ((self.state._fsm_state == FsmState.LOCKED and
+             self.state.cycles_in_this_state == 0)):
+            self.state.ext_regs.write('INSN_CNT', 0, True)
 
         changes = self.state.changes()
         self.state.commit(sim_stalled=True)

--- a/hw/ip/otbn/dv/otbnsim/sim/state.py
+++ b/hw/ip/otbn/dv/otbnsim/sim/state.py
@@ -145,6 +145,10 @@ class OTBNState:
         # being locked.
         self.software_errs_fatal = False
 
+        # This is a counter that keeps track of how many cycles have elapsed in
+        # current fsm_state.
+        self.cycles_in_this_state = 0
+
     def get_next_pc(self) -> int:
         if self._pc_next_override is not None:
             return self._pc_next_override
@@ -330,6 +334,12 @@ class OTBNState:
         old_state = self._fsm_state
 
         self._fsm_state = self._next_fsm_state
+
+        if self._fsm_state == old_state:
+            self.cycles_in_this_state += 1
+        else:
+            self.cycles_in_this_state = 0
+
         self.ext_regs.commit()
 
         # Pull URND out separately because we also want to commit this in some


### PR DESCRIPTION
This commit fixes insn count mismatch issue occuring due to a bug inside
ISS model when an error is injected when OTBN is in idle state.

Instruction counter is cleared on the first clock after the FSM state
goes to LOCKED from IDLE.

Signed-off-by: Prajwala Puttappa <prajwalaputtappa@lowrisc.org>