### PR TITLE
[otbn,dv] Correct the boundary of a "critical section"

### DIFF
--- a/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
+++ b/hw/ip/otbn/dv/uvm/env/seq_lib/otbn_base_vseq.sv
@@ -323,8 +323,6 @@ class otbn_base_vseq extends cip_base_vseq #(
     end
     cfg.m_alert_agent_cfg["recov"].vif.wait_ack_complete();
 
-    running_ = 1'b0;
-
     if (cfg.model_agent_cfg.vif.status == otbn_pkg::StatusLocked) begin
       bit cmd_wr;
       `DV_CHECK_STD_RANDOMIZE_WITH_FATAL(cmd_wr, cmd_wr dist { 0 :/ 9, 1 :/ 1};)
@@ -347,6 +345,10 @@ class otbn_base_vseq extends cip_base_vseq #(
       `DV_CHECK_STD_RANDOMIZE_FATAL(wdata)
       csr_utils_pkg::csr_wr(ral.err_bits, wdata);
     end
+
+    // Note: This must be the last thing in the function before we return. We use this flag to
+    // synchronise with a "disable fork" in start_running_otbn().
+    running_ = 1'b0;
   endtask
 
   // The guts of the run_otbn task. Writes to the CMD register to start OTBN and polls the status


### PR DESCRIPTION
The `running_` flag is used to handle process control in
`start_running_otbn`. The idea is that it gets set when we start
`run_otbn()` and then cleared just before we exit. That lets us get the
timing right before running a "disable fork" in `start_running_otbn`.

A series of commits starting with 1b1b7aa had added some extra stuff
that run after we cleared the flag, causing occasional weird errors
where a UVM sequencer spots that a process has been killed while
waiting to send a sequence item.
