### PR TITLE
[dv/chip] Fix two items in sw test

### DIFF
--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_base_vseq.sv
@@ -359,7 +359,7 @@ class chip_sw_base_vseq extends chip_base_vseq;
       end
     end
 
-    if (i > max_attemp) begin
+    if (i >= max_attemp) begin
       `uvm_fatal(`gfn, $sformatf("max attempt reached to get lc status %0s!", expect_status.name))
     end
   endtask

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -21,9 +21,8 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
 
   // Reassign `select_jtag` variable to drive LC JTAG tap and disable mubi assertion errors.
   virtual task pre_start();
-    string dest_state_s;
-    void'($value$plusargs("dest_dec_state=%0s", dest_state_s));
-    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, dest_dec_state, dest_state_s)
+    `DV_GET_ENUM_PLUSARG(lc_ctrl_state_pkg::dec_lc_state_e, dest_dec_state, dest_dec_state)
+    `uvm_info(`gfn, $sformatf("Destination state is %0s", dest_dec_state.name), UVM_MEDIUM)
 
     select_jtag = SelectLCJtagTap;
     otp_raw_img_mubi_assertion_ctrl(.enable(0));


### PR DESCRIPTION
1). The `wait_lc_status` function in chip_sw_base_vseq did not correctly
  calculate the timeout. The threshold should be `>=`
2). Lc_walkthrough test remove some redundant code.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>