### PR TITLE
[otbn, rtl] Add fatal error when prefetch isn't correct

### DIFF
--- a/hw/ip/otbn/dv/rig/rig/gens/loop.py
+++ b/hw/ip/otbn/dv/rig/rig/gens/loop.py
@@ -119,11 +119,14 @@ class Loop(SnippetGen):
             warp = None
             iters = actual_iters
         else:
-            # We will start '1 + lo' iterations before the warp (and finish
-            # 'lo' of them). We'll then finish 'max_iters - lo' iterations
-            # after the warp. Both '1 + lo' and 'max_iters - lo' must be
-            # positive.
-            lo = random.randint(0, max_iters - 1)
+            # We will start '1 + lo' iterations before the warp (and finish 'lo'
+            # of them). We'll then finish 'max_iters - lo' iterations after the
+            # warp. Both '1 + lo' and 'max_iters - lo' must be positive. `lo`
+            # must not be more than `max_iters - 2` as otherwise we can warp to
+            # 1 remaining iteration. If this happens right at the end of a loop
+            # the prefetch stage will have fetched the wrong instruction and a
+            # fatal error will be raised.
+            lo = random.randint(0, max_iters - 2)
             hi = actual_iters - (max_iters - lo)
             assert 0 <= lo <= hi < actual_iters
             warp = (lo, hi)

--- a/hw/ip/otbn/rtl/otbn_controller.sv
+++ b/hw/ip/otbn/rtl/otbn_controller.sv
@@ -30,6 +30,7 @@ module otbn_controller
 
   // Next instruction selection (to instruction fetch)
   output logic                     insn_fetch_req_valid_o,
+  output logic                     insn_fetch_req_valid_raw_o,
   output logic [ImemAddrWidth-1:0] insn_fetch_req_addr_o,
   output logic                     insn_fetch_resp_clear_o,
 
@@ -455,7 +456,11 @@ module otbn_controller
   // Anything that moves us or keeps us in the stall state should cause `stall` to be asserted
   `ASSERT(StallIfNextStateStall, insn_valid_i & (state_d == OtbnStateStall) |-> stall)
 
-  assign insn_fetch_req_valid_o = err ? 1'b0 : insn_fetch_req_valid_raw;
+  // The raw signal is needed by the instruction fetch stage for generating instruction address
+  // errors (where instruction fetch and prefetch disagree on address). `err` will factor this in so
+  // using the qualified signal results in a combinational loop.
+  assign insn_fetch_req_valid_raw_o = insn_fetch_req_valid_raw;
+  assign insn_fetch_req_valid_o     = err ? 1'b0 : insn_fetch_req_valid_raw;
 
   // Determine if there are any errors related to the Imem fetch address.
   always_comb begin

--- a/hw/ip/otbn/rtl/otbn_core.sv
+++ b/hw/ip/otbn/rtl/otbn_core.sv
@@ -91,6 +91,7 @@ module otbn_core
   // Fetch request (the next instruction)
   logic [ImemAddrWidth-1:0] insn_fetch_req_addr;
   logic                     insn_fetch_req_valid;
+  logic                     insn_fetch_req_valid_raw;
 
   // Fetch response (the current instruction before it is decoded)
   logic                     insn_fetch_resp_valid;
@@ -98,6 +99,7 @@ module otbn_core
   logic [31:0]              insn_fetch_resp_data;
   logic                     insn_fetch_resp_clear;
   logic                     insn_fetch_err;
+  logic                     insn_addr_err;
 
   rf_predec_bignum_t   rf_predec_bignum;
   alu_predec_bignum_t  alu_predec_bignum;
@@ -308,8 +310,9 @@ module otbn_core
     .imem_rvalid_i,
 
     // Instruction to fetch
-    .insn_fetch_req_addr_i (insn_fetch_req_addr),
-    .insn_fetch_req_valid_i(insn_fetch_req_valid),
+    .insn_fetch_req_addr_i     (insn_fetch_req_addr),
+    .insn_fetch_req_valid_i    (insn_fetch_req_valid),
+    .insn_fetch_req_valid_raw_i(insn_fetch_req_valid_raw),
 
     // Fetched instruction
     .insn_fetch_resp_addr_o (insn_fetch_resp_addr),
@@ -317,6 +320,7 @@ module otbn_core
     .insn_fetch_resp_data_o (insn_fetch_resp_data),
     .insn_fetch_resp_clear_i(insn_fetch_resp_clear),
     .insn_fetch_err_o       (insn_fetch_err),
+    .insn_addr_err_o        (insn_addr_err),
 
     .rf_predec_bignum_o  (rf_predec_bignum),
     .alu_predec_bignum_o (alu_predec_bignum),
@@ -389,9 +393,10 @@ module otbn_core
     .recoverable_err_o,
 
     // Next instruction selection (to instruction fetch)
-    .insn_fetch_req_addr_o  (insn_fetch_req_addr),
-    .insn_fetch_req_valid_o (insn_fetch_req_valid),
-    .insn_fetch_resp_clear_o(insn_fetch_resp_clear),
+    .insn_fetch_req_addr_o     (insn_fetch_req_addr),
+    .insn_fetch_req_valid_o    (insn_fetch_req_valid),
+    .insn_fetch_req_valid_raw_o(insn_fetch_req_valid_raw),
+    .insn_fetch_resp_clear_o   (insn_fetch_resp_clear),
 
     // The current instruction
     .insn_valid_i  (insn_valid),
@@ -527,7 +532,8 @@ module otbn_core
     bad_internal_state:  |{controller_err_bits.bad_internal_state,
                            start_stop_internal_error,
                            urnd_all_zero,
-                           predec_error},
+                           predec_error,
+                           insn_addr_err},
     reg_intg_violation:  |{controller_err_bits.reg_intg_violation,
                            alu_bignum_reg_intg_violation_err,
                            mac_bignum_reg_intg_violation_err,


### PR DESCRIPTION
By design the prefetch stage either prefetches the correct address or
doesn't prefetch. If a prefetched instruction has a different address to
the one required by the instruction fetch stage a fault has ocurred.