### PR TITLE
[DV/rstmgr] Updated templates to skip reset consistency check on pon_io_div4 leaf

### DIFF
--- a/hw/ip/rstmgr/data/rstmgr.sv.tpl
+++ b/hw/ip/rstmgr/data/rstmgr.sv.tpl
@@ -312,7 +312,11 @@ module rstmgr
     % for domain in power_domains:
        % if domain in rst.domains:
   rstmgr_leaf_rst #(
+    % if rst.name==rst_ni:
+    .SecCheck(0),
+    % else:
     .SecCheck(SecCheck),
+    % endif
     .SecMaxSyncDelay(SecMaxSyncDelay),
     % if rst.sw:
     .SwRstReq(1'b1)
@@ -337,13 +341,14 @@ module rstmgr
     .fsm_err_o(${err_prefix[j]}fsm_errs[${i}][Domain${domain}Sel])
   );
 
+  % if rst.name!=rst_ni:
   if (SecCheck) begin : gen_d${domain.lower()}_${name}_assert
   `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
     D${domain.capitalize()}${rst_name.as_camel_case()}FsmCheck_A,
     u_d${domain.lower()}_${name}.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
+  % endif
       % else:
   assign resets_o.rst_${name}_n[Domain${domain}Sel] = '0;
   assign ${err_prefix[j]}cnsty_chk_errs[${i}][Domain${domain}Sel] = '0;

--- a/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
+++ b/hw/ip/rstmgr/dv/env/rstmgr_env_pkg.sv
@@ -38,8 +38,6 @@ package rstmgr_env_pkg;
   parameter string LIST_OF_LEAFS[] = {"u_daon_por",
                                       "u_daon_por_io",
                                       "u_daon_por_io_div2",
-                                      "u_daon_por_io_div4",
-                                      "u_daon_por_io_div4_shadowed",
                                       "u_daon_por_usb",
                                       "u_daon_sys_aon",
                                       "u_daon_sys_io_div4",
@@ -64,8 +62,7 @@ package rstmgr_env_pkg;
                                       "u_d0_i2c2"};
 
   // leaf reset which has shadow pair
-  parameter string LIST_OF_SHADOW_LEAFS[] = {"u_daon_por_io_div4",
-                                             "u_d0_lc",
+  parameter string LIST_OF_SHADOW_LEAFS[] = {"u_d0_lc",
                                              "u_d0_lc_io_div4",
                                              "u_daon_lc_io_div4",
                                              "u_d0_sys"};

--- a/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
+++ b/hw/ip/rstmgr/dv/sva/rstmgr_cascading_sva_if.sv
@@ -153,12 +153,6 @@ interface rstmgr_cascading_sva_if (
     // The latter is checked independently in pwrmgr_rstmgr_sva_if.
     `CASCADED_ASSERTS(CascadeLcToSys, lc_rst_or_sys_req_n[pd], rst_sys_src_n[pd], SysCycles, clk_i)
 
