### PR TITLE
[sw/silicon_creator] Set bank erase permissions in bootstrap

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.c
@@ -528,6 +528,27 @@ void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page,
   sec_mmio_write32(cfg_addr, reg);
 }
 
+void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
+  uint32_t reg;
+  switch (launder32(enable)) {
+    case kHardenedBoolTrue:
+      HARDENED_CHECK_EQ(enable, kHardenedBoolTrue);
+      reg = bitfield_bit32_write(
+          0, FLASH_CTRL_MP_BANK_CFG_SHADOWED_ERASE_EN_0_BIT, true);
+      reg = bitfield_bit32_write(
+          reg, FLASH_CTRL_MP_BANK_CFG_SHADOWED_ERASE_EN_1_BIT, true);
+      break;
+    case kHardenedBoolFalse:
+      HARDENED_CHECK_EQ(enable, kHardenedBoolFalse);
+      reg = 0;
+      break;
+    default:
+      HARDENED_UNREACHABLE();
+  }
+  sec_mmio_write32_shadowed(kBase + FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET,
+                            reg);
+}
+
 /**
  * Information pages that should be locked by ROM_EXT before handing over
  * execution to the first owner boot stage. See

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl.h
@@ -152,6 +152,7 @@ enum {
   kFlashCtrlSecMmioExecSet = 1,
   kFlashCtrlSecMmioInfoCfgSet = 1,
   kFlashCtrlSecMmioInfoPermsSet = 1,
+  kFlashCtrlSecMmioBankErasePermsSet = 1,
   kFlashCtrlSecMmioInit = 5,
 };
 
@@ -430,6 +431,17 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg);
  * @param cfg New configuration settings.
  */
 void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page, flash_ctrl_cfg_t cfg);
+
+/**
+ * Set bank erase permissions for both flash banks.
+ *
+ * The caller is responsible for calling
+ * `SEC_MMIO_WRITE_INCREMENT(kFlashCtrlSecMmioBankErasePermsSet)` when
+ * sec_mmio is being used to check expectations.
+ *
+ * @param enable Whether to enable bank erase.
+ */
+void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable);
 
 /**
  * Enable execution from flash.

--- a/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/flash_ctrl_unittest.cc
@@ -601,6 +601,20 @@ TEST_F(FlashCtrlTest, CreatorInfoLockdown) {
   flash_ctrl_creator_info_pages_lockdown();
 }
 
+TEST_F(FlashCtrlTest, BankErasePermsSet) {
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET,
+      {
+          {FLASH_CTRL_MP_BANK_CFG_SHADOWED_ERASE_EN_0_BIT, 1},
+          {FLASH_CTRL_MP_BANK_CFG_SHADOWED_ERASE_EN_1_BIT, 1},
+      });
+  flash_ctrl_bank_erase_perms_set(kHardenedBoolTrue);
+
+  EXPECT_SEC_WRITE32_SHADOWED(
+      base_ + FLASH_CTRL_MP_BANK_CFG_SHADOWED_REG_OFFSET, 0);
+  flash_ctrl_bank_erase_perms_set(kHardenedBoolFalse);
+}
+
 struct EraseVerifyCase {
   /**
    * Address.

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.cc
@@ -70,6 +70,10 @@ void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page,
   MockFlashCtrl::Instance().InfoCfgSet(info_page, cfg);
 }
 
+void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
+  MockFlashCtrl::Instance().BankErasePermsSet(enable);
+}
+
 void flash_ctrl_exec_set(uint32_t exec_val) {
   MockFlashCtrl::Instance().ExecSet(exec_val);
 }

--- a/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
+++ b/sw/device/silicon_creator/lib/drivers/mock_flash_ctrl.h
@@ -33,6 +33,7 @@ class MockFlashCtrl : public global_mock::GlobalMock<MockFlashCtrl> {
   MOCK_METHOD(void, InfoPermsSet, (flash_ctrl_info_page_t, flash_ctrl_perms_t));
   MOCK_METHOD(void, DataDefaultCfgSet, (flash_ctrl_cfg_t));
   MOCK_METHOD(void, InfoCfgSet, (flash_ctrl_info_page_t, flash_ctrl_cfg_t));
+  MOCK_METHOD(void, BankErasePermsSet, (hardened_bool_t));
   MOCK_METHOD(void, ExecSet, (uint32_t));
   MOCK_METHOD(void, CreatorInfoPagesLockdown, ());
 };
@@ -105,6 +106,10 @@ void flash_ctrl_data_default_cfg_set(flash_ctrl_cfg_t cfg) {
 void flash_ctrl_info_cfg_set(flash_ctrl_info_page_t info_page,
                              flash_ctrl_cfg_t cfg) {
   MockFlashCtrl::Instance().InfoCfgSet(info_page, cfg);
+}
+
+void flash_ctrl_bank_erase_perms_set(hardened_bool_t enable) {
+  MockFlashCtrl::Instance().BankErasePermsSet(enable);
 }
 
 void flash_ctrl_exec_set(uint32_t exec_val) {

--- a/sw/device/silicon_creator/mask_rom/bootstrap.c
+++ b/sw/device/silicon_creator/mask_rom/bootstrap.c
@@ -69,19 +69,11 @@ typedef enum bootstrap_state {
  * @return Result of the operation.
  */
 static rom_error_t bootstrap_chip_erase(void) {
-  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
-      .read = kMultiBitBool4False,
-      .write = kMultiBitBool4False,
-      .erase = kMultiBitBool4True,
-  });
+  flash_ctrl_bank_erase_perms_set(kHardenedBoolTrue);
   rom_error_t err_0 = flash_ctrl_data_erase(0, kFlashCtrlEraseTypeBank);
   rom_error_t err_1 = flash_ctrl_data_erase(FLASH_CTRL_PARAM_BYTES_PER_BANK,
                                             kFlashCtrlEraseTypeBank);
