### PR TITLE
[ci] Report and correct bitstreams available on the FPGA pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -446,10 +446,10 @@ jobs:
       BITCACHE_FILE=$BITCACHE_DIR/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig
       cp $BIN_DIR/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit ${BITCACHE_FILE}
       echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
-      BITSTREAM="${SHA} --offline" ci/bazelisk.sh test \
+      BITSTREAM="--offline --list ${SHA}" ci/bazelisk.sh test \
           --define DISABLE_VERILATOR_BUILD=true \
           --test_tag_filters=cw310,-broken \
-          --test_output=errors \
+          --test_output=all \
           --build_tests_only \
           --flaky_test_attempts=4 \
           --define cw310=lowrisc \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -446,7 +446,9 @@ jobs:
       BITCACHE_FILE=$BITCACHE_DIR/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.orig
       cp $BIN_DIR/hw/top_earlgrey/lowrisc_systems_chip_earlgrey_cw310_0.1.bit ${BITCACHE_FILE}
       echo "" >> ${BITCACHE_DIR}/lowrisc_systems_chip_earlgrey_cw310_0.1.bit.splice
-      BITSTREAM="--offline --list ${SHA}" ci/bazelisk.sh test \
+      echo -n ${SHA} > ${BITCACHE_DIR}/../../latest.txt
+      export BITSTREAM="--offline --list ${SHA}"
+      ci/bazelisk.sh test \
           --define DISABLE_VERILATOR_BUILD=true \
           --test_tag_filters=cw310,-broken \
           --test_output=all \

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -291,9 +291,8 @@ def main(argv):
 
     # Do we need a refresh?
     need_refresh = (args.refresh or bitstream != 'latest' or
-                    (cache.NeedRefresh(args.refresh_time) and
-                     not args.offline))
-    cache.GetBitstreamsAvailable(need_refresh)
+                    cache.NeedRefresh(args.refresh_time))
+    cache.GetBitstreamsAvailable(need_refresh and not args.offline)
 
     # If commanded to print bitstream availability, do so.
     if args.list:

--- a/rules/scripts/bitstreams_workspace.py
+++ b/rules/scripts/bitstreams_workspace.py
@@ -309,7 +309,7 @@ def main(argv):
                 'Cannot find a bitstream close to {}'.format(bitstream))
             return 1
         if closest != bitstream:
-            logging.info('Closest bitstream to {} is {}.'.format(
+            logging.error('Closest bitstream to {} is {}.'.format(
                 bitstream, closest))
             bitstream = closest
 
@@ -319,7 +319,7 @@ def main(argv):
     #   @bitstreams//:bitstream_mask_rom
     configured = cache.WriteBuildFile(args.build_file, bitstream)
     if args.bitstream != configured:
-        logging.info('Configured bitstream "{}" as {}.'.format(
+        logging.error('Configured bitstream "{}" as {}.'.format(
             args.bitstream, configured))
     else:
         logging.info('Configured bitstream {}.'.format(configured))


### PR DESCRIPTION
Fixes #12755
makes tests use an offline bitstream,
pushes a latest file into the bitstream cache so bazel can identify the cache.

Signed-off-by: Drew Macrae <drewmacrae@google.com>