### PR TITLE
[tlul] Clarify unselected bytes integrity

### DIFF
--- a/hw/ip/tlul/rtl/tlul_cmd_intg_gen.sv
+++ b/hw/ip/tlul/rtl/tlul_cmd_intg_gen.sv
@@ -32,9 +32,7 @@ module tlul_cmd_intg_gen import tlul_pkg::*; #(
   logic [DataIntgWidth-1:0] data_intg;
 
   if (EnableDataIntgGen) begin : gen_data_intg
-    for (genvar i = 0; i < top_pkg::TL_DBW; i++) begin : gen_data_fill
-      assign data_final[i*8 +: 8] = tl_i.a_mask[i] ? tl_i.a_data[i*8 +: 8] : '0;
-    end
+    assign data_final = tl_i.a_data;
 
     logic [DataMaxWidth-1:0] unused_data;
     prim_secded_inv_39_32_enc u_data_gen (


### PR DESCRIPTION
- clarify the point raised in #11576
- The original intent of the integrity generation / checker was to
  check even if the source data is garbage in byte lanes that were
  not selected.  This broadens the surface of "detection". Meaning
  even if someone were to attack lanes that we do not care about,
  we still flag as it is an attack on the system.
- By removing the byte lane masking in this PR however, we also make
  it a requirement that DV ever only drive "random" data on unselected
  byte lanes, not "don't care" data.  This is also more reflective
  of real silicon, since x is not a realy value.  No matter if the value
  is 0/1, we generate integrity on it and expect it to be kept throughout
  the transaction.

Signed-off-by: Timothy Chen <timothytim@google.com>