### PR TITLE
[flash_ctrl] Harden FIFO pointers

### DIFF
--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson
@@ -1834,6 +1834,12 @@
               Flash ctrl read/prog has encountered a count error.
             '''
           },
+          { bits: "8",
+            name: "fifo_err",
+            desc: '''
+              Flash primitive fifo's have encountered a count error.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.hjson.tpl
@@ -1309,6 +1309,12 @@
               Flash ctrl read/prog has encountered a count error.
             '''
           },
+          { bits: "8",
+            name: "fifo_err",
+            desc: '''
+              Flash primitive fifo's have encountered a count error.
+            '''
+          },
         ]
       },
 

--- a/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl.sv.tpl
@@ -1047,6 +1047,7 @@ module flash_ctrl
   assign hw2reg.std_fault_status.storage_err.d     = 1'b1;
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
+  assign hw2reg.std_fault_status.fifo_err.d        = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
@@ -1055,6 +1056,7 @@ module flash_ctrl
   assign hw2reg.std_fault_status.storage_err.de    = storage_err;
   assign hw2reg.std_fault_status.phy_fsm_err.de    = flash_phy_rsp.fsm_err;
   assign hw2reg.std_fault_status.ctrl_cnt_err.de   = rd_cnt_err | prog_cnt_err;
+  assign hw2reg.std_fault_status.fifo_err.de       = flash_phy_rsp.fifo_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg
@@ -1358,5 +1360,33 @@ module flash_ctrl
      `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyProgFsmCheck_A,
        u_eflash.gen_flash_cores[i].u_core.gen_prog_data.u_prog.u_state_regs, alert_tx_o[1])
    end
+
+  `ifdef INC_ASSERT
+   `define PHY u_eflash.gen_flash_cores[i]
+   `define PHY_CORE `PHY.u_core
+   for (genvar i=0; i<NumBanks; i++) begin : gen_phy_cnt_errs
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRspFifoWPtr_A,
+       `PHY.u_host_rsp_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr, alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRspFifoRPtr_A,
+       `PHY.u_host_rsp_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr, alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdRspFifoWPtr_A,
+       `PHY_CORE.u_rd.u_rsp_order_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr,
+       alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdRspFifoRPtr_A,
+       `PHY_CORE.u_rd.u_rsp_order_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
+       alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdDataFifoWPtr_A,
+       `PHY_CORE.u_rd.u_rd_storage.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr,
+       alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdDataFifoRPtr_A,
+       `PHY_CORE.u_rd.u_rd_storage.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
+       alert_tx_o[1])
+   end
+   `endif
 
 endmodule

--- a/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
+++ b/hw/ip/flash_ctrl/data/flash_ctrl_pkg.sv.tpl
@@ -433,6 +433,7 @@ package flash_ctrl_pkg;
     logic                    spurious_ack;
     logic                    arb_err;
     logic                    host_gnt_err;
+    logic                    fifo_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -454,7 +455,8 @@ package flash_ctrl_pkg;
     fsm_err:            '0,
     spurious_ack:       '0,
     arb_err:            '0,
-    host_gnt_err:       '0
+    host_gnt_err:       '0,
+    fifo_err:           '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl.sv
@@ -1048,6 +1048,7 @@ module flash_ctrl
   assign hw2reg.std_fault_status.storage_err.d     = 1'b1;
   assign hw2reg.std_fault_status.phy_fsm_err.d     = 1'b1;
   assign hw2reg.std_fault_status.ctrl_cnt_err.d    = 1'b1;
+  assign hw2reg.std_fault_status.fifo_err.d        = 1'b1;
   assign hw2reg.std_fault_status.reg_intg_err.de   = intg_err | eflash_cmd_intg_err;
   assign hw2reg.std_fault_status.prog_intg_err.de  = flash_phy_rsp.prog_intg_err;
   assign hw2reg.std_fault_status.lcmgr_err.de      = lcmgr_err;
@@ -1056,6 +1057,7 @@ module flash_ctrl
   assign hw2reg.std_fault_status.storage_err.de    = storage_err;
   assign hw2reg.std_fault_status.phy_fsm_err.de    = flash_phy_rsp.fsm_err;
   assign hw2reg.std_fault_status.ctrl_cnt_err.de   = rd_cnt_err | prog_cnt_err;
+  assign hw2reg.std_fault_status.fifo_err.de       = flash_phy_rsp.fifo_err;
 
   // Correctable ECC count / address
   for (genvar i = 0; i < NumBanks; i++) begin : gen_ecc_single_err_reg
@@ -1359,5 +1361,33 @@ module flash_ctrl
      `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(PhyProgFsmCheck_A,
        u_eflash.gen_flash_cores[i].u_core.gen_prog_data.u_prog.u_state_regs, alert_tx_o[1])
    end
+
+  `ifdef INC_ASSERT
+   `define PHY u_eflash.gen_flash_cores[i]
+   `define PHY_CORE `PHY.u_core
+   for (genvar i=0; i<NumBanks; i++) begin : gen_phy_cnt_errs
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRspFifoWPtr_A,
+       `PHY.u_host_rsp_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr, alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRspFifoRPtr_A,
+       `PHY.u_host_rsp_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr, alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdRspFifoWPtr_A,
+       `PHY_CORE.u_rd.u_rsp_order_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr,
+       alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdRspFifoRPtr_A,
+       `PHY_CORE.u_rd.u_rsp_order_fifo.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
+       alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdDataFifoWPtr_A,
+       `PHY_CORE.u_rd.u_rd_storage.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_wptr,
+       alert_tx_o[1])
+
+     `ASSERT_PRIM_COUNT_ERROR_TRIGGER_ALERT(PhyRdDataFifoRPtr_A,
+       `PHY_CORE.u_rd.u_rd_storage.gen_normal_fifo.u_fifo_cnt.gen_secure_ptrs.u_rptr,
+       alert_tx_o[1])
+   end
+   `endif
 
 endmodule

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_core_reg_top.sv
@@ -969,6 +969,7 @@ module flash_ctrl_core_reg_top (
   logic std_fault_status_storage_err_qs;
   logic std_fault_status_phy_fsm_err_qs;
   logic std_fault_status_ctrl_cnt_err_qs;
+  logic std_fault_status_fifo_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
   logic fault_status_prog_err_qs;
@@ -10168,6 +10169,31 @@ module flash_ctrl_core_reg_top (
     .qs     (std_fault_status_ctrl_cnt_err_qs)
   );
 
+  //   F[fifo_err]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_std_fault_status_fifo_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.std_fault_status.fifo_err.de),
+    .d      (hw2reg.std_fault_status.fifo_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.std_fault_status.fifo_err.q),
+
+    // to register interface (read)
+    .qs     (std_fault_status_fifo_err_qs)
+  );
+
 
   // R[fault_status]: V(False)
   //   F[mp_err]: 1:1
@@ -12645,6 +12671,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[5] = std_fault_status_storage_err_qs;
         reg_rdata_next[6] = std_fault_status_phy_fsm_err_qs;
         reg_rdata_next[7] = std_fault_status_ctrl_cnt_err_qs;
+        reg_rdata_next[8] = std_fault_status_fifo_err_qs;
       end
 
       addr_hit[95]: begin

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_pkg.sv
@@ -433,6 +433,7 @@ package flash_ctrl_pkg;
     logic                    spurious_ack;
     logic                    arb_err;
     logic                    host_gnt_err;
+    logic                    fifo_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -454,7 +455,8 @@ package flash_ctrl_pkg;
     fsm_err:            '0,
     spurious_ack:       '0,
     arb_err:            '0,
-    host_gnt_err:       '0
+    host_gnt_err:       '0,
+    fifo_err:           '0
   };
 
   // RMA entries

--- a/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_ctrl_reg_pkg.sv
@@ -398,6 +398,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } ctrl_cnt_err;
+    struct packed {
+      logic        q;
+    } fifo_err;
   } flash_ctrl_reg2hw_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -610,6 +613,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } ctrl_cnt_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fifo_err;
   } flash_ctrl_hw2reg_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -704,28 +711,28 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1320:1315]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1314:1309]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1308:1297]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1296:1291]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [1290:1287]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [1286:1255]
-    flash_ctrl_reg2hw_init_reg_t init; // [1254:1254]
-    flash_ctrl_reg2hw_control_reg_t control; // [1253:1234]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [1233:1214]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1213:1212]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1211:1211]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1210:987]
-    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [986:835]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [834:811]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [810:531]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [530:503]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [502:447]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [446:167]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [166:139]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [138:83]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [82:81]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [80:73]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1321:1316]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1315:1310]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1309:1298]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1297:1292]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [1291:1288]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [1287:1256]
+    flash_ctrl_reg2hw_init_reg_t init; // [1255:1255]
+    flash_ctrl_reg2hw_control_reg_t control; // [1254:1235]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [1234:1215]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1214:1213]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1212:1212]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1211:988]
+    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [987:836]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [835:812]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [811:532]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [531:504]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [503:448]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [447:168]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [167:140]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [139:84]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [83:82]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [81:73]
     flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [72:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -736,14 +743,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [181:170]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [169:169]
-    flash_ctrl_hw2reg_control_reg_t control; // [168:167]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [166:165]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [164:161]
-    flash_ctrl_hw2reg_status_reg_t status; // [160:151]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [150:137]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [136:121]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [183:172]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [171:171]
+    flash_ctrl_hw2reg_control_reg_t control; // [170:169]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [168:167]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [166:163]
+    flash_ctrl_hw2reg_status_reg_t status; // [162:153]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [152:139]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [138:121]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [120:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [75:58]
@@ -1090,7 +1097,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[ 91] FLASH_CTRL_OP_STATUS
     4'b 0001, // index[ 92] FLASH_CTRL_STATUS
     4'b 0001, // index[ 93] FLASH_CTRL_ERR_CODE
-    4'b 0001, // index[ 94] FLASH_CTRL_STD_FAULT_STATUS
+    4'b 0011, // index[ 94] FLASH_CTRL_STD_FAULT_STATUS
     4'b 0011, // index[ 95] FLASH_CTRL_FAULT_STATUS
     4'b 0111, // index[ 96] FLASH_CTRL_ERR_ADDR
     4'b 0011, // index[ 97] FLASH_CTRL_ECC_SINGLE_ERR_CNT

--- a/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
+++ b/hw/ip/flash_ctrl/rtl/flash_phy_core.sv
@@ -59,7 +59,8 @@ module flash_phy_core
   output logic                       intg_ecc_err_o,
   output logic                       spurious_ack_o,
   output logic                       arb_err_o,
-  output logic                       host_gnt_err_o
+  output logic                       host_gnt_err_o,
+  output logic                       fifo_err_o
 );
 
 
@@ -401,7 +402,8 @@ module flash_phy_core
     .ecc_single_err_o,
     .ecc_addr_o,
     .relbl_ecc_err_o,
-    .intg_ecc_err_o
+    .intg_ecc_err_o,
+    .fifo_err_o
     );
 
   ////////////////////////

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -11,6 +11,7 @@ module prim_fifo_sync #(
   parameter bit Pass                 = 1'b1, // if == 1 allow requests to pass through empty FIFO
   parameter int unsigned Depth       = 4,
   parameter bit OutputZeroIfEmpty    = 1'b1, // if == 1 always output 0 when FIFO is empty
+  parameter bit Secure               = 1'b0, // use prim count for pointers
   // derived parameter
   localparam int          DepthW     = prim_util_pkg::vbits(Depth+1)
 ) (
@@ -101,7 +102,7 @@ module prim_fifo_sync #(
     prim_fifo_sync_cnt #(
       .Width(PTR_WIDTH),
       .Depth(Depth),
-      .Secure('0)
+      .Secure(Secure)
     ) u_fifo_cnt (
       .clk_i,
       .rst_ni,

--- a/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
+++ b/hw/ip/pwrmgr/data/pwrmgr.hjson.tpl
@@ -376,7 +376,7 @@
           ]
           tags: [// Turning off USB clock in active state impacts other CSRs
                  // at the chip level (in other blocks, such as clkmgr).
-                 "excl:CsrNonInitTests:CsrExclWrite"]
+                 "excl:CsrAllTests:CsrExclWrite"]
         },
 
         { bits: "8",

--- a/hw/ip/tlul/rtl/tlul_adapter_sram.sv
+++ b/hw/ip/tlul/rtl/tlul_adapter_sram.sv
@@ -31,6 +31,7 @@ module tlul_adapter_sram
   parameter bit EnableRspIntgGen  = 0,  // 1: Generate response integrity
   parameter bit EnableDataIntgGen = 0,  // 1: Generate response data integrity
   parameter bit EnableDataIntgPt  = 0,  // 1: Passthrough command/response data integrity
+  parameter bit SecFifoPtr        = 0,  // 1: Duplicated fifo pointers
   localparam int WidthMult        = SramDw / top_pkg::TL_DW,
   localparam int IntgWidth        = tlul_pkg::DataIntgWidth * WidthMult,
   localparam int DataOutW         = EnableDataIntgPt ? SramDw + IntgWidth : SramDw
@@ -70,6 +71,7 @@ module tlul_adapter_sram
   logic instr_error;
   logic wr_vld_error;
   logic rd_vld_error;
+  logic rsp_fifo_error;
   logic intg_error;
   logic tlul_error;
 
@@ -88,14 +90,14 @@ module tlul_adapter_sram
   always_ff @(posedge clk_i or negedge rst_ni) begin
     if (!rst_ni) begin
       intg_error_q <= '0;
-    end else if (intg_error) begin
+    end else if (intg_error || rsp_fifo_error) begin
       intg_error_q <= 1'b1;
     end
   end
 
   // integrity error output is permanent and should be used for alert generation
   // or other downstream effects
-  assign intg_error_o = intg_error | intg_error_q;
+  assign intg_error_o = intg_error | rsp_fifo_error | intg_error_q;
 
   // wr_attr_error: Check if the request size,mask are permitted.
   //    Basic check of size, mask, addr align is done in tlul_err module.
@@ -508,7 +510,8 @@ module tlul_adapter_sram
   prim_fifo_sync #(
     .Width   (RspFifoWidth),
     .Pass    (1'b1),
-    .Depth   (Outstanding)
+    .Depth   (Outstanding),
+    .Secure  (SecFifoPtr)
   ) u_rspfifo (
     .clk_i,
     .rst_ni,
@@ -521,7 +524,7 @@ module tlul_adapter_sram
     .rdata_o (rspfifo_rdata),
     .full_o  (),
     .depth_o (),
-    .err_o   ()
+    .err_o   (rsp_fifo_error)
   );
 
   // below assertion fails when SRAM rvalid is asserted even though ReqFifo is empty

--- a/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
+++ b/hw/top_earlgrey/ip/flash_ctrl/data/autogen/flash_ctrl.hjson
@@ -1840,6 +1840,12 @@
               Flash ctrl read/prog has encountered a count error.
             '''
           },
