### PR TITLE
[bazel] remove "test_suite" tag from opentitan_test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -554,6 +554,6 @@ jobs:
             --build_tests_only=false \
             --define DISABLE_VERILATOR_BUILD=true \
             --test_tag_filters=-broken,-cw310,-verilator,-dv \
-            --build_tag_filters=-verilator,-test_suite \
+            --build_tag_filters=-verilator,-cw310,-dv \
             //sw/...
       displayName: "Build and Unit Test Software with Bazel"

--- a/rules/opentitan_test.bzl
+++ b/rules/opentitan_test.bzl
@@ -392,5 +392,4 @@ def opentitan_functest(
     native.test_suite(
         name = name,
         tests = all_tests,
-        tags = ["test_suite"],
     )


### PR DESCRIPTION
This removes the "test_suite" tag that was applied to the
"opentitan_functest" test_suite rule as this prevented running `bazel
test //<package>:<target>` without prepending the device name (e.g.,
"sim_verilator") to the <target>.

Signed-off-by: Timothy Trippel <ttrippel@google.com>