### PR TITLE
fix(spi_device): Re-timing sck_cmdfifo_set clear time

### DIFF
--- a/hw/ip/spi_device/rtl/spi_device.sv
+++ b/hw/ip/spi_device/rtl/spi_device.sv
@@ -1492,6 +1492,7 @@ module spi_device
 
     .clk_csb_i (clk_csb),
 
+    .sck_csb_asserted_pulse_i   (sck_csb_asserted_pulse),
     .sys_csb_deasserted_pulse_i (sys_csb_deasserted_pulse),
 
     .sel_dp_i (cmd_dp_sel),

--- a/hw/ip/spi_device/rtl/spid_upload.sv
+++ b/hw/ip/spi_device/rtl/spid_upload.sv
@@ -57,6 +57,7 @@ module spid_upload
 
   input clk_csb_i, // CSb as a clock source
 
+  input sck_csb_asserted_pulse_i,
   input sys_csb_deasserted_pulse_i,
 
   input sel_datapath_e sel_dp_i,
@@ -297,7 +298,7 @@ module spid_upload
     // Can't use cmdfifo_depth != '0 as cmdfifo_depth is latched by SCK
     // CmdOnly SPI transaction cannot catch
     else if (cmdfifo_wvalid && cmdfifo_wready) sck_cmdfifo_set <= 1'b 1;
-    else if (cmdfifo_depth == '0)              sck_cmdfifo_set <= 1'b 0;
+    else if (sck_csb_asserted_pulse_i)         sck_cmdfifo_set <= 1'b 0;
   end
   `ASSERT(CmdFifoPush_A,
           cmdfifo_wvalid && cmdfifo_wready |=> cmdfifo_depth != 0,


### PR DESCRIPTION

Related issue https://github.com/lowRISC/opentitan/issues/11871

In previous design, the `sck_cmdfifo_set` signal is set by the ACK of
CMDFIFO write port and cleared by the FIFO DEPTH == 0.

THe clearing of FIFO depth depends on the SW processing time. This
commit revises it to CSb assertion pulse signal.

It is still bounded by the clock ratio between the SYS_CLK and the SCK.
SYS_CLK should not be 3 times slower than the SCK to correctly generate
the pulse signal within the opcode timeline.