### PR TITLE
[bazel,dvsim] update dvsim.py to use Bazel to build SW

### DIFF
--- a/ci/scripts/run-verilator-tests.sh
+++ b/ci/scripts/run-verilator-tests.sh
@@ -16,16 +16,16 @@ xargs ci/bazelisk.sh test \
     --test_tag_filters=verilator,-failing_verilator,-broken \
     --test_output=errors \
     --//hw:verilator_options=--threads,1 \
-    //sw/device/tests:sim_verilator_crt_test \
-    //sw/device/tests:sim_verilator_otbn_randomness_test \
-    //sw/device/tests:sim_verilator_otbn_irq_test \
-    //sw/device/tests:sim_verilator_kmac_mode_cshake_test \
-    //sw/device/tests:sim_verilator_kmac_mode_kmac_test \
-    //sw/device/tests:sim_verilator_flash_ctrl_test \
-    //sw/device/tests:sim_verilator_usbdev_test \
-    //sw/device/silicon_creator/lib/drivers:sim_verilator_hmac_functest \
-    //sw/device/silicon_creator/lib/drivers:sim_verilator_uart_functest \
-    //sw/device/silicon_creator/lib/drivers:sim_verilator_retention_sram_functest \
-    //sw/device/silicon_creator/lib/drivers:sim_verilator_alert_functest \
-    //sw/device/silicon_creator/lib/drivers:sim_verilator_watchdog_functest \
-    //sw/device/silicon_creator/lib:sim_verilator_irq_asm_functest
+    //sw/device/tests:crt_test_sim_verilator \
+    //sw/device/tests:otbn_randomness_test_sim_verilator \
+    //sw/device/tests:otbn_irq_test_sim_verilator \
+    //sw/device/tests:kmac_mode_cshake_test_sim_verilator \
+    //sw/device/tests:kmac_mode_kmac_test_sim_verilator \
+    //sw/device/tests:flash_ctrl_test_sim_verilator \
+    //sw/device/tests:usbdev_test_sim_verilator \
+    //sw/device/silicon_creator/lib/drivers:hmac_functest_sim_verilator \
+    //sw/device/silicon_creator/lib/drivers:uart_functest_sim_verilator \
+    //sw/device/silicon_creator/lib/drivers:retention_sram_functest_sim_verilator \
+    //sw/device/silicon_creator/lib/drivers:alert_functest_sim_verilator \
+    //sw/device/silicon_creator/lib/drivers:watchdog_functest_sim_verilator \
+    //sw/device/silicon_creator/lib:irq_asm_functest_sim_verilator

--- a/hw/top_earlgrey/dv/chip_sim_cfg.hjson
+++ b/hw/top_earlgrey/dv/chip_sim_cfg.hjson
@@ -66,7 +66,7 @@
     }
     // Used by 'cover_reg_top' only builds - we only cover the *_reg_top of
     // the non-pre-verified modules at the chip level. See