-    // Controlled by rst_lc_src_n.
-    `CASCADED_ASSERTS(CascadeLcToLcIoDiv4, rst_lc_src_n[pd], resets_o.rst_lc_io_div4_n[pd],
-                      SysCycles, clk_io_div4_i)
-    `CASCADED_ASSERTS(CascadeLcToLcIoDiv4Shadowed, rst_lc_src_n[pd],
-                      resets_o.rst_lc_io_div4_shadowed_n[pd], SysCycles, clk_io_div4_i)
-
     // Controlled by rst_sys_src_n.
     `CASCADED_ASSERTS(CascadeSysToSysAon, rst_sys_src_n[pd], resets_o.rst_sys_aon_n[pd], SysCycles,
                       clk_aon_i)

--- a/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
+++ b/hw/top_earlgrey/ip/rstmgr/rtl/autogen/rstmgr.sv
@@ -325,7 +325,6 @@ module rstmgr
     u_daon_por.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign resets_o.rst_por_n[Domain0Sel] = '0;
   assign cnsty_chk_errs[0][Domain0Sel] = '0;
   assign fsm_errs[0][Domain0Sel] = '0;
@@ -360,7 +359,6 @@ module rstmgr
     u_daon_por_io.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign resets_o.rst_por_io_n[Domain0Sel] = '0;
   assign cnsty_chk_errs[1][Domain0Sel] = '0;
   assign fsm_errs[1][Domain0Sel] = '0;
@@ -395,7 +393,6 @@ module rstmgr
     u_daon_por_io_div2.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign resets_o.rst_por_io_div2_n[Domain0Sel] = '0;
   assign cnsty_chk_errs[2][Domain0Sel] = '0;
   assign fsm_errs[2][Domain0Sel] = '0;
@@ -407,7 +404,7 @@ module rstmgr
   // Power Domains: ['Aon']
   // Shadowed: True
   rstmgr_leaf_rst #(
-    .SecCheck(SecCheck),
+    .SecCheck(0),
     .SecMaxSyncDelay(SecMaxSyncDelay),
     .SwRstReq(1'b0)
   ) u_daon_por_io_div4 (
@@ -424,19 +421,12 @@ module rstmgr
     .fsm_err_o(fsm_errs[3][DomainAonSel])
   );
 
-  if (SecCheck) begin : gen_daon_por_io_div4_assert
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
-    DAonPorIoDiv4FsmCheck_A,
-    u_daon_por_io_div4.gen_rst_chk.u_rst_chk.u_state_regs,
-    alert_tx_o[0])
-  end
-
   assign resets_o.rst_por_io_div4_n[Domain0Sel] = '0;
   assign cnsty_chk_errs[3][Domain0Sel] = '0;
   assign fsm_errs[3][Domain0Sel] = '0;
   assign rst_en_o.por_io_div4[Domain0Sel] = MuBi4True;
   rstmgr_leaf_rst #(
-    .SecCheck(SecCheck),
+    .SecCheck(0),
     .SecMaxSyncDelay(SecMaxSyncDelay),
     .SwRstReq(1'b0)
   ) u_daon_por_io_div4_shadowed (
@@ -452,13 +442,6 @@ module rstmgr
     .err_o(shadow_cnsty_chk_errs[3][DomainAonSel]),
     .fsm_err_o(shadow_fsm_errs[3][DomainAonSel])
   );
-
-  if (SecCheck) begin : gen_daon_por_io_div4_shadowed_assert
-  `ASSERT_PRIM_FSM_ERROR_TRIGGER_ALERT(
-    DAonPorIoDiv4ShadowedFsmCheck_A,
-    u_daon_por_io_div4_shadowed.gen_rst_chk.u_rst_chk.u_state_regs,
-    alert_tx_o[0])
-  end
 
   assign resets_o.rst_por_io_div4_shadowed_n[Domain0Sel] = '0;
   assign shadow_cnsty_chk_errs[3][Domain0Sel] = '0;
@@ -492,7 +475,6 @@ module rstmgr
     u_daon_por_usb.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign resets_o.rst_por_usb_n[Domain0Sel] = '0;
   assign cnsty_chk_errs[4][Domain0Sel] = '0;
   assign fsm_errs[4][Domain0Sel] = '0;
@@ -531,7 +513,6 @@ module rstmgr
     u_d0_lc.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign resets_o.rst_lc_shadowed_n[DomainAonSel] = '0;
   assign shadow_cnsty_chk_errs[5][DomainAonSel] = '0;
   assign shadow_fsm_errs[5][DomainAonSel] = '0;
@@ -561,7 +542,6 @@ module rstmgr
     alert_tx_o[0])
   end
 
-
   // Generating resets for lc_io_div4
   // Power Domains: ['0', 'Aon']
   // Shadowed: True
@@ -589,7 +569,6 @@ module rstmgr
     u_daon_lc_io_div4.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
     .SecMaxSyncDelay(SecMaxSyncDelay),
@@ -614,7 +593,6 @@ module rstmgr
     u_d0_lc_io_div4.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
     .SecMaxSyncDelay(SecMaxSyncDelay),
@@ -639,7 +617,6 @@ module rstmgr
     u_daon_lc_io_div4_shadowed.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
     .SecMaxSyncDelay(SecMaxSyncDelay),
@@ -664,7 +641,6 @@ module rstmgr
     u_d0_lc_io_div4_shadowed.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
 
   // Generating resets for lc_aon
   // Power Domains: ['Aon']
@@ -693,7 +669,6 @@ module rstmgr
     u_daon_lc_aon.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign resets_o.rst_lc_aon_n[Domain0Sel] = '0;
   assign cnsty_chk_errs[7][Domain0Sel] = '0;
   assign fsm_errs[7][Domain0Sel] = '0;
