### PR TITLE
[dif/csrng] move DIF to S2

### DIFF
--- a/hw/ip/csrng/data/csrng.prj.hjson
+++ b/hw/ip/csrng/data/csrng.prj.hjson
@@ -12,5 +12,5 @@
     life_stage:         "L1",
     design_stage:       "D2S",
     verification_stage: "V1",
-    dif_stage:          "S1",
+    dif_stage:          "S2",
 }

--- a/sw/device/lib/dif/dif_csrng.md
+++ b/sw/device/lib/dif/dif_csrng.md
@@ -24,8 +24,8 @@ Tests          | [DIF_TEST_SMOKE][]   | Done        |
 Type           | Item                        | Resolution  | Note/Collaterals
 ---------------|-----------------------------|-------------|------------------
 Coordination   | [DIF_HW_FEATURE_COMPLETE][] | Done        | [HW Dashboard]({{< relref "hw" >}})
-Implementation | [DIF_FEATURES][]            | In Progress |
-Coordination   | [DIF_DV_TESTS][]            | Not Started |
+Implementation | [DIF_FEATURES][]            | Done        |
+Coordination   | [DIF_DV_TESTS][]            | Done        |
 
 [DIF_HW_FEATURE_COMPLETE]: {{< relref "/doc/project/checklist.md#dif_hw_feature_complete" >}}
 [DIF_FEATURES]:            {{< relref "/doc/project/checklist.md#dif_features" >}}
@@ -39,7 +39,7 @@ Coordination   | [DIF_HW_DESIGN_COMPLETE][]       | Not Started |
 Coordination   | [DIF_HW_VERIFICATION_COMPLETE][] | Not Started |
 Documentation  | [DIF_DOC_HW][]                   | Not Started |
 Code Quality   | [DIF_CODE_STYLE][]               | Not Started |
-Tests          | [DIF_TEST_UNIT][]                | Not Started |
+Tests          | [DIF_TEST_UNIT][]                | Done        |
 Review         | [DIF_TODO_COMPLETE][]            | Not Started |
 Review         | Reviewer(s)                      | Not Started |
 Review         | Signoff date                     | Not Started |


### PR DESCRIPTION
This updates the CSRNG DIF library to S2 and updates its checklist.

Signed-off-by: Timothy Trippel <ttrippel@google.com>