### PR TITLE
[dv] Update prim_sparse_fsm_flop_if to force at the flop

### DIFF
--- a/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
+++ b/hw/dv/sv/sec_cm/prim_double_lfsr_if.sv
@@ -35,11 +35,12 @@ interface prim_double_lfsr_if #(
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(force_value,
                                          force_value != orig_value;)
 
-      `DV_CHECK(uvm_hdl_deposit(signal_forced, force_value))
+      `DV_CHECK(uvm_hdl_force(signal_forced, force_value))
       `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
                                   signal_forced, orig_value, force_value), UVM_LOW)
 
-      @(posedge clk_i);
+      @(negedge clk_i);
+      `DV_CHECK(uvm_hdl_release(signal_forced))
     endtask
 
     virtual task automatic restore_fault();

--- a/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
+++ b/hw/dv/sv/sec_cm/prim_sparse_fsm_flop_if.sv
@@ -44,13 +44,15 @@ interface prim_sparse_fsm_flop_if #(
 
       `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
                                   signal_forced, orig_value, force_value), UVM_LOW)
-      `DV_CHECK(uvm_hdl_deposit(signal_forced, force_value))
+      `DV_CHECK(uvm_hdl_force(signal_forced, force_value))
       if (CustomForceName != "") begin
         `uvm_info(msg_id, $sformatf("Forcing %s from %0d to %0d",
                                     custom_signal_forced, orig_value, force_value), UVM_LOW)
-        `DV_CHECK(uvm_hdl_deposit(custom_signal_forced, force_value))
+        `DV_CHECK(uvm_hdl_force(custom_signal_forced, force_value))
       end
-      @(posedge clk_i);
+      @(negedge clk_i);
+      `DV_CHECK(uvm_hdl_release(signal_forced))
+      if (CustomForceName != "") `DV_CHECK(uvm_hdl_release(custom_signal_forced))
     endtask
 
     virtual task automatic restore_fault();


### PR DESCRIPTION
To solve the FSM coverage issue, we deposit invalid value to the FSM
at these 2 places.
1. the __q at the same hierarchy of the state machine
2. state_o in the prim_sparse_fsm_flop

But `state_o` isn't the actual flop, after depositing the value, it
won't be changed unless `state_d` is updated, while __q will be changed
back to __d in the next cycle.
changed to deposit to `force and release`
Signed-off-by: Weicai Yang <weicai@google.com>