+          { bits: "8",
+            name: "fifo_err",
+            desc: '''
+              Flash primitive fifo's have encountered a count error.
+            '''
+          },
         ]
       },
 

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_core_reg_top.sv
@@ -969,6 +969,7 @@ module flash_ctrl_core_reg_top (
   logic std_fault_status_storage_err_qs;
   logic std_fault_status_phy_fsm_err_qs;
   logic std_fault_status_ctrl_cnt_err_qs;
+  logic std_fault_status_fifo_err_qs;
   logic fault_status_mp_err_qs;
   logic fault_status_rd_err_qs;
   logic fault_status_prog_err_qs;
@@ -10168,6 +10169,31 @@ module flash_ctrl_core_reg_top (
     .qs     (std_fault_status_ctrl_cnt_err_qs)
   );
 
+  //   F[fifo_err]: 8:8
+  prim_subreg #(
+    .DW      (1),
+    .SwAccess(prim_subreg_pkg::SwAccessRO),
+    .RESVAL  (1'h0)
+  ) u_std_fault_status_fifo_err (
+    .clk_i   (clk_i),
+    .rst_ni  (rst_ni),
+
+    // from register interface
+    .we     (1'b0),
+    .wd     ('0),
+
+    // from internal hardware
+    .de     (hw2reg.std_fault_status.fifo_err.de),
+    .d      (hw2reg.std_fault_status.fifo_err.d),
+
+    // to internal hardware
+    .qe     (),
+    .q      (reg2hw.std_fault_status.fifo_err.q),
+
+    // to register interface (read)
+    .qs     (std_fault_status_fifo_err_qs)
+  );
+
 
   // R[fault_status]: V(False)
   //   F[mp_err]: 1:1
@@ -12645,6 +12671,7 @@ module flash_ctrl_core_reg_top (
         reg_rdata_next[5] = std_fault_status_storage_err_qs;
         reg_rdata_next[6] = std_fault_status_phy_fsm_err_qs;
         reg_rdata_next[7] = std_fault_status_ctrl_cnt_err_qs;
+        reg_rdata_next[8] = std_fault_status_fifo_err_qs;
       end
 
       addr_hit[95]: begin

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_pkg.sv
@@ -439,6 +439,7 @@ package flash_ctrl_pkg;
     logic                    spurious_ack;
     logic                    arb_err;
     logic                    host_gnt_err;
+    logic                    fifo_err;
   } flash_rsp_t;
 
   // default value of flash_rsp_t (for dangling ports)
@@ -460,7 +461,8 @@ package flash_ctrl_pkg;
     fsm_err:            '0,
     spurious_ack:       '0,
     arb_err:            '0,
-    host_gnt_err:       '0
+    host_gnt_err:       '0,
+    fifo_err:           '0
   };
 
   // RMA entries

--- a/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
+++ b/hw/top_earlgrey/ip/flash_ctrl/rtl/autogen/flash_ctrl_reg_pkg.sv
@@ -398,6 +398,9 @@ package flash_ctrl_reg_pkg;
     struct packed {
       logic        q;
     } ctrl_cnt_err;
+    struct packed {
+      logic        q;
+    } fifo_err;
   } flash_ctrl_reg2hw_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -610,6 +613,10 @@ package flash_ctrl_reg_pkg;
       logic        d;
       logic        de;
     } ctrl_cnt_err;
