### PR TITLE
[dv/chip] Fix alert_ping_timeout regression error

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -591,6 +591,7 @@
       uvm_test_seq: chip_sw_base_vseq
       sw_images: ["sw/device/tests/alert_handler_ping_timeout_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
+      run_opts: ["+en_scb=0"]
     }
     {
       name: chip_sw_aes_entropy


### PR DESCRIPTION
This PR fixes regression error due to ping_timeout scb error.
Because all the checkings are done in seq, we will disable the scb.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>