### PR TITLE
fix(prim): Lint warning for `err_o`

### DIFF
--- a/hw/ip/prim/lint/prim_assert.waiver
+++ b/hw/ip/prim/lint/prim_assert.waiver
@@ -9,7 +9,8 @@ waive -rules {UNDEF_MACRO_REF} -location {prim_assert.sv} -regexp {Macro definit
 
 # unfortunately most tools do not support line wrapping within the declaration of macro functions,
 # hence we have to waive line length violations.
-waive -rules {LINE_LENGTH} -location {prim_assert.sv} -msg {Line length of} \
+waive -rules {LINE_LENGTH} -location {prim_assert.sv prim_assert_sec_cm.svh}  \
+      -msg {Line length of} \
       -comment "Some macros cannot be line-wrapped, as some tools do not support that."
 waive -rules {LINE_LENGTH} -location {prim_flop_macros.sv} -msg {Line length of} \
       -comment "Some macros cannot be line-wrapped, as some tools do not support that."

--- a/hw/ip/prim/rtl/prim_assert_sec_cm.svh
+++ b/hw/ip/prim/rtl/prim_assert_sec_cm.svh
@@ -9,7 +9,9 @@
 
 // Helper macros
 `define ASSERT_ERROR_TRIGGER_ALERT(NAME_, PRIM_HIER_, ALERT_, GATE_, MAX_CYCLES_, ERR_NAME_) \
-  `ASSERT(FpvSecCm``NAME_``, $rose(PRIM_HIER_.ERR_NAME_) && !(GATE_) |-> ##[0:MAX_CYCLES_] (ALERT_.alert_p)) \
+  `ASSERT(FpvSecCm``NAME_``, \
+          $rose(PRIM_HIER_.ERR_NAME_) && !(GATE_) \
+          |-> ##[0:MAX_CYCLES_] (ALERT_.alert_p)) \
   `ifdef INC_ASSERT \
   assign PRIM_HIER_.unused_assert_connected = 1'b1; \
   `endif \

--- a/hw/ip/prim/rtl/prim_fifo_sync.sv
+++ b/hw/ip/prim/rtl/prim_fifo_sync.sv
@@ -51,6 +51,9 @@ module prim_fifo_sync #(
     logic unused_clr;
     assign unused_clr = clr_i;
 
+    // No error
+    assign err_o = 1'b 0;
+
   // Normal FIFO construction
   end else begin : gen_normal_fifo
 


### PR DESCRIPTION
This commit fixes lint warning for undriven `err_o` in case of `Depth ==
0`.
