### PR TITLE
[dv/chip] Fix walkthrough RMA test error

### DIFF
--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -429,15 +429,15 @@
       sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
-      reseed: 1
     }
     {
       name: chip_sw_lc_walkthrough_rma
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
       sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
-      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma"]
-      reseed: 1
+      run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma",
+                 // The test takes long time because it will transit to RMA state
+                 "+sw_test_timeout_ns=200_000_000"]
     }
     {
       name: chip_sw_rstmgr_sw_req

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_sw_lc_walkthrough_vseq.sv
@@ -60,8 +60,15 @@ class chip_sw_lc_walkthrough_vseq extends chip_sw_base_vseq;
     apply_reset();
 
     wait (cfg.sw_logger_vif.printed_log == "Waiting for LC transtition done and reboot.");
-    wait_lc_status(LcTransitionSuccessful);
+    // Wait for a large number of cycles to transit to RMA state.
+    wait_lc_status(LcTransitionSuccessful, 50_000);
     apply_reset();
+
+    // Reload flash bootstrap and reforce the sw symbols because RMA state wiped out flash.
+    cfg.mem_bkdr_util_h[FlashBank0Data].load_mem_from_file(
+        {cfg.sw_images[SwTypeTest], ".64.scr.vmem"});
+    sw_symbol_backdoor_overwrite("kDestState", selected_dest_state);
+
   endtask
 
 endclass


### PR DESCRIPTION
This PR fixes the token error from testunlock -> Rma. It actually
requires all zero token instead of test exit token.
This PR also increase the runtime to avoid timeout,
because transfer to RMA state takes a long time.

Signed-off-by: Cindy Chen <chencindy@opentitan.org>