### PR TITLE
[sw/silicon_creator] Add OTP item for retention RAM init and store reset reason in retention RAM

### DIFF
--- a/hw/ip/otp_ctrl/data/otp_ctrl.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl.hjson
@@ -291,6 +291,18 @@
       default: "4",
       local: "true"
     },
+    { name: "CreatorSwCfgRetRamResetMaskOffset",
+      desc: "Offset of CREATOR_SW_CFG_RET_RAM_RESET_MASK",
+      type: "int",
+      default: "256",
+      local: "true"
+    },
+    { name: "CreatorSwCfgRetRamResetMaskSize",
+      desc: "Size of CREATOR_SW_CFG_RET_RAM_RESET_MASK",
+      type: "int",
+      default: "4",
+      local: "true"
+    },
     { name: "CreatorSwCfgDigestOffset",
       desc: "Offset of CREATOR_SW_CFG_DIGEST",
       type: "int",

--- a/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
+++ b/hw/ip/otp_ctrl/data/otp_ctrl_mmap.hjson
@@ -148,6 +148,10 @@
                     name: "CREATOR_SW_CFG_JITTER_EN",
                     size: "4"
                 }
+                {
+                    name: "CREATOR_SW_CFG_RET_RAM_RESET_MASK",
+                    size: "4"
+                }
             ],
             desc: '''Software configuration partition for
             device-specific calibration data (Clock, LDO,

--- a/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
+++ b/hw/ip/otp_ctrl/doc/otp_ctrl_mmap.md
@@ -16,6 +16,7 @@ It has been generated with ./util/design/gen-otp-mmap.py
 |         |                |            |      32bit       |        CREATOR_SW_CFG_FLASH_INFO_BOOT_DATA_CFG        |     0x0F4      |     4      |
 |         |                |            |      32bit       |                 CREATOR_SW_CFG_RNG_EN                 |     0x0F8      |     4      |
 |         |                |            |      32bit       |               CREATOR_SW_CFG_JITTER_EN                |     0x0FC      |     4      |
+|         |                |            |      32bit       |           CREATOR_SW_CFG_RET_RAM_RESET_MASK           |     0x100      |     4      |
 |         |                |            |      64bit       | [CREATOR_SW_CFG_DIGEST](#Reg_creator_sw_cfg_digest_0) |     0x358      |     8      |
 |    2    |  OWNER_SW_CFG  |    800     |      32bit       |                  ROM_ERROR_REPORTING                  |     0x360      |     4      |
 |         |                |            |      32bit       |                   ROM_BOOTSTRAP_EN                    |     0x364      |     4      |

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_part_pkg.sv
@@ -321,7 +321,8 @@ package otp_ctrl_part_pkg;
     }),
     6400'({
       64'h7D7EA64D850E128D,
-      4800'h0, // unallocated space
+      4768'h0, // unallocated space
+      32'h0,
       32'h0,
       32'h0,
       32'h0,

--- a/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
+++ b/hw/ip/otp_ctrl/rtl/otp_ctrl_reg_pkg.sv
@@ -41,6 +41,8 @@ package otp_ctrl_reg_pkg;
   parameter int CreatorSwCfgRngEnSize = 4;
   parameter int CreatorSwCfgJitterEnOffset = 252;
   parameter int CreatorSwCfgJitterEnSize = 4;
+  parameter int CreatorSwCfgRetRamResetMaskOffset = 256;
+  parameter int CreatorSwCfgRetRamResetMaskSize = 4;
   parameter int CreatorSwCfgDigestOffset = 856;
   parameter int CreatorSwCfgDigestSize = 8;
   parameter int OwnerSwCfgOffset = 864;

--- a/sw/device/silicon_creator/lib/drivers/retention_sram.h
+++ b/sw/device/silicon_creator/lib/drivers/retention_sram.h
@@ -30,12 +30,18 @@ typedef struct retention_sram {
   uint32_t boot_info;
 
   /**
+   * Reset reasons reported by the reset manager before they were reset in mask
+   * ROM.
+   */
+  uint32_t reset_reasons;
+
+  /**
    * Space reserved for future allocation by the silicon creator.
    *
    * TODO(lowRISC/opentitan#5760): the size / offset of this allocation should
    * be reviewed.
    */
-  uint32_t reserved_creator[447];
+  uint32_t reserved_creator[446];
 
   /**
    * Panic record.

--- a/sw/device/silicon_creator/mask_rom/BUILD
+++ b/sw/device/silicon_creator/mask_rom/BUILD
@@ -120,6 +120,7 @@ opentitan_rom_binary(
         "//sw/device/silicon_creator/lib/drivers:ibex",
         "//sw/device/silicon_creator/lib/drivers:keymgr",
         "//sw/device/silicon_creator/lib/drivers:lifecycle",
+        "//sw/device/silicon_creator/lib/drivers:otp",
         "//sw/device/silicon_creator/lib/drivers:pinmux",
         "//sw/device/silicon_creator/lib/drivers:retention_sram",
         "//sw/device/silicon_creator/lib/drivers:rnd",

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -114,18 +114,16 @@ static rom_error_t mask_rom_init(void) {
   mask_rom_epmp_state_init(&epmp, lc_state);
 
   // Initialize the retention RAM based on the reset reason and the OTP value.
-  //
-  // Retention RAM is always reset on PoR regardless of the OTP value.
-  //
-  // TODO(lowRISC/opentitan#7887): once the retention SRAM is initialized the
-  // reset reason should probably be saved into either main SRAM or the
-  // retention SRAM and the reset reason register cleared.
+  // Note: Retention RAM is always reset on PoR regardless of the OTP value.
   uint32_t reset_reasons = rstmgr_reason_get();
   uint32_t reset_mask = (1 << kRstmgrReasonPowerOn)
       | otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_OFFSET);
   if ((reset_reasons & reset_mask) != 0) {
     retention_sram_init();
   }
+  // Store the reset reason in retention RAM and clear the register.
+  retention_sram_get()->reset_reasons = reset_reasons;
+  rstmgr_reason_clear(reset_reasons);
 
   // If running on an FPGA, print the FPGA version-id.
   // This value is guaranteed to be zero on all non-FPGA implementations.

--- a/sw/device/silicon_creator/mask_rom/mask_rom.c
+++ b/sw/device/silicon_creator/mask_rom/mask_rom.c
@@ -20,6 +20,7 @@
 #include "sw/device/silicon_creator/lib/drivers/ibex.h"
 #include "sw/device/silicon_creator/lib/drivers/keymgr.h"
 #include "sw/device/silicon_creator/lib/drivers/lifecycle.h"
+#include "sw/device/silicon_creator/lib/drivers/otp.h"
 #include "sw/device/silicon_creator/lib/drivers/pinmux.h"
 #include "sw/device/silicon_creator/lib/drivers/retention_sram.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
@@ -36,6 +37,7 @@
 #include "sw/device/silicon_creator/mask_rom/sigverify_keys.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
+#include "otp_ctrl_regs.h"
 
 /**
  * Table of forward branch Control Flow Integrity (CFI) counters.
@@ -111,18 +113,17 @@ static rom_error_t mask_rom_init(void) {
   // Initialize in-memory copy of the ePMP register configuration.
   mask_rom_epmp_state_init(&epmp, lc_state);
 
-  // Initialize the retention SRAM at power-on.
+  // Initialize the retention RAM based on the reset reason and the OTP value.
   //
-  // The reset reason is treated as power-on if the POR bit is asserted
-  // regardless of whether or not any other reset reason bits are set. This is
-  // because we cannot guarantee that the retention SRAM was fully initialized
-  // if the device was reset before the POR bit was cleared.
+  // Retention RAM is always reset on PoR regardless of the OTP value.
   //
   // TODO(lowRISC/opentitan#7887): once the retention SRAM is initialized the
   // reset reason should probably be saved into either main SRAM or the
   // retention SRAM and the reset reason register cleared.
   uint32_t reset_reasons = rstmgr_reason_get();
-  if (bitfield_bit32_read(reset_reasons, kRstmgrReasonPowerOn)) {
+  uint32_t reset_mask = (1 << kRstmgrReasonPowerOn)
+      | otp_read32(OTP_CTRL_PARAM_CREATOR_SW_CFG_RET_RAM_RESET_MASK_OFFSET);
+  if ((reset_reasons & reset_mask) != 0) {
     retention_sram_init();
   }
 

--- a/sw/device/silicon_creator/mask_rom/meson.build
+++ b/sw/device/silicon_creator/mask_rom/meson.build
@@ -234,6 +234,7 @@ mask_rom_lib = declare_dependency(
       sw_silicon_creator_lib_driver_ibex,
       sw_silicon_creator_lib_driver_keymgr,
       sw_silicon_creator_lib_driver_lifecycle,
+      sw_silicon_creator_lib_driver_otp,
       sw_silicon_creator_lib_driver_pinmux,
       sw_silicon_creator_lib_driver_retention_sram,
       sw_silicon_creator_lib_driver_rnd,
@@ -254,6 +255,7 @@ mask_rom_lib = declare_dependency(
     link_with: static_library(
       'mask_rom_lib',
       sources: [
+        hw_ip_otp_ctrl_reg_h,
         'mask_rom.c',
       ],
       link_depends: [rom_linkfile],


### PR DESCRIPTION
This PR adds an OTP item for controlling the reset reasons that should trigger a retention RAM init. `mask_rom.c` is also updated so that we now save the reset reason in retention RAM before clearing the rstmgr register.