+    struct packed {
+      logic        d;
+      logic        de;
+    } fifo_err;
   } flash_ctrl_hw2reg_std_fault_status_reg_t;
 
   typedef struct packed {
@@ -704,28 +711,28 @@ package flash_ctrl_reg_pkg;
 
   // Register -> HW type for core interface
   typedef struct packed {
-    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1320:1315]
-    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1314:1309]
-    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1308:1297]
-    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1296:1291]
-    flash_ctrl_reg2hw_dis_reg_t dis; // [1290:1287]
-    flash_ctrl_reg2hw_exec_reg_t exec; // [1286:1255]
-    flash_ctrl_reg2hw_init_reg_t init; // [1254:1254]
-    flash_ctrl_reg2hw_control_reg_t control; // [1253:1234]
-    flash_ctrl_reg2hw_addr_reg_t addr; // [1233:1214]
-    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1213:1212]
-    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1211:1211]
-    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1210:987]
-    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [986:835]
-    flash_ctrl_reg2hw_default_region_reg_t default_region; // [834:811]
-    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [810:531]
-    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [530:503]
-    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [502:447]
-    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [446:167]
-    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [166:139]
-    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [138:83]
-    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [82:81]
-    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [80:73]
+    flash_ctrl_reg2hw_intr_state_reg_t intr_state; // [1321:1316]
+    flash_ctrl_reg2hw_intr_enable_reg_t intr_enable; // [1315:1310]
+    flash_ctrl_reg2hw_intr_test_reg_t intr_test; // [1309:1298]
+    flash_ctrl_reg2hw_alert_test_reg_t alert_test; // [1297:1292]
+    flash_ctrl_reg2hw_dis_reg_t dis; // [1291:1288]
+    flash_ctrl_reg2hw_exec_reg_t exec; // [1287:1256]
+    flash_ctrl_reg2hw_init_reg_t init; // [1255:1255]
+    flash_ctrl_reg2hw_control_reg_t control; // [1254:1235]
+    flash_ctrl_reg2hw_addr_reg_t addr; // [1234:1215]
+    flash_ctrl_reg2hw_prog_type_en_reg_t prog_type_en; // [1214:1213]
+    flash_ctrl_reg2hw_erase_suspend_reg_t erase_suspend; // [1212:1212]
+    flash_ctrl_reg2hw_mp_region_cfg_mreg_t [7:0] mp_region_cfg; // [1211:988]
+    flash_ctrl_reg2hw_mp_region_mreg_t [7:0] mp_region; // [987:836]
+    flash_ctrl_reg2hw_default_region_reg_t default_region; // [835:812]
+    flash_ctrl_reg2hw_bank0_info0_page_cfg_mreg_t [9:0] bank0_info0_page_cfg; // [811:532]
+    flash_ctrl_reg2hw_bank0_info1_page_cfg_mreg_t [0:0] bank0_info1_page_cfg; // [531:504]
+    flash_ctrl_reg2hw_bank0_info2_page_cfg_mreg_t [1:0] bank0_info2_page_cfg; // [503:448]
+    flash_ctrl_reg2hw_bank1_info0_page_cfg_mreg_t [9:0] bank1_info0_page_cfg; // [447:168]
+    flash_ctrl_reg2hw_bank1_info1_page_cfg_mreg_t [0:0] bank1_info1_page_cfg; // [167:140]
+    flash_ctrl_reg2hw_bank1_info2_page_cfg_mreg_t [1:0] bank1_info2_page_cfg; // [139:84]
+    flash_ctrl_reg2hw_mp_bank_cfg_shadowed_mreg_t [1:0] mp_bank_cfg_shadowed; // [83:82]
+    flash_ctrl_reg2hw_std_fault_status_reg_t std_fault_status; // [81:73]
     flash_ctrl_reg2hw_fault_status_reg_t fault_status; // [72:61]
     flash_ctrl_reg2hw_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [60:45]
     flash_ctrl_reg2hw_phy_alert_cfg_reg_t phy_alert_cfg; // [44:43]
