### PR TITLE
[dv/lc_ctrl] Add waivers for V2S

### DIFF
--- a/hw/ip/lc_ctrl/doc/checklist.md
+++ b/hw/ip/lc_ctrl/doc/checklist.md
@@ -225,9 +225,9 @@ Review        | [V3_CHECKLIST_SCOPED][]                 | Done        |
  Type         | Item                                    | Resolution  | Note/Collaterals
 --------------|-----------------------------------------|-------------|------------------
 Documentation | [SEC_CM_TESTPLAN_COMPLETED][]           | Done        |
-Tests         | [FPV_SEC_CM_VERIFIED][]                 | Done        |
+Tests         | [FPV_SEC_CM_VERIFIED][]                 | Done        | Waive tool issue #13693
 Tests         | [SIM_SEC_CM_VERIFIED][]                 | Done        |
-Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        |
+Coverage      | [SIM_COVERAGE_REVIEWED][]               | Done        | Waive reg_en coverage that will implement in common test and FSM coverage covered in FPV test
 Review        | [SEC_CM_DV_REVIEWED][]                  | Done        |
 
 [SEC_CM_TESTPLAN_COMPLETED]:          {{<relref "/doc/project/checklist.md#sec_cm_testplan_completed" >}}


### PR DESCRIPTION
This PR adds waivers to V2S status:
1). FPV issue - proved when enum length is 16 bits instead of 300+ bits.
2). Waive conditional coverage on reg_en, will be covered in common
  tests.
3). Waive FSM coverage, should be covered in FPV and V3 tests.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>