### PR TITLE
[chip, dv] Add chip_tap_straps

### DIFF
--- a/hw/dv/sv/jtag_agent/jtag_driver.sv
+++ b/hw/dv/sv/jtag_agent/jtag_driver.sv
@@ -63,10 +63,10 @@ class jtag_driver extends dv_base_driver #(jtag_item, jtag_agent_cfg);
     cfg.vif.tck_en <= 1'b1;
     @(`HOST_CB); // wait one cycle to ensure clock is stable. TODO: remove.
     if (req.ir_len) begin
-      if (!(req.skip_reselected_ir && req.ir == selected_ir && req.ir_len == selected_ir_len)) begin
-        drive_jtag_ir(req.ir_len, req.ir);
-      end else begin
+      if (req.skip_reselected_ir && req.ir == selected_ir && req.ir_len == selected_ir_len) begin
         `uvm_info(`gfn, $sformatf("UpdateIR for 0x%0h skipped", selected_ir), UVM_HIGH)
+      end else begin
+        drive_jtag_ir(req.ir_len, req.ir);
       end
     end
     if (req.dr_len) drive_jtag_dr(req.dr_len, req.dr, rsp.dout);

--- a/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
+++ b/hw/dv/sv/jtag_riscv_agent/jtag_riscv_agent_cfg.sv
@@ -17,6 +17,13 @@ class jtag_riscv_agent_cfg extends dv_base_agent_cfg;
   // while RV_DM jtag uses the original DM CSR addresses without the normalization.
   bit is_rv_dm = 0;
 
+  // Indicates the rv_dm jtag is activated or not. Only valid when is_rv_dm = 1.
+  // It can be only updated by driver and sequence shouldn't set this variable.
+  bit rv_dm_activated = 0;
+
+  // Allows activation to fail. Only valid when is_rv_dm = 1.
+  bit allow_rv_dm_activation_fail = 0;
+
   // Max attempts to activate rv_dm.
   int max_rv_dm_activation_attempts = 100;
 

--- a/hw/top_earlgrey/data/chip_testplan.hjson
+++ b/hw/top_earlgrey/data/chip_testplan.hjson
@@ -410,7 +410,7 @@
             and RMA, regardless of the value on DFT SW straps.
             '''
       milestone: V2
-      tests: []
+      tests: ["chip_tap_straps_dev", "chip_tap_straps_rma"]
     }
 
     // PADCTRL tests:

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -806,21 +806,24 @@
     {
       name: chip_tap_straps_dev
       uvm_test_seq: chip_tap_straps_vseq
-      en_run_modes: ["stub_cpu_mode"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStDev",
                  "+create_jtag_riscv_map=1",
                  // select DFT tap
-                 "+uart0_sel=0"]
+                 "+uart0_sel=0",
+                 // test will exit while SW is still running
+                 "+disable_assert_final_checks"]
     }
     {
       name: chip_tap_straps_rma
       uvm_test_seq: chip_tap_straps_vseq
-      en_run_modes: ["stub_cpu_mode"]
+      en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRma",
                  "+create_jtag_riscv_map=1",
                  // select DFT tap
-                 "+uart0_sel=0"]
+                 "+uart0_sel=0",
+                 // test will exit while SW is still running
+                 "+disable_assert_final_checks"]
     }
   ]
 

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_common_vseq.sv
@@ -11,32 +11,8 @@ class chip_common_vseq extends chip_stub_cpu_base_vseq;
   `uvm_object_new
 
   virtual task apply_reset(string kind = "HARD");
-    // The CSR tests (handled by this class) need to wait until the rom_ctrl block has finished
-    // running KMAC before they can start issuing reads and writes. Otherwise, they might write to a
-    // KMAC register while KMAC is in operation. This would have no effect and a subsequent read
-    // from the register would show a mismatched value. We handle this by considering rom_ctrl's
-    // operation as "part of reset".
-    //
-    // Once the base class reset is finished, we're just after a chip reset. In a second, rom_ctrl
-    // is going to start asking KMAC to do an operation. At that point, KMAC's CFG_REGWEN register
-    // will go low. When the operation is finished, it will go high again. Wait until then.
-    int unsigned rc_phase = 0;
-
     super.apply_reset(kind);
-
-    `uvm_info(`gfn, "waiting for rom_ctrl after reset", UVM_MEDIUM)
-    while (rc_phase < 2) begin
-      bit [BUS_DW-1:0] rd_data;
-      tl_access(.addr(ral.kmac.cfg_regwen.get_address()),
-                .write(1'b0),
-                .data(rd_data),
-                .blocking(1'b1));
-      if (rd_data[0] == rc_phase[0]) begin
-        `uvm_info(`gfn, "KMAC's cfg_regwen has changed; bumping phase", UVM_HIGH)
-        rc_phase++;
-      end
-    end
-    `uvm_info(`gfn, "rom_ctrl done after reset", UVM_HIGH)
+    wait_rom_check_done();
   endtask
 
   virtual task body();

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_tap_straps_vseq.sv
@@ -11,9 +11,9 @@
 // top_earlgrey.dft_strap_test_o in TEST_UNLOCKED* and RMA states.
 // Verify pimux.dft_strap_test_o is always 0 in the states other than TEST_UNLOCKED* and
 // RMA, regardless of the value on DFT SW straps.
-class chip_tap_straps_vseq extends chip_common_vseq;
+// TODO, only RMA and Dev states are tested
+class chip_tap_straps_vseq extends chip_sw_base_vseq;
   string path_dft_strap_test_o = {`DUT_HIER_STR, ".top_earlgrey.dft_strap_test_o"};
-  bit init_rv_dm_done;
   lc_ctrl_state_pkg::lc_state_e cur_lc_state;
 
   local uvm_reg lc_csrs[$];
@@ -22,13 +22,26 @@ class chip_tap_straps_vseq extends chip_common_vseq;
 
   `uvm_object_new
 
+  virtual task pre_start();
+    // Disable checking as pinmux isn't enabled for uart
+    foreach (cfg.m_uart_agent_cfgs[i]) cfg.m_uart_agent_cfgs[i].en_tx_monitor = 0;
+
+    super.pre_start();
+    enable_asserts_in_hw_reset_rand_wr = 0;
+  endtask
+
   virtual task dut_init(string reset_kind = "HARD");
-    init_rv_dm_done = 0;
     randomize_dft_straps();
     `DV_CHECK_STD_RANDOMIZE_FATAL(select_jtag)
     cfg.tap_straps_vif.drive(select_jtag);
 
+    cur_lc_state = cfg.use_otp_image;
+
     super.dut_init(reset_kind);
+  endtask
+
+  // no need to wait for SW test to complete, as we only need rom image for init
+  virtual task wait_for_sw_test_done();
   endtask
 
   virtual task body();
@@ -36,48 +49,47 @@ class chip_tap_straps_vseq extends chip_common_vseq;
     chip_tap_type_e allowed_taps_q[$];
 
     `DV_CHECK_FATAL(uvm_hdl_check_path(path_dft_strap_test_o))
-
     ral.lc_ctrl.get_registers(lc_csrs);
 
-    cur_lc_state = cfg.use_otp_image;
+    // load rom/flash and wait for rom_check to complete
+    cpu_init();
+    wait_rom_check_done();
+    wait(cfg.sw_test_status_vif.sw_test_status == SwTestStatusInBootRom);
+
     check_dft_straps();
 
-    // TODO, #12500 don't switch back to rv_dm again, limit to 2
-    // repeat (2) begin
-    //   random_enable_jtag_tap();
-    //   test_jtag_tap();
-    // end
-
-    // reproduce #12500
-    enable_jtag_tap(SelectRVJtagTap);
-    test_jtag_tap();
-    enable_jtag_tap(SelectLCJtagTap);
-    test_jtag_tap();
-    enable_jtag_tap(SelectRVJtagTap);
-    test_jtag_tap();
+    repeat ($urandom_range(3, 10)) begin
+      random_enable_jtag_tap();
+      test_jtag_tap();
+    end
 
     // check again, it shouldn't be changed
     check_dft_straps();
   endtask : body
 
   virtual task random_enable_jtag_tap();
+    chip_tap_type_e tap;
+    `DV_CHECK_STD_RANDOMIZE_FATAL(tap)
+
     if (is_lc_in_unlocked_or_rma()) begin
-      `DV_CHECK_STD_RANDOMIZE_FATAL(select_jtag)
+      enable_jtag_tap(tap);
     end else begin // switch won't take effect. tap_straps won't be sampled again
-      cfg.tap_straps_vif.drive($urandom());
+      enable_jtag_tap(select_jtag);
+      cfg.tap_straps_vif.drive(tap);
     end
-    enable_jtag_tap(select_jtag);
   endtask
 
   // TODO, add DFT tap
   virtual task enable_jtag_tap(chip_tap_type_e tap);
-    select_jtag = tap;
+    if (select_jtag != tap) begin
+      select_jtag = tap;
+      reset_jtag_tap();
+    end
     cfg.tap_straps_vif.drive(select_jtag);
+
     case (select_jtag)
       SelectRVJtagTap: begin
-        if (!init_rv_dm_done) begin
-          init_rv_dm();
-        end
+        if (!cfg.m_jtag_riscv_agent_cfg.rv_dm_activated) init_rv_dm();
         cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
       end
       SelectLCJtagTap:begin
@@ -91,13 +103,25 @@ class chip_tap_straps_vseq extends chip_common_vseq;
     endcase
   endtask
 
-  virtual task init_rv_dm();
+  virtual task reset_jtag_tap();
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 1;
+    #1000ns;
+    cfg.m_jtag_riscv_agent_cfg.in_reset = 0;
+  endtask
+
+  virtual task init_rv_dm(bit exp_to_be_activated = 1);
     jtag_riscv_dm_activation_seq jtag_dm_activation_seq =
         jtag_riscv_dm_activation_seq::type_id::create("jtag_dm_activation_seq");
 
     cfg.m_jtag_riscv_agent_cfg.allow_errors = 1;
+    if (!exp_to_be_activated) cfg.m_jtag_riscv_agent_cfg.allow_rv_dm_activation_fail = 1;
     jtag_dm_activation_seq.start(p_sequencer.jtag_sequencer_h);
     cfg.m_jtag_riscv_agent_cfg.allow_errors = 0;
+    cfg.m_jtag_riscv_agent_cfg.allow_rv_dm_activation_fail = 0;
+
+    `DV_CHECK_EQ(cfg.m_jtag_riscv_agent_cfg.rv_dm_activated, exp_to_be_activated)
+    `uvm_info(`gfn, $sformatf("rv_dm_activated: %0d", cfg.m_jtag_riscv_agent_cfg.rv_dm_activated),
+              UVM_LOW)
   endtask
 
   virtual task test_jtag_tap();
@@ -128,7 +152,6 @@ class chip_tap_straps_vseq extends chip_common_vseq;
   virtual task test_lc_access_via_jtag();
     foreach (ral.lc_ctrl.device_id[i]) begin
       bit [31:0] act_device_id, exp_device_id;
-      ral.lc_ctrl.device_id[i].print(); // TODO, remove
       csr_peek(ral.lc_ctrl.device_id[i], exp_device_id);
       jtag_riscv_agent_pkg::jtag_read_csr(ral.lc_ctrl.device_id[i].get_offset(),
                                           p_sequencer.jtag_sequencer_h,
@@ -139,27 +162,24 @@ class chip_tap_straps_vseq extends chip_common_vseq;
 
   // if no tap is selected, expect to read all 0s
   virtual task test_no_tap_selected();
-    bit [TL_DW-1:0] rdata;
     repeat (10) begin
-      cfg.m_jtag_riscv_agent_cfg.is_rv_dm = $urandom_range(0, 1);
       randcase
         // enable rv_dm
         1: begin
           cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 1;
-          all_csrs.shuffle();
-          csr_rd(all_csrs[0], rdata);
+          init_rv_dm(.exp_to_be_activated(0));
         end
         // enable LC
         1: begin
+          bit [TL_DW-1:0] rdata;
           cfg.m_jtag_riscv_agent_cfg.is_rv_dm = 0;
           lc_csrs.shuffle();
           jtag_riscv_agent_pkg::jtag_read_csr(lc_csrs[0].get_offset(),
                                               p_sequencer.jtag_sequencer_h,
                                               rdata);
+          `DV_CHECK_EQ(rdata, 0)
         end
       endcase
-      $display("wcy is_rv_dm %0d", cfg.m_jtag_riscv_agent_cfg.is_rv_dm);
-      `DV_CHECK_EQ(rdata, 0)
     end
   endtask
 
@@ -184,7 +204,7 @@ class chip_tap_straps_vseq extends chip_common_vseq;
   endfunction
 
   virtual function bit is_lc_in_unlocked_or_rma();
-    return cur_lc_state inside {lc_ctrl_state_pkg::LcStRma,
+    return cur_lc_state inside {LcStRma,
         LcStTestUnlocked0, LcStTestUnlocked1, LcStTestUnlocked2, LcStTestUnlocked3,
         LcStTestUnlocked4, LcStTestUnlocked5, LcStTestUnlocked6, LcStTestUnlocked7};
   endfunction

--- a/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
+++ b/hw/top_earlgrey/dv/env/seq_lib/chip_vseq_list.sv
@@ -8,7 +8,6 @@
 `include "chip_common_vseq.sv"
 `include "chip_jtag_csr_rw_vseq.sv"
 `include "chip_jtag_mem_vseq.sv"
-`include "chip_tap_straps_vseq.sv"
 // This needs to be listed prior to all sequences that derive from it.
 `include "chip_sw_base_vseq.sv"
 `include "chip_sw_full_aon_reset_vseq.sv"
@@ -31,3 +30,4 @@
 `include "chip_sw_sensor_ctrl_status_intr_vseq.sv"
 `include "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq.sv"
 `include "chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq.sv"
+`include "chip_tap_straps_vseq.sv"


### PR DESCRIPTION
Verify pinmux can select the life_cycle, RISC-V taps in RMA and Dev states
- in PROD state, only the LC tap can be selected.
- in DEV state, only the LC tap and RISC-V taps can be selected.
Verify DFT test mode straps are sampled and output to AST via top_earlgrey.dft_strap_test_o

Signed-off-by: Weicai Yang <weicai@google.com>