### PR TITLE
[dv/flash_ctrl] Temp fix flash_ctrl regression compile error

### DIFF
--- a/hw/dv/tools/xcelium/common.ccf
+++ b/hw/dv/tools/xcelium/common.ccf
@@ -41,7 +41,8 @@ set_fsm_reset_scoring
 set_toggle_portsonly
 
 // Enable scoring of FSM arcs (state transitions).
-set_fsm_arc_scoring
+// TODO: re-enable this setting, temp disable due to #12544
+// set_fsm_arc_scoring
 
 // Include X->1|0 for toggle coverage collection. #10332
 set_toggle_includex


### PR DESCRIPTION
This PR temp fix the flash_ctrl regression error when `-c` is enabled.
Right now we are working with AE to find the root cause and solve this.

Issue #12544 

Signed-off-by: Cindy Chen <chencindy@opentitan.org>