### PR TITLE
[otbn,rtl] Fix overflow in stack_top_idx

### DIFF
--- a/hw/ip/otbn/rtl/otbn_stack.sv
+++ b/hw/ip/otbn/rtl/otbn_stack.sv
@@ -52,10 +52,10 @@ module otbn_stack
   output logic                   next_top_valid_o
 );
   logic [StackWidth-1:0]  stack_storage [StackDepth];
-  logic [StackDepthW:0]   stack_wr_ptr;
-  logic [StackDepthW-1:0] stack_top_idx, stack_rd_idx, stack_wr_idx;
-  logic [StackDepthW-1:0] next_stack_rd_idx, next_stack_top_idx;
-  logic [StackDepthW-1:0] stack_top_idx_step;
+  logic [StackDepthW:0]   stack_wr_ptr, stack_top_idx;
+  logic [StackDepthW-1:0] stack_rd_idx, stack_wr_idx;
+  logic [StackDepthW:0]   next_stack_top_idx, stack_top_idx_step;
+  logic [StackDepthW-1:0] next_stack_rd_idx;
 
   logic stack_empty;
   logic stack_full;
@@ -69,9 +69,9 @@ module otbn_stack
   assign stack_write = push_i & (~full_o | pop_i);
   assign stack_read  = top_valid_o & pop_i;
 
-  assign stack_top_idx = stack_wr_ptr[StackDepthW-1:0];
-  assign stack_rd_idx = stack_top_idx - 1'b1;
-  assign stack_wr_idx = pop_i ? stack_rd_idx : stack_top_idx;
+  assign stack_top_idx = stack_wr_ptr[StackDepthW:0];
+  assign stack_rd_idx = stack_top_idx[StackDepthW-1:0] - 1'b1;
+  assign stack_wr_idx = pop_i ? stack_rd_idx : stack_top_idx[StackDepthW-1:0];
 
   logic signed [StackDepthW:0] stack_wr_ptr_step;
   always_comb begin
@@ -162,14 +162,14 @@ module otbn_stack
       next_stack_top_idx = '0;
     end else begin
       if (stack_wr_ptr_en) begin
-        stack_top_idx_step = stack_wr_ptr_step[StackDepthW-1:0];
+        stack_top_idx_step = stack_wr_ptr_step;
       end
 
       next_stack_top_idx = stack_top_idx + stack_top_idx_step;
     end
   end
 
-  assign next_stack_rd_idx = next_stack_top_idx - 1'b1;
+  assign next_stack_rd_idx = next_stack_top_idx[StackDepthW-1:0] - 1'b1;
 
   assign next_top_data_o = stack_write ? push_data_i : stack_storage[next_stack_rd_idx];
   assign next_top_valid_o = next_stack_top_idx != '0;


### PR DESCRIPTION
We use `next_stack_top_idx` to derive `next_top_valid_o`, which says
whether the stack has data in it. This check is based on seeing
whether the index just above the top of the stack is nonzero or not.
We were using `StackDepthW` bits and got an overflow when the stack
filled up.

To see the bug (in a rather roundabout way), run e.g. `util/dvsim/dvsim.py hw/ip/otbn/dv/uvm/otbn_sim_cfg.hjson --tool=xcelium -i otbn_single --fixed-seed 1023075738` with current master. The symptom is a failed assertion in the prefetcher, which turns out to be because we take a loop back-edge when the prefetcher doesn't think there's a loop. That, in turn, is because the prefetcher's notion of whether there's a loop or not comes from `next_top_valid_o`.