@@ -732,7 +707,6 @@ module rstmgr
     u_d0_sys.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign resets_o.rst_sys_shadowed_n[DomainAonSel] = '0;
   assign shadow_cnsty_chk_errs[8][DomainAonSel] = '0;
   assign shadow_fsm_errs[8][DomainAonSel] = '0;
@@ -762,7 +736,6 @@ module rstmgr
     alert_tx_o[0])
   end
 
-
   // Generating resets for sys_io_div4
   // Power Domains: ['0', 'Aon']
   // Shadowed: False
@@ -790,7 +763,6 @@ module rstmgr
     u_daon_sys_io_div4.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
     .SecMaxSyncDelay(SecMaxSyncDelay),
@@ -815,7 +787,6 @@ module rstmgr
     u_d0_sys_io_div4.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[9] = '0;
   assign shadow_fsm_errs[9] = '0;
 
@@ -846,7 +817,6 @@ module rstmgr
     u_daon_sys_aon.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   rstmgr_leaf_rst #(
     .SecCheck(SecCheck),
     .SecMaxSyncDelay(SecMaxSyncDelay),
@@ -871,7 +841,6 @@ module rstmgr
     u_d0_sys_aon.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[10] = '0;
   assign shadow_fsm_errs[10] = '0;
 
@@ -906,7 +875,6 @@ module rstmgr
     u_d0_spi_device.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[11] = '0;
   assign shadow_fsm_errs[11] = '0;
 
@@ -941,7 +909,6 @@ module rstmgr
     u_d0_spi_host0.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[12] = '0;
   assign shadow_fsm_errs[12] = '0;
 
@@ -976,7 +943,6 @@ module rstmgr
     u_d0_spi_host1.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[13] = '0;
   assign shadow_fsm_errs[13] = '0;
 
@@ -1011,7 +977,6 @@ module rstmgr
     u_d0_usb.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[14] = '0;
   assign shadow_fsm_errs[14] = '0;
 
@@ -1046,7 +1011,6 @@ module rstmgr
     u_d0_usbif.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[15] = '0;
   assign shadow_fsm_errs[15] = '0;
 
@@ -1081,7 +1045,6 @@ module rstmgr
     u_d0_i2c0.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[16] = '0;
   assign shadow_fsm_errs[16] = '0;
 
@@ -1116,7 +1079,6 @@ module rstmgr
     u_d0_i2c1.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[17] = '0;
   assign shadow_fsm_errs[17] = '0;
 
@@ -1151,7 +1113,6 @@ module rstmgr
     u_d0_i2c2.gen_rst_chk.u_rst_chk.u_state_regs,
     alert_tx_o[0])
   end
-
   assign shadow_cnsty_chk_errs[18] = '0;
   assign shadow_fsm_errs[18] = '0;
 

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -470,6 +470,9 @@ def generate_pwrmgr(top, out_path):
     # Generate reg files
     generate_regfile_from_path(hjson_path, rtl_path, original_rtl_path)
 
+def get_rst_ni(top):
+    rstmgrs = [m for m in top['module'] if m['type'] == 'rstmgr']
+    return rstmgrs[0]["reset_connections"]
 
 # generate rstmgr
 def generate_rstmgr(topcfg, out_path):
@@ -510,6 +513,9 @@ def generate_rstmgr(topcfg, out_path):
     # sw controlled resets
     sw_rsts = reset_obj.get_sw_resets()
 
+    # rst_ni
+    rst_ni = get_rst_ni(topcfg)
+
     # leaf resets
     leaf_rsts = reset_obj.get_generated_resets()
 
@@ -528,6 +534,7 @@ def generate_rstmgr(topcfg, out_path):
                                  sw_rsts=sw_rsts,
                                  output_rsts=output_rsts,
                                  leaf_rsts=leaf_rsts,
+                                 rst_ni = rst_ni['rst_ni']['name'],
                                  export_rsts=topcfg["exported_rsts"],
                                  reset_obj=topcfg["resets"])
 


### PR DESCRIPTION
[DV/rstmgr] removed unnecessary DV checkers on skipped rst leaf

Details : https://github.com/lowRISC/opentitan/issues/11858 and https://github.com/lowRISC/opentitan/pull/12627