### PR TITLE
[otbn] Move to D2S

### DIFF
--- a/hw/ip/otbn/data/otbn.prj.hjson
+++ b/hw/ip/otbn/data/otbn.prj.hjson
@@ -21,7 +21,7 @@
         {
             version:            "1.0",
             life_stage:         "L1",
-            design_stage:       "D2",
+            design_stage:       "D2S",
             verification_stage: "V2",
             dif_stage:          "S2",
         },

--- a/hw/ip/otbn/doc/checklist.md
+++ b/hw/ip/otbn/doc/checklist.md
@@ -77,13 +77,13 @@ Security      | [SEC_CM_DOCUMENTED][]     | Done        | Two things are not yet
 
  Type         | Item                         | Resolution  | Note/Collaterals
 --------------|------------------------------|-------------|------------------
-Security      | [SEC_CM_ASSETS_LISTED][]     | Not Started |
-Security      | [SEC_CM_IMPLEMENTED][]       | Not Started |
-Security      | [SEC_CM_RND_CNST][]          | Not Started |
-Security      | [SEC_CM_NON_RESET_FLOPS][]   | Not Started |
-Security      | [SEC_CM_SHADOW_REGS][]       | Not Started |
-Security      | [SEC_CM_RTL_REVIEWED][]      | Not Started |
-Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Not Started |
+Security      | [SEC_CM_ASSETS_LISTED][]     | Done        |
+Security      | [SEC_CM_IMPLEMENTED][]       | Done        |
+Security      | [SEC_CM_RND_CNST][]          | Done        |
+Security      | [SEC_CM_NON_RESET_FLOPS][]   | Done        |
+Security      | [SEC_CM_SHADOW_REGS][]       | Done        |
+Security      | [SEC_CM_RTL_REVIEWED][]      | Done        |
+Security      | [SEC_CM_COUNCIL_REVIEWED][]  | Done        |
 
 [SEC_CM_ASSETS_LISTED]:    {{<relref "/doc/project/checklist.md#sec_cm_assets_listed" >}}
 [SEC_CM_IMPLEMENTED]:      {{<relref "/doc/project/checklist.md#sec_cm_implemented" >}}


### PR DESCRIPTION
We're not quite ready to close OTBN D2S as there's a few outstanding tasks:

- 1. [x] Add the `SEC_CM` labels
- 2. [x] Add functionality to zero flags at the end of an operation (request from D2S review meeting)
- 3. [x] Merge https://github.com/lowRISC/opentitan/pull/12734
- 4. [x] Review use of prim_buf (I think there's some still places where these need to be inserted I can do this at the same time as the SEC_CM labels as I'll be going through all of the relevant RTL)

However we're basically there so I wanted to get this PR out so we can close D2S ASAP.

Note the PC duplication/Ibex style PC hardening in the D2S tasks has been done a bit differently, as we can utilize the existing duplication between the prefetch stage and the execute stage which https://github.com/lowRISC/opentitan/pull/12734 does. For reference @andreaskurth implemented duplicated PCs here: https://github.com/lowRISC/opentitan/pull/12518 but we were proposing to reject this change.

I have also had some additional ideas about further hardening for control, using predecode to check control signals (such as call stack push and pop) are as expected. I will open up a draft PR/issue with more details soon. I'd consider this more of a post D2S addition so shouldn't factor into the D2S closing. We need to discuss if the extra hardening is worth having at this late stage.

Signed-off-by: Greg Chadwick <gac@lowrisc.org>