@@ -736,14 +743,14 @@ package flash_ctrl_reg_pkg;
 
   // HW -> register type for core interface
   typedef struct packed {
-    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [181:170]
-    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [169:169]
-    flash_ctrl_hw2reg_control_reg_t control; // [168:167]
-    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [166:165]
-    flash_ctrl_hw2reg_op_status_reg_t op_status; // [164:161]
-    flash_ctrl_hw2reg_status_reg_t status; // [160:151]
-    flash_ctrl_hw2reg_err_code_reg_t err_code; // [150:137]
-    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [136:121]
+    flash_ctrl_hw2reg_intr_state_reg_t intr_state; // [183:172]
+    flash_ctrl_hw2reg_ctrl_regwen_reg_t ctrl_regwen; // [171:171]
+    flash_ctrl_hw2reg_control_reg_t control; // [170:169]
+    flash_ctrl_hw2reg_erase_suspend_reg_t erase_suspend; // [168:167]
+    flash_ctrl_hw2reg_op_status_reg_t op_status; // [166:163]
+    flash_ctrl_hw2reg_status_reg_t status; // [162:153]
+    flash_ctrl_hw2reg_err_code_reg_t err_code; // [152:139]
+    flash_ctrl_hw2reg_std_fault_status_reg_t std_fault_status; // [138:121]
     flash_ctrl_hw2reg_fault_status_reg_t fault_status; // [120:97]
     flash_ctrl_hw2reg_err_addr_reg_t err_addr; // [96:76]
     flash_ctrl_hw2reg_ecc_single_err_cnt_mreg_t [1:0] ecc_single_err_cnt; // [75:58]
@@ -1090,7 +1097,7 @@ package flash_ctrl_reg_pkg;
     4'b 0001, // index[ 91] FLASH_CTRL_OP_STATUS
     4'b 0001, // index[ 92] FLASH_CTRL_STATUS
     4'b 0001, // index[ 93] FLASH_CTRL_ERR_CODE
-    4'b 0001, // index[ 94] FLASH_CTRL_STD_FAULT_STATUS
+    4'b 0011, // index[ 94] FLASH_CTRL_STD_FAULT_STATUS
     4'b 0011, // index[ 95] FLASH_CTRL_FAULT_STATUS
     4'b 0111, // index[ 96] FLASH_CTRL_ERR_ADDR
     4'b 0011, // index[ 97] FLASH_CTRL_ECC_SINGLE_ERR_CNT

--- a/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
+++ b/hw/top_earlgrey/ip/pwrmgr/data/autogen/pwrmgr.hjson
@@ -415,7 +415,7 @@
           ]
           tags: [// Turning off USB clock in active state impacts other CSRs
                  // at the chip level (in other blocks, such as clkmgr).
-                 "excl:CsrNonInitTests:CsrExclWrite"]
+                 "excl:CsrAllTests:CsrExclWrite"]
         },
 
         { bits: "8",


### PR DESCRIPTION
- Hardening FIFO pointers along the read path should in theory
  make execution out of flash more robust

First two commits will be rebased away.