### PR TITLE
[sysrst_ctrl, dv] Fix wrong sequence name in stress_all

### DIFF
--- a/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_stress_all_vseq.sv
+++ b/hw/ip/sysrst_ctrl/dv/env/seq_lib/sysrst_ctrl_stress_all_vseq.sv
@@ -22,7 +22,7 @@ class sysrst_ctrl_stress_all_vseq extends sysrst_ctrl_base_vseq;
                           "sysrst_ctrl_ec_pwr_on_rst_vseq",
                           "sysrst_ctrl_flash_wr_prot_vseq",
                           "sysrst_ctrl_ultra_low_pwr_vseq",
-                          "sysrst_ctrl_combo_detect",
+                          "sysrst_ctrl_combo_detect_vseq",
                           "sysrst_ctrl_edge_detect_vseq",
                           "sysrst_ctrl_common_vseq"};
 


### PR DESCRIPTION
Signed-off-by: Weicai Yang <weicai@google.com>