-    // `hw/dv/tools/dvsim//common_sim_cfg.hjson` for the default value.
+    // `hw/dv/tools/dvsim/common_sim_cfg.hjson` for the default value.
     {
       name: cover_reg_top_vcs_cov_cfg_file
       value: "-cm_hier {proj_root}/hw/top_earlgrey/dv/cov/chip_cover_reg_top.cfg"
@@ -227,16 +227,14 @@
 
   // List of test specifications.
   //
-  // If you are adding a test that has been generated from the `sw_tests`
-  // dictionary declared in `sw/device/tests/meson.build`, the `sw_images` list
-  // below should contain `sw/device/tests/<sw_test_name>` (without any more
-  // subdirectories) because that is where the meson target is created. For
-  // example `gpio_test` is added to `sw_tests` in
-  // `sw/device/tests/sim_dv/meson.build`, but the final meson targets all
-  // start with `sw/device/tests/gpio_test_`.
+  // If you are adding a test that has been generated from a Bazel
+  // `opentitan_functest` macro, you can specify the test using the path to the
+  // Bazel target. For example, if the Bazel target is:
+  // `//sw/device/tests:example_test_from_flash`, then you would specify this as
+  // `sw/device/tests/example_test_from_flash`.
   //
-  // Each entry in `sw_images` is followed by an index separated with ':' which
-  // is used by the testbench to know what type of image is it:
+  // Additionally, each entry in `sw_images` is followed by an index separated
+  // with ':' which is used by the testbench to know what type of image is it:
   // - 0 for Boot ROM,
   // - 1 for SW test,
   // - 2 for OTBN test,
@@ -269,7 +267,7 @@
     {
       name: chip_sw_uart_tx_rx
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=0"]
       reseed: 5
@@ -277,7 +275,7 @@
     {
       name: chip_sw_uart_tx_rx_idx1
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=1"]
       reseed: 5
@@ -285,7 +283,7 @@
     {
       name: chip_sw_uart_tx_rx_idx2
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=2"]
       reseed: 5
@@ -293,7 +291,7 @@
     {
       name: chip_sw_uart_tx_rx_idx3
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+uart_idx=3"]
       reseed: 5
@@ -301,14 +299,14 @@
     {
       name: chip_sw_uart_tx_rx_bootstrap
       uvm_test_seq: chip_sw_uart_tx_rx_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_spi_load_bootstrap=1"]
     }
     {
       name: chip_sw_uart_rand_baudrate
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000"]
       reseed: 20
@@ -316,7 +314,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1"]
@@ -325,7 +323,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_freq_low_speed
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
                  "+ext_clk_type=ExtClkLowSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
@@ -339,7 +337,7 @@
     {
       name: chip_sw_uart_tx_rx_alt_clk_fast_ip_clk
       uvm_test_seq: chip_sw_uart_rand_baudrate_vseq
-      sw_images: ["sw/device/tests/uart_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/uart_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=80_000_000", "+use_otp_image=LcStRma",
                  "+ext_clk_type=ExtClkHighSpeed", "+use_extclk=1", "+extclk_low_speed_sel=1"]
@@ -348,13 +346,13 @@
     {
       name: chip_sw_spi_device_tx_rx
       uvm_test_seq: chip_sw_spi_tx_rx_vseq
-      sw_images: ["sw/device/tests/spi_tx_rx_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/spi_tx_rx_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_gpio
       uvm_test_seq: chip_sw_gpio_vseq
-      sw_images: ["sw/device/tests/gpio_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/gpio_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -374,7 +372,7 @@
     {
       name: chip_sw_flash_ctrl_lc_rw_en
       uvm_test_seq: chip_sw_flash_ctrl_lc_rw_en_vseq
-      sw_images: ["sw/device/tests/flash_ctrl_lc_rw_en_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/flash_ctrl_lc_rw_en_test:1"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
@@ -400,7 +398,7 @@
     {
       name: chip_sw_flash_rma_unlocked
       uvm_test_seq: chip_sw_flash_rma_unlocked_vseq
-      sw_images: ["sw/device/tests/flash_rma_unlocked_test:0"]
+      sw_images: ["sw/device/tests/sim_dv/flash_rma_unlocked_test:0"]
       en_run_modes: ["sw_test_mode_common"]
       run_opts: ["+sw_test_timeout_ns=200_000_000"]
     }
@@ -420,21 +418,21 @@
       // Set higher reseed value to reach all kmac_data to lc_ctrl toggle coverage.
       name: chip_sw_lc_ctrl_transition
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
-      sw_images: ["sw/device/tests/lc_ctrl_transition_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_ctrl_transition_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       reseed: 15
     }
     {
       name: chip_sw_lc_walkthrough_prodend
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStProdEnd"]
     }
     {
       name: chip_sw_lc_walkthrough_rma
       uvm_test_seq: chip_sw_lc_walkthrough_vseq
-      sw_images: ["sw/device/tests/lc_walkthrough_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/lc_walkthrough_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+use_otp_image=LcStRaw", "+dest_dec_state=DecLcStRma",
                  // The test takes long time because it will transit to RMA state
@@ -470,7 +468,7 @@
     {
       name: chip_sw_pwrmgr_usbdev_wakeup
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/pwrmgr_usbdev_smoketest:1"]
+      sw_images: ["sw/device/tests/sim_dv/pwrmgr_usbdev_smoketest:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -482,26 +480,26 @@
     {
       name: chip_sw_pwrmgr_main_power_glitch_reset
       uvm_test_seq: chip_sw_main_power_glitch_vseq
-      sw_images: ["sw/device/tests/pwrmgr_main_power_glitch_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/pwrmgr_main_power_glitch_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
     }
     {
       name: chip_sw_pwrmgr_sysrst_ctrl_reset
       uvm_test_seq: chip_sw_sysrst_ctrl_vseq
-      sw_images: ["sw/device/tests/pwrmgr_sysrst_ctrl_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/pwrmgr_sysrst_ctrl_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_pwrmgr_deep_sleep_sysrst_reqs
       uvm_test_seq: chip_sw_sysrst_ctrl_vseq
-      sw_images: ["sw/device/tests/pwrmgr_deep_sleep_sysrst_reqs_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/pwrmgr_deep_sleep_sysrst_reqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_pwrmgr_sleep_power_glitch_reset
       uvm_test_seq: chip_sw_main_power_glitch_vseq
-      sw_images: ["sw/device/tests/pwrmgr_sleep_power_glitch_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/pwrmgr_sleep_power_glitch_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+bypass_alert_ready_to_end_check=1"]
     }
@@ -555,7 +553,7 @@
     {
       name: chip_sw_adc_ctrl_sleep_debug_cable_wakeup
       uvm_test_seq: chip_sw_adc_ctrl_sleep_debug_cable_wakeup_vseq
-      sw_images: ["sw/device/tests/adc_ctrl_sleep_debug_cable_wakeup_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/adc_ctrl_sleep_debug_cable_wakeup_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }
@@ -611,7 +609,7 @@
     {
       name: chip_sw_alert_test
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/alert_test:1"]
+      sw_images: ["sw/device/tests/autogen/alert_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -650,7 +648,7 @@
     {
       name: chip_sw_keymgr_key_derivation
       uvm_test_seq: chip_sw_keymgr_key_derivation_vseq
-      sw_images: ["sw/device/tests/keymgr_key_derivation_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/keymgr_key_derivation_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=20000000"]
     }
@@ -695,20 +693,20 @@
     {
       name: chip_sw_rom_ctrl_integrity_check
       uvm_test_seq: chip_sw_rom_ctrl_integrity_check_vseq
-      sw_images: ["sw/device/tests/rom_ctrl_integrity_check_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/rom_ctrl_integrity_check_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
       name: chip_sw_sram_ctrl_ret_scrambled_access
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
-      sw_images: ["sw/device/tests/sram_ctrl_ret_scrambled_access_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/sram_ctrl_ret_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=ret"]
     }
     {
       name: chip_sw_sram_ctrl_main_scrambled_access_jitter_en
       uvm_test_seq: chip_sw_sram_ctrl_scrambled_access_vseq
-      sw_images: ["sw/device/tests/sram_ctrl_main_scrambled_access_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/sram_ctrl_main_scrambled_access_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+mem_sel=main",
                  "+sw_test_timeout_ns=7000000",
@@ -717,7 +715,7 @@
     {
       name: chip_sw_sram_ctrl_execution_main
       uvm_test_seq: chip_sw_sram_ctrl_execution_main_vseq
-      sw_images: ["sw/device/tests/sram_ctrl_execution_test_main:1"]
+      sw_images: ["sw/device/tests/sim_dv/sram_ctrl_execution_test_main:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -777,7 +775,7 @@
     {
       name: chip_plic_all_irqs
       uvm_test_seq: chip_sw_base_vseq
-      sw_images: ["sw/device/tests/plic_all_irqs_test:1"]
+      sw_images: ["sw/device/tests/autogen/plic_all_irqs_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
     }
     {
@@ -789,7 +787,7 @@
     {
       name: chip_sw_clkmgr_external_clk_src_for_lc
       uvm_test_seq: chip_sw_lc_ctrl_transition_vseq
-      sw_images: ["sw/device/tests/clkmgr_external_clk_src_for_lc_test:1"]
+      sw_images: ["sw/device/tests/sim_dv/clkmgr_external_clk_src_for_lc_test:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+ext_clk_type=ExtClkLowSpeed", "+calibrate_usb_clk=1"]
     }
@@ -834,7 +832,7 @@
     {
       name: chip_sw_pwrmgr_deep_sleep_all_wake_ups
       uvm_test_seq: "chip_sw_pwrmgr_deep_sleep_all_wake_ups_vseq"
-      sw_images: ["sw/device/tests/pwrmgr_deep_sleep_all_wake_ups:1"]
+      sw_images: ["sw/device/tests/sim_dv/pwrmgr_deep_sleep_all_wake_ups:1"]
       en_run_modes: ["sw_test_mode_test_rom"]
       run_opts: ["+sw_test_timeout_ns=18000000"]
     }

--- a/hw/top_earlgrey/dv/env/chip_env_cfg.sv
+++ b/hw/top_earlgrey/dv/env/chip_env_cfg.sv
@@ -212,10 +212,15 @@ class chip_env_cfg #(type RAL_T = chip_ral_pkg::chip_reg_block) extends cip_base
       end else if ("signed" inside {sw_image_flags[i]}) begin
         // TODO: support multiple signing keys. See "signing_keys" in
         // `sw/device/meson.build` for options.
-        sw_images[i] = $sformatf("%0s/%0s_%0s.test_key_0.signed",
+        sw_images[i] = $sformatf("%0s/%0s_prog_%0s.test_key_0.signed",
           sw_build_bin_dir, sw_images[i], sw_build_device);
       end else begin
-        sw_images[i] = $sformatf("%0s/%0s_%0s", sw_build_bin_dir, sw_images[i], sw_build_device);
+        if (i == SwTypeTest) begin
+          sw_images[i] = $sformatf("%0s/%0s_prog_%0s", sw_build_bin_dir, sw_images[i],
+            sw_build_device);
+        end else begin
+          sw_images[i] = $sformatf("%0s/%0s_%0s", sw_build_bin_dir, sw_images[i], sw_build_device);
+        end
       end
     end
   endfunction

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -564,7 +564,7 @@ def opentitan_rom_binary(
         targets.extend(opentitan_binary(
             name = devname,
             deps = deps + dev_deps,
-            extract_sw_logs_db = extract_sw_logs_db and device == "sim_dv",
+            extract_sw_logs_db = extract_sw_logs_db and device.startswith("sim_"),
             **kwargs
         ))
         elf_name = "{}_{}".format(devname, "elf")
@@ -638,7 +638,7 @@ def opentitan_flash_binary(
         targets.extend(opentitan_binary(
             name = devname,
             deps = deps + dev_deps,
-            extract_sw_logs_db = extract_sw_logs_db and device == "sim_dv",
+            extract_sw_logs_db = extract_sw_logs_db and device.startswith("sim_"),
             **kwargs
         ))
         elf_name = "{}_{}".format(devname, "elf")

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -289,15 +289,17 @@ def opentitan_functest(
             continue
 
         # Set test name.
-        test_name = "{}_{}".format(target, name)
+        test_name = "{}_{}".format(name, target)
         if "manual" not in params.get("tags"):
             all_tests.append(test_name)
 
         # Set flash image.
         if target in ["sim_dv", "sim_verilator"]:
             flash = "{}_prog_{}_scr_vmem64".format(name, target)
+            sw_logs_db = ["{}_prog_{}_logs_db".format(name, target)]
         else:
             flash = "{}_prog_{}_bin".format(name, target)
+            sw_logs_db = []
         if signed:
             flash += "_signed_{}".format(key)
 
@@ -385,7 +387,7 @@ def opentitan_functest(
                 flash,
                 rom,
                 otp,
-            ] + concat_data,
+            ] + concat_data + sw_logs_db,
             **params
         )
 

--- a/sw/device/tests/sim_dv/BUILD
+++ b/sw/device/tests/sim_dv/BUILD
@@ -6,6 +6,27 @@ load("//rules:opentitan.bzl", "OPENTITAN_CPU")
 load("//rules:opentitan_test.bzl", "opentitan_functest", "verilator_params")
 
 opentitan_functest(
+    name = "uart_tx_rx_test",
+    srcs = ["uart_tx_rx_test.c"],
+    targets = ["dv"],
+    deps = [
+        "//hw/ip/lc_ctrl/data:lc_ctrl_regs",
+        "//hw/top_earlgrey/ip/clkmgr/data/autogen:clkmgr_regs",
+        "//hw/top_earlgrey/ip/pinmux/data/autogen:pinmux_regs",
+        "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/lib:irq",
+        "//sw/device/lib/base:mmio",
+        "//sw/device/lib/dif:clkmgr",
+        "//sw/device/lib/dif:lc_ctrl",
+        "//sw/device/lib/dif:rv_plic",
+        "//sw/device/lib/dif:uart",
+        "//sw/device/lib/runtime:hart",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_functest(
     name = "flash_ctrl_lc_rw_en_test",
     srcs = ["flash_ctrl_lc_rw_en_test.c"],
     targets = ["dv"],


### PR DESCRIPTION
This fixes #11563 by updating dvsim.py, and the chip-level testbench, to
build SW artifacts with Bazel (instead of meson).

Signed-off-by: Timothy Trippel <ttrippel@google.com>