-  flash_ctrl_data_default_perms_set((flash_ctrl_perms_t){
-      .read = kMultiBitBool4False,
-      .write = kMultiBitBool4False,
-      .erase = kMultiBitBool4False,
-  });
+  flash_ctrl_bank_erase_perms_set(kHardenedBoolFalse);
 
   HARDENED_RETURN_IF_ERROR(err_0);
   return err_1;

--- a/sw/device/silicon_creator/mask_rom/bootstrap_unittest.cc
+++ b/sw/device/silicon_creator/mask_rom/bootstrap_unittest.cc
@@ -75,17 +75,6 @@ class BootstrapTest : public mask_rom_test::MaskRomTest {
   }
 
   /**
-   * Sets an expectation for enabling erase for the data partition.
-   */
-  void ExpectFlashCtrlEraseEnable() {
-    EXPECT_CALL(flash_ctrl_, DataDefaultPermsSet((flash_ctrl_perms_t){
-                                 .read = kMultiBitBool4False,
-                                 .write = kMultiBitBool4False,
-                                 .erase = kMultiBitBool4True,
-                             }));
-  }
-
-  /**
    * Sets an expectation for enabling write for the data partition.
    */
   void ExpectFlashCtrlWriteEnable() {
@@ -114,13 +103,13 @@ class BootstrapTest : public mask_rom_test::MaskRomTest {
    * @param err1 Result of erase for the second bank.
    */
   void ExpectFlashCtrlChipErase(rom_error_t err0, rom_error_t err1) {
-    ExpectFlashCtrlEraseEnable();
+    EXPECT_CALL(flash_ctrl_, BankErasePermsSet(kHardenedBoolTrue));
     EXPECT_CALL(flash_ctrl_, DataErase(0, kFlashCtrlEraseTypeBank))
         .WillOnce(Return(err0));
     EXPECT_CALL(flash_ctrl_, DataErase(FLASH_CTRL_PARAM_BYTES_PER_BANK,
                                        kFlashCtrlEraseTypeBank))
         .WillOnce(Return(err1));
-    ExpectFlashCtrlAllDisable();
+    EXPECT_CALL(flash_ctrl_, BankErasePermsSet(kHardenedBoolFalse));
   }
 
   /**
@@ -132,7 +121,11 @@ class BootstrapTest : public mask_rom_test::MaskRomTest {
    */
   void ExpectFlashCtrlSectorErase(rom_error_t err0, rom_error_t err1,
                                   uint32_t addr) {
-    ExpectFlashCtrlEraseEnable();
+    EXPECT_CALL(flash_ctrl_, DataDefaultPermsSet((flash_ctrl_perms_t){
+                                 .read = kMultiBitBool4False,
+                                 .write = kMultiBitBool4False,
+                                 .erase = kMultiBitBool4True,
+                             }));
     EXPECT_CALL(flash_ctrl_, DataErase(addr, kFlashCtrlEraseTypePage))
         .WillOnce(Return(err0));
     EXPECT_CALL(flash_ctrl_, DataErase(addr + FLASH_CTRL_PARAM_BYTES_PER_PAGE,


### PR DESCRIPTION
Doc for flash_ctrl bank erase permissions was added in #11449. This PR adds `flash_ctrl_bank_erase_perms_set()` and uses it during bootstrap. 