### PR TITLE
[rstmgr] Minor fsm_err_o fix in cnsty check FSM

### DIFF
--- a/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
+++ b/hw/ip/rstmgr/rtl/rstmgr_cnsty_chk.sv
@@ -254,6 +254,7 @@ module rstmgr_cnsty_chk
 
       default: begin
         state_d = FsmError;
+        fsm_err_o = 1'b1;
       end
     endcase // unique case (state_q)
   end // always_comb


### PR DESCRIPTION
This was uncovered by the associated SEC_CM assertion.
@tjaychen let me know if this violates any of the design assumptions...

Signed-off-by: Michael Schaffner <msf@google.com>