### PR TITLE
[ci, bazel] Run englishbreakfast tests in CI with bazel

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -287,6 +287,25 @@ jobs:
         --napoleon-docstrings
     displayName: Execute tests
 
+# TODO: change this name and replace sw_build_englishbreakfast and execute_verilated_tests_englishbreakfast
+# once testing shows it's stable
+- job: bazel_build_and_execute_verilated_tests_englishbreakfast
+  displayName: Build and execute tests on the Verilated English Breakfast toplevel design with Bazel
+  pool:
+    vmImage: ubuntu-18.04
+  dependsOn: chip_englishbreakfast_verilator
+  steps:
+  - template: ci/install-package-dependencies.yml
+  - template: ci/download-artifacts-template.yml
+    parameters:
+      downloadPartialBuildBinFrom:
+        - chip_englishbreakfast_verilator
+  - bash: |
+      . util/build_consts.sh
+      ci/scripts/run-english-breakfast-verilator-tests.sh
+    displayName: Execute tests
+    continueOnError: true #TODO: remove this line once this job is proven to be stable
+
 - job: otbn_standalone_tests
   displayName: Run OTBN Smoke Test
   dependsOn: lint

--- a/ci/scripts/build-chip-verilator.sh
+++ b/ci/scripts/build-chip-verilator.sh
@@ -21,11 +21,14 @@ case "$tl" in
         fileset=fileset_top
         fusesoc_core=lowrisc:dv:chip_verilator_sim
         vname=Vchip_sim_tb
+        verilator_options="--threads 4"
         ;;
     englishbreakfast)
         fileset=fileset_topgen
         fusesoc_core=lowrisc:systems:chip_englishbreakfast_verilator
         vname=Vchip_englishbreakfast_verilator
+        # Englishbreakfast on CI runs on a 2-core CPU
+        verilator_options="--threads 2"
 
         util/topgen-fusesoc.py --files-root=. --topname=top_englishbreakfast
         ;;
@@ -48,7 +51,7 @@ fusesoc --cores-root=. \
   run --flag=$fileset --target=sim --setup --build \
   --build-root="$OBJ_DIR/hw" \
   $fusesoc_core \
-  --verilator_options="--threads 4"
+  --verilator_options="${verilator_options}"
 
 cp "$OBJ_DIR/hw/sim-verilator/${vname}" \
    "$BIN_DIR/hw/top_${tl}/Vchip_${tl}_verilator"

