### PR TITLE
[silicon_creator] Set OTBN software errors to fatal in the ROM drivers.

### DIFF
--- a/sw/device/silicon_creator/lib/BUILD
+++ b/sw/device/silicon_creator/lib/BUILD
@@ -247,6 +247,7 @@ cc_library(
     hdrs = ["otbn_util.h"],
     deps = [
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:otbn",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/BUILD
+++ b/sw/device/silicon_creator/lib/drivers/BUILD
@@ -298,6 +298,7 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/silicon_creator/lib:error",
+        "//sw/device/silicon_creator/lib/base:sec_mmio",
         "//sw/device/silicon_creator/lib/drivers:rnd",
     ],
 )

--- a/sw/device/silicon_creator/lib/drivers/otbn.c
+++ b/sw/device/silicon_creator/lib/drivers/otbn.c
@@ -10,6 +10,7 @@
 
 #include "sw/device/lib/base/abs_mmio.h"
 #include "sw/device/lib/base/bitfield.h"
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/rnd.h"
 #include "sw/device/silicon_creator/lib/error.h"
 
@@ -125,6 +126,7 @@ static rom_error_t otbn_cmd_run(otbn_cmd_t cmd, rom_error_t error) {
 }
 
 rom_error_t otbn_execute(void) {
+  otbn_set_ctrl_software_errs_fatal(true);
   return otbn_cmd_run(kOtbnCmdExecute, kErrorOtbnExecutionFailed);
 }
 
@@ -184,7 +186,7 @@ void otbn_zero_dmem(void) {
   HARDENED_CHECK_EQ(i, kOtbnDMemSizeBytes);
 }
 
-rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
+void otbn_set_ctrl_software_errs_fatal(bool enable) {
   // Only one bit in the CTRL register so no need to read current value.
   uint32_t new_ctrl;
 
@@ -194,10 +196,5 @@ rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable) {
     new_ctrl = 0;
   }
 
-  abs_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET, new_ctrl);
-  if (abs_mmio_read32(kBase + OTBN_CTRL_REG_OFFSET) != new_ctrl) {
-    return kErrorOtbnUnavailable;
-  }
-
-  return kErrorOk;
+  sec_mmio_write32(kBase + OTBN_CTRL_REG_OFFSET, new_ctrl);
 }

--- a/sw/device/silicon_creator/lib/drivers/otbn.h
+++ b/sw/device/silicon_creator/lib/drivers/otbn.h
@@ -46,6 +46,22 @@ typedef enum otbn_status {
 } otbn_status_t;
 
 /**
+ * The following constants represent the expected number of sec_mmio register
+ * writes performed by functions in provided in this module. See
+ * `SEC_MMIO_WRITE_INCREMENT()` for more details.
+ *
+ * Example:
+ * ```
+ *  otbn_execute();
+ *  SEC_MMIO_WRITE_INCREMENT(kOtbnSecMMioExecute);
+ * ```
+ */
+enum {
+  kOtbnSecMmioExecute = 1,
+  kOtbnSecMmioSetCtrlSwErrsFatal = 1,
+};
+
+/**
  * Start the execution of the application loaded into OTBN.
  *
  * This function blocks until OTBN is idle.
@@ -180,7 +196,7 @@ void otbn_zero_dmem(void);
  * @return `kErrorOtbnUnavailable` if the requested change cannot be made or
  * `kErrorOk` otherwise.
  */
-rom_error_t otbn_set_ctrl_software_errs_fatal(bool enable);
+void otbn_set_ctrl_software_errs_fatal(bool enable);
 
 #ifdef __cplusplus
 }

--- a/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
+++ b/sw/device/silicon_creator/lib/drivers/otbn_unittest.cc
@@ -8,6 +8,7 @@
 
 #include "gtest/gtest.h"
 #include "sw/device/lib/base/testing/mock_abs_mmio.h"
+#include "sw/device/silicon_creator/lib/base/mock_sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/mock_rnd.h"
 #include "sw/device/silicon_creator/testing/mask_rom_test.h"
 
@@ -48,8 +49,9 @@ class OtbnTest : public mask_rom_test::MaskRomTest {
   }
 
   uint32_t base_ = TOP_EARLGREY_OTBN_BASE_ADDR;
-  mask_rom_test::MockAbsMmio mmio_;
+  mask_rom_test::MockAbsMmio abs_mmio_;
   mask_rom_test::MockRnd rnd_;
+  mask_rom_test::MockSecMmio sec_mmio_;
 };
 
 class ExecuteTest : public OtbnTest {};
@@ -58,12 +60,16 @@ TEST_F(ExecuteTest, Success) {
   // Test assumption.
   static_assert(OTBN_IMEM_SIZE_BYTES >= 8, "OTBN IMEM size too small.");
 
+  EXPECT_SEC_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
+
   ExpectCmdRun(kOtbnCmdExecute, kOtbnErrBitsNoError);
 
   EXPECT_EQ(otbn_execute(), kErrorOk);
 }
 
 TEST_F(ExecuteTest, Failure) {
+  EXPECT_SEC_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
+
   ExpectCmdRun(kOtbnCmdExecute, kOtbnErrBitsFatalSoftware);
 
   EXPECT_EQ(otbn_execute(), kErrorOtbnExecutionFailed);
@@ -218,17 +224,9 @@ TEST_F(DmemReadTest, SuccessWithOffset) {
 class ControlSoftwareErrorsFatalTest : public OtbnTest {};
 
 TEST_F(ControlSoftwareErrorsFatalTest, Success) {
-  EXPECT_ABS_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
-  EXPECT_ABS_READ32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
+  EXPECT_SEC_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
 
-  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(true), kErrorOk);
-}
-
-TEST_F(ControlSoftwareErrorsFatalTest, Failure) {
-  EXPECT_ABS_WRITE32(base_ + OTBN_CTRL_REG_OFFSET, 0x0);
-  EXPECT_ABS_READ32(base_ + OTBN_CTRL_REG_OFFSET, 0x1);
-
-  EXPECT_EQ(otbn_set_ctrl_software_errs_fatal(false), kErrorOtbnUnavailable);
+  otbn_set_ctrl_software_errs_fatal(true);
 }
 
 class ZeroDmemTest : public OtbnTest {};

--- a/sw/device/silicon_creator/lib/otbn_util.c
+++ b/sw/device/silicon_creator/lib/otbn_util.c
@@ -8,6 +8,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "sw/device/silicon_creator/lib/base/sec_mmio.h"
 #include "sw/device/silicon_creator/lib/drivers/otbn.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -86,7 +87,9 @@ rom_error_t otbn_execute_app(otbn_t *ctx) {
   }
   HARDENED_CHECK_EQ(ctx->app_is_loaded, kHardenedBoolTrue);
 
-  return otbn_execute();
+  rom_error_t err = otbn_execute();
+  SEC_MMIO_WRITE_INCREMENT(kOtbnSecMmioExecute);
+  return err;
 }
 
 rom_error_t otbn_copy_data_to_otbn(otbn_t *ctx, size_t len, const uint32_t *src,


### PR DESCRIPTION
This setting ensures OTBN treats software errors as non-recoverable. Setting it just before application execution time makes fault injection harder for attackers, because the CTRL register that holds this setting is locked while OTBN is busy.