--- a/ci/scripts/run-english-breakfast-verilator-tests.sh
+++ b/ci/scripts/run-english-breakfast-verilator-tests.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright lowRISC contributors.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Only a single test is supported on English Breakfast (EB).
+# Currently, Bazel cannot build the EB Verilator model, so we only build the test with Bazel and then use opentitantool directly
+# EB Verilator model is built in a previous CI step
+
+set -e
+
+. util/build_consts.sh
+
+# Cleaning is necessary for the find commands below to work correctly
+ci/bazelisk.sh clean
+
+# Build the modified EB software.
+./hw/top_englishbreakfast/util/prepare_sw.py --bazel -b
+
+# Build some other dependencies.
+ci/bazelisk.sh build //sw/host/opentitantool //hw/ip/otp_ctrl/data:rma_image_verilator
+
+# Run the one test.
+# This needs to be run outside the bazel sandbox, so we do not use `bazel run`
+bazel-bin/sw/host/opentitantool/opentitantool \
+    --rcfile="" \
+    --logging=info \
+    --interface=verilator \
+    --conf=sw/host/opentitantool/config/opentitan_verilator.json \
+    --verilator-bin=$BIN_DIR/hw/top_englishbreakfast/Vchip_englishbreakfast_verilator \
+    --verilator-rom=$(find bazel-out/* -name 'test_rom_sim_verilator.32.vmem') \
+    --verilator-flash=$(find bazel-out/* -name 'aes_smoketest_prog_sim_verilator.64.scr.vmem') \
+    console \
+    --exit-failure="(FAIL|FAULT).*\n" \
+    --exit-success="PASS.*\n" \
+    --timeout=3600s

--- a/hw/top_englishbreakfast/util/prepare_sw.py
+++ b/hw/top_englishbreakfast/util/prepare_sw.py
@@ -31,7 +31,7 @@ BINARIES = [
 BAZEL_BINARIES = [
     '//sw/device/lib/testing/test_rom',
     '//sw/device/sca:aes_serial',
-    '//sw/device/tests:aes_smoketest',
+    '//sw/device/tests:aes_smoketest_prog',
     '//sw/device/examples/hello_world',
 ]
 
@@ -157,7 +157,7 @@ def main():
     # Build the software including test_rom to enable the FPGA build.
     if args.bazel:
         shell_out([
-            'bazel', 'build',
+            REPO_TOP / 'bazelisk.sh', 'build',
             '--copt=-DOT_IS_ENGLISH_BREAKFAST_REDUCED_SUPPORT_FOR_INTERNAL_USE_ONLY_',
         ] + BAZEL_BINARIES)
     else:

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -579,7 +579,7 @@ def opentitan_rom_binary(
             name = vmem_name,
             bin = bin_name,
             platform = platform,
-            word_size = 32, 
+            word_size = 32,
         )
 
         # Generate Scrambled ROM VMEM

--- a/rules/opentitan.bzl
+++ b/rules/opentitan.bzl
@@ -204,7 +204,7 @@ elf_to_scrambled_rom_vmem = rv_rule(
     },
 )
 
-def _bin_to_flash_vmem_impl(ctx):
+def _bin_to_vmem_impl(ctx):
     outputs = []
     vmem = ctx.actions.declare_file("{}.{}.vmem".format(
         # Remove ".bin" from file basename.
@@ -248,8 +248,8 @@ def _bin_to_flash_vmem_impl(ctx):
         data_runfiles = ctx.runfiles(files = outputs),
     )]
 
-bin_to_flash_vmem = rv_rule(
-    implementation = _bin_to_flash_vmem_impl,
+bin_to_vmem = rv_rule(
+    implementation = _bin_to_vmem_impl,
     attrs = {
         "bin": attr.label(allow_single_file = True),
         "word_size": attr.int(
@@ -530,12 +530,13 @@ def opentitan_rom_binary(
         **kwargs):
     """A helper macro for generating OpenTitan binary artifacts for ROM.
 
-    This macro is mostly a wrapper around a opentitan_binary macro, which itself
-    is a wrapper around cc_binary, but also creates artifacts for each of the
-    keys in `per_device_deps`. The actual artifacts created are an ELF file, a
-    BIN file, the disassembly, the sim_dv logs database, and the scrambled (ROM)
-    VMEM file. Each of these output targets performs a bazel transition to the
-    RV32I toolchain to build the target under the correct compiler.
+    This macro is mostly a wrapper around a opentitan_binary macro, which
+    itself is a wrapper around cc_binary, but also creates artifacts for each
+    of the keys in `per_device_deps`. The actual artifacts created are an ELF
+    file, a BIN file, the disassembly, the sim_dv logs database, the
+    unscrambled (ROM) VMEM file, and the scrambled (ROM) VMEM file. Each of
+    these output targets performs a bazel transition to the RV32I toolchain to
+    build the target under the correct compiler.
     Args:
       @param name: The name of this rule.
       @param platform: The target platform for the artifacts.
@@ -548,6 +549,7 @@ def opentitan_rom_binary(
         obj_transform             named: <name>_<device>_elf
         obj_transform             named: <name>_<device>_bin
         elf_to_dissassembly       named: <name>_<device>_dis
+        bin_to_rom_vmem           named: <name>_<device>_vmem
         elf_to_scrambled_rom_vmem named: <name>_<device>_scr_vmem
       For the sim_dv device:
         gen_sim_dv_logs_db        named: <name>_sim_dv_logs
@@ -568,6 +570,17 @@ def opentitan_rom_binary(
             **kwargs
         ))
         elf_name = "{}_{}".format(devname, "elf")
+        bin_name = "{}_{}".format(devname, "bin")
+
+        # Generate Un-scrambled ROM VMEM
+        vmem_name = "{}_vmem".format(devname)
+        targets.append(":" + vmem_name)
+        bin_to_vmem(
+            name = vmem_name,
+            bin = bin_name,
+            platform = platform,
+            word_size = 32, 
+        )
 
         # Generate Scrambled ROM VMEM
         scr_vmem_name = "{}_scr_vmem".format(devname)
@@ -617,11 +630,11 @@ def opentitan_flash_binary(
         obj_transform          named: <name>_<device>_elf
         obj_transform          named: <name>_<device>_bin
         elf_to_dissassembly    named: <name>_<device>_dis
-        bin_to_flash_vmem      named: <name>_<device>_flash_vmem
+        bin_to_vmem            named: <name>_<device>_flash_vmem
         scrambled_flash_vmem   named: <name>_<device>_scr_flash_vmem
         optionally:
           sign_bin             named: <name>_<device>_bin_signed_<key_name>
-          bin_to_flash_vmem    named: <name>_<device>_flash_vmem_signed_<key_name>
+          bin_to_vmem          named: <name>_<device>_flash_vmem_signed_<key_name>
           scrambled_flash_vmem named: <name>_<device>_scr_flash_vmem_signed_<key_name>
       For the sim_dv device:
         gen_sim_dv_logs_db     named: <name>_sim_dv_logs
@@ -654,7 +667,7 @@ def opentitan_flash_binary(
             )
             frames_vmem_name = "{}_frames_vmem".format(devname)
             targets.append(":" + frames_vmem_name)
-            bin_to_flash_vmem(
+            bin_to_vmem(
                 name = frames_vmem_name,
                 bin = frames_bin_name,
                 platform = platform,
@@ -681,7 +694,7 @@ def opentitan_flash_binary(
                     key_name,
                 )
                 targets.append(":" + signed_vmem_name)
-                bin_to_flash_vmem(
+                bin_to_vmem(
                     name = signed_vmem_name,
                     bin = signed_bin_name,
                     platform = platform,
@@ -703,7 +716,7 @@ def opentitan_flash_binary(
             # Generate a VMEM64 from the binary.
             vmem_name = "{}_vmem64".format(devname)
             targets.append(":" + vmem_name)
-            bin_to_flash_vmem(
+            bin_to_vmem(
                 name = vmem_name,
                 bin = bin_name,
                 platform = platform,


### PR DESCRIPTION
The title is only partially true. A shell script handles the setup work and the running, but the tests are now built with bazel and run with opentitantool.

This PR adds the test with bazel as a separate job in CI while keeping the previous meson/systemtest infrastructure in place. Once this PR is shown to be stable, then we